### PR TITLE
Carousel: skip data-image-meta output when EXIF display is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-exif-html-output
+++ b/projects/plugins/jetpack/changelog/fix-carousel-exif-html-output
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: stop adding EXIF image metadata to the page markup when the option to display it is disabled.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -948,11 +948,7 @@ class Jetpack_Carousel {
 		$size            = isset( $meta['width'] ) ? (int) $meta['width'] . ',' . (int) $meta['height'] : '';
 		$img_meta        = ( ! empty( $meta['image_meta'] ) ) ? (array) $meta['image_meta'] : array();
 		$comments_opened = (int) comments_open( $attachment_id );
-
-		// Only emit the EXIF metadata when the option to display it is enabled,
-		// to avoid bloating the markup on sites that have turned EXIF off.
-		// See https://github.com/Automattic/jetpack/issues/32862.
-		$display_exif = $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) );
+		$display_exif    = $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) );
 
 		/**
 		 * Note: Cannot generate a filename from the width and height wp_get_attachment_image_src() returns because

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -949,6 +949,11 @@ class Jetpack_Carousel {
 		$img_meta        = ( ! empty( $meta['image_meta'] ) ) ? (array) $meta['image_meta'] : array();
 		$comments_opened = (int) comments_open( $attachment_id );
 
+		// Only emit the EXIF metadata when the option to display it is enabled,
+		// to avoid bloating the markup on sites that have turned EXIF off.
+		// See https://github.com/Automattic/jetpack/issues/32862.
+		$display_exif = $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) );
+
 		/**
 		 * Note: Cannot generate a filename from the width and height wp_get_attachment_image_src() returns because
 		 * it takes the $content_width global variable themes can set in consideration, therefore returning sizes
@@ -971,19 +976,22 @@ class Jetpack_Carousel {
 		$attachment_desc    = wpautop( wptexturize( $attachment->post_content ) );
 		$attachment_caption = wpautop( wptexturize( $attachment->post_excerpt ) );
 
-		// See https://github.com/Automattic/jetpack/issues/2765.
-		if ( isset( $img_meta['keywords'] ) ) {
-			unset( $img_meta['keywords'] );
-		}
-
-		$img_meta = wp_json_encode( array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_AMP );
-
 		$attr['data-attachment-id']   = $attachment_id;
 		$attr['data-permalink']       = esc_attr( get_permalink( $attachment_id ) );
 		$attr['data-orig-file']       = esc_attr( $orig_file );
 		$attr['data-orig-size']       = $size;
 		$attr['data-comments-opened'] = $comments_opened;
-		$attr['data-image-meta']      = esc_attr( $img_meta );
+
+		if ( $display_exif ) {
+			// See https://github.com/Automattic/jetpack/issues/2765.
+			if ( isset( $img_meta['keywords'] ) ) {
+				unset( $img_meta['keywords'] );
+			}
+
+			$img_meta                = wp_json_encode( array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_AMP );
+			$attr['data-image-meta'] = esc_attr( $img_meta );
+		}
+
 		// The lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here.
 		$attr['data-image-title']       = esc_attr( htmlspecialchars( $attachment_title, ENT_COMPAT ) );
 		$attr['data-image-description'] = esc_attr( htmlspecialchars( $attachment_desc, ENT_COMPAT ) );

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -18,16 +18,17 @@ $item = $context['item'];
 // avoid bloating the markup on sites that have turned EXIF off. Mirrors the
 // gating in Jetpack_Carousel::add_data_to_images().
 // See https://github.com/Automattic/jetpack/issues/32862.
-$display_exif = 1 === (int) Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', 1 );
+$display_exif     = 1 === (int) Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', 1 );
+$fuzzy_image_meta = '';
 
 if ( $display_exif ) {
-	$fuzzy_image_meta = $item->fuzzy_image_meta(); // See https://github.com/Automattic/jetpack/issues/2765 .
-	if ( isset( $fuzzy_image_meta['keywords'] ) ) {
-		unset( $fuzzy_image_meta['keywords'] );
+	$image_meta = $item->fuzzy_image_meta(); // See https://github.com/Automattic/jetpack/issues/2765 .
+	if ( isset( $image_meta['keywords'] ) ) {
+		unset( $image_meta['keywords'] );
 	}
 
 	// Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
-	$fuzzy_image_meta = wp_json_encode( map_deep( $fuzzy_image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	$fuzzy_image_meta = (string) wp_json_encode( map_deep( $image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 }
 
 ?>

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -12,21 +12,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- HTML template, let Phan handle it.
 
-$item             = $context['item'];
-$fuzzy_image_meta = $item->fuzzy_image_meta(); // See https://github.com/Automattic/jetpack/issues/2765 .
-if ( isset( $fuzzy_image_meta['keywords'] ) ) {
-	unset( $fuzzy_image_meta['keywords'] );
-}
+$item = $context['item'];
 
-// Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
-$fuzzy_image_meta = wp_json_encode( map_deep( $fuzzy_image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+// Only emit the EXIF metadata when the option to display it is enabled, to
+// avoid bloating the markup on sites that have turned EXIF off. Mirrors the
+// gating in Jetpack_Carousel::add_data_to_images().
+// See https://github.com/Automattic/jetpack/issues/32862.
+$display_exif = 1 === (int) Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', 1 );
+
+if ( $display_exif ) {
+	$fuzzy_image_meta = $item->fuzzy_image_meta(); // See https://github.com/Automattic/jetpack/issues/2765 .
+	if ( isset( $fuzzy_image_meta['keywords'] ) ) {
+		unset( $fuzzy_image_meta['keywords'] );
+	}
+
+	// Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
+	$fuzzy_image_meta = wp_json_encode( map_deep( $fuzzy_image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+}
 
 ?>
 data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"
 data-orig-file="<?php echo esc_url( wp_get_attachment_url( $item->image->ID ) ); ?>"
 data-orig-size="<?php echo esc_attr( $item->meta_width() ); ?>,<?php echo esc_attr( $item->meta_height() ); ?>"
 data-comments-opened="<?php echo esc_attr( comments_open( $item->image->ID ) ); ?>"
+<?php if ( $display_exif ) : ?>
 data-image-meta="<?php echo esc_attr( $fuzzy_image_meta ); ?>"
+<?php endif; ?>
 <?php // The two lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here. ?>
 data-image-title="<?php echo esc_attr( htmlspecialchars( wptexturize( $item->image->post_title ), ENT_COMPAT ) ); ?>"
 data-image-description="<?php echo esc_attr( htmlspecialchars( wpautop( wptexturize( $item->image->post_content ) ), ENT_COMPAT ) ); ?>"

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -37,6 +37,43 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Creates an image attachment populated with EXIF image metadata.
+	 *
+	 * @return WP_Post The attachment post object.
+	 */
+	private function create_image_attachment_with_exif() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => dirname( __DIR__, 2 ) . '/jetpack-icon.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+				'post_content'   => 'Test Image Description',
+				'post_excerpt'   => 'Test Image Caption',
+				'post_status'    => 'publish',
+			)
+		);
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'width'      => 100,
+				'height'     => 100,
+				'file'       => 'jetpack-icon.jpg',
+				'image_meta' => array(
+					'camera'        => 'JetpackCam',
+					'aperture'      => '2.8',
+					'focal_length'  => '35',
+					'shutter_speed' => '0.005',
+					'iso'           => '200',
+				),
+			)
+		);
+
+		return get_post( $attachment_id );
+	}
+
+	/**
 	 * Gets the test data for test_add_data_img_tags_and_enqueue_assets().
 	 *
 	 * @return array The test data.
@@ -121,5 +158,38 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		if ( $is_amp ) {
 			$this->assertFalse( wp_script_is( 'jetpack-carousel' ) );
 		}
+	}
+
+	/**
+	 * When the EXIF display option is enabled (the default), add_data_to_images()
+	 * should include the data-image-meta attribute.
+	 */
+	public function test_add_data_to_images_includes_image_meta_when_exif_enabled() {
+		update_option( 'carousel_display_exif', 1 );
+		$attachment = $this->create_image_attachment_with_exif();
+
+		$attr = $this->instance->add_data_to_images( array(), $attachment );
+
+		$this->assertArrayHasKey( 'data-image-meta', $attr );
+		$this->assertStringContainsString( 'JetpackCam', $attr['data-image-meta'] );
+		$this->assertArrayHasKey( 'data-attachment-id', $attr );
+	}
+
+	/**
+	 * When the EXIF display option is disabled, add_data_to_images() should NOT
+	 * include the data-image-meta attribute, while still emitting the other
+	 * data-* attributes the carousel modal relies on.
+	 */
+	public function test_add_data_to_images_omits_image_meta_when_exif_disabled() {
+		update_option( 'carousel_display_exif', 0 );
+		$attachment = $this->create_image_attachment_with_exif();
+
+		$attr = $this->instance->add_data_to_images( array(), $attachment );
+
+		$this->assertArrayNotHasKey( 'data-image-meta', $attr );
+		// Other attributes the modal needs must still be present.
+		$this->assertArrayHasKey( 'data-attachment-id', $attr );
+		$this->assertArrayHasKey( 'data-permalink', $attr );
+		$this->assertArrayHasKey( 'data-image-title', $attr );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/tiled-gallery/Carousel_Image_Args_Template_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/tiled-gallery/Carousel_Image_Args_Template_Test.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Tests for the tiled gallery carousel-image-args partial template.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Class Carousel_Image_Args_Template_Test
+ */
+class Carousel_Image_Args_Template_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Path to the partial under test.
+	 *
+	 * @var string
+	 */
+	private $template;
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->template = JETPACK__PLUGIN_DIR . 'modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php';
+	}
+
+	/**
+	 * Builds a stand-in gallery item backed by a real attachment carrying EXIF
+	 * metadata. The anonymous object exposes only the methods the partial reads,
+	 * avoiding the heavier Image CDN / srcset setup the real item performs.
+	 *
+	 * @return object
+	 */
+	private function create_stub_item_with_exif() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => dirname( __DIR__, 2 ) . '/jetpack-icon.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+				'post_content'   => 'Test Image Description',
+				'post_status'    => 'publish',
+			)
+		);
+
+		$image = get_post( $attachment_id );
+		$meta  = array(
+			'camera'   => 'JetpackCam',
+			'aperture' => '2.8',
+		);
+
+		return new class( $image, $meta ) {
+			/**
+			 * The attachment post backing the item.
+			 *
+			 * @var WP_Post
+			 */
+			public $image;
+
+			/**
+			 * The EXIF image metadata to return from fuzzy_image_meta().
+			 *
+			 * @var array
+			 */
+			private $meta;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param WP_Post $image The attachment post.
+			 * @param array   $meta  The EXIF image metadata.
+			 */
+			public function __construct( $image, $meta ) {
+				$this->image = $image;
+				$this->meta  = $meta;
+			}
+
+			/**
+			 * Return the EXIF image metadata.
+			 *
+			 * @return array
+			 */
+			public function fuzzy_image_meta() {
+				return $this->meta;
+			}
+
+			/**
+			 * Return the image width.
+			 *
+			 * @return int
+			 */
+			public function meta_width() {
+				return 100;
+			}
+
+			/**
+			 * Return the image height.
+			 *
+			 * @return int
+			 */
+			public function meta_height() {
+				return 100;
+			}
+
+			/**
+			 * Return the medium file URL.
+			 *
+			 * @return string
+			 */
+			public function medium_file() {
+				return 'http://example.org/medium.jpg';
+			}
+
+			/**
+			 * Return the large file URL.
+			 *
+			 * @return string
+			 */
+			public function large_file() {
+				return 'http://example.org/large.jpg';
+			}
+		};
+	}
+
+	/**
+	 * Renders the partial with the given item in context.
+	 *
+	 * @param object $item The gallery item.
+	 * @return string The rendered template output.
+	 */
+	private function render( $item ) {
+		$context = array( 'item' => $item ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Read by the required template.
+		ob_start();
+		require $this->template;
+		return ob_get_clean();
+	}
+
+	/**
+	 * When the EXIF display option is enabled (the default), the partial should
+	 * output the data-image-meta attribute.
+	 */
+	public function test_outputs_image_meta_when_exif_enabled() {
+		update_option( 'carousel_display_exif', 1 );
+		$output = $this->render( $this->create_stub_item_with_exif() );
+
+		$this->assertStringContainsString( 'data-image-meta=', $output );
+		$this->assertStringContainsString( 'JetpackCam', $output );
+		$this->assertStringContainsString( 'data-attachment-id=', $output );
+	}
+
+	/**
+	 * When the EXIF display option is disabled, the partial should NOT output the
+	 * data-image-meta attribute, while still emitting the other data-* attributes.
+	 */
+	public function test_omits_image_meta_when_exif_disabled() {
+		update_option( 'carousel_display_exif', 0 );
+		$output = $this->render( $this->create_stub_item_with_exif() );
+
+		$this->assertStringNotContainsString( 'data-image-meta=', $output );
+		$this->assertStringNotContainsString( 'JetpackCam', $output );
+		// Other attributes the modal needs must still be present.
+		$this->assertStringContainsString( 'data-attachment-id=', $output );
+		$this->assertStringContainsString( 'data-image-title=', $output );
+	}
+}


### PR DESCRIPTION
Fixes #32862

## Proposed changes

When Carousel's "Show photo EXIF metadata in carousel" option (`carousel_display_exif`) is **disabled**, Jetpack was still injecting the full `data-image-meta="{…}"` attribute into every gallery image's HTML. The option was only enforced client-side in `jetpack-carousel.js` (`updateExif()` returns early), so the server always computed and emitted the metadata — bloating the DOM/page weight for image-heavy sites, with no way to suppress it.

This gates the server-side output on the option, in `Jetpack_Carousel::add_data_to_images()`:

* Reads `carousel_display_exif` once (reusing the same `test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( … ) )` pattern already used to localize the value for JS).
* Wraps the EXIF work — the `keywords` unset, the `wp_json_encode()`, and the `$attr['data-image-meta']` assignment — in `if ( $display_exif )`. When EXIF display is off, the metadata is **neither computed nor emitted** (a small per-image perf win too).
* All other `data-*` attributes the modal relies on (attachment-id, permalink, orig-file, orig-size, comments-opened, image-title/description/caption, large-file) remain unconditional.

This mirrors how `carousel_display_comments` already gates the comments markup server-side. **The option defaults to `true`, so sites that never changed the setting see no difference** — only sites that explicitly disabled EXIF lose the attribute, which is the requested behavior. No JavaScript change is needed: the client already falls back to `{}` when the attribute is absent and `updateExif()` early-returns when the option is off.

## Related product discussion/links

* Reported in #32862 (open ~3 years; reporter has been manually patching `jetpack-carousel.php` after each update).

## Does this pull request change what data or activity we track or use?

No. It only removes already-derived EXIF metadata from the page markup when the site owner has opted out of displaying it.

## Testing instructions

* Enable the **Carousel** feature (Jetpack → Settings, or `wp jetpack module activate carousel`).
* Create a post with a gallery of images that have EXIF metadata.
* In **Settings → Media**, **uncheck** "Show photo EXIF metadata in carousel".
* View the page source → confirm there is **no** `data-image-meta` attribute on the gallery images.
* Open the carousel modal → confirm it still opens and shows the image, title, caption, comments area, and "View full size" link.
* Re-**check** the option → confirm `data-image-meta` is present again and the EXIF panel renders inside the modal.

Verified live on a Jurassic Ninja site running this branch: with EXIF off, `data-image-meta` is absent (0 occurrences) while all other `data-*` attributes remain; the modal opens correctly with no console errors. With EXIF on, the attribute is present.

A PHPUnit regression test (`Jetpack_Carousel_Test`) covers both option states.
