### PR TITLE
Newsletter: surface a site-wide subscriber total on the Subscribers list

### DIFF
--- a/projects/packages/newsletter/_inc/components/newsletter-page.scss
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.scss
@@ -84,7 +84,6 @@ body.jetpack_page_jetpack-newsletter {
 			padding-block: var(--wpds-dimension-padding-md, 12px);
 			padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 			color: var(--wpds-color-fg-content-neutral-weak, #50575e);
-			font-size: var(--wpds-typography-font-size-sm, 13px);
 		}
 
 		// The dataviews "no results" message centres within the area below the

--- a/projects/packages/newsletter/_inc/components/newsletter-page.scss
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.scss
@@ -82,7 +82,7 @@ body.jetpack_page_jetpack-newsletter {
 			flex: 0 0 auto;
 			margin: 0;
 			padding-block: var(--wpds-dimension-padding-md, 12px);
-			padding-inline: var(--wpds-dimension-padding-lg, 16px);
+			padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 			color: var(--wpds-color-fg-content-neutral-weak, #50575e);
 			font-size: var(--wpds-typography-font-size-sm, 13px);
 		}

--- a/projects/packages/newsletter/_inc/components/newsletter-page.scss
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.scss
@@ -11,7 +11,6 @@
 $jetpack-newsletter-inset: var(--wpds-dimension-padding-2xl, 24px);
 
 body.jetpack_page_jetpack-newsletter {
-
 	// Off-white page surface so the white settings cards stand out against the
 	// background. `AdminPage` paints `.jp-admin-page` (its outer wrapper) and
 	// `.jp-admin-page__page` (the admin-ui `Page` shell) white by default via
@@ -74,6 +73,18 @@ body.jetpack_page_jetpack-newsletter {
 		.dataviews-wrapper {
 			flex: 1 1 auto;
 			min-block-size: 0;
+		}
+
+		// Site-wide subscriber total above the table. A fixed-height flex item so
+		// `.dataviews-wrapper` (flex: 1) still absorbs the remaining height and
+		// pins its pagination footer to the viewport bottom.
+		.jetpack-newsletter__subscribers-count {
+			flex: 0 0 auto;
+			margin: 0;
+			padding-block: var(--wpds-dimension-padding-md, 12px);
+			padding-inline: var(--wpds-dimension-padding-lg, 16px);
+			color: var(--wpds-color-fg-content-neutral-weak, #50575e);
+			font-size: var(--wpds-typography-font-size-sm, 13px);
 		}
 
 		// The dataviews "no results" message centres within the area below the

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -1,7 +1,7 @@
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Notice } from '@wordpress/ui';
+import { Notice, Text } from '@wordpress/ui';
 import { useSubscriberRemoveMutation } from '../data/use-subscriber-remove-mutation';
 import { useSubscribers } from '../data/use-subscribers';
 import {
@@ -370,9 +370,13 @@ export default function SubscribersDataViews( {
 	return (
 		<>
 			{ hasTotal && (
-				<p className="jetpack-newsletter__subscribers-count" aria-live="polite">
+				<Text
+					variant="body-sm"
+					className="jetpack-newsletter__subscribers-count"
+					aria-live="polite"
+				>
 					{ countLabel }
-				</p>
+				</Text>
 			) }
 			<DataViews< Subscriber >
 				data={ displayedSubscribers }

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -336,7 +336,7 @@ export default function SubscribersDataViews( {
 	const hasTotal = totalData !== undefined;
 	const countLabel = sprintf(
 		// translators: %s is the formatted total number of subscribers.
-		_n( '%s subscriber', '%s subscribers', totalSubscribers, 'jetpack-newsletter' ),
+		_n( '%s total subscriber', '%s total subscribers', totalSubscribers, 'jetpack-newsletter' ),
 		new Intl.NumberFormat().format( totalSubscribers )
 	);
 

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -1,6 +1,6 @@
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import { useSubscriberRemoveMutation } from '../data/use-subscriber-remove-mutation';
 import { useSubscribers } from '../data/use-subscribers';
@@ -27,6 +27,21 @@ const DEFAULT_PER_PAGE = 20;
 
 // Stable reference so passing "no rows" to DataViews doesn't churn on every render.
 const NO_SUBSCRIBERS: Subscriber[] = [];
+
+// Unfiltered query used solely to read the site-wide subscriber total for the
+// count header. Frozen at module scope so it keeps a stable React Query key —
+// when the visitor has no active filter/search it matches the main list query
+// and is served from the same cache entry (no extra request); once a filter or
+// search narrows the list it falls back to its own cached total so the headline
+// keeps reporting the full count rather than the filtered subset.
+const TOTAL_QUERY_PARAMS = {
+	page: 1,
+	perPage: DEFAULT_PER_PAGE,
+	sort: 'date_subscribed' as SubscribersSortField,
+	sortOrder: 'desc' as const,
+	search: '',
+	filters: [ 'all' ] as SubscribersFilter[],
+};
 
 const defaultView: View = {
 	type: 'table',
@@ -90,6 +105,9 @@ export default function SubscribersDataViews( {
 	);
 
 	const { data, isLoading, error } = useSubscribers( queryParams );
+	// Site-wide total for the count header — independent of the active filter /
+	// search so the headline never collapses to the filtered subset.
+	const { data: totalData } = useSubscribers( TOTAL_QUERY_PARAMS );
 	const removeMutation = useSubscriberRemoveMutation();
 
 	// Fired off `onChangeView` rather than per-control handlers because DataViews owns
@@ -303,6 +321,25 @@ export default function SubscribersDataViews( {
 		( view.filters && view.filters.length > 0 ) || ( view.search && view.search.length > 0 )
 	);
 
+	// Site-wide subscriber total for the count header. Sourced from the
+	// unfiltered query so it stays constant while the visitor filters or
+	// searches. The owner is always returned in the list but isn't a real
+	// subscriber until they subscribe, so collapse the owner-only case to 0 to
+	// match the cold-start empty state.
+	const totalSubscribers = hasNoSubscribersOtherThanOwner(
+		totalData?.total ?? 0,
+		totalData?.is_owner_subscribed ?? false
+	)
+		? 0
+		: totalData?.total ?? 0;
+
+	const hasTotal = totalData !== undefined;
+	const countLabel = sprintf(
+		// translators: %s is the formatted total number of subscribers.
+		_n( '%s subscriber', '%s subscribers', totalSubscribers, 'jetpack-newsletter' ),
+		new Intl.NumberFormat().format( totalSubscribers )
+	);
+
 	// The owner is always returned in the list, so when they're the only subscriber the table
 	// would render a single row and DataViews' `empty` slot would never fire. Mirror Calypso's
 	// launchpad condition and present the cold-start empty state ourselves. Gated on no active
@@ -332,6 +369,11 @@ export default function SubscribersDataViews( {
 
 	return (
 		<>
+			{ hasTotal && (
+				<p className="jetpack-newsletter__subscribers-count" aria-live="polite">
+					{ countLabel }
+				</p>
+			) }
 			<DataViews< Subscriber >
 				data={ displayedSubscribers }
 				fields={ fields }

--- a/projects/packages/newsletter/changelog/fix-newsletter-subscribers-list
+++ b/projects/packages/newsletter/changelog/fix-newsletter-subscribers-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers dashboard: surface a site-wide subscriber total above the list that stays constant while filtering or searching


### PR DESCRIPTION
Fixes #

## Proposed changes

From the p8oabR-1P8-p2 feedback on the modernized Newsletter Subscribers list: the surface showed no subscriber total. The only count present was the DataViews pagination footer, which reflects the *filtered* subset and changes as you filter or search.

This adds a count line above the table that always reports the full, site-wide total. It reads from the existing `useSubscribers` hook with a fixed, unfiltered param set, so on the default view it resolves to the same React Query cache entry as the list (no extra request); once a filter or search narrows the list, the count keeps reporting the full total instead of the filtered subset. The owner-only cold start collapses the total to zero to stay consistent with the existing empty state. Uses `_n()` + `Intl.NumberFormat` for pluralization/formatting and `aria-live="polite"` so screen readers announce it.

<img width="343" height="252" alt="image" src="https://github.com/user-attachments/assets/c2e05c1c-4c51-4acc-aef3-75db418d0bab" />



## Related product discussion/links

* Call for Testing: Modernized Jetpack Dashboards (Newsletter, VideoPress & Social) p8oabR-1P8-p2

## Does this pull request change what data or activity we track or use?

No new tracking. The count is read from the existing `/wpcom/v2/subscribers/list` endpoint.

## Testing instructions

* On a site with the modernized Newsletter dashboard, go to **Jetpack → Newsletter → Subscribers**.
* Confirm a subscriber total (e.g. "1,234 subscribers") now appears above the table.
* Apply a filter (Subscription type or Email subscription) and/or type a search query. The total above the table must **not** change — it keeps reporting the full site-wide count, even as the DataViews pagination footer reflects the filtered subset.
* On a brand-new site where only the owner is subscribed, confirm the total reads zero and the cold-start empty state still shows.

