### PR TITLE
Newsletter: label subscription placement options with a section header

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-add-subscriber-copy
+++ b/projects/packages/newsletter/changelog/fix-newsletter-add-subscriber-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter: label the subscription placement options with a "Homepage and posts" section header.

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -225,22 +225,27 @@ export function SubscriptionsSection( {
 					</Text>
 					<Fieldset.Root disabled={ ! isNewsletterEnabled }>
 						<Stack gap="lg" direction="column">
-							<div className="jetpack-newsletter-placements-grid">
-								{ placements.map( placement => (
-									<PlacementCard
-										key={ placement.key }
-										id={ `placement-${ placement.key }` }
-										name={ String( placement.key ) }
-										title={ placement.title }
-										illustration={ placement.illustration }
-										previewUrl={ placement.previewUrl }
-										checked={ Boolean( data[ placement.key ] ) }
-										onChange={ handlePlacementChange }
-										onPreviewClick={ handlePlacementPreviewClick }
-										disabled={ ! isNewsletterEnabled }
-									/>
-								) ) }
-							</div>
+							<Stack gap="sm" direction="column">
+								<Text variant="heading-sm" render={ <h3 /> }>
+									{ __( 'Homepage and posts', 'jetpack-newsletter' ) }
+								</Text>
+								<div className="jetpack-newsletter-placements-grid">
+									{ placements.map( placement => (
+										<PlacementCard
+											key={ placement.key }
+											id={ `placement-${ placement.key }` }
+											name={ String( placement.key ) }
+											title={ placement.title }
+											illustration={ placement.illustration }
+											previewUrl={ placement.previewUrl }
+											checked={ Boolean( data[ placement.key ] ) }
+											onChange={ handlePlacementChange }
+											onPreviewClick={ handlePlacementPreviewClick }
+											disabled={ ! isNewsletterEnabled }
+										/>
+									) ) }
+								</div>
+							</Stack>
 
 							<Stack gap="sm" direction="column">
 								<Text variant="heading-sm" render={ <h3 /> }>


### PR DESCRIPTION
Fixes #

## Proposed changes

From the p8oabR-1P8-p2 feedback on the modernized Newsletter dashboard: the subscription form placement options (overlay / pop-up / Subscribe block) had no heading. This adds a **"Homepage and posts"** section header above the options grid, matching the existing labeled section below it (the label mirrors the component's own internal "Homepage and posts" naming). Labeling only — no behavior change.

<img width="726" height="471" alt="Subscription placement options with the new Homepage and posts header" src="https://github.com/user-attachments/assets/bb756e54-d021-4da2-bd75-6920f016a104" />

## Related product discussion/links

* Call for Testing: Modernized Jetpack Dashboards (Newsletter, VideoPress & Social) p8oabR-1P8-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the modernized Newsletter dashboard, go to **Jetpack → Newsletter → Settings** and scroll to the subscription form placement options (overlay / pop-up / Subscribe block).
* Confirm a **"Homepage and posts"** section header now appears above the options grid, consistent with the labeled section beneath it.
* Confirm nothing else in the Settings tab changed — this PR is labeling only.