### PR TITLE
Settings REST API: load Monitor and Post by Email classes before updating their options

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -716,9 +716,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'monitor_receive_notifications':
-					// The module class is only loaded when the module is active. On a bulk ( slug "any" )
-					// update the inactive-module check is skipped, so load the class on demand to avoid a fatal.
-					if ( ! class_exists( 'Jetpack_Monitor' ) && ! include_once Jetpack::get_module_path( $option_attrs['jp_group'] ) ) {
+					if ( ! class_exists( 'Jetpack_Monitor' ) ) {
 						$updated = false;
 						break;
 					}
@@ -730,9 +728,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'post_by_email_address':
-					// The module class is only loaded when the module is active. On a bulk ( slug "any" )
-					// update the inactive-module check is skipped, so load the class on demand to avoid a fatal.
-					if ( ! class_exists( 'Jetpack_Post_By_Email' ) && ! include_once Jetpack::get_module_path( $option_attrs['jp_group'] ) ) {
+					if ( ! class_exists( 'Jetpack_Post_By_Email' ) ) {
 						$updated = false;
 						break;
 					}

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -716,6 +716,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'monitor_receive_notifications':
+					// The module class is only loaded when the module is active. On a bulk ( slug "any" )
+					// update the inactive-module check is skipped, so load the class on demand to avoid a fatal.
+					if ( ! class_exists( 'Jetpack_Monitor' ) && ! include_once Jetpack::get_module_path( $option_attrs['jp_group'] ) ) {
+						$updated = false;
+						break;
+					}
+
 					$monitor = new Jetpack_Monitor();
 
 					// If we got true as response, consider it done.
@@ -723,6 +730,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'post_by_email_address':
+					// The module class is only loaded when the module is active. On a bulk ( slug "any" )
+					// update the inactive-module check is skipped, so load the class on demand to avoid a fatal.
+					if ( ! class_exists( 'Jetpack_Post_By_Email' ) && ! include_once Jetpack::get_module_path( $option_attrs['jp_group'] ) ) {
+						$updated = false;
+						break;
+					}
+
 					$result = Jetpack_Post_By_Email::init()->process_api_request( $value );
 
 					// If we got an email address (create or regenerate) or 1 (delete), consider it done.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-1710-load-module-class-on-settings-update
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-1710-load-module-class-on-settings-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Settings REST API: load the Monitor and Post by Email module classes on demand when updating their options, preventing a fatal on bulk settings updates while the module is inactive.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/JETPACK-1710

## Proposed changes

`Jetpack_Core_API_Data::update_data()` (the `/jetpack/v4/settings` handler) updates a mixed bag of options in a loop. Two of those option cases instantiate a module class directly:

- `monitor_receive_notifications` → `new Jetpack_Monitor()`
- `post_by_email_address` → `Jetpack_Post_By_Email::init()`

Those classes are only loaded via `jetpack_modules_loaded` **when the module is active**. On the bulk route (`/jetpack/v4/settings`, no slug → `slug = 'any'`), the per-option inactive-module check is intentionally skipped so a module can be activated and configured in the same request. But if the module is inactive *and not* being activated in that request, the option still gets processed and the class is missing → uncaught fatal:

```
PHP Fatal error: Uncaught Error: Class "Jetpack_Post_By_Email" not found in
.../_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php:726
```

This ads a guard the **read** similar to the one in (`Jetpack_Core_Json_Api_Endpoints::get_remote_value()`): load the class on demand and bail gracefully if it can't be loaded. Both write cases now do the same:

No behavior change when the module is active (class already loaded). When inactive, the option is skipped (`$updated = false`) instead of fataling. The `'any'` activate-and-configure flow is untouched.

## Why this surfaced recently

A new Calypso dashboard feature ("AI assistant email address", wp-calypso#111134) drives `post_by_email_address` regardless of whether the Post by Email *module* is active, via `/jetpack-blogs/$id/rest-api/` → `/jetpack/v4/settings/` (`slug=any`). On self-hosted Jetpack sites with the module inactive, toggling it triggers the latent fatal (which has existed since the 2020 refactor in #15139).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack-connected site, ensure the **Post by Email** module is **inactive**.
2. Send a bulk settings update to the no-slug route, e.g.:
   ```
   POST /wp-json/jetpack/v4/settings
   { "post_by_email_address": "create" }
   ```
   (or trigger it from the new Calypso AI-tools "Email assistant" toggle).
3. **Before:** PHP fatal `Class "Jetpack_Post_By_Email" not found` at `class.jetpack-core-api-module-endpoints.php`.
4. **After:** no fatal; the class is loaded on demand and the address is created (or the option is skipped if the module file can't be loaded).
5. Repeat with **Monitor** inactive and `monitor_receive_notifications` in the payload.
6. Confirm a single-module update (`/jetpack/v4/settings/post-by-email`) on an inactive module still returns the `409 inactive` error as before.
