### PR TITLE
renovate: Configure minor Actions version bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -97,6 +97,22 @@
 			matchPackageNames: [ 'docker/**' ],
 		},
 
+		// QualityOps decided they want all these pinned to digests.
+		// They were going to have Dependabot create PRs automatically, but as we use Renovate, do it here instead.
+		// We'll leave major updates ungrouped though, as those likely need more individualized attention.
+		{
+			extends: [ 'helpers:pinGitHubActionDigests' ],
+			matchPackageNames: [ '!actions/**' ],
+		},
+		{
+			groupName: 'GitHub Actions minor version bumps',
+			matchDepTypes: [ 'action' ],
+			matchUpdateTypes: [ 'minor', 'patch', 'pin', 'digest' ],
+			matchPackageNames: [ '!actions/**' ],
+			schedule: [ '* 0-3 * * 1' ],
+			additionalReviewers: [ 'team:qualityops' ],
+		},
+
 		// Bundled, WordPress dependencies are separated from 'monorepo:wordpress' while
 		// they're still considered unstable and can have significant breaking changes.
 		// Since they're not externalized to WP, they have higher chance of impacting functionality.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is a followup to #49337. In that PR, QualityOps pinned all non-GitHub actions with shas. They were going to set up Dependabot to create update PRs, but as we use Renovate we'd rather configure that to do it instead.

I intentionally left out the creation of a grouped-update for major version bumps. It seems likely those will need closer attention, so I think it's probably better to have separate PRs for those.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None linkable

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* I suppose you could trigger a Renovate run with this branch, and see if it updates the dashboard to include an entry for "GitHub Actions minor version bumps" (assuming any actions have minor bumps available). Or merge into a fork repo and see how it does.
  * [x] https://github.com/anomiex/jetpack/pull/52
  * [x] https://github.com/anomiex/jetpack/pull/53
  * [x] https://github.com/anomiex/jetpack/pull/54