### PR TITLE
Forms: hide Jetpack footer across the wp-build Forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/change-forms-responses-hide-footer
+++ b/projects/packages/forms/changelog/change-forms-responses-hide-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: hide the Jetpack footer across the wp-build Forms dashboard (both the Forms list and Responses views) so it doesn't compete with the DataViews pagination and full-height layout.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -601,6 +601,7 @@ function StageInner() {
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }
+			showFooter={ false }
 		>
 			<DataViews
 				paginationInfo={ paginationInfo }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -689,6 +689,7 @@ function StageInner() {
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }
+			showFooter={ false }
 		>
 			<DataViews
 				empty={

--- a/projects/packages/forms/src/dashboard/wp-build/components/page/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/page/index.tsx
@@ -9,6 +9,7 @@ type PageProps = ComponentProps< typeof Page >;
 
 type FormsPageProps = PageProps & {
 	children: ReactNode;
+	showFooter?: boolean;
 };
 
 /**
@@ -23,16 +24,24 @@ type FormsPageProps = PageProps & {
  * `hasPadding`) and rely on `<Page>` rendering their DataViews children directly
  * rather than inside `<AdminPage>`'s `<Container><Col>` wrap.
  *
- * @param props          - All `<Page>` props are forwarded through.
- * @param props.children - Page content (rendered inside `<Page>`, above the footer).
+ * @param props            - All `<Page>` props are forwarded through.
+ * @param props.children   - Page content (rendered inside `<Page>`, above the footer).
+ * @param props.showFooter - Whether to render the trailing `<JetpackFooter>`. Defaults to
+ *                         `true`; pass `false` on full-height routes (e.g. the DataViews
+ *                         Responses inbox) where the footer competes with the view's own
+ *                         pagination/scroll chrome. Mirrors `<AdminPage>`'s `showFooter`.
  * @return The Forms page chrome.
  */
-export default function FormsPage( { children, ...pageProps }: FormsPageProps ): JSX.Element {
+export default function FormsPage( {
+	children,
+	showFooter = true,
+	...pageProps
+}: FormsPageProps ): JSX.Element {
 	return (
 		<div className="jp-admin-page">
 			<Page className="jp-admin-page__page" { ...pageProps }>
 				{ children }
-				<JetpackFooter />
+				{ showFooter && <JetpackFooter /> }
 			</Page>
 		</div>
 	);


### PR DESCRIPTION
Part of the Jetpack admin header/footer unification work.

## Proposed changes

Hide the Jetpack footer across the **wp-build Forms dashboard** — both the **Forms list** and the **Responses** views. Both are full-height `@wordpress/dataviews` surfaces with their own pagination/scroll chrome, so the trailing `<JetpackFooter>` ("An Automattic Airline") competes with the view and gets pushed below the fold.

* **`src/dashboard/wp-build/components/page/index.tsx`** — the wp-build dashboard's local `FormsPage` chrome wrapper always rendered a trailing `<JetpackFooter>`. Add an optional **`showFooter`** prop (default `true`) and render the footer as `{ showFooter && <JetpackFooter /> }`. Mirrors the `showFooter` prop on `<AdminPage>` from `@automattic/jetpack-components` (which Forms can't use directly because its routes pass `<Page>` props AdminPage doesn't forward), so the API stays consistent and discoverable.
* **`routes/forms/stage.tsx`** and **`routes/responses/stage.tsx`** — pass `showFooter={ false }` on each `<FormsPage>`.

Default stays `true`, so any other/future `FormsPage` consumer keeps its footer unless it opts out.

## Related product discussion/links

* Part of the Jetpack header/footer unification project (JETPACK-1391 / standardize-the-jetpack-header-and-footer).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Ensure the wp-build Forms dashboard is active (default).
2. Go to **Jetpack → Forms** (`admin.php?page=jetpack-forms-responses-wp-admin`).
3. On the **Forms** list tab and the **Responses** tab, the "An Automattic Airline" Jetpack footer should **no longer render**; the DataViews table/pagination uses the full height with no footer gap.

Verified locally (built into a dev site): footer absent on both the Forms list (`/forms`) and Responses inbox (`/responses/inbox`); DataViews pagination sits at the bottom edge, clean reflow. Screenshots below.

### Screenshots

Forms list — no footer:

<!-- drag forms-list-no-footer.png here -->

Responses inbox — no footer:

<!-- drag forms-responses-inbox-no-footer.png here -->
