### PR TITLE
CI: Fix single-artifact coverage runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,6 +348,7 @@ jobs:
       - name: Merge coverage artifacts
         run: |
           mkdir coverage
+          # If there's only one matching artifact, actions/download-artifact puts it directly in the specified path. If multiple, it makes subdirectories that need merging.
           if [[ -f coverage_dl/summary.tsv ]]; then
             mv coverage_dl/* coverage/
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,9 +348,13 @@ jobs:
       - name: Merge coverage artifacts
         run: |
           mkdir coverage
-          sort coverage_dl/*/summary.tsv > coverage/summary.tsv
-          rm coverage_dl/*/summary.tsv
-          mv coverage_dl/*/* coverage/
+          if [[ -f coverage_dl/summary.tsv ]]; then
+            mv coverage_dl/* coverage/
+          else
+            sort coverage_dl/*/summary.tsv > coverage/summary.tsv
+            rm coverage_dl/*/summary.tsv
+            mv coverage_dl/*/* coverage/
+          fi
 
       - name: Upload coverage results
         env:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
If there's a single artifact downloaded, `actions/download-artifact` extracts it directly into the path rather than into a subdirectory, which was breaking the merge job. This PR puts the file in its place.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://github.com/Automattic/jetpack/pull/49414#discussion_r3358978322

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

The code should be fairly clear, but if one really wants, they can make a change like #49414 that only generates one coverage artifact and see if it passes.

I've done something like that in #49417 and it seems to have worked:
https://github.com/Automattic/jetpack/actions/runs/26982875426/job/79626083919