### PR TITLE
Gate Generate Feedback in Jetpack AI Sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-generate-feedback-jetpack-ai-gate
+++ b/projects/plugins/jetpack/changelog/add-generate-feedback-jetpack-ai-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI Sidebar: Gate the Generate Feedback suggestion behind the preview feature flag.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -59,7 +59,7 @@ class Jetpack_AI_Sidebar {
 		// Priority 20 so Jetpack loads AFTER Image Studio (priority 10).
 		add_filter( 'agents_manager_agent_providers', array( __CLASS__, 'register_provider' ), 20 );
 
-		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
+		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 20, 1 );
 
 		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
 		// post editor on WordPress.com and Atomic sites.
@@ -515,16 +515,12 @@ class Jetpack_AI_Sidebar {
 	 *
 	 * Server-side permission checks still gate execution. This site-side flag
 	 * controls whether the Jetpack AI Sidebar exposes the Generate Feedback
-	 * suggestion, matching the temporary dev-mode gate used during the AI
-	 * Editorial Review rollout.
+	 * suggestion. It follows Image Studio's internal rollout pattern.
 	 *
 	 * @return bool
 	 */
 	private static function is_generate_feedback_enabled(): bool {
-		return (bool) apply_filters(
-			'jetpack_ai_generate_feedback_enabled',
-			self::is_dev_mode()
-		);
+		return self::is_dev_mode();
 	}
 
 	/**
@@ -643,8 +639,9 @@ class Jetpack_AI_Sidebar {
 	 * Gives Atomic parity with Jurassic Ninja without depending on a wpcomsh
 	 * redeploy.
 	 *
-	 * Skipped on WordPress.com Simple — wpcom's data extension owns the predicate
-	 * there, including any WordPress.com-specific kill-switch override.
+	 * Skipped on WordPress.com Simple — the bundled Jetpack AI Sidebar data
+	 * filter owns the predicate there, including any WordPress.com-specific
+	 * kill-switch override.
 	 *
 	 * @return void
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -511,6 +511,23 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * UI feature flag for Generate Feedback.
+	 *
+	 * Server-side permission checks still gate execution. This site-side flag
+	 * controls whether the Jetpack AI Sidebar exposes the Generate Feedback
+	 * suggestion, matching the temporary dev-mode gate used during the AI
+	 * Editorial Review rollout.
+	 *
+	 * @return bool
+	 */
+	private static function is_generate_feedback_enabled(): bool {
+		return (bool) apply_filters(
+			'jetpack_ai_generate_feedback_enabled',
+			self::is_dev_mode()
+		);
+	}
+
+	/**
 	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
 	 *
 	 * AI Editorial Review remains a feature inside the preview. Hosts can open
@@ -522,7 +539,7 @@ class Jetpack_AI_Sidebar {
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
 		return (bool) apply_filters(
 			'jetpack_ai_sidebar_preview_enabled',
-			self::is_ai_editorial_review_enabled()
+			self::is_ai_editorial_review_enabled() || self::is_generate_feedback_enabled()
 		);
 	}
 
@@ -534,6 +551,7 @@ class Jetpack_AI_Sidebar {
 	private static function get_jetpack_ai_sidebar_preview_config(): array {
 		$features = array(
 			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
+			'generateFeedback'        => self::is_generate_feedback_enabled(),
 			'blockTransformations'    => true,
 			'optimizeTitleSuggestion' => self::is_optimize_title_suggestion_enabled(),
 			'chatHistory'             => false,
@@ -547,6 +565,7 @@ class Jetpack_AI_Sidebar {
 		 */
 		$filtered_features                   = apply_filters( 'jetpack_ai_sidebar_preview_features', $features );
 		$features                            = is_array( $filtered_features ) ? array_merge( $features, $filtered_features ) : $features;
+		$features['generateFeedback']        = self::is_generate_feedback_enabled();
 		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && self::is_optimize_title_suggestion_enabled();
 
 		return array(

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -100,7 +100,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
 		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
-		remove_all_filters( 'jetpack_ai_generate_feedback_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -524,19 +523,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The Generate Feedback-specific filter can enable the flag outside dev mode.
-	 */
-	public function test_maybe_enqueue_am_allows_generate_feedback_filter_to_enable() {
-		$this->set_block_editor_screen();
-		$this->cache_am_asset_data();
-		add_filter( 'jetpack_ai_generate_feedback_enabled', '__return_true' );
-
-		Jetpack_AI_Sidebar::maybe_enqueue_am();
-
-		$this->assertStringContainsString( '"generateFeedback":true', $this->get_agents_manager_inline_script() );
-	}
-
-	/**
 	 * The generic preview features filter cannot bypass the Generate Feedback gate.
 	 */
 	public function test_maybe_enqueue_am_prevents_preview_features_filter_from_enabling_generate_feedback() {
@@ -588,20 +574,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"optimizeTitleSuggestion":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"generateFeedback":true', $this->get_agents_manager_inline_script() );
-	}
-
-	/**
-	 * The Generate Feedback-specific filter can suppress the flag even in dev mode.
-	 */
-	public function test_maybe_enqueue_am_allows_generate_feedback_filter_to_disable_dev_mode() {
-		$this->set_block_editor_screen();
-		$this->cache_am_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter( 'jetpack_ai_generate_feedback_enabled', '__return_false' );
-
-		Jetpack_AI_Sidebar::maybe_enqueue_am();
-
-		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -100,6 +100,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
 		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
+		remove_all_filters( 'jetpack_ai_generate_feedback_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -480,6 +481,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -495,6 +497,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"blockTransformations":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"optimizeTitleSuggestion":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"chatHistory":false', $this->get_agents_manager_inline_script() );
@@ -518,6 +521,38 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
 		$this->assertStringContainsString( '"optimizeTitleSuggestion":false', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
+	 * The Generate Feedback-specific filter can enable the flag outside dev mode.
+	 */
+	public function test_maybe_enqueue_am_allows_generate_feedback_filter_to_enable() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		add_filter( 'jetpack_ai_generate_feedback_enabled', '__return_true' );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"generateFeedback":true', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
+	 * The generic preview features filter cannot bypass the Generate Feedback gate.
+	 */
+	public function test_maybe_enqueue_am_prevents_preview_features_filter_from_enabling_generate_feedback() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			function ( $features ) {
+				$features['generateFeedback'] = true;
+				return $features;
+			}
+		);
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -552,6 +587,21 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"optimizeTitleSuggestion":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":true', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
+	 * The Generate Feedback-specific filter can suppress the flag even in dev mode.
+	 */
+	public function test_maybe_enqueue_am_allows_generate_feedback_filter_to_disable_dev_mode() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'jetpack_ai_generate_feedback_enabled', '__return_false' );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -569,6 +619,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":true', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -584,6 +635,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['chatHistory'] );
@@ -642,6 +694,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
 	}
@@ -711,6 +764,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -734,6 +788,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"generateFeedback":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -822,6 +877,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 		$this->assertStringContainsString(
 			'"optimizeTitleSuggestion":true',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'"generateFeedback":true',
 			$this->get_agents_manager_inline_script()
 		);
 	}


### PR DESCRIPTION
Companion PRs:
- Calypso: [Automattic/wp-calypso#111403](https://github.com/Automattic/wp-calypso/pull/111403)
- WPCOM: `221958-ghe-Automattic/wpcom`

## Proposed changes

- Adds a Generate Feedback feature flag at `jetpackAiSidebarPreview.features.generateFeedback`.
- Enables the Generate Feedback UI flag only in Jetpack dev mode, following the internal rollout shape used by Image Studio.
- Opens the Jetpack AI Sidebar preview surface when either AI Editorial Review or Generate Feedback is enabled.
- Prevents the generic `jetpack_ai_sidebar_preview_features` filter from force-enabling Generate Feedback.
- Runs the Jetpack AI Sidebar data filter after Image Studio so the preview config composes in the expected order.
- Adds a Jetpack changelog entry and focused test coverage for default, dev-mode, and generic-filter behavior.

## Related product discussion/links

- Companion frontend PR: [Automattic/wp-calypso#111403](https://github.com/Automattic/wp-calypso/pull/111403)
- Companion backend PR: `221958-ghe-Automattic/wpcom`

## Does this pull request change what data or activity we track or use?

No. This PR only exposes a boolean sidebar feature flag to the existing Agents Manager bootstrap data. It does not add new tracking, storage, or user-content transmission.

## Testing instructions

Suggested targeted checks for this PR:

```sh
vendor/bin/phpcs projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test
```

Integrated manual testing is covered by the WPCOM companion PR: `221958-ghe-Automattic/wpcom`.
