### PR TITLE
Sync features list with WPCOM - removing social unified UI feature flag.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-sync-wpcom-features
+++ b/projects/plugins/wpcomsh/changelog/update-sync-wpcom-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync features list with WPCOM - removing social unified UI feature flag.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -487,7 +487,6 @@ class WPCOM_Features {
 	public const SOCIAL_SHARES_1000                = 'social-shares-1000';
 	public const SOCIAL_ENHANCED_PUBLISHING        = 'social-enhanced-publishing';
 	public const SOCIAL_IMAGE_AUTO_CONVERT         = 'social-image-auto-convert';
-	public const SOCIAL_UNIFIED_UI_V1              = 'social-unified-ui-v1';
 	public const SPACE                             = 'space';
 	public const SPACE_UPGRADED_STORAGE            = 'space-upgraded-storage';
 	public const SSH                               = 'ssh';
@@ -1357,10 +1356,6 @@ class WPCOM_Features {
 			self::JETPACK_SOCIAL_PLANS,
 			self::JETPACK_GROWTH_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
-		),
-		self::SOCIAL_UNIFIED_UI_V1              => array(
-			self::WPCOM_ALL_SITES,
-			// For Jetpack sites, the feature is controlled in Store_Product_List.
 		),
 		self::SOCIAL_MESSAGE_TEMPLATES          => array(
 			// Gated on the paid social plans, matching SOCIAL_ENHANCED_PUBLISHING.


### PR DESCRIPTION
Related to 221830-ghe-Automattic/wpcom
Follow up of #47759

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Sync features list with WPCOM - removing social unified UI feature flag.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*