### PR TITLE
Blocks: Guard against null JETPACK__PLUGIN_FILE

### DIFF
--- a/projects/packages/blocks/changelog/fix-jetpack-guard_against_null_JETPACK__PLUGIN_FILE
+++ b/projects/packages/blocks/changelog/fix-jetpack-guard_against_null_JETPACK__PLUGIN_FILE
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors when JETPACK__PLUGIN_FILE is null.
+
+

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -470,8 +470,19 @@ class Blocks {
 	 */
 	public static function get_path_to_block_metadata( $block_src_dir, $package_dist_dir = '' ) {
 		$dir       = basename( $block_src_dir );
-		$dist_path = empty( $package_dist_dir ) ? dirname( Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ) . '/_inc/blocks' : $package_dist_dir;
-		$result    = realpath( "$dist_path/$dir" );
+		$dist_path = $package_dist_dir;
+
+		if ( empty( $dist_path ) ) {
+			$plugin_file = Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' );
+			// Guard against strange situations where JETPACK__PLUGIN_FILE is undefined.
+			if ( empty( $plugin_file ) ) {
+				return $block_src_dir;
+			}
+
+			$dist_path = dirname( $plugin_file ) . '/_inc/blocks';
+		}
+
+		$result = realpath( "$dist_path/$dir" );
 
 		return false === $result ? $block_src_dir : $result;
 	}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This addresses the following:
```
PHP Deprecated: dirname(): Passing null to parameter #1 ($path) of type string is deprecated in /wordpress/plugins/jetpack/15.9-beta/jetpack_vendor/automattic/jetpack-blocks/src/class-blocks.php on line 473
```

See Slack thread for more details, but for now let's just gracefully handle the broken scenario and avoid log noise.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1780942469958209/1780938225.579699-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

The only way I could trigger this manually is by clicking the "Back up now" button at `https://wordpress.com/backup/<some site here>`. When using this branch, clicking the button should no longer trigger the deprecation.