### PR TITLE
Add JSON API REST  callback filter fields

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-json-api-rest-callback-filter-fields
+++ b/projects/plugins/jetpack/changelog/fix-json-api-rest-callback-filter-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+JSON API: Honor the `fields` parameter on REST-dispatched responses so they return the same keys as the XML-RPC transport.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2791,6 +2791,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$response = new WP_Error( 'empty_response', 'Endpoint response is empty', 500 );
 		}
 
+		// Mirror the XML-RPC path, which runs filter_fields() in WPCOM_JSON_API::output() before
+		// returning, so a `fields` request yields the same keys on both transports. Endpoints may
+		// force-add keys past `fields` for internal processors (e.g. the post type/status/password);
+		// without this they would leak on the REST transport only.
+		if ( ! is_wp_error( $response ) ) {
+			$response = $this->api->filter_fields( $response );
+		}
+
 		$status_code = 200;
 
 		if ( is_wp_error( $response ) ) {

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_GET_Site_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_GET_Site_Endpoint_Test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * WPCOM_JSON_API_GET_Site_Endpoint REST-vs-XML-RPC parity tests.
+ *
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_GET_Site_Endpoint_Test
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+// Registers every endpoint version so the get-site endpoint resolves.
+require_once JETPACK__PLUGIN_DIR . 'json-endpoints.php';
+require_once __DIR__ . '/trait-assert-rest-xmlrpc-parity.php';
+
+/**
+ * Tests for the /sites/%s get-site endpoint.
+ *
+ * @covers \WPCOM_JSON_API_GET_Site_Endpoint
+ */
+#[CoversClass( WPCOM_JSON_API_GET_Site_Endpoint::class )]
+class WPCOM_JSON_API_GET_Site_Endpoint_Test extends WP_UnitTestCase {
+	use WP_UnitTestCase_Fix;
+	use Assert_Rest_Xmlrpc_Parity;
+
+	/**
+	 * Prepare the environment for each test.
+	 */
+	public function set_up() {
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		parent::set_up();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		$this->tear_down_rest_parity();
+		parent::tear_down();
+		WPCOM_JSON_API::init()->query = array();
+	}
+
+	/**
+	 * The SAL `after_render()` adds `updates` for admins -- past the `fields` filter, and only when
+	 * `options` is in the response (is_main_site() reads it). XML-RPC's output() trims it via
+	 * filter_fields(); before rest_callback() did the same, it leaked on the REST transport only.
+	 * A distinct trigger from the posts force-add: the extra key comes from after_render(), not the
+	 * endpoint's own render loop.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_rest_xmlrpc_parity_fields_trims_after_render_updates() {
+		// Precondition: with `updates` (and `options`, which is_main_site() requires) in `fields`,
+		// our admin sees it -- confirming this environment actually surfaces the key to be trimmed.
+		list( , $with_updates ) = $this->assert_rest_parity(
+			$this->get_endpoint(),
+			array( 'fields' => 'ID,options,updates' )
+		);
+		if ( ! array_key_exists( 'updates', $with_updates ) ) {
+			$this->markTestSkipped( 'Environment did not surface get-site `updates`; nothing to assert.' );
+		}
+
+		// The fix: with `updates` NOT requested (but `options` present so after_render still adds it),
+		// both transports must trim it.
+		list( $xmlrpc, $rest ) = $this->assert_rest_parity(
+			$this->get_endpoint(),
+			array( 'fields' => 'ID,options' )
+		);
+
+		$this->assertArrayHasKey( 'ID', $rest );
+		$this->assertArrayNotHasKey( 'updates', $rest, 'rest_callback() must trim after_render-added `updates` not in `fields`.' );
+		$this->assertArrayNotHasKey( 'updates', $xmlrpc );
+		// assert_rest_parity() already asserts the bodies match; this pins the regression.
+		$this->assertSame( array_keys( $xmlrpc ), array_keys( $rest ) );
+	}
+
+	/**
+	 * Retrieve the registered v1.1 get-site endpoint.
+	 *
+	 * @return WPCOM_JSON_API_GET_Site_Endpoint
+	 *
+	 * @phan-suppress PhanTypeArraySuspicious
+	 */
+	private function get_endpoint() {
+		$api = WPCOM_JSON_API::init();
+		foreach ( $api->endpoints as $endpoints_by_method ) {
+			$endpoint = $endpoints_by_method['GET'] ?? null;
+			// Pick the get-site endpoint (base or v1.2 subclass) that is actually REST-enabled,
+			// rather than matching a specific version -- robust to registration order/state.
+			if (
+				$endpoint instanceof WPCOM_JSON_API_GET_Site_Endpoint
+				&& '/sites/%s' === $endpoint->path
+				&& ! empty( $endpoint->rest_route )
+			) {
+				return $endpoint;
+			}
+		}
+		$this->markTestSkipped( 'No REST-enabled get-site endpoint (/sites/%s) is registered in this run.' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_List_Posts_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_List_Posts_Endpoint_Test.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\Attributes\Group;
 
 require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
 require_once JETPACK__PLUGIN_DIR . 'json-endpoints/class.wpcom-json-api-list-posts-endpoint.php';
+// Registers every endpoint version (incl. the v1.1 list-posts endpoint that force-adds
+// type/status/password) so the fields-parity case below can resolve it.
+require_once JETPACK__PLUGIN_DIR . 'json-endpoints.php';
 require_once __DIR__ . '/trait-assert-rest-xmlrpc-parity.php';
 
 /**
@@ -147,6 +150,73 @@ class WPCOM_JSON_API_List_Posts_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A `fields` request must return the same keys on both transports. get_post_by() force-adds
+	 * type/status/password regardless of `fields` because internal processors need them; the
+	 * XML-RPC output() path strips the unrequested ones back out via filter_fields(). Before
+	 * rest_callback() did the same, those keys leaked past `fields` on the REST transport only.
+	 *
+	 * Uses the v1.1 endpoint: only it (not v1) force-adds those keys.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_rest_xmlrpc_parity_fields_strips_forced_keys() {
+		$this->create_post();
+
+		list( $xmlrpc, $rest ) = $this->assert_rest_parity(
+			$this->get_endpoint_v1_1(),
+			array(
+				'number' => 5,
+				'fields' => 'ID,title,date',
+			)
+		);
+
+		$this->assertNotEmpty( $rest['posts'] );
+
+		$post = $rest['posts'][0];
+		$this->assertArrayHasKey( 'ID', $post );
+		$this->assertArrayHasKey( 'title', $post );
+		$this->assertArrayNotHasKey( 'type', $post );
+		$this->assertArrayNotHasKey( 'status', $post );
+		$this->assertArrayNotHasKey( 'password', $post );
+
+		// assert_rest_parity() already asserts the full bodies match; this pins the regression.
+		$this->assertSame( array_keys( $xmlrpc['posts'][0] ), array_keys( $post ) );
+	}
+
+	/**
+	 * The v1 endpoint only honors `fields` in display context -- get_post_by() guards the filter
+	 * on `'display' === $context`, so an edit-context request renders the full object. Before
+	 * rest_callback() ran filter_fields(), that leaked every key on REST while XML-RPC (via
+	 * output()) returned only the requested ones. A distinct trigger from the v1.1 force-add.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_rest_xmlrpc_parity_fields_edit_context_v1() {
+		$this->create_post();
+
+		list( $xmlrpc, $rest ) = $this->assert_rest_parity(
+			$this->get_endpoint(),
+			array(
+				'number'  => 5,
+				'context' => 'edit',
+				'fields'  => 'ID,title,date',
+			)
+		);
+
+		$this->assertNotEmpty( $rest['posts'] );
+
+		$post = $rest['posts'][0];
+		$this->assertCount( 3, $post, 'REST returns only the requested fields, not the full object.' );
+		$this->assertArrayHasKey( 'ID', $post );
+		$this->assertArrayHasKey( 'title', $post );
+		$this->assertArrayHasKey( 'date', $post );
+		$this->assertArrayNotHasKey( 'content', $post );
+		$this->assertSame( array_keys( $xmlrpc['posts'][0] ), array_keys( $post ) );
+	}
+
+	/**
 	 * Retrieve the registered endpoint instance.
 	 *
 	 * The endpoint file registers itself via a top-level `new` call when required,
@@ -168,6 +238,28 @@ class WPCOM_JSON_API_List_Posts_Endpoint_Test extends WP_UnitTestCase {
 			}
 		}
 		$this->fail( 'WPCOM_JSON_API_List_Posts_Endpoint (v1) not found in registered endpoints.' );
+	}
+
+	/**
+	 * Retrieve the registered v1.1 list-posts endpoint (the version that force-adds
+	 * type/status/password in get_post_by()).
+	 *
+	 * @return WPCOM_JSON_API_List_Posts_v1_1_Endpoint
+	 *
+	 * @phan-suppress PhanTypeArraySuspicious
+	 */
+	private function get_endpoint_v1_1() {
+		$api = WPCOM_JSON_API::init();
+		foreach ( $api->endpoints as $endpoints_by_method ) {
+			if (
+				isset( $endpoints_by_method['GET'] )
+				&& get_class( $endpoints_by_method['GET'] ) === 'WPCOM_JSON_API_List_Posts_v1_1_Endpoint'
+				&& '1.1' === $endpoints_by_method['GET']->max_version
+			) {
+				return $endpoints_by_method['GET'];
+			}
+		}
+		$this->fail( 'WPCOM_JSON_API_List_Posts_v1_1_Endpoint not found in registered endpoints.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
@@ -95,6 +95,24 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Each endpoint also matches across transports for a `fields`-scoped request. This guards the
+	 * rest_callback()->filter_fields() fix generically: any key that reaches the body past the
+	 * caller's `fields` must be trimmed on REST exactly as output()/filter_fields() trims it on
+	 * XML-RPC. (Endpoints needing fixtures or specific `fields` to surface such a key get their own
+	 * bespoke case -- e.g. get-site `updates`, posts `type`/`password` -- next to that endpoint.)
+	 *
+	 * @dataProvider simple_get_endpoints_provider
+	 * @group json-api
+	 *
+	 * @param WPCOM_JSON_API_Endpoint $endpoint The discovered endpoint.
+	 */
+	#[DataProvider( 'simple_get_endpoints_provider' )]
+	#[Group( 'json-api' )]
+	public function test_endpoint_fields_parity( WPCOM_JSON_API_Endpoint $endpoint ) {
+		$this->assert_rest_parity( $endpoint, array( 'fields' => 'ID' ) );
+	}
+
+	/**
 	 * Fail if discovery finds nothing -- an empty provider would mark the parity test risky.
 	 *
 	 * @group json-api

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -3,17 +3,19 @@
  * Reusable assertion: a JSON API endpoint's REST dispatch produces the same
  * response body as its XML-RPC dispatch, for the same logical request.
  *
- * Both paths run on the Jetpack site and both end in the same `callback()`:
+ * Both paths run on the Jetpack site and both end in the same `callback()`, then apply
+ * filter_fields() before returning:
  *
  *   XML-RPC: WPCOM_JSON_API::serve()  -> adds user_can_richedit + comment_edit_pre,
  *                                        sets $api->endpoint/path/version
- *                                     -> process_request() -> callback()
- *   REST:    WPCOM_JSON_API_Endpoint::rest_callback() -> the SAME setup -> callback()
+ *                                     -> process_request() -> callback() -> output()/filter_fields()
+ *   REST:    WPCOM_JSON_API_Endpoint::rest_callback() -> the SAME setup -> callback() -> filter_fields()
  *
- * So the only ways the two can diverge are (1) the edit-context filter set drifting
- * out of sync (the jetpack#42377 regression class) and (2) the REST route failing to
- * pass through a request param the XML-RPC query carried. This assertion drives both
- * paths over shared fixtures and compares the decoded bodies, catching exactly that.
+ * So the ways the two can diverge are (1) the edit-context filter set drifting out of sync
+ * (the jetpack#42377 regression class), (2) the REST route failing to pass through a request
+ * param the XML-RPC query carried, and (3) the REST path skipping the field filtering that
+ * output() applies on XML-RPC. This assertion drives both paths over shared fixtures (including
+ * a `fields=` request) and compares the decoded bodies, catching exactly that.
  *
  * Self-contained: it creates its own admin user, aligns the Jetpack blog id, and mocks
  * the request signature internally. A consuming WP_UnitTestCase only needs to call
@@ -225,6 +227,12 @@ trait Assert_Rest_Xmlrpc_Parity {
 
 		remove_filter( 'user_can_richedit', '__return_true' );
 		remove_filter( 'comment_edit_pre', array( $api, 'comment_edit_pre' ) );
+
+		// Mirror WPCOM_JSON_API::output(), which the real serve() path runs after callback():
+		// it applies filter_fields() so a `fields=` request returns only the requested keys.
+		if ( ! is_wp_error( $response ) ) {
+			$response = $api->filter_fields( $response );
+		}
 
 		return $this->normalize_body( $response );
 	}


### PR DESCRIPTION
Fixes CONNECT-244

## Proposed changes
  
  * `WPCOM_JSON_API_Endpoint::rest_callback()` now applies `filter_fields()` to the response before returning, mirroring the XML-RPC path (`WPCOM_JSON_API::serve()` → `output()` → `filter_fields()`). Previously the REST transport skipped
  it, so any key that ends up in the body *past* the caller's `fields` — endpoint force-adds (a post's `type`/`status`/`password`) or `after_render()` additions (get-site `updates`) — was returned on REST but trimmed on XML-RPC.
  * Updates the REST-vs-XML-RPC parity test helper to model the real `output()`/`filter_fields()` stage on the XML-RPC side, so `fields`-related divergence is actually exercised (previously both sides compared raw `callback()` output and
  never hit `filter_fields()`).
  * Adds regression coverage: a `fields`-scoped run across every REST-enabled simple GET endpoint in the auto-discovery sweep, plus bespoke `fields` parity cases for posts (v1.1 force-add, v1 edit-context) and get-site (`updates` added by
  `after_render()`).
  
  ## Related product discussion/links
pf5801-24W-p2
  
  ## Does this pull request change what data or activity we track or use?
 
  No. 
 
  ## Testing instructions

  * Run the JSON API parity suite — all green:
    jetpack docker phpunit jetpack -- --filter='WPCOM_JSON_API_List_Posts_Endpoint_Test|WPCOM_JSON_API_GET_Site_Endpoint_Test|WPCOM_JSON_API_Rest_Parity_Coverage_Test'
  * Confirm the tests actually guard the fix: temporarily comment out the `filter_fields()` block in `rest_callback()` and re-run — these should **fail**: the coverage sweep's `test_endpoint_fields_parity`, posts
  `test_rest_xmlrpc_parity_fields_strips_forced_keys` / `..._fields_edit_context_v1`, and get-site `test_rest_xmlrpc_parity_fields_trims_after_render_updates`. Restore the block → all pass.
  * More TBD