### PR TITLE
Social: fix Generate image button closing the Social preview modal

### DIFF
--- a/projects/js-packages/components/changelog/fix-navigator-modal-closes-on-external-modal
+++ b/projects/js-packages/components/changelog/fix-navigator-modal-closes-on-external-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+NavigatorModal: don't close when a control inside the modal opens an external WP Modal (e.g. Image Studio from the Social preview Generate image button); only true overlay/backdrop clicks dismiss the modal.

--- a/projects/js-packages/components/changelog/fix-navigator-modal-closes-on-external-modal
+++ b/projects/js-packages/components/changelog/fix-navigator-modal-closes-on-external-modal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-NavigatorModal: don't close when a control inside the modal opens an external WP Modal (e.g. Image Studio from the Social preview Generate image button); only true overlay/backdrop clicks dismiss the modal.
+NavigatorModal: Don't close when a control inside the modal opens an external WP Modal (e.g. Image Studio from the Social preview Generate image button); only true overlay/backdrop clicks dismiss the modal.

--- a/projects/js-packages/components/components/navigator-modal/index.tsx
+++ b/projects/js-packages/components/components/navigator-modal/index.tsx
@@ -27,16 +27,27 @@ function InternalNavigatorModal( {
 	const overlayRef = useRef< HTMLDivElement >( null );
 	const isUserInteracting = useRef( false );
 
-	// Track pointer interaction on the overlay so we can distinguish
-	// user-initiated overlay clicks from the WP Modal dismisser mechanism,
-	// which also calls onRequestClose() without an event argument.
+	/*
+	 * Track pointer interaction on the overlay so we can distinguish
+	 * user-initiated overlay (backdrop) clicks from the WP Modal dismisser
+	 * mechanism, which also calls onRequestClose() without an event argument.
+	 *
+	 * Only a pointerdown on the overlay element itself counts as a backdrop
+	 * interaction — mirroring WP Modal's own `event.target === event.currentTarget`
+	 * check. Without this target guard, a pointerdown on any control inside the
+	 * modal (e.g. the "Generate image" button) would bubble up and set the flag,
+	 * so when that control opens an external Modal (Image Studio) the resulting
+	 * dismisser call would be misread as an overlay click and wrongly close us.
+	 */
 	useEffect( () => {
 		const overlay = overlayRef.current;
 		if ( ! overlay ) {
 			return;
 		}
-		const handler = () => {
-			isUserInteracting.current = true;
+		const handler = ( event: PointerEvent ) => {
+			if ( event.target === overlay ) {
+				isUserInteracting.current = true;
+			}
 		};
 		overlay.addEventListener( 'pointerdown', handler );
 		return () => overlay.removeEventListener( 'pointerdown', handler );

--- a/projects/js-packages/components/components/navigator-modal/test/component.tsx
+++ b/projects/js-packages/components/components/navigator-modal/test/component.tsx
@@ -92,7 +92,7 @@ describe( 'NavigatorModal', () => {
 			expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'calls onClose on overlay click (onRequestClose without event but after pointer interaction)', async () => {
+		it( 'calls onClose on overlay click (pointerdown on the overlay itself, then onRequestClose without event)', async () => {
 			const user = userEvent.setup();
 			const mockOnClose = jest.fn();
 
@@ -102,12 +102,33 @@ describe( 'NavigatorModal', () => {
 				</NavigatorModal>
 			);
 
-			// Clicking the button triggers pointerdown on the overlay (bubbles up
-			// to mock-modal ref), then the button calls onRequestClose() without event.
-			// This mirrors the real overlay click flow.
+			// A genuine backdrop click: the pointerdown target is the overlay
+			// element itself (the mock-modal ref), then WP Modal calls
+			// onRequestClose() without an event from its pointerup handler.
+			await user.click( screen.getByTestId( 'mock-modal' ) );
 			await user.click( screen.getByTestId( 'close-without-event' ) );
 
 			expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not close when an inner control opens another modal (dismisser fires onRequestClose without event)', async () => {
+			const user = userEvent.setup();
+			const mockOnClose = jest.fn();
+
+			render(
+				<NavigatorModal onClose={ mockOnClose }>
+					<button data-testid="inner-control">Generate image</button>
+				</NavigatorModal>
+			);
+
+			// Regression for SOCIAL-477: pressing a control inside the modal (e.g.
+			// "Generate image") must not mark the next eventless onRequestClose as a
+			// backdrop click. The pointerdown target is the inner control, not the
+			// overlay, so the dismisser-driven close (Image Studio mounting) is ignored.
+			await user.click( screen.getByTestId( 'inner-control' ) );
+			await user.click( screen.getByTestId( 'close-without-event' ) );
+
+			expect( mockOnClose ).not.toHaveBeenCalled();
 		} );
 
 		it( 'does not crash when onClose is not provided', async () => {


### PR DESCRIPTION
Fixes SOCIAL-477

## Proposed changes
* Fix the Social preview / unified modal closing when clicking the **Generate image** button in the media section.
* Root cause: `NavigatorModal`'s overlay `pointerdown` listener set the "user is interacting" flag for *any* pointerdown that bubbled up to the overlay — including clicks on controls inside the modal. WordPress's `Modal` calls `onRequestClose()` with **no event** both for a real backdrop click *and* for its dismisser (when another non-nested `Modal` mounts). So when **Generate image** opened Image Studio's `Modal`, the dismisser-driven `onRequestClose()` was misread as a backdrop click and the modal closed.
* The fix only treats a pointerdown as a backdrop interaction when its target **is the overlay element itself** (`event.target === overlay`), mirroring WP Modal's own `event.target === event.currentTarget` check. Clicks on inner controls no longer arm the flag, so the dismisser-driven close is correctly ignored. Escape and the close button already pass an event and are unaffected.
* Updated the existing overlay-click unit test and added a regression test covering the Image Studio scenario (inner control opening an external modal must not dismiss `NavigatorModal`).

## Related product discussion/links
* SOCIAL-477

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with both Jetpack Social and the AI Image Studio flow available (the `jetpack.ai.imageGenerationHandler` filter registered).
* Open a post in the block editor and open the Social preview modal (the unified "Preview" modal).
* In the Media section, open the source dropdown and choose **Generate image**.
* Confirm Image Studio opens **and the Social preview modal stays open** behind/around it (before this fix, the preview modal closed).
* Regression check: confirm the modal still closes normally via the Escape key, the close (X) button, and a click on the backdrop/overlay outside the modal frame.

Automated:
* `jetpack test js js-packages/components` — the `navigator-modal` suite covers the guard (9 tests, including the new SOCIAL-477 regression).
