### PR TITLE
Newsletter subscribers: show empty state when the owner is the only subscriber

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/empty-state.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/empty-state.tsx
@@ -1,8 +1,11 @@
-import { useEffect } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { envelope, search as searchIcon } from '@wordpress/icons';
 import { Button, EmptyState } from '@wordpress/ui';
 import { recordTracksEvent } from '../lib/tracks';
+
+const SUBSCRIPTION_FORM_SUPPORT_URL =
+	'https://jetpack.com/support/jetpack-blocks/subscription-form-block/';
 
 type Props = {
 	hasFiltersOrSearch: boolean;
@@ -55,9 +58,14 @@ export default function SubscribersEmptyState( {
 			</EmptyState.Visual>
 			<EmptyState.Title>{ __( 'No subscribers yet', 'jetpack-newsletter' ) }</EmptyState.Title>
 			<EmptyState.Description>
-				{ __(
-					'Bring readers in by inviting them by email. They’ll get a confirmation message and start receiving your posts.',
-					'jetpack-newsletter'
+				{ createInterpolateElement(
+					__(
+						'<link>Turn your site visitors into subscribers</link> or bring readers in by inviting them by email. They’ll get a confirmation message and start receiving your posts.',
+						'jetpack-newsletter'
+					),
+					{
+						link: <a href={ SUBSCRIPTION_FORM_SUPPORT_URL } target="_blank" rel="noreferrer" />,
+					}
 				) }
 			</EmptyState.Description>
 			<EmptyState.Actions>

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -4,7 +4,11 @@ import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import { useSubscriberRemoveMutation } from '../data/use-subscriber-remove-mutation';
 import { useSubscribers } from '../data/use-subscribers';
-import { getSubscribedAt, getSubscriberRowId } from '../lib/subscriber-helpers';
+import {
+	getSubscribedAt,
+	getSubscriberRowId,
+	hasNoSubscribersOtherThanOwner,
+} from '../lib/subscriber-helpers';
 import { getSubscriptionType } from '../lib/subscription-plans';
 import { getSubscriptionStatusLabel } from '../lib/subscription-status';
 import { recordTracksEvent } from '../lib/tracks';
@@ -20,6 +24,9 @@ import type { Subscriber, SubscribersFilter, SubscribersSortField } from '../dat
 import type { Action, Field, View } from '@wordpress/dataviews';
 
 const DEFAULT_PER_PAGE = 20;
+
+// Stable reference so passing "no rows" to DataViews doesn't churn on every render.
+const NO_SUBSCRIBERS: Subscriber[] = [];
 
 const defaultView: View = {
 	type: 'table',
@@ -290,14 +297,28 @@ export default function SubscribersDataViews( {
 	const subscribers = data?.subscribers ?? [];
 	const totalItems = data?.total ?? 0;
 	const totalPages = data?.pages ?? 0;
-
-	const paginationInfo = useMemo(
-		() => ( { totalItems, totalPages } ),
-		[ totalItems, totalPages ]
-	);
+	const isOwnerSubscribed = data?.is_owner_subscribed ?? false;
 
 	const hasActiveFiltersOrSearch = Boolean(
 		( view.filters && view.filters.length > 0 ) || ( view.search && view.search.length > 0 )
+	);
+
+	// The owner is always returned in the list, so when they're the only subscriber the table
+	// would render a single row and DataViews' `empty` slot would never fire. Mirror Calypso's
+	// launchpad condition and present the cold-start empty state ourselves. Gated on no active
+	// filter/search so a filtered-to-nothing result still shows the "no matching subscribers"
+	// message instead.
+	const showColdStartEmpty =
+		! hasActiveFiltersOrSearch && hasNoSubscribersOtherThanOwner( totalItems, isOwnerSubscribed );
+
+	const displayedSubscribers = showColdStartEmpty ? NO_SUBSCRIBERS : subscribers;
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: showColdStartEmpty ? 0 : totalItems,
+			totalPages: showColdStartEmpty ? 0 : totalPages,
+		} ),
+		[ showColdStartEmpty, totalItems, totalPages ]
 	);
 
 	if ( error ) {
@@ -312,7 +333,7 @@ export default function SubscribersDataViews( {
 	return (
 		<>
 			<DataViews< Subscriber >
-				data={ subscribers }
+				data={ displayedSubscribers }
 				fields={ fields }
 				view={ view }
 				onChangeView={ handleChangeView }

--- a/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
+++ b/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
@@ -57,3 +57,21 @@ export function getRemovePayload( subscriber: Subscriber ): RemoveSubscriberPayl
 export function getSubscriberLabel( subscriber: Subscriber ): string {
 	return subscriber.display_name || subscriber.email_address;
 }
+
+/**
+ * Whether the subscribers list is empty except for the site owner. The WP.com endpoint always
+ * returns the owner in the list (it only flags `is_owner_subscribed` rather than filtering them
+ * out), so a brand-new site reports a single row and DataViews' `empty` slot never fires. Mirrors
+ * Calypso's `hasNoSubscriberOtherThanAdmin` launchpad condition so the caller can present the
+ * cold-start empty state instead.
+ *
+ * @param total             - Total subscriber count for the current (unfiltered) query.
+ * @param isOwnerSubscribed - Whether the site owner is among the subscribers (`is_owner_subscribed`).
+ * @return True when there are no subscribers, or the only subscriber is the owner.
+ */
+export function hasNoSubscribersOtherThanOwner(
+	total: number,
+	isOwnerSubscribed: boolean
+): boolean {
+	return total === 0 || ( total === 1 && isOwnerSubscribed );
+}

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-filter-subscriber
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-filter-subscriber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers dashboard: show the empty state when the site owner is the only subscriber, and point the empty-state copy at the subscription form documentation

--- a/projects/packages/newsletter/tests/subscriber-helpers.test.ts
+++ b/projects/packages/newsletter/tests/subscriber-helpers.test.ts
@@ -1,0 +1,22 @@
+import { hasNoSubscribersOtherThanOwner } from '../_inc/subscribers/lib/subscriber-helpers';
+
+describe( 'hasNoSubscribersOtherThanOwner', () => {
+	it( 'is true when there are no subscribers at all', () => {
+		expect( hasNoSubscribersOtherThanOwner( 0, false ) ).toBe( true );
+		// Owner flag is irrelevant when the total is zero.
+		expect( hasNoSubscribersOtherThanOwner( 0, true ) ).toBe( true );
+	} );
+
+	it( 'is true when the only subscriber is the site owner', () => {
+		expect( hasNoSubscribersOtherThanOwner( 1, true ) ).toBe( true );
+	} );
+
+	it( 'is false when the single subscriber is not the owner', () => {
+		expect( hasNoSubscribersOtherThanOwner( 1, false ) ).toBe( false );
+	} );
+
+	it( 'is false once there is more than one subscriber, owner included', () => {
+		expect( hasNoSubscribersOtherThanOwner( 2, true ) ).toBe( false );
+		expect( hasNoSubscribersOtherThanOwner( 5, false ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Fixes #

This targets the modernized Newsletter **Subscribers** dashboard (behind the `rsm_jetpack_ui_modernization_newsletter` feature flag).

## Proposed changes
* **Empty state for owner-only sites.** The WP.com subscribers endpoint always returns the site owner in the list (it only flags `is_owner_subscribed` rather than filtering them out), so a brand-new site rendered the owner as a single row and DataViews' `empty` slot never fired. We now mirror Calypso's launchpad condition (`hasNoSubscribersOtherThanOwner`): present the cold-start empty state when there are no subscribers, or the only subscriber is the owner — gated on no active filter/search so a filtered-to-nothing result still shows the "No matching subscribers" message. The owner is **not** removed from the list in any other case.
* **Empty-state copy.** Updated the cold-start description to "Turn your site visitors into subscribers or bring readers in by inviting them by email…", linking *Turn your site visitors into subscribers* to the [Subscription Form block docs](https://jetpack.com/support/jetpack-blocks/subscription-form-block/).
* Added a unit test for the new `hasNoSubscribersOtherThanOwner` helper.

## Related product discussion/links
<!-- Automatticians: add the P2/Slack/Linear links. -->
* Subscriber **removal** on Jetpack sites currently 403s for site owners (the granular WP.com follower-delete endpoints gate on the `remove_users` capability, which a Jetpack-connected admin does not hold on the wpcom-side blog). That is fixed separately on the WP.com side — _**add dotcom PR (Dxxxxx) link here**_ — and needs no Jetpack change.

## Does this pull request change what data or activity we track or use?
No. No new Tracks events or data collection are introduced; the existing `jetpack_subscribers_empty_view_displayed` event is unchanged.

## Testing instructions
* Enable the modernized Newsletter dashboard on a Jetpack-connected site (filter `rsm_jetpack_ui_modernization_newsletter` → `true`), then go to **Jetpack → Newsletter → Subscribers**.
* **Empty state (owner only):** On a site whose only subscriber is the owner (or none), confirm the table shows the **"No subscribers yet"** empty state with the *Turn your site visitors into subscribers* link pointing to `https://jetpack.com/support/jetpack-blocks/subscription-form-block/`, plus the **Add subscribers** button. Confirm the owner is no longer listed as a row.
* **Populated list:** With at least one non-owner subscriber, confirm the table renders normally and the owner still appears as a regular row.
* **Filtered-empty:** Apply a filter or search that matches nothing → confirm the **"No matching subscribers"** state shows (not the cold-start one).
* Run the package unit tests: `pnpm test` in `projects/packages/newsletter` (38 passing).

<img width="1102" height="808" alt="Screenshot from 2026-06-04 15-42-20" src="https://github.com/user-attachments/assets/b1b2ab07-dde3-41fc-80e4-253b728ffbe8" />
