### PR TITLE
Stylelint: lint wordpress/theme design token usage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1785,6 +1785,9 @@ importers:
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.46.0
         version: 6.46.0(webpack@5.105.2)
+      '@wordpress/theme':
+        specifier: 0.13.0
+        version: 0.13.0
       babel-loader:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2)
@@ -23487,12 +23490,12 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)':
     dependencies:
@@ -25907,6 +25910,14 @@ snapshots:
       lib0: 0.2.99
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
+
+  '@wordpress/theme@0.13.0':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/private-apis': 1.46.0
+      '@wordpress/style-runtime': 0.2.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
 
   '@wordpress/theme@0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34024,7 +34035,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6585,6 +6585,9 @@ importers:
       '@wordpress/stylelint-config':
         specifier: 23.38.0
         version: 23.38.0(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@7.0.0(stylelint@17.7.0(typescript@5.9.3)))(stylelint@17.7.0(typescript@5.9.3))
+      '@wordpress/theme':
+        specifier: 0.13.0
+        version: 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0(typescript@5.9.3))
       babel-jest:
         specifier: 30.4.1
         version: 30.4.1(@babel/core@7.29.0)

--- a/projects/js-packages/webpack-config/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Webpack config: Add shared PostCSS pipeline that injects WPDS design-token fallbacks for webpack builds.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -18,6 +18,7 @@
 		".": "./src/index.js",
 		"./babel": "./src/babel.js",
 		"./babel/preset": "./src/babel-preset.js",
+		"./postcss": "./src/postcss.js",
 		"./webpack": "./src/webpack.js"
 	},
 	"dependencies": {
@@ -36,6 +37,7 @@
 		"@pmmmwh/react-refresh-webpack-plugin": "0.6.2",
 		"@wordpress/browserslist-config": "6.46.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.46.0",
+		"@wordpress/theme": "0.13.0",
 		"babel-loader": "10.0.0",
 		"babel-plugin-polyfill-corejs3": "0.14.0",
 		"browserslist": "4.28.2",

--- a/projects/js-packages/webpack-config/src/postcss.js
+++ b/projects/js-packages/webpack-config/src/postcss.js
@@ -1,0 +1,94 @@
+/**
+ * Shared PostCSS helpers for Jetpack webpack builds.
+ *
+ * Injects `@wordpress/theme` design-token fallbacks into bare `var(--wpds-*)`
+ * references before other transforms run. See:
+ * https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#build-plugins
+ */
+
+const path = require( 'path' );
+
+/**
+ * Resolve a package subpath from the consuming project's dependency tree.
+ *
+ * @param {string} specifier - Module specifier.
+ * @param {string} fromDir   - Directory of the consumer's `postcss.config.js`.
+ * @return {string} Absolute path.
+ */
+function resolvePeer( specifier, fromDir ) {
+	return require.resolve( specifier, {
+		paths: [ fromDir, process.cwd(), path.join( __dirname, '../../..' ) ],
+	} );
+}
+
+/**
+ * Require a PostCSS-related package from the consuming project's dependency tree.
+ *
+ * @param {string} moduleName - Package name.
+ * @param {string} fromDir    - Directory of the consumer's `postcss.config.js`.
+ * @return {*} Required module export.
+ */
+function requirePeer( moduleName, fromDir ) {
+	return require( resolvePeer( moduleName, fromDir ) );
+}
+
+/**
+ * Load the WPDS token fallback PostCSS plugin when `@wordpress/theme` is available.
+ *
+ * @param {string} fromDir - Directory of the consumer's `postcss.config.js`.
+ * @return {import('postcss').Plugin | null} WPDS token fallback plugin, if available.
+ */
+function loadDsTokenFallbacks( fromDir ) {
+	try {
+		return requirePeer( '@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks', fromDir )
+			.default;
+	} catch {
+		// @wordpress/theme is optional; skip token fallbacks when unavailable.
+		return null;
+	}
+}
+
+/**
+ * Build the standard PostCSS plugin list for Jetpack webpack `postcss-loader` configs.
+ *
+ * @param {object}  [options]            - PostCSS pipeline options.
+ * @param {string}  [options.fromDir]    - Directory of the consumer `postcss.config.js`.
+ * @param {boolean} [options.preserve]   - Passed to `postcss-custom-properties`.
+ * @param {boolean} [options.wpdsTokens] - Include `@wordpress/theme/design-tokens.css`
+ *                                       in global data for `postcss-custom-properties`.
+ * @return {import('postcss').AcceptedPlugin[]} PostCSS plugins for webpack `postcss-loader`.
+ */
+function webpackPostcssPlugins( {
+	fromDir = process.cwd(),
+	preserve = false,
+	wpdsTokens = false,
+} = {} ) {
+	const globalDataFiles = [
+		resolvePeer( '@automattic/calypso-color-schemes/root-only/index.css', fromDir ),
+	];
+
+	if ( wpdsTokens ) {
+		globalDataFiles.push( resolvePeer( '@wordpress/theme/design-tokens.css', fromDir ) );
+	}
+
+	return [
+		loadDsTokenFallbacks( fromDir ),
+		requirePeer(
+			'@csstools/postcss-global-data',
+			fromDir
+		)( {
+			files: globalDataFiles,
+		} ),
+		requirePeer(
+			'postcss-custom-properties',
+			fromDir
+		)( {
+			preserve,
+		} ),
+		requirePeer( 'autoprefixer', fromDir ),
+	].filter( Boolean );
+}
+
+module.exports = {
+	webpackPostcssPlugins,
+};

--- a/projects/packages/publicize/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/packages/publicize/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Inject WPDS design-token fallbacks during webpack CSS builds.

--- a/projects/packages/publicize/postcss.config.js
+++ b/projects/packages/publicize/postcss.config.js
@@ -1,21 +1,5 @@
+const { webpackPostcssPlugins } = require( '@automattic/jetpack-webpack-config/postcss' );
+
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: webpackPostcssPlugins( { fromDir: __dirname } ),
 } );

--- a/projects/packages/search/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/packages/search/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Inject WPDS design-token fallbacks during webpack CSS builds.

--- a/projects/packages/search/postcss.blocks.config.js
+++ b/projects/packages/search/postcss.blocks.config.js
@@ -8,14 +8,8 @@
 // (inline-search, customberg, instant-search) keep `postcss.config.js`
 // with `preserve: false` — `instant-search` in particular reads
 // calypso-color-schemes vars that aren't shipped to the runtime.
+const { webpackPostcssPlugins } = require( '@automattic/jetpack-webpack-config/postcss' );
+
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			preserve: true,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: webpackPostcssPlugins( { fromDir: __dirname, preserve: true } ),
 } );

--- a/projects/packages/search/postcss.config.js
+++ b/projects/packages/search/postcss.config.js
@@ -1,21 +1,5 @@
+const { webpackPostcssPlugins } = require( '@automattic/jetpack-webpack-config/postcss' );
+
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: webpackPostcssPlugins( { fromDir: __dirname } ),
 } );

--- a/projects/packages/videopress/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/packages/videopress/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Inject WPDS design-token fallbacks during webpack CSS builds.

--- a/projects/packages/videopress/postcss.config.js
+++ b/projects/packages/videopress/postcss.config.js
@@ -1,21 +1,5 @@
+const { webpackPostcssPlugins } = require( '@automattic/jetpack-webpack-config/postcss' );
+
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: webpackPostcssPlugins( { fromDir: __dirname } ),
 } );

--- a/projects/plugins/jetpack/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/plugins/jetpack/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Inject WPDS design-token fallbacks during legacy dashboard CSS builds.

--- a/projects/plugins/jetpack/tools/postcss.config.js
+++ b/projects/plugins/jetpack/tools/postcss.config.js
@@ -1,31 +1,5 @@
+const { webpackPostcssPlugins } = require( '@automattic/jetpack-webpack-config/postcss' );
+
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [
-				require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ),
-				// Feed the WPDS design tokens to postcss-custom-properties so the legacy
-				// `_inc/` dashboard's `var(--wpds-*, #fallback)` usages inline to the actual
-				// token value (e.g. #707070) instead of the hand-written hex fallback. These
-				// tokens normally arrive transitively via `@wordpress/ui`'s CSS bundle, which
-				// this dashboard doesn't import. Modernized (admin-ui) pages get them at
-				// runtime instead; see the shared token stylesheet enqueued there.
-				// The `design-tokens.css` subpath is exposed via @wordpress/theme's exports map.
-				require.resolve( '@wordpress/theme/design-tokens.css' ),
-			],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: webpackPostcssPlugins( { fromDir: __dirname, wpdsTokens: true } ),
 } );

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/eslint-plugin": "25.2.0",
 		"@wordpress/jest-console": "8.46.0",
 		"@wordpress/stylelint-config": "23.38.0",
+		"@wordpress/theme": "0.13.0",
 		"babel-jest": "30.4.1",
 		"chalk": "5.6.2",
 		"debug": "4.4.3",

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -5,7 +5,15 @@ import { fileURLToPath } from 'node:url';
  */
 const baseConfig = {
 	extends: fileURLToPath( import.meta.resolve( '@wordpress/stylelint-config/scss-stylistic' ) ),
+	plugins: [
+		'@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens',
+		'@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties',
+		'@wordpress/theme/stylelint-plugins/no-token-fallback-values',
+	],
 	rules: {
+		'plugin-wpds/no-unknown-ds-tokens': true,
+		'plugin-wpds/no-setting-wpds-custom-properties': true,
+		'plugin-wpds/no-token-fallback-values': true,
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds build pipeline to inject WPDS token fallbacks:
   * Shared PostCSS configs instead of redefining the list each time
   * WP Build already has this so parts of the repo built with it are already fine
* Adds stylelint for consistent clean WPDS usage
* Fix lint issues

See [build config](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#build-plugins) and [stylelint plugin](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#stylelint-plugins) docs for `@wordpress/theme` for details.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Lint is passing
* Tokens get fallbacks in final bundles