### PR TITLE
Custom Colors: prevent Customizer styles from affecting the block editor UI

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-custom-colors-block-editor-ui-leak
+++ b/projects/plugins/wpcomsh/changelog/fix-custom-colors-block-editor-ui-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: Scope Customizer colors to the editor content so they no longer leak into the block editor UI (e.g. the sidebar's Categories panel).

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1424,7 +1424,8 @@ class Colors_Manager_Common {
 	}
 
 	/**
-	 * Enqueue theme CSS for the block editor.
+	 * Enqueue the Customizer's custom colors for the block editor, scoped to the
+	 * editor content so they can't leak into the editor UI.
 	 *
 	 * @since 9.0.0
 	 */
@@ -1432,17 +1433,12 @@ class Colors_Manager_Common {
 		if ( ! self::should_enable_colors() ) {
 			return;
 		}
-		$css = self::get_theme_css();
 
-		// Gutenberg 22.6.0+ renders the editor in an iframe for all themes.
-		// #editor no longer exists inside the iframe, so extend any
-		// "#editor .editor-styles-wrapper" selector to also match the
-		// iframe context while keeping the original for older versions.
-		$css = str_replace(
-			'#editor .editor-styles-wrapper',
-			'#editor .editor-styles-wrapper, :root :where(.editor-styles-wrapper)',
-			$css
-		);
+		// `@scope` already scopes to the wrapper, so map any legacy explicit
+		// "#editor .editor-styles-wrapper" prefix to `:scope` (the scope root)
+		// rather than leaving a redundant — and no-longer-matching — prefix.
+		$css = str_replace( '#editor .editor-styles-wrapper', ':scope', self::get_theme_css() );
+		$css = '@scope (.editor-styles-wrapper) {' . $css . '}';
 
 		wp_register_style( 'custom-colors-editor-css', false, array(), '20210311' ); // Register an empty stylesheet to append custom CSS to.
 		wp_enqueue_style( 'custom-colors-editor-css' );


### PR DESCRIPTION
Fixes EDI-266

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* The Customizer's custom colors are loaded into the block editor, but their (front-end) selectors were also matching the editor's own UI — breaking the layout of the sidebar's Categories panel on some themes.
* Confine those styles to the editor content so they can no longer affect the editor UI. The editor canvas itself renders exactly as before.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* EDI-266
* Follow-up to #41073 and #47603.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an Atomic site using a classic theme with custom-color annotations, set non-default colors in **Appearance → Customize → Colors & Backgrounds** and save.
* Open the block editor for a post or page.
* Confirm the sidebar's **Categories** panel renders normally — on `trunk` it is broken on affected themes.
* Confirm the editor canvas looks the same as it did before this change.
