### PR TITLE
CI: Enable tests and test coverage in various packages

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/github-actions/repo-gardening/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/github-actions/repo-gardening/composer.json
+++ b/projects/github-actions/repo-gardening/composer.json
@@ -7,6 +7,12 @@
 	"scripts": {
 		"build-development": [
 			"pnpm run build"
+		],
+		"test-js": [
+			"pnpm run test"
+		],
+		"test-js-coverage": [
+			"pnpm run test-coverage"
 		]
 	},
 	"repositories": [

--- a/projects/packages/activity-log/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/activity-log/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/activity-log/composer.json
+++ b/projects/packages/activity-log/composer.json
@@ -45,6 +45,9 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		]
 	},
 	"repositories": [

--- a/projects/packages/agents-manager/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/agents-manager/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -34,9 +34,11 @@
 		"test-js": [
 			"pnpm run test"
 		],
+		"test-js-coverage": "pnpm run test-coverage",
 		"test-php": [
 			"@composer phpunit"
-		]
+		],
+		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 	},
 	"repositories": [
 		{

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -46,6 +46,7 @@
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
 		"test-coverage": "@composer test-php-coverage",
+		"test-js": "pnpm run test",
 		"test-php": "@composer phpunit",
 		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"",
 		"build-production": "pnpm run build-production-js",

--- a/projects/packages/newsletter/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/newsletter/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/newsletter/composer.json
+++ b/projects/packages/newsletter/composer.json
@@ -34,6 +34,7 @@
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
 		"test-coverage": "pnpm concurrently --names php,js 'composer test-php-coverage' 'composer test-js-coverage'",
+		"test-js": "pnpm run test",
 		"test-js-coverage": "pnpm run test-coverage",
 		"test-php": "@composer phpunit",
 		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"",

--- a/projects/packages/podcast/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/podcast/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -37,6 +37,9 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		]
 	},
 	"repositories": [

--- a/projects/packages/scan/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/scan/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/scan/composer.json
+++ b/projects/packages/scan/composer.json
@@ -40,6 +40,15 @@
 		"test-php": [
 			"@composer phpunit"
 		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
+		"test-js": [
+			"pnpm run test"
+		],
+		"test-js-coverage": [
+			"pnpm run test-coverage"
+		],
 		"watch": [
 			"Composer\\Config::disableProcessTimeout",
 			"pnpm run watch"

--- a/projects/packages/scan/package.json
+++ b/projects/packages/scan/package.json
@@ -25,6 +25,7 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run build:strip-unminified-prod && pnpm run validate",
 		"clean": "rm -rf build/",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.js",
+		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/packages/seo/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/seo/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/packages/seo/composer.json
+++ b/projects/packages/seo/composer.json
@@ -30,8 +30,14 @@
 		"test-php": [
 			"@composer phpunit"
 		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
 		"test-js": [
 			"pnpm run test"
+		],
+		"test-js-coverage": [
+			"pnpm run test-coverage"
 		],
 		"build-development": [
 			"pnpm run build"

--- a/projects/plugins/jetpack/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/plugins/jetpack/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock file.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -205,7 +205,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/activity-log",
-                "reference": "e90384cb6fab6777b72d9179a1b34fc88e4abd74"
+                "reference": "62cbc8f7ab7209547bfce1e9d6451526f1202006"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -264,6 +264,9 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [
@@ -2365,7 +2368,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/newsletter",
-                "reference": "3bb98c0c48214065e07d41fa666f4063fcc64df0"
+                "reference": "4d0d432d0abc4def9977c6b3ff889d107f76fda7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2422,6 +2425,9 @@
                 ],
                 "test-coverage": [
                     "pnpm concurrently --names php,js 'composer test-php-coverage' 'composer test-js-coverage'"
+                ],
+                "test-js": [
+                    "pnpm run test"
                 ],
                 "test-js-coverage": [
                     "pnpm run test-coverage"
@@ -3201,7 +3207,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scan",
-                "reference": "1c06f353d803e20ce0b3e665cbffb0bd0af6bf85"
+                "reference": "236b3d66cfef584acb43b2a87fc3d811fd50f638"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -3254,6 +3260,15 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "watch": [
                     "Composer\\Config::disableProcessTimeout",
@@ -3362,7 +3377,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/seo",
-                "reference": "e4e85d930daca71eed75c11b4a7d2c5ce5cf537b"
+                "reference": "0ed54c11e62b2bd90470902e72590a74764d41e7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -3406,8 +3421,14 @@
                 "test-php": [
                     "@composer phpunit"
                 ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
                 "test-js": [
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "build-development": [
                     "pnpm run build"

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock file.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -214,7 +214,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "7a3344385cb6a784403c71886548868a41038c02"
+                "reference": "b48bfd989bbc7146c513d6eaa19c2b5133d4842f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -268,8 +268,14 @@
                 "test-js": [
                     "pnpm run test"
                 ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [
@@ -1359,7 +1365,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "a8b4456637170545675656bbe36122812e4f6c6e"
+                "reference": "9e9b5943ed0c3ed9bb076ff61d4087e31025bec2"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1417,6 +1423,9 @@
                 ],
                 "test-coverage": [
                     "@composer test-php-coverage"
+                ],
+                "test-js": [
+                    "pnpm run test"
                 ],
                 "test-php": [
                     "@composer phpunit"
@@ -1572,7 +1581,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "7689dce6984ad7d23f76f02c1138b01cc6d3629f"
+                "reference": "d4a89b99f139d8d4f746af1d512d064c48eb7560"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1628,6 +1637,9 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [

--- a/projects/plugins/premium-analytics/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/plugins/premium-analytics/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Enable tests or test coverage.
+
+

--- a/projects/plugins/premium-analytics/composer.json
+++ b/projects/plugins/premium-analytics/composer.json
@@ -23,6 +23,9 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		]
 	},
 	"repositories": [

--- a/projects/plugins/wpcomsh/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/plugins/wpcomsh/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock file.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -282,7 +282,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "7a3344385cb6a784403c71886548868a41038c02"
+                "reference": "b48bfd989bbc7146c513d6eaa19c2b5133d4842f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -336,8 +336,14 @@
                 "test-js": [
                     "pnpm run test"
                 ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [
@@ -1569,7 +1575,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "a8b4456637170545675656bbe36122812e4f6c6e"
+                "reference": "9e9b5943ed0c3ed9bb076ff61d4087e31025bec2"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1627,6 +1633,9 @@
                 ],
                 "test-coverage": [
                     "@composer test-php-coverage"
+                ],
+                "test-js": [
+                    "pnpm run test"
                 ],
                 "test-php": [
                     "@composer phpunit"
@@ -1782,7 +1791,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "7689dce6984ad7d23f76f02c1138b01cc6d3629f"
+                "reference": "d4a89b99f139d8d4f746af1d512d064c48eb7560"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1838,6 +1847,9 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [

--- a/tools/cli/skeletons/common/composer.json
+++ b/tools/cli/skeletons/common/composer.json
@@ -22,6 +22,9 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		]
 	},
 	"repositories": [


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* `github-actions/repo-gardening`: added `test-js` and `test-js-coverage` to `composer.json`
* `packages/activity-log`: added `test-php-coverage` to `composer.json` (cc: @keoshi)
* `packages/agents-manager`: added `test-js-coverage` and `test-php-coverage` to `composer.json` (cc: @zaguiini)
* `packages/jetpack-mu-wpcom: added `test-js` to `composer.json`
* `packages/newsletter`: added `test-js` to `composer.json`
* `packages/podcast`: added `test-php-coverage` to `composer.json` (cc: @arcangelini)
* `packages/scan`: added `test-php-coverage`, `test-js`, and `test-js-coverage` to `composer.json`, and `test-coverage` to `package.json` (cc: @dhasilva, @ilonagl)
* `packages/seo`: added `test-php-coverage` and `test-js-coverage` to `composer.json` (cc: @angelablake)
* `plugins/premium-analytics`: added `test-php-coverage` to `composer.json` (cc: @retrofox)

These two have JS tests, but they're invoked with `node --test`; presumably we'd need to update the munger for that but I haven't looked further:
* `packages/wp-build-polyfills`
* `packages/jetpack-mu-wpcom`

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Is CI happy?