### PR TITLE
WAF: Ensure that non-set $_SERVER['REQUEST_METHOD'] is treated the same as CLI in the sense that the WAF is skipped.

### DIFF
--- a/projects/packages/waf/changelog/fix-protect-174-cli-cron-403
+++ b/projects/packages/waf/changelog/fix-protect-174-cli-cron-403
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WAF: Skip rule evaluation when there is no HTTP request (e.g. server-side cron executed via a PHP CLI wrapper), preventing false-positive 403 blocks from rule 911100.

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -238,8 +238,12 @@ class Waf_Runner {
 		// like PHP's prepend_file setting (yay!).
 		define( 'JETPACK_WAF_RUN', defined( 'ABSPATH' ) ? 'plugin' : 'preload' );
 
-		// if the WAF is being run before a command line script, don't try to execute rules (there's no request).
-		if ( PHP_SAPI === 'cli' ) {
+		// If the WAF is being run before a command line script, or in any other non-HTTP
+		// context (e.g. server-side cron executed via a PHP wrapper that does not report
+		// PHP_SAPI as 'cli'), there is no HTTP request to evaluate. Skip rule execution so
+		// HTTP-specific rules (e.g. rule 911100, which checks the request method) don't
+		// produce a false-positive 403 block.
+		if ( PHP_SAPI === 'cli' || empty( $_SERVER['REQUEST_METHOD'] ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -243,7 +243,7 @@ class Waf_Runner {
 		// PHP_SAPI as 'cli'), there is no HTTP request to evaluate. Skip rule execution so
 		// HTTP-specific rules (e.g. rule 911100, which checks the request method) don't
 		// produce a false-positive 403 block.
-		if ( PHP_SAPI === 'cli' || empty( $_SERVER['REQUEST_METHOD'] ) ) {
+		if ( PHP_SAPI === 'cli' || ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/tests/php/unit/WafRunnerTest.php
+++ b/projects/packages/waf/tests/php/unit/WafRunnerTest.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Waf\Waf_Constants;
 use Automattic\Jetpack\Waf\Waf_Runner;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
@@ -50,5 +51,49 @@ final class WafRunnerTest extends PHPUnit\Framework\TestCase {
 		Waf_Runner::run();
 		$this->assertSame( '/pseudo/dir/jetpack-waf', JETPACK_WAF_DIR );
 		$this->assertSame( '/pseudo/dir/../wp-config.php', JETPACK_WAF_WPCONFIG );
+	}
+
+	/**
+	 * Test that run does not evaluate rules when there is no HTTP request method.
+	 *
+	 * Reproduces PROTECT-174: when wp-cron.php is executed directly (e.g. via a PHP
+	 * wrapper for a server-side cron) there is no HTTP context, so REQUEST_METHOD is
+	 * absent. The WAF must skip rule evaluation in that case so that HTTP-specific
+	 * rules (e.g. rule 911100, which checks the request method) don't fire a
+	 * false-positive 403.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function testRunSkipsRulesWhenRequestMethodIsAbsent() {
+		define( 'ABSPATH', '/pseudo' );
+		define( 'WP_CONTENT_DIR', '/pseudo/dir' );
+
+		// Simulate a non-HTTP execution context: no REQUEST_METHOD present.
+		unset( $_SERVER['REQUEST_METHOD'] );
+
+		// Point the WAF at a rules file that would set a flag if it were ever included.
+		$rules_dir  = sys_get_temp_dir() . '/jetpack-waf-test-' . uniqid();
+		$rules_file = $rules_dir . '/rules.php';
+		mkdir( $rules_dir );
+		file_put_contents( $rules_file, '<?php define( "JETPACK_WAF_RULES_EXECUTED", true );' );
+
+		define( 'JETPACK_WAF_DIR', $rules_dir );
+		define( 'JETPACK_WAF_WPCONFIG', '/pseudo/wp-config.php' );
+		define( 'JETPACK_WAF_ENTRYPOINT', 'rules.php' );
+		define( 'JETPACK_WAF_MODE', 'normal' );
+
+		Waf_Runner::run();
+
+		// run() reached the guard (the run-context constant is set before it)...
+		$this->assertTrue( defined( 'JETPACK_WAF_RUN' ), 'Waf_Runner::run() should have started executing.' );
+		// ...but returned early without ever including the rules file.
+		$this->assertFalse( defined( 'JETPACK_WAF_RULES_EXECUTED' ), 'WAF rules must not be evaluated when there is no HTTP request method.' );
+
+		// Clean up.
+		unlink( $rules_file );
+		rmdir( $rules_dir );
 	}
 }

--- a/projects/packages/waf/tests/php/unit/WafRunnerTest.php
+++ b/projects/packages/waf/tests/php/unit/WafRunnerTest.php
@@ -85,15 +85,17 @@ final class WafRunnerTest extends PHPUnit\Framework\TestCase {
 		define( 'JETPACK_WAF_ENTRYPOINT', 'rules.php' );
 		define( 'JETPACK_WAF_MODE', 'normal' );
 
-		Waf_Runner::run();
+		try {
+			Waf_Runner::run();
 
-		// run() reached the guard (the run-context constant is set before it)...
-		$this->assertTrue( defined( 'JETPACK_WAF_RUN' ), 'Waf_Runner::run() should have started executing.' );
-		// ...but returned early without ever including the rules file.
-		$this->assertFalse( defined( 'JETPACK_WAF_RULES_EXECUTED' ), 'WAF rules must not be evaluated when there is no HTTP request method.' );
-
-		// Clean up.
-		unlink( $rules_file );
-		rmdir( $rules_dir );
+			// run() reached the guard (the run-context constant is set before it)...
+			$this->assertTrue( defined( 'JETPACK_WAF_RUN' ), 'Waf_Runner::run() should have started executing.' );
+			// ...but returned early without ever including the rules file.
+			$this->assertFalse( defined( 'JETPACK_WAF_RULES_EXECUTED' ), 'WAF rules must not be evaluated when there is no HTTP request method.' );
+		} finally {
+			// Clean up, even if an assertion fails.
+			unlink( $rules_file );
+			rmdir( $rules_dir );
+		}
 	}
 }


### PR DESCRIPTION
Supersedes https://github.com/Automattic/jetpack/pull/49458



## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Skip WAF rule evaluation when `$_SERVER['REQUEST_METHOD']` is empty, treating any non-HTTP context the same as CLI (PHP_SAPI `cli`).
* Add a regression test (`testRunSkipsRulesWhenRequestMethodIsAbsent`) verifying that `Waf_Runner::run()` starts but returns early without including the rules file when no request method is present.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://linear.app/a8c/issue/PROTECT-174

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI should cover it.
