### PR TITLE
VideoPress: restructure upgrade notice as Title + Description + ActionButton

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
+++ b/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the upgrade notice CTA rendering as an out-of-place dark button; restore the standard primary button styling.
+Fix the upgrade notice CTA rendering as an out-of-place dark button; restore the lightweight text-link styling.

--- a/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
+++ b/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the upgrade notice CTA rendering as an out-of-place dark button; restore the lightweight text-link styling.
+Restructure the free-plan upgrade notice into a balanced Notice.Title heads-up line, a Notice.Description upsell pitch, and a concise "Upgrade" Notice.ActionButton, replacing the out-of-place dark button.

--- a/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
+++ b/projects/packages/videopress/changelog/fix-videopress-upgrade-cta-black-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the upgrade notice CTA rendering as an out-of-place dark button; restore the standard primary button styling.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -271,14 +271,24 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 		<Notice.Root intent="info" className={ styles[ 'upgrade-trigger' ] }>
 			<Notice.Description>{ description }</Notice.Description>
 			<Notice.Actions>
-				{ /* Render a standard primary Button rather than `Notice.ActionButton`:
-				   base-ui styles the latter as a dark/high-contrast button, which looks
-				   out of place here (see PR #48909). This restores the primary CTA the
-				   legacy `ContextualUpgradeTrigger` rendered. The click handler still
-				   records the Tracks event and runs the checkout workflow. */ }
-				<Button variant="primary" onClick={ onButtonClickHandler }>
+				{ /* Render the CTA as `Notice.ActionLink` rather than a filled Button:
+				   base-ui's `Notice.ActionButton` styles as a dark/high-contrast button
+				   and a filled primary Button carries too much weight for an upgrade
+				   nudge (see PR #48909). The lightweight text link matches the legacy
+				   `ContextualUpgradeTrigger` look and the modern dashboard's
+				   `free-tier-notice.tsx`. `ActionLink` is an anchor, so the placeholder
+				   `href="#"` is cancelled in the click handler; the wrapped
+				   `onButtonClickHandler` still records the Tracks event and then runs the
+				   checkout workflow. */ }
+				<Notice.ActionLink
+					href="#"
+					onClick={ event => {
+						event.preventDefault();
+						onButtonClickHandler();
+					} }
+				>
 					{ cta }
-				</Button>
+				</Notice.ActionLink>
 			</Notice.Actions>
 		</Notice.Root>
 	);

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -271,7 +271,14 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 		<Notice.Root intent="info" className={ styles[ 'upgrade-trigger' ] }>
 			<Notice.Description>{ description }</Notice.Description>
 			<Notice.Actions>
-				<Notice.ActionButton onClick={ onButtonClickHandler }>{ cta }</Notice.ActionButton>
+				{ /* Render a standard primary Button rather than `Notice.ActionButton`:
+				   base-ui styles the latter as a dark/high-contrast button, which looks
+				   out of place here (see PR #48909). This restores the primary CTA the
+				   legacy `ContextualUpgradeTrigger` rendered. The click handler still
+				   records the Tracks event and runs the checkout workflow. */ }
+				<Button variant="primary" onClick={ onButtonClickHandler }>
+					{ cta }
+				</Button>
 			</Notice.Actions>
 		</Notice.Root>
 	);

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -223,6 +223,10 @@ const UPGRADE_TRIGGER_FREE_PLAN_TEXT = __(
 	'The free plan includes one video upload.',
 	'jetpack-videopress-pkg'
 );
+const UPGRADE_TRIGGER_UNLOCK_TEXT = __(
+	'Unlock unlimited videos, 1TB of storage, and more!',
+	'jetpack-videopress-pkg'
+);
 
 const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) => {
 	const { adminUri, siteSuffix } = window.jetpackVideoPressInitialState;
@@ -252,43 +256,22 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 	// VIDP-245: keep the `Notice.Root` children shape invariant across the
 	// `hasUsedVideo` flip. base-ui@1.4.1's `useRenderElement` swaps between two
 	// different ref-merge hooks depending on subtree shape, so conditionally
-	// mounting `<Notice.Description>` (as this did before) misaligns its stored
-	// fork-ref and crashes on the next upload/delete. Always render the
-	// Description — mirroring the modern dashboard's `free-tier-notice.tsx` —
-	// varying only its text, with a non-empty fallback nudge before the first
-	// upload so we never render an empty styled row. The two strings are hoisted
-	// to module scope (above) to avoid the terser i18n ternary-fold.
-	const description = hasUsedVideo
-		? UPGRADE_TRIGGER_USED_VIDEO_TEXT
-		: UPGRADE_TRIGGER_FREE_PLAN_TEXT;
-
-	const cta = __(
-		'Upgrade now to unlock unlimited videos, 1TB of storage, and more!',
-		'jetpack-videopress-pkg'
-	);
+	// mounting/unmounting a `Notice` subcomponent across the flip misaligns its
+	// stored fork-ref and crashes on the next upload/delete. Therefore always
+	// render `Notice.Title`, `Notice.Description` and `Notice.Actions` — never
+	// wrap any of them in a `hasUsedVideo && (...)` conditional. Vary only the
+	// TEXT: the `title` line carries the contextual heads-up (non-empty in both
+	// states) while the Description holds the constant upsell pitch. The strings
+	// are hoisted to module scope (above) to avoid the terser i18n ternary-fold.
+	const title = hasUsedVideo ? UPGRADE_TRIGGER_USED_VIDEO_TEXT : UPGRADE_TRIGGER_FREE_PLAN_TEXT;
+	const cta = __( 'Upgrade', 'jetpack-videopress-pkg' );
 
 	return (
 		<Notice.Root intent="info" className={ styles[ 'upgrade-trigger' ] }>
-			<Notice.Description>{ description }</Notice.Description>
+			<Notice.Title>{ title }</Notice.Title>
+			<Notice.Description>{ UPGRADE_TRIGGER_UNLOCK_TEXT }</Notice.Description>
 			<Notice.Actions>
-				{ /* Render the CTA as `Notice.ActionLink` rather than a filled Button:
-				   base-ui's `Notice.ActionButton` styles as a dark/high-contrast button
-				   and a filled primary Button carries too much weight for an upgrade
-				   nudge (see PR #48909). The lightweight text link matches the legacy
-				   `ContextualUpgradeTrigger` look and the modern dashboard's
-				   `free-tier-notice.tsx`. `ActionLink` is an anchor, so the placeholder
-				   `href="#"` is cancelled in the click handler; the wrapped
-				   `onButtonClickHandler` still records the Tracks event and then runs the
-				   checkout workflow. */ }
-				<Notice.ActionLink
-					href="#"
-					onClick={ event => {
-						event.preventDefault();
-						onButtonClickHandler();
-					} }
-				>
-					{ cta }
-				</Notice.ActionLink>
+				<Notice.ActionButton onClick={ onButtonClickHandler }>{ cta }</Notice.ActionButton>
 			</Notice.Actions>
 		</Notice.Root>
 	);


### PR DESCRIPTION
Fixes the upgrade-notice CTA styling regression reported by @obenland on #48909 ([comment](https://github.com/Automattic/jetpack/pull/48909#issuecomment-4563531955)).

## Proposed changes

* PR #48909 migrated the legacy `ContextualUpgradeTrigger` on the VideoPress admin page to a `@wordpress/ui` `Notice`, rendering the CTA via `<Notice.ActionButton>`. base-ui styles that as a dark/high-contrast (black) button, which "looks quite out of place" on the page.
* Per PR review (thanks @keoshi and @simison): @keoshi preferred a clear **button** over a long text link, and @simison suggested structuring the notice as two balanced lines — a `Notice.Title` plus a `Notice.Description` — followed by `Notice.Actions` > `Notice.ActionButton`. This PR adopts exactly that structure.
* The notice now renders:
  * `<Notice.Title>` — a contextual heads-up line. Before the first upload it reads "The free plan includes one video upload."; after a video has been uploaded it reads "You have used your free video upload". It is **always non-empty**.
  * `<Notice.Description>` — the constant upsell pitch: "Unlock unlimited videos, 1TB of storage, and more!".
  * `<Notice.Actions>` > `<Notice.ActionButton>` — a concise "Upgrade" button.
* Because `Notice.ActionButton` takes `onClick` directly, the previous `Notice.ActionLink` `href="#"` + `event.preventDefault()` workaround (the gutenberg#77098 anchor-navigation hack) is dropped entirely.
* The `Notice` container migration from #48909 is **not** reverted — only the action element and copy structure change.

```diff
 <Notice.Root intent="info" className={ styles[ 'upgrade-trigger' ] }>
-  <Notice.Description>
-    { hasUsedVideo && ( <>{ UPGRADE_TRIGGER_USED_VIDEO_TEXT }<br /></> ) }
-    { UPGRADE_TRIGGER_UNLOCK_TEXT }
-  </Notice.Description>
-  <Notice.Actions>
-    <Notice.ActionLink href="#" onClick={ e => { e.preventDefault(); onButtonClickHandler(); } }>
-      { cta }
-    </Notice.ActionLink>
-  </Notice.Actions>
+  <Notice.Title>{ title }</Notice.Title>
+  <Notice.Description>{ UPGRADE_TRIGGER_UNLOCK_TEXT }</Notice.Description>
+  <Notice.Actions>
+    <Notice.ActionButton onClick={ onButtonClickHandler }>{ cta }</Notice.ActionButton>
+  </Notice.Actions>
 </Notice.Root>
```

<img width="725" height="155" alt="image" src="https://github.com/user-attachments/assets/4d3c1a9a-2950-48e1-971d-4772bb524e54" />

### VIDP-245 invariant

base-ui@1.4.1's `useRenderElement` swaps ref-merge hooks based on the `Notice.Root` subtree shape; conditionally mounting/unmounting a `Notice` subcomponent across the `hasUsedVideo` flip misaligns a stored fork-ref and crashes on the next video upload/delete. So `Notice.Title`, `Notice.Description` and `Notice.Actions` are **all rendered unconditionally** — only the `title` text varies via a ternary, keeping the subtree shape stable.

## Related product discussion/links

* Originating PR: #48909 ("Componentry: migrate ContextualUpgradeTrigger to @wordpress/ui Notice")
* Regression report: https://github.com/Automattic/jetpack/pull/48909#issuecomment-4563531955

## Does this pull request change what data or activity we track or use?

No. The click handler still records the `jetpack_videopress_upgrade_trigger_link_click` Tracks event **and** still invokes the checkout `run` workflow. The wiring `recordEventHandler( 'jetpack_videopress_upgrade_trigger_link_click', run )` is unchanged; `Notice.ActionButton` now receives that handler directly as `onClick` (no anchor, no `preventDefault`). Verified in the compiled `build/admin/index.js` bundle: `Notice.ActionButton` is rendered with `onClick: onButtonClickHandler`, and `onButtonClickHandler = recordEventHandler('jetpack_videopress_upgrade_trigger_link_click', run)` is intact.

## Testing instructions

The upgrade notice only renders when there is **no** VideoPress purchase (`hasVideoPressPurchase === false`). On a site with a VideoPress subscription, remove/cancel it first so the free-tier upgrade notice appears.

* Go to **Jetpack → VideoPress** (`/wp-admin/admin.php?page=jetpack-videopress`).
* Confirm the notice shows two balanced lines — a bold `Notice.Title` heads-up ("The free plan includes one video upload." before any upload) and a `Notice.Description` pitch ("Unlock unlimited videos, 1TB of storage, and more!") — followed by a concise "Upgrade" **button** (not a black button and not a filled primary button).
* Upload one video, then revisit: the title should switch to "You have used your free video upload" while the description and button stay the same.
* Click the **Upgrade** button and confirm it still kicks off the checkout flow, and that the `jetpack_videopress_upgrade_trigger_link_click` Tracks event still fires.
* Sanity-check the VIDP-245 path: upload a video then delete it; the page must not crash (the always-rendered `Notice.Title`/`Notice.Description`/`Notice.Actions` invariant is intact).
