### PR TITLE
Hello Dolly: retire legacy per-page #dolly rules (#49285 Phase 4)

### DIFF
--- a/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
@@ -42,26 +42,6 @@
 	}
 }
 
-// Hello Dolly positioning overwrite
-.jetpack-pagestyles #dolly {
-	float: none;
-	position: relative;
-	right: 0;
-	left: 0;
-	top: 0;
-	padding: rem.convert(10px);
-	text-align: right;
-	background: colors.$white;
-	font-size: rem.convert(12px);
-	font-style: italic;
-	color: colors.$gray;
-	border-bottom: none;
-
-	@include breakpoints.breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-
 .dops-notice__text a {
 	text-decoration: underline;
 }

--- a/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
@@ -200,18 +200,3 @@
 #jp-plugin-container .wrap .jetpack-wrap-container {
 	margin-top: 1em;
 }
-
-.wp-admin #dolly {
-	float: none;
-	position: relative;
-	right: 0;
-	left: 0;
-	top: 0;
-	padding: 0.625rem;
-	text-align: right;
-	background: #fff;
-	font-size: 0.75rem;
-	font-style: italic;
-	color: #87a6bc;
-	border-bottom: none;
-}

--- a/projects/plugins/jetpack/changelog/change-retire-legacy-dolly-rules
+++ b/projects/plugins/jetpack/changelog/change-retire-legacy-dolly-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Hello Dolly: retire the legacy per-page `#dolly` color rules so the normalized `.jetpack-admin-page #dolly` treatment (WPDS design token) governs consistently across admin pages.


### PR DESCRIPTION
Part of #49285 (Phase 4 — the final phase).

## Proposed changes

Retire the two legacy per-page Hello Dolly rules now that WPDS design tokens load on every Jetpack admin page (build-time for the legacy `_inc` pages via #48750, runtime for modernized pages via #49345), so the single normalized central rule governs Dolly consistently.

* **Remove `.wp-admin #dolly`** — `_inc/client/scss/shared/admin-static.scss` (static `#87a6bc`).
* **Remove `.jetpack-pagestyles #dolly`** — `_inc/client/scss/shared/_main.scss` (SCSS `$gray` ≈ `#a1a1a1`).

The central `:global(.jetpack-admin-page #dolly)` rule (token-based, resolves to `#707070`) is left as the sole rule. The three rules all had **equal specificity** (class + id), so the legacy two only competed with the central one by load order. Their `position: relative` used **all-zero offsets** (`top/right/left: 0`) — visually identical to `static` — so removing them causes **no layout shift**; the central rule's `@media (max-width: 659px) { display: none }` already covers the `<660px` breakpoint the legacy rules handled.

**Net visible effect:** Hello Dolly converges to `#707070` on the pages where a legacy rule previously won (Settings/Dashboard/Debugger), with `hello.php`'s default padding (`5px 10px` vs the legacy `10px` — Dolly is ~10px shorter). Intended per the tracking issue.

**Preserved (untouched):** My Jetpack's `p#dolly { display: none }` (its own package CSS) and JITM adjacency.

## Related product discussion/links

* Issue: #49285
* Phase 2 companions (merged): #48750 (build-time tokens, legacy `_inc`), #49345 (runtime tokens stylesheet)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a Jetpack admin page where Hello Dolly is active (the `hello.php` plugin enabled):

1. Go to **Jetpack → Dashboard** (and **Settings**, **Debugger**).
2. Inspect the `<p id="dolly">` strip at the top of the content area.
3. Its color should be `#707070` (WPDS `--wpds-color-fg-content-neutral-weak`), governed solely by `.jetpack-admin-page #dolly` — the `.wp-admin #dolly` and `.jetpack-pagestyles #dolly` rules should no longer exist in the loaded CSS.
4. Confirm no positioning regression: Dolly remains top-right-aligned in normal flow, not overlapping the page title.
5. **My Jetpack:** Hello Dolly remains hidden (`display: none`).

Verified locally (dev site, with #48750 + #49345 on trunk): Dashboard `#dolly` computed `color: rgb(112, 112, 112)` (`#707070`), `position: static`, same `top/left/width` as before — no layout regression; only the two legacy rules removed, central rule governs.

### Screenshots

Before (legacy rule wins → `#87a6bc`):

<!-- drag before screenshot here -->

After (central token rule → `#707070`):

<!-- drag phase4-dolly-dashboard-707070.png here -->
