### PR TITLE
Add default social image setting for Open Graph previews

### DIFF
--- a/projects/packages/publicize/_inc/social-store/actions/social-settings.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/social-settings.ts
@@ -1,7 +1,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { MESSAGE_TEMPLATE_KEY, SHOW_PRICING_PAGE_KEY } from '../constants';
+import { MESSAGE_TEMPLATE_KEY, OPEN_GRAPH_SETTINGS_KEY, SHOW_PRICING_PAGE_KEY } from '../constants';
+import { OpenGraphSettingsConfig } from '../types';
 
 /**
  * Sets the Show Pricing Page enabled status.
@@ -35,6 +36,34 @@ export function setMessageTemplate( value: string ) {
 		if ( lastError ) {
 			let message: string = __(
 				'There was an error saving the default share message.',
+				'jetpack-publicize-pkg'
+			);
+			if ( lastError?.message ) {
+				message += ' ' + lastError.message;
+			}
+			createErrorNotice( message, { type: 'snackbar' } );
+		}
+	};
+}
+
+/**
+ * Saves the default Open Graph image settings.
+ *
+ * @param  data - The Open Graph settings to save.
+ * @return {Function} A thunk.
+ */
+export function updateOpenGraphSettings( data: Partial< OpenGraphSettingsConfig > ) {
+	return async function ( { registry } ) {
+		const { saveSite } = registry.dispatch( coreStore );
+		const { getLastEntitySaveError } = registry.select( coreStore );
+		const { createErrorNotice } = registry.dispatch( noticesStore );
+
+		await saveSite( { [ OPEN_GRAPH_SETTINGS_KEY ]: data } );
+
+		const lastError = getLastEntitySaveError( 'root', 'site' );
+		if ( lastError ) {
+			let message: string = __(
+				'There was an error saving the default social image.',
 				'jetpack-publicize-pkg'
 			);
 			if ( lastError?.message ) {

--- a/projects/packages/publicize/_inc/social-store/actions/test/save-error-notices.test.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/test/save-error-notices.test.ts
@@ -2,7 +2,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { updateSocialImageGeneratorConfig } from '../social-image-generator';
 import { toggleSocialNotes, updateSocialNotesConfig } from '../social-notes';
-import { setMessageTemplate } from '../social-settings';
+import { setMessageTemplate, updateOpenGraphSettings } from '../social-settings';
 import { updateUtmSettings } from '../utm-settings';
 
 // Each save thunk surfaces a snackbar error notice when the most recent
@@ -59,6 +59,7 @@ describe( 'site-save thunks surface an error notice on save failure', () => {
 			() => updateSocialImageGeneratorConfig( { enabled: true } ),
 		],
 		[ 'updateUtmSettings', () => updateUtmSettings( { enabled: true } ) ],
+		[ 'updateOpenGraphSettings', () => updateOpenGraphSettings( { default_image_id: 123 } ) ],
 		[ 'toggleSocialNotes', () => toggleSocialNotes( true ) ],
 		[ 'updateSocialNotesConfig', () => updateSocialNotesConfig( { append_link: false } ) ],
 		[ 'setMessageTemplate', () => setMessageTemplate( 'Hello {title}' ) ],

--- a/projects/packages/publicize/_inc/social-store/constants.ts
+++ b/projects/packages/publicize/_inc/social-store/constants.ts
@@ -1,5 +1,6 @@
 // See projects/packages/publicize/src/jetpack-social-settings/class-settings.php
 export const SIG_SETTINGS_KEY = 'jetpack_social_image_generator_settings';
+export const OPEN_GRAPH_SETTINGS_KEY = 'jetpack_social_open_graph_settings';
 export const UTM_ENABLED_KEY = 'jetpack_social_utm_settings';
 export const SOCIAL_NOTES_ENABLED_KEY = 'jetpack-social-note';
 export const SOCIAL_NOTES_CONFIG_KEY = 'jetpack_social_notes_config';

--- a/projects/packages/publicize/_inc/social-store/selectors/social-settings.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/social-settings.ts
@@ -36,6 +36,10 @@ export const getSocialSettings = createRegistrySelector( select => () => {
 			...settings.socialImageGenerator,
 			...data.jetpack_social_image_generator_settings,
 		},
+		openGraphSettings: {
+			...settings.openGraphSettings,
+			...data.jetpack_social_open_graph_settings,
+		},
 		utmSettings: {
 			...settings.utmSettings,
 			...data.jetpack_social_utm_settings,

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -203,6 +203,10 @@ export type UtmSettingsConfig = {
 	enabled: boolean;
 };
 
+export type OpenGraphSettingsConfig = {
+	default_image_id?: number;
+};
+
 export type SocialNotesConfig = {
 	append_link: boolean;
 	link_format: 'full_url' | 'shortlink' | 'permashortcitation';
@@ -219,6 +223,7 @@ export type SocialModuleSettings = {
 
 export type SocialSettingsFields = {
 	jetpack_social_image_generator_settings: SocialImageGeneratorConfig;
+	jetpack_social_open_graph_settings: OpenGraphSettingsConfig;
 	jetpack_social_utm_settings: UtmSettingsConfig;
 	[ 'jetpack-social-note' ]: boolean;
 	jetpack_social_notes_config: SocialNotesConfig;

--- a/projects/packages/publicize/_inc/types.ts
+++ b/projects/packages/publicize/_inc/types.ts
@@ -1,6 +1,7 @@
 import {
 	SocialImageGeneratorConfig,
 	UtmSettingsConfig,
+	OpenGraphSettingsConfig,
 	SocialStoreState,
 	SocialNotesSettings,
 } from './social-store/types';
@@ -37,6 +38,7 @@ export interface ApiPaths {
 
 export type SocialSettings = {
 	socialImageGenerator: SocialImageGeneratorConfig;
+	openGraphSettings: OpenGraphSettingsConfig;
 	utmSettings: UtmSettingsConfig;
 	socialNotes: SocialNotesSettings;
 	showPricingPage: boolean;

--- a/projects/packages/publicize/_inc/utils/test-utils.js
+++ b/projects/packages/publicize/_inc/utils/test-utils.js
@@ -196,6 +196,7 @@ export function mockScriptData( data = {} ) {
 						config: {},
 					},
 					socialImageGenerator: {},
+					openGraphSettings: {},
 					messageTemplate: '',
 					...data.social?.settings,
 				},

--- a/projects/packages/publicize/changelog/add-social-default-og-image
+++ b/projects/packages/publicize/changelog/add-social-default-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Settings: Add a default social image setting for Open Graph previews.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -157,6 +157,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'socialImageGenerator' => $settings->get_image_generator_settings(),
+			'openGraphSettings'    => $settings->get_open_graph_settings(),
 			'utmSettings'          => $settings->get_utm_settings(),
 			'socialNotes'          => array(
 				'enabled' => $settings->is_social_notes_enabled(),

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -72,6 +72,8 @@ class Publicize_Setup {
 			return;
 		}
 
+		Jetpack_Social_Settings\Settings::register_open_graph_filters();
+
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
 		/**

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize\Jetpack_Social_Settings;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Post_Media\Images;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
 
 /**
@@ -37,6 +38,12 @@ class Settings {
 
 	const DEFAULT_UTM_SETTINGS = array(
 		'enabled' => false,
+	);
+
+	const OPEN_GRAPH_SETTINGS = 'open_graph_settings';
+
+	const DEFAULT_OPEN_GRAPH_SETTINGS = array(
+		'default_image_id' => 0,
 	);
 
 	const NOTES_CONFIG = 'notes_config';
@@ -70,6 +77,13 @@ class Settings {
 	protected static $actions_hooked_in = false;
 
 	/**
+	 * Whether the Open Graph filters have been hooked into.
+	 *
+	 * @var bool
+	 */
+	protected static $open_graph_filters_hooked_in = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -80,6 +94,25 @@ class Settings {
 
 			self::$actions_hooked_in = true;
 		}
+
+		self::register_open_graph_filters();
+	}
+
+	/**
+	 * Register Open Graph filters for the configured default social image.
+	 *
+	 * @return void
+	 */
+	public static function register_open_graph_filters() {
+		if ( self::$open_graph_filters_hooked_in ) {
+			return;
+		}
+
+		add_filter( 'jetpack_og_default_site_image', array( __CLASS__, 'filter_default_site_image' ), 10, 2 );
+		add_filter( 'jetpack_open_graph_image_default', array( __CLASS__, 'filter_default_image_url' ) );
+		add_filter( 'jetpack_open_graph_tags', array( __CLASS__, 'add_default_image_to_open_graph_tags' ), 13 );
+
+		self::$open_graph_filters_hooked_in = true;
 	}
 
 	/**
@@ -179,6 +212,26 @@ class Settings {
 						'properties' => array(
 							'enabled' => array(
 								'type' => 'boolean',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_setting(
+			'jetpack_social',
+			self::OPTION_PREFIX . self::OPEN_GRAPH_SETTINGS,
+			array(
+				'type'         => 'object',
+				'default'      => self::DEFAULT_OPEN_GRAPH_SETTINGS,
+				'show_in_rest' => array(
+					'schema' => array(
+						'type'       => 'object',
+						'context'    => array( 'view', 'edit' ),
+						'properties' => array(
+							'default_image_id' => array(
+								'type' => 'number',
 							),
 						),
 					),
@@ -296,6 +349,30 @@ class Settings {
 	}
 
 	/**
+	 * Get the Open Graph settings.
+	 *
+	 * @return array
+	 */
+	public function get_open_graph_settings() {
+		return self::get_stored_open_graph_settings();
+	}
+
+	/**
+	 * Get the stored Open Graph settings.
+	 *
+	 * @return array
+	 */
+	private static function get_stored_open_graph_settings() {
+		$settings = get_option( self::OPTION_PREFIX . self::OPEN_GRAPH_SETTINGS, self::DEFAULT_OPEN_GRAPH_SETTINGS );
+
+		if ( empty( $settings ) || ! is_array( $settings ) ) {
+			return self::DEFAULT_OPEN_GRAPH_SETTINGS;
+		}
+
+		return array_replace_recursive( self::DEFAULT_OPEN_GRAPH_SETTINGS, $settings );
+	}
+
+	/**
 	 * Get the global message template.
 	 *
 	 * @return string
@@ -343,6 +420,7 @@ class Settings {
 
 		$settings = array(
 			'socialImageGeneratorSettings' => $this->get_image_generator_settings(),
+			'openGraphSettings'            => $this->get_open_graph_settings(),
 		);
 
 		// The feature cannot be enabled without Publicize.
@@ -394,6 +472,11 @@ class Settings {
 			return update_option( self::OPTION_PREFIX . self::UTM_SETTINGS, array_replace_recursive( $current_utm_settings, $value ) );
 		}
 
+		// Open Graph Settings.
+		if ( self::OPTION_PREFIX . self::OPEN_GRAPH_SETTINGS === $name ) {
+			return $this->update_open_graph_settings( $value );
+		}
+
 		// Social Notes.
 		if ( self::JETPACK_SOCIAL_NOTE_CPT_ENABLED === $name ) {
 			// Delete this option, so the rules get flushed in maybe_flush_rewrite_rules when the CPT is registered.
@@ -429,6 +512,145 @@ class Settings {
 		}
 
 		return update_option( self::OPTION_PREFIX . self::IMAGE_GENERATOR_SETTINGS, array_replace_recursive( $sig_settings, $new_setting ) );
+	}
+
+	/**
+	 * Update the Open Graph settings.
+	 *
+	 * @param array $new_setting The new settings.
+	 *
+	 * @return bool
+	 */
+	public function update_open_graph_settings( $new_setting ) {
+		$open_graph_settings = $this->get_open_graph_settings();
+
+		if ( ! is_array( $new_setting ) ) {
+			$new_setting = array();
+		}
+
+		if ( array_key_exists( 'default_image_id', $new_setting ) ) {
+			$new_setting['default_image_id'] = absint( $new_setting['default_image_id'] );
+		}
+
+		return update_option( self::OPTION_PREFIX . self::OPEN_GRAPH_SETTINGS, array_replace_recursive( $open_graph_settings, $new_setting ) );
+	}
+
+	/**
+	 * Get the default Open Graph image ID.
+	 *
+	 * @return int
+	 */
+	public static function og_get_default_image_id() {
+		$settings = self::get_stored_open_graph_settings();
+
+		return absint( $settings['default_image_id'] );
+	}
+
+	/**
+	 * Get the default Open Graph image.
+	 *
+	 * @return array The source ('src'), 'width', 'height', and source type of the image.
+	 */
+	public static function og_get_default_image() {
+		$image_id = self::og_get_default_image_id();
+
+		if ( ! $image_id ) {
+			return array();
+		}
+
+		$image = wp_get_attachment_image_src( $image_id, 'full' );
+
+		if ( empty( $image[0] ) ) {
+			return array();
+		}
+
+		$default_image = array(
+			'src'    => $image[0],
+			'width'  => isset( $image[1] ) ? absint( $image[1] ) : 0,
+			'height' => isset( $image[2] ) ? absint( $image[2] ) : 0,
+			'type'   => 'jetpack_social_default_og_image',
+		);
+
+		$alt_text = Images::get_alt_text( $image_id );
+		if ( ! empty( $alt_text ) ) {
+			$default_image['alt_text'] = $alt_text;
+		}
+
+		return $default_image;
+	}
+
+	/**
+	 * Filter the site's representative Open Graph image.
+	 *
+	 * @param array $custom_site_image The custom site image provided by filters.
+	 * @param array $site_image        The site image picked by Jetpack.
+	 *
+	 * @return array
+	 */
+	public static function filter_default_site_image( $custom_site_image, $site_image ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! empty( $custom_site_image['src'] ) ) {
+			return $custom_site_image;
+		}
+
+		$default_image = self::og_get_default_image();
+
+		if ( empty( $default_image['src'] ) ) {
+			return $custom_site_image;
+		}
+
+		return $default_image;
+	}
+
+	/**
+	 * Filter the default Open Graph image URL.
+	 *
+	 * @param string $default_url The default image URL.
+	 *
+	 * @return string
+	 */
+	public static function filter_default_image_url( $default_url ) {
+		$default_image = self::og_get_default_image();
+
+		if ( empty( $default_image['src'] ) ) {
+			return $default_url;
+		}
+
+		return $default_image['src'];
+	}
+
+	/**
+	 * Add the default image to Open Graph tags when no image has been set yet.
+	 *
+	 * @param array $tags Current Open Graph tags.
+	 *
+	 * @return array
+	 */
+	public static function add_default_image_to_open_graph_tags( $tags ) {
+		if ( ! empty( $tags['og:image'] ) ) {
+			return $tags;
+		}
+
+		$default_image = self::og_get_default_image();
+
+		if ( empty( $default_image['src'] ) ) {
+			return $tags;
+		}
+
+		$tags['og:image'] = $default_image['src'];
+
+		if ( ! empty( $default_image['width'] ) ) {
+			$tags['og:image:width'] = $default_image['width'];
+		}
+
+		if ( ! empty( $default_image['height'] ) ) {
+			$tags['og:image:height'] = $default_image['height'];
+		}
+
+		if ( ! empty( $default_image['alt_text'] ) ) {
+			$tags['og:image:alt'] = $default_image['alt_text'];
+		}
+
+		return $tags;
 	}
 
 	/**

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -517,7 +517,7 @@ class Settings {
 	/**
 	 * Update the Open Graph settings.
 	 *
-	 * @param array $new_setting The new settings.
+	 * @param mixed $new_setting The new settings.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
@@ -57,6 +57,24 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Reset Open Graph filter registration state.
+	 *
+	 * @return void
+	 */
+	private function reset_open_graph_filters() {
+		remove_filter( 'jetpack_og_default_site_image', array( SocialSettings::class, 'filter_default_site_image' ), 10 );
+		remove_filter( 'jetpack_open_graph_image_default', array( SocialSettings::class, 'filter_default_image_url' ) );
+		remove_filter( 'jetpack_open_graph_tags', array( SocialSettings::class, 'add_default_image_to_open_graph_tags' ), 13 );
+
+		$reflection = new \ReflectionClass( SocialSettings::class );
+		$property   = $reflection->getProperty( 'open_graph_filters_hooked_in' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, false );
+	}
+
+	/**
 	 * Create an upload object.
 	 *
 	 * @param string $file File path.
@@ -121,6 +139,63 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that Open Graph filters are registered for the default image setting.
+	 */
+	public function test_register_open_graph_filters_hooks_callbacks() {
+		$this->reset_open_graph_filters();
+
+		SocialSettings::register_open_graph_filters();
+
+		$this->assertSame(
+			10,
+			has_filter( 'jetpack_og_default_site_image', array( SocialSettings::class, 'filter_default_site_image' ) )
+		);
+		$this->assertSame(
+			10,
+			has_filter( 'jetpack_open_graph_image_default', array( SocialSettings::class, 'filter_default_image_url' ) )
+		);
+		$this->assertSame(
+			13,
+			has_filter( 'jetpack_open_graph_tags', array( SocialSettings::class, 'add_default_image_to_open_graph_tags' ) )
+		);
+	}
+
+	/**
+	 * Tests that invalid stored Open Graph settings fall back to defaults.
+	 */
+	public function test_open_graph_settings_default_when_stored_value_is_invalid() {
+		update_option( 'jetpack_social_open_graph_settings', 'invalid-settings' );
+
+		$this->assertSame(
+			array( 'default_image_id' => 0 ),
+			$this->settings->get_open_graph_settings()
+		);
+	}
+
+	/**
+	 * Tests that non-array Open Graph setting updates are ignored.
+	 */
+	public function test_open_graph_settings_ignore_non_array_updates() {
+		$this->settings->update_open_graph_settings( 'invalid-settings' );
+
+		$this->assertSame( 0, $this->settings->og_get_default_image_id() );
+	}
+
+	/**
+	 * Tests that update_settings routes Open Graph settings to their updater.
+	 */
+	public function test_update_settings_routes_open_graph_settings() {
+		$updated = $this->settings->update_settings(
+			false,
+			'jetpack_social_open_graph_settings',
+			array( 'default_image_id' => '123' )
+		);
+
+		$this->assertTrue( $updated );
+		$this->assertSame( 123, $this->settings->og_get_default_image_id() );
+	}
+
+	/**
 	 * Tests that the default Open Graph image ID can be updated and cleared.
 	 */
 	public function test_open_graph_default_image_id_can_be_set_and_cleared() {
@@ -147,6 +222,26 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that no Open Graph image is returned without a configured image.
+	 */
+	public function test_get_open_graph_default_image_returns_empty_without_attachment() {
+		$this->assertSame( array(), $this->settings->og_get_default_image() );
+	}
+
+	/**
+	 * Tests that the configured Open Graph image includes alt text.
+	 */
+	public function test_get_open_graph_default_image_returns_alt_text() {
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../images/jetpack-logo.png' );
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'Jetpack logo' );
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => $attachment_id ) );
+
+		$image = $this->settings->og_get_default_image();
+
+		$this->assertSame( 'Jetpack logo', $image['alt_text'] );
+	}
+
+	/**
 	 * Tests that the default Open Graph filters use the configured image.
 	 */
 	public function test_open_graph_filters_use_configured_default_image() {
@@ -165,6 +260,27 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 		$this->assertSame( $image_url, $site_image['src'] );
 		$this->assertSame( 100, $site_image['width'] );
 		$this->assertSame( 38, $site_image['height'] );
+	}
+
+	/**
+	 * Tests that Open Graph filters keep existing fallbacks without a configured image.
+	 */
+	public function test_open_graph_filters_keep_existing_values_without_configured_image() {
+		$custom_site_image = array( 'src' => 'https://example.com/custom.jpg' );
+		$tags              = array( 'og:title' => 'Test post' );
+
+		$this->assertSame(
+			$custom_site_image,
+			$this->settings->filter_default_site_image( $custom_site_image, array() )
+		);
+		$this->assertSame(
+			'https://example.com/default.jpg',
+			$this->settings->filter_default_image_url( 'https://example.com/default.jpg' )
+		);
+		$this->assertSame(
+			$tags,
+			$this->settings->add_default_image_to_open_graph_tags( $tags )
+		);
 	}
 
 	/**
@@ -194,6 +310,24 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 		);
 
 		$this->assertSame( 'https://example.com/post-image.jpg', $tags_with_image['og:image'] );
+	}
+
+	/**
+	 * Tests that the default Open Graph tag filter includes alt text.
+	 */
+	public function test_open_graph_tags_filter_adds_alt_text() {
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../images/jetpack-logo.png' );
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'Jetpack logo' );
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => $attachment_id ) );
+
+		$tags = apply_filters(
+			'jetpack_open_graph_tags',
+			array(
+				'og:title' => 'Test post',
+			)
+		);
+
+		$this->assertSame( 'Jetpack logo', $tags['og:image:alt'] );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
@@ -57,6 +57,32 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Create an upload object.
+	 *
+	 * @param string $file File path.
+	 * @return int
+	 */
+	private function create_upload_object( $file ) {
+		$contents = file_get_contents( $file );
+		$upload   = wp_upload_bits( basename( $file ), null, $contents );
+		$mime     = wp_check_filetype( $upload['file'] );
+
+		$attachment = array(
+			'post_title'     => basename( $upload['file'] ),
+			'post_content'   => '',
+			'post_type'      => 'attachment',
+			'post_mime_type' => $mime['type'],
+			'guid'           => $upload['url'],
+		);
+
+		$id = wp_insert_attachment( $attachment, $upload['file'] );
+
+		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
+
+		return $id;
+	}
+
+	/**
 	 * Mock Publicize being active.
 	 *
 	 * @return array
@@ -84,11 +110,90 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 		$settings = $this->settings->get_settings();
 
 		$this->assertArrayHasKey( 'socialImageGeneratorSettings', $settings );
+		$this->assertArrayHasKey( 'openGraphSettings', $settings );
 		$this->assertArrayHasKey( 'enabled', $settings['socialImageGeneratorSettings'] );
 		$this->assertArrayHasKey( 'template', $settings['socialImageGeneratorSettings'] );
+		$this->assertArrayHasKey( 'default_image_id', $settings['openGraphSettings'] );
 
 		$this->assertFalse( $settings['socialImageGeneratorSettings']['enabled'] );
 		$this->assertEquals( Templates::DEFAULT_TEMPLATE, $settings['socialImageGeneratorSettings']['template'] );
+		$this->assertSame( 0, $settings['openGraphSettings']['default_image_id'] );
+	}
+
+	/**
+	 * Tests that the default Open Graph image ID can be updated and cleared.
+	 */
+	public function test_open_graph_default_image_id_can_be_set_and_cleared() {
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => '123' ) );
+		$this->assertSame( 123, $this->settings->og_get_default_image_id() );
+
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => 0 ) );
+		$this->assertSame( 0, $this->settings->og_get_default_image_id() );
+	}
+
+	/**
+	 * Tests that the configured Open Graph image is returned with dimensions.
+	 */
+	public function test_get_open_graph_default_image_returns_attachment_details() {
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../images/jetpack-logo.png' );
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => $attachment_id ) );
+
+		$image = $this->settings->og_get_default_image();
+
+		$this->assertSame( wp_get_attachment_url( $attachment_id ), $image['src'] );
+		$this->assertSame( 100, $image['width'] );
+		$this->assertSame( 38, $image['height'] );
+		$this->assertSame( 'jetpack_social_default_og_image', $image['type'] );
+	}
+
+	/**
+	 * Tests that the default Open Graph filters use the configured image.
+	 */
+	public function test_open_graph_filters_use_configured_default_image() {
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../images/jetpack-logo.png' );
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => $attachment_id ) );
+
+		$image_url = wp_get_attachment_url( $attachment_id );
+
+		$this->assertSame(
+			$image_url,
+			apply_filters( 'jetpack_open_graph_image_default', 'https://s0.wp.com/i/blank.jpg' )
+		);
+
+		$site_image = apply_filters( 'jetpack_og_default_site_image', array(), array() );
+
+		$this->assertSame( $image_url, $site_image['src'] );
+		$this->assertSame( 100, $site_image['width'] );
+		$this->assertSame( 38, $site_image['height'] );
+	}
+
+	/**
+	 * Tests that the default Open Graph tag filter only adds an image when one is missing.
+	 */
+	public function test_open_graph_tags_filter_only_adds_missing_image() {
+		$attachment_id = $this->create_upload_object( __DIR__ . '/../images/jetpack-logo.png' );
+		$this->settings->update_open_graph_settings( array( 'default_image_id' => $attachment_id ) );
+
+		$tags = apply_filters(
+			'jetpack_open_graph_tags',
+			array(
+				'og:title' => 'Test post',
+			)
+		);
+
+		$this->assertSame( wp_get_attachment_url( $attachment_id ), $tags['og:image'] );
+		$this->assertSame( 100, $tags['og:image:width'] );
+		$this->assertSame( 38, $tags['og:image:height'] );
+
+		$tags_with_image = apply_filters(
+			'jetpack_open_graph_tags',
+			array(
+				'og:title' => 'Test post',
+				'og:image' => 'https://example.com/post-image.jpg',
+			)
+		);
+
+		$this->assertSame( 'https://example.com/post-image.jpg', $tags_with_image['og:image'] );
 	}
 
 	/**
@@ -109,6 +214,9 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 				'enabled'  => true,
 				'template' => 'example_template',
 			),
+			'openGraphSettings'            => array(
+				'default_image_id' => 0,
+			),
 		);
 
 		$this->settings = new SocialSettings();
@@ -126,6 +234,9 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 			'socialImageGeneratorSettings' => array(
 				'enabled'  => false,
 				'template' => Templates::DEFAULT_TEMPLATE,
+			),
+			'openGraphSettings'            => array(
+				'default_image_id' => 0,
 			),
 		);
 

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
@@ -176,7 +176,10 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 	 * Tests that non-array Open Graph setting updates are ignored.
 	 */
 	public function test_open_graph_settings_ignore_non_array_updates() {
-		$this->settings->update_open_graph_settings( 'invalid-settings' );
+		/** @var mixed $settings */
+		$settings = get_option( 'missing_open_graph_settings', 'invalid-settings' );
+
+		$this->settings->update_open_graph_settings( $settings );
 
 		$this->assertSame( 0, $this->settings->og_get_default_image_id() );
 	}

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -22,6 +22,7 @@ import SEO from './seo';
 import Shortlinks from './shortlinks';
 import { SiteStats } from './site-stats';
 import Sitemaps from './sitemaps';
+import './style.scss';
 import { VerificationServices } from './verification-services';
 
 export class Traffic extends Component {

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/social-previews';
 import { ToggleControl } from '@wordpress/components';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -479,7 +480,7 @@ export const SEO = withModuleSettingsFormHelpers(
 												/>
 											</div>
 										) }
-										<div className="jp-seo-default-social-image-actions">
+										<Stack direction="row" gap="sm" wrap="wrap">
 											<Button
 												id="jp-seo-default-social-image-button"
 												rna
@@ -497,10 +498,13 @@ export const SEO = withModuleSettingsFormHelpers(
 													{ __( 'Remove image', 'jetpack' ) }
 												</Button>
 											) }
-										</div>
-										<p className="jp-form-setting-explanation jp-seo-default-social-image-recommendation">
+										</Stack>
+										<Text
+											variant="body-sm"
+											render={ <p className="jp-form-setting-explanation" /> }
+										>
 											{ __( 'Recommended size is 1200x630px and < 600 KB.', 'jetpack' ) }
-										</p>
+										</Text>
 										<div className="jp-seo-default-social-image-save-button">
 											{ this.saveButton( this.props ) }
 										</div>

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -29,6 +29,8 @@ import { siteHasFeature } from 'state/site';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
 
+const OPEN_GRAPH_SETTINGS_OPTION = 'jetpack_social_open_graph_settings';
+
 export const conflictingSeoPluginsList = [
 	{
 		name: 'Yoast SEO',
@@ -84,9 +86,14 @@ export const SEO = withModuleSettingsFormHelpers(
 			moduleOptionsArray: [
 				'advanced_seo_front_page_description',
 				'advanced_seo_title_formats',
+				OPEN_GRAPH_SETTINGS_OPTION,
 				'ai_seo_enhancer_enabled',
 			],
 			siteIconPreviewSize: 512,
+		};
+
+		state = {
+			defaultSocialImageUrl: undefined,
 		};
 
 		toggleSeoEnhancer = () => {
@@ -120,7 +127,7 @@ export const SEO = withModuleSettingsFormHelpers(
 				type="website"
 				imageMode="landscape"
 				description={ siteData.frontPageMetaDescription }
-				image={ this.props.siteRepresentativeImage }
+				image={ siteData.socialImage }
 			/>
 		);
 
@@ -129,9 +136,73 @@ export const SEO = withModuleSettingsFormHelpers(
 				title={ siteData.title }
 				url={ siteData.url }
 				description={ siteData.frontPageMetaDescription }
-				image={ this.props.siteRepresentativeImage }
+				image={ siteData.socialImage }
 			/>
 		);
+
+		getOpenGraphSettings = () => {
+			const settings = this.props.getOptionValue( OPEN_GRAPH_SETTINGS_OPTION );
+
+			return settings && 'object' === typeof settings ? settings : { default_image_id: 0 };
+		};
+
+		getDefaultSocialImageId = () => {
+			return Number( this.getOpenGraphSettings().default_image_id || 0 );
+		};
+
+		getDefaultSocialImagePreview = () => {
+			if ( undefined !== this.state.defaultSocialImageUrl ) {
+				return this.state.defaultSocialImageUrl;
+			}
+
+			return this.props.siteRepresentativeImage;
+		};
+
+		selectDefaultSocialImage = event => {
+			event.preventDefault();
+
+			if ( ! window.wp?.media ) {
+				return;
+			}
+
+			const frame = window.wp.media( {
+				title: __( 'Select default social image', 'jetpack' ),
+				button: {
+					text: __( 'Use this image', 'jetpack' ),
+				},
+				library: {
+					type: 'image',
+				},
+				multiple: false,
+			} );
+
+			frame.on( 'select', () => {
+				const attachment = frame.state().get( 'selection' ).first().toJSON();
+				const imageUrl =
+					attachment.sizes?.large?.url || attachment.sizes?.full?.url || attachment.url;
+				const settings = this.getOpenGraphSettings();
+
+				this.setState( { defaultSocialImageUrl: imageUrl } );
+				this.props.updateFormStateOptionValue( OPEN_GRAPH_SETTINGS_OPTION, {
+					...settings,
+					default_image_id: Number( attachment.id || 0 ),
+				} );
+			} );
+
+			frame.open();
+		};
+
+		removeDefaultSocialImage = event => {
+			event.preventDefault();
+
+			const settings = this.getOpenGraphSettings();
+
+			this.setState( { defaultSocialImageUrl: '' } );
+			this.props.updateFormStateOptionValue( OPEN_GRAPH_SETTINGS_OPTION, {
+				...settings,
+				default_image_id: 0,
+			} );
+		};
 
 		updateCustomSeoTitleInputState = newCustomSeoTitles => {
 			this.props.updateFormStateOptionValue( 'advanced_seo_title_formats', newCustomSeoTitles );
@@ -167,6 +238,7 @@ export const SEO = withModuleSettingsFormHelpers(
 				tagline: this.props.siteData.description || '',
 				url: this.props.siteData.URL || '',
 				siteIcon: this.props.siteIcon || '',
+				socialImage: this.getDefaultSocialImagePreview(),
 				frontPageMetaDescription: frontPageMetaDescription
 					? frontPageMetaDescription
 					: this.props.siteData.description || '',
@@ -188,6 +260,10 @@ export const SEO = withModuleSettingsFormHelpers(
 					frontPageMetaDescription.length > this.constants.frontPageMetaSuggestedLength &&
 					frontPageMetaDescription.length < this.constants.frontPageMetaMaxLength,
 			} );
+			const defaultSocialImageId = this.getDefaultSocialImageId();
+			const defaultSocialImagePreview = this.getDefaultSocialImagePreview();
+			const selectDefaultSocialImageLabel = __( 'Select image', 'jetpack' );
+			const replaceDefaultSocialImageLabel = __( 'Replace image', 'jetpack' );
 
 			// Destructure feature out to ensure our explicit prop takes precedence
 			const { feature: _ignoredFeature, ...restProps } = this.props;
@@ -382,13 +458,54 @@ export const SEO = withModuleSettingsFormHelpers(
 									</SettingsGroup>
 								</FoldableCard>
 								<FoldableCard
-									header={ __(
-										'Expand to preview how the SEO settings will look for your homepage on Google, Facebook, and Twitter.',
-										'jetpack'
-									) }
+									header={ __( 'Expand to choose a default social image and preview.', 'jetpack' ) }
 									clickableHeader={ true }
 									className="jp-seo-social-previews"
 								>
+									<div className="jp-seo-default-social-image">
+										<p className="jp-form-setting-explanation">
+											{ __(
+												"Choose an image for social previews when a post doesn't have its own image, and preview how your homepage will look on Google, Facebook, and X.",
+												'jetpack'
+											) }
+										</p>
+										{ !! defaultSocialImageId && !! defaultSocialImagePreview && (
+											<div className="jp-seo-default-social-image-preview">
+												<img
+													src={ defaultSocialImagePreview }
+													alt={ __( 'Default social image preview', 'jetpack' ) }
+													width={ 550 }
+													height={ 288 }
+												/>
+											</div>
+										) }
+										<div className="jp-seo-default-social-image-actions">
+											<Button
+												id="jp-seo-default-social-image-button"
+												rna
+												compact
+												type="button"
+												onClick={ this.selectDefaultSocialImage }
+												disabled={ ! window.wp?.media }
+											>
+												{ defaultSocialImageId
+													? replaceDefaultSocialImageLabel
+													: selectDefaultSocialImageLabel }
+											</Button>
+											{ !! defaultSocialImageId && (
+												<Button rna compact type="button" onClick={ this.removeDefaultSocialImage }>
+													{ __( 'Remove image', 'jetpack' ) }
+												</Button>
+											) }
+										</div>
+										<p className="jp-form-setting-explanation jp-seo-default-social-image-recommendation">
+											{ __( 'Recommended size is 1200x630px and < 600 KB.', 'jetpack' ) }
+										</p>
+										<div className="jp-seo-default-social-image-save-button">
+											{ this.saveButton( this.props ) }
+										</div>
+									</div>
+									<hr />
 									<div className="jp-seo-social-previews-container">
 										<SocialLogo icon="google" size={ 24 } />
 										<span className="jp-seo-social-previews-label">

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -158,6 +158,50 @@
 $previews-max-width: 550px;
 $twitter-pofile-image-padding: 17px;
 
+.jp-seo-default-social-image {
+	max-width: $previews-max-width;
+
+	&-preview {
+		border: 1px solid colors.$gray-light;
+		background: colors.$gray-light;
+		margin: 1rem 0;
+		max-width: $previews-max-width;
+		overflow: hidden;
+		width: 100%;
+
+		img {
+			aspect-ratio: 1.91 / 1;
+			display: block;
+			height: auto;
+			object-fit: cover;
+			width: 100%;
+		}
+	}
+
+	&-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
+	}
+
+	&-recommendation {
+		color: colors.$gray-text-min;
+		display: block;
+		font-size: typography.$font-body-small;
+		font-style: italic;
+		font-weight: 400;
+		margin: rem.convert(5px) rem.convert(14px) rem.convert(5px) 0;
+		overflow-wrap: break-word;
+	}
+
+	&-save-button {
+		display: flex;
+		justify-content: end;
+		margin-top: 0.75rem;
+	}
+}
+
 .jp-seo-social-previews {
 	margin-bottom: 0;
 

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -178,23 +178,6 @@ $twitter-pofile-image-padding: 17px;
 		}
 	}
 
-	&-actions {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-		margin-top: 0.75rem;
-	}
-
-	&-recommendation {
-		color: colors.$gray-text-min;
-		display: block;
-		font-size: typography.$font-body-small;
-		font-style: italic;
-		font-weight: 400;
-		margin: rem.convert(5px) rem.convert(14px) rem.convert(5px) 0;
-		overflow-wrap: break-word;
-	}
-
 	&-save-button {
 		display: flex;
 		justify-content: end;

--- a/projects/plugins/jetpack/_inc/client/traffic/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/component.js
@@ -1,0 +1,309 @@
+import restApi from '@automattic/jetpack-api';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, within } from 'test/test-utils';
+import { SEO } from '../seo.jsx';
+
+jest.mock( '@automattic/jetpack-api', () => ( {
+	fetchSettings: jest.fn().mockResolvedValue( {} ),
+	updateSettings: jest.fn().mockResolvedValue( {} ),
+} ) );
+
+jest.mock( '@automattic/social-previews', () => ( {
+	FacebookLinkPreview: ( { image } ) => <div data-testid="facebook-preview">{ image }</div>,
+	GoogleSearchPreview: ( { title } ) => <div data-testid="google-preview">{ title }</div>,
+	TwitterLinkPreview: ( { image } ) => <div data-testid="twitter-preview">{ image }</div>,
+} ) );
+
+jest.mock( 'components/button', () => {
+	return function Button( { children, compact, primary, rna, ...props } ) {
+		return <button { ...props }>{ children }</button>;
+	};
+} );
+
+jest.mock( 'components/foldable-card', () => {
+	return function FoldableCard( { children, header } ) {
+		return (
+			<section aria-label={ header }>
+				<div>{ header }</div>
+				{ children }
+			</section>
+		);
+	};
+} );
+
+jest.mock( 'components/forms', () => ( {
+	FormFieldset: ( { children } ) => <fieldset>{ children }</fieldset>,
+	FormLabel: ( { children, ...props } ) => <div { ...props }>{ children }</div>,
+	FormTextarea: props => <textarea { ...props } />,
+} ) );
+
+jest.mock( 'components/module-toggle', () => ( {
+	ModuleToggle: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'components/notice', () => {
+	return function SimpleNotice( { children } ) {
+		return <div>{ children }</div>;
+	};
+} );
+
+jest.mock( 'components/settings-card', () => {
+	return function SettingsCard( { children, onSubmit } ) {
+		return <form onSubmit={ onSubmit }>{ children }</form>;
+	};
+} );
+
+jest.mock( 'components/settings-group', () => {
+	return function SettingsGroup( { children } ) {
+		return <div>{ children }</div>;
+	};
+} );
+
+jest.mock( 'social-logos', () => ( {
+	SocialLogo: ( { icon } ) => <span>{ icon }</span>,
+} ) );
+
+jest.mock( '../seo/custom-seo-titles.jsx', () => {
+	return function CustomSeoTitles() {
+		return <div />;
+	};
+} );
+
+describe( 'Traffic - SEO', () => {
+	const defaultSocialImageOption = 'jetpack_social_open_graph_settings';
+	const representativeImage = 'https://example.com/site-social-image.jpg';
+	const getSeoModule = () => ( {
+		module: 'seo-tools',
+		name: 'SEO Tools',
+	} );
+
+	const getInitialState = ( settings = {} ) => ( {
+		jetpack: {
+			connection: {
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+			},
+			initialState: {
+				adminUrl: 'https://example.com/wp-admin/',
+				currentIp: '127.0.0.1',
+				getModules: {
+					'seo-tools': {
+						options: {
+							ai_seo_enhancer_enabled: {
+								current_value: false,
+							},
+						},
+					},
+				},
+				siteData: {
+					representativeImage,
+				},
+				stats: {
+					roles: {},
+				},
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true,
+						},
+						wpcomUser: {
+							email: 'admin@example.com',
+						},
+					},
+				},
+			},
+			pluginsData: {
+				items: {},
+				requests: {
+					isFetchingPluginsData: false,
+				},
+			},
+			settings: {
+				items: {
+					advanced_seo_front_page_description: 'A homepage description.',
+					advanced_seo_title_formats: {},
+					'canonical-urls': true,
+					'seo-tools': true,
+					[ defaultSocialImageOption ]: {
+						default_image_id: 0,
+					},
+					...settings,
+				},
+				requests: {
+					fetchingSettingsList: false,
+					settingsSent: {},
+					updatedSettings: {},
+				},
+			},
+		},
+	} );
+
+	const setupSeo = ( settings = {} ) => {
+		const initialState = getInitialState( settings );
+
+		render(
+			<SEO
+				// eslint-disable-next-line react/jsx-no-bind -- The settings component expects getModule as a function prop.
+				getModule={ getSeoModule }
+				hasSeoEnhancer={ false }
+				seoEnhancerAvailable={ false }
+				siteData={ {
+					URL: 'https://example.com',
+					description: 'Example site description',
+					name: 'Example Site',
+				} }
+				siteIcon=""
+				siteRepresentativeImage={ representativeImage }
+				state={ initialState }
+			/>,
+			{ initialState }
+		);
+
+		return screen.getByRole( 'region', {
+			name: 'Expand to choose a default social image and preview.',
+		} );
+	};
+
+	const mockMediaFrame = attachment => {
+		let selectHandler;
+		const frame = {
+			on: jest.fn( ( event, handler ) => {
+				if ( event === 'select' ) {
+					selectHandler = handler;
+				}
+			} ),
+			open: jest.fn( () => selectHandler() ),
+			state: jest.fn( () => ( {
+				get: jest.fn( () => ( {
+					first: jest.fn( () => ( {
+						toJSON: jest.fn( () => attachment ),
+					} ) ),
+				} ) ),
+			} ) ),
+		};
+
+		window.wp = {
+			media: jest.fn( () => frame ),
+		};
+
+		return frame;
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		restApi.fetchSettings.mockResolvedValue( {} );
+		restApi.updateSettings.mockResolvedValue( {} );
+		window.wp = {
+			media: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		delete window.wp;
+	} );
+
+	it( 'renders and removes a configured default social image', async () => {
+		const user = userEvent.setup();
+		const socialImageSection = setupSeo( {
+			[ defaultSocialImageOption ]: {
+				default_image_id: 123,
+			},
+		} );
+
+		expect(
+			within( socialImageSection ).getByText( 'Recommended size is 1200x630px and < 600 KB.' )
+		).toBeInTheDocument();
+		expect(
+			within( socialImageSection ).getByRole( 'button', { name: 'Replace image' } )
+		).toBeEnabled();
+		expect(
+			within( socialImageSection ).getByAltText( 'Default social image preview' )
+		).toHaveAttribute( 'src', representativeImage );
+		expect( within( socialImageSection ).getByTestId( 'facebook-preview' ) ).toHaveTextContent(
+			representativeImage
+		);
+
+		await user.click(
+			within( socialImageSection ).getByRole( 'button', { name: 'Remove image' } )
+		);
+
+		await waitFor( () =>
+			expect(
+				within( socialImageSection ).queryByAltText( 'Default social image preview' )
+			).not.toBeInTheDocument()
+		);
+		expect(
+			within( socialImageSection ).getByRole( 'button', { name: 'Select image' } )
+		).toBeEnabled();
+
+		await user.click(
+			within( socialImageSection ).getByRole( 'button', { name: 'Save settings' } )
+		);
+
+		await waitFor( () =>
+			expect( restApi.updateSettings ).toHaveBeenCalledWith( {
+				[ defaultSocialImageOption ]: {
+					default_image_id: 0,
+				},
+			} )
+		);
+	} );
+
+	it( 'selects a default social image from the media library and saves it', async () => {
+		const user = userEvent.setup();
+		const selectedImageUrl = 'https://example.com/uploads/social-large.jpg';
+		const frame = mockMediaFrame( {
+			id: '456',
+			sizes: {
+				large: {
+					url: selectedImageUrl,
+				},
+			},
+			url: 'https://example.com/uploads/social-full.jpg',
+		} );
+		const socialImageSection = setupSeo();
+
+		await user.click(
+			within( socialImageSection ).getByRole( 'button', { name: 'Select image' } )
+		);
+
+		expect( window.wp.media ).toHaveBeenCalledWith( {
+			title: 'Select default social image',
+			button: {
+				text: 'Use this image',
+			},
+			library: {
+				type: 'image',
+			},
+			multiple: false,
+		} );
+		expect( frame.open ).toHaveBeenCalled();
+
+		await waitFor( () =>
+			expect(
+				within( socialImageSection ).getByAltText( 'Default social image preview' )
+			).toHaveAttribute( 'src', selectedImageUrl )
+		);
+		expect(
+			within( socialImageSection ).getByRole( 'button', { name: 'Replace image' } )
+		).toBeEnabled();
+		expect( within( socialImageSection ).getByTestId( 'twitter-preview' ) ).toHaveTextContent(
+			selectedImageUrl
+		);
+
+		await user.click(
+			within( socialImageSection ).getByRole( 'button', { name: 'Save settings' } )
+		);
+
+		await waitFor( () =>
+			expect( restApi.updateSettings ).toHaveBeenCalledWith( {
+				[ defaultSocialImageOption ]: {
+					default_image_id: 456,
+				},
+			} )
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -440,9 +440,13 @@ class Jetpack_Redux_State_Helper {
 	 * @return string
 	 */
 	public static function get_site_image(): string {
+		if ( class_exists( 'Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings' ) ) {
+			Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings::register_open_graph_filters();
+		}
+
 		// Get the dynamic image generated for the Open Graph Meta tags.
 		require_once JETPACK__PLUGIN_DIR . 'functions.opengraph.php';
-		return jetpack_og_get_fallback_social_image( 200, 200 )['src'];
+		return jetpack_og_get_fallback_social_image( 1200, 628 )['src'];
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -286,6 +286,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			$version             = $asset_manifest['version'];
 		}
 
+		wp_enqueue_media();
+
 		$blog_id_prop = '';
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 			$blog_id = Connection_Manager::get_site_id( true );

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2947,6 +2947,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'Jetpack_SEO_Titles::sanitize_title_formats',
 			),
 
+			'jetpack_social_open_graph_settings'        => array(
+				'description'       => esc_html__( 'Default Open Graph image settings.', 'jetpack' ),
+				'type'              => 'object',
+				'default'           => array(
+					'default_image_id' => 0,
+				),
+				'jp_group'          => 'seo-tools',
+				'validate_callback' => __CLASS__ . '::validate_open_graph_settings',
+			),
+
 			// VideoPress.
 			'videopress_private_enabled_for_site'       => array(
 				'description'       => esc_html__( 'Video Privacy: Restrict views to members of this site', 'jetpack' ),
@@ -3621,6 +3631,38 @@ class Jetpack_Core_Json_Api_Endpoints {
 				)
 			);
 		}
+		return true;
+	}
+
+	/**
+	 * Validate Open Graph image settings.
+	 *
+	 * @param array           $values  Values to validate.
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * @param string          $param   Name of the parameter passed to endpoint holding $values.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function validate_open_graph_settings( $values, $request, $param ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$array_validation = self::validate_array( $values, $request, $param );
+		if ( is_wp_error( $array_validation ) ) {
+			return $array_validation;
+		}
+
+		if (
+			isset( $values['default_image_id'] )
+			&& ( ! is_numeric( $values['default_image_id'] ) || $values['default_image_id'] < 0 )
+		) {
+			return new WP_Error(
+				'invalid_param',
+				sprintf(
+					/* Translators: Placeholder is a parameter name. */
+					esc_html__( '%s.default_image_id must be a non-negative integer.', 'jetpack' ),
+					$param
+				)
+			);
+		}
+
 		return true;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3637,7 +3637,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validate Open Graph image settings.
 	 *
-	 * @param array           $values  Values to validate.
+	 * @param mixed           $values  Values to validate.
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string          $param   Name of the parameter passed to endpoint holding $values.
 	 *

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1075,6 +1075,17 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 					break;
 
+				case 'jetpack_social_open_graph_settings':
+					if ( class_exists( 'Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings' ) ) {
+						$settings = new Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings();
+						$updated  = $settings->update_open_graph_settings( $value );
+
+						if ( $updated ) {
+							$response[ $option ] = $settings->get_open_graph_settings();
+						}
+					}
+					break;
+
 				default:
 					// Boolean values are stored as 1 or 0.
 					if ( isset( $options[ $option ]['type'] ) && 'boolean' === $options[ $option ]['type'] ) {

--- a/projects/plugins/jetpack/changelog/add-social-default-og-image
+++ b/projects/plugins/jetpack/changelog/add-social-default-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Settings: Add a default social image setting for Open Graph previews.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -730,8 +730,11 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_validate_open_graph_settings_requires_array() {
+		/** @var mixed $settings */
+		$settings = get_option( 'missing_open_graph_settings', 'invalid-settings' );
+
 		$result = Jetpack_Core_Json_Api_Endpoints::validate_open_graph_settings(
-			'invalid-settings',
+			$settings,
 			new WP_REST_Request(),
 			'jetpack_social_open_graph_settings'
 		);

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -725,6 +725,37 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that Open Graph settings only accept an array.
+	 *
+	 * @return void
+	 */
+	public function test_validate_open_graph_settings_requires_array() {
+		$result = Jetpack_Core_Json_Api_Endpoints::validate_open_graph_settings(
+			'invalid-settings',
+			new WP_REST_Request(),
+			'jetpack_social_open_graph_settings'
+		);
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Test that Open Graph settings reject invalid default image IDs.
+	 *
+	 * @return void
+	 */
+	public function test_validate_open_graph_settings_rejects_invalid_default_image_id() {
+		$result = Jetpack_Core_Json_Api_Endpoints::validate_open_graph_settings(
+			array( 'default_image_id' => -1 ),
+			new WP_REST_Request(),
+			'jetpack_social_open_graph_settings'
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_param', $result->get_error_code() );
+	}
+
+	/**
 	 * Regression for NL-618: re-posting newsletter categories with the same selection the option
 	 * already holds must return 200, not a `some_updated` 400. The previous code left `$updated`
 	 * false on the "values equal" short-circuit, so any save without an actual change blew up.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -759,6 +759,35 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that Open Graph settings can be saved through the Jetpack settings endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_open_graph_settings_save() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		delete_option( 'jetpack_social_open_graph_settings' );
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array(
+				'jetpack_social_open_graph_settings' => array(
+					'default_image_id' => 123,
+				),
+			),
+			'POST'
+		);
+
+		$expected = array( 'default_image_id' => 123 );
+
+		$this->assertResponseStatus( 200, $response );
+		$this->assertSame( $expected, $response->get_data()['jetpack_social_open_graph_settings'] );
+		$this->assertSame( $expected, get_option( 'jetpack_social_open_graph_settings' ) );
+	}
+
+	/**
 	 * Regression for NL-618: re-posting newsletter categories with the same selection the option
 	 * already holds must return 200, not a `some_updated` 400. The previous code left `$updated`
 	 * false on the "values equal" short-circuit, so any save without an actual change blew up.

--- a/projects/plugins/jetpack/tests/php/core-api/Jetpack_Core_Api_Module_Activate_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/Jetpack_Core_Api_Module_Activate_Endpoint_Test.php
@@ -99,6 +99,36 @@ class Jetpack_Core_Api_Module_Activate_Endpoint_Test extends Jetpack_REST_TestCa
 	}
 
 	/**
+	 * Tests updating Jetpack Social Open Graph settings through the Jetpack settings endpoint.
+	 */
+	public function test_update_data_open_graph_settings() {
+		delete_option( 'jetpack_social_open_graph_settings' );
+
+		$request = new WP_REST_Request();
+		$request->set_body_params(
+			array(
+				'jetpack_social_open_graph_settings' => array(
+					'default_image_id' => '123',
+				),
+			)
+		);
+
+		$result = ( new Jetpack_Core_API_Data() )->update_data( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'success', $result->get_data()['code'] );
+		$this->assertSame(
+			array( 'default_image_id' => 123 ),
+			$result->get_data()['jetpack_social_open_graph_settings']
+		);
+		$this->assertSame(
+			array( 'default_image_id' => 123 ),
+			get_option( 'jetpack_social_open_graph_settings' )
+		);
+	}
+
+	/**
 	 * Tests the update of a comment subscription setting in the Jetpack_Core_API_Data::update_data() method.
 	 *
 	 * @param int         $new_value The new value of the comment subscription setting.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
@@ -107,6 +107,21 @@ class WPCOM_REST_API_V2_Endpoint_External_Media_Test extends Jetpack_REST_TestCa
 	}
 
 	/**
+	 * Tests that external media cannot be created with an existing attachment ID.
+	 */
+	public function test_create_item_permissions_check_rejects_existing_post() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_External_Media();
+		$request  = new WP_REST_Request( Requests::POST, '/wpcom/v2/external-media/copy/pexels' );
+		$request->set_param( 'id', 123 );
+
+		$result = $endpoint->create_item_permissions_check( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_post_exists', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
 	 * Tests copy response with pexels while not setting metadata.
 	 */
 	public function test_copy_image() {

--- a/projects/plugins/social/changelog/add-social-default-og-image
+++ b/projects/plugins/social/changelog/add-social-default-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Settings: Add a default social image setting for Open Graph previews.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings as Jetpack_Social_Settings;
 use Automattic\Jetpack\Publicize\Social_Admin_Page;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
@@ -80,6 +81,7 @@ class Jetpack_Social {
 		);
 
 		Social_Admin_Page::init();
+		Jetpack_Social_Settings::register_open_graph_filters();
 
 		add_action( 'init', array( $this, 'do_init' ) );
 


### PR DESCRIPTION
Fixes #26042

## Proposed changes
* Add a site-level `jetpack_social_open_graph_settings` option with a `default_image_id` value for a default social/Open Graph image.
* Register the default image with Jetpack's Open Graph fallback filters so the selected image can be used when content does not have its own image.
* Add a default social image control to Jetpack Settings > Traffic > SEO, using the WordPress media library for image selection.
* Reuse the existing Google, Facebook, and X preview UI so admins can see how the homepage preview changes when the default social image is selected.
* Add REST option validation and save handling for the new Open Graph settings object.
* Add Publicize social settings store support and tests for saving the new Open Graph settings.
* Add changelog entries for Jetpack, Publicize, and Social.

## Related product discussion/links
* Primary request: #26042 asks for a way to upload a default custom image for Publicize when a post does not have a Featured Image. This PR productizes that request in Jetpack settings instead of requiring a code filter workaround.
* Open Publicize customization umbrella: #261 tracks long-running Publicize customization requests and includes many customer/support references; the discussion also includes image-control pain points around Publicize and Open Graph behavior.
* Related open Social image/preview work: #33847 asks for a default Social Image Generator template for pages, #39206 asks for Social Image Generator previews to reflect selected media, and #40244 discusses explicit image fallback/preview accuracy when posts lack a Featured Image.
* Related Social admin modernization: #48824 tracks the active Social wp-admin modernization work. This PR keeps the setting in Jetpack Settings > Traffic because the existing homepage search/social preview UI lives there today.
* Open Graph fallback history: #1191 includes a request to choose the default homepage `og:image` via the media library, #1931 covers blank fallback `og:image` behavior, #2284 covers small-image fallback behavior, and #33861 documents limitations of the existing default image filter workaround.

## Does this pull request change what data or activity we track or use?
No new tracking or activity data is introduced.

This stores a site option containing the media attachment ID selected by an admin as the site's default social/Open Graph image.

## Testing instructions
### Automated/local checks
* `CI=1 jetpack test js packages/publicize`
* `CI=1 jetpack test php packages/publicize`
* `CI=1 jetpack test js plugins/jetpack`
* `CI=1 jetpack build -v --production plugins/jetpack`
* `git diff --check`
* Pre-commit checks during commit: Prettier, ESLint, PHP lint, PHPCS, Stylelint.
* Pre-push checks during push: filename collision check and changelog check.

### Jurassic Ninja verification
Test site used: https://interim-tambourine.jurassic.ninja/wp-admin/admin.php?page=jetpack#/traffic

* Built the Jetpack plugin locally and deployed it to the Jurassic Ninja site with `jetpack rsync`.
* Opened Jetpack Settings > Traffic.
* Expanded the "Expand to choose a default social image and preview." foldout.
* Selected an image from the media library.
* Confirmed the selected image appears in the default social image area.
* Confirmed the Google, Facebook, and X previews use the selected default social image.
* Confirmed the helper text reads: `Recommended size is 1200x630px and < 600 KB.`
* Confirmed the helper text matches existing Jetpack settings helper text styling: 14px, italic, 400 weight, `rgb(116, 116, 116)`.
* Removed the image, saved settings, and confirmed the UI returns to the unselected state.

Not tested:
* Live external network crawler refreshes for Facebook, X, LinkedIn, or other social platforms.
* Multisite.
* The Jetpack Beta Tester PR build flow.

## Screenshots
After selecting a default social image in Jetpack Settings > Traffic:

![Default social image setting and previews](https://gist.githubusercontent.com/dhanson-wp/e9a0595a7bdc12b718aba035afa5bc99/raw/e5752444a1ed3aa82db68f3bb1bedba2ee1804f9/traffic-default-social-image-helper-refinement.png)


## Closes
Closes #26042.

