### PR TITLE
[codex] Fix VideoPress submenu toggle in My Jetpack

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-videopress-submenu-toggle
+++ b/projects/packages/admin-ui/changelog/fix-videopress-submenu-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Admin Menu: Add helper for reading registered Jetpack submenu item order.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -128,20 +128,7 @@ class Admin_Menu {
 		 * Let's order the items before registering them.
 		 * Since this all happens after the Jetpack plugin menu items were added, all items will be added after Jetpack plugin items - unless position is very low number (smaller than the number of menu items present in Jetpack plugin).
 		 */
-		usort(
-			self::$menu_items,
-			function ( $a, $b ) {
-				$position_a = empty( $a['position'] ) ? 0 : $a['position'];
-				$position_b = empty( $b['position'] ) ? 0 : $b['position'];
-				$result     = $position_a <=> $position_b;
-
-				if ( 0 === $result ) {
-					$result = strcmp( $a['menu_title'], $b['menu_title'] );
-				}
-
-				return $result;
-			}
-		);
+		self::$menu_items = self::sort_menu_items( self::$menu_items );
 
 		foreach ( self::$menu_items as $menu_item ) {
 			if ( ! current_user_can( $menu_item['capability'] ) ) {
@@ -209,6 +196,48 @@ class Admin_Menu {
 		add_action( 'load-' . $hook . '-network', array( __CLASS__, 'hide_core_admin_notices' ) );
 
 		return $hook;
+	}
+
+	/**
+	 * Gets the Jetpack submenu items queued through this wrapper in registration order.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array[] List of queued menu item arrays.
+	 */
+	public static function get_registered_menu_items() {
+		return self::sort_menu_items( self::$menu_items );
+	}
+
+	/**
+	 * Sorts Jetpack submenu items the same way they are sorted before registration.
+	 *
+	 * @param array[] $menu_items The menu items to sort.
+	 * @return array[] Sorted menu items.
+	 */
+	private static function sort_menu_items( $menu_items ) {
+		usort( $menu_items, array( __CLASS__, 'compare_menu_items' ) );
+
+		return $menu_items;
+	}
+
+	/**
+	 * Compares two submenu items by position and title.
+	 *
+	 * @param array $a The first menu item.
+	 * @param array $b The second menu item.
+	 * @return int Comparison result.
+	 */
+	private static function compare_menu_items( $a, $b ) {
+		$position_a = empty( $a['position'] ) ? 0 : $a['position'];
+		$position_b = empty( $b['position'] ) ? 0 : $b['position'];
+		$result     = $position_a <=> $position_b;
+
+		if ( 0 === $result ) {
+			$result = strcmp( $a['menu_title'], $b['menu_title'] );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -209,6 +209,24 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
+	 * Registered menu items are returned in the same order used by admin_menu_hook_callback().
+	 *
+	 * @return void
+	 */
+	public function test_get_registered_menu_items_returns_sorted_items() {
+		Admin_Menu::add_menu( 'Test', 'Zulu', 'edit_posts', 'menu_3', '__return_null', 3 );
+		Admin_Menu::add_menu( 'Test', 'Alpha', 'edit_posts', 'menu_2', '__return_null', 3 );
+		Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'menu_1', '__return_null', 1 );
+
+		$menu_items = Admin_Menu::get_registered_menu_items();
+
+		$this->assertSame(
+			array( 'menu_1', 'menu_2', 'menu_3' ),
+			array_column( $menu_items, 'menu_slug' )
+		);
+	}
+
+	/**
 	 * Calling hide_core_admin_notices queues the inline style printer.
 	 *
 	 * @return void

--- a/projects/packages/my-jetpack/_inc/data/products/use-activate-plugins.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-activate-plugins.ts
@@ -1,6 +1,7 @@
 import { useGlobalNotices } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import useAnalytics from '../../hooks/use-analytics';
+import { syncVideoPressWpAdminMenuForProductResponse } from '../../utils/sync-wp-admin-menu';
 import { REST_API_SITE_PRODUCTS_ENDPOINT, QUERY_ACTIVATE_PRODUCT_KEY } from '../constants';
 import useSimpleMutation from '../use-simple-mutation';
 import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
@@ -51,7 +52,9 @@ const useActivatePlugins = ( productSlugs: string | string[] ) => {
 			data: { products: productIds },
 		},
 		options: {
-			onSuccess: () => {
+			onSuccess: activatedProducts => {
+				syncVideoPressWpAdminMenuForProductResponse( activatedProducts, true );
+
 				products?.forEach( product => {
 					if ( ! getIsPluginAlreadyActive( product ) ) {
 						recordEvent( 'jetpack_myjetpack_product_activated', {

--- a/projects/packages/my-jetpack/_inc/data/products/use-deactivate-plugins.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-deactivate-plugins.ts
@@ -1,6 +1,7 @@
 import { useGlobalNotices } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import useAnalytics from '../../hooks/use-analytics';
+import { syncVideoPressWpAdminMenuForProductResponse } from '../../utils/sync-wp-admin-menu';
 import { QUERY_ACTIVATE_PRODUCT_KEY, REST_API_SITE_PRODUCTS_ENDPOINT } from '../constants';
 import useSimpleMutation from '../use-simple-mutation';
 import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
@@ -49,7 +50,9 @@ export const useDeactivatePlugins = ( productSlugs: string | string[] ) => {
 			data: { products: productIds },
 		},
 		options: {
-			onSuccess: () => {
+			onSuccess: deactivatedProducts => {
+				syncVideoPressWpAdminMenuForProductResponse( deactivatedProducts, false );
+
 				products?.forEach( product => {
 					if ( isPluginActive( product ) ) {
 						recordEvent( 'jetpack_myjetpack_product_deactivated', {

--- a/projects/packages/my-jetpack/_inc/data/products/use-install-plugins.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-install-plugins.ts
@@ -1,8 +1,10 @@
 import { useGlobalNotices } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
+import { syncVideoPressWpAdminMenuForProductResponse } from '../../utils/sync-wp-admin-menu';
 import { REST_API_SITE_PRODUCTS_ENDPOINT, QUERY_INSTALL_PRODUCT_KEY } from '../constants';
 import useSimpleMutation from '../use-simple-mutation';
 import useProducts from './use-products';
+import type { ProductSnakeCase } from '../types';
 
 const useInstallPlugins = ( productSlugs: string | string[] ) => {
 	const productIds = Array.isArray( productSlugs ) ? productSlugs : [ productSlugs ];
@@ -18,26 +20,30 @@ const useInstallPlugins = ( productSlugs: string | string[] ) => {
 	const successMessagePlural = __( 'Plugins installed successfully!', 'jetpack-my-jetpack' );
 	const successMessage = products?.length === 1 ? successMessageSingular : successMessagePlural;
 
-	const { mutate: install, isPending } = useSimpleMutation( {
-		name: QUERY_INSTALL_PRODUCT_KEY,
-		query: {
-			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/install`,
-			method: 'POST',
-			data: { products: productIds },
-		},
-		options: {
-			onSuccess: () => {
-				refetch().then( () => {
-					createSuccessNotice( successMessage );
-				} );
+	const { mutate: install, isPending } = useSimpleMutation< { [ key: string ]: ProductSnakeCase } >(
+		{
+			name: QUERY_INSTALL_PRODUCT_KEY,
+			query: {
+				path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/install`,
+				method: 'POST',
+				data: { products: productIds },
 			},
-		},
-		errorMessage: sprintf(
-			// translators: %s is the Jetpack plugin name or comma-separated list of multiple Jetpack plugin names.
-			__( 'There was a problem installing and activating %s.', 'jetpack-my-jetpack' ),
-			products?.map( product => product?.name ).join( ', ' )
-		),
-	} );
+			options: {
+				onSuccess: installedProducts => {
+					syncVideoPressWpAdminMenuForProductResponse( installedProducts, true );
+
+					refetch().then( () => {
+						createSuccessNotice( successMessage );
+					} );
+				},
+			},
+			errorMessage: sprintf(
+				// translators: %s is the Jetpack plugin name or comma-separated list of multiple Jetpack plugin names.
+				__( 'There was a problem installing and activating %s.', 'jetpack-my-jetpack' ),
+				products?.map( product => product?.name ).join( ', ' )
+			),
+		}
+	);
 
 	return {
 		install,

--- a/projects/packages/my-jetpack/_inc/utils/sync-wp-admin-menu.ts
+++ b/projects/packages/my-jetpack/_inc/utils/sync-wp-admin-menu.ts
@@ -1,0 +1,198 @@
+import type { ProductCamelCase, ProductSnakeCase } from '../data/types';
+
+const VIDEOPRESS_PRODUCT_FEATURE = 'videopress';
+const VIDEOPRESS_MENU_SLUG = 'jetpack-videopress';
+const VIDEOPRESS_MENU_TITLE = 'VideoPress';
+const VIDEOPRESS_MENU_POSITION = 3;
+const JETPACK_SUBMENU_SELECTOR = '#toplevel_page_jetpack .wp-submenu';
+
+type InitialState = Window[ 'myJetpackInitialState' ];
+type JetpackAdminMenu = NonNullable< InitialState >[ 'jetpackAdminMenu' ];
+type JetpackAdminMenuItem = JetpackAdminMenu[ 'items' ][ number ];
+type ProductWithFeature = ProductCamelCase | ProductSnakeCase | undefined;
+
+const matchesVideoPressFeatureIdentifier = ( product: ProductWithFeature ) => {
+	if ( ! product ) {
+		return false;
+	}
+
+	if ( 'featureIdentifyingPaidPlan' in product ) {
+		return product.featureIdentifyingPaidPlan === VIDEOPRESS_PRODUCT_FEATURE;
+	}
+
+	return product.feature_identifying_paid_plan === VIDEOPRESS_PRODUCT_FEATURE;
+};
+
+const includesVideoPressFeatureIdentifier = ( products: ProductWithFeature[] ) => {
+	return products.some( product => matchesVideoPressFeatureIdentifier( product ) );
+};
+
+const normalizeProducts = ( products: ProductWithFeature | ProductWithFeature[] ) => {
+	return Array.isArray( products ) ? products : [ products ];
+};
+
+const shouldSyncVideoPressMenu = ( products: ProductWithFeature | ProductWithFeature[] ) => {
+	return includesVideoPressFeatureIdentifier( normalizeProducts( products ) );
+};
+
+const getProductValues = < T extends ProductWithFeature >( products?: Record< string, T > ) => {
+	return Object.values( products || {} );
+};
+
+const getAdminUrl = () => {
+	const adminUrl = window.myJetpackInitialState?.adminUrl || '/wp-admin/';
+
+	return adminUrl.endsWith( '/' ) ? adminUrl : `${ adminUrl }/`;
+};
+
+const getVideoPressMenuItem = (): JetpackAdminMenuItem => {
+	return (
+		window.myJetpackInitialState?.jetpackAdminMenu?.videoPressMenuItem || {
+			menuSlug: VIDEOPRESS_MENU_SLUG,
+			menuTitle: VIDEOPRESS_MENU_TITLE,
+			position: VIDEOPRESS_MENU_POSITION,
+		}
+	);
+};
+
+const getVideoPressMenuUrl = () => {
+	return `${ getAdminUrl() }admin.php?page=${ getVideoPressMenuItem().menuSlug }`;
+};
+
+const escapeRegExp = ( value: string ) => {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+};
+
+const isUrlLikeMenuSlug = ( menuSlug: string ) => {
+	return (
+		menuSlug.startsWith( '/' ) ||
+		menuSlug.includes( '://' ) ||
+		menuSlug.includes( '?' ) ||
+		menuSlug.includes( '#' )
+	);
+};
+
+const itemMatchesSlug = ( href: string, slug: string ) => {
+	const normalizedHref = href.replace( /&amp;/g, '&' );
+	const normalizedSlug = slug.replace( /&amp;/g, '&' );
+
+	if ( isUrlLikeMenuSlug( normalizedSlug ) ) {
+		return normalizedHref === normalizedSlug || normalizedHref.includes( normalizedSlug );
+	}
+
+	return new RegExp( `[?&]page=${ escapeRegExp( normalizedSlug ) }(?:[#&]|$)` ).test(
+		normalizedHref
+	);
+};
+
+const findMenuItem = ( submenu: Element, menuSlug: string ) => {
+	const links = submenu.querySelectorAll< HTMLAnchorElement >( 'li:not(.wp-submenu-head) a' );
+
+	return Array.from( links ).find( link => {
+		const href = link.href || link.getAttribute( 'href' ) || '';
+
+		return itemMatchesSlug( href, menuSlug );
+	} );
+};
+
+const removeVideoPressMenuItems = ( submenu: Element ) => {
+	const links = submenu.querySelectorAll< HTMLAnchorElement >( 'li:not(.wp-submenu-head) a' );
+	const { menuSlug } = getVideoPressMenuItem();
+
+	links.forEach( link => {
+		const href = link.href || link.getAttribute( 'href' ) || '';
+
+		if ( itemMatchesSlug( href, menuSlug ) ) {
+			link.closest( 'li' )?.remove();
+		}
+	} );
+};
+
+const compareMenuItems = ( a: JetpackAdminMenuItem, b: JetpackAdminMenuItem ) => {
+	const positionResult = ( a.position || 0 ) - ( b.position || 0 );
+
+	if ( positionResult !== 0 ) {
+		return positionResult;
+	}
+
+	if ( a.menuTitle === b.menuTitle ) {
+		return 0;
+	}
+
+	return a.menuTitle > b.menuTitle ? 1 : -1;
+};
+
+const getRegisteredMenuItems = () => {
+	return window.myJetpackInitialState?.jetpackAdminMenu?.items || [];
+};
+
+const findInsertionPoint = ( submenu: Element ) => {
+	const videoPressMenuItem = getVideoPressMenuItem();
+	const laterMenuItems = getRegisteredMenuItems().filter(
+		menuItem =>
+			menuItem.menuSlug !== videoPressMenuItem.menuSlug &&
+			compareMenuItems( menuItem, videoPressMenuItem ) > 0
+	);
+
+	for ( const menuItem of laterMenuItems ) {
+		const link = findMenuItem( submenu, menuItem.menuSlug );
+
+		if ( link ) {
+			return link.closest( 'li' );
+		}
+	}
+
+	return null;
+};
+
+const addVideoPressMenuItem = ( submenu: Element ) => {
+	removeVideoPressMenuItems( submenu );
+
+	const menuItem = document.createElement( 'li' );
+	const link = document.createElement( 'a' );
+	link.href = getVideoPressMenuUrl();
+	link.textContent = getVideoPressMenuItem().menuTitle;
+	menuItem.appendChild( link );
+
+	const insertionPoint = findInsertionPoint( submenu );
+
+	if ( insertionPoint ) {
+		submenu.insertBefore( menuItem, insertionPoint );
+		return;
+	}
+
+	submenu.appendChild( menuItem );
+};
+
+export const syncVideoPressWpAdminMenu = (
+	products: ProductWithFeature | ProductWithFeature[],
+	isActive: boolean
+) => {
+	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
+		return;
+	}
+
+	if ( ! shouldSyncVideoPressMenu( products ) ) {
+		return;
+	}
+
+	const submenu = document.querySelector( JETPACK_SUBMENU_SELECTOR );
+
+	if ( ! submenu ) {
+		return;
+	}
+
+	if ( ! isActive ) {
+		removeVideoPressMenuItems( submenu );
+		return;
+	}
+
+	addVideoPressMenuItem( submenu );
+};
+
+export const syncVideoPressWpAdminMenuForProductResponse = (
+	products: Record< string, ProductSnakeCase > | undefined,
+	isActive: boolean
+) => {
+	return syncVideoPressWpAdminMenu( getProductValues( products ), isActive );
+};

--- a/projects/packages/my-jetpack/_inc/utils/test/sync-wp-admin-menu.test.ts
+++ b/projects/packages/my-jetpack/_inc/utils/test/sync-wp-admin-menu.test.ts
@@ -1,0 +1,175 @@
+import {
+	syncVideoPressWpAdminMenu,
+	syncVideoPressWpAdminMenuForProductResponse,
+} from '../sync-wp-admin-menu';
+import type { ProductCamelCase, ProductSnakeCase } from '../../data/types';
+
+const videoPressProduct = {
+	featureIdentifyingPaidPlan: 'videopress',
+} as ProductCamelCase;
+
+const videoPressProductResponse = {
+	videopress: {
+		feature_identifying_paid_plan: 'videopress',
+	} as ProductSnakeCase,
+};
+
+const boostProductResponse = {
+	boost: {
+		feature_identifying_paid_plan: 'cloud-critical-css',
+	} as ProductSnakeCase,
+};
+
+const setJetpackSubmenu = ( items: Array< { label: string; href: string } > ) => {
+	document.body.innerHTML = `
+		<ul id="adminmenu">
+			<li id="toplevel_page_jetpack">
+				<ul class="wp-submenu">
+					<li class="wp-submenu-head" aria-hidden="true">Jetpack</li>
+					${ items.map( item => `<li><a href="${ item.href }">${ item.label }</a></li>` ).join( '' ) }
+				</ul>
+			</li>
+		</ul>
+	`;
+};
+
+const getSubmenuLinks = () => {
+	return Array.from(
+		document.querySelectorAll< HTMLAnchorElement >(
+			'#toplevel_page_jetpack .wp-submenu li:not(.wp-submenu-head) a'
+		)
+	);
+};
+
+const getSubmenuLabels = () => {
+	return getSubmenuLinks().map( link => link.textContent );
+};
+
+const getVideoPressLinks = () => {
+	return getSubmenuLinks().filter( link => link.href.includes( 'page=jetpack-videopress' ) );
+};
+
+const setJetpackAdminMenuData = (
+	items: Window[ 'myJetpackInitialState' ][ 'jetpackAdminMenu' ][ 'items' ]
+) => {
+	window.myJetpackInitialState = {
+		adminUrl: 'https://example.com/wp-admin',
+		jetpackAdminMenu: {
+			items,
+			videoPressMenuItem: {
+				menuSlug: 'jetpack-videopress',
+				menuTitle: 'VideoPress',
+				position: 3,
+			},
+		},
+	} as Window[ 'myJetpackInitialState' ];
+};
+
+describe( 'syncVideoPressWpAdminMenu', () => {
+	const originalInitialState = window.myJetpackInitialState;
+
+	beforeEach( () => {
+		setJetpackAdminMenuData( [] );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		window.myJetpackInitialState = originalInitialState;
+	} );
+
+	it( 'adds VideoPress at the same relative position as the PHP admin menu', () => {
+		setJetpackSubmenu( [
+			{ label: 'My Jetpack', href: 'https://example.com/wp-admin/admin.php?page=my-jetpack' },
+			{ label: 'Dashboard', href: 'https://example.com/wp-admin/admin.php?page=jetpack' },
+			{ label: 'Boost', href: 'https://example.com/wp-admin/admin.php?page=jetpack-boost' },
+			{ label: 'SEO', href: 'https://example.com/wp-admin/admin.php?page=jetpack-seo' },
+			{ label: 'AI', href: 'https://example.com/wp-admin/admin.php?page=jetpack-ai' },
+			{ label: 'Social', href: 'https://example.com/wp-admin/admin.php?page=jetpack-social' },
+			{ label: 'Backup', href: 'https://example.com/wp-admin/admin.php?page=jetpack-backup' },
+			{ label: 'Settings', href: 'https://example.com/wp-admin/admin.php?page=jetpack#/settings' },
+		] );
+		setJetpackAdminMenuData( [
+			{ menuSlug: 'my-jetpack', menuTitle: 'My Jetpack', position: -1 },
+			{ menuSlug: 'jetpack-boost', menuTitle: 'Boost', position: 2 },
+			{ menuSlug: 'jetpack-seo', menuTitle: 'SEO', position: 2 },
+			{ menuSlug: 'jetpack-ai', menuTitle: 'AI', position: 4 },
+			{ menuSlug: 'jetpack-social', menuTitle: 'Social', position: 4 },
+			{ menuSlug: 'jetpack-backup', menuTitle: 'Backup', position: 7 },
+			{ menuSlug: 'jetpack#/settings', menuTitle: 'Settings', position: 13 },
+		] );
+
+		syncVideoPressWpAdminMenuForProductResponse( videoPressProductResponse, true );
+
+		expect( getSubmenuLabels() ).toEqual( [
+			'My Jetpack',
+			'Dashboard',
+			'Boost',
+			'SEO',
+			'VideoPress',
+			'AI',
+			'Social',
+			'Backup',
+			'Settings',
+		] );
+		expect( getVideoPressLinks()[ 0 ] ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-admin/admin.php?page=jetpack-videopress'
+		);
+	} );
+
+	it( 'deduplicates and repositions an existing VideoPress item', () => {
+		setJetpackSubmenu( [
+			{ label: 'Boost', href: 'https://example.com/wp-admin/admin.php?page=jetpack-boost' },
+			{ label: 'Settings', href: 'https://example.com/wp-admin/admin.php?page=jetpack#/settings' },
+			{
+				label: 'VideoPress',
+				href: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+			},
+			{
+				label: 'VideoPress',
+				href: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+			},
+		] );
+		setJetpackAdminMenuData( [
+			{ menuSlug: 'jetpack-boost', menuTitle: 'Boost', position: 2 },
+			{ menuSlug: 'jetpack#/settings', menuTitle: 'Settings', position: 13 },
+		] );
+
+		syncVideoPressWpAdminMenu( videoPressProduct, true );
+
+		expect( getSubmenuLabels() ).toEqual( [ 'Boost', 'VideoPress', 'Settings' ] );
+		expect( getVideoPressLinks() ).toHaveLength( 1 );
+	} );
+
+	it( 'removes VideoPress when the product is deactivated', () => {
+		setJetpackSubmenu( [
+			{ label: 'Boost', href: 'https://example.com/wp-admin/admin.php?page=jetpack-boost' },
+			{
+				label: 'VideoPress',
+				href: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+			},
+			{ label: 'AI', href: 'https://example.com/wp-admin/admin.php?page=jetpack-ai' },
+		] );
+
+		syncVideoPressWpAdminMenuForProductResponse( videoPressProductResponse, false );
+
+		expect( getSubmenuLabels() ).toEqual( [ 'Boost', 'AI' ] );
+		expect( getVideoPressLinks() ).toHaveLength( 0 );
+	} );
+
+	it( 'ignores unrelated products and missing admin menus', () => {
+		setJetpackSubmenu( [
+			{ label: 'Boost', href: 'https://example.com/wp-admin/admin.php?page=jetpack-boost' },
+		] );
+
+		syncVideoPressWpAdminMenuForProductResponse( boostProductResponse, true );
+
+		expect( getSubmenuLabels() ).toEqual( [ 'Boost' ] );
+
+		document.body.innerHTML = '';
+
+		expect( () =>
+			syncVideoPressWpAdminMenuForProductResponse( videoPressProductResponse, true )
+		).not.toThrow();
+	} );
+} );

--- a/projects/packages/my-jetpack/changelog/fix-videopress-submenu-toggle
+++ b/projects/packages/my-jetpack/changelog/fix-videopress-submenu-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Update the wp-admin submenu when toggling the module in My Jetpack.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -479,6 +479,18 @@ interface Window {
 		canUserViewStats: boolean;
 		isUserFromKnownHost: string;
 		loadAddLicenseScreen: string;
+		jetpackAdminMenu: {
+			items: Array< {
+				menuSlug: string;
+				menuTitle: string;
+				position: number;
+			} >;
+			videoPressMenuItem: {
+				menuSlug: string;
+				menuTitle: string;
+				position: number;
+			};
+		};
 		myJetpackCheckoutUri: string;
 		myJetpackFlags: {
 			showFullJetpackStatsCard: boolean;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -26,6 +26,7 @@ use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\VideoPress\Admin_UI as VideoPress_Admin_UI;
 use Jetpack;
 use WP_Error;
 
@@ -303,6 +304,7 @@ class Initializer {
 				'fileSystemWriteAccess'  => self::has_file_system_write_access(),
 				'loadAddLicenseScreen'   => self::is_licensing_ui_enabled(),
 				'adminUrl'               => esc_url( admin_url() ),
+				'jetpackAdminMenu'       => self::get_jetpack_admin_menu(),
 				'IDCContainerID'         => static::get_idc_container_id(),
 				'userIsAdmin'            => current_user_can( 'manage_options' ),
 				'lifecycleStats'         => array(
@@ -344,6 +346,40 @@ class Initializer {
 		if ( self::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
+	}
+
+	/**
+	 * Gets Jetpack wp-admin submenu data needed for client-side menu updates.
+	 *
+	 * @return array
+	 */
+	private static function get_jetpack_admin_menu() {
+		$items = array();
+
+		foreach ( Admin_Menu::get_registered_menu_items() as $menu_item ) {
+			if ( ! current_user_can( $menu_item['capability'] ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'menuSlug'  => $menu_item['menu_slug'],
+				'menuTitle' => $menu_item['menu_title'],
+				'position'  => empty( $menu_item['position'] ) ? 0 : (int) $menu_item['position'],
+			);
+		}
+
+		$has_videopress_admin_ui = class_exists( VideoPress_Admin_UI::class );
+
+		return array(
+			'items'              => $items,
+			'videoPressMenuItem' => array(
+				'menuSlug'  => $has_videopress_admin_ui
+					? VideoPress_Admin_UI::ADMIN_PAGE_SLUG
+					: 'jetpack-videopress',
+				'menuTitle' => 'VideoPress',
+				'position'  => $has_videopress_admin_ui ? VideoPress_Admin_UI::ADMIN_MENU_POSITION : 3,
+			),
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/changelog/fix-videopress-submenu-toggle
+++ b/projects/packages/videopress/changelog/fix-videopress-submenu-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to share the VideoPress admin menu position.
+

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -27,6 +27,8 @@ class Admin_UI {
 
 	const ADMIN_PAGE_SLUG = 'jetpack-videopress';
 
+	const ADMIN_MENU_POSITION = 3;
+
 	/**
 	 * Filter name that gates the wp-build–based dashboard.
 	 *
@@ -76,7 +78,7 @@ class Admin_UI {
 			'manage_options',
 			self::ADMIN_PAGE_SLUG,
 			$callback,
-			3
+			self::ADMIN_MENU_POSITION
 		);
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 	}


### PR DESCRIPTION
Fixes MYJP-300

## Proposed changes
* Add an `Admin_Menu` helper that exposes registered Jetpack submenu items in the same order PHP uses to render them.
* Expose that ordered menu metadata to My Jetpack, along with VideoPress' submenu slug and position.
* Sync the current wp-admin Jetpack submenu after successful VideoPress install, activation, or deactivation in My Jetpack, without a PHP reload.
* Insert the VideoPress row by comparing against PHP-provided menu positions and titles, instead of maintaining a hardcoded client-side list of later submenu items.

## Related product discussion/links
* MYJP-300

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Start from a Jetpack site where the VideoPress module can be toggled from My Jetpack.
* Go to WP Admin > Jetpack > My Jetpack.
* Deactivate the VideoPress module if active, and confirm the WP Admin > Jetpack submenu no longer contains VideoPress without reloading the page.
* Activate VideoPress from My Jetpack, and confirm the WP Admin > Jetpack submenu adds VideoPress immediately.
* Confirm the inserted VideoPress submenu item appears in the same relative position as after a page reload.
* Run `CI=true pnpm jetpack test js packages/my-jetpack`.
* Run `CI=true pnpm jetpack test php packages/admin-ui -v`.
* Run `CI=true pnpm jetpack test php packages/my-jetpack -v`.
* Run `CI=true pnpm jetpack test php packages/videopress -v`.
* Run `pnpm -C projects/packages/my-jetpack run typecheck`.
* Run `pnpm -C projects/packages/my-jetpack run build`.
