### PR TITLE
Newsletter: keep the modernized Settings tab bar pinned while scrolling

### DIFF
--- a/projects/packages/newsletter/_inc/components/newsletter-page.scss
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.scss
@@ -28,12 +28,19 @@ body.jetpack_page_jetpack-newsletter {
 
 	// `AdminPage` wraps its children in `<Container><Col>`; the layout mixin
 	// flexes that pair but stops at `Col`. Continue the flex column through our
-	// `Tabs.Root` so the active tab fills the bounded middle.
+	// `Tabs.Root`. The tab strip (`.jp-admin-page-tabs`) is `position: sticky`
+	// inside this element, and a sticky child only stays pinned while its
+	// containing block is in view. So by default — the Settings tab, a long
+	// scrolling document — let `Tabs.Root` size to its full content height
+	// (`flex: 0 0 auto`) so the strip stays stuck the whole way down. Capping
+	// it to the viewport here (as the Subscribers branch below does, so its
+	// DataViews surface can fill the middle and pin its pagination footer)
+	// shrinks the containing block to ~one screen and drops the tab strip
+	// after the first viewport of scrolling.
 	.jetpack-newsletter-tabs {
 		display: flex;
-		flex: 1 1 auto;
+		flex: 0 0 auto;
 		flex-direction: column;
-		min-block-size: 0;
 	}
 
 	// On the Subscribers tab, let the DataViews surface fill the tab panel
@@ -46,6 +53,15 @@ body.jetpack_page_jetpack-newsletter {
 	// renames the panel's generated class across versions (the old
 	// `[class*="__tabpanel"]` hook silently broke on the 0.13.0 bump).
 	.jp-admin-page:has(.dataviews-wrapper) {
+
+		// Cap `Tabs.Root` to the bounded middle so the DataViews surface below
+		// can fill it (and pin its pagination footer) instead of growing to its
+		// natural height. Only the Subscribers tab wants this — see the base
+		// `.jetpack-newsletter-tabs` rule above for why Settings must not.
+		.jetpack-newsletter-tabs {
+			flex: 1 1 auto;
+			min-block-size: 0;
+		}
 
 		.jetpack-newsletter-page__content,
 		.jetpack-newsletter-page__content > [role="tabpanel"] {

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-scroll
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: keep the Subscribers/Settings tab bar pinned while scrolling the modernized Settings tab


### PR DESCRIPTION
Fixes #

## Proposed changes
* On the modernized Newsletter dashboard, the Subscribers/Settings tab bar (`.jp-admin-page-tabs`) is `position: sticky`. A sticky element only stays pinned while its containing block is in view, and `.jetpack-newsletter-tabs` carried `flex: 1 1 auto; min-block-size: 0`, which capped it to the scroll viewport on **both** tabs. On the long Settings document the containing block was therefore only ~one screen tall, so the tab strip unstuck and scrolled away after the first viewport — visibly when the first "Save" button passed under it.
* That viewport cap is only needed on the **Subscribers** tab, so its DataViews surface fills the bounded middle and pins its pagination footer. Moved the cap behind the existing `:has(.dataviews-wrapper)` gate and let `.jetpack-newsletter-tabs` size to its full content height (`flex: 0 0 auto`) by default. The strip now stays pinned all the way down the Settings tab, while the Subscribers tab is unchanged.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the modernized Newsletter dashboard, go to **Jetpack → Newsletter** and open the **Settings** tab.
* Scroll down past the first "Save" button (in the Subscriptions card) and keep scrolling to the bottom of the page.
* Confirm the **Subscribers / Settings** tab bar stays pinned at the top the entire way down (before this fix, it scrolled up and out of view once the first Save button reached it).
* Switch to the **Subscribers** tab and confirm it is unchanged: the subscribers DataViews table fills the viewport and its pagination footer stays pinned at the bottom.

| Before | After |
| - | - |
| <img width="2388" height="935" alt="Screenshot from 2026-06-08 12-45-36" src="https://github.com/user-attachments/assets/c1d289da-5323-4665-b0f5-8d79dfe3c48b" />  | <img width="1791" height="1034" alt="Screenshot from 2026-06-08 12-41-29" src="https://github.com/user-attachments/assets/db5ce6c5-abfd-4acf-ac8e-7c325ddaa2da" /> |
