### PR TITLE
Write editor: link Tips popover to the Help Center

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-3984-write-editor-help-panel-is-disconnected-from-the-main-help
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-3984-write-editor-help-panel-is-disconnected-from-the-main-help
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write editor: link from the Tips popover to the Help Center, opening the Write editor support article in the existing Help Center panel

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -125,6 +125,21 @@
 	color: #888;
 }
 
+.bw-help-link {
+	display: block;
+	margin-top: 12px;
+	padding-top: 12px;
+	border-top: 1px solid #f0f0f0;
+	font-size: 13px;
+	color: #2271b1;
+	text-decoration: none;
+}
+
+.bw-help-link:hover,
+.bw-help-link:focus {
+	text-decoration: underline;
+}
+
 .bw-back {
 	font-size: 22px;
 	color: #999;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -919,7 +919,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-help-row"><kbd>Tab</kbd><span><?php echo esc_html__( 'Navigate slash menu options', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Shift+Tab</kbd><span><?php echo esc_html__( 'Focus formatting toolbar', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>#tag</kbd><span><?php echo esc_html__( 'A line containing only #tags assigns them to the post on save', 'jetpack-mu-wpcom' ); ?></span></div>
-			<a class="bw-help-link" data-target="wpcom-help-center" href="https://wordpress.com/support/editors/write-editor/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Browse all help articles', 'jetpack-mu-wpcom' ); ?> <span aria-hidden="true">&#8599;</span></a>
+			<a class="bw-help-link" data-target="wpcom-help-center" href="https://wordpress.com/support/editors/write-editor/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Read the Write editor guide', 'jetpack-mu-wpcom' ); ?> <span aria-hidden="true">&#8599;</span></a>
 		</div>
 		</div><!-- /.bw-help-wrap -->
 		<span class="bw-status" data-wp-text="state.displayStatus"></span>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -179,7 +179,6 @@ add_action(
 			#adminmenuback,
 			#adminmenumain,
 			#wpfooter,
-			#wpcom-help-center,
 			.wp-admin-bar-fix { display: none !important; }
 			#wpcontent,
 			#wpbody,
@@ -920,6 +919,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-help-row"><kbd>Tab</kbd><span><?php echo esc_html__( 'Navigate slash menu options', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Shift+Tab</kbd><span><?php echo esc_html__( 'Focus formatting toolbar', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>#tag</kbd><span><?php echo esc_html__( 'A line containing only #tags assigns them to the post on save', 'jetpack-mu-wpcom' ); ?></span></div>
+			<a class="bw-help-link" data-target="wpcom-help-center" href="https://wordpress.com/support/editors/write-editor/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Browse all help articles', 'jetpack-mu-wpcom' ); ?> <span aria-hidden="true">&#8599;</span></a>
 		</div>
 		</div><!-- /.bw-help-wrap -->
 		<span class="bw-status" data-wp-text="state.displayStatus"></span>


### PR DESCRIPTION
Fixes RSM-3984

## Proposed changes
* Adds a "Read the Write editor guide" link inside the Write editor's Tips popover. Clicking it opens the [Write editor support article](https://wordpress.com/support/editors/write-editor/) inside the wpcom Help Center panel (already loaded on the page via the `wp-admin` Help Center variant). The link uses the established `data-target="wpcom-help-center"` pattern, so the Help Center's global click handler intercepts the click and dispatches `setShowSupportDoc`.
* Stops hiding `#wpcom-help-center` in the Write editor's hide-chrome CSS so the Help Center panel can render when opened.
* Falls back to opening the link in a new tab when the Help Center isn't loaded (e.g. unconnected sites), via `target="_blank"`.

This gives users an escape hatch from the Tips popover to deeper documentation without replacing the keyboard-shortcut surface they already have.

<img width="1888" height="844" alt="Screenshot 2026-06-08 at 11 56 43 AM" src="https://github.com/user-attachments/assets/1af41f24-b88e-4df8-9a7f-f56aa31b28f0" />


## Related product discussion/links
* RSM-3984

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

On a Simple or Atomic site where the Write editor and Help Center are available (e.g. a Jurassic Ninja site with `jetpack-mu-wpcom` loaded):

1. Go to `wp-admin/admin.php?page=write`.
2. Click the `i` icon in the top bar to open the Tips popover.
3. Confirm the "Read the Write editor guide ↗" link appears at the bottom of the popover, separated from the shortcut rows.
4. Click the link.
5. Confirm the Help Center panel opens in-page and lands on the Write editor support article (rather than opening in a new tab).
6. Close the Help Center panel and confirm the Write editor is still usable.
7. As a fallback check: on a site where the Help Center is not available, confirm the link opens `https://wordpress.com/support/editors/write-editor/` in a new tab.
