### PR TITLE
PCG: load plugin-conflicts-guardian again in jetpack-mu-wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-reload
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: load the feature again in jetpack-mu-wpcom. The PCG rollout default is 0%, so the guards stay off until a rollout filter opts a site in.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -299,6 +299,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/logo-tool/logo-tool.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
+		require_once __DIR__ . '/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php';
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';
 		require_once __DIR__ . '/features/post-like-from-email/post-like-from-email.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';


### PR DESCRIPTION
## Summary

Re-adds the `require_once` for `plugin-conflicts-guardian.php` in `Jetpack_Mu_Wpcom::load_features()`. #49108 removed it after an early rollout snag, but the rollout default is 0%, so re-adding the line keeps the guards off on every blog until a rollout filter opts a site in — it just makes the feature reachable again so we can land follow-up work (force-override controls in #49220, future probe coverage, etc.) and ramp the rollout deliberately.

Split out of #49220 so it can be merged on its own when we're ready to start opting sites in.

## Testing instructions

1. With this branch applied to a wpcom-flavored site, confirm `Plugin_Conflicts_Guardian` boots — e.g. `wp eval 'var_export( has_filter( "upgrader_source_selection", "pcg_update_guard_check" ) );'` returns a truthy priority.
2. Confirm the guards stay off by default: `apply_filters( 'pcg_guard_activation', false )` and `apply_filters( 'pcg_guard_updates', false )` both return false until a rollout filter raises `pcg_rollout_percentage` or a test hook flips `pcg_guard_*` to true.

## Does this pull request change what data or activity we track or use?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)