### PR TITLE
Remove empty agency-managed and wpcom-site-menu feature stubs

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-empty-feature-stubs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-empty-feature-stubs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the empty agency-managed and wpcom-site-menu feature stubs, which contained only a docblock and were never loaded.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Features related to fully managed agency sites.
- *
- * @package jetpack-mu-wpcom
- */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -1,8 +1,0 @@
-<?php
-/**
- * WordPress.com Site Menu
- *
- * Add's a WordPress.com menu item to the admin menu linking back to the sites WordPress.com home page.
- *
- * @package automattic/jetpack-mu-wpcom
- */


### PR DESCRIPTION
## Proposed changes

* Delete two `jetpack-mu-wpcom` feature directories — `agency-managed` and `wpcom-site-menu` — that had been reduced to a bare docblock with no executable code.
* Neither file was `require`d by the package loader, and neither is referenced anywhere else in the monorepo. `wpcom-site-menu` was emptied during the 2024 admin nav redesign and never refilled; the real `is_fully_managed_agency_site()` logic still lives in `utils.php` and is untouched.
* Removing the dead stubs changes no runtime behavior.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* This is a no-op cleanup — the deleted files contained only a docblock and were never loaded.
* Confirm `agency-managed` site detection still works (e.g. `is_fully_managed_agency_site()` is defined in `src/utils.php`, not the deleted stub).
* Smoke-test wp-admin on a WP.com/WoA site to confirm no errors and the admin menu/nav is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)