### PR TITLE
Agents Manager: add standalone AI chat button to the admin bar

### DIFF
--- a/projects/packages/agents-manager/changelog/add-agents-manager-ai-chat-button
+++ b/projects/packages/agents-manager/changelog/add-agents-manager-ai-chat-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a standalone AI chat button to the admin bar.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -162,6 +162,23 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Add the standalone AI chat button to the admin bar.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 */
+	public function add_ai_chat_button( $wp_admin_bar ) {
+		$wp_admin_bar->add_menu(
+			array(
+				'id'     => 'agents-manager-ai-chat',
+				'parent' => 'top-secondary',
+				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '"><svg class="ab-icon" role="img" aria-label="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '" width="24" height="24" viewBox="-45 -45 490 490" xmlns="http://www.w3.org/2000/svg">
+								<path fill="currentColor" d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
+							</svg></span>',
+			)
+		);
+	}
+
+	/**
 	 * Enqueue Agents Manager scripts and add inline script data.
 	 */
 	public function enqueue_scripts() {
@@ -234,6 +251,11 @@ class Agents_Manager {
 			// Initialize the agents manager menu panel (only for full variants, not disconnected)
 			if ( ! $use_disconnected ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			}
+
+			// Standalone AI chat button, shown only in the unified experience.
+			if ( ! $use_disconnected && apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}
 

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -497,6 +497,52 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that the standalone AI chat button is added to the admin bar when the
+	 * unified experience is enabled.
+	 */
+	public function test_ai_chat_button_registered_in_unified_experience() {
+		// Set admin context so the admin bar nodes are registered.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
+		// Register the script so enqueue_scripts can attach its inline data.
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Enable the unified experience (priority 20 runs after the class's own filter).
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that the standalone AI chat button is not added to the admin bar when
+	 * the unified experience is disabled.
+	 */
+	public function test_ai_chat_button_not_registered_without_unified_experience() {
+		// Same admin context as the enabled case, so only the unified flag differs.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Disable the unified experience (priority 20 runs after the class's own filter).
+		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+	}
+
+	/**
 	 * Tests that should_display_menu_panel returns false by default.
 	 */
 	public function test_should_display_menu_panel_returns_false_by_default() {


### PR DESCRIPTION
Part of AI-995

## Proposed changes
* Add a standalone "Ask AI" button to the wp-admin bar (`agents-manager-ai-chat` node under `top-secondary`), separate from the Help Center menu.
* Registered only in the unified experience (`agents_manager_use_unified_experience`), for connected, non-Gutenberg, non-CIAB variants.
* Add PHPUnit coverage for the gating (the button is registered only when the unified experience is enabled, and not otherwise).

## Related product discussion/links
* AI-995

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* This change only renders the admin-bar button element; its styling and click behavior (reopening the chat) come from the Calypso side. Refer to the testing instructions in Automattic/wp-calypso#111434.
