### PR TITLE
Podcast: clean-up side quest

### DIFF
--- a/projects/packages/podcast/changelog/automattic-podcasting-rem
+++ b/projects/packages/podcast/changelog/automattic-podcasting-rem
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add Settings::raw_show_image_url() and validate the stored category ID in Customize_Feed::resolve_category_id(), matching legacy WPCOM semantics
+Podcast: ignore a deleted podcast category and add a raw show image URL accessor

--- a/projects/packages/podcast/changelog/automattic-podcasting-rem
+++ b/projects/packages/podcast/changelog/automattic-podcasting-rem
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Settings::raw_show_image_url() and validate the stored category ID in Customize_Feed::resolve_category_id(), matching legacy WPCOM semantics

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -231,6 +231,28 @@ class Settings {
 	}
 
 	/**
+	 * Raw show cover image URL for settings reads. `podcasting_image_id`
+	 * resolved to its attachment URL when it points at an actual image,
+	 * otherwise the raw `podcasting_image` option. Never Photon-routed —
+	 * feed rendering applies its own square resize separately.
+	 *
+	 * Mirrors `Automattic_Podcasting::podcasting_get_image_url` in the wpcom
+	 * mu-plugin (with `''` in place of its falsy returns).
+	 *
+	 * @return string Image URL, or '' when not configured.
+	 */
+	public static function raw_show_image_url(): string {
+		$image_id = (int) get_option( 'podcasting_image_id', 0 );
+		if ( $image_id > 0 && wp_attachment_is_image( $image_id ) ) {
+			$url = wp_get_attachment_url( $image_id );
+			if ( false !== $url ) {
+				return $url;
+			}
+		}
+		return (string) get_option( 'podcasting_image', '' );
+	}
+
+	/**
 	 * `'yes'` (any case) or boolean true → true; everything else → false. The
 	 * feed only emits true/false; the legacy `'clean'` value collapses to false
 	 * because the WPCOM feed builder already treats it that way.

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -231,13 +231,9 @@ class Settings {
 	}
 
 	/**
-	 * Raw show cover image URL for settings reads. `podcasting_image_id`
-	 * resolved to its attachment URL when it points at an actual image,
-	 * otherwise the raw `podcasting_image` option. Never Photon-routed —
-	 * feed rendering applies its own square resize separately.
-	 *
-	 * Mirrors `Automattic_Podcasting::podcasting_get_image_url` in the wpcom
-	 * mu-plugin (with `''` in place of its falsy returns).
+	 * Show cover image URL: `podcasting_image_id` resolved to its attachment
+	 * URL when it points at an image, otherwise the raw `podcasting_image`
+	 * option. Never Photon-routed — feed rendering applies its own resize.
 	 *
 	 * @return string Image URL, or '' when not configured.
 	 */

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -363,22 +363,13 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Show-level cover image URL. Prefers `podcasting_image_id` (resolves to
-	 * an attachment URL) when it points at an actual image attachment, falls
-	 * back to the raw `podcasting_image` URL. Routes through Photon at
-	 * 3000×3000 when available.
+	 * Show-level cover image URL — `Settings::raw_show_image_url()` routed
+	 * through Photon at 3000×3000 when available.
 	 *
 	 * @return string
 	 */
 	private static function show_image_url(): string {
-		$image_id = (int) get_option( 'podcasting_image_id', 0 );
-		if ( $image_id > 0 && wp_attachment_is_image( $image_id ) ) {
-			$url = wp_get_attachment_url( $image_id );
-			if ( false !== $url ) {
-				return self::maybe_photon( $url );
-			}
-		}
-		$url = (string) get_option( 'podcasting_image', '' );
+		$url = Settings::raw_show_image_url();
 		return '' === $url ? '' : self::maybe_photon( $url );
 	}
 
@@ -416,14 +407,17 @@ class Customize_Feed {
 	 * storage and only have the slug. Returns 0 when neither resolves.
 	 *
 	 * Mirrors `Automattic_Podcasting::podcasting_get_podcasting_category_id`
-	 * in the wpcom mu-plugin.
+	 * in the wpcom mu-plugin, including its deleted-category semantics: a
+	 * numeric ID whose term no longer exists means "not configured" — no
+	 * fallback to the slug in that case.
 	 *
 	 * @return int
 	 */
 	public static function resolve_category_id(): int {
 		$category_id = (int) get_option( 'podcasting_category_id', 0 );
 		if ( $category_id > 0 ) {
-			return $category_id;
+			$category = get_category( $category_id );
+			return ( $category && ! is_wp_error( $category ) && isset( $category->term_id ) ) ? (int) $category->term_id : 0;
 		}
 
 		$slug = (string) get_option( 'podcasting_archive', '' );

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -406,10 +406,8 @@ class Customize_Feed {
 	 * legacy `podcasting_archive` option — older sites pre-date numeric
 	 * storage and only have the slug. Returns 0 when neither resolves.
 	 *
-	 * Mirrors `Automattic_Podcasting::podcasting_get_podcasting_category_id`
-	 * in the wpcom mu-plugin, including its deleted-category semantics: a
-	 * numeric ID whose term no longer exists means "not configured" — no
-	 * fallback to the slug in that case.
+	 * A numeric ID whose term was deleted means "not configured" — the slug
+	 * is not consulted in that case.
 	 *
 	 * @return int
 	 */

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -38,8 +38,27 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		Jetpack_Options::delete_option( 'id' );
+		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
+	}
+
+	/**
+	 * WorDBless lacks term-taxonomy plumbing, so seed the `terms` object cache
+	 * with a fully-formed `WP_Term` directly — `get_category()` short-circuits
+	 * to that before falling through to its DB query.
+	 */
+	private function seed_category_term( int $id ): void {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => 'Podcast',
+				'slug'             => 'podcast-' . $id,
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
 	}
 
 	/**
@@ -314,6 +333,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	public function test_resolve_category_id_prefers_numeric_id_over_archive_slug() {
+		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );
 		update_option( 'podcasting_archive', 'unrelated-slug' );
 
@@ -321,6 +341,40 @@ class Customize_Feed_Test extends BaseTestCase {
 		// find no term, and return 0 — so the assertion below covers both
 		// "right answer" and "took the right code path".
 		$this->assertSame( 17, Customize_Feed::resolve_category_id() );
+	}
+
+	/**
+	 * Deleted-category semantics, matching legacy wpcom: a numeric ID whose
+	 * term no longer exists means "not configured" — the legacy
+	 * `podcasting_archive` slug must NOT be consulted as a fallback, even
+	 * when it would resolve.
+	 */
+	public function test_resolve_category_id_returns_zero_when_stored_category_deleted() {
+		update_option( 'podcasting_category_id', 12345 ); // No such term seeded.
+
+		// A resolvable slug that must be ignored on the deleted-ID path.
+		$callback = static function ( $terms, $query ) {
+			if ( isset( $query->query_vars['slug'] ) && 'resolvable-slug' === $query->query_vars['slug'][0] ) {
+				return array(
+					new WP_Term(
+						(object) array(
+							'term_id'  => 777,
+							'slug'     => 'resolvable-slug',
+							'name'     => 'Podcast',
+							'taxonomy' => 'category',
+						)
+					),
+				);
+			}
+			return $terms;
+		};
+		add_filter( 'terms_pre_query', $callback, 10, 2 );
+
+		update_option( 'podcasting_archive', 'resolvable-slug' );
+
+		$this->assertSame( 0, Customize_Feed::resolve_category_id() );
+
+		remove_filter( 'terms_pre_query', $callback, 10 );
 	}
 
 	public function test_output_namespaces_declares_itunes_and_podcast() {
@@ -349,6 +403,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	public function test_filter_posts_with_enclosure_passes_through_when_queried_term_does_not_match() {
+		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );
 
 		$posts = array( new WP_Post( (object) array( 'ID' => 1 ) ) );
@@ -358,6 +413,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	public function test_filter_posts_with_enclosure_drops_posts_without_enclosure_meta() {
+		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );
 
 		$with_enclosure    = new WP_Post( (object) array( 'ID' => 100 ) );

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -344,8 +344,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Deleted-category semantics, matching legacy wpcom: a numeric ID whose
-	 * term no longer exists means "not configured" — the legacy
+	 * A numeric ID whose term no longer exists means "not configured" — the
 	 * `podcasting_archive` slug must NOT be consulted as a fallback, even
 	 * when it would resolve.
 	 */

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -167,4 +167,56 @@ class Settings_Test extends BaseTestCase {
 
 		$this->assertSame( 'active', $result['apple'] );
 	}
+
+	public function test_raw_show_image_url_prefers_image_attachment_over_raw_option() {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Show Cover',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', '2026/06/cover.jpg' );
+
+		update_option( 'podcasting_image_id', $attachment_id );
+		update_option( 'podcasting_image', 'https://example.com/raw-fallback.png' );
+
+		$url = Settings::raw_show_image_url();
+
+		$this->assertStringEndsWith( '2026/06/cover.jpg', $url );
+
+		delete_option( 'podcasting_image_id' );
+		delete_option( 'podcasting_image' );
+	}
+
+	/**
+	 * The `wp_attachment_is_image` gate: an ID pointing at a non-image
+	 * attachment (or nothing at all) must fall back to the raw option —
+	 * matches legacy `Automattic_Podcasting::podcasting_get_image_url`.
+	 */
+	public function test_raw_show_image_url_falls_back_to_raw_option_for_non_image_id() {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'audio/mpeg',
+				'post_title'     => 'Episode Audio',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', '2026/06/episode.mp3' );
+
+		update_option( 'podcasting_image_id', $attachment_id );
+		update_option( 'podcasting_image', 'https://example.com/cover.png' );
+
+		$this->assertSame( 'https://example.com/cover.png', Settings::raw_show_image_url() );
+
+		delete_option( 'podcasting_image_id' );
+		delete_option( 'podcasting_image' );
+	}
+
+	public function test_raw_show_image_url_returns_empty_string_when_unconfigured() {
+		delete_option( 'podcasting_image_id' );
+		delete_option( 'podcasting_image' );
+
+		$this->assertSame( '', Settings::raw_show_image_url() );
+	}
 }

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -191,8 +191,7 @@ class Settings_Test extends BaseTestCase {
 
 	/**
 	 * The `wp_attachment_is_image` gate: an ID pointing at a non-image
-	 * attachment (or nothing at all) must fall back to the raw option —
-	 * matches legacy `Automattic_Podcasting::podcasting_get_image_url`.
+	 * attachment (or nothing at all) must fall back to the raw option.
 	 */
 	public function test_raw_show_image_url_falls_back_to_raw_option_for_non_image_id() {
 		$attachment_id = wp_insert_post(


### PR DESCRIPTION
## Proposed changes

We are cleaning up the legacy version of Podcasting on wpcom and I want to make sure there is no regression. There were some slight variations in how we were doing this previously in `Automattic_Podcasting` and this should line the classes up.

* `Customize_Feed::resolve_category_id()` now checks that the stored `podcasting_category_id` still points to an existing category. If the category was deleted it returns `0`, with no fallback to the legacy `podcasting_archive` slug — same behavior as the legacy class. The slug fallback still applies when no numeric ID is set.
* Adds `Settings::raw_show_image_url()`, which returns the show cover image URL without Photon. WPCOM's settings endpoint will use this in place of `Automattic_Podcasting::podcasting_get_image_url()`.
* `Customize_Feed::show_image_url()` now uses the new accessor and applies Photon on top. No behavior change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack test php packages/podcast` — includes new tests for both changes.
* On a site with a podcast category configured, the feed should render with podcast tags as before.
* Delete the configured category: the feed should render as a plain feed with no podcast tags, even if a legacy `podcasting_archive` slug is set.
* `Settings::raw_show_image_url()` should return the attachment URL when `podcasting_image_id` is a valid image, the raw `podcasting_image` option otherwise, and never a Photon URL.
