### PR TITLE
AI Sidebar: preserve Agents Manager provider composition

### DIFF
--- a/projects/plugins/jetpack/changelog/enable-ai-sidebar-optimize-title
+++ b/projects/plugins/jetpack/changelog/enable-ai-sidebar-optimize-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Sidebar: Enable Optimize Title suggestions in the Jetpack AI Sidebar Preview.

--- a/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
+++ b/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+AI Sidebar: Preserve peer Agents Manager providers when loading Jetpack AI.

--- a/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
+++ b/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
@@ -1,4 +1,4 @@
 Significance: patch
 Type: compat
 
-AI Sidebar: Preserve peer Agents Manager providers when loading Jetpack AI.
+AI Sidebar: Improve Agents Manager compatibility with Big Sky editor surfaces.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -61,7 +61,7 @@ class Jetpack_AI_Sidebar {
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
 		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
-		// post editor on WordPress.com and Atomic sites.
+		// post editor and Big Sky editor composition surfaces.
 		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Load AM from CDN if not already present.
@@ -599,7 +599,11 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Enable Agents Manager in the post editor when Jetpack AI Sidebar Preview is available.
+	 * Enable Agents Manager when Jetpack AI Sidebar Preview is available.
+	 *
+	 * Jetpack owns the post-editor entrypoint. Big Sky owns its Page/Site Editor
+	 * provider, but Jetpack can open AM there so peer providers compose through
+	 * Agents Manager instead of Big Sky's standalone dock.
 	 *
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
@@ -609,7 +613,11 @@ class Jetpack_AI_Sidebar {
 			return true;
 		}
 
-		return self::is_jetpack_ai_sidebar_preview_enabled() && self::is_post_editor() && self::has_ai_features();
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::has_ai_features() ) {
+			return false;
+		}
+
+		return self::is_post_editor() || self::is_big_sky_editor_composition_surface();
 	}
 
 	/**
@@ -704,6 +712,55 @@ class Jetpack_AI_Sidebar {
 		return $screen instanceof \WP_Screen
 			&& 'post' === $screen->base
 			&& 'post' === $screen->post_type;
+	}
+
+	/**
+	 * Check if the current screen is the page block editor.
+	 *
+	 * @return bool
+	 */
+	private static function is_page_editor(): bool {
+		if ( ! self::is_block_editor() ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return $screen instanceof \WP_Screen
+			&& 'post' === $screen->base
+			&& 'page' === $screen->post_type;
+	}
+
+	/**
+	 * Check if the current screen is the Site Editor.
+	 *
+	 * @return bool
+	 */
+	private static function is_site_editor(): bool {
+		if ( ! self::is_block_editor() ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return $screen instanceof \WP_Screen
+			&& ( 'site-editor' === $screen->base || 'site-editor' === $screen->id );
+	}
+
+	/**
+	 * Check whether Big Sky should compose through Agents Manager on this editor surface.
+	 *
+	 * @return bool
+	 */
+	private static function is_big_sky_editor_composition_surface(): bool {
+		return self::is_big_sky_enabled() && ( self::is_page_editor() || self::is_site_editor() );
+	}
+
+	/**
+	 * Check whether Big Sky is installed and enabled.
+	 *
+	 * @return bool
+	 */
+	private static function is_big_sky_enabled(): bool {
+		return class_exists( 'Big_Sky' ) && (bool) get_option( 'big_sky_enable', '1' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -19,16 +19,15 @@ use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 require_once __DIR__ . '/../../../shared/cdn-locale.php';
 
-const AM_ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
-const AM_ASSET_TRANSIENT          = 'jetpack_am_gutenberg_asset';
-const AM_ASSET_DC_TRANSIENT       = 'jetpack_am_gutenberg_dc_asset';
-const AI_SIDEBAR_ASSET_TRANSIENT  = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL           = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL      = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID         = 'wp-orchestrator';
-const BIG_SKY_AGENT_PROVIDER_PATH = '/big-sky-plugin/build/calypso-agent-provider/';
+const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
+const AM_ASSET_TRANSIENT         = 'jetpack_am_gutenberg_asset';
+const AM_ASSET_DC_TRANSIENT      = 'jetpack_am_gutenberg_dc_asset';
+const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -272,9 +271,9 @@ class Jetpack_AI_Sidebar {
 		$filtered = apply_filters( 'jetpack_ai_sidebar_agents_manager_data', $am_data );
 		$am_data  = is_array( $filtered ) ? $filtered : $am_data;
 
-		// Direct CDN-loader fallback. Jetpack owns these defaults; hosts can
-		// override via the AI Editorial Review and preview filters.
-		$am_data['agentId']                  = AI_SIDEBAR_AGENT_ID;
+		// Direct CDN-loader fallback. Preserve a host-provided agentId so AM
+		// can compose Jetpack AI with host-owned agents such as Dolly.
+		$am_data                             = self::add_default_agent_id( $am_data );
 		$am_data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$am_data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $am_data;
@@ -408,7 +407,7 @@ class Jetpack_AI_Sidebar {
 		}
 
 		// The provider IIFE is only enqueued in the post editor. Avoid registering
-		// the ESM wrapper on other block-editor surfaces, where AM may import it
+		// the ESM wrapper on other editor surfaces, where AM may import it
 		// before window.__JetpackAIProvider exists.
 		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return $providers;
@@ -422,11 +421,27 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
+		return self::append_ai_sidebar_provider_url( $providers );
+	}
+
+	/**
+	 * Append the Jetpack AI Sidebar provider URL if it is not already registered.
+	 *
+	 * @param array $providers Existing provider URLs.
+	 * @return array Updated providers.
+	 */
+	private static function append_ai_sidebar_provider_url( array $providers ): array {
+		if ( ! self::get_ai_sidebar_asset_data() ) {
+			return $providers;
+		}
+
 		// Register as AM provider via CDN-hosted ESM wrapper.
 		// AM dynamically imports this module to merge tools, suggestions, and components.
 		// No ?ver= needed — the wrapper re-exports from window.__JetpackAIProvider
 		// at import time, so its behavior always matches the loaded IIFE bundle.
-		$providers[] = AI_SIDEBAR_PROVIDER_URL;
+		if ( ! in_array( AI_SIDEBAR_PROVIDER_URL, $providers, true ) ) {
+			$providers[] = AI_SIDEBAR_PROVIDER_URL;
+		}
 
 		return $providers;
 	}
@@ -556,32 +571,31 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
-		// intentional overrides should use the AI Editorial Review and preview filters.
-		if ( isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] ) ) {
-			$data['agentProviders'] = self::filter_agent_providers_for_jetpack_ai_sidebar( $data['agentProviders'] );
-		}
-		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
+		// Set Jetpack's defaults for externally emitted payloads without
+		// replacing a host-provided agentId.
+		$data['agentProviders']           = self::append_ai_sidebar_provider_url(
+			isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] )
+				? $data['agentProviders']
+				: array()
+		);
+		$data                             = self::add_default_agent_id( $data );
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
 	}
 
 	/**
-	 * Remove providers that should not participate in the Jetpack AI Sidebar surface.
+	 * Add Jetpack AI's default agent only when a host has not already selected one.
 	 *
-	 * @param array $providers Provider URLs.
-	 * @return array Filtered provider URLs.
+	 * @param array $data Data encoded into `agentsManagerData`.
+	 * @return array Data with a default agent ID.
 	 */
-	private static function filter_agent_providers_for_jetpack_ai_sidebar( array $providers ): array {
-		return array_values(
-			array_filter(
-				$providers,
-				static function ( $provider ): bool {
-					return ! is_string( $provider ) || ! str_contains( $provider, BIG_SKY_AGENT_PROVIDER_PATH );
-				}
-			)
-		);
+	private static function add_default_agent_id( array $data ): array {
+		if ( empty( $data['agentId'] ) || ! is_string( $data['agentId'] ) ) {
+			$data['agentId'] = AI_SIDEBAR_AGENT_ID;
+		}
+
+		return $data;
 	}
 
 	/**
@@ -641,16 +655,20 @@ class Jetpack_AI_Sidebar {
 			AI_SIDEBAR_AGENT_ID,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
-		$big_sky_provider_payload    = wp_json_encode(
-			BIG_SKY_AGENT_PROVIDER_PATH,
+		$provider_url_payload        = wp_json_encode(
+			AI_SIDEBAR_PROVIDER_URL,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+		$provider_patch_script       = self::get_ai_sidebar_asset_data()
+			? ' if ( ! Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = []; }'
+				. ' if ( agentsManagerData.agentProviders.indexOf( ' . $provider_url_payload . ' ) === -1 ) { agentsManagerData.agentProviders.push( ' . $provider_url_payload . ' ); }'
+			: '';
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
-				. ' if ( Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter( function( provider ) { return typeof provider !== "string" || provider.indexOf( ' . $big_sky_provider_payload . ' ) === -1; } ); }'
-				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
+				. $provider_patch_script
+				. ' if ( typeof agentsManagerData.agentId !== "string" || agentsManagerData.agentId === "" ) { agentsManagerData.agentId = ' . $agent_id_payload . '; }'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'
 				. ' }',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -60,8 +60,8 @@ class Jetpack_AI_Sidebar {
 
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
-		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
-		// post editor and Big Sky editor composition surfaces.
+		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount on Jetpack
+		// AI Sidebar editor surfaces.
 		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Load AM from CDN if not already present.
@@ -69,7 +69,7 @@ class Jetpack_AI_Sidebar {
 		// so wp_script_is('agents-manager') correctly detects if AM is already loaded.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_am' ), 200 );
 
-		// Enqueue the IIFE bundle in the preview post editor — it registers
+		// Enqueue the IIFE bundle on Jetpack AI Sidebar surfaces — it registers
 		// Jetpack AI abilities via @wordpress/abilities, which Big Sky or AM
 		// can discover regardless of which provider system is active.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_abilities_script' ), 201 );
@@ -86,12 +86,12 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Load AM from CDN if not already present and we're in the preview post editor.
+	 * Load AM from CDN if not already present and we're on a Jetpack AI Sidebar surface.
 	 *
 	 * @return void
 	 */
 	public static function maybe_enqueue_am(): void {
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_ai_sidebar_surface() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -127,7 +127,7 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function maybe_enqueue_abilities_script(): void {
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_ai_sidebar_surface() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -406,10 +406,10 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
-		// The provider IIFE is only enqueued in the post editor. Avoid registering
-		// the ESM wrapper on other editor surfaces, where AM may import it
+		// The provider IIFE is enqueued only on Jetpack AI Sidebar surfaces.
+		// Avoid registering the ESM wrapper elsewhere, where AM may import it
 		// before window.__JetpackAIProvider exists.
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_ai_sidebar_surface() || ! self::has_ai_features() ) {
 			return $providers;
 		}
 
@@ -567,7 +567,7 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_ai_sidebar_surface() || ! self::has_ai_features() ) {
 			return $data;
 		}
 
@@ -601,9 +601,8 @@ class Jetpack_AI_Sidebar {
 	/**
 	 * Enable Agents Manager when Jetpack AI Sidebar Preview is available.
 	 *
-	 * Jetpack owns the post-editor entrypoint. Big Sky owns its Page/Site Editor
-	 * provider, but Jetpack can open AM there so peer providers compose through
-	 * Agents Manager instead of Big Sky's standalone dock.
+	 * Jetpack opens AM on post, page, and site editor surfaces so peer providers
+	 * can compose through Agents Manager even when Big Sky is absent.
 	 *
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
@@ -617,7 +616,7 @@ class Jetpack_AI_Sidebar {
 			return false;
 		}
 
-		return self::is_post_editor() || self::is_big_sky_editor_composition_surface();
+		return self::is_ai_sidebar_surface();
 	}
 
 	/**
@@ -641,7 +640,7 @@ class Jetpack_AI_Sidebar {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_ai_sidebar_surface() || ! self::has_ai_features() ) {
 			return;
 		}
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
@@ -746,21 +745,12 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Check whether Big Sky should compose through Agents Manager on this editor surface.
+	 * Check whether the current screen supports the Jetpack AI Sidebar.
 	 *
 	 * @return bool
 	 */
-	private static function is_big_sky_editor_composition_surface(): bool {
-		return self::is_big_sky_enabled() && ( self::is_page_editor() || self::is_site_editor() );
-	}
-
-	/**
-	 * Check whether Big Sky is installed and enabled.
-	 *
-	 * @return bool
-	 */
-	private static function is_big_sky_enabled(): bool {
-		return class_exists( 'Big_Sky' ) && (bool) get_option( 'big_sky_enable', '1' );
+	private static function is_ai_sidebar_surface(): bool {
+		return self::is_post_editor() || self::is_page_editor() || self::is_site_editor();
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -537,7 +537,7 @@ class Jetpack_AI_Sidebar {
 		$features = array(
 			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
 			'blockTransformations'    => true,
-			'optimizeTitleSuggestion' => false,
+			'optimizeTitleSuggestion' => true,
 			'chatHistory'             => false,
 			'supportGuides'           => false,
 		);

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
@@ -32,6 +32,13 @@ class WPCOM_REST_API_V2_Endpoint_External_Media_Test extends Jetpack_REST_TestCa
 	private $image_name = 'example_image';
 
 	/**
+	 * Counter for unique test image names.
+	 *
+	 * @var int
+	 */
+	private static $image_counter = 0;
+
+	/**
 	 * Path to test image.
 	 *
 	 * @var string
@@ -57,6 +64,9 @@ class WPCOM_REST_API_V2_Endpoint_External_Media_Test extends Jetpack_REST_TestCa
 		$this->image_name = 'example_image-' . getmypid() . '-' . uniqid();
 
 		wp_set_current_user( static::$user_id );
+
+		++static::$image_counter;
+		$this->image_name = 'example_image_' . static::$image_counter;
 
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -148,6 +148,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set the current screen to the Site Editor.
+	 */
+	private function set_site_editor_screen() {
+		set_current_screen( 'site-editor' );
+		get_current_screen()->is_block_editor = true;
+	}
+
+	/**
 	 * Enable the AI sidebar feature via filter.
 	 */
 	private function enable_sidebar() {
@@ -352,6 +360,39 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that the Agents Manager block-editor gate does not open in the page editor.
 	 */
 	public function test_enable_agents_manager_in_post_editor_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate opens in the page editor when Big Sky is enabled.
+	 */
+	public function test_enable_agents_manager_in_post_editor_enables_page_editor_for_big_sky() {
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '1' );
+		$this->set_page_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate opens in the Site Editor when Big Sky is enabled.
+	 */
+	public function test_enable_agents_manager_in_post_editor_enables_site_editor_for_big_sky() {
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '1' );
+		$this->set_site_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that Big Sky must be enabled before Jetpack opens the page editor gate.
+	 */
+	public function test_enable_agents_manager_in_post_editor_skips_page_editor_when_big_sky_is_disabled() {
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '0' );
 		$this->set_page_block_editor_screen();
 
 		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
@@ -672,6 +713,36 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
 		$this->assertArrayNotHasKey( 'agentProviders', $data );
+		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+	}
+
+	/**
+	 * Jetpack opens AM for Big Sky Page/Site Editor composition without injecting
+	 * the post-editor Jetpack AI provider payload into those surfaces.
+	 */
+	public function test_add_agents_manager_data_skips_page_editor_when_big_sky_is_enabled() {
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '1' );
+		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+			),
+			$data['agentProviders']
+		);
+		$this->assertArrayNotHasKey( 'agentId', $data );
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -548,7 +548,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"blockTransformations":true', $this->get_agents_manager_inline_script() );
-		$this->assertStringContainsString( '"optimizeTitleSuggestion":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"optimizeTitleSuggestion":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"chatHistory":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"supportGuides":false', $this->get_agents_manager_inline_script() );
 	}
@@ -619,7 +619,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['chatHistory'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['supportGuides'] );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -502,6 +502,26 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A host-selected agent ID should not be replaced by Jetpack AI.
+	 */
+	public function test_maybe_enqueue_am_preserves_host_agent_id() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		add_filter(
+			'jetpack_ai_sidebar_agents_manager_data',
+			function ( $data ) {
+				$data['agentId'] = 'dolly';
+				return $data;
+			}
+		);
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"agentId":"dolly"', $this->get_agents_manager_inline_script() );
+		$this->assertStringNotContainsString( '"agentId":"wp-orchestrator"', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
 	 * Dev-mode signals keep AI Editorial Review enabled by default.
 	 */
 	public function test_maybe_enqueue_am_exposes_ai_editorial_review_enabled_in_dev_mode() {
@@ -536,11 +556,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
@@ -551,10 +573,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Big Sky's provider should not participate in the Jetpack AI Sidebar surface.
+	 * Platform-emitted Agents Manager data keeps an existing host agent.
 	 */
-	public function test_add_agents_manager_data_filters_big_sky_provider() {
+	public function test_add_agents_manager_data_preserves_existing_agent_id() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName' => 'gutenberg',
+				'agentId'     => 'dolly',
+			)
+		);
+
+		$this->assertSame( 'dolly', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+	}
+
+	/**
+	 * Provider composition remains owned by Agents Manager.
+	 */
+	public function test_add_agents_manager_data_preserves_registered_providers_for_am_composition() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
@@ -569,6 +611,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
+				'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
 				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
 				array( 'provider' => 'metadata' ),
 			),
@@ -577,10 +620,35 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Platform-emitted provider lists get the Jetpack provider appended when missing.
+	 */
+	public function test_add_agents_manager_data_appends_jetpack_provider_when_missing() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+				),
+			)
+		);
+
+		$this->assertCount( 2, $data['agentProviders'] );
+		$this->assertSame(
+			'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+			$data['agentProviders'][0]
+		);
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][1] );
+	}
+
+	/**
 	 * Preview and AI Editorial Review have separate gates.
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
 
@@ -598,10 +666,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_skips_page_editor() {
 		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertArrayNotHasKey( 'agentProviders', $data );
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
 	}
@@ -735,28 +805,37 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Simulate an external host having enqueued AM and declared upstream
-		// data with both Jetpack AI Sidebar and Big Sky providers.
+		// data with Big Sky's provider but without Jetpack's provider.
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script(
 			'agents-manager',
-			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123", "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" ] };',
+			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123" ] };',
 			'before'
 		);
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringNotContainsString(
 			'agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'/big-sky-plugin/build/calypso-agent-provider/',
+			'agentsManagerData.agentProviders.push',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'agentsManagerData.agentId = "wp-orchestrator"',
+			'jetpack-ai-sidebar.provider.mjs',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'if ( typeof agentsManagerData.agentId !== "string" || agentsManagerData.agentId === "" ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
@@ -786,12 +865,17 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_skips_page_editor() {
 		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
+		$this->assertStringNotContainsString(
+			'agentsManagerData.agentProviders.push',
+			$this->get_agents_manager_inline_script()
+		);
 		$this->assertStringNotContainsString(
 			'agentsManagerData.agentId',
 			$this->get_agents_manager_inline_script()
@@ -954,6 +1038,20 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
 		$this->assertSame( 'https://example.com/provider-b.mjs', $providers[1] );
 		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[2] );
+	}
+
+	/**
+	 * Test that register_provider does not duplicate the Jetpack provider.
+	 */
+	public function test_register_provider_does_not_duplicate_provider_url() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$existing  = array( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertCount( 1, $providers );
+		$this->assertSame( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL, $providers[0] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -245,7 +245,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	private function is_sidebar_dev_mode() {
 		$method = new ReflectionMethod( Jetpack_AI_Sidebar::class, 'is_dev_mode' );
-		$method->setAccessible( true );
+		// setAccessible() is required on PHP < 8.1, a no-op on 8.1-8.4,
+		// and deprecated on PHP 8.5+.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method->invoke( null );
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -238,6 +238,17 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Check the class's dev-mode predicate for tests that need asset fetch failures.
+	 *
+	 * @return bool Whether Jetpack_AI_Sidebar sees the request as dev mode.
+	 */
+	private function is_sidebar_dev_mode() {
+		$method = new ReflectionMethod( Jetpack_AI_Sidebar::class, 'is_dev_mode' );
+		$method->setAccessible( true );
+		return $method->invoke( null );
+	}
+
 	// ──────────────────────────────────────────────────
 	// init() tests
 	// ──────────────────────────────────────────────────
@@ -357,43 +368,39 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Agents Manager block-editor gate does not open in the page editor.
+	 * Test that the Agents Manager block-editor gate opens in the page editor.
 	 */
-	public function test_enable_agents_manager_in_post_editor_skips_page_editor() {
-		$this->set_page_block_editor_screen();
-
-		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
-	}
-
-	/**
-	 * Test that the Agents Manager block-editor gate opens in the page editor when Big Sky is enabled.
-	 */
-	public function test_enable_agents_manager_in_post_editor_enables_page_editor_for_big_sky() {
-		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '1' );
+	public function test_enable_agents_manager_in_post_editor_enables_page_editor() {
 		$this->set_page_block_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	/**
-	 * Test that the Agents Manager block-editor gate opens in the Site Editor when Big Sky is enabled.
+	 * Test that the Agents Manager block-editor gate does not depend on Big Sky.
 	 */
-	public function test_enable_agents_manager_in_post_editor_enables_site_editor_for_big_sky() {
+	public function test_enable_agents_manager_in_post_editor_enables_page_editor_when_big_sky_is_disabled() {
 		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '1' );
+		update_option( 'big_sky_enable', '0' );
+		$this->set_page_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate opens in the Site Editor.
+	 */
+	public function test_enable_agents_manager_in_post_editor_enables_site_editor() {
 		$this->set_site_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	/**
-	 * Test that Big Sky must be enabled before Jetpack opens the page editor gate.
+	 * Test that the Agents Manager block-editor gate does not open outside supported editor surfaces.
 	 */
-	public function test_enable_agents_manager_in_post_editor_skips_page_editor_when_big_sky_is_disabled() {
-		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '0' );
-		$this->set_page_block_editor_screen();
+	public function test_enable_agents_manager_in_post_editor_skips_unsupported_editor_surface() {
+		set_current_screen( 'dashboard' );
 
 		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
@@ -456,15 +463,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that maybe_enqueue_am does nothing outside the post editor.
+	 * Test that maybe_enqueue_am can load AM in the page editor without Big Sky.
 	 */
-	public function test_maybe_enqueue_am_skips_page_editor() {
+	public function test_maybe_enqueue_am_enqueues_in_page_editor_without_big_sky() {
 		$this->set_page_block_editor_screen();
 		$this->cache_am_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'agents-manager', 'enqueued' ) );
 	}
 
 	/**
@@ -685,6 +692,41 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Platform-emitted data still gets Jetpack flags when the provider manifest is unavailable.
+	 */
+	public function test_add_agents_manager_data_skips_provider_append_when_asset_data_is_missing() {
+		if ( $this->is_sidebar_dev_mode() ) {
+			$this->markTestSkipped( 'Dev mode falls back to a minimal asset manifest.' );
+		}
+
+		$this->set_block_editor_screen();
+		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'blocked', 'No HTTP.' );
+			}
+		);
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/provider-a.mjs',
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'https://example.com/provider-a.mjs' ),
+			$data['agentProviders']
+		);
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+	}
+
+	/**
 	 * Preview and AI Editorial Review have separate gates.
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
@@ -703,25 +745,24 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted preview data is scoped to the post editor.
+	 * Platform-emitted preview data is available in the page editor.
 	 */
-	public function test_add_agents_manager_data_skips_page_editor() {
+	public function test_add_agents_manager_data_exposes_preview_data_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertArrayNotHasKey( 'agentId', $data );
-		$this->assertArrayNotHasKey( 'agentProviders', $data );
-		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
+		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 	}
 
 	/**
-	 * Jetpack opens AM for Big Sky Page/Site Editor composition without injecting
-	 * the post-editor Jetpack AI provider payload into those surfaces.
+	 * Big Sky providers are preserved and composed with Jetpack on Page/Site Editor surfaces.
 	 */
-	public function test_add_agents_manager_data_skips_page_editor_when_big_sky_is_enabled() {
+	public function test_add_agents_manager_data_composes_page_editor_providers_when_big_sky_is_enabled() {
 		$this->simulate_big_sky_class();
 		update_option( 'big_sky_enable', '1' );
 		$this->set_page_block_editor_screen();
@@ -730,6 +771,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
 				'sectionName'    => 'gutenberg',
+				'agentId'        => 'dolly',
 				'agentProviders' => array(
 					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
 				),
@@ -739,12 +781,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
 			),
 			$data['agentProviders']
 		);
-		$this->assertArrayNotHasKey( 'agentId', $data );
-		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+		$this->assertSame( 'dolly', $data['agentId'] );
+		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 	}
 
 	/**
@@ -932,12 +975,51 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch is limited to the post editor.
+	 * The external AM payload patch runs in the page editor.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_skips_page_editor() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
+
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders.push',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.agentId',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.aiEditorialReviewEnabled',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.jetpackAiSidebarPreview',
+			$this->get_agents_manager_inline_script()
+		);
+	}
+
+	/**
+	 * The external AM payload patch does not append a provider when the manifest is unavailable.
+	 */
+	public function test_patch_jetpack_ai_sidebar_preview_data_skips_provider_append_when_asset_data_is_missing() {
+		if ( $this->is_sidebar_dev_mode() ) {
+			$this->markTestSkipped( 'Dev mode falls back to a minimal asset manifest.' );
+		}
+
+		$this->set_block_editor_screen();
+		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'blocked', 'No HTTP.' );
+			}
+		);
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
@@ -947,15 +1029,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'agentsManagerData.agentProviders.push',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
 			'agentsManagerData.agentId',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
 			'agentsManagerData.aiEditorialReviewEnabled',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
 			'agentsManagerData.jetpackAiSidebarPreview',
 			$this->get_agents_manager_inline_script()
 		);
@@ -1003,15 +1085,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued outside the post editor.
+	 * Test that abilities script is enqueued in the page editor.
 	 */
-	public function test_abilities_script_skips_page_editor() {
+	public function test_abilities_script_enqueues_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
-		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 	}
 
 	/**
@@ -1126,16 +1208,18 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers unchanged outside the post editor.
+	 * Test that register_provider appends Jetpack on page editor surfaces.
 	 */
-	public function test_register_provider_skips_page_editor() {
+	public function test_register_provider_adds_url_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
 
-		$this->assertSame( $existing, $providers );
+		$this->assertCount( 2, $providers );
+		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Preserve a host-provided Agents Manager `agentId` instead of forcing Jetpack AI Sidebar to `wp-orchestrator` on every surface.
* Append the Jetpack AI Sidebar provider to existing `agentsManagerData.agentProviders` instead of filtering peer providers out.
* Enable Agents Manager and the Jetpack AI Sidebar provider bundle on post, page, and site editor surfaces when Jetpack AI Sidebar Preview is enabled, so Jetpack AI can run in Page/Site Editor even when Big Sky is absent.
* Enable the Optimize Title preview feature so the Jetpack AI Sidebar provider can expose the Jetpack-owned title suggestion/component path in the composed AM flow.
* Register the Jetpack AI Sidebar provider without duplicating the provider URL.
* Add tests for preserving peer providers, preserving host `agentId`, Page/Site editor support, Big Sky disabled behavior, and missing payload defaults.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Pairs with Automattic/wp-calypso#111335.
* Big Sky / Dolly Page/Site Editor testing should include Automattic/big-sky-plugin#5900.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
1. Run `pnpm jetpack docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test`.
2. Checkout WPCOM PR 221819.
3. Install this Jetpack PR and Calypso PR Automattic/wp-calypso#111335.

```
bin/jetpack-downloader test jetpack forno-326/merge-bigsky-jetpack-in-am
install-plugin.sh am forno-326/merge-bigsky-jetpack-in-am
```

### Page/Site Editor
1. Change font. Confirm the picker renders.
2. Optimize Title. Confirm the picker renders.
3. Select text, then run Translate to. Confirm the text is translated.
4. Select text, then run Move this to top of the page. Confirm the text moves.

### Post Editor
1. Run AI Editorial Review. Confirm the review UI renders.
2. Run Optimize Title. Confirm the picker renders.
3. Select text, then run Translate to. Confirm the text is translated.
4. Select text, then run Move this to top of the page. Confirm the text moves.

### Suggestions UI
Test this in both Page/Site Editor and Post Editor.

1. On load, confirm only Change font/color and Optimize Title suggestions show. Text, image, and column prompts should not show.
2. Select text. Confirm only text suggestions show. Site editor and image prompts should not show.
3. Select an image. Confirm only image suggestions show.

