### PR TITLE
AI Sidebar: enable Optimize Title preview suggestion

### DIFF
--- a/projects/plugins/jetpack/changelog/enable-ai-sidebar-optimize-title
+++ b/projects/plugins/jetpack/changelog/enable-ai-sidebar-optimize-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Sidebar: Enable Optimize Title suggestions in the Jetpack AI Sidebar Preview.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -537,7 +537,7 @@ class Jetpack_AI_Sidebar {
 		$features = array(
 			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
 			'blockTransformations'    => true,
-			'optimizeTitleSuggestion' => false,
+			'optimizeTitleSuggestion' => true,
 			'chatHistory'             => false,
 			'supportGuides'           => false,
 		);

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -549,7 +549,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"blockTransformations":true', $this->get_agents_manager_inline_script() );
-		$this->assertStringContainsString( '"optimizeTitleSuggestion":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"optimizeTitleSuggestion":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"chatHistory":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"supportGuides":false', $this->get_agents_manager_inline_script() );
 	}
@@ -620,7 +620,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['chatHistory'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['supportGuides'] );
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes

* Enable the Jetpack AI Sidebar Preview `optimizeTitleSuggestion` feature flag emitted by Jetpack.
* Update the matching AI Sidebar PHP assertions for the new preview feature state.
* Add a Jetpack changelog entry.

## Related product discussion/links

* Stacked on Automattic/jetpack#49387.
* Pairs with Automattic/wp-calypso#111364 for Calypso sidebar coverage.

## Does this pull request change what data or activity we track or use?

No. This only changes the existing feature flag emitted to the Jetpack AI Sidebar Preview config.

## Testing instructions

* This PR is stacked on Automattic/jetpack#49387.
* Pair with Automattic/wp-calypso#111364.
* Run `php -l projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php`.
* Run `php -l projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php`.
* Run `PATH=/Users/katre/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test`.
* Manual: with the Calypso stacked PR active, confirm `agentsManagerData.jetpackAiSidebarPreview.features.optimizeTitleSuggestion` is `true`.
* Manual: in the Page/Site Editor with no selected block, confirm Optimize Title is available from Jetpack AI.
* Manual: select a text block and confirm block-level suggestions remain block-specific and do not include Optimize Title.