### PR TITLE
Brute force protection: Avoid a fatal error when rendering the login recovery form while an output buffer handler is active.

### DIFF
--- a/projects/packages/waf/changelog/jetpack-bfp-dont-fatal-on-output-buffer
+++ b/projects/packages/waf/changelog/jetpack-bfp-dont-fatal-on-output-buffer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Brute force protection: Avoid a fatal error when rendering the login recovery form while an output buffer handler is active.

--- a/projects/packages/waf/src/abstract-blocked-login-page.php
+++ b/projects/packages/waf/src/abstract-blocked-login-page.php
@@ -438,23 +438,24 @@ abstract class Blocked_Login_Page {
 	 * Get the HTML recovery form.
 	 */
 	public function get_html_recovery_form() {
-		ob_start(); ?>
-		<div>
+		// Build the markup as a string instead of using output buffering. Calling
+		// ob_start() while PHP is executing an output-buffer handler (e.g. a page
+		// cache or compression handler) raises a fatal: "Cannot use output buffering
+		// in output buffering display handlers".
+		return sprintf(
+			'<div>
 			<form method="post" action="?jetpack-protect-recovery=true">
-				<?php wp_nonce_field( 'bypass-protect' ); ?> 
-				<p><label for="email"><?php esc_html_e( 'Your email', 'jetpack-waf' ); ?><br/></label>
+				%1$s
+				<p><label for="email">%2$s<br/></label>
 					<input type="email" name="email" class="text-input"/>
-					<input type="submit" class="button"
-						value="<?php esc_attr_e( 'Send email', 'jetpack-waf' ); ?>"/>
+					<input type="submit" class="button" value="%3$s"/>
 				</p>
 			</form>
-		</div>
-
-		<?php
-		$contents = ob_get_contents();
-		ob_end_clean();
-
-		return $contents;
+		</div>',
+			wp_nonce_field( 'bypass-protect', '_wpnonce', true, false ),
+			esc_html__( 'Your email', 'jetpack-waf' ),
+			esc_attr__( 'Send email', 'jetpack-waf' )
+		);
 	}
 
 	/**
@@ -479,7 +480,7 @@ abstract class Blocked_Login_Page {
 		}
 		?>
 		<!DOCTYPE html>
-		<html xmlns="http://www.w3.org/1999/xhtml" 
+		<html xmlns="http://www.w3.org/1999/xhtml"
 		<?php
 		if ( function_exists( 'language_attributes' ) && function_exists( 'is_rtl' ) ) {
 			language_attributes();
@@ -702,7 +703,7 @@ abstract class Blocked_Login_Page {
 				?>
 			</style>
 		</head>
-		<body id="error-page" <?php echo $rtl_class; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>> 
+		<body id="error-page" <?php echo $rtl_class; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<h1 id="error-title"><?php echo esc_html( $title ); ?></h1>
 			<div id="error-message">
 				<svg id="image" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 250 134">


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/PROTECT-172

## Proposed changes
<!--- Explain what functional changes your PR includes -->
  * Rebuild `get_html_recovery_form()` in the WAF brute-force protection blocked-login page to assemble its HTML via `sprintf()` instead of `ob_start()` / `ob_get_contents()` / `ob_end_clean()`.
  * Generate the nonce field with `wp_nonce_field( 'bypass-protect', '_wpnonce', true, false )` so it returns markup rather than echoing.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*  https://linear.app/a8c/issue/PROTECT-172

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* On a Jetpack-connected test site with Brute Force Protection (formerly known as Protect) active, force the locked login page by defining `JETPACK_ALWAYS_PROTECT_LOGIN` as `true` (e.g. via an mu-plugin or `wp config set   JETPACK_ALWAYS_PROTECT_LOGIN true --raw`). In the Jetpack dev env you can drop a file into for example `tools/docker/mu-plugins/protect-always-block-login.php` like 
```php
<?php

defined( 'JETPACK_ALWAYS_PROTECT_LOGIN' ) || define( 'JETPACK_ALWAYS_PROTECT_LOGIN', true );
```
  * Visit `/wp-login.php` and confirm the locked page renders with the email recovery form (email input + "Send email" button) and that submitting it still behaves as before.