### PR TITLE
My Jetpack: fix fatal "Class Automattic\Jetpack\Search\Plan not found" on sites without the Search package

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-plan-class-not-found
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-plan-class-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fix a fatal error on sites that include My Jetpack without the Search package (e.g. standalone Jetpack Boost).

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-plan-class-not-found
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-plan-class-not-found
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fixed
+Comment: Search: fix a fatal error on sites that include My Jetpack without the Search package (e.g. standalone Jetpack Boost).
 
-Search: fix a fatal error on sites that include My Jetpack without the Search package (e.g. standalone Jetpack Boost).
+

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
-use Automattic\Jetpack\Search\Plan as Search_Plan;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,6 +30,18 @@ class Search extends Hybrid_Product {
 	 * @var float
 	 */
 	const FALLBACK_STARTING_PRICE_USD = 100;
+
+	/**
+	 * Search "new pricing" version identifier (introduced 202208).
+	 *
+	 * Intentionally duplicated from Automattic\Jetpack\Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION
+	 * rather than referencing that class. My Jetpack is bundled into standalone plugins (e.g. Jetpack
+	 * Boost) that do NOT ship the jetpack-search package, so referencing Search\Plan here fatals with
+	 * "Class not found" the moment this product builds its pricing data (introduced by PR #48892).
+	 *
+	 * @var string
+	 */
+	const SEARCH_NEW_PRICING_VERSION = '202208';
 
 	/**
 	 * The product slug
@@ -179,7 +190,7 @@ class Search extends Hybrid_Product {
 		if ( is_wp_error( $search_pricing ) ) {
 			// Default to the current pricing experience when the WPCOM fetch fails so the
 			// dashboard degrades to the production default, not the legacy single-card view.
-			$pricing['pricing_version'] = Search_Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
+			$pricing['pricing_version'] = self::SEARCH_NEW_PRICING_VERSION;
 
 			// If the generic product pricing was also unavailable, fall back to a USD
 			// starting price so the pricing grid renders a price instead of "$0".
@@ -240,7 +251,7 @@ class Search extends Hybrid_Product {
 			return true;
 		}
 
-		return Search_Plan::JETPACK_SEARCH_NEW_PRICING_VERSION === $search_pricing['pricing_version'];
+		return self::SEARCH_NEW_PRICING_VERSION === $search_pricing['pricing_version'];
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -372,13 +372,14 @@ class Search_Product_Test extends TestCase {
 		add_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
 		$tripwire = $this->block_search_plan_autoload();
 
-		try {
-			$is_new_pricing = Search::is_new_pricing_202208();
-			$pricing        = Search::get_pricing_for_ui();
-		} finally {
-			spl_autoload_unregister( $tripwire );
-			remove_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
-		}
+		// If production regresses to a Search\Plan reference, the tripwire throws here and the test
+		// errors with the contract message; the separate process is torn down regardless, so the
+		// unregister/remove_filter below only need to run on the success path.
+		$is_new_pricing = Search::is_new_pricing_202208();
+		$pricing        = Search::get_pricing_for_ui();
+
+		spl_autoload_unregister( $tripwire );
+		remove_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
 
 		// The comparison line ran without loading Search\Plan and matched the self-owned constant.
 		$this->assertTrue( $is_new_pricing );
@@ -414,12 +415,13 @@ class Search_Product_Test extends TestCase {
 		add_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
 		$tripwire = $this->block_search_plan_autoload();
 
-		try {
-			$pricing = Search::get_pricing_for_ui();
-		} finally {
-			spl_autoload_unregister( $tripwire );
-			remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
-		}
+		// If production regresses to a Search\Plan reference, the tripwire throws here and the test
+		// errors with the contract message; the separate process is torn down regardless, so the
+		// unregister/remove_filter below only need to run on the success path.
+		$pricing = Search::get_pricing_for_ui();
+
+		spl_autoload_unregister( $tripwire );
+		remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
 
 		// The fallback assignment ran without loading Search\Plan and used the self-owned constant.
 		$this->assertSame( Search::SEARCH_NEW_PRICING_VERSION, $pricing['pricing_version'] );

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -319,4 +319,109 @@ class Search_Product_Test extends TestCase {
 			Search::SEARCH_NEW_PRICING_VERSION
 		);
 	}
+
+	/**
+	 * Registers a prepended autoloader that throws if Automattic\Jetpack\Search\Plan is ever
+	 * requested, modelling a standalone bundle (e.g. Jetpack Boost) that ships My Jetpack without the
+	 * jetpack-search package. Returns the callable so the caller can unregister it in a finally block.
+	 *
+	 * Prepended so it runs before Composer's classmap loader -- a no-op loader would not stop Composer
+	 * from loading the class from the dev-only jetpack-search package, so the tripwire must throw.
+	 *
+	 * @return callable The registered autoloader, for spl_autoload_unregister().
+	 */
+	private function block_search_plan_autoload(): callable {
+		$tripwire = static function ( $class ) {
+			if ( 'Automattic\\Jetpack\\Search\\Plan' === $class ) {
+				throw new \RuntimeException(
+					'Standalone-bundle contract broken: My Jetpack pricing code attempted to load '
+					. 'Automattic\\Jetpack\\Search\\Plan, which is absent in bundles without jetpack-search (e.g. Boost).'
+				);
+			}
+		};
+		spl_autoload_register( $tripwire, true, true );
+		return $tripwire;
+	}
+
+	/**
+	 * Contract test: the success-branch pricing-version comparison must work when the jetpack-search
+	 * package is absent -- the standalone Jetpack Boost runtime that originally fataled.
+	 *
+	 * Before the fix, the is_new_pricing_202208() comparison referenced Automattic\Jetpack\Search\Plan,
+	 * fataling on bundles without the Search package; it now uses the self-owned SEARCH_NEW_PRICING_VERSION
+	 * constant. A tripwire autoloader throws if Search\Plan is loaded, so any reintroduced runtime reference
+	 * fails here instead of in production -- unlike the constant-drift guard, which runs with Search present.
+	 *
+	 * Runs in a separate process for two reasons: (1) the drift-guard test loads Search\Plan into the
+	 * shared process, and an already-loaded class never triggers the autoloader, defeating the tripwire;
+	 * (2) the function-static $pricings cache in get_pricing_from_wpcom() must start empty. The opening
+	 * assertion confirms Search\Plan is not already loaded, proving the isolated process is clean.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_pricing_succeeds_when_search_plan_unavailable() {
+		$this->assertFalse(
+			class_exists( \Automattic\Jetpack\Search\Plan::class, false ),
+			'Search\Plan must not be pre-loaded, or the tripwire cannot detect a regression.'
+		);
+
+		unset( $_GET['new_pricing_202208'] );
+		add_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
+		$tripwire = $this->block_search_plan_autoload();
+
+		try {
+			$is_new_pricing = Search::is_new_pricing_202208();
+			$pricing        = Search::get_pricing_for_ui();
+		} finally {
+			spl_autoload_unregister( $tripwire );
+			remove_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
+		}
+
+		// The comparison line ran without loading Search\Plan and matched the self-owned constant.
+		$this->assertTrue( $is_new_pricing );
+		// estimated_record_count is only set on the success branch, proving we did not fall back.
+		$this->assertArrayHasKey( 'estimated_record_count', $pricing );
+		$this->assertSame( Search::SEARCH_NEW_PRICING_VERSION, $pricing['pricing_version'] );
+	}
+
+	/**
+	 * Contract test: the WP_Error fallback in get_pricing_for_ui() must work when the jetpack-search
+	 * package is absent -- the standalone Jetpack Boost runtime that originally fataled.
+	 *
+	 * When the WPCOM pricing fetch errors, get_pricing_for_ui() defaults pricing_version to the
+	 * new-pricing value. Before the fix this assignment referenced Automattic\Jetpack\Search\Plan,
+	 * fataling on bundles without the Search package. The tripwire autoloader throws if Search\Plan is
+	 * loaded, so a reintroduced runtime reference fails here instead of in production.
+	 *
+	 * Runs in a separate process so Search\Plan is not already loaded (the drift-guard test loads it in
+	 * the shared process) and so the function-static $pricings cache starts empty. The opening assertion
+	 * confirms the isolated process is clean.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_pricing_fallback_succeeds_when_search_plan_unavailable() {
+		$this->assertFalse(
+			class_exists( \Automattic\Jetpack\Search\Plan::class, false ),
+			'Search\Plan must not be pre-loaded, or the tripwire cannot detect a regression.'
+		);
+
+		add_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+		$tripwire = $this->block_search_plan_autoload();
+
+		try {
+			$pricing = Search::get_pricing_for_ui();
+		} finally {
+			spl_autoload_unregister( $tripwire );
+			remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+		}
+
+		// The fallback assignment ran without loading Search\Plan and used the self-owned constant.
+		$this->assertSame( Search::SEARCH_NEW_PRICING_VERSION, $pricing['pricing_version'] );
+	}
 }

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -298,4 +298,25 @@ class Search_Product_Test extends TestCase {
 		$this->assertArrayHasKey( 'estimated_record_count', $pricing );
 		$this->assertSame( '202208', $pricing['pricing_version'] );
 	}
+
+	/**
+	 * The locally-owned SEARCH_NEW_PRICING_VERSION constant must stay in sync with the Search
+	 * package's canonical Automattic\Jetpack\Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION.
+	 *
+	 * The two are intentionally duplicated -- My Jetpack ships in standalone plugins that do not
+	 * bundle jetpack-search, so this class cannot reference Search\Plan at runtime -- but they
+	 * describe the same WPCOM pricing-API contract and must not drift. jetpack-search is a dev
+	 * dependency of this package, so this guard runs in CI and fails if the Search package ever
+	 * changes the version without updating the My Jetpack copy.
+	 */
+	public function test_new_pricing_version_constant_matches_search_package() {
+		if ( ! class_exists( \Automattic\Jetpack\Search\Plan::class ) ) {
+			$this->markTestSkipped( 'jetpack-search package not available; cannot compare constants.' );
+		}
+
+		$this->assertSame(
+			\Automattic\Jetpack\Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION,
+			Search::SEARCH_NEW_PRICING_VERSION
+		);
+	}
 }

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -5,6 +5,8 @@ namespace Automattic\Jetpack\My_Jetpack;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\My_Jetpack\Products\Search;
 use Jetpack_Options;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -245,5 +247,55 @@ class Search_Product_Test extends TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
 
 		$this->assertTrue( $is_new_pricing );
+	}
+
+	/**
+	 * Forces the WPCOM pricing fetch to succeed with a 200 carrying the new-pricing version.
+	 *
+	 * @return array
+	 */
+	public function force_pricing_success() {
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => '{"pricing_version":"202208"}',
+		);
+	}
+
+	/**
+	 * Success-path regression test for the pricing-version comparison.
+	 *
+	 * PR #48892 swapped the hardcoded '202208' literal for a reference to
+	 * Automattic\Jetpack\Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION. That class ships only in the
+	 * jetpack-search package, so in standalone plugins that bundle My Jetpack without it (e.g. Jetpack
+	 * Boost) the success-path comparison in is_new_pricing_202208() fatals with "Class not found".
+	 * The existing tests only cover the WP_Error branch, so the comparison line was never exercised.
+	 * This locks in the success path against the self-owned SEARCH_NEW_PRICING_VERSION constant.
+	 *
+	 * Runs in a separate process so the function-static $pricings cache in get_pricing_from_wpcom()
+	 * starts empty; otherwise a WP_Error cached by an earlier failure-path test (same record-count
+	 * key) would be returned and the success comparison would never run.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_new_pricing_202208_true_on_successful_fetch() {
+		unset( $_GET['new_pricing_202208'] );
+		add_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
+
+		$is_new_pricing = Search::is_new_pricing_202208();
+		$pricing        = Search::get_pricing_for_ui();
+
+		remove_filter( 'pre_http_request', array( $this, 'force_pricing_success' ) );
+
+		// Comparison line (the one that fataled) ran on the success path and matched the constant.
+		$this->assertTrue( $is_new_pricing );
+		// estimated_record_count is only set on the success branch, proving we did not fall back.
+		$this->assertArrayHasKey( 'estimated_record_count', $pricing );
+		$this->assertSame( '202208', $pricing['pricing_version'] );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/bootstrap.php
+++ b/projects/packages/my-jetpack/tests/php/bootstrap.php
@@ -13,5 +13,25 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 define( 'WP_DEBUG', true );
 define( 'JETPACK_ENABLE_MY_JETPACK', true );
 
+/*
+ * Seed request globals before WordPress boots.
+ *
+ * PHPUnit separate-process tests (#[RunInSeparateProcess] / @preserveGlobalState disabled) start the
+ * child with an empty $_SERVER. When WordPress then guesses the site URL, wp_guess_url() in
+ * wp-includes/functions.php runs dirname( $_SERVER['SCRIPT_FILENAME'] ) and strpos() against it; on
+ * PHP 7.x an empty value raises a "strpos(): Empty needle" warning, which PHPUnit promotes to a test
+ * error (only on the PHP 7.x lanes -- PHP 8 allows an empty needle). Provide sane values so the URL
+ * guess stays quiet and deterministic across the PHP version matrix.
+ */
+if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
+	$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+}
+if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+	$_SERVER['REQUEST_URI'] = '/';
+}
+if ( empty( $_SERVER['HTTP_HOST'] ) ) {
+	$_SERVER['HTTP_HOST'] = 'example.org';
+}
+
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();

--- a/projects/packages/my-jetpack/tests/php/bootstrap.php
+++ b/projects/packages/my-jetpack/tests/php/bootstrap.php
@@ -10,28 +10,32 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-define( 'WP_DEBUG', true );
-define( 'JETPACK_ENABLE_MY_JETPACK', true );
-
-/*
- * Seed request globals before WordPress boots.
- *
- * PHPUnit separate-process tests (#[RunInSeparateProcess] / @preserveGlobalState disabled) start the
- * child with an empty $_SERVER. When WordPress then guesses the site URL, wp_guess_url() in
- * wp-includes/functions.php runs dirname( $_SERVER['SCRIPT_FILENAME'] ) and strpos() against it; on
- * PHP 7.x an empty value raises a "strpos(): Empty needle" warning, which PHPUnit promotes to a test
- * error (only on the PHP 7.x lanes -- PHP 8 allows an empty needle). Provide sane values so the URL
- * guess stays quiet and deterministic across the PHP version matrix.
- */
+// Work around WordPress bug when `@runInSeparateProcess` is used.
 if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
-	$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+	$_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/vendor/phpunit/phpunit/phpunit';
 }
+
+if ( empty( $_SERVER['SCRIPT_NAME'] ) ) {
+	$_SERVER['SCRIPT_NAME'] = __DIR__ . '/vendor/phpunit/phpunit/phpunit';
+}
+
+if ( empty( $_SERVER['PHP_SELF'] ) ) {
+	$_SERVER['PHP_SELF'] = '';
+}
+
+// REQUEST_URI/HTTP_HOST aren't part of the shared bootstrap pattern, but My Jetpack's
+// separate-process tests reach wp_guess_url(), which reads them too -- so seed them as
+// well to keep the URL guess quiet and deterministic across the PHP version matrix.
 if ( empty( $_SERVER['REQUEST_URI'] ) ) {
 	$_SERVER['REQUEST_URI'] = '/';
 }
+
 if ( empty( $_SERVER['HTTP_HOST'] ) ) {
 	$_SERVER['HTTP_HOST'] = 'example.org';
 }
+
+define( 'WP_DEBUG', true );
+define( 'JETPACK_ENABLE_MY_JETPACK', true );
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();


### PR DESCRIPTION
Fixes [MYJP-308: My Jetpack Search product fatals on standalone plugins that don't bundle jetpack-search (Boost 4.6.0)](https://linear.app/a8c/issue/MYJP-308/my-jetpack-search-product-fatals-on-standalone-plugins-that-dont)

## Proposed changes

Fixes a PHP fatal on the My Jetpack products endpoint for any standalone plugin that bundles My Jetpack **without** the `jetpack-search` package — most notably **Jetpack Boost**:

```
PHP Fatal error: Uncaught Error: Class "Automattic\Jetpack\Search\Plan" not found
in .../jetpack-my-jetpack/src/products/class-search.php:243
```

* **Root cause:** #48892 replaced a hardcoded `'202208'` string with a reference to `Automattic\Jetpack\Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION` (and added `use Automattic\Jetpack\Search\Plan`). `Search\Plan` ships only in `jetpack-search`, which is a `require-dev` of this package — so CI stayed green — but is **not** bundled by standalone consumers like Boost. The reference is reached via `GET /wp-json/my-jetpack/v1/site/products` → `Products::get_products_api_data()` → `Search::get_wpcom_info()` → `get_pricing_for_ui()`. It is neither cache- nor connection-gated: the WPCOM-fetch **success** path fatals at the `is_new_pricing_202208()` comparison (line 243), the **failure** path at the `get_pricing_for_ui()` fallback (line 182). So it fatals on essentially every hit of that endpoint on a Search-less site. New in Boost 4.6.0 (4.5.9 predates #48892 and uses the bare literal).
* **Fix:** add a self-owned `const SEARCH_NEW_PRICING_VERSION = '202208'` to the My Jetpack `Search` class (mirrors the existing `FALLBACK_STARTING_PRICE_USD` pattern, with a doc comment explaining the intentional duplication), drop the now-unused `use … Search\Plan` import, and swap both references to `self::SEARCH_NEW_PRICING_VERSION`. #48892's behavior is preserved exactly (new-pricing default on error, USD fallback, failure caching).
* **Tests:** adds a success-path regression test — only the `WP_Error` branch was previously covered, so the line that fataled was never exercised — plus a drift-guard test asserting the local constant stays equal to `Search\Plan::JETPACK_SEARCH_NEW_PRICING_VERSION` when the dev-only package is present.
* **Propagation:** lands in the `jetpack-my-jetpack` package; Boost's committed `jetpack_vendor/` picks it up on the next `jetpack build` (Boost pins `automattic/jetpack-my-jetpack: ^5.38.1`). Must be carried into the Boost 4.6.0 release branch for that release.

## Related product discussion/links

* Regression introduced by #48892 (Search — Linear `SEARCH-196`).
* Tracking: MYJP-308 (My Jetpack & Web).

## Does this pull request change what data or activity we track or use?

No. This only replaces a cross-package class-constant reference with an equivalent local constant; there are no changes to telemetry, tracking, or stored data.

## Testing instructions

* From `projects/packages/my-jetpack`, run `composer phpunit` — green (includes the new success-path and drift-guard tests).
* On a connected, **Boost-only** site (no full Jetpack, no Jetpack Search active, so `Search\Plan` is genuinely absent), load the **My Jetpack** page, or hit the endpoint directly:
  ```
  wp eval 'print_r( \Automattic\Jetpack\My_Jetpack\Products::get_products_api_data( array( "search" ) ) );'
  ```
  * **Before:** HTTP 500 / broken product cards + `Class "Automattic\Jetpack\Search\Plan" not found` in the PHP error log.
  * **After:** HTTP 200, the Search product card renders with pricing, and there is no `Search\Plan` error in the log.

---

### Alternatives considered

* **Bundle `jetpack-search` as a runtime dependency of My Jetpack** (so consumers auto-install `Search\Plan`). Rejected: it creates a circular dependency (`jetpack-search` already requires `jetpack-my-jetpack`), and there is no small carve-out — `Plan` lives inside the full ~25 MB Search module (indexing, instant-search UI, REST controllers), which would then ship into Boost (a performance plugin) and every other My Jetpack consumer just to read one string. (Contrast `jetpack-protect-status`, a ~1.2k-LOC data package that My Jetpack *does* require.) The clean long-term version is a small shared Search-owned package, which is overkill for one constant.
* **Bare `'202208'` literal** — fixes the fatal but reintroduces a magic string.
* **`class_exists()` guard around `Search\Plan`** — would change #48892's intended successful-fetch behavior when the class is absent (defaulting to "new pricing" instead of honoring the returned version).

### Out of scope

The same anti-pattern (My Jetpack product classes statically referencing feature-package classes a standalone plugin may not bundle) exists elsewhere — e.g. `class-protect.php` (`Protect_Status::get_status()`, unguarded but Boost bundles `jetpack-protect-status`), and a separate `Agents_Manager\WP_REST_Jetpack_AI_JWT` reference in `class-initializer.php` that errors in this package's own test env. Those don't fatal in Boost specifically and are left for a separate audit.