### PR TITLE
Mirror audit: Check needed secrets

### DIFF
--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -178,7 +178,7 @@ for repo in $REPOS; do
 	fi
 
 	# Fetch the repo's secrets once, then verify each required one is present.
-	if [[ -n "${SECRETS_NEEDED[*]}" ]]; then
+	if [[ ${#SECRETS_NEEDED[@]} -gt 0 ]]; then
 		if SECRETS=$( gh api "/repos/$repo/actions/secrets" --jq '.secrets[].name' 2>/dev/null ); then
 			for secret in "${SECRETS_NEEDED[@]}"; do
 				workflow=$( jq -r --arg s "$secret" '.[$s]' <<<"$WORKFLOW_SECRETS" )

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -49,19 +49,6 @@ function check {
 	fi
 }
 
-function check_secret {
-	local JSON=
-	if JSON=$( gh api "/repos/$repo/actions/secrets/$2" 2>/dev/null ); then
-		ok "Secret $2 is set (required by $1 workflow)"
-	elif jq -e '.status == 404 or .status == "404"' <<<"$JSON" &>/dev/null; then
-		err "Secret $2 is not set, but is required by the $1 workflow (see PCYsg-xsv-p2#mirror-repo-secrets)"
-	elif jq -e '.message' <<<"$JSON" &>/dev/null; then
-		err "Failed to fetch secret $2: $( jq -r '.message' <<<"$JSON" )"
-	else
-		err "Failed to fetch secret $2"
-	fi
-}
-
 # Sets options.
 QUIET=
 while getopts ":qh" opt; do
@@ -108,6 +95,14 @@ WPSVN_REPOS=$( jq -r 'select( .extra["wp-svn-autopublish"] ) | .extra["mirror-re
 E2E_REPOS=$( for f in projects/*/*/composer.json; do
 	[[ -d "${f%composer.json}tests/e2e" ]] && jq -r '.extra["mirror-repo"] // empty' "$f"
 done )
+
+# Maps each secret to the workflow that requires it.
+WORKFLOW_SECRETS='{
+	"API_TOKEN_GITHUB": "Autotagger",
+	"WPSVN_USERNAME": "WordPress.org SVN autopublish",
+	"WPSVN_PASSWORD": "WordPress.org SVN autopublish",
+	"REPO_DISPATCH_TOKEN": "E2E tests"
+}'
 
 cd "$BASE"
 for repo in $REPOS; do
@@ -171,15 +166,31 @@ for repo in $REPOS; do
 	fi
 
 	# Mirror repos using these workflows need their corresponding secrets set.
+	SECRETS_NEEDED=()
 	if grep -qxF "$repo" <<<"$AUTOTAGGER_REPOS"; then
-		check_secret Autotagger API_TOKEN_GITHUB
+		SECRETS_NEEDED+=( API_TOKEN_GITHUB )
 	fi
 	if grep -qxF "$repo" <<<"$WPSVN_REPOS"; then
-		check_secret 'WordPress.org SVN autopublish' WPSVN_USERNAME
-		check_secret 'WordPress.org SVN autopublish' WPSVN_PASSWORD
+		SECRETS_NEEDED+=( WPSVN_USERNAME WPSVN_PASSWORD )
 	fi
 	if grep -qxF "$repo" <<<"$E2E_REPOS"; then
-		check_secret 'E2E tests' REPO_DISPATCH_TOKEN
+		SECRETS_NEEDED+=( REPO_DISPATCH_TOKEN )
+	fi
+
+	# Fetch the repo's secrets once, then verify each required one is present.
+	if [[ -n "${SECRETS_NEEDED[*]}" ]]; then
+		if SECRETS=$( gh api "/repos/$repo/actions/secrets" --jq '.secrets[].name' 2>/dev/null ); then
+			for secret in "${SECRETS_NEEDED[@]}"; do
+				workflow=$( jq -r --arg s "$secret" '.[$s]' <<<"$WORKFLOW_SECRETS" )
+				if grep -qxF "$secret" <<<"$SECRETS"; then
+					ok "Secret $secret is set (required by $workflow workflow)"
+				else
+					err "Secret $secret is not set, but is required by the $workflow workflow (see PCYsg-xsv-p2#mirror-repo-secrets)"
+				fi
+			done
+		else
+			err "Failed to fetch secrets"
+		fi
 	fi
 done
 

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -49,6 +49,19 @@ function check {
 	fi
 }
 
+function check_secret {
+	JSON=
+	if JSON=$( gh api "/repos/$repo/actions/secrets/$2" 2>/dev/null ); then
+		ok "Secret $2 is set (required by $1 workflow)"
+	elif jq -e '.status == 404 or .status == "404"' <<<"$JSON" &>/dev/null; then
+		err "Secret $2 is not set, but is required by the $1 workflow"
+	elif jq -e '.message' <<<"$JSON" &>/dev/null; then
+		err "Failed to fetch secret $2: $( jq -r '.message' <<<"$JSON" )"
+	else
+		err "Failed to fetch secret $2"
+	fi
+}
+
 # Sets options.
 QUIET=
 while getopts ":qh" opt; do
@@ -88,6 +101,13 @@ if [[ -n "$1" ]]; then
 else
 	REPOS=$( jq -r '.extra["mirror-repo"] // empty' projects/*/*/composer.json | sort -u )
 fi
+
+# Index mirror repos by the workflows they use so we can verify they have the secrets those workflows require.
+AUTOTAGGER_REPOS=$( jq -r 'select( .extra.autotagger ) | .extra["mirror-repo"] // empty' projects/*/*/composer.json )
+WPSVN_REPOS=$( jq -r 'select( .extra["wp-svn-autopublish"] ) | .extra["mirror-repo"] // empty' projects/*/*/composer.json )
+E2E_REPOS=$( for f in projects/*/*/composer.json; do
+	[[ -d "${f%composer.json}tests/e2e" ]] && jq -r '.extra["mirror-repo"] // empty' "$f"
+done )
 
 cd "$BASE"
 for repo in $REPOS; do
@@ -148,6 +168,18 @@ for repo in $REPOS; do
 		err "Failed to fetch workflow permissions setting: $( jq -e '.message' <<<"$JSON" )"
 	else
 		err "Failed to fetch workflow permissions setting"
+	fi
+
+	# Mirror repos using these workflows need their corresponding secrets set.
+	if grep -qxF "$repo" <<<"$AUTOTAGGER_REPOS"; then
+		check_secret Autotagger API_TOKEN_GITHUB
+	fi
+	if grep -qxF "$repo" <<<"$WPSVN_REPOS"; then
+		check_secret 'WordPress.org SVN autopublish' WPSVN_USERNAME
+		check_secret 'WordPress.org SVN autopublish' WPSVN_PASSWORD
+	fi
+	if grep -qxF "$repo" <<<"$E2E_REPOS"; then
+		check_secret 'E2E tests' REPO_DISPATCH_TOKEN
 	fi
 done
 

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -81,7 +81,7 @@ if ! gh auth status --hostname github.com &> /dev/null; then
 fi
 
 DESC_RE1='^\[READ ONLY\] '
-DESC_RE2=' This repository is a mirror([,;] f|\. F)or issue tracking and development,? (go|head) (to:?|here:) https://github\.com/[Aa]utomattic/[Jj]etpack/?\.?\s*$'
+DESC_RE2=' This repository is a mirror([,;] f|\. F)or issue tracking and development,? (go|head) (to:?|here:) https://github\.com/[Aa]utomattic/[Jj]etpack/?\.?[[:space:]]*$'
 
 if [[ -n "$1" ]]; then
 	REPOS="$1"

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -50,7 +50,7 @@ function check {
 }
 
 function check_secret {
-	JSON=
+	local JSON=
 	if JSON=$( gh api "/repos/$repo/actions/secrets/$2" 2>/dev/null ); then
 		ok "Secret $2 is set (required by $1 workflow)"
 	elif jq -e '.status == 404 or .status == "404"' <<<"$JSON" &>/dev/null; then

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -54,7 +54,7 @@ function check_secret {
 	if JSON=$( gh api "/repos/$repo/actions/secrets/$2" 2>/dev/null ); then
 		ok "Secret $2 is set (required by $1 workflow)"
 	elif jq -e '.status == 404 or .status == "404"' <<<"$JSON" &>/dev/null; then
-		err "Secret $2 is not set, but is required by the $1 workflow"
+		err "Secret $2 is not set, but is required by the $1 workflow (see PCYsg-xsv-p2#mirror-repo-secrets)"
 	elif jq -e '.message' <<<"$JSON" &>/dev/null; then
 		err "Failed to fetch secret $2: $( jq -r '.message' <<<"$JSON" )"
 	else


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This adds a secret check for mirror repos. In particular, it indexes all the repos that use a given workflow, and then when looping through the repos to check, if it belongs to a given index it checks for the relevant secret(s).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1780934108471069/1780932837.375029-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Run `tools/audit-mirror-repos.sh` and verify the output is as one would expect.
2. Modify the script to try a fake secret, and run on `tools/audit-mirror-repos.sh Automattic/jetpack-seo` or something.