### PR TITLE
Newsletter: fix Comp modal in the modernized subscribers dashboard

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
@@ -113,8 +113,11 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 	const compedPlanIds = useMemo( () => {
 		const ids = new Set< number >();
 		( detailsQuery.data?.plans ?? [] ).forEach( ( plan: SubscriptionPlan ) => {
-			if ( plan.is_comp && plan.subscription_id ) {
-				ids.add( plan.subscription_id );
+			// The wpcom payload is loosely typed (it sends `price` as a string), so coerce the id —
+			// a string would never match the numeric `product.id` in the Set's strict `has()`.
+			const subscriptionId = Number( plan.subscription_id );
+			if ( plan.is_comp && subscriptionId > 0 ) {
+				ids.add( subscriptionId );
 			}
 		} );
 		return ids;
@@ -134,7 +137,7 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 				label: __( 'Select a plan…', 'jetpack-newsletter' ),
 			},
 			...products.map( product => {
-				const isComped = compedPlanIds.has( product.id );
+				const isComped = compedPlanIds.has( Number( product.id ) );
 				return {
 					value: String( product.id ),
 					label: formatPlanLabel( product ),

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
@@ -4,8 +4,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dialog, Notice, Stack, Text } from '@wordpress/ui';
 import { useCompMutation } from '../../data/use-comp-mutation';
 import { useMembershipsProducts } from '../../data/use-memberships-products';
+import { useSubscriberDetails } from '../../data/use-subscriber-details';
 import { getSubscriberLabel } from '../../lib/subscriber-helpers';
 import { recordTracksEvent } from '../../lib/tracks';
+import type { MembershipsProduct } from '../../data/api';
 import type { Subscriber, SubscriptionPlan } from '../../data/types';
 
 type Props = {
@@ -14,25 +16,60 @@ type Props = {
 };
 
 /**
- * Format a plan label for the picker — `Plan name (currency price)`. Mirrors how Calypso renders
- * its `<ProductsSelector />` rows.
+ * Translate a membership billing interval (e.g. `1 year`) into a short, localized cadence word
+ * shown after the price. Falls back to the raw interval for anything we don't recognize.
+ *
+ * @param interval - Raw interval string from the wpcom proxy (e.g. `1 month`, `1 year`).
+ * @return Localized cadence (e.g. `year`), or an empty string when no interval is set.
+ */
+function formatInterval( interval?: string ): string {
+	switch ( interval ) {
+		case '1 day':
+			return __( 'day', 'jetpack-newsletter' );
+		case '1 week':
+			return __( 'week', 'jetpack-newsletter' );
+		case '1 month':
+			return __( 'month', 'jetpack-newsletter' );
+		case '1 year':
+			return __( 'year', 'jetpack-newsletter' );
+		default:
+			return interval ?? '';
+	}
+}
+
+/**
+ * Format a plan label for the picker — `Plan name (currency price / interval)`. Mirrors how Calypso
+ * renders its `<ProductsSelector />` rows. The interval disambiguates plans that share a name and
+ * currency but bill on different cadences (e.g. a $1/month vs $12/year tier).
  *
  * @param product          - Membership product entry returned by the wpcom proxy.
  * @param product.title    - Plan name.
- * @param product.price    - Plan price (numeric).
+ * @param product.price    - Plan price (preformatted string, e.g. `12.00`).
  * @param product.currency - ISO currency code.
+ * @param product.interval - Billing interval (e.g. `1 year`).
  * @return Display string.
  */
-function formatPlanLabel( product: { title: string; price?: number; currency?: string } ): string {
+function formatPlanLabel( product: MembershipsProduct ): string {
 	if ( ! product.price || ! product.currency ) {
 		return product.title;
 	}
+	const cadence = formatInterval( product.interval );
+	if ( ! cadence ) {
+		return sprintf(
+			// translators: %1$s: plan title. %2$s: currency code. %3$s: price.
+			__( '%1$s (%2$s %3$s)', 'jetpack-newsletter' ),
+			product.title,
+			product.currency,
+			product.price
+		);
+	}
 	return sprintf(
-		// translators: %1$s: plan title. %2$s: currency code. %3$s: numeric price.
-		__( '%1$s (%2$s %3$s)', 'jetpack-newsletter' ),
+		// translators: %1$s: plan title. %2$s: currency code. %3$s: price. %4$s: billing cadence, e.g. "year".
+		__( '%1$s (%2$s %3$s / %4$s)', 'jetpack-newsletter' ),
 		product.title,
 		product.currency,
-		String( product.price )
+		product.price,
+		cadence
 	);
 }
 
@@ -51,6 +88,14 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 	const productsQuery = useMembershipsProducts( isOpen );
 	const mutation = useCompMutation();
 
+	// The subscriber list payload omits plans, so pull the reader's existing comps from the
+	// individual-subscriber endpoint (shared React Query cache with the detail panel) to filter
+	// out plans they're already comped on.
+	const detailsQuery = useSubscriberDetails( {
+		subscription_id: subscriber?.email_subscription_id || subscriber?.wpcom_subscription_id,
+		user_id: subscriber?.user_id,
+	} );
+
 	const [ planId, setPlanId ] = useState< string >( '' );
 	const [ noExpiration, setNoExpiration ] = useState( false );
 
@@ -63,42 +108,46 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 		recordTracksEvent( 'jetpack_subscribers_comp_modal_open' );
 	}, [ isOpen ] );
 
+	// A comp's `subscription_id` is the membership product id, so the ids collected here line up
+	// with `product.id` in the picker below — letting us flag plans the reader already has.
 	const compedPlanIds = useMemo( () => {
-		if ( ! subscriber ) {
-			return new Set< number >();
-		}
 		const ids = new Set< number >();
-		( subscriber.plans ?? [] ).forEach( ( plan: SubscriptionPlan ) => {
+		( detailsQuery.data?.plans ?? [] ).forEach( ( plan: SubscriptionPlan ) => {
 			if ( plan.is_comp && plan.subscription_id ) {
 				ids.add( plan.subscription_id );
 			}
 		} );
 		return ids;
-	}, [ subscriber ] );
+	}, [ detailsQuery.data ] );
 
 	const products = useMemo( () => productsQuery.data ?? [], [ productsQuery.data ] );
-	const availableProducts = useMemo(
-		() => products.filter( product => ! compedPlanIds.has( product.ID ) ),
-		[ products, compedPlanIds ]
-	);
 
-	const options = useMemo(
-		() => [
+	// Keep every plan in the picker but disable the ones the reader is already comped on — that
+	// surfaces "this plan exists and they already have it" rather than silently hiding it. The
+	// disabled rows carry a `title` so the browser explains the why on hover (a native tooltip —
+	// a styled one can't attach to a native `<option>`).
+	const options = useMemo( () => {
+		const compedHint = __( 'This reader already has this plan.', 'jetpack-newsletter' );
+		return [
 			{
 				value: '',
 				label: __( 'Select a plan…', 'jetpack-newsletter' ),
 			},
-			...availableProducts.map( product => ( {
-				value: String( product.ID ),
-				label: formatPlanLabel( product ),
-			} ) ),
-		],
-		[ availableProducts ]
-	);
+			...products.map( product => {
+				const isComped = compedPlanIds.has( product.id );
+				return {
+					value: String( product.id ),
+					label: formatPlanLabel( product ),
+					disabled: isComped,
+					title: isComped ? compedHint : undefined,
+				};
+			} ),
+		];
+	}, [ products, compedPlanIds ] );
 
 	const selectedProduct = useMemo(
-		() => availableProducts.find( product => String( product.ID ) === planId ),
-		[ availableProducts, planId ]
+		() => products.find( product => String( product.id ) === planId ),
+		[ products, planId ]
 	);
 
 	const handleSubmit = useCallback( () => {
@@ -120,7 +169,9 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 				planTitle: selectedProduct?.title,
 				subscriberName: getSubscriberLabel( subscriber as Subscriber ),
 			},
-			{ onSuccess: onClose }
+			// Close on settle (success or error), mirroring Calypso: the snackbar carries the
+			// outcome — including the upstream reason like "User has already been comped this plan".
+			{ onSettled: onClose }
 		);
 	}, [ mutation, onClose, planId, noExpiration, subscriber, selectedProduct ] );
 
@@ -138,7 +189,9 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 	}
 
 	const allComped =
-		! productsQuery.isLoading && products.length > 0 && availableProducts.length === 0;
+		! productsQuery.isLoading &&
+		products.length > 0 &&
+		products.every( product => compedPlanIds.has( product.id ) );
 
 	return (
 		<Dialog.Root open onOpenChange={ handleOpenChange }>
@@ -154,7 +207,7 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 					<Dialog.CloseIcon />
 				</Dialog.Header>
 				<Dialog.Content>
-					<Stack direction="column" gap="md">
+					<Stack direction="column" gap="md" className="jetpack-newsletter__comp-modal-body">
 						<Text variant="body-md">
 							{ __(
 								'Pick a paid plan and we’ll add a complimentary subscription for this reader.',

--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -119,11 +119,13 @@ export function fetchSubscriberStats( params: IndividualParams ): Promise< Subsc
 }
 
 export type MembershipsProduct = {
-	ID: number;
+	id: number;
 	title: string;
 	currency?: string;
-	price?: number;
-	renewal_schedule?: string;
+	// The wpcom proxy sends the price as a preformatted string (e.g. `12.00`), not a number.
+	price?: string;
+	// Billing cadence, e.g. `1 month` or `1 year`.
+	interval?: string;
 };
 
 /**

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-comp
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-comp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers dashboard: fix several Comp modal issues — show the plan billing interval in the picker, correct plan selection, disable and explain (via tooltip) plans the reader already has, surface the specific already-comped error message, and fix a clipped focus ring

--- a/projects/packages/newsletter/routes/dashboard/route.scss
+++ b/projects/packages/newsletter/routes/dashboard/route.scss
@@ -71,3 +71,11 @@
 .jetpack-newsletter__detail-link {
 	word-break: break-all;
 }
+
+// Comp modal body. The dialog content is a scroll area (`overflow: auto`),
+// which clips the focus ring of the last control — the "Doesn't expire"
+// checkbox — as it sits flush against the bottom edge. Reserve a little space
+// so the ring renders in full.
+.jetpack-newsletter__comp-modal-body {
+	padding-bottom: var(--wpds-dimension-padding-xs, 4px);
+}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -662,11 +662,14 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 		$status = (int) wp_remote_retrieve_response_code( $response );
 		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		if ( $status >= 400 ) {
+		// The Memberships API can report a failure either with an HTTP error status or with a 2xx
+		// response carrying an `error` payload (e.g. "User has already been comped this plan"), so
+		// treat both as failures and surface the upstream message rather than a generic one.
+		if ( $status >= 400 || ( is_array( $body ) && ! empty( $body['error'] ) ) ) {
 			return new WP_Error(
 				'subscribers_comp_failed',
-				is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'Could not comp the subscription.', 'jetpack' ),
-				array( 'status' => $status )
+				$this->get_wpcom_error_message( $body, __( 'Could not comp the subscription.', 'jetpack' ) ),
+				array( 'status' => $status >= 400 ? $status : 400 )
 			);
 		}
 
@@ -709,15 +712,42 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 		$status = (int) wp_remote_retrieve_response_code( $response );
 		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		if ( $status >= 400 ) {
+		// Mirror add_comp: the Memberships API can report a failure with an error status or with a
+		// 2xx response that carries an `error` payload, so treat both as failures.
+		if ( $status >= 400 || ( is_array( $body ) && ! empty( $body['error'] ) ) ) {
 			return new WP_Error(
 				'subscribers_remove_comp_failed',
-				is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'Could not remove the comp.', 'jetpack' ),
-				array( 'status' => $status )
+				$this->get_wpcom_error_message( $body, __( 'Could not remove the comp.', 'jetpack' ) ),
+				array( 'status' => $status >= 400 ? $status : 400 )
 			);
 		}
 
 		return rest_ensure_response( $body );
+	}
+
+	/**
+	 * Extract the most specific human-readable error message from a wpcom Memberships API response
+	 * body. The Memberships endpoints nest the reason under `error.message` (e.g. "User has already
+	 * been comped this plan"); fall back to a top-level `message`, a string `error`, then the default.
+	 *
+	 * @param mixed  $body            Decoded response body.
+	 * @param string $default_message Fallback used when the body carries no message.
+	 * @return string Error message.
+	 */
+	private function get_wpcom_error_message( $body, $default_message ) {
+		if ( is_array( $body ) ) {
+			if ( isset( $body['error']['message'] ) && is_string( $body['error']['message'] ) ) {
+				return $body['error']['message'];
+			}
+			if ( isset( $body['message'] ) && is_string( $body['message'] ) ) {
+				return $body['message'];
+			}
+			if ( isset( $body['error'] ) && is_string( $body['error'] ) ) {
+				return $body['error'];
+			}
+		}
+
+		return $default_message;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-comp
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-comp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribers: surface the specific Memberships API error (such as when a reader is already comped) from the comp endpoints instead of a generic failure message

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-comp
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-comp
@@ -1,4 +1,3 @@
 Significance: patch
-Type: bugfix
-
-Subscribers: surface the specific Memberships API error (such as when a reader is already comped) from the comp endpoints instead of a generic failure message
+Type: other
+Comment: Subscribers (Newsletter modernization, behind a feature flag): surface the specific Memberships API error such as "User has already been comped this plan" from the comp endpoints instead of a generic failure message.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -242,7 +242,11 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	public function test_get_wpcom_error_message( $expected, $body, $default ) {
 		$endpoint = new WPCOM_REST_API_V2_Endpoint_Subscribers_List();
 		$method   = new ReflectionMethod( WPCOM_REST_API_V2_Endpoint_Subscribers_List::class, 'get_wpcom_error_message' );
-		$method->setAccessible( true );
+		// setAccessible() is required on PHP < 8.1 to invoke a private method, but is a deprecated
+		// no-op from 8.5 — only call it where it's actually needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$this->assertSame( $expected, $method->invoke( $endpoint, $body, $default ) );
 	}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WpOrg\Requests\Requests;
 
 require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
@@ -224,5 +225,80 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame( 'subscriber_stats_missing_id', $response->get_data()['code'] );
+	}
+
+	/**
+	 * `get_wpcom_error_message()` digs the most specific reason out of a Memberships API body:
+	 * the nested `error.message` the comp endpoints use, then a top-level `message`, then a string
+	 * `error`, and finally the supplied default. This is what lets the comp/remove-comp endpoints
+	 * surface "User has already been comped this plan" instead of a generic failure.
+	 *
+	 * @param string $expected Expected message.
+	 * @param mixed  $body     Decoded response body.
+	 * @param string $default  Fallback message.
+	 * @dataProvider provider_wpcom_error_messages
+	 */
+	#[DataProvider( 'provider_wpcom_error_messages' )]
+	public function test_get_wpcom_error_message( $expected, $body, $default ) {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Subscribers_List();
+		$method   = new ReflectionMethod( WPCOM_REST_API_V2_Endpoint_Subscribers_List::class, 'get_wpcom_error_message' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $endpoint, $body, $default ) );
+	}
+
+	/**
+	 * Data for {@see test_get_wpcom_error_message()}.
+	 *
+	 * @return array<string, array{0: string, 1: mixed, 2: string}>
+	 */
+	public static function provider_wpcom_error_messages() {
+		$default = 'Could not comp the subscription.';
+
+		return array(
+			'nested error.message (already-comped case)' => array(
+				'User has already been comped this plan',
+				array(
+					'error' => array(
+						'code'    => 'validation_error',
+						'message' => 'User has already been comped this plan',
+					),
+				),
+				$default,
+			),
+			'nested error.message wins over top-level message' => array(
+				'Nested wins',
+				array(
+					'message' => 'Top level',
+					'error'   => array( 'message' => 'Nested wins' ),
+				),
+				$default,
+			),
+			'top-level message when no nested error.message' => array(
+				'Top level reason',
+				array( 'message' => 'Top level reason' ),
+				$default,
+			),
+			'string error'                               => array(
+				'Plain string error',
+				array( 'error' => 'Plain string error' ),
+				$default,
+			),
+			'default when error.message is not a string' => array(
+				$default,
+				array( 'error' => array( 'message' => array( 'unexpected' ) ) ),
+				$default,
+			),
+			'default when body has no usable message'    => array(
+				$default,
+				array( 'error' => array( 'code' => 'validation_error' ) ),
+				$default,
+			),
+			'default when body is not an array'          => array(
+				$default,
+				null,
+				$default,
+			),
+		);
 	}
 }


### PR DESCRIPTION
Fixes #

Fixes several issues in the **Comp subscription modal** of the modernized Newsletter subscribers dashboard (`projects/packages/newsletter/`), plus the wpcom proxy endpoint that backs it (`projects/plugins/jetpack/`).

## Proposed changes
* **Focus ring no longer clipped.** The "Doesn't expire" checkbox is the last child of the dialog's scroll area (`overflow: auto`), so its focus ring was cut off at the bottom. Reserve a little bottom padding inside the content so the ring renders in full.
* **Plan picker now shows the billing interval.** Labels read e.g. `Newsletter Tier (USD 12.00 / year)` vs `… (USD 1.00 / month)`, so plans that differ only by cadence are distinguishable.
* **Plan selection actually works.** The `MembershipsProduct` type was modelled against an assumed payload; corrected it to the real wpcom shape (`id` lowercase, `price` as string, `interval`). Previously every option's value resolved to `"undefined"`, so confirming a comp silently no-op'd.
* **Specific error surfaced on re-comp.** The Memberships API nests its reason under `error.message` (e.g. _"User has already been comped this plan"_), but the proxy only read a top-level `message` and fell back to a generic string. It now extracts the nested reason (and treats a `2xx` response carrying an `error` payload as a failure, for both the comp and remove-comp endpoints). The modal closes on settle (success **or** error), mirroring Calypso.
* **Already-comped plans are disabled.** The modal now pulls the reader's existing comps from the individual-subscriber endpoint and disables (rather than hides) plans they already have, with a native `title` tooltip explaining why.
* **Tests.** Added PHP unit coverage for the proxy's error-message extraction helper (7 cases across all branches).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No. Existing Tracks events (`jetpack_subscribers_comp_modal_open` / `_confirm`) are unchanged; no new data is tracked.

## Testing instructions
Requires a site with the modernized Newsletter subscribers dashboard (`rsm_jetpack_ui_modernization_newsletter` filter enabled) and at least one **paid newsletter plan** configured. Creating a monthly **and** a yearly tier makes the interval/disable behavior easiest to see.

* Go to **Jetpack → Newsletter → Subscribers**.
* Open a subscriber's three-dot actions menu and choose **Comp a subscription**.
* **Interval label:** open the **Plan** dropdown — each plan shows its cadence (e.g. `… / year`, `… / month`).
* **Focus ring:** Tab to the **Doesn't expire** checkbox — the focus ring is fully visible (not clipped at the bottom).
* **Happy path:** pick a plan, click **Add comp** — the modal closes and a success snackbar appears; the comp shows on the subscriber.
* **Already-comped (disabled):** reopen the modal for that same subscriber — the plan they now hold appears **disabled**; hovering it shows _"This reader already has this plan."_
* **Already-comped (error path):** to exercise the server message directly, POST `/wpcom/v2/subscribers/comp` for a plan the reader already has — the response message is _"User has already been comped this plan"_ rather than the generic _"Could not comp the subscription."_
