### PR TITLE
wpcom-block-editor: Add missing script dependencies

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-block-editor-script-deps
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-block-editor-script-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-block-editor: Add missing script dependencies for remote editor assets.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,19 +328,19 @@ class Jetpack_WPCOM_Block_Editor {
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 		$version = gmdate( 'Ymd' );
 
+		// Keep these dependencies in sync with the generated asset metadata from
+		// the Calypso wpcom-block-editor app.
 		wp_enqueue_script(
 			'wpcom-block-editor-default-editor-script',
 			$debug
 				? '//widgets.wp.com/wpcom-block-editor/default.editor.js?minify=false'
 				: '//widgets.wp.com/wpcom-block-editor/default.editor.min.js',
 			array(
-				'jquery',
-				'lodash',
-				'wp-annotations',
+				'react',
+				'wp-block-editor',
+				'wp-blocks',
 				'wp-compose',
 				'wp-data',
-				'wp-editor',
-				'wp-element',
 				'wp-rich-text',
 			),
 			$version,
@@ -367,10 +367,19 @@ class Jetpack_WPCOM_Block_Editor {
 				: '//widgets.wp.com/wpcom-block-editor/wpcom.editor.min.js',
 			array(
 				'lodash',
+				'react',
+				'wp-block-editor',
 				'wp-blocks',
+				'wp-components',
+				'wp-compose',
 				'wp-data',
 				'wp-dom-ready',
+				'wp-element',
+				'wp-hooks',
+				'wp-i18n',
 				'wp-plugins',
+				'wp-primitives',
+				'wp-url',
 			),
 			$version,
 			true

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-block-editor/Jetpack_WPCOM_Block_Editor_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-block-editor/Jetpack_WPCOM_Block_Editor_Test.php
@@ -37,6 +37,29 @@ class Jetpack_WPCOM_Block_Editor_Test extends \WorDBless\BaseTestCase {
 		);
 		Constants::set_constant( 'JETPACK__API_VERSION', '1' );
 	}
+
+	/**
+	 * Runs the routine after each test is executed.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		foreach (
+			array(
+				'wpcom-block-editor-default-editor-script',
+				'wpcom-block-editor-wpcom-editor-script',
+				'wpcom-block-editor-wpcom-editor-styles',
+				'wpcom-block-editor-calypso-editor-script',
+				'wpcom-block-editor-calypso-editor-styles',
+			) as $handle
+		) {
+			wp_dequeue_script( $handle );
+			wp_deregister_script( $handle );
+			wp_dequeue_style( $handle );
+			wp_deregister_style( $handle );
+		}
+	}
+
 	/**
 	 * Test_verify_frame_nonce.
 	 */
@@ -66,6 +89,63 @@ class Jetpack_WPCOM_Block_Editor_Test extends \WorDBless\BaseTestCase {
 
 		// Cleanup.
 		Jetpack_Options::delete_option( array( 'user_tokens', 'master_user' ) );
+	}
+
+	/**
+	 * Tests that remote block editor scripts declare their WordPress package dependencies.
+	 */
+	public function test_enqueue_block_editor_assets_declares_remote_script_dependencies() {
+		$wpcom_block_editor = Jetpack_WPCOM_Block_Editor::init();
+		$wpcom_block_editor->enqueue_block_editor_assets();
+
+		$this->assertScriptDependencies(
+			'wpcom-block-editor-default-editor-script',
+			array(
+				'react',
+				'wp-block-editor',
+				'wp-blocks',
+				'wp-compose',
+				'wp-data',
+				'wp-rich-text',
+			)
+		);
+
+		$this->assertScriptDependencies(
+			'wpcom-block-editor-wpcom-editor-script',
+			array(
+				'lodash',
+				'react',
+				'wp-block-editor',
+				'wp-blocks',
+				'wp-components',
+				'wp-compose',
+				'wp-data',
+				'wp-dom-ready',
+				'wp-element',
+				'wp-hooks',
+				'wp-i18n',
+				'wp-plugins',
+				'wp-primitives',
+				'wp-url',
+			)
+		);
+	}
+
+	/**
+	 * Asserts that a script declares the exact generated asset metadata dependencies.
+	 *
+	 * @param string $handle                Script handle.
+	 * @param array  $expected_dependencies Expected dependencies.
+	 */
+	private function assertScriptDependencies( $handle, $expected_dependencies ) {
+		$registered_script = wp_scripts()->registered[ $handle ] ?? null;
+
+		$this->assertNotNull( $registered_script, "Expected $handle to be registered." );
+		$this->assertSame(
+			$expected_dependencies,
+			$registered_script->deps,
+			"Expected $handle dependencies to match generated Calypso asset metadata."
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes TESTOPS-129

Follow-up to #49319. That PR fixed the earlier Jetpack Edge fatal, but Atomic Edge still timed out waiting for the editor/editor canvas to load.

The remaining failure mode is dependency drift: the remote `wpcom.editor.min.js` bundle reads `window.wp.blockEditor`, `window.wp.components`, `window.wp.i18n`, `window.wp.primitives`, and related packages before Jetpack declares them as script dependencies.

## Proposed changes
* Sync the remote WordPress.com block editor script dependencies with the generated Calypso Apps asset metadata.
* Add PHP coverage for the dependency contract used when enqueuing the remote editor assets.

## Related product discussion/links
* TESTOPS-129
* Coverage publisher fix split to #49416.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `php -l projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php`.
* Run `php -l projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-block-editor/Jetpack_WPCOM_Block_Editor_Test.php`.
* Run `JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack test php packages/jetpack-mu-wpcom -v`.
* After this lands and deploys, trigger the Gutenberg Atomic Edge desktop and mobile jobs to confirm editor-load recovery.
