### PR TITLE
VideoPress: open video details from the grid thumbnail and hover action

### DIFF
--- a/projects/packages/videopress/changelog/open-video-details-from-grid
+++ b/projects/packages/videopress/changelog/open-video-details-from-grid
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Open a video's details from the Library grid by clicking the thumbnail or title, with a hover "Edit details" affordance and full keyboard support.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -347,7 +347,7 @@ const StageInner = () => {
 				</>
 			}
 		>
-			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
+			<UploadActionsProvider value={ { promoteLocal, retryUpload, openVideoDetails } }>
 				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
 					<DropZone
 						label={ __( 'Drop a video to upload', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -111,6 +111,48 @@
 		}
 	}
 
+	// Full-cover, transparent button that turns the whole idle-VideoPress
+	// thumbnail into a single keyboard-reachable target that opens Details
+	// (mirroring Core, where clicking the media opens it). It carries the
+	// shared `&__hover-action` overlay as a non-interactive child, so the
+	// "Edit details" label reveals on hover/focus without adding a second
+	// tab stop.
+	&__open-details {
+		position: absolute;
+		inset: 0;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		cursor: pointer;
+		appearance: none;
+
+		// The hover-action child is purely a visual label here; let clicks
+		// fall through to this button so the entire thumbnail is clickable.
+		.vp-library__hover-action {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			pointer-events: none;
+		}
+
+		&-label {
+			padding: 4px 12px;
+			border-radius: 2px;
+			background: #fff;
+			color: #1e1e1e;
+			font-size: 13px;
+			font-weight: 500;
+			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+		}
+
+		// Keep the keyboard focus ring visible above the overlay.
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #3858e9);
+			outline-offset: -2px;
+		}
+	}
+
 	&__progress {
 		position: absolute;
 		inset: 0;
@@ -140,6 +182,28 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	// Link-styled button used by the title cell for idle VideoPress videos so
+	// the title opens Details (mirroring Core). Rendered as a <button> rather
+	// than an <a> because navigation is handled by the in-app router, not an
+	// href; styled to read as a link and inherit the cell's typography.
+	&__title-link {
+		display: inline;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: none;
+		color: inherit;
+		font: inherit;
+		text-align: inherit;
+		cursor: pointer;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--wp-admin-theme-color, #3858e9);
+			text-decoration: underline;
+		}
 	}
 
 	// Table view: DataViews gives a 32x32 cell slot but doesn't force the img,

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -3,12 +3,41 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Badge, Stack, Text } from '@wordpress/ui';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './thumbnail-field';
+import { useUploadActions } from './upload-actions-context';
 import type { LibraryItem } from '../../types/library';
 import type { Field, Operator } from '@wordpress/dataviews';
 
 const dateSettings = getDateSettings();
 
 type BadgeIntent = React.ComponentProps< typeof Badge >[ 'intent' ];
+
+/**
+ * Render a video's title. For idle VideoPress videos it's a link-styled button
+ * that opens the video's Details (mirroring Core); for every other state it's a
+ * plain span so uploading/failed/local rows stay non-navigable.
+ *
+ * @param props      - Component props.
+ * @param props.item - The library item rendered by this cell.
+ * @return The title element.
+ */
+const TitleText = ( { item }: { item: LibraryItem } ) => {
+	const { openVideoDetails } = useUploadActions();
+	const { type, upload, title, id } = item;
+
+	if ( type === 'videopress' && upload.status === 'idle' ) {
+		return (
+			<button
+				type="button"
+				className="vp-library__title-link"
+				onClick={ () => openVideoDetails( id ) }
+			>
+				{ title }
+			</button>
+		);
+	}
+
+	return <span>{ title }</span>;
+};
 
 const privacyLabel = ( privacy: LibraryItem[ 'privacy' ] ): string => {
 	switch ( privacy ) {
@@ -22,7 +51,7 @@ const privacyLabel = ( privacy: LibraryItem[ 'privacy' ] ): string => {
 };
 
 const TitleCell = ( { item }: { item: LibraryItem } ) => {
-	const { upload, type, title, isProcessing } = item;
+	const { upload, type, isProcessing } = item;
 	let pill: { intent: BadgeIntent; label: string } | null = null;
 	if ( upload.status === 'uploading' ) {
 		pill = {
@@ -56,11 +85,11 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 	}
 
 	if ( ! pill ) {
-		return <>{ title }</>;
+		return <TitleText item={ item } />;
 	}
 	return (
 		<Stack direction="row" gap="sm" align="center" className="vp-library__title-cell">
-			<span>{ title }</span>
+			<TitleText item={ item } />
 			<Badge intent={ pill.intent }>{ pill.label }</Badge>
 		</Stack>
 	);

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { libraryFields } from '../fields';
+import ThumbnailField from '../thumbnail-field';
+import { UploadActionsProvider, type UploadActions } from '../upload-actions-context';
+import type { LibraryItem } from '../../../types/library';
+import type { Field } from '@wordpress/dataviews';
+
+// Avoid the react-query/apiFetch poster request; the poster URL is irrelevant here.
+jest.mock( '../../../hooks/use-poster-url', () => ( {
+	usePosterUrl: jest.fn( () => null ),
+} ) );
+
+const item = ( overrides: Partial< LibraryItem > = {} ): LibraryItem => ( {
+	id: '42',
+	guid: 'abc123',
+	type: 'videopress',
+	title: 'My Clip',
+	filename: 'clip.mp4',
+	thumbnailUrl: null,
+	durationSeconds: 0,
+	uploadDate: '2026-01-01T00:00:00',
+	privacy: 'public',
+	isPrivate: false,
+	fileSizeBytes: 0,
+	upload: { status: 'idle', progress: 0 },
+	description: '',
+	rating: 'G',
+	displayEmbed: true,
+	allowDownloads: false,
+	shortcode: '',
+	isProcessing: false,
+	...overrides,
+} );
+
+const makeActions = ( overrides: Partial< UploadActions > = {} ): UploadActions => ( {
+	promoteLocal: jest.fn(),
+	retryUpload: jest.fn(),
+	openVideoDetails: jest.fn(),
+	...overrides,
+} );
+
+const renderField = ( ui: React.ReactNode, actions: UploadActions ) =>
+	render( <UploadActionsProvider value={ actions }>{ ui }</UploadActionsProvider> );
+
+// The title cell render is whatever the exported `title` field declares.
+const TitleCellRender = ( libraryFields.find( f => f.id === 'title' ) as Field< LibraryItem > )
+	.render as ( args: { item: LibraryItem } ) => React.ReactNode;
+
+describe( 'ThumbnailField — grid Details access', () => {
+	it( 'renders an "Edit details" button that opens details for an idle VideoPress video', async () => {
+		const actions = makeActions();
+		renderField( <ThumbnailField item={ item( { id: '7', title: 'Holiday' } ) } />, actions );
+
+		const button = screen.getByRole( 'button', { name: 'Edit details for Holiday' } );
+		await userEvent.click( button );
+
+		expect( actions.openVideoDetails ).toHaveBeenCalledWith( '7' );
+		expect( actions.openVideoDetails ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows a duration badge when the idle VideoPress video has a duration', () => {
+		renderField( <ThumbnailField item={ item( { durationSeconds: 75 } ) } />, makeActions() );
+		expect( screen.getByText( '01:15' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the open-details button for a local video, and offers Upload instead', async () => {
+		const actions = makeActions();
+		renderField( <ThumbnailField item={ item( { id: '9', type: 'local' } ) } />, actions );
+
+		expect( screen.queryByRole( 'button', { name: /Edit details/ } ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Upload to VideoPress' } ) );
+		expect( actions.promoteLocal ).toHaveBeenCalledWith( '9' );
+	} );
+
+	it( 'offers Retry for a failed upload', async () => {
+		const actions = makeActions();
+		renderField(
+			<ThumbnailField
+				item={ item( { id: '5', type: 'local', upload: { status: 'failed', progress: 0 } } ) }
+			/>,
+			actions
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		expect( actions.retryUpload ).toHaveBeenCalledWith( '5' );
+	} );
+
+	it( 'does not render the open-details button while uploading', () => {
+		renderField(
+			<ThumbnailField item={ item( { upload: { status: 'uploading', progress: 40 } } ) } />,
+			makeActions()
+		);
+		expect( screen.queryByRole( 'button', { name: /Edit details/ } ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '40%' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'TitleCell — grid Details access', () => {
+	it( 'renders the title as a button that opens details for an idle VideoPress video', async () => {
+		const actions = makeActions();
+		renderField( <TitleCellRender item={ item( { id: '3', title: 'Launch' } ) } />, actions );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Launch' } ) );
+		expect( actions.openVideoDetails ).toHaveBeenCalledWith( '3' );
+	} );
+
+	it( 'renders the title as plain text (no button) for a local video', () => {
+		renderField(
+			<TitleCellRender item={ item( { type: 'local', title: 'Raw Footage' } ) } />,
+			makeActions()
+		);
+		expect( screen.getByText( 'Raw Footage' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Raw Footage' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
 import { usePosterUrl } from '../../hooks/use-poster-url';
 import { formatDuration } from '../../utils/format';
@@ -13,16 +13,23 @@ type Props = { item: LibraryItem };
  * 1. uploading → ProgressBar overlay
  * 2. failed    → red overlay with Retry
  * 3. local     → "Local video" placeholder + hover-revealed Upload button
- * 4. videopress → thumbnail image + duration badge
+ * 4. videopress → thumbnail image + duration badge + click/hover "Edit details"
+ *
+ * For idle VideoPress videos the whole thumbnail is a button that opens the
+ * video's Details (mirroring Core, where clicking the media opens it), and the
+ * shared `.vp-library__hover-action` overlay reveals an "Edit details" label on
+ * hover/focus. Local videos keep their existing "Upload to VideoPress" button.
  *
  * @param props      - Component props.
  * @param props.item - The library item rendered by this card.
  * @return The thumbnail element.
  */
 export default function ThumbnailField( { item }: Props ) {
-	const { promoteLocal, retryUpload } = useUploadActions();
+	const { promoteLocal, retryUpload, openVideoDetails } = useUploadActions();
 	const { type, upload, durationSeconds, id, title, isProcessing } = item;
 	const posterUrl = usePosterUrl( item );
+
+	const isVideoPressIdle = type === 'videopress' && upload.status === 'idle';
 
 	return (
 		<div className="vp-library__thumbnail">
@@ -30,7 +37,7 @@ export default function ThumbnailField( { item }: Props ) {
 				<img className="vp-library__thumbnail-image" src={ posterUrl } alt={ title } />
 			) : null }
 
-			{ type === 'videopress' && upload.status === 'idle' && isProcessing ? (
+			{ isVideoPressIdle && isProcessing ? (
 				<Stack
 					direction="column"
 					align="center"
@@ -41,10 +48,33 @@ export default function ThumbnailField( { item }: Props ) {
 				</Stack>
 			) : null }
 
-			{ type === 'videopress' && upload.status === 'idle' && durationSeconds > 0 ? (
+			{ isVideoPressIdle && durationSeconds > 0 ? (
 				<span className="vp-library__thumbnail-duration-badge">
 					{ formatDuration( durationSeconds ) }
 				</span>
+			) : null }
+
+			{ isVideoPressIdle ? (
+				<button
+					type="button"
+					className="vp-library__open-details"
+					onClick={ () => openVideoDetails( id ) }
+					aria-label={ sprintf(
+						/* translators: %s: video title. */
+						__( 'Edit details for %s', 'jetpack-videopress-pkg' ),
+						title
+					) }
+				>
+					{ /* Reuses the shared hover-action overlay; revealed on
+					     hover/focus by the thumbnail's :hover / :focus-within. The
+					     overlay is non-interactive (pointer-events: none) so the
+					     whole thumbnail stays a single keyboard-reachable button. */ }
+					<span className="vp-library__hover-action">
+						<span className="vp-library__hover-action-label">
+							{ __( 'Edit details', 'jetpack-videopress-pkg' ) }
+						</span>
+					</span>
+				</button>
 			) : null }
 
 			{ type === 'local' && upload.status === 'idle' ? (

--- a/projects/packages/videopress/src/dashboard/components/library/upload-actions-context.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/upload-actions-context.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from '@wordpress/element';
 export type UploadActions = {
 	promoteLocal: ( id: string ) => void;
 	retryUpload: ( id: string ) => void;
+	openVideoDetails: ( id: string ) => void;
 };
 
 const UploadActionsContext = createContext< UploadActions | null >( null );
@@ -11,8 +12,9 @@ export const UploadActionsProvider = UploadActionsContext.Provider;
 
 /**
  * Read the upload-actions callbacks supplied by the Library Stage. Used by
- * `ThumbnailField` so the per-card hover button and Retry overlay can call
- * the hook's mutators without prop-drilling through DataViews's grid layout.
+ * `ThumbnailField` (and the title cell) so the per-card hover buttons, the
+ * Retry overlay, and the click-to-open-details affordance can call the hook's
+ * mutators without prop-drilling through DataViews's grid layout.
  *
  * @return The upload-action callbacks.
  */


### PR DESCRIPTION
Before:

<img width="289" height="287" alt="Screenshot 2026-06-08 at 8 58 39 PM" src="https://github.com/user-attachments/assets/1c250155-7f62-42e0-a869-96094697fc22" />

After:
<img width="362" height="464" alt="Screenshot 2026-06-08 at 8 58 27 PM" src="https://github.com/user-attachments/assets/26f6e0a8-5fb2-4a78-84b4-c54687a63583" />


## Proposed changes

In the modernized VideoPress dashboard's **grid** view, the only way to open a video's Details was the three-dot menu → "Edit details". This makes Details reachable directly from the card, mirroring Core (where clicking the media opens it).

* The grid thumbnail for idle VideoPress videos is now a full-cover, keyboard-reachable button that opens Details via the existing `openVideoDetails(id)` handler.
* The video **title** in grid/table is now a link-styled button that also opens Details for idle VideoPress videos.
* A hover "Edit details" affordance is revealed on the card, reusing the existing `.vp-library__hover-action` overlay pattern (the same one local uploads use for "Upload to VideoPress").
* Local-video states are unchanged: uploading/failed/local-placeholder rows keep their existing overlays and the "Upload to VideoPress" hover button.
* `openVideoDetails` is provided through the existing `UploadActionsProvider` context (no prop-drilling through DataViews).

Keyboard accessibility: the thumbnail is a single `<button>` with a descriptive `aria-label` ("Edit details for &lt;title&gt;"); focusing it reveals the overlay via the existing `:focus-within` rule and shows a `:focus-visible` ring. The title button shows a link underline on hover/focus.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the modernization filter `rsm_jetpack_ui_modernization_videopress` (defaults off) via an mu-plugin, e.g. `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`.
2. Open the VideoPress dashboard → **Library** tab and ensure you're in **grid** view (toggle in the DataViews toolbar).
3. Click a VideoPress video's **thumbnail** — it should navigate to that video's Details page.
4. Click a video's **title** — it should also open Details.
5. **Hover** a VideoPress card — an "Edit details" overlay button should appear.
6. **Keyboard:** press Tab to focus a card's thumbnail (focus ring + overlay appear), press Enter — Details should open.
7. Confirm **local** videos still show "Local video" + the "Upload to VideoPress" hover button, and uploading/failed rows are unchanged.
8. Switch to **table** view and confirm rows still behave (title click opens Details; small thumbnail click opens Details; no stray overlays).
