### PR TITLE
VideoPress: make Videos the default dashboard tab and rename tabs

### DIFF
--- a/projects/packages/videopress/changelog/videopress-videos-first-tabs
+++ b/projects/packages/videopress/changelog/videopress-videos-first-tabs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: Make Videos the default dashboard tab and rename the dashboard tabs to Videos, Stats, and Settings.

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -14,7 +14,7 @@
 		"@wordpress/ui": "0.13.0"
 	},
 	"route": {
-		"path": "/library",
+		"path": "/",
 		"page": "jetpack-videopress-dashboard"
 	}
 }

--- a/projects/packages/videopress/routes/overview/package.json
+++ b/projects/packages/videopress/routes/overview/package.json
@@ -17,7 +17,7 @@
 		"@wordpress/url": "4.48.0"
 	},
 	"route": {
-		"path": "/",
+		"path": "/stats",
 		"page": "jetpack-videopress-dashboard"
 	}
 }

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -25,19 +25,19 @@ const isEditable = ( item: LibraryItem ): boolean =>
 
 /**
  * Parent breadcrumb item — labelled "VideoPress" in every case, but the
- * link target depends on where the user arrived from. Overview's ranking
- * links tag their navigation with `state: { from: 'overview' }`; we read
- * that here so the breadcrumb routes back to the Overview tab instead of
- * defaulting to Library. TanStack stores user state on `window.history.state`,
- * so reading it directly avoids needing `useLocation` (which `@wordpress/route`
- * doesn't re-export from TanStack). Stable for the lifetime of the mount,
- * so no reactivity hook is needed.
+ * link target depends on where the user arrived from. The Stats tab's
+ * ranking links tag their navigation with `state: { from: 'overview' }`;
+ * we read that here so the breadcrumb routes back to the Stats tab
+ * (`/stats`) instead of defaulting to the Videos tab (`/`). TanStack stores
+ * user state on `window.history.state`, so reading it directly avoids needing
+ * `useLocation` (which `@wordpress/route` doesn't re-export from TanStack).
+ * Stable for the lifetime of the mount, so no reactivity hook is needed.
  *
  * @return The parent breadcrumb item.
  */
 const getParentBreadcrumbItem = (): { label: string; to: string } => {
 	const from = ( window.history.state as { from?: string } | null )?.from;
-	return { label: 'VideoPress', to: from === 'overview' ? '/' : '/library' };
+	return { label: 'VideoPress', to: from === 'overview' ? '/stats' : '/' };
 };
 
 const NotFound = () => (
@@ -54,7 +54,7 @@ const NotFound = () => (
 		<div className="vp-video-details vp-video-details__not-found">
 			<Stack direction="column" gap="md" align="center">
 				<Text>{ __( "We couldn't find that video.", 'jetpack-videopress-pkg' ) }</Text>
-				<Link to="/library">{ __( 'Back to Library', 'jetpack-videopress-pkg' ) }</Link>
+				<Link to="/">{ __( 'Back to Videos', 'jetpack-videopress-pkg' ) }</Link>
 			</Stack>
 		</div>
 	</AdminPage>
@@ -189,7 +189,7 @@ const StageReady = ( { video }: StageReadyProps ) => {
 				deleteVideo( Number( video.id ), {
 					onSuccess: () => {
 						createSuccessNotice( __( 'Video deleted.', 'jetpack-videopress-pkg' ) );
-						navigate( { href: '/library' } );
+						navigate( { href: '/' } );
 					},
 					onError: () => {
 						createErrorNotice( __( 'Failed to delete video.', 'jetpack-videopress-pkg' ) );

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 	hideFooter?: boolean;
 };
 
-const TAB_VALUES: DashboardTab[] = [ 'overview', 'library', 'settings' ];
+const TAB_VALUES: DashboardTab[] = [ 'library', 'overview', 'settings' ];
 
 /**
  * Shared chrome for every wp-build VideoPress dashboard tab. Renders

--- a/projects/packages/videopress/src/dashboard/components/dashboard-tabs/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-tabs/index.tsx
@@ -4,19 +4,20 @@
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
 
-export type DashboardTab = 'overview' | 'library' | 'settings';
+export type DashboardTab = 'library' | 'overview' | 'settings';
 
 export const TAB_PATHS: Record< DashboardTab, string > = {
-	overview: '/',
-	library: '/library',
+	library: '/',
+	overview: '/stats',
 	settings: '/settings',
 };
 
 /**
- * The Overview / Library / Settings tab strip. Must be rendered inside a
+ * The Videos / Stats / Settings tab strip. Must be rendered inside a
  * `<Tabs.Root>` whose `value` and `onValueChange` are managed by the parent
  * (DashboardLayout) so the strip and its sibling `<Tabs.Panel>`s share
- * Tabs context.
+ * Tabs context. The tab values keep their original keys (`library`,
+ * `overview`) for stability; only the visible labels and routes changed.
  *
  * @return The tab list element.
  */
@@ -24,8 +25,8 @@ export default function DashboardTabs() {
 	return (
 		<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 			<Tabs.List variant="minimal">
-				<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
-				<Tabs.Tab value="library">{ __( 'Library', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
+				<Tabs.Tab value="library">{ __( 'Videos', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
+				<Tabs.Tab value="overview">{ __( 'Stats', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 				<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 			</Tabs.List>
 		</div>

--- a/projects/packages/videopress/src/dashboard/components/overview/most-viewed-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/most-viewed-card.tsx
@@ -40,7 +40,7 @@ export default function MostViewedCard( { videos, isLoading }: Props ): ReactEle
 			emptyMessage={ __( 'No videos viewed in the chosen period.', 'jetpack-videopress-pkg' ) }
 			footer={
 				<Stack direction="row" justify="center" className="vp-overview__ranking-footer">
-					<Link to="/library">{ __( 'See all videos', 'jetpack-videopress-pkg' ) }</Link>
+					<Link to="/">{ __( 'See all videos', 'jetpack-videopress-pkg' ) }</Link>
 				</Stack>
 			}
 		/>

--- a/projects/packages/videopress/src/dashboard/components/overview/top-by-watch-time-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/top-by-watch-time-card.tsx
@@ -44,7 +44,7 @@ export default function TopByWatchTimeCard( { videos, isLoading }: Props ): Reac
 			formatValue={ formatWatchTime }
 			footer={
 				<Stack direction="row" justify="center" className="vp-overview__ranking-footer">
-					<Link to="/library">{ __( 'See all videos', 'jetpack-videopress-pkg' ) }</Link>
+					<Link to="/">{ __( 'See all videos', 'jetpack-videopress-pkg' ) }</Link>
 				</Stack>
 			}
 		/>


### PR DESCRIPTION
Before:
<img width="1735" height="519" alt="Screenshot 2026-06-08 at 8 47 31 PM" src="https://github.com/user-attachments/assets/ca2393d6-9145-4380-afa6-ac7c3b3c53a4" />


After: 
<img width="1738" height="562" alt="Screenshot 2026-06-08 at 8 47 03 PM" src="https://github.com/user-attachments/assets/a7879f4e-c812-47b1-bd91-bf828d84b785" />


## Proposed changes

Reworks the modernized VideoPress dashboard so the most-used view is the landing tab and the tab labels read more clearly.

* Make the Videos view (the Library / DataViews listing) the default tab, served at the dashboard root (`/`).
* Move the stats view to `/stats`.
* Rename and reorder the tabs to: **Videos**, **Stats**, **Settings** (previously Overview, Library, Settings).
* Update the video-details breadcrumb/back logic so "back" lands on Videos (`/`) by default, while videos opened from a Stats ranking card still return to `/stats`.
* Point the Stats ranking "See all videos" links and the not-found "Back to Videos" link at the new root route.
* Route definitions live in each route's `package.json` (`route.path`); the generated `build/routes/registry.php` is produced from those at build time (the `build/` directory is gitignored, so there is no generated output to commit).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The modernized VideoPress dashboard is gated behind the `rsm_jetpack_ui_modernization_videopress` filter. Enable it with an mu-plugin:

```php
add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
```

* Go to **wp-admin → VideoPress** (`admin.php?page=jetpack-videopress`).
* Confirm the dashboard now lands on the **Videos** tab by default (the DataViews video listing), and that the tab strip reads **Videos / Stats / Settings** in that order.
* Click **Stats** and confirm the URL changes to `/stats` and the stats view renders.
* Open a video from the Videos tab, then use the breadcrumb / back action and confirm it returns to **Videos** (`/`).
* From the **Stats** tab, open a video via a ranking card ("Most viewed" / "Top by watch time"), then use the breadcrumb and confirm it returns to **Stats** (`/stats`).
* Confirm the "See all videos" links on the Stats ranking cards open the Videos tab.
