### PR TITLE
VideoPress: add bulk privacy actions to the dashboard library

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-bulk-privacy-actions
+++ b/projects/packages/videopress/changelog/add-videopress-bulk-privacy-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Allow changing privacy (public, private, site default) on multiple videos at once from the new Library, skipping items that can't accept the change and reporting any partial failures.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -13,7 +13,7 @@ import QueryClientWrapper from '../../src/dashboard/components/query-client-wrap
 import { DeleteVideosError, useDeleteVideo } from '../../src/dashboard/hooks/use-delete-video';
 import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
 import { useLibrary } from '../../src/dashboard/hooks/use-library';
-import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
+import { useSetPrivacy } from '../../src/dashboard/hooks/use-set-privacy';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
 import { useVideoPressUpgrade } from '../../src/dashboard/hooks/use-videopress-upgrade';
@@ -73,7 +73,7 @@ const StageInner = () => {
 	const { items, isLoading, paginationInfo } = useLibrary( view );
 	const { uploadQueue, startUpload, retryUpload } = useUpload();
 	const { mutateAsync: deleteVideo } = useDeleteVideo();
-	const { mutate: updateMeta } = useUpdateVideoMeta();
+	const { mutateAsync: setPrivacyAsync } = useSetPrivacy();
 	const { mutate: uploadFromLibrary } = useUploadFromLibrary();
 	const { isAtLimit, isFree, isUnlimited, videoCount, limit } = useFreeTier();
 	const runUpgrade = useVideoPressUpgrade();
@@ -288,31 +288,63 @@ const StageInner = () => {
 					const requested = new Set( ids );
 					setSelection( prev => prev.filter( id => ! requested.has( id ) || failedIds.has( id ) ) );
 				},
-				setPrivacy: ( id: string, privacy: LibraryItemPrivacy ) => {
-					updateMeta(
-						{ id, patch: { privacy } },
-						{
-							onSuccess: () => {
+				setPrivacy: ( ids: string[], privacy: LibraryItemPrivacy ) => {
+					// Batch through useSetPrivacy: each id is POSTed individually so one
+					// failure doesn't abort the rest, and the result reports which ids
+					// succeeded vs. failed so we can surface an accurate notice.
+					setPrivacyAsync( { ids, privacy } )
+						.then( ( { succeeded, failed } ) => {
+							if ( failed.length === 0 ) {
 								createSuccessNotice(
 									sprintf(
-										/* translators: %s: new privacy label. */
-										__( 'Privacy updated to %s.', 'jetpack-videopress-pkg' ),
+										/* translators: 1: number of videos updated. 2: new privacy label, e.g. "Public". */
+										_n(
+											'%1$d video set to %2$s.',
+											'%1$d videos set to %2$s.',
+											succeeded.length,
+											'jetpack-videopress-pkg'
+										),
+										succeeded.length,
 										PRIVACY_LABELS[ privacy ]
 									)
 								);
-							},
-							onError: () => {
-								createErrorNotice( __( 'Failed to update privacy.', 'jetpack-videopress-pkg' ) );
-							},
-						}
-					);
+								return;
+							}
+
+							if ( succeeded.length === 0 ) {
+								createErrorNotice(
+									_n(
+										'Failed to update privacy.',
+										'Failed to update privacy for the selected videos.',
+										failed.length,
+										'jetpack-videopress-pkg'
+									)
+								);
+								return;
+							}
+
+							createErrorNotice(
+								sprintf(
+									/* translators: 1: number of videos updated. 2: number of videos that could not be updated. */
+									__(
+										'Privacy updated for %1$d video; %2$d could not be updated.',
+										'jetpack-videopress-pkg'
+									),
+									succeeded.length,
+									failed.length
+								)
+							);
+						} )
+						.catch( () => {
+							createErrorNotice( __( 'Failed to update privacy.', 'jetpack-videopress-pkg' ) );
+						} );
 				},
 			} ),
 		[
 			promoteLocal,
 			retryUpload,
 			deleteVideo,
-			updateMeta,
+			setPrivacyAsync,
 			openVideoDetails,
 			createSuccessNotice,
 			createErrorNotice,

--- a/projects/packages/videopress/src/dashboard/components/library/actions.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/actions.ts
@@ -6,7 +6,7 @@ type Api = {
 	promoteLocal: ( id: string ) => void;
 	retryUpload: ( id: string ) => void;
 	deleteItems: ( ids: string[] ) => void;
-	setPrivacy: ( id: string, privacy: LibraryItemPrivacy ) => void;
+	setPrivacy: ( ids: string[], privacy: LibraryItemPrivacy ) => void;
 	openVideoDetails: ( id: string ) => void;
 };
 
@@ -17,11 +17,42 @@ const isVideoPressIdle = ( item: LibraryItem ) =>
 	item.type === 'videopress' && item.upload.status === 'idle';
 
 /**
+ * Eligibility for a privacy action: the item must be an idle VideoPress video
+ * that does not already have the target privacy. Local items, in-flight videos,
+ * and videos already at the requested setting are filtered out, so a mixed bulk
+ * selection only touches the rows that actually need to change.
+ *
+ * @param target - The privacy value the action would apply.
+ * @return An `isEligible` predicate for the DataViews action.
+ */
+const isPrivacyChangeEligible = ( target: LibraryItemPrivacy ) => ( item: LibraryItem ) =>
+	isVideoPressIdle( item ) && item.privacy !== target;
+
+// The privacy actions differ only by target value, label, and id suffix, so
+// build them from one descriptor to keep them in lockstep. The id suffix is
+// kept separate because `site-default` ships under the shorter `set-privacy-site`.
+const PRIVACY_ACTIONS: { idSuffix: string; label: string; privacy: LibraryItemPrivacy }[] = [
+	{ idSuffix: 'public', label: __( 'Make public', 'jetpack-videopress-pkg' ), privacy: 'public' },
+	{
+		idSuffix: 'private',
+		label: __( 'Make private', 'jetpack-videopress-pkg' ),
+		privacy: 'private',
+	},
+	{
+		idSuffix: 'site',
+		label: __( 'Reset to site default', 'jetpack-videopress-pkg' ),
+		privacy: 'site-default',
+	},
+];
+
+/**
  * Build the DataViews actions array for the Library tab. Eligibility predicates
  * gate per-row availability based on `item.type` and `item.upload.status`. The
- * Delete action sets `supportsBulk: true` and `isEligible` to filter local items
- * out of mixed selections (DataViews silently skips ineligible items). Rows with
- * a delete already in flight are ineligible for every action so a slow delete
+ * Delete and privacy actions set `supportsBulk: true` and use `isEligible` to
+ * filter out items that can't accept the change (local items, in-flight videos,
+ * or videos already at the target privacy). DataViews silently skips ineligible
+ * items, so a mixed selection only applies to the rows that qualify. Rows with a
+ * delete already in flight are ineligible for every action so a slow delete
  * can't be double-fired or raced by an edit.
  *
  * @param api - Hook mutators forwarded into the action callbacks.
@@ -42,42 +73,18 @@ export function buildLibraryActions( api: Api ): Action< LibraryItem >[] {
 				}
 			},
 		},
-		{
-			id: 'set-privacy-public',
-			label: __( 'Make public', 'jetpack-videopress-pkg' ),
-			supportsBulk: false,
-			isEligible: item => isVideoPressIdle( item ) && item.privacy !== 'public',
-			callback: items => {
-				const [ item ] = items;
-				if ( item ) {
-					api.setPrivacy( item.id, 'public' );
-				}
+		...PRIVACY_ACTIONS.map( ( { idSuffix, label, privacy } ) => ( {
+			id: `set-privacy-${ idSuffix }`,
+			label,
+			supportsBulk: true,
+			isEligible: isPrivacyChangeEligible( privacy ),
+			callback: ( items: LibraryItem[] ) => {
+				api.setPrivacy(
+					items.map( i => i.id ),
+					privacy
+				);
 			},
-		},
-		{
-			id: 'set-privacy-private',
-			label: __( 'Make private', 'jetpack-videopress-pkg' ),
-			supportsBulk: false,
-			isEligible: item => isVideoPressIdle( item ) && item.privacy !== 'private',
-			callback: items => {
-				const [ item ] = items;
-				if ( item ) {
-					api.setPrivacy( item.id, 'private' );
-				}
-			},
-		},
-		{
-			id: 'set-privacy-site',
-			label: __( 'Reset to site default', 'jetpack-videopress-pkg' ),
-			supportsBulk: false,
-			isEligible: item => isVideoPressIdle( item ) && item.privacy !== 'site-default',
-			callback: items => {
-				const [ item ] = items;
-				if ( item ) {
-					api.setPrivacy( item.id, 'site-default' );
-				}
-			},
-		},
+		} ) ),
 		{
 			id: 'delete',
 			label: __( 'Delete', 'jetpack-videopress-pkg' ),

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-set-privacy.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-set-privacy.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useSetPrivacy } from '../use-set-privacy';
+
+describe( 'useSetPrivacy', () => {
+	it( 'POSTs the mapped privacy_setting for each id', async () => {
+		const requests: { id: number; privacy_setting: number }[] = [];
+		mockApiFetch( async ( { path, method, data } ) => {
+			if ( method === 'POST' && path === '/wpcom/v2/videopress/meta' ) {
+				requests.push( data as { id: number; privacy_setting: number } );
+				return { code: 'success' };
+			}
+			throw new Error( 'unexpected' );
+		} );
+
+		const wrapper = createTestWrapper( createTestQueryClient() );
+		const { result } = renderHook( () => useSetPrivacy(), { wrapper } );
+
+		let outcome;
+		await act( async () => {
+			outcome = await result.current.mutateAsync( { ids: [ 1, 2 ], privacy: 'private' } );
+		} );
+
+		expect( requests ).toEqual( [
+			{ id: 1, privacy_setting: 1 },
+			{ id: 2, privacy_setting: 1 },
+		] );
+		expect( outcome ).toEqual( { succeeded: [ 1, 2 ], failed: [] } );
+	} );
+
+	it( 'reports partial failures without aborting the batch', async () => {
+		mockApiFetch( async ( { method, data } ) => {
+			if ( method === 'POST' ) {
+				const { id } = data as { id: number };
+				if ( id === 2 ) {
+					throw new Error( 'nope' );
+				}
+				return { code: 'success' };
+			}
+			throw new Error( 'unexpected' );
+		} );
+
+		const wrapper = createTestWrapper( createTestQueryClient() );
+		const { result } = renderHook( () => useSetPrivacy(), { wrapper } );
+
+		let outcome;
+		await act( async () => {
+			outcome = await result.current.mutateAsync( { ids: [ 1, 2, 3 ], privacy: 'public' } );
+		} );
+
+		expect( outcome ).toEqual( {
+			succeeded: [ 1, 3 ],
+			failed: [ { id: 2, message: 'nope' } ],
+		} );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/use-set-privacy.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-set-privacy.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { privacyStringToInt, LIBRARY_QUERY_KEY } from './use-library';
+import type { LibraryItemPrivacy } from '../types/library';
+
+type Id = number | string;
+
+export type SetPrivacyVars = {
+	ids: Id[];
+	privacy: LibraryItemPrivacy;
+};
+
+export type SetPrivacyResult = {
+	succeeded: Id[];
+	failed: { id: Id; message: string }[];
+};
+
+/**
+ * Return a mutation that sets the privacy for one or more videos.
+ *
+ * Each id is POSTed individually to wpcom/v2/videopress/meta with the mapped
+ * `privacy_setting` integer (mirroring the single-item meta update). Requests
+ * run in parallel (matching useDeleteVideo) and a failure on one video doesn't
+ * abort the rest; the result reports which ids succeeded and which failed,
+ * letting the caller surface a partial-failure notice. The library cache is
+ * invalidated once at the end so the grid reflects whatever did change.
+ *
+ * @return A TanStack Query mutation whose mutateAsync accepts `{ ids, privacy }`.
+ */
+export function useSetPrivacy() {
+	const client = useQueryClient();
+	return useMutation< SetPrivacyResult, Error, SetPrivacyVars >( {
+		mutationFn: async ( { ids, privacy } ) => {
+			const privacySetting = privacyStringToInt( privacy );
+			const results = await Promise.allSettled(
+				ids.map( id =>
+					apiFetch( {
+						path: '/wpcom/v2/videopress/meta',
+						method: 'POST',
+						data: { id: Number( id ), privacy_setting: privacySetting },
+					} )
+				)
+			);
+
+			const succeeded: Id[] = [];
+			const failed: { id: Id; message: string }[] = [];
+			results.forEach( ( result, index ) => {
+				const id = ids[ index ];
+				if ( result.status === 'fulfilled' ) {
+					succeeded.push( id );
+					return;
+				}
+				const { reason } = result;
+				const message =
+					reason instanceof Error
+						? reason.message
+						: ( reason as { message?: string } )?.message ?? String( reason );
+				failed.push( { id, message } );
+			} );
+
+			return { succeeded, failed };
+		},
+		onSettled: () => {
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+		},
+	} );
+}


### PR DESCRIPTION
Before:
<img width="430" height="98" alt="Screenshot 2026-06-08 at 9 02 22 PM" src="https://github.com/user-attachments/assets/9ecc02e9-86d6-407f-976a-976edace907c" />


After:

<img width="1125" height="107" alt="Screenshot 2026-06-08 at 9 01 33 PM" src="https://github.com/user-attachments/assets/64350d85-238d-42c4-b474-ffde6bc1b022" />

Or if the video is set to public then we have.

<img width="599" height="113" alt="Screenshot 2026-06-08 at 9 02 54 PM" src="https://github.com/user-attachments/assets/b37ead97-fb5d-4930-90ab-90c44e363f90" />



## Proposed changes

Builds on the modernized VideoPress Library dashboard (gated behind the `rsm_jetpack_ui_modernization_videopress` filter).

**Bulk privacy actions**
* The three Library privacy actions — Make public, Make private, Reset to site default — now set `supportsBulk: true`, so they appear in the DataViews selection toolbar when multiple videos are selected.
* Their callbacks accept the full selection and batch the privacy mutations. A new `useSetPrivacy` hook mirrors the bulk `delete` hook: it POSTs each id to the existing `wpcom/v2/videopress/meta` endpoint **in parallel** (`Promise.allSettled`) and returns a `{ succeeded, failed }` result so the caller can surface partial-failure feedback.
* Mixed selections are handled the same way Delete handles them: each action's `isEligible` predicate filters out local items, in-flight videos, and videos already at the target privacy, and DataViews silently skips ineligible rows.
* The three privacy actions are generated from a single descriptor so their `id`, label, eligibility, and callback stay in lockstep.

This reuses the existing `wpcom/v2/videopress/meta` REST endpoint (already used by the dashboard and block editor) — no new endpoints or business logic.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Enable the modernized dashboard first:
* Enable the `rsm_jetpack_ui_modernization_videopress` filter (e.g. via mu-plugin) to surface the new VideoPress Library.

Bulk privacy actions:
* Go to the VideoPress dashboard → Library tab.
* Select multiple VideoPress videos via the row checkboxes.
* **Before:** the selection toolbar offered only **Delete** as a bulk action.
* **After:** the toolbar also offers **Make public**, **Make private**, and **Reset to site default**. Applying one updates every eligible selected video; videos already at that privacy (and local-only items) are skipped.
* With a partial failure, the notice reports how many succeeded vs. could not be updated.

Automated checks: the `use-set-privacy` unit test passes; typecheck and lint are clean on the changed files.
