### PR TITLE
WAF: Prevent PHP warning on malformed array

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-prevent_php_warning_on_malformed_ip_object
+++ b/projects/packages/waf/changelog/fix-waf-prevent_php_warning_on_malformed_ip_object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Guard against malformed allowlist data.

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -155,6 +155,9 @@ class Waf_Compatibility {
 	 */
 	public static function merge_ip_allow_lists( $waf_allow_list, $brute_force_allow_list ) {
 
+		// Drop malformed entries.
+		$brute_force_allow_list = is_array( $brute_force_allow_list ) ? array_filter( $brute_force_allow_list, 'is_object' ) : array();
+
 		if ( empty( $brute_force_allow_list ) ) {
 			return $waf_allow_list;
 		}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This addresses a high rate of this from a single site (and its staging variant):
```
PHP Warning: Attempt to read property "ip_address" on string in /wordpress/plugins/jetpack/15.9-beta/jetpack_vendor/automattic/jetpack-waf/src/class-compatibility.php on line 169
```

It seems both calls to `merge_ip_allow_lists()` pass a `$brute_force_allow_list` that comes directly from an option (either from `get_option()` or a direct database query).

It's expected that this would be an array of objects, but clearly it's sometimes an array of strings instead. My proposed solution is to filter out non-objects before trying to use them.

I also considered using the string as a potential IP fallback, but at a glance in the history, it doesn't seem the expected data shape has changed since it was introduced, so I think it's safer to discard as invalid.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I guess one could populate the database with bad data? Or just look at the code.