### PR TITLE
Newsletter: Move the Email defaults section up

### DIFF
--- a/projects/packages/newsletter/changelog/update-newsletter-modernization-settings-order
+++ b/projects/packages/newsletter/changelog/update-newsletter-modernization-settings-order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Moving a settings section behind feature flag
+
+

--- a/projects/packages/newsletter/src/settings/newsletter-settings.tsx
+++ b/projects/packages/newsletter/src/settings/newsletter-settings.tsx
@@ -445,6 +445,12 @@ export function NewsletterSettingsBody( {
 									hasActivePlan={ data.newsletter_has_active_plan }
 								/>
 
+								<EmailDefaultsSection
+									data={ data }
+									onChange={ handleAutoSave }
+									isNewsletterEnabled={ data.subscriptions }
+								/>
+
 								<SubscriptionsSection
 									data={ data }
 									onChange={ handleSubscriptionChange }
@@ -452,12 +458,6 @@ export function NewsletterSettingsBody( {
 									isSaving={ isSavingSubscriptions }
 									hasChanges={ hasSubscriptionChanges }
 									changedKeys={ Object.keys( subscriptionChanges ) }
-									isNewsletterEnabled={ data.subscriptions }
-								/>
-
-								<EmailDefaultsSection
-									data={ data }
-									onChange={ handleAutoSave }
 									isNewsletterEnabled={ data.subscriptions }
 								/>
 


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Just what the title says

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Enable the feature flag for the modernized Newsletter dashboard
* Go to Newsletter > Setttings
* Check that the section moved above the Subscriptions section

<img width="921" height="772" alt="Screenshot from 2026-06-05 07-52-21" src="https://github.com/user-attachments/assets/2a94b409-628a-4e5f-98f5-1593cc9175ea" />

