### PR TITLE
Plugin Conflicts Guardian: enable rollout at 5% by default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/enable-pcg-rollout-5-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/enable-pcg-rollout-5-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: enable rollout at 5% by default.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -90,7 +90,7 @@ Update mode never confirms — the candidate is already loaded by WP's normal bo
 
 ## Percentage rollout
 
-`PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. Default is **0%** — PCG is off everywhere until the operator opts in:
+`PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. Default is **5%** — the `pcg_rollout_percentage` filter overrides it per environment:
 
 ```php
 add_filter( 'pcg_rollout_percentage', fn () => 10 ); // 10% cohort

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -10,7 +10,7 @@
  */
 class PCG_Rollout {
 
-	const DEFAULT_PERCENTAGE = 0;
+	const DEFAULT_PERCENTAGE = 5;
 
 	/**
 	 * Priority 100 leaves room for emergency overrides at higher priorities.


### PR DESCRIPTION
## Proposed changes
* Bump `PCG_Rollout::DEFAULT_PERCENTAGE` from `0` to `5`, enabling the Plugin Conflicts Guardian on the 5% blog-ID cohort.
* With the existing `crc32(blog_id) % 100` bucketing, raising the percentage strictly adds blogs — no reshuffling of the cohort.
* The `pcg_rollout_percentage` filter still overrides the default per environment, and the priority >100 emergency-override gates on `pcg_guard_activation` / `pcg_guard_updates` are untouched.
* Updated the README's documented default and added a changelog entry.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Confirm `PCG_Rollout::is_enabled_for_blog( $blog_id )` returns `true` for blog IDs whose `crc32(blog_id) % 100` bucket is `< 5`, and `false` otherwise, with no `pcg_rollout_percentage` filter applied.
* Confirm an explicit `add_filter( 'pcg_rollout_percentage', fn () => 0 )` still disables the feature everywhere, and `=> 100` enables it everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)