### PR TITLE
SEO: migrate Sitemaps + Canonical URLs module state to durable options (PR #5a)

### DIFF
--- a/projects/packages/seo/changelog/read-canonical-enabled-from-option
+++ b/projects/packages/seo/changelog/read-canonical-enabled-from-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Read the canonical-URLs enabled-state from the durable `jetpack_seo_canonical_urls_enabled` option (falling back to the live module state when unset) so it survives the standalone Canonical URLs module's eventual removal.

--- a/projects/packages/seo/changelog/read-sitemap-enabled-from-option
+++ b/projects/packages/seo/changelog/read-sitemap-enabled-from-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Read the sitemap enabled-state from the durable `jetpack_seo_sitemap_enabled` option (falling back to the live module state when unset) so it survives the standalone Sitemaps module's eventual removal.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -81,6 +81,20 @@ class Initializer {
 	const META_SCHEMA_TYPE = 'jetpack_seo_schema_type';
 
 	/**
+	 * Option recording whether sitemap generation is enabled.
+	 *
+	 * Read in place of the standalone `sitemaps` module's active state. Module-active
+	 * state is filtered against the modules present on disk, so once that module is
+	 * removed it would read as inactive even for sites that had it on. A one-time
+	 * migration in the Jetpack plugin seeds this option from the site's existing module
+	 * state and keeps it in sync while the legacy module still exists. See
+	 * `Jetpack::migrate_sitemaps_module_to_seo_option()`.
+	 *
+	 * @var string
+	 */
+	const SITEMAP_ENABLED_OPTION = 'jetpack_seo_sitemap_enabled';
+
+	/**
 	 * Whether the package has been initialized.
 	 *
 	 * @var bool
@@ -282,6 +296,21 @@ class Initializer {
 	}
 
 	/**
+	 * Whether sitemap generation is enabled.
+	 *
+	 * Reads the durable {@see self::SITEMAP_ENABLED_OPTION} flag. The default is only
+	 * used when the option is absent (for example before the Jetpack plugin's migration
+	 * has run on a freshly upgraded site), in which case it falls back to the live
+	 * `sitemaps` module state so behavior is unchanged in that gap.
+	 *
+	 * @param Modules $modules Modules instance to read live module state from.
+	 * @return bool
+	 */
+	private static function is_sitemap_enabled( Modules $modules ) {
+		return (bool) get_option( self::SITEMAP_ENABLED_OPTION, $modules->is_active( 'sitemaps' ) );
+	}
+
+	/**
 	 * Build the aggregated Overview state the dashboard renders.
 	 *
 	 * @return array
@@ -299,9 +328,9 @@ class Initializer {
 		return array(
 			'site_visibility'   => array(
 				'search_engines_visible' => (int) get_option( 'blog_public', 1 ) === 1,
-				// The real `sitemaps` module is the source of truth (the Settings
-				// toggle drives it via `/jetpack/v4/settings`).
-				'sitemap_active'         => $modules->is_active( 'sitemaps' ),
+				// Read the durable SEO option (seeded/synced from the `sitemaps` module
+				// by the Jetpack plugin) so the state survives the module's removal.
+				'sitemap_active'         => self::is_sitemap_enabled( $modules ),
 				'sitemap_url'            => home_url( '/sitemap.xml' ),
 				'seo_tools_active'       => $modules->is_active( 'seo-tools' ),
 			),
@@ -451,9 +480,9 @@ class Initializer {
 
 		return array(
 			'search_engines_visible' => (int) get_option( 'blog_public', 1 ) === 1,
-			// The real `sitemaps` module is the source of truth (not a bespoke
-			// option). The Settings toggle drives it via `/jetpack/v4/settings`.
-			'sitemap_active'         => $modules->is_active( 'sitemaps' ),
+			// Read the durable SEO option (seeded/synced from the `sitemaps` module
+			// by the Jetpack plugin) so the state survives the module's removal.
+			'sitemap_active'         => self::is_sitemap_enabled( $modules ),
 			// Canonical URLs is its own module, toggled the same way as sitemaps.
 			'canonical_active'       => $modules->is_active( 'canonical-urls' ),
 			// Cast to object so an empty format set serializes as `{}`, not `[]`.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -307,7 +307,16 @@ class Initializer {
 	 * @return bool
 	 */
 	private static function is_sitemap_enabled( Modules $modules ) {
-		return (bool) get_option( self::SITEMAP_ENABLED_OPTION, $modules->is_active( 'sitemaps' ) );
+		$enabled = get_option( self::SITEMAP_ENABLED_OPTION, null );
+
+		// Only fall back to the live module state when the durable option is absent.
+		// Passing it as get_option()'s default would evaluate it on every call, since
+		// PHP resolves function arguments eagerly even when the option exists.
+		if ( null === $enabled ) {
+			$enabled = $modules->is_active( 'sitemaps' );
+		}
+
+		return (bool) $enabled;
 	}
 
 	/**

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -95,6 +95,20 @@ class Initializer {
 	const SITEMAP_ENABLED_OPTION = 'jetpack_seo_sitemap_enabled';
 
 	/**
+	 * Option recording whether canonical URLs are enabled.
+	 *
+	 * Read in place of the standalone `canonical-urls` module's active state. Module-active
+	 * state is filtered against the modules present on disk, so once that module is
+	 * removed it would read as inactive even for sites that had it on. A one-time
+	 * migration in the Jetpack plugin seeds this option from the site's existing module
+	 * state and keeps it in sync while the legacy module still exists. See
+	 * `Jetpack::migrate_canonical_urls_module_to_seo_option()`.
+	 *
+	 * @var string
+	 */
+	const CANONICAL_ENABLED_OPTION = 'jetpack_seo_canonical_urls_enabled';
+
+	/**
 	 * Whether the package has been initialized.
 	 *
 	 * @var bool
@@ -320,6 +334,30 @@ class Initializer {
 	}
 
 	/**
+	 * Whether canonical URLs are enabled.
+	 *
+	 * Reads the durable {@see self::CANONICAL_ENABLED_OPTION} flag. The default is only
+	 * used when the option is absent (for example before the Jetpack plugin's migration
+	 * has run on a freshly upgraded site), in which case it falls back to the live
+	 * `canonical-urls` module state so behavior is unchanged in that gap.
+	 *
+	 * @param Modules $modules Modules instance to read live module state from.
+	 * @return bool
+	 */
+	private static function is_canonical_enabled( Modules $modules ) {
+		$enabled = get_option( self::CANONICAL_ENABLED_OPTION, null );
+
+		// Only fall back to the live module state when the durable option is absent.
+		// Passing it as get_option()'s default would evaluate it on every call, since
+		// PHP resolves function arguments eagerly even when the option exists.
+		if ( null === $enabled ) {
+			$enabled = $modules->is_active( 'canonical-urls' );
+		}
+
+		return (bool) $enabled;
+	}
+
+	/**
 	 * Build the aggregated Overview state the dashboard renders.
 	 *
 	 * @return array
@@ -492,8 +530,9 @@ class Initializer {
 			// Read the durable SEO option (seeded/synced from the `sitemaps` module
 			// by the Jetpack plugin) so the state survives the module's removal.
 			'sitemap_active'         => self::is_sitemap_enabled( $modules ),
-			// Canonical URLs is its own module, toggled the same way as sitemaps.
-			'canonical_active'       => $modules->is_active( 'canonical-urls' ),
+			// Read the durable SEO option (seeded/synced from the `canonical-urls` module
+			// by the Jetpack plugin) so the state survives the module's removal.
+			'canonical_active'       => self::is_canonical_enabled( $modules ),
 			// Cast to object so an empty format set serializes as `{}`, not `[]`.
 			'title_formats'          => (object) $title_formats,
 			'front_page_description' => (string) $front_page_desc,

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -204,4 +204,26 @@ class InitializerTest extends TestCase {
 		$this->assertIsString( $site['icon'] );
 		$this->assertIsString( $site['image'] );
 	}
+
+	/**
+	 * Reads the durable sitemap option without consulting the live module state
+	 * when the option is present (set or explicitly off).
+	 */
+	public function test_is_sitemap_enabled_reads_durable_option() {
+		$method = new \ReflectionMethod( Initializer::class, 'is_sitemap_enabled' );
+		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$modules = new \Automattic\Jetpack\Modules();
+
+		update_option( Initializer::SITEMAP_ENABLED_OPTION, '1' );
+		$this->assertTrue( $method->invoke( null, $modules ) );
+
+		// Present-but-off: still read from the option, never the module fallback.
+		update_option( Initializer::SITEMAP_ENABLED_OPTION, '' );
+		$this->assertFalse( $method->invoke( null, $modules ) );
+
+		delete_option( Initializer::SITEMAP_ENABLED_OPTION );
+	}
 }

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -248,4 +248,23 @@ class InitializerTest extends TestCase {
 
 		delete_option( Initializer::CANONICAL_ENABLED_OPTION );
 	}
+
+	/**
+	 * The Settings bootstrap sources `sitemap_active` / `canonical_active` from the durable
+	 * options, so the module toggles hydrate correctly without reading live module state.
+	 */
+	public function test_get_settings_data_reads_module_toggles_from_options() {
+		update_option( Initializer::SITEMAP_ENABLED_OPTION, '1' );
+		update_option( Initializer::CANONICAL_ENABLED_OPTION, '' );
+
+		$settings = Initializer::get_settings_data();
+
+		$this->assertArrayHasKey( 'sitemap_active', $settings );
+		$this->assertArrayHasKey( 'canonical_active', $settings );
+		$this->assertTrue( $settings['sitemap_active'] );
+		$this->assertFalse( $settings['canonical_active'] );
+
+		delete_option( Initializer::SITEMAP_ENABLED_OPTION );
+		delete_option( Initializer::CANONICAL_ENABLED_OPTION );
+	}
 }

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -226,4 +226,26 @@ class InitializerTest extends TestCase {
 
 		delete_option( Initializer::SITEMAP_ENABLED_OPTION );
 	}
+
+	/**
+	 * Reads the durable canonical-urls option without consulting the live module state
+	 * when the option is present (set or explicitly off).
+	 */
+	public function test_is_canonical_enabled_reads_durable_option() {
+		$method = new \ReflectionMethod( Initializer::class, 'is_canonical_enabled' );
+		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$modules = new \Automattic\Jetpack\Modules();
+
+		update_option( Initializer::CANONICAL_ENABLED_OPTION, '1' );
+		$this->assertTrue( $method->invoke( null, $modules ) );
+
+		// Present-but-off: still read from the option, never the module fallback.
+		update_option( Initializer::CANONICAL_ENABLED_OPTION, '' );
+		$this->assertFalse( $method->invoke( null, $modules ) );
+
+		delete_option( Initializer::CANONICAL_ENABLED_OPTION );
+	}
 }

--- a/projects/packages/seo/tests/php/stubs/class-jetpack-seo-utils.php
+++ b/projects/packages/seo/tests/php/stubs/class-jetpack-seo-utils.php
@@ -31,5 +31,15 @@ if ( ! class_exists( 'Jetpack_SEO_Utils' ) ) {
 		public static function is_enabled_jetpack_seo() {
 			return self::$enabled;
 		}
+
+		/**
+		 * Stub for the host plugin's front-page meta description getter, read by
+		 * Initializer::get_settings_data().
+		 *
+		 * @return string
+		 */
+		public static function get_front_page_meta_description() {
+			return '';
+		}
 	}
 }

--- a/projects/plugins/jetpack/changelog/migrate-canonical-urls-module-to-seo-option
+++ b/projects/plugins/jetpack/changelog/migrate-canonical-urls-module-to-seo-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO: seed and keep in sync a durable `jetpack_seo_canonical_urls_enabled` option from the Canonical URLs module's active state, so the setting is preserved when the standalone module is later absorbed into Jetpack SEO. Non-destructive: no settings are changed or removed.

--- a/projects/plugins/jetpack/changelog/migrate-sitemaps-module-to-seo-option
+++ b/projects/plugins/jetpack/changelog/migrate-sitemaps-module-to-seo-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO: seed and keep in sync a durable `jetpack_seo_sitemap_enabled` option from the Sitemaps module's active state, so the setting is preserved when the standalone module is later absorbed into Jetpack SEO. Non-destructive: no sitemap data is regenerated or removed.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2858,7 +2858,7 @@ p {
 	 *
 	 * Extracted from file scope so the wiring is unit-testable (file-scope `add_action()`
 	 * calls run during bootstrap and can't be exercised by a test). Removed alongside the
-	 * modules in the #5b cleanup.
+	 * modules in the deferred post-convergence follow-up that absorbs them into Jetpack SEO.
 	 */
 	public static function register_seo_module_migration_hooks() {
 		add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) );

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2769,6 +2769,48 @@ p {
 	}
 
 	/**
+	 * Records whether the standalone Sitemaps module is active so the setting survives
+	 * the module's removal.
+	 *
+	 * The Jetpack SEO product reads the {@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION}
+	 * option instead of the `sitemaps` module's active state. Module-active state is
+	 * filtered against the modules present on disk, so once the standalone module is
+	 * removed it would read as inactive even for sites that had it on. This one-time
+	 * migration captures the raw `active_modules` membership — which persists regardless
+	 * of whether the module file is present — into the durable option.
+	 *
+	 * Deliberately non-destructive: it never touches generated sitemap data
+	 * (`jp_sitemap*` posts), the `jetpack-sitemap-state` option, sitemap settings, or the
+	 * `jp_sitemap_cron_hook` cron, so no regeneration is triggered. `add_option()` only
+	 * seeds when the option is absent, so it is safe to run on every version bump and
+	 * never reverts a value the user has since set.
+	 *
+	 * Hooked on `updating_jetpack_version`; the version arguments are not needed because
+	 * `add_option()` provides the run-once guard.
+	 */
+	public static function migrate_sitemaps_module_to_seo_option() {
+		// $available_only = false reads raw `active_modules` membership, so the value is
+		// correct even when the standalone sitemaps module file has already been removed.
+		$sitemaps_active = ( new Modules() )->is_active( 'sitemaps', false );
+
+		add_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, $sitemaps_active );
+	}
+
+	/**
+	 * Keeps the Jetpack SEO sitemap option in sync with the legacy `sitemaps` module
+	 * while both still exist.
+	 *
+	 * Hooked to the module's activate/deactivate actions, so toggling sitemaps from any
+	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
+	 * durable {@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION} option current. The
+	 * actions fire after `active_modules` is updated, so the module state read here
+	 * already reflects the new value. Removed alongside the module itself.
+	 */
+	public static function sync_seo_sitemap_option() {
+		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, ( new Modules() )->is_active( 'sitemaps' ) );
+	}
+
+	/**
 	 * Sets the display_update_modal state.
 	 */
 	public static function set_update_modal_display() {

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2811,6 +2811,46 @@ p {
 	}
 
 	/**
+	 * Records whether the standalone Canonical URLs module is active so the setting survives
+	 * the module's removal.
+	 *
+	 * The Jetpack SEO product reads the {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION}
+	 * option instead of the `canonical-urls` module's active state. Module-active state is
+	 * filtered against the modules present on disk, so once the standalone module is
+	 * removed it would read as inactive even for sites that had it on. This one-time
+	 * migration captures the raw `active_modules` membership — which persists regardless
+	 * of whether the module file is present — into the durable option.
+	 *
+	 * Deliberately non-destructive: `add_option()` only seeds when the option is absent, so
+	 * it is safe to run on every version bump and never reverts a value the user has since
+	 * set.
+	 *
+	 * Hooked on `updating_jetpack_version`; the version arguments are not needed because
+	 * `add_option()` provides the run-once guard.
+	 */
+	public static function migrate_canonical_urls_module_to_seo_option() {
+		// $available_only = false reads raw `active_modules` membership, so the value is
+		// correct even when the standalone canonical-urls module file has already been removed.
+		$canonical_active = ( new Modules() )->is_active( 'canonical-urls', false );
+
+		add_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, $canonical_active );
+	}
+
+	/**
+	 * Keeps the Jetpack SEO canonical-urls option in sync with the legacy `canonical-urls`
+	 * module while both still exist.
+	 *
+	 * Hooked to the module's activate/deactivate actions, so toggling canonical URLs from any
+	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
+	 * durable {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION} option current. The
+	 * actions fire after `active_modules` is updated, so the module state read here
+	 * already reflects the new value. Removed alongside the module itself.
+	 */
+	public static function sync_seo_canonical_urls_option() {
+		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, ( new Modules() )->is_active( 'canonical-urls' ) );
+	}
+
+	/**
 	 * Sets the display_update_modal state.
 	 */
 	public static function set_update_modal_display() {

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2851,6 +2851,26 @@ p {
 	}
 
 	/**
+	 * Wires up the migration + sync hooks that keep the durable Jetpack SEO module-state
+	 * options ({@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION} /
+	 * {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION}) seeded and in sync with their
+	 * legacy modules. Called once from `load-jetpack.php`.
+	 *
+	 * Extracted from file scope so the wiring is unit-testable (file-scope `add_action()`
+	 * calls run during bootstrap and can't be exercised by a test). Removed alongside the
+	 * modules in the #5b cleanup.
+	 */
+	public static function register_seo_module_migration_hooks() {
+		add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) );
+		add_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
+		add_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
+
+		add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) );
+		add_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
+		add_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
+	}
+
+	/**
 	 * Sets the display_update_modal state.
 	 */
 	public static function set_update_modal_display() {

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -86,6 +86,11 @@ if ( is_admin() ) {
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'activate_subscriptions_module_for_existing_sites' ), 10, 2 );
+add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) );
+// Keep the Jetpack SEO sitemap option in sync with the legacy `sitemaps` module while
+// both still exist. Removed when the standalone module is removed.
+add_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
+add_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -91,6 +91,11 @@ add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_modu
 // both still exist. Removed when the standalone module is removed.
 add_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
 add_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
+add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) );
+// Keep the Jetpack SEO canonical-urls option in sync with the legacy `canonical-urls`
+// module while both still exist. Removed when the standalone module is removed.
+add_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
+add_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -86,16 +86,9 @@ if ( is_admin() ) {
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'activate_subscriptions_module_for_existing_sites' ), 10, 2 );
-add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) );
-// Keep the Jetpack SEO sitemap option in sync with the legacy `sitemaps` module while
-// both still exist. Removed when the standalone module is removed.
-add_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
-add_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) );
-add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) );
-// Keep the Jetpack SEO canonical-urls option in sync with the legacy `canonical-urls`
-// module while both still exist. Removed when the standalone module is removed.
-add_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
-add_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
+// Seed + keep in sync the durable Jetpack SEO module-state options while the legacy
+// Sitemaps / Canonical URLs modules still exist. Removed in the #5b cleanup.
+Jetpack::register_seo_module_migration_hooks();
 add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -87,7 +87,8 @@ if ( is_admin() ) {
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'activate_subscriptions_module_for_existing_sites' ), 10, 2 );
 // Seed + keep in sync the durable Jetpack SEO module-state options while the legacy
-// Sitemaps / Canonical URLs modules still exist. Removed in the #5b cleanup.
+// Sitemaps / Canonical URLs modules still exist. Removed in the deferred post-convergence
+// follow-up that absorbs those modules into Jetpack SEO.
 Jetpack::register_seo_module_migration_hooks();
 add_filter( 'is_jetpack_site', '__return_true' );
 

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -138,6 +138,10 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="seo-module-migration">
+			<file>tests/php/SEO_Sitemap_Migration_Test.php</file>
+			<file>tests/php/SEO_Canonical_URLs_Migration_Test.php</file>
+		</testsuite>
 	</testsuites>
 
 	<groups>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -129,6 +129,10 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="seo-module-migration">
+			<file>tests/php/SEO_Sitemap_Migration_Test.php</file>
+			<file>tests/php/SEO_Canonical_URLs_Migration_Test.php</file>
+		</testsuite>
 	</testsuites>
 
 	<groups>

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -10,11 +10,13 @@ use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
+ * Covers only \Jetpack here: the migration is seeded/synced from the plugin, while the
+ * seo package's Initializer (whose option getters this test also exercises) lives outside
+ * this suite's coverage scope and is measured by the package's own unit tests.
+ *
  * @covers \Jetpack
- * @covers \Automattic\Jetpack\SEO\Initializer
  */
 #[CoversClass( Jetpack::class )]
-#[CoversClass( Jetpack_SEO_Initializer::class )]
 class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests the one-time migration that records the Canonical URLs module's state into the
+ * durable Jetpack SEO option, and the sync that keeps the two aligned.
+ *
+ * @package jetpack
+ */
+
+use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Jetpack
+ * @covers \Automattic\Jetpack\SEO\Initializer
+ */
+#[CoversClass( Jetpack::class )]
+#[CoversClass( Jetpack_SEO_Initializer::class )]
+class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The durable option under test.
+	 *
+	 * @var string
+	 */
+	private $option = Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION;
+
+	/**
+	 * Reset the option and active-modules list between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( $this->option );
+		Jetpack_Options::delete_option( 'active_modules' );
+	}
+
+	/**
+	 * Mark the given modules active in the raw `active_modules` option.
+	 *
+	 * @param array $modules Module slugs to store as active.
+	 */
+	private function set_active_modules( array $modules ) {
+		Jetpack_Options::update_option( 'active_modules', $modules );
+	}
+
+	/**
+	 * With canonical-urls active, the migration seeds the option truthy.
+	 */
+	public function test_migration_seeds_true_when_canonical_active() {
+		$this->set_active_modules( array( 'canonical-urls' ) );
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * With canonical-urls inactive, the migration seeds the option (present) but falsey.
+	 */
+	public function test_migration_seeds_false_when_canonical_inactive() {
+		$this->set_active_modules( array() );
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		// The option exists (a sentinel default would be returned only if absent)...
+		$this->assertNotSame( 'sentinel', get_option( $this->option, 'sentinel' ) );
+		// ...and reads as disabled.
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The migration never overwrites a value the user has already set.
+	 */
+	public function test_migration_does_not_clobber_existing_value() {
+		add_option( $this->option, true );
+		$this->set_active_modules( array() ); // Module inactive — a re-run must not flip it off.
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The sync reflects the current module state into the option, in both directions.
+	 */
+	public function test_sync_tracks_module_state() {
+		$this->set_active_modules( array( 'canonical-urls' ) );
+		Jetpack::sync_seo_canonical_urls_option();
+		$this->assertTrue( (bool) get_option( $this->option ) );
+
+		$this->set_active_modules( array() );
+		Jetpack::sync_seo_canonical_urls_option();
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The SEO Settings read sources `canonical_active` from the durable option.
+	 */
+	public function test_settings_read_sources_canonical_active_from_option() {
+		update_option( $this->option, true );
+		$settings = Jetpack_SEO_Initializer::get_settings_data();
+		$this->assertTrue( $settings['canonical_active'] );
+
+		update_option( $this->option, false );
+		$settings = Jetpack_SEO_Initializer::get_settings_data();
+		$this->assertFalse( $settings['canonical_active'] );
+	}
+
+	/**
+	 * When the option has not been seeded yet, the read falls back to live module state.
+	 */
+	public function test_settings_read_falls_back_to_module_when_option_absent() {
+		delete_option( $this->option );
+		$this->set_active_modules( array( 'canonical-urls' ) );
+
+		$settings = Jetpack_SEO_Initializer::get_settings_data();
+
+		$this->assertTrue( $settings['canonical_active'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -117,4 +117,19 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $settings['canonical_active'] );
 	}
+
+	/**
+	 * The registrar wires up every migration + sync hook for both modules at the
+	 * expected priority, from a single bootstrap call.
+	 */
+	public function test_register_seo_module_migration_hooks_wires_all_hooks() {
+		Jetpack::register_seo_module_migration_hooks();
+
+		$this->assertSame( 10, has_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) ) );
+		$this->assertSame( 10, has_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ) );
+		$this->assertSame( 10, has_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ) );
+		$this->assertSame( 10, has_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) ) );
+		$this->assertSame( 10, has_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ) );
+		$this->assertSame( 10, has_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ) );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -125,13 +125,26 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	 * expected priority, from a single bootstrap call.
 	 */
 	public function test_register_seo_module_migration_hooks_wires_all_hooks() {
+		$hooks = array(
+			array( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) ),
+			array( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ),
+			array( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ),
+			array( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) ),
+			array( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ),
+			array( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ),
+		);
+
+		// Start from a clean slate so this proves the registrar wires the hooks, not the
+		// plugin bootstrap (which registers the same hooks at load time).
+		foreach ( $hooks as list( $hook, $callback ) ) {
+			remove_action( $hook, $callback );
+			$this->assertFalse( has_action( $hook, $callback ), "Expected {$hook} to be unhooked before registering." );
+		}
+
 		Jetpack::register_seo_module_migration_hooks();
 
-		$this->assertSame( 10, has_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_sitemaps_module_to_seo_option' ) ) );
-		$this->assertSame( 10, has_action( 'jetpack_activate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ) );
-		$this->assertSame( 10, has_action( 'jetpack_deactivate_module_sitemaps', array( 'Jetpack', 'sync_seo_sitemap_option' ) ) );
-		$this->assertSame( 10, has_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) ) );
-		$this->assertSame( 10, has_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ) );
-		$this->assertSame( 10, has_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ) );
+		foreach ( $hooks as list( $hook, $callback ) ) {
+			$this->assertSame( 10, has_action( $hook, $callback ), "Expected {$hook} to be hooked at priority 10." );
+		}
 	}
 }

--- a/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
@@ -10,11 +10,13 @@ use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
+ * Covers only \Jetpack here: the migration is seeded/synced from the plugin, while the
+ * seo package's Initializer (whose option getters this test also exercises) lives outside
+ * this suite's coverage scope and is measured by the package's own unit tests.
+ *
  * @covers \Jetpack
- * @covers \Automattic\Jetpack\SEO\Initializer
  */
 #[CoversClass( Jetpack::class )]
-#[CoversClass( Jetpack_SEO_Initializer::class )]
 class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 

--- a/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests the one-time migration that records the Sitemaps module's state into the
+ * durable Jetpack SEO option, and the sync that keeps the two aligned.
+ *
+ * @package jetpack
+ */
+
+use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Jetpack
+ * @covers \Automattic\Jetpack\SEO\Initializer
+ */
+#[CoversClass( Jetpack::class )]
+#[CoversClass( Jetpack_SEO_Initializer::class )]
+class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The durable option under test.
+	 *
+	 * @var string
+	 */
+	private $option = Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION;
+
+	/**
+	 * Reset the option, active-modules list, and sitemap cron between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( $this->option );
+		Jetpack_Options::delete_option( 'active_modules' );
+		wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
+		delete_option( 'jetpack-sitemap-state' );
+	}
+
+	/**
+	 * Mark the given modules active in the raw `active_modules` option.
+	 *
+	 * @param array $modules Module slugs to store as active.
+	 */
+	private function set_active_modules( array $modules ) {
+		Jetpack_Options::update_option( 'active_modules', $modules );
+	}
+
+	/**
+	 * With sitemaps active, the migration seeds the option truthy.
+	 */
+	public function test_migration_seeds_true_when_sitemaps_active() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * With sitemaps inactive, the migration seeds the option (present) but falsey.
+	 */
+	public function test_migration_seeds_false_when_sitemaps_inactive() {
+		$this->set_active_modules( array() );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		// The option exists (a sentinel default would be returned only if absent)...
+		$this->assertNotSame( 'sentinel', get_option( $this->option, 'sentinel' ) );
+		// ...and reads as disabled.
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The migration never overwrites a value the user has already set.
+	 */
+	public function test_migration_does_not_clobber_existing_value() {
+		add_option( $this->option, true );
+		$this->set_active_modules( array() ); // Module inactive — a re-run must not flip it off.
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The migration is non-destructive: it touches no generated sitemap data, the
+	 * generation-state option, or the regeneration cron.
+	 */
+	public function test_migration_is_non_destructive() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		// No sitemap posts were created.
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'   => 'jp_sitemap',
+					'post_status' => 'draft',
+				)
+			)
+		);
+		// Generation state was not initialized.
+		$this->assertFalse( get_option( 'jetpack-sitemap-state' ) );
+		// No regeneration was scheduled.
+		$this->assertFalse( wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+	}
+
+	/**
+	 * The sync reflects the current module state into the option, in both directions.
+	 */
+	public function test_sync_tracks_module_state() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+		Jetpack::sync_seo_sitemap_option();
+		$this->assertTrue( (bool) get_option( $this->option ) );
+
+		$this->set_active_modules( array() );
+		Jetpack::sync_seo_sitemap_option();
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * The SEO Overview read sources `sitemap_active` from the durable option.
+	 */
+	public function test_overview_read_sources_sitemap_active_from_option() {
+		update_option( $this->option, true );
+		$overview = Jetpack_SEO_Initializer::get_overview_data();
+		$this->assertTrue( $overview['site_visibility']['sitemap_active'] );
+
+		update_option( $this->option, false );
+		$overview = Jetpack_SEO_Initializer::get_overview_data();
+		$this->assertFalse( $overview['site_visibility']['sitemap_active'] );
+	}
+
+	/**
+	 * When the option has not been seeded yet, the read falls back to live module state.
+	 */
+	public function test_overview_read_falls_back_to_module_when_option_absent() {
+		delete_option( $this->option );
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		$overview = Jetpack_SEO_Initializer::get_overview_data();
+
+		$this->assertTrue( $overview['site_visibility']['sitemap_active'] );
+	}
+}


### PR DESCRIPTION
> **Part of the [Jetpack SEO product split](https://github.com/Automattic/jetpack/pull/48154).** Foundation (#49203) and Settings tab (#49256) are merged to trunk; the rest are independent PRs off trunk, reviewable in any order:
> - #49351 — Content tab / per-post schema / Content coverage card
> - **#49407 — Sitemaps + Canonical URLs module-state migration, no UI (this PR)**
> - #49408 — AI tab + AI SEO Enhancer
> - #49412 — Google site auto-verify port
> - #49463 — Canonical URLs port
> - #49470 — Duplicate snackbar fix

## Related product discussion/links

- [JETPACK-1681](https://linear.app/a8c/issue/JETPACK-1681) — this issue (5a: Sitemaps + Canonical URLs state migration).
- Parent project PR: [Jetpack SEO product split #48154](https://github.com/Automattic/jetpack/pull/48154).
- [JETPACK-1682](https://linear.app/a8c/issue/JETPACK-1682) — #5b, the cohort-gated surface handoff. **Note:** #5b was re-scoped (per Devin Walker's direction that existing self-hosted users *opt in* to the new experience) and no longer deletes the modules or depends on this PR; the module deletion this migration protects is the deferred post-convergence follow-up.

### Proposed changes

This PR is the **state-preservation migration only** — no UI changes — ahead of two standalone modules, **Sitemaps** and **Canonical URLs**, being absorbed into Jetpack SEO. The actual removal of the modules is **deferred to a post-convergence follow-up** (a separate Linear project, forthcoming) — it can only happen once existing self-hosted installs have converged onto the new SEO experience. This migration is the safety net that must land before that future deletion removes the modules.

**Background.** The Jetpack SEO product reads each feature's enabled-state via `Modules::is_active( '<module>' )`. `is_active()` filters the active list against the modules present *on disk*, so the moment that future deletion removes `modules/sitemaps.php` / `modules/canonical-urls.php`, those reads flip to `false` for every site that had the feature enabled — silently losing the setting. The only thing that needs migrating is the on/off intent.

**What this PR does** — the same seed-once-plus-sync pattern, applied to each module:

- **`Jetpack::migrate_sitemaps_module_to_seo_option()`** / **`Jetpack::migrate_canonical_urls_module_to_seo_option()`** — one-time migrations hooked on `updating_jetpack_version` (modeled on the existing `activate_subscriptions_module_for_existing_sites`). Each seeds a durable option (`jetpack_seo_sitemap_enabled` / `jetpack_seo_canonical_urls_enabled`) from the site's **raw** `active_modules` membership (`is_active( '<module>', false )`), which is correct even after the module file is removed — so a site that upgrades straight past the removal still migrates correctly. `add_option()` makes them seed-once and idempotent: they never revert a value the user later sets. They are **deliberately non-destructive** — no feature data, settings, or cron are touched, so nothing is regenerated or disturbed.
- **`Jetpack::sync_seo_sitemap_option()`** / **`Jetpack::sync_seo_canonical_urls_option()`** — hooked on the respective `jetpack_activate_module_<module>` / `jetpack_deactivate_module_<module>` actions to keep the option current while the legacy modules (and their Traffic-page toggles) still exist. Toggling from any surface — the legacy Traffic settings, the SEO Settings tab (`/jetpack/v4/settings`), or WP-CLI — routes through `Jetpack::(de)activate_module`, which fires these actions, so the options stay in sync regardless of source. These hooks are removed alongside the modules in that deferred follow-up.
- **`Initializer::is_sitemap_enabled()`** / **`Initializer::is_canonical_enabled()`** (jetpack-seo package) — the dashboard reads now source `sitemap_active` / `canonical_active` from the options, falling back to live module state when an option hasn't been seeded yet (the brief pre-migration window), so behavior is unchanged in that gap.
- **`Jetpack::register_seo_module_migration_hooks()`** — the migrate/sync hooks above are registered from this one method, called once from `load-jetpack.php`, rather than as loose `add_action()` calls at file scope. Extracted purely so the wiring is unit-testable (file-scope hooks run during bootstrap and can't be exercised by a test). Removed alongside the modules in that deferred follow-up.

Scope is **sitemaps + canonical-urls** — the two SEO settings still backed by live module state. `verification-tools` needs no migration (the product already reads `verification_services_codes` directly, which persists); the remaining settings (title formats, front-page description, AI SEO Enhancer) already live in durable Jetpack options.

### Other information

- [x] Have you written new tests for your changes? — `projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php` and `SEO_Canonical_URLs_Migration_Test.php` cover seeding (true/false), idempotency (no-clobber), the activate/deactivate sync, the product read with fallback, and that `register_seo_module_migration_hooks()` wires every hook (plus non-destructiveness for sitemaps' generated data/cron). The package-level `InitializerTest` covers each durable-option read and the `get_settings_data()` reads.
- [x] Have you added a changelog entry? — yes, in both `projects/plugins/jetpack` and `projects/packages/seo`.
- **No screenshots** — this is back-end migration logic (durable options + sync hooks) with **no UI changes**, so there is nothing visual to capture.

### Does this pull request change what data or activity we track or use?

Adds two site options, `jetpack_seo_sitemap_enabled` and `jetpack_seo_canonical_urls_enabled`, recording whether each feature is enabled. No new analytics/telemetry.

### Testing instructions

This is back-end migration logic with **no UI changes — no screenshots needed.** The goal is to exercise the migration/upgrade path and confirm each durable option ends up with correct state. Run through these for **both** Sitemaps and Canonical URLs (substituting the module slug and option name).

**Migration (seed-once) path:**

1. On a site with the **Sitemaps** (and/or **Canonical URLs**) module active, apply this branch (Jetpack Beta) and trigger an upgrade run so `updating_jetpack_version` fires — e.g. `wp jetpack options update version <old-version>` then load wp-admin to force the upgrade routine.
2. Confirm the durable option is written: `wp option get jetpack_seo_sitemap_enabled` / `wp option get jetpack_seo_canonical_urls_enabled` is truthy.
3. (Sitemaps) Confirm non-destructiveness: the existing `/sitemap.xml` is unchanged and was **not** regenerated — `jetpack-sitemap-state` and the `jp_sitemap*` posts are untouched, and no new `jp_sitemap_cron_hook` cron was scheduled.

**Live sync (toggle) path:**

4. Toggle the module **off** then **on** again, via the legacy Traffic settings, the Jetpack SEO Settings tab, or WP-CLI (`wp jetpack module deactivate <module>` / `... activate <module>`). After each toggle, confirm the option tracks the change in both directions.
5. Confirm the SEO product reads correct state: the SEO Overview/Settings reflect the feature as on/off matching the option after each toggle.

**Inactive / fallback path:**

6. On a site with the module **inactive**, confirm the option is present and falsey after migration, and the SEO dashboard still shows the feature as off.
7. (Pre-migration fallback) Before the option has been seeded, confirm the SEO reads fall back to live module state, so behavior is unchanged in that gap.

### Test environments

_Author to confirm — check only what you've personally verified. This is back-end logic, but Connected vs Offline and the hosting type still matter for where module toggling is exercised:_

- [ ] wpcom Simple
- [ ] wpcom Atomic
- [ ] Self-hosted
- [ ] Connected mode
- [ ] Offline mode

---

Tracked: [JETPACK-1681](https://linear.app/a8c/issue/JETPACK-1681) (this PR). Removal of both modules is deferred to a post-convergence follow-up (a separate Linear project).


