### PR TITLE
Connection: Fix Connection_Notice_Test for PHPUnit 11+

### DIFF
--- a/projects/packages/connection/changelog/2026-06-04-11-25-44-208353
+++ b/projects/packages/connection/changelog/2026-06-04-11-25-44-208353
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix Connection_Notice_Test to avoid multiple expectOutputRegex() calls, unsupported in PHPUnit 11+.
+
+

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -53,11 +53,12 @@ class Connection_Notice_Test extends TestCase {
 
 		$notice = new Connection_Notice();
 
-		$this->expectOutputRegex( '#Connect to WordPress.com#i' );
-
-		$this->expectOutputRegex( '#https:\/\/jetpack\.wordpress\.com\/jetpack\.authorize\/1\/\?response_type=code#i' ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
-
+		ob_start();
 		$notice->delete_user_update_connection_owner_notice();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '#Connect to WordPress.com#i', $output );
+		$this->assertMatchesRegularExpression( '#https:\/\/jetpack\.wordpress\.com\/jetpack\.authorize\/1\/\?response_type=code#i', $output ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 
 		\Jetpack_Options::update_option( 'user_tokens', $tokens );
 	}
@@ -68,10 +69,12 @@ class Connection_Notice_Test extends TestCase {
 	public function test_delete_user_change_owner_notice() {
 		$notice = new Connection_Notice();
 
-		$this->expectOutputRegex( '#Set new connection owner#i' );
-		$this->expectOutputRegex( '#' . preg_quote( 'http://example.org/index.php?rest_route=/jetpack/v4/connection/owner', '#' ) . '#i' );
-
+		ob_start();
 		$notice->delete_user_update_connection_owner_notice();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '#Set new connection owner#i', $output );
+		$this->assertMatchesRegularExpression( '#' . preg_quote( 'http://example.org/index.php?rest_route=/jetpack/v4/connection/owner', '#' ) . '#i', $output );
 	}
 
 	/**


### PR DESCRIPTION
Fixes failing `packages/connection` PHP tests on PHPUnit 11+.

## Proposed changes
* `Connection_Notice_Test` called `expectOutputRegex()` twice per test. PHPUnit 11+ (the version `trunk` now runs) disallows configuring more than one output expectation, producing the warning `Only one expectation on output can be configured: expectOutputString() and expectOutputRegex() cannot be combined and must not be called more than once` and failing the suite.
* Capture the rendered output once via `ob_start()`/`ob_get_clean()` and assert against it with multiple `assertMatchesRegularExpression()` calls, which is allowed and backward-compatible with older PHPUnit.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `jp test php packages/connection -- --filter Connection_Notice_Test`.
* Confirm the suite passes with no PHPUnit output-expectation warnings (locally: 752 tests, 1620 assertions, OK on PHP 8.5 / PHPUnit 12.5).
