### PR TITLE
Posts module: Allow syncing 'deleted_post_meta' with empty object_id

### DIFF
--- a/projects/packages/sync/changelog/fix-post-meta-delete-by-key-sync
+++ b/projects/packages/sync/changelog/fix-post-meta-delete-by-key-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Mirror cross-object post meta delete-all events.

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -727,6 +727,45 @@ class Replicastore implements Replicastore_Interface {
 	}
 
 	/**
+	 * Delete metadata with a certain key and value for all objects.
+	 *
+	 * @access public
+	 *
+	 * @param string $type       Meta type.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value to match.
+	 */
+	public function delete_metadata_by_key_value( $type, $meta_key, $meta_value ) {
+		global $wpdb;
+
+		$table = _get_meta_table( $type );
+		if ( ! $table ) {
+			return false;
+		}
+
+		if ( '' === $meta_value || null === $meta_value || false === $meta_value ) {
+			return false;
+		}
+
+		$column     = sanitize_key( $type . '_id' );
+		$meta_value = maybe_serialize( $meta_value );
+
+		$object_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT %i FROM %i WHERE meta_key = %s AND meta_value = %s', $column, $table, $meta_key, $meta_value ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Direct replica query is needed to identify caches invalidated below.
+		$wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Direct replica mutation.
+			$table,
+			array(
+				'meta_key'   => $meta_key,
+				'meta_value' => $meta_value,
+			),
+			array( '%s', '%s' )
+		);
+
+		foreach ( $object_ids as $object_id ) {
+			wp_cache_delete( $object_id, $type . '_meta' );
+		}
+	}
+
+	/**
 	 * Retrieve value of a constant based on the constant name.
 	 *
 	 * We explicitly return null instead of false if the constant doesn't exist.

--- a/projects/packages/sync/src/interface-replicastore.php
+++ b/projects/packages/sync/src/interface-replicastore.php
@@ -314,6 +314,17 @@ interface Replicastore_Interface {
 	public function delete_batch_metadata( $type, $object_ids, $meta_key );
 
 	/**
+	 * Delete metadata with a certain key and value for all objects.
+	 *
+	 * @access public
+	 *
+	 * @param string $type       Meta type.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value to match.
+	 */
+	public function delete_metadata_by_key_value( $type, $meta_key, $meta_value );
+
+	/**
 	 * Retrieve value of a constant based on the constant name.
 	 *
 	 * @access public

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -167,10 +167,9 @@ class Posts extends Module {
 
 		// Listen for meta changes.
 		$this->init_listeners_for_meta_type( 'post', $callable );
-		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
-
-		add_filter( 'jetpack_sync_before_enqueue_updated_post_meta', array( $this, 'on_before_enqueue_updated_attachment_metadata' ), 1 );
-		add_filter( 'jetpack_sync_before_enqueue_deleted_post_meta', array( $this, 'maybe_skip_deleted_post_meta' ) );
+		add_filter( 'jetpack_sync_before_enqueue_added_post_meta', array( $this, 'filter_meta' ) );
+		add_filter( 'jetpack_sync_before_enqueue_updated_post_meta', array( $this, 'filter_updated_post_meta' ) );
+		add_filter( 'jetpack_sync_before_enqueue_deleted_post_meta', array( $this, 'filter_deleted_post_meta' ) );
 
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_save_post', array( $this, 'filter_jetpack_sync_before_enqueue_jetpack_sync_save_post' ) );
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_published_post', array( $this, 'filter_jetpack_sync_before_enqueue_jetpack_published_post' ) );
@@ -539,17 +538,75 @@ class Posts extends Module {
 	 * @return array|false Hook arguments, or false if meta was filtered.
 	 */
 	public function filter_meta( $args ) {
-		if ( ! is_array( $args ) || count( $args ) < 3 ) {
+		if ( ! $this->has_valid_meta_args( $args ) || ! is_numeric( $args[1] ) ) {
 			return false;
-		}
-		if ( ! is_numeric( $args[1] ) || ! is_string( $args[2] ) ) {
-			return false;
-		}
-		if ( $this->is_post_type_allowed( $args[1] ) && $this->is_whitelisted_post_meta( $args[2] ) ) {
-			return $args;
 		}
 
-		return false;
+		return $this->is_allowed_post_meta( $args[1], $args[2] ) ? $args : false;
+	}
+
+	/**
+	 * Filter updated post meta that is not whitelisted, is stored for a disallowed post type,
+	 * or is duplicate attachment metadata.
+	 *
+	 * @param array|false $args Hook arguments.
+	 * @return array|false Hook arguments, or false if meta was filtered.
+	 */
+	public function filter_updated_post_meta( $args ) {
+		$args = $this->on_before_enqueue_updated_attachment_metadata( $args );
+		if ( false === $args ) {
+			return false;
+		}
+
+		return $this->filter_meta( $args );
+	}
+
+	/**
+	 * Filter deleted post meta that is not whitelisted, or is stored for a disallowed post type.
+	 *
+	 * @param array|false $args Hook arguments.
+	 * @return array|false Hook arguments, or false if meta was filtered.
+	 */
+	public function filter_deleted_post_meta( $args ) {
+		if ( ! $this->has_valid_meta_args( $args ) ) {
+			return false;
+		}
+		// Core uses post ID 0 on this hook for delete-all metadata operations. Only mirror value-constrained deletes.
+		if ( 0 === $args[1] ) {
+			if ( ! array_key_exists( 3, $args ) || '' === $args[3] || null === $args[3] || false === $args[3] ) {
+				return false;
+			}
+
+			return $this->is_whitelisted_post_meta( $args[2] ) ? $args : false;
+		}
+
+		$args = $this->filter_meta( $args );
+		if ( false === $args ) {
+			return false;
+		}
+
+		return $this->maybe_skip_deleted_post_meta( $args );
+	}
+
+	/**
+	 * Whether metadata hook arguments include a meta key.
+	 *
+	 * @param array|false $args Hook arguments.
+	 * @return bool Whether metadata hook arguments include a meta key.
+	 */
+	private function has_valid_meta_args( $args ) {
+		return is_array( $args ) && array_key_exists( 1, $args ) && array_key_exists( 2, $args ) && is_string( $args[2] );
+	}
+
+	/**
+	 * Whether post metadata is allowed to sync.
+	 *
+	 * @param int|string $object_id Post ID.
+	 * @param string     $meta_key  Meta key.
+	 * @return bool Whether post metadata is allowed to sync.
+	 */
+	private function is_allowed_post_meta( $object_id, $meta_key ) {
+		return $this->is_post_type_allowed( $object_id ) && $this->is_whitelisted_post_meta( $meta_key );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-sync-delete-metadata-no-object-id
+++ b/projects/plugins/jetpack/changelog/fix-sync-delete-metadata-no-object-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
@@ -150,7 +150,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 		$this->server_event_storage->reset();
 
-		delete_metadata( 'post', null, $this->whitelisted_post_meta, 'stale', true );
+		delete_metadata( 'post', 0, $this->whitelisted_post_meta, 'stale', true );
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' );
@@ -181,7 +181,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 		$this->server_event_storage->reset();
 
-		delete_metadata( 'post', null, $this->whitelisted_post_meta, '', true );
+		delete_metadata( 'post', 0, $this->whitelisted_post_meta, '', true );
 		$this->sender->do_sync();
 
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' ) );
@@ -196,7 +196,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$this->sender->do_sync();
 		$this->server_event_storage->reset();
 
-		delete_metadata( 'post', null, '_private_meta', 'private', true );
+		delete_metadata( 'post', 0, '_private_meta', 'private', true );
 		$this->sender->do_sync();
 
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' ) );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
@@ -137,6 +137,72 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 	}
 
 	/**
+	 * Verify deleting all post meta matching a key and value is synced.
+	 */
+	public function test_delete_all_post_meta_by_key_value_is_synced() {
+		$second_post_id = self::factory()->post->create();
+
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'stale' );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'current' );
+		add_post_meta( $second_post_id, $this->whitelisted_post_meta, 'stale' );
+		add_post_meta( $second_post_id, $this->whitelisted_post_meta, 'other' );
+
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+
+		delete_metadata( 'post', null, $this->whitelisted_post_meta, 'stale', true );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' );
+		$this->assertNotFalse( $event );
+		$this->assertSame( 0, $event->args[1] );
+		$this->assertEquals( $this->whitelisted_post_meta, $event->args[2] );
+		$this->assertEquals( 'stale', $event->args[3] );
+
+		$this->assertEquals(
+			get_post_meta( $this->post_id, $this->whitelisted_post_meta, false ),
+			$this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta )
+		);
+		$this->assertEquals(
+			get_post_meta( $second_post_id, $this->whitelisted_post_meta, false ),
+			$this->server_replica_storage->get_metadata( 'post', $second_post_id, $this->whitelisted_post_meta )
+		);
+	}
+
+	/**
+	 * Verify deleting all post meta without a value constraint is not synced.
+	 */
+	public function test_delete_all_post_meta_by_key_without_value_is_not_synced() {
+		$second_post_id = self::factory()->post->create();
+
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'current' );
+		add_post_meta( $second_post_id, $this->whitelisted_post_meta, 'other' );
+
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+
+		delete_metadata( 'post', null, $this->whitelisted_post_meta, '', true );
+		$this->sender->do_sync();
+
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' ) );
+	}
+
+	/**
+	 * Verify delete-by-key post meta sync still respects the whitelist.
+	 */
+	public function test_delete_all_post_meta_by_key_ignores_non_whitelisted_meta() {
+		add_post_meta( $this->post_id, '_private_meta', 'private' );
+
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+
+		delete_metadata( 'post', null, '_private_meta', 'private', true );
+		$this->sender->do_sync();
+
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'deleted_post_meta' ) );
+	}
+
+	/**
 	 * Verify private meta is not synced.
 	 */
 	public function test_doesn_t_sync_private_meta() {

--- a/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
@@ -738,6 +738,46 @@ class Z_IJetpack_Sync_Replicastore_Test extends TestCase {
 	 * @dataProvider store_provider
 	 */
 	#[DataProvider( 'store_provider' )]
+	public function test_replica_delete_meta_by_key_value( $store ) {
+		$store->upsert_post( self::$factory->post( 1 ) );
+		$store->upsert_post( self::$factory->post( 2 ) );
+
+		$store->upsert_metadata( 'post', 1, 'foo', 'delete', 3 );
+		$store->upsert_metadata( 'post', 1, 'foo', 'keep', 4 );
+		$store->upsert_metadata( 'post', 2, 'foo', 'delete', 5 );
+		$store->upsert_metadata( 'post', 2, 'bar', 'delete', 6 );
+
+		$store->delete_metadata_by_key_value( 'post', 'foo', 'delete' );
+
+		$this->assertEquals( array( 'keep' ), $store->get_metadata( 'post', 1, 'foo' ) );
+		$this->assertEquals( array(), $store->get_metadata( 'post', 2, 'foo' ) );
+		$this->assertEquals( array( 'delete' ), $store->get_metadata( 'post', 2, 'bar' ) );
+	}
+
+	/**
+	 * @dataProvider store_provider
+	 */
+	#[DataProvider( 'store_provider' )]
+	public function test_replica_delete_meta_by_key_value_requires_value( $store ) {
+		$store->upsert_post( self::$factory->post( 1 ) );
+		$store->upsert_post( self::$factory->post( 2 ) );
+
+		$store->upsert_metadata( 'post', 1, 'foo', 'delete', 3 );
+		$store->upsert_metadata( 'post', 1, 'foo', 'keep', 4 );
+		$store->upsert_metadata( 'post', 2, 'foo', 'delete', 5 );
+		$store->upsert_metadata( 'post', 2, 'bar', 'keep', 6 );
+
+		$store->delete_metadata_by_key_value( 'post', 'foo', '' );
+
+		$this->assertEquals( array( 'delete', 'keep' ), $store->get_metadata( 'post', 1, 'foo' ) );
+		$this->assertEquals( array( 'delete' ), $store->get_metadata( 'post', 2, 'foo' ) );
+		$this->assertEquals( array( 'keep' ), $store->get_metadata( 'post', 2, 'bar' ) );
+	}
+
+	/**
+	 * @dataProvider store_provider
+	 */
+	#[DataProvider( 'store_provider' )]
 	public function test_replica_update_meta_array( $store ) {
 		$meta_array = array(
 			'trees' => 'green',

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -104,9 +104,13 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			case ( preg_match( '/^deleted_(.*)_meta$/', $action_name, $matches ) ? true : false ):
-				list( $meta_ids, $object_id, $meta_key, $meta_value ) = $args;
+				list( $meta_ids, $object_id, $meta_key, $meta_value ) = array_pad( $args, 4, '' );
 				$type = $matches[1];
-				$this->store->delete_metadata( $type, $object_id, $meta_ids );
+				if ( 0 === $object_id ) {
+					$this->store->delete_metadata_by_key_value( $type, $meta_key, $meta_value );
+				} else {
+					$this->store->delete_metadata( $type, $object_id, $meta_ids );
+				}
 				break;
 			case 'jetpack_post_meta_batch_delete':
 				list( $object_ids, $meta_key ) = $args;

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -109,7 +109,10 @@ class Jetpack_Sync_Server_Replicator {
 				if ( 0 === $object_id ) {
 					$this->store->delete_metadata_by_key_value( $type, $meta_key, $meta_value );
 				} else {
-					$this->store->delete_metadata( $type, $object_id, $meta_ids );
+					if ( ! is_numeric( $object_id ) || ! is_array( $meta_ids ) ) {
+						break;
+					}
+					$this->store->delete_metadata( $type, (int) $object_id, array_map( 'intval', $meta_ids ) );
 				}
 				break;
 			case 'jetpack_post_meta_batch_delete':

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -360,6 +360,29 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		}
 	}
 
+	public function delete_metadata_by_key_value( $type, $meta_key, $meta_value ) {
+		$blog_id = get_current_blog_id();
+		if ( ! isset( $this->meta[ $blog_id ][ $type ] ) ) {
+			return;
+		}
+
+		if ( '' === $meta_value || null === $meta_value || false === $meta_value ) {
+			return;
+		}
+
+		foreach ( $this->meta[ $blog_id ][ $type ] as $meta_id => $meta_data ) {
+			if ( $meta_data->meta_key !== $meta_key ) {
+				continue;
+			}
+
+			if ( $meta_data->meta_value !== $meta_value ) {
+				continue;
+			}
+
+			unset( $this->meta[ $blog_id ][ $type ][ $meta_id ] );
+		}
+	}
+
 	/** Constants **/
 	public function get_constant( $constant ) {
 		if ( ! isset( $this->constants[ get_current_blog_id() ][ $constant ] ) ) {


### PR DESCRIPTION
Fixes SYNC-344

## Proposed changes
* Sync value-constrained delete-all post meta events where Core emits `deleted_post_meta` with post ID `0`.
* Keep the normal `deleted_post_meta` action instead of introducing a separate Sync action.
* Add a `delete_metadata_by_key_value()` replica-store operation for deleting matching meta rows across objects.
* Filter out key-only delete-all post meta events to avoid broad replica deletes without a value constraint.
* Refactor post meta enqueue filters so added, updated, and deleted post meta each have a single dedicated filter path.
* Add Sync regression coverage for value-constrained delete-all post meta, key-only delete-all filtering, whitelist enforcement, and replica-store behavior.

## Related product discussion/links
* SYNC-344

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Needs wpcom counterpart PR applied: 221900-ghe-Automattic/wpcom
* Use a connected Jetpack test site with Sync enabled.
* Create or edit a test post.
* Upload image A and set it as the post's featured image.
* Allow Sync to send the post and post meta changes.
* Delete image A from the Media Library. This exercises Core's delete-all metadata cleanup for `_thumbnail_id`.
* Upload image B and set it as the same post's featured image.
* Allow Sync to send the new post meta changes. -- you will note a `deleted_post_meta` Sync action for `_thumbnail_id` with `object_id` set to `0` 
* Verify consumers that read the synced featured image, such as post sharing/newsletter preview flows, show image B rather than a missing featured image.
* For a lower-level check, verify the remote replica no longer has the stale `_thumbnail_id` row for image A and resolves the post's featured image to image B via `get_post_meta(YOUR_POST_ID, '_thumbnail_id')` in `wpsh`