### PR TITLE
Social Image Generator: pre-warm the generated image cache after publish

### DIFF
--- a/projects/packages/publicize/changelog/fix-sig-cache-warming
+++ b/projects/packages/publicize/changelog/fix-sig-cache-warming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social Image Generator: Pre-warm the generated image cache after publish so freshly published posts shared on X get a preview thumbnail without waiting on a cold render.

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -25,6 +25,7 @@ class Setup {
 		// We're using the `wp_after_insert_post` hook because we need access to the updated post meta. By using the default priority
 		// of 10 we make sure that our code runs before Sync processes the post.
 		add_action( 'wp_after_insert_post', array( $this, 'generate_token_on_save' ), 10, 3 );
+		add_action( 'jetpack_social_sig_warm_image', array( $this, 'warm_social_image' ) );
 		add_action( 'rest_api_init', array( new REST_Token_Controller(), 'register_routes' ) );
 
 		// Flagged to be removed after deprecation.
@@ -111,5 +112,55 @@ class Setup {
 		}
 
 		$this->generate_token( $post_settings );
+
+		// Prime the Social Image Generator cache out-of-band right after publish.
+		// SIG renders the preview image on the first request to its URL, so a post
+		// shared immediately after publishing can race that cold render and end up
+		// with no preview image (notably on X, which does not retry). Warming the
+		// URL here means the image is already rendered and edge-cached before any
+		// crawler fetches it. Scheduled rather than inline so it never delays the
+		// publish request itself.
+		if (
+			'publish' === $post->post_status &&
+			! wp_next_scheduled( 'jetpack_social_sig_warm_image', array( $post_id ) )
+		) {
+			wp_schedule_single_event( time(), 'jetpack_social_sig_warm_image', array( $post_id ) );
+		}
+	}
+
+	/**
+	 * Warm the edge cache for a post's generated social image.
+	 *
+	 * Runs from a scheduled single event (see generate_token_on_save) so it never
+	 * blocks the publish request. Issues one blocking request to the same URL the
+	 * Open Graph tags expose, which forces the on-demand render and lets the full
+	 * response populate the edge cache before a crawler fetches it.
+	 *
+	 * @param int $post_id Post ID whose social image should be primed.
+	 */
+	public function warm_social_image( $post_id ) {
+		$post_settings = new Post_Settings( $post_id );
+
+		if ( ! $post_settings->is_enabled() ) {
+			return;
+		}
+
+		$image_url = get_image_url( $post_id );
+
+		if ( empty( $image_url ) ) {
+			return;
+		}
+
+		// Blocking so the rendered response travels back through the edge cache and
+		// is stored; redirection is followed to the final image URL the crawler hits.
+		wp_remote_get(
+			$image_url,
+			array(
+				'timeout'     => 15,
+				'redirection' => 5,
+				'blocking'    => true,
+				'user-agent'  => 'WordPress.com Social Image Generator cache warmer',
+			)
+		);
 	}
 }

--- a/projects/packages/publicize/tests/php/test-social-image-generator/Setup_Test.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/Setup_Test.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Testing the Setup class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Publicize\Social_Image_Generator\Setup;
+use WorDBless\BaseTestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Posts as WorDBless_Posts;
+
+/**
+ * Testing the Setup class, in particular the cache-warming behaviour.
+ */
+class Setup_Test extends BaseTestCase {
+	/**
+	 * Post ID of the testing post.
+	 *
+	 * @var int $post_id
+	 */
+	protected $post_id;
+
+	/**
+	 * Instance of the Setup class under test.
+	 *
+	 * @var Setup $setup
+	 */
+	protected $setup;
+
+	/**
+	 * URLs that wp_remote_get would have fetched, captured via pre_http_request.
+	 *
+	 * @var string[] $http_requests
+	 */
+	protected $http_requests = array();
+
+	/**
+	 * Initialize tests.
+	 */
+	public function set_up() {
+		/*
+		 * Anonymous class to disable the constructor so we can register post meta,
+		 * and to force SIG availability without depending on Current_Plan state
+		 * (its plan lookup is statically cached and can leak between tests).
+		 */
+		global $publicize;
+		$publicize = new class() extends Publicize {
+			public function __construct() {
+			}
+
+			public function has_social_image_generator_feature() {
+				return true;
+			}
+		};
+		$publicize->register_post_meta();
+
+		// Force the block editor check to pass and intercept any outgoing HTTP.
+		add_filter( 'use_block_editor_for_post', '__return_true' );
+		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+
+		$this->post_id = wp_insert_post(
+			array(
+				'post_title'   => 'hello',
+				'post_content' => 'world',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->setup   = new Setup();
+	}
+
+	/**
+	 * Reset state after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'use_block_editor_for_post', '__return_true' );
+		remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10 );
+		wp_clear_scheduled_hook( 'jetpack_social_sig_warm_image', array( $this->post_id ) );
+
+		global $publicize;
+		$publicize = null;
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+	}
+
+	/**
+	 * Intercept wp_remote_get and record the requested URL instead of hitting the network.
+	 *
+	 * @param false|array|\WP_Error $preempt A preemptive return value of an HTTP request.
+	 * @param array                 $args    HTTP request arguments.
+	 * @param string                $url     The request URL.
+	 * @return array A canned successful response.
+	 */
+	public function mock_http_request( $preempt, $args, $url ) {
+		$this->http_requests[] = $url;
+
+		return array(
+			'headers'  => array(),
+			'body'     => '',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Enable SIG for the test post, optionally with a token.
+	 *
+	 * @param array $settings Image generator settings to store.
+	 */
+	private function enable_sig( $settings = array( 'enabled' => true ) ) {
+		update_post_meta( $this->post_id, Publicize::POST_JETPACK_SOCIAL_OPTIONS, array( 'image_generator_settings' => $settings ) );
+	}
+
+	/**
+	 * Publishing a SIG-enabled post schedules a single warm event for the post.
+	 */
+	public function test_publish_schedules_warm_event() {
+		$this->enable_sig();
+		$this->assertFalse( wp_next_scheduled( 'jetpack_social_sig_warm_image', array( $this->post_id ) ) );
+
+		$this->setup->generate_token_on_save( $this->post_id, get_post( $this->post_id ), true );
+
+		$this->assertIsInt( wp_next_scheduled( 'jetpack_social_sig_warm_image', array( $this->post_id ) ) );
+	}
+
+	/**
+	 * A non-publish status (e.g. draft) does not schedule the warm event.
+	 */
+	public function test_draft_does_not_schedule_warm_event() {
+		$this->enable_sig();
+		wp_update_post(
+			array(
+				'ID'          => $this->post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$this->setup->generate_token_on_save( $this->post_id, get_post( $this->post_id ), true );
+
+		$this->assertFalse( wp_next_scheduled( 'jetpack_social_sig_warm_image', array( $this->post_id ) ) );
+	}
+
+	/**
+	 * A SIG-disabled post does not schedule the warm event.
+	 */
+	public function test_sig_disabled_does_not_schedule_warm_event() {
+		$this->setup->generate_token_on_save( $this->post_id, get_post( $this->post_id ), true );
+
+		$this->assertFalse( wp_next_scheduled( 'jetpack_social_sig_warm_image', array( $this->post_id ) ) );
+	}
+
+	/**
+	 * Warming fetches the image URL when SIG is enabled and a token exists.
+	 */
+	public function test_warm_social_image_fetches_url_when_enabled() {
+		$this->enable_sig(
+			array(
+				'enabled' => true,
+				'token'   => 'testtoken',
+			)
+		);
+
+		$this->setup->warm_social_image( $this->post_id );
+
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertStringContainsString( 'sigenerate', $this->http_requests[0] );
+	}
+
+	/**
+	 * Warming makes no request when SIG is disabled for the post.
+	 */
+	public function test_warm_social_image_no_request_when_disabled() {
+		$this->setup->warm_social_image( $this->post_id );
+
+		$this->assertCount( 0, $this->http_requests );
+	}
+
+	/**
+	 * Warming makes no request when the image URL is empty (no token yet).
+	 */
+	public function test_warm_social_image_no_request_when_url_empty() {
+		$this->enable_sig( array( 'enabled' => true ) );
+
+		$this->setup->warm_social_image( $this->post_id );
+
+		$this->assertCount( 0, $this->http_requests );
+	}
+}


### PR DESCRIPTION
Fixes SOCIAL-493

## Proposed changes
* When Social Image Generator (SIG) is enabled, the `og:image` / `twitter:image` URL points at a redirect that renders the preview image **on demand on the first fetch**. A post shared on X immediately after publishing can race that cold render and end up with no preview thumbnail (X, unlike Facebook, does not retry).
* On publishing a SIG-enabled post, schedule a single out-of-band event (`jetpack_social_sig_warm_image`) via `wp_schedule_single_event`. The handler issues one blocking `wp_remote_get` to the same URL the Open Graph tags expose, forcing the render and letting the full response populate the edge cache before any crawler fetches it.
* Scheduled rather than inline so it never adds latency to the publish request. Gated to `publish` status (skips draft autosaves) and de-duped with `wp_next_scheduled`. Uses only core APIs, so it works on both WordPress.com and self-hosted Jetpack sites.
* **Strictly additive:** if a crawler still beats the warm, behavior is exactly as today.

### Known limitation
The edge cache is per-POP (per datacenter). The warm runs on the publishing server and warms its POP; a crawler hitting a different POP still gets a (fast, ~1.4s) cold render that is then cached for a week. So this is a guaranteed win for same-POP fetches / re-scrapes and surfaces render errors at publish, never worse than today. If real-world misses persist, the heavier follow-up is to render once at publish, persist the JPEG, and point OG tags at a globally-cached static URL.

## Related product discussion/links

SOCIAL-493

## Does this pull request change what data or activity we track or use?
No. It issues one server-side request to the post's own already-public social image URL after publish; it adds no new user tracking or data collection.

## Testing instructions
* On a SIG-enabled blog, publish a post.
* Force the scheduled warm to run: `wp cron event run jetpack_social_sig_warm_image --due-now`.
* Grab the `og:image` URL and confirm it is already a warm cache HIT on the first manual fetch:
  ```bash
  URL=$(curl -s "<post-permalink>" | grep -oP '(?<=og:image" content=")[^"]+')
  curl -s -o /dev/null -D - "$URL" -w 'time=%{time_total}\n' | grep -iE '^x-nc:|time='
  # Expect: x-nc: HIT ...  (the publish-time warm pre-populated the edge)
  ```
* Automated coverage: `jetpack test php packages/publicize` (see `tests/php/test-social-image-generator/Setup_Test.php`) verifies a publish schedules the event, drafts and SIG-disabled posts do not, and `warm_social_image()` only fetches when SIG is enabled and a token exists.
