### PR TITLE
Fix Claude settings link in Jetpack AI MCP setup

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
@@ -32,13 +32,13 @@ const CLIENT_OPTIONS = [
 	{ label: __( 'Other MCP client', 'jetpack' ), value: 'default' },
 ];
 
-const CLIENT_DOCS = {
-	claude: getRedirectUrl( 'https://docs.claude.com/en/docs/mcp' ),
-	'claude-code': getRedirectUrl( 'https://code.claude.com/docs/en/mcp' ),
-	vscode: getRedirectUrl( 'https://code.visualstudio.com/docs/copilot/customization/mcp-servers' ),
-	cursor: getRedirectUrl( 'https://docs.cursor.com/en/context/mcp' ),
-	continue: getRedirectUrl( 'https://docs.continue.dev/customize/deep-dives/mcp' ),
-	default: getRedirectUrl( 'https://modelcontextprotocol.io/docs/develop/connect-local-servers' ),
+const CLIENT_DOCS_SOURCES = {
+	claude: 'jetpack-ai-docs-claude',
+	'claude-code': 'jetpack-ai-docs-claude-code',
+	vscode: 'jetpack-ai-docs-vscode',
+	cursor: 'jetpack-ai-docs-cursor',
+	continue: 'jetpack-ai-docs-continue',
+	default: 'jetpack-ai-docs-mcp',
 };
 
 const CLIENT_DOCS_LABELS = {
@@ -266,8 +266,8 @@ export default function McpSetup() {
 							onChange={ handleConfigChange }
 							readOnly
 						/>
-						{ CLIENT_DOCS[ selectedClient ] && (
-							<Link href={ CLIENT_DOCS[ selectedClient ] } openInNewTab>
+						{ CLIENT_DOCS_SOURCES[ selectedClient ] && (
+							<Link href={ getRedirectUrl( CLIENT_DOCS_SOURCES[ selectedClient ] ) } openInNewTab>
 								{ CLIENT_DOCS_LABELS[ selectedClient ] }
 							</Link>
 						) }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
@@ -21,6 +21,7 @@ import { Button, Link, Stack } from '@wordpress/ui';
 
 const MCP_SERVER_NAME = 'wpcom-mcp';
 const MCP_SERVER_URL = 'https://public-api.wordpress.com/wpcom/v2/mcp/v1';
+const CLAUDE_SETTINGS_CONNECTOR_REDIRECT_SOURCE = 'jetpack-ai-claude-settings-connector';
 
 const CLIENT_OPTIONS = [
 	{ label: 'Claude', value: 'claude' },
@@ -132,7 +133,7 @@ export default function McpSetup() {
 											{ createInterpolateElement( __( 'Open <ClaudeSettings/>.', 'jetpack' ), {
 												ClaudeSettings: (
 													<Link
-														href={ getRedirectUrl( 'https://claude.ai/settings/connectors' ) }
+														href={ getRedirectUrl( CLAUDE_SETTINGS_CONNECTOR_REDIRECT_SOURCE ) }
 														openInNewTab
 													>
 														{ __( 'Claude settings', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
@@ -1,4 +1,3 @@
-import { render, screen } from '@testing-library/react';
 import {
 	DISPLAY_CATEGORIES,
 	getDisplayCategory,
@@ -6,7 +5,6 @@ import {
 	isWriteTool,
 	sortTools,
 } from '../categories';
-import McpSetup from '../setup';
 
 describe( 'MCP category mapping', () => {
 	test.each( [ 'wpcom-mcp', 'developer-testing' ] )(
@@ -86,19 +84,5 @@ describe( 'MCP category mapping', () => {
 		];
 
 		expect( sortTools( tools ) ).toBe( tools );
-	} );
-} );
-
-describe( 'MCP setup', () => {
-	test( 'uses the registered redirect source for the Claude settings link', () => {
-		render( <McpSetup /> );
-
-		const url = new URL(
-			screen.getByRole( 'link', { name: /Claude settings/ } ).getAttribute( 'href' )
-		);
-
-		expect( url.origin + url.pathname ).toBe( 'https://jetpack.com/redirect/' );
-		expect( url.searchParams.get( 'source' ) ).toBe( 'jetpack-ai-claude-settings-connector' );
-		expect( url.searchParams.has( 'url' ) ).toBe( false );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
@@ -1,3 +1,4 @@
+import { render, screen } from '@testing-library/react';
 import {
 	DISPLAY_CATEGORIES,
 	getDisplayCategory,
@@ -5,6 +6,7 @@ import {
 	isWriteTool,
 	sortTools,
 } from '../categories';
+import McpSetup from '../setup';
 
 describe( 'MCP category mapping', () => {
 	test.each( [ 'wpcom-mcp', 'developer-testing' ] )(
@@ -84,5 +86,19 @@ describe( 'MCP category mapping', () => {
 		];
 
 		expect( sortTools( tools ) ).toBe( tools );
+	} );
+} );
+
+describe( 'MCP setup', () => {
+	test( 'uses the registered redirect source for the Claude settings link', () => {
+		render( <McpSetup /> );
+
+		const url = new URL(
+			screen.getByRole( 'link', { name: /Claude settings/ } ).getAttribute( 'href' )
+		);
+
+		expect( url.origin + url.pathname ).toBe( 'https://jetpack.com/redirect/' );
+		expect( url.searchParams.get( 'source' ) ).toBe( 'jetpack-ai-claude-settings-connector' );
+		expect( url.searchParams.has( 'url' ) ).toBe( false );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-claude-settings-link
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-claude-settings-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-AI: Fix the Claude settings link in MCP quick setup.
+AI: Fix broken external links (Claude settings and agent documentation) in the MCP quick setup.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-claude-settings-link
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-claude-settings-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Fix the Claude settings link in MCP quick setup.


### PR DESCRIPTION
Fixes AIINT-393

Fixes a broken Claude settings redirect in Jetpack AI MCP setup.

## Proposed changes
* Update the Claude quick setup link to use the registered Jetpack Redirect source for Claude connector settings.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open Jetpack -> AI -> Connect external AI agent, keep Claude selected, and inspect the "Claude settings" link.
* It should use `https://jetpack.com/redirect/?source=jetpack-ai-claude-settings-connector` and open Claude connector settings.