### PR TITLE
Daily writing prompt widget: use wp-ui components

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-daily-writing-prompt-use-wp-ui
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-daily-writing-prompt-use-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Daily writing prompt: Update dashboard widget to use WordPress UI components.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -35,7 +35,7 @@ export default () => {
 				<Text variant="body-md" render={ <p /> }>
 					{ prompt.text }
 				</Text>
-				<Stack direction="row" justify="flex-end" gap="xs">
+				<Stack direction="row" justify="flex-end">
 					<Button
 						variant="minimal"
 						size="small"

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -1,6 +1,8 @@
 import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Link, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 
 import './style.scss';
@@ -31,36 +33,49 @@ export default () => {
 	return (
 		<>
 			<div className="wpcom-daily-writing-prompt--prompt">
-				<p>{ prompt.text }</p>
-				<div className="wpcom-daily-writing-prompt--previous-next">
-					<button
-						className="button button-link"
-						onClick={ () => setIndex( index - 1 ) }
-						disabled={ index === 0 }
-					>
+				<Text variant="body-md" render={ <p /> }>
+					{ prompt.text }
+				</Text>
+				<Stack
+					className="wpcom-daily-writing-prompt--previous-next"
+					direction="row"
+					justify="flex-end"
+					gap="sm"
+				>
+					<Button variant="link" onClick={ () => setIndex( index - 1 ) } disabled={ index === 0 }>
 						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
-					</button>
-					{ ' ' }
-					<button
-						className="button button-link"
+					</Button>
+					<Button
+						variant="link"
 						onClick={ () => setIndex( index + 1 ) }
 						disabled={ index === prompts.length - 1 }
 					>
 						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
-					</button>
-				</div>
+					</Button>
+				</Stack>
 			</div>
-			<div className="wpcom-daily-writing-prompt--action-row">
-				<a className="button" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
+			<Stack
+				className="wpcom-daily-writing-prompt--action-row"
+				direction="row"
+				justify="space-between"
+				align="center"
+				gap="sm"
+			>
+				<Button variant="secondary" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
 					{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
-				</a>
+				</Button>
 				{ prompt.answered_users_sample.length > 0 && (
-					<div className="wpcom-daily-writing-prompt--answered-users">
+					<Stack
+						className="wpcom-daily-writing-prompt--answered-users"
+						direction="row"
+						align="center"
+						gap="xs"
+					>
 						{ prompt.answered_users_count > 0 && (
-							<a href={ new URL( prompt.answered_link ) }>
+							<Link href={ new URL( prompt.answered_link ).toString() }>
 								{ __( 'View all responses', 'jetpack-mu-wpcom' ) }
-							</a>
-						) }{ ' ' }
+							</Link>
+						) }
 						<span>
 							{ prompt.answered_users_sample.map( sample => {
 								return (
@@ -76,9 +91,9 @@ export default () => {
 								);
 							} ) }
 						</span>
-					</div>
+					</Stack>
 				) }
-			</div>
+			</Stack>
 		</>
 	);
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -54,7 +54,7 @@ export default () => {
 					</Button>
 				</Stack>
 			</Stack>
-			<Stack direction="row" justify="space-between" align="center" gap="sm">
+			<Stack direction="row" justify="space-between" align="center" gap="sm" wrap="wrap">
 				{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
 				<Button
 					variant="outline"

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -30,17 +30,12 @@ export default () => {
 	const prompt = prompts[ index ];
 
 	return (
-		<Stack className="wpcom-daily-writing-prompt" direction="column" gap="md">
+		<Stack direction="column" gap="md">
 			<Stack className="wpcom-daily-writing-prompt--prompt" direction="column" gap="md">
 				<Text variant="body-md" render={ <p /> }>
 					{ prompt.text }
 				</Text>
-				<Stack
-					className="wpcom-daily-writing-prompt--previous-next"
-					direction="row"
-					justify="flex-end"
-					gap="sm"
-				>
+				<Stack direction="row" justify="flex-end" gap="xs">
 					<Button
 						variant="minimal"
 						size="small"
@@ -59,13 +54,7 @@ export default () => {
 					</Button>
 				</Stack>
 			</Stack>
-			<Stack
-				className="wpcom-daily-writing-prompt--action-row"
-				direction="row"
-				justify="space-between"
-				align="center"
-				gap="sm"
-			>
+			<Stack direction="row" justify="space-between" align="center" gap="sm">
 				{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
 				<Button
 					variant="outline"

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -1,8 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Link, Stack, Text } from '@wordpress/ui';
+import { Button, Link, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 
 import './style.scss';
@@ -42,11 +41,17 @@ export default () => {
 					justify="flex-end"
 					gap="sm"
 				>
-					<Button variant="link" onClick={ () => setIndex( index - 1 ) } disabled={ index === 0 }>
+					<Button
+						variant="minimal"
+						size="small"
+						onClick={ () => setIndex( index - 1 ) }
+						disabled={ index === 0 }
+					>
 						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
 					</Button>
 					<Button
-						variant="link"
+						variant="minimal"
+						size="small"
 						onClick={ () => setIndex( index + 1 ) }
 						disabled={ index === prompts.length - 1 }
 					>
@@ -61,7 +66,14 @@ export default () => {
 				align="center"
 				gap="sm"
 			>
-				<Button variant="secondary" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
+				{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
+				<Button
+					variant="outline"
+					size="compact"
+					onClick={ () => {
+						document.location = `post-new.php?answer_prompt=${ prompt.id }`;
+					} }
+				>
 					{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
 				</Button>
 				{ prompt.answered_users_sample.length > 0 && (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -31,8 +31,8 @@ export default () => {
 	const prompt = prompts[ index ];
 
 	return (
-		<>
-			<div className="wpcom-daily-writing-prompt--prompt">
+		<Stack className="wpcom-daily-writing-prompt" direction="column" gap="md">
+			<Stack className="wpcom-daily-writing-prompt--prompt" direction="column" gap="md">
 				<Text variant="body-md" render={ <p /> }>
 					{ prompt.text }
 				</Text>
@@ -53,7 +53,7 @@ export default () => {
 						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
 					</Button>
 				</Stack>
-			</div>
+			</Stack>
 			<Stack
 				className="wpcom-daily-writing-prompt--action-row"
 				direction="row"
@@ -94,6 +94,6 @@ export default () => {
 					</Stack>
 				) }
 			</Stack>
-		</>
+		</Stack>
 	);
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -1,11 +1,8 @@
-.wpcom-daily-writing-prompt {
-	padding: var(--wpds-dimension-padding-md);
-}
 
 .wpcom-daily-writing-prompt--prompt {
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
 	padding: var(--wpds-dimension-padding-md);
-	border-radius: var(--wpds-border-radius-sm);
+	border-radius: var(--wpds-border-radius-md);
 }
 
 .wpcom-daily-writing-prompt--answered-users {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -3,47 +3,18 @@
 	padding: 1px 16px;
 	border-radius: 4px;
 	margin: 1em 0;
-
-	button.button-link {
-		border: 0;
-		line-height: inherit;
-		min-height: auto;
-		// Override mobile styles.
-		padding: 0;
-		margin: 0;
-
-		&[disabled] {
-			background-color: transparent !important;
-		}
-	}
 }
 
-.wpcom-daily-writing-prompt--previous-next {
-	display: flex;
-	justify-content: flex-end;
-	margin: 1em 0;
-}
-
-.wpcom-daily-writing-prompt--action-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	gap: 10px;
+.wpcom-daily-writing-prompt--answered-users {
 
 	img {
 		vertical-align: middle;
 		border-radius: 100%;
 		border: 2px solid #fff;
-		margin-left: -10px;
+		margin-inline-start: -10px;
 	}
 
 	img:first-child {
-		margin-left: 0;
-	}
-
-	.wpcom-daily-writing-prompt--previous-next {
-		display: flex;
-		flex-direction: row;
-		gap: 5px;
+		margin-inline-start: 0;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -1,17 +1,20 @@
+.wpcom-daily-writing-prompt {
+	padding: var(--wpds-dimension-padding-md);
+}
+
 .wpcom-daily-writing-prompt--prompt {
-	background-color: #f0f0f1;
-	padding: 1px 16px;
-	border-radius: 4px;
-	margin: 1em 0;
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	padding: var(--wpds-dimension-padding-md);
+	border-radius: var(--wpds-border-radius-sm);
 }
 
 .wpcom-daily-writing-prompt--answered-users {
 
 	img {
 		vertical-align: middle;
-		border-radius: 100%;
-		border: 2px solid #fff;
-		margin-inline-start: -10px;
+		border-radius: 50%;
+		border: var(--wpds-border-width-sm) solid var(--wpds-color-bg-surface-neutral);
+		margin-inline-start: calc(-1 * (var(--wpds-dimension-gap-sm) + var(--wpds-border-width-sm)));
 	}
 
 	img:first-child {


### PR DESCRIPTION
(Note to either merge first or rebase after https://github.com/Automattic/jetpack/pull/49425)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Updates Daily Writing prompt widget to use `@wordpress/ui` components, making it more consistent with modern WP UIs like in the editor.
* Changed button from full size to compact; looks more balanced but can put back the regular size if anyone prefers.

### Before
<img width="451" alt="image" src="https://github.com/user-attachments/assets/8ca5527b-21b3-41c8-8ee6-4e6e5ffad4d9" />

### After
<img width="485" height="212" alt="image" src="https://github.com/user-attachments/assets/ed1f0b88-c058-47da-b519-790fb395d2f2" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* See testing instructions at PCYsg-Osp-p2
* Test the widget on WP.com simple; it should continue look good in different sizes.