### PR TITLE
wpcomsh: enable Copy a site for all paid Atomic-capable plans

### DIFF
--- a/projects/plugins/wpcomsh/changelog/copy-site-enable-for-atomic-capable-plans
+++ b/projects/plugins/wpcomsh/changelog/copy-site-enable-for-atomic-capable-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Copy a site: enable for all paid Atomic-capable plans (Personal, Premium, and Business or higher), mirroring WPCOM.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -713,8 +713,15 @@ class WPCOM_Features {
 			self::WPCOM_BUSINESS_PLANS,
 		),
 		self::COPY_SITE                         => array(
-			self::WPCOM_BUSINESS_PLANS,
-			self::WPCOM_ECOMMERCE_PLANS,
+			self::WPCOM_PRO_PLANS,
+			self::EXCLUDE_PLANS => array(
+				self::WPCOM_ECOMMERCE_TRIAL_PLANS,
+			),
+			// Copy a site requires an Atomic site, so this mirrors the plans that can be
+			// Atomic: Personal, Premium, and Business or higher plans (not all paid plans).
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::WPCOM_PERSONAL_AND_PREMIUM_PLANS,
+			self::WPCOM_FLEX_CACHE_SITE_FREE_PLANS,
 		),
 		// CORE_AUDIO - core/audio requires a paid plan for uploading audio files.
 		self::CORE_AUDIO                        => array(


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Mirrors the WPCOM-side change to `WPCOM_Features::COPY_SITE` in wpcomsh's verbatim copy of `class-wpcom-features.php`, keeping the two files in sync.
* **Copy a site** is now available on every Atomic-capable paid plan — Personal, Premium, Pro, and Business or higher — instead of Business + Ecommerce only. Ecommerce trial and non-Atomic-capable plans (Starter/Blogger/Free) remain excluded.

## Related product discussion/links
* Follows up the corresponding WPCOM change.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WPCOM/Atomic-backed environment running this build of wpcomsh, confirm `wpcom_site_has_feature( WPCOM_Features::COPY_SITE )` returns `true` for a site on a Personal, Premium, Pro, Business, or Ecommerce plan.
* Confirm it returns `false` for an Ecommerce trial, Starter, Blogger, or Free plan (no flex-cache-site sticker).
* Confirm the **Copy site** action is offered in the UI for the newly enabled plans and remains hidden for the excluded ones.
