### PR TITLE
Layout Grid Usage Tracking: classify the origin of observed layout-grid blocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-layout-grid-usage-origin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-layout-grid-usage-origin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Layout Grid Usage Tracking: add an `origin` field to the logstash event so explicit editor inserts can be told apart from migration, import, XML-RPC, WP-CLI, cron, headless REST/AJAX, programmatic, and theme/template-render arrivals.

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -173,6 +173,7 @@ function wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron 
  * @return string One of: migration, import, xmlrpc, cli, cron, editor, rest, ajax, programmatic.
  */
 function wpcom_layout_grid_usage_classify_origin() {
+	// @phan-suppress-next-line PhanUndeclaredFunction -- wpcomsh-provided; present on WoA, guarded by function_exists.
 	if ( function_exists( 'wpcomsh_is_migration_in_progress' ) && wpcomsh_is_migration_in_progress() ) {
 		return 'migration';
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -2,10 +2,13 @@
 /**
  * Layout-grid usage tracking — emit a logstash event when a `jetpack/layout-grid`
  * block is inserted or first rendered on a WoA site. The payload carries the
- * active theme, active plugins, request-context flags, and a sanitized
- * backtrace so the source can be attributed to a responsible plugin or theme
- * rather than just the candidate set. Events ship to the
- * `atomic_layout_grid_block` logstash bucket.
+ * active theme, active plugins, request-context flags, an `origin` label that
+ * separates an explicit editor insert (the expected, noisy case) from the
+ * arrivals we actually want to surface — migration, import, XML-RPC, WP-CLI,
+ * cron, a headless REST or AJAX write, a programmatic write with no user behind
+ * it, or a theme/template render — and a sanitized backtrace so the source can
+ * be attributed to a responsible plugin or theme rather than just the candidate
+ * set. Events ship to the `atomic_layout_grid_block` logstash bucket.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -75,6 +78,7 @@ function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update,
 		array(
 			'surface'   => 'post_insert',
 			'post_type' => (string) $post->post_type,
+			'origin'    => wpcom_layout_grid_usage_classify_origin(),
 		)
 	);
 	// Burn the 24h budget only after a successful dispatch — otherwise a
@@ -135,6 +139,68 @@ function wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron 
 }
 
 /**
+ * Classify how an inserted block arrived, so the expected and noisy case — a
+ * logged-in user adding the block in the editor — can be told apart from the
+ * arrivals worth investigating. Checked in priority order:
+ *
+ *  - `migration`:    the WoA transfer is mid-flight — the block came over with
+ *                    the site. Checked before `import` because migration runs
+ *                    also set `WP_IMPORTING`, and "arrived during transfer" is
+ *                    the more specific (and, post-conditional-activation, the
+ *                    more interesting) answer.
+ *  - `import`:       a `WP_IMPORTING` run (an importer plugin, a WXR import).
+ *  - `xmlrpc`:       a remote publishing client (legacy apps, some migration
+ *                    tools) writing over XML-RPC.
+ *  - `cli`:          a WP-CLI invocation.
+ *  - `cron`:         a scheduled / background job.
+ *  - `editor`:       a logged-in user on an ordinary request — the expected case.
+ *  - `rest`:         a REST write with no user behind it — a headless client or
+ *                    server-to-server integration rather than the block editor.
+ *  - `ajax`:         an admin-ajax write with no user — a front-end handler.
+ *  - `programmatic`: none of the above — internal PHP wrote the post on a normal
+ *                    request with no HTTP API surface and no user.
+ *
+ * The batch / transport contexts win over the user check on purpose: an import,
+ * cron, or CLI run isn't a person at the editor even when a user happens to be
+ * set. The `editor` check sits above `rest`/`ajax` so a normal block-editor save
+ * (REST + a logged-in user) reads as `editor`, leaving those two buckets for the
+ * no-user writes they're meant to catch. The remaining false negative — a plugin
+ * calling `wp_insert_post()` on a normal admin request with a user logged in —
+ * reads as `editor`; the `trace` field is the backstop for naming that source.
+ * Used for the insert surfaces; the render backstop sets its own `origin` since
+ * by render time the context is gone.
+ *
+ * @return string One of: migration, import, xmlrpc, cli, cron, editor, rest, ajax, programmatic.
+ */
+function wpcom_layout_grid_usage_classify_origin() {
+	if ( function_exists( 'wpcomsh_is_migration_in_progress' ) && wpcomsh_is_migration_in_progress() ) {
+		return 'migration';
+	}
+	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+		return 'import';
+	}
+	if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+		return 'xmlrpc';
+	}
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return 'cli';
+	}
+	if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+		return 'cron';
+	}
+	if ( function_exists( 'get_current_user_id' ) && get_current_user_id() > 0 ) {
+		return 'editor';
+	}
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return 'rest';
+	}
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		return 'ajax';
+	}
+	return 'programmatic';
+}
+
+/**
  * `add_option_widget_block` handler. Logs when the initial value carries the block.
  *
  * @param string $option Unused — pinned by hook name.
@@ -146,7 +212,12 @@ function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) 
 	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
 		return;
 	}
-	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_add' ) );
+	wpcom_layout_grid_usage_log_observation(
+		array(
+			'surface' => 'widget_add',
+			'origin'  => wpcom_layout_grid_usage_classify_origin(),
+		)
+	);
 }
 
 /**
@@ -163,7 +234,12 @@ function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $val
 	if ( wpcom_layout_grid_usage_widget_value_contains_block( $old_value ) ) {
 		return;
 	}
-	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_update' ) );
+	wpcom_layout_grid_usage_log_observation(
+		array(
+			'surface' => 'widget_update',
+			'origin'  => wpcom_layout_grid_usage_classify_origin(),
+		)
+	);
 }
 
 /**
@@ -185,7 +261,15 @@ function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_
 	// Persist the sentinel only after a successful dispatch. The option has no
 	// TTL, so a filter-blocked observation that wrote it first would
 	// permanently disable the backstop for this blog.
-	if ( wpcom_layout_grid_usage_log_observation( array( 'surface' => 'render' ) ) ) {
+	if ( wpcom_layout_grid_usage_log_observation(
+		array(
+			'surface' => 'render',
+			// The block was only ever seen at render, never at insert — it came
+			// from a theme template, a pattern, or a direct write, not a user
+			// adding it in the editor.
+			'origin'  => 'render',
+		)
+	) ) {
 		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
 	}
 	return $block_content;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -31,6 +31,7 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-trackin
  * @covers ::wpcom_layout_grid_usage_should_log_in_context
  * @covers ::wpcom_layout_grid_usage_mark_context_seen
  * @covers ::wpcom_layout_grid_usage_context_transient_key
+ * @covers ::wpcom_layout_grid_usage_classify_origin
  * @covers ::wpcom_layout_grid_usage_log_observation
  */
 #[CoversFunction( 'wpcom_layout_grid_usage_widget_value_contains_block' )]
@@ -44,6 +45,7 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-trackin
 #[CoversFunction( 'wpcom_layout_grid_usage_should_log_in_context' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_mark_context_seen' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_context_transient_key' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_classify_origin' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_log_observation' )]
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
@@ -67,6 +69,10 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
 		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
 		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
+		// No user, no import/cron/cli constants in the test process → the insert
+		// surfaces classify as `programmatic`. Pinned here so origin assertions
+		// don't depend on a user another test may have left set.
+		wp_set_current_user( 0 );
 		$this->observations = array();
 		add_filter( 'wpcom_layout_grid_usage_log_enabled', array( $this, 'spy_observation' ), 11, 2 );
 	}
@@ -254,6 +260,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 				array(
 					'surface'   => 'post_insert',
 					'post_type' => 'page',
+					'origin'    => 'programmatic',
 				),
 			),
 			$this->observations
@@ -267,6 +274,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 				array(
 					'surface'   => 'post_insert',
 					'post_type' => 'post',
+					'origin'    => 'programmatic',
 				),
 			),
 			$this->observations
@@ -307,7 +315,12 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		// Add: initial value has the block.
 		wpcom_layout_grid_usage_react_to_widget_block_added( 'widget_block', $this->widget_with( self::LAYOUT_GRID ) );
 		$this->assertSame(
-			array( array( 'surface' => 'widget_add' ) ),
+			array(
+				array(
+					'surface' => 'widget_add',
+					'origin'  => 'programmatic',
+				),
+			),
 			$this->observations
 		);
 
@@ -315,7 +328,12 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->observations = array();
 		wpcom_layout_grid_usage_react_to_widget_block_updated( $this->widget_with( self::PARAGRAPH ), $this->widget_with( self::LAYOUT_GRID ) );
 		$this->assertSame(
-			array( array( 'surface' => 'widget_update' ) ),
+			array(
+				array(
+					'surface' => 'widget_update',
+					'origin'  => 'programmatic',
+				),
+			),
 			$this->observations
 		);
 
@@ -345,7 +363,12 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
 		$this->assertSame(
-			array( array( 'surface' => 'render' ) ),
+			array(
+				array(
+					'surface' => 'render',
+					'origin'  => 'render',
+				),
+			),
 			$this->observations
 		);
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
@@ -403,5 +426,32 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 				"cron transient for: {$label}"
 			);
 		}
+	}
+
+	/**
+	 * Origin classification: a request with a logged-in user and none of the
+	 * batch / transport contexts reads as `editor`; with no user it falls
+	 * through to `programmatic`. The context-driven branches (migration, import,
+	 * xmlrpc, cli, cron, rest, ajax) aren't exercised here — they hinge on
+	 * request constants or the wpcomsh migration helper, neither of which can be
+	 * toggled without leaking into the rest of the phpunit process.
+	 */
+	public function test_classify_origin_separates_editor_from_programmatic() {
+		wp_set_current_user( 0 );
+		$this->assertSame( 'programmatic', wpcom_layout_grid_usage_classify_origin() );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'grid-editor',
+				'user_pass'  => 'x',
+				'role'       => 'editor',
+			)
+		);
+		$this->assertIsInt( $user_id );
+		wp_set_current_user( $user_id );
+		$this->assertSame( 'editor', wpcom_layout_grid_usage_classify_origin() );
+
+		// Restore the no-user default for any later test in this instance.
+		wp_set_current_user( 0 );
 	}
 }


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

* Adds an `origin` field to the `atomic_layout_grid_block` logstash event so observations can be split by how the layout-grid block actually arrived, rather than treating every first-landing the same.
* The expected, high-volume case — a logged-in user adding the block in the editor — becomes one clearly-labelled bucket (`editor`) that can be filtered out, leaving the arrivals worth investigating: `migration`, `import`, `xmlrpc`, `cli`, `cron`, headless `rest`/`ajax`, `programmatic`, and `render` (block only ever seen at display time — i.e. a theme template, pattern, or direct write).
* `migration` is checked ahead of `import` so blocks that come over during a WoA transfer are distinguished from generic importer activity.

This follows up the change that stops activating the Layout Grid plugin on transferred sites that had no layout-grid block at transfer time. The goal here is to learn what is putting layout-grid blocks on sites that didn't explicitly add them, so the impact of that change can be measured.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?

Yes — it adds one enum field (`origin`) to the existing internal `atomic_layout_grid_block` logstash event, which only fires on WoA sites. No user content or personally identifying information is added; the value is a fixed classification string derived from request context. The event itself, its WoA-only gate, path redaction, and rate limiting are unchanged.

## Testing instructions

* From `projects/packages/jetpack-mu-wpcom`, run the feature's unit tests and confirm they pass:
  * `composer phpunit -- --filter Layout_Grid_Usage_Tracking_Test`
* Confirm the linter is clean for the changed files:
  * `composer phpcs:lint -- src/features/layout-grid-usage-tracking tests/php/features/layout-grid-usage-tracking`
* Behaviourally (on a WoA-like environment), confirm the emitted event now carries an `origin` field and that:
  * Adding a layout-grid block in the editor as a logged-in user reports `origin: editor`.
  * A block that appears only at render (e.g. from a theme template or pattern) reports `origin: render`.
  * The remaining buckets reflect their context (import, cron, WP-CLI, XML-RPC, etc.).
