### PR TITLE
renovate: Fix post-upgrade script

### DIFF
--- a/.github/files/renovate-post-upgrade-run.sh
+++ b/.github/files/renovate-post-upgrade-run.sh
@@ -8,14 +8,15 @@ fi
 
 docker pull --quiet ghcr.io/automattic/jetpack-wordpress-dev:latest
 
-# Work around https://github.com/fabiospampinato/atomically/issues/13 by extracting /etc/passwd from the container and appending the entry for $EUID to it.
+# Create an entry in the container's /etc/passwd for $EUID.
 TMPFILE=$( mktemp )
 function cleanup {
 	rm -f "$TMPFILE"
 }
 trap cleanup exit
 chmod 0644 "$TMPFILE"
-docker run --rm ghcr.io/automattic/jetpack-wordpress-dev:latest cat /etc/passwd > "$TMPFILE"
-getent passwd $EUID >> "$TMPFILE"
+docker run --rm ghcr.io/automattic/jetpack-wordpress-dev:latest cat /etc/passwd | grep -v "^[^:]*:[^:]*:$EUID:" > "$TMPFILE"
+echo "renovate:x:$EUID:$EUID::/home/renovate:/bin/bash" >> $TMPFILE
 
-docker run --rm --workdir "$PWD" --user $EUID --volume "$TMPFILE":/etc/passwd --volume /tmp/:/tmp/ --volume /tmp/dummy-log:/var/log/php ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"
+mkdir -p /tmp/homedir
+docker run --rm --workdir "$PWD" --user $EUID --volume "$TMPFILE":/etc/passwd --volume /tmp/:/tmp/ --volume /tmp/dummy-log:/var/log/php --volume /tmp/homedir:/home/renovate ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"

--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -46,9 +46,9 @@ fi
 # Do the pnpm install. Turn off some strictness settings to make it more likely this will work.
 cd "$BASE"
 TMP=$(< pnpm-workspace.yaml )
-pnpm config set --location project strict-peer-dependencies false
-pnpm config set --location project strict-dep-builds false
-pnpm config set --location project allow-unused-patches true
+pnpm config set --location project strictPeerDependencies false
+pnpm config set --location project strictDepBuilds false
+pnpm config set --location project allowUnusedPatches true
 pnpm install || EXIT=$?
 echo "$TMP" > pnpm-workspace.yaml
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
pnpm 11 seems unhappy if `$HOME` is not writable, even though we're not having it write anything to it. So update the code that's creating an `/etc/passwd` entry to make sure it points HOME to a writable directory.

Then, also, `pnpm config` apparently no longer recognizes `allow-unused-patches` as an alias for `allowUnusedPatches`. Convert all the setting commands to camelCase.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Trigger a renovate run using this branch to update #49448, and see if it works now.
  * [x] https://github.com/Automattic/jetpack/actions/runs/27212750439