### PR TITLE
Connectors: surface Safe Mode (Identity Crisis) state and resolution options

### DIFF
--- a/projects/packages/connection/changelog/connector-card-script-version
+++ b/projects/packages/connection/changelog/connector-card-script-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connectors: Add cache-busting version to the connector card script module so updated assets are served after changes.

--- a/projects/packages/connection/changelog/idc-confirm-safe-mode-cache
+++ b/projects/packages/connection/changelog/idc-confirm-safe-mode-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Identity Crisis: Fix confirming Safe Mode again after clearing it from the admin bar, which could silently fail when the safe_mode_confirmed option was stale in a persistent object cache.

--- a/projects/packages/connection/changelog/idc-connector-card
+++ b/projects/packages/connection/changelog/idc-connector-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connectors: Surface Jetpack Safe Mode (Identity Crisis) state and resolution options in the connector card.

--- a/projects/packages/connection/changelog/idc-migrate-stale-cache
+++ b/projects/packages/connection/changelog/idc-migrate-stale-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Identity Crisis: Prevent the migrate (Update address) action from failing with a false "Could not delete sync error option" error when the sync_error_idc option is stale in cache.

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -115,6 +115,7 @@ class Jetpack_Connector {
 			(string) @filemtime( $css_path ) // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- fallback to empty string if file is missing.
 		);
 
+		$js_path = __DIR__ . '/js/connectors-card.js';
 		wp_register_script_module(
 			static::MODULE_ID,
 			plugins_url( 'js/connectors-card.js', __FILE__ ),
@@ -123,7 +124,8 @@ class Jetpack_Connector {
 					'id'     => '@wordpress/connectors',
 					'import' => 'static',
 				),
-			)
+			),
+			(string) @filemtime( $js_path ) // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- fallback to empty string if file is missing.
 		);
 		wp_enqueue_script_module( static::MODULE_ID );
 

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -11,6 +11,7 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -168,6 +169,8 @@ class Jetpack_Connector {
 			if ( in_array( 'jetpack', array_column( $data['connectedPlugins'], 'slug' ), true ) ) {
 				$data['ssoStatus'] = ( new Modules() )->is_active( 'sso', false );
 			}
+
+			static::add_identity_crisis_data( $data );
 		}
 
 		if ( $is_connected ) {
@@ -185,6 +188,42 @@ class Jetpack_Connector {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Add Jetpack Identity Crisis (Safe Mode) data to the script module data.
+	 *
+	 * The connector card uses this to swap the status badge to "Safe Mode" and
+	 * to render IDC resolution options (migrate / start fresh / stay in safe
+	 * mode) in the expanded details. Mirrors the data assembled by
+	 * \Automattic\Jetpack\IdentityCrisis\UI::get_initial_state_data().
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $data Script module data passed by reference.
+	 */
+	private static function add_identity_crisis_data( &$data ) {
+		if ( ! class_exists( Identity_Crisis::class ) ) {
+			return;
+		}
+
+		$in_safe_mode = ( new Status() )->in_safe_mode();
+
+		$data['isInSafeMode'] = $in_safe_mode;
+
+		if ( ! $in_safe_mode ) {
+			return;
+		}
+
+		$idc_urls = Identity_Crisis::get_mismatched_urls();
+
+		$data['isSafeModeConfirmed'] = (bool) Identity_Crisis::$is_safe_mode_confirmed;
+		$data['idc']                 = array(
+			'currentUrl'                     => ( is_array( $idc_urls ) && array_key_exists( 'current_url', $idc_urls ) ) ? $idc_urls['current_url'] : home_url(),
+			'wpcomHomeUrl'                   => ( is_array( $idc_urls ) && array_key_exists( 'wpcom_url', $idc_urls ) ) ? $idc_urls['wpcom_url'] : '',
+			'isDevelopmentSite'              => (bool) Status::is_development_site(),
+			'possibleDynamicSiteUrlDetected' => (bool) Identity_Crisis::detect_possible_dynamic_site_url(),
+		);
 	}
 
 	/**

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -28,6 +28,20 @@
 	margin-block-end: 16px;
 }
 
+/*
+ * Stretch the option cards to equal height so their buttons stay aligned at
+ * the bottom regardless of copy length (paired with margin-block-start: auto
+ * on the button). On mobile each card wraps to its own row, so the stretch
+ * has no effect and the stacked layout is unaffected.
+ *
+ * The selector is doubled to outrank the HStack's emotion-generated
+ * `align-items: center/flex-start` rule, which has the same single-class
+ * specificity but is injected later in the document.
+ */
+.jetpack-connector__idc-options.jetpack-connector__idc-options {
+	align-items: stretch;
+}
+
 .jetpack-connector__idc-footer {
 	flex-wrap: wrap;
 }
@@ -44,6 +58,24 @@
 
 .jetpack-connector__idc-safe-mode-link {
 	margin-inline-start: 0;
+}
+
+.jetpack-connector__idc-why-toggle {
+	align-self: flex-start;
+	padding-inline: 0;
+	height: auto;
+}
+
+.jetpack-connector__idc-why-list {
+	margin: 0;
+	padding-inline-start: 20px;
+	list-style: disc;
+	font-size: 12px;
+	color: #757575;
+}
+
+.jetpack-connector__idc-why-list li {
+	margin-block-end: 4px;
 }
 
 .jetpack-connector__status-badge {

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -51,7 +51,14 @@
 	min-inline-size: 200px;
 }
 
+/*
+ * Size the action to its label instead of stretching full-width (the option
+ * card is a VStack, which stretches its children on the cross axis).
+ * margin-block-start: auto keeps it pinned to the bottom so the two cards'
+ * buttons stay aligned regardless of copy length.
+ */
 .jetpack-connector__idc-option .jetpack-connector__inline-action {
+	align-self: flex-start;
 	margin-inline-start: 0;
 	margin-block-start: auto;
 }

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -60,6 +60,12 @@
 	margin-inline-start: 0;
 }
 
+.jetpack-connector__idc-safe-mode-group {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
 .jetpack-connector__idc-why-toggle {
 	align-self: flex-start;
 	padding-inline: 0;

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -66,6 +66,10 @@
 	gap: 4px;
 }
 
+.jetpack-connector__idc-choose {
+	margin-block-start: 16px;
+}
+
 .jetpack-connector__idc-why-toggle {
 	align-self: flex-start;
 	padding-inline: 0;

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -23,6 +23,29 @@
 	padding-inline: 20px;
 }
 
+.jetpack-connector__idc-options {
+	flex-wrap: wrap;
+	margin-block-end: 16px;
+}
+
+.jetpack-connector__idc-footer {
+	flex-wrap: wrap;
+}
+
+.jetpack-connector__idc-option {
+	flex: 1 1 200px;
+	min-inline-size: 200px;
+}
+
+.jetpack-connector__idc-option .jetpack-connector__inline-action {
+	margin-inline-start: 0;
+	margin-block-start: auto;
+}
+
+.jetpack-connector__idc-safe-mode-link {
+	margin-inline-start: 0;
+}
+
 .jetpack-connector__status-badge {
 	padding-block: 4px;
 	padding-inline: 12px;
@@ -40,6 +63,11 @@
 .jetpack-connector__status-badge--site-registered {
 	color: #1e4c5e;
 	background-color: #e9f0f5;
+}
+
+.jetpack-connector__status-badge--safe-mode {
+	color: #4f3500;
+	background-color: #fcf0e5;
 }
 
 .jetpack-connector__section {

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -877,7 +877,7 @@ function IDCPanel() {
 		isBusy: busyAction === 'migrate',
 		disabled: Boolean( busyAction ),
 		onClick: handleMigrate,
-		isPrimary: ! isDevelopmentSite,
+		isPrimary: true,
 	} );
 
 	const freshOption = createElement( IDCOption, {
@@ -900,7 +900,7 @@ function IDCPanel() {
 		isBusy: busyAction === 'start-fresh',
 		disabled: Boolean( busyAction ),
 		onClick: handleStartFresh,
-		isPrimary: isDevelopmentSite,
+		isPrimary: true,
 	} );
 
 	// Development/staging sites are most often intentional clones, so migrating
@@ -922,7 +922,7 @@ function IDCPanel() {
 			)
 		),
 		createElement( Text, { size: 13 }, intro ),
-		// Collapsible "Why am I seeing this?" explanation keeps the panel compact
+		// Collapsible "Show more details?" explanation keeps the panel compact
 		// while making the likely causes available to anyone who wants them.
 		createElement(
 			Button,
@@ -933,7 +933,7 @@ function IDCPanel() {
 				'aria-controls': 'jetpack-connector-idc-why',
 				className: 'jetpack-connector__idc-why-toggle',
 			},
-			__( 'Why am I seeing this?', 'jetpack-connection' )
+			__( 'Show more details?', 'jetpack-connection' )
 		),
 		// Wrap in a plain element so the `hidden` attribute actually hides the
 		// region: VStack renders `display: flex`, which would override `hidden`.
@@ -971,7 +971,7 @@ function IDCPanel() {
 		createElement(
 			Text,
 			{ weight: 600, size: 14, className: 'jetpack-connector__idc-choose' },
-			__( 'Choose the option below that matches your situation.', 'jetpack-connection' )
+			__( 'Choose the option below that matches your situation', 'jetpack-connection' )
 		),
 		createElement(
 			HStack,
@@ -1348,9 +1348,9 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 			};
 		}
 
-		// In Safe Mode the toggle becomes a red "Resolve" call to action that
-		// surfaces the identity-crisis options. Once expanded it reverts to a
-		// neutral "Close".
+		// In Safe Mode the toggle becomes a primary "Resolve" call to action
+		// that surfaces the identity-crisis options. Once expanded it reverts to
+		// a neutral "Close".
 		const toggleProps = {
 			variant: 'secondary',
 			size: 'compact',
@@ -1362,7 +1362,6 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 			: __( 'Details', 'jetpack-connection' );
 		if ( isInSafeMode && ! isExpanded ) {
 			toggleProps.variant = 'primary';
-			toggleProps.isDestructive = true;
 			toggleLabel = __( 'Resolve', 'jetpack-connection' );
 		}
 

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -52,6 +52,16 @@ const CONNECTOR_LOGO = data.connectorLogoUrl
 const ssoStatus = data.ssoStatus ?? null;
 const isFirstConnection = Boolean( data.isFirstConnection );
 const isOfflineMode = Boolean( data.isOfflineMode );
+const isInSafeMode = Boolean( data.isInSafeMode );
+const isSafeModeConfirmed = Boolean( data.isSafeModeConfirmed );
+const idc = data.idc || null;
+// Stats and Backups are Jetpack-plugin features, so only cite them as examples
+// of paused features when a Jetpack-family plugin is actually connected.
+// Other plugin families (WooCommerce, Automattic for Agencies) fall back to the
+// generic "features that sync with WordPress.com" wording.
+const hasJetpackPlugin = connectedPlugins.some(
+	plugin => plugin.slug === 'jetpack' || plugin.slug.startsWith( 'jetpack-' )
+);
 
 /**
  * Start the Jetpack connection flow: register the site (if needed),
@@ -529,6 +539,379 @@ function SiteDetailsModal( { onClose } ) {
 	);
 }
 
+/* ── Identity crisis (Safe Mode) panel ──────────────────────────── */
+
+/**
+ * POST to an identity-crisis REST endpoint.
+ *
+ * @param {string} action - Endpoint suffix (e.g. 'migrate', 'start-fresh', 'confirm-safe-mode').
+ * @param {object} [body] - Optional JSON body.
+ * @return {Promise<object|string>} Parsed JSON response.
+ */
+async function postIdcAction( action, body = null ) {
+	const options = {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'X-WP-Nonce': apiNonce,
+		},
+	};
+	if ( body ) {
+		options.body = JSON.stringify( body );
+	}
+
+	const response = await window.fetch( apiRoot + 'jetpack/v4/identity-crisis/' + action, options );
+
+	if ( ! response.ok ) {
+		const errBody = await response.json().catch( () => null );
+		throw new Error( errBody?.message || __( 'Something went wrong.', 'jetpack-connection' ) );
+	}
+
+	return response.json();
+}
+
+/**
+ * A single identity-crisis resolution option (title, description, action button).
+ *
+ * @param {object}   props             - Component props.
+ * @param {string}   props.title       - Option heading.
+ * @param {object}   props.description - Body element/text describing the option.
+ * @param {string}   props.buttonLabel - Action button label.
+ * @param {string}   props.busyLabel   - Action button label while busy.
+ * @param {boolean}  props.isBusy      - Whether this action is in progress.
+ * @param {boolean}  props.disabled    - Whether the button is disabled.
+ * @param {Function} props.onClick     - Action callback.
+ * @param {boolean}  props.isPrimary   - Whether to render a primary (vs secondary) button.
+ * @return {object} React element.
+ */
+function IDCOption( {
+	title,
+	description,
+	buttonLabel,
+	busyLabel,
+	isBusy,
+	disabled,
+	onClick,
+	isPrimary,
+} ) {
+	return createElement(
+		VStack,
+		{ spacing: 2, className: 'jetpack-connector__idc-option' },
+		createElement( Text, { weight: 600, size: 13 }, title ),
+		createElement( Text, { variant: 'muted', size: 12 }, description ),
+		createElement(
+			Button,
+			{
+				variant: isPrimary ? 'primary' : 'secondary',
+				size: 'compact',
+				isBusy,
+				disabled,
+				onClick,
+				className: 'jetpack-connector__inline-action',
+			},
+			isBusy ? busyLabel : buttonLabel
+		)
+	);
+}
+
+/**
+ * Identity crisis (Safe Mode) resolution panel.
+ *
+ * Replaces the standard expanded details when the site URL recorded with
+ * WordPress.com no longer matches the current site URL. Offers the same
+ * resolutions as the standard Jetpack IDC screen (migrate the connection,
+ * create a fresh connection, stay in Safe Mode) via the identity-crisis REST
+ * endpoints, and adds a Disconnect site option.
+ *
+ * @return {object} React element.
+ */
+function IDCPanel() {
+	const [ busyAction, setBusyAction ] = useState( null );
+	const [ isMigrated, setIsMigrated ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const [ pendingConfirm, setPendingConfirm ] = useState( null );
+
+	const handleMigrate = async () => {
+		setBusyAction( 'migrate' );
+		setError( null );
+		try {
+			await postIdcAction( 'migrate' );
+			setIsMigrated( true );
+		} catch ( err ) {
+			setError(
+				err?.message ||
+					__( 'Failed to move the connection. Please try again.', 'jetpack-connection' )
+			);
+		} finally {
+			setBusyAction( null );
+		}
+	};
+
+	const handleStartFresh = async () => {
+		setBusyAction( 'start-fresh' );
+		setError( null );
+		try {
+			const body = redirectUri ? { redirect_uri: redirectUri } : null;
+			const result = await postIdcAction( 'start-fresh', body );
+			const url = typeof result === 'string' ? result : result?.authorizeUrl || result?.url;
+			if ( typeof url !== 'string' || ! url ) {
+				throw new Error( __( 'No connection URL received.', 'jetpack-connection' ) );
+			}
+			window.location.href = url;
+		} catch ( err ) {
+			setError(
+				err?.message ||
+					__( 'Failed to create a fresh connection. Please try again.', 'jetpack-connection' )
+			);
+			setBusyAction( null );
+		}
+	};
+
+	const handleStaySafe = async () => {
+		setBusyAction( 'safe-mode' );
+		setError( null );
+		try {
+			await postIdcAction( 'confirm-safe-mode' );
+			window.location.reload();
+		} catch ( err ) {
+			setError(
+				err?.message || __( 'Failed to confirm Safe Mode. Please try again.', 'jetpack-connection' )
+			);
+			setBusyAction( null );
+		}
+	};
+
+	// Disconnect is safe during IDC: Identity_Crisis filters out the remote
+	// WordPress.com deregister call, so only this (cloned) site's local tokens
+	// are removed — the original site keeps its connection.
+	const executeDisconnect = async () => {
+		setPendingConfirm( null );
+		setBusyAction( 'disconnect' );
+		setError( null );
+		try {
+			const response = await window.fetch( apiRoot + 'jetpack/v4/connection', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': apiNonce,
+				},
+				body: JSON.stringify( { isActive: false } ),
+			} );
+
+			if ( response.ok ) {
+				window.location.reload();
+				return;
+			}
+
+			const errBody = await response.json().catch( () => null );
+			setError(
+				errBody?.message ||
+					__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
+			);
+			setBusyAction( null );
+		} catch {
+			setError( __( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' ) );
+			setBusyAction( null );
+		}
+	};
+
+	const handleDisconnect = () => {
+		setPendingConfirm( {
+			title: __( 'Disconnect site', 'jetpack-connection' ),
+			message: __(
+				'Are you sure you want to disconnect from WordPress.com? This will affect all plugins using this connection.',
+				'jetpack-connection'
+			),
+			onConfirm: executeDisconnect,
+		} );
+	};
+
+	if ( isMigrated ) {
+		return createElement(
+			VStack,
+			{ spacing: 4, className: 'jetpack-connector__idc-panel' },
+			createElement(
+				Text,
+				{ weight: 600, size: 14 },
+				__( 'Connection moved', 'jetpack-connection' )
+			),
+			createElement(
+				Text,
+				{ variant: 'muted', size: 13 },
+				__( 'This site now uses the existing connection and all its data.', 'jetpack-connection' )
+			),
+			createElement(
+				Button,
+				{
+					variant: 'primary',
+					size: 'compact',
+					onClick: () => window.location.reload(),
+					className: 'jetpack-connector__inline-action',
+				},
+				__( 'Got it, thanks', 'jetpack-connection' )
+			)
+		);
+	}
+
+	const currentUrl = idc?.currentUrl || ( siteDetails ? siteDetails.homeUrl : '' );
+	const wpcomUrl = idc?.wpcomHomeUrl || '';
+	const isDevelopmentSite = Boolean( idc?.isDevelopmentSite );
+	const possibleDynamicSiteUrl = Boolean( idc?.possibleDynamicSiteUrlDetected );
+
+	// Build a fresh <strong> element for a URL on each call so the same React
+	// element is never reused across parents.
+	const urlEl = ( url, fallback ) =>
+		url
+			? createElement( 'strong', { title: url }, url )
+			: createElement( 'strong', null, fallback );
+
+	const introText = hasJetpackPlugin
+		? __(
+				'Connected to <wpcom />, but now loading at <current />. Features that sync with WordPress.com — like Stats and Backups — are paused until you choose how to continue.',
+				'jetpack-connection'
+		  )
+		: __(
+				'Connected to <wpcom />, but now loading at <current />. Features that sync with WordPress.com are paused until you choose how to continue.',
+				'jetpack-connection'
+		  );
+
+	const intro = createInterpolateElement( introText, {
+		wpcom: urlEl( wpcomUrl, __( 'its original address', 'jetpack-connection' ) ),
+		current: urlEl( currentUrl, __( 'this address', 'jetpack-connection' ) ),
+	} );
+
+	const migrateOption = createElement( IDCOption, {
+		key: 'migrate',
+		title: __( 'Same site, new address', 'jetpack-connection' ),
+		description: __(
+			'Move the connection here. The site ID and all its connected data and features follow this address.',
+			'jetpack-connection'
+		),
+		buttonLabel: __( 'Move connection', 'jetpack-connection' ),
+		busyLabel: __( 'Moving…', 'jetpack-connection' ),
+		isBusy: busyAction === 'migrate',
+		disabled: Boolean( busyAction ),
+		onClick: handleMigrate,
+		isPrimary: ! isDevelopmentSite,
+	} );
+
+	const freshOption = createElement( IDCOption, {
+		key: 'fresh',
+		title: __( 'A separate site', 'jetpack-connection' ),
+		description: __(
+			'Start a new connection here. The original site keeps its data.',
+			'jetpack-connection'
+		),
+		buttonLabel: __( 'Create a fresh connection', 'jetpack-connection' ),
+		busyLabel: __( 'Connecting…', 'jetpack-connection' ),
+		isBusy: busyAction === 'start-fresh',
+		disabled: Boolean( busyAction ),
+		onClick: handleStartFresh,
+		isPrimary: isDevelopmentSite,
+	} );
+
+	// Development/staging sites are most often intentional clones, so migrating
+	// (which would reassign the production site's ID and data to this copy) is
+	// not offered — only a fresh connection, matching the Jetpack IDC screen
+	// (ScreenMain in @automattic/jetpack-idc).
+	const options = isDevelopmentSite ? [ freshOption ] : [ migrateOption, freshOption ];
+
+	return createElement(
+		VStack,
+		{ spacing: 5, className: 'jetpack-connector__idc-panel' },
+		createElement(
+			Text,
+			{ weight: 600, size: 14 },
+			__( 'Your site address has changed', 'jetpack-connection' )
+		),
+		createElement( Text, { size: 13 }, intro ),
+		// A dynamic site URL in wp-config.php can keep re-triggering Safe Mode,
+		// so resolving the crisis won't stick until it's made static.
+		possibleDynamicSiteUrl
+			? createElement(
+					Notice,
+					{
+						status: 'warning',
+						isDismissible: false,
+						className: 'jetpack-connector__notice',
+					},
+					createInterpolateElement(
+						__(
+							'Your <code>wp-config.php</code> may set the site URL dynamically, which can keep re-triggering Safe Mode. <link>Learn how to set a static site URL.</link>',
+							'jetpack-connection'
+						),
+						{
+							code: createElement( 'code' ),
+							link: createElement( 'a', {
+								href: 'https://jetpack.com/redirect/?source=jetpack-idcscreen-dynamic-site-urls',
+								target: '_blank',
+								rel: 'noopener noreferrer',
+							} ),
+						}
+					)
+			  )
+			: null,
+		error
+			? createElement( ErrorNotice, { message: error, onDismiss: () => setError( null ) } )
+			: null,
+		createElement(
+			HStack,
+			{ spacing: 4, alignment: 'top', className: 'jetpack-connector__idc-options' },
+			...options
+		),
+		createElement( 'hr', { className: 'jetpack-connector__divider' } ),
+		createElement(
+			HStack,
+			{ spacing: 3, alignment: 'center', className: 'jetpack-connector__idc-footer' },
+			isSafeModeConfirmed
+				? createElement(
+						Text,
+						{ variant: 'muted', size: 12 },
+						__(
+							'In Safe Mode. Features stay paused until you choose an option above.',
+							'jetpack-connection'
+						)
+				  )
+				: createElement(
+						Button,
+						{
+							variant: 'link',
+							isBusy: busyAction === 'safe-mode',
+							disabled: Boolean( busyAction ),
+							onClick: handleStaySafe,
+							className: 'jetpack-connector__idc-safe-mode-link',
+						},
+						busyAction === 'safe-mode'
+							? __( 'Saving…', 'jetpack-connection' )
+							: __( 'Not sure? Stay in Safe Mode', 'jetpack-connection' )
+				  ),
+			isManagedPlatformSite
+				? null
+				: createElement(
+						Button,
+						{
+							variant: 'secondary',
+							isDestructive: true,
+							size: 'compact',
+							isBusy: busyAction === 'disconnect',
+							disabled: Boolean( busyAction ),
+							onClick: handleDisconnect,
+							className: 'jetpack-connector__disconnect-site',
+						},
+						__( 'Disconnect site', 'jetpack-connection' )
+				  )
+		),
+		pendingConfirm
+			? createElement( ConfirmationModal, {
+					title: pendingConfirm.title,
+					message: pendingConfirm.message,
+					onConfirm: pendingConfirm.onConfirm,
+					onCancel: () => setPendingConfirm( null ),
+			  } )
+			: null
+	);
+}
+
 /* ── Expanded details panel ─────────────────────────────────────── */
 
 /**
@@ -842,12 +1225,21 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 
 	if ( isConnected || isSiteRegistered ) {
 		// Site is registered with WordPress.com (with or without a connected owner).
-		const badgeProps = isConnected
-			? { label: __( 'Connected', 'jetpack-connection' ) }
-			: {
-					label: __( 'Site registered', 'jetpack-connection' ),
-					modifier: 'site-registered',
-			  };
+		let badgeProps;
+		if ( isInSafeMode ) {
+			// Identity crisis: the recorded site URL no longer matches WordPress.com.
+			badgeProps = {
+				label: __( 'Safe Mode', 'jetpack-connection' ),
+				modifier: 'safe-mode',
+			};
+		} else if ( isConnected ) {
+			badgeProps = { label: __( 'Connected', 'jetpack-connection' ) };
+		} else {
+			badgeProps = {
+				label: __( 'Site registered', 'jetpack-connection' ),
+				modifier: 'site-registered',
+			};
+		}
 
 		actionArea = createElement(
 			HStack,
@@ -870,10 +1262,14 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 			expandedContent = createElement(
 				'div',
 				{ className: 'jetpack-connector__expanded' },
-				createElement( ExpandedDetails, {
-					isConnecting: needsUserConnection ? isConnecting : false,
-					onConnect: needsUserConnection ? handleConnect : null,
-				} )
+				// While in Safe Mode, the identity-crisis resolution options
+				// replace the standard connection details.
+				isInSafeMode
+					? createElement( IDCPanel )
+					: createElement( ExpandedDetails, {
+							isConnecting: needsUserConnection ? isConnecting : false,
+							onConnect: needsUserConnection ? handleConnect : null,
+					  } )
 			);
 		}
 	} else {

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -990,8 +990,10 @@ function IDCPanel() {
 				: createElement(
 						Button,
 						{
+							// No isBusy here: the striped "busy" background looks
+							// odd on a link-style button, so the "Saving…" label
+							// plus the disabled state convey progress instead.
 							variant: 'link',
-							isBusy: busyAction === 'safe-mode',
 							disabled: Boolean( busyAction ),
 							onClick: handleStaySafe,
 							className: 'jetpack-connector__idc-safe-mode-link',

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -75,6 +75,88 @@ const subjectNoun = hasWooPlugin
 	: _x( 'site', 'The thing connected to WordPress.com.', 'jetpack-connection' );
 
 /**
+ * Make a POST/GET request to a Jetpack REST endpoint with the standard
+ * connection headers and error handling.
+ *
+ * Resolves with the parsed JSON body (or null if there is no body), and
+ * throws an Error whose message is the server-provided message — falling
+ * back to `fallbackError` — for both non-OK responses and network failures.
+ *
+ * @param {string} endpoint                - REST path relative to apiRoot.
+ * @param {object} [options]               - Request options.
+ * @param {string} [options.method]        - HTTP method (default 'GET').
+ * @param {object} [options.body]          - JSON body; sets Content-Type when present.
+ * @param {string} [options.fallbackError] - Message used when the server provides none.
+ * @return {Promise<object|string|null>} Parsed JSON response.
+ */
+async function apiRequest( endpoint, { method = 'GET', body = null, fallbackError = '' } = {} ) {
+	const errorMessage = fallbackError || __( 'Something went wrong.', 'jetpack-connection' );
+	const options = { method, headers: { 'X-WP-Nonce': apiNonce } };
+	if ( body ) {
+		options.headers[ 'Content-Type' ] = 'application/json';
+		options.body = JSON.stringify( body );
+	}
+
+	let response;
+	try {
+		response = await window.fetch( apiRoot + endpoint, options );
+	} catch {
+		throw new Error( errorMessage );
+	}
+
+	if ( ! response.ok ) {
+		const errBody = await response.json().catch( () => null );
+		throw new Error( errBody?.message || errorMessage );
+	}
+
+	// Some endpoints (e.g. disconnect) return an empty body on success; treat
+	// an unparseable body as a successful no-content response rather than a
+	// failure.
+	return response.json().catch( () => null );
+}
+
+/**
+ * Decorate a Calypso authorize URL with the params every connector flow needs:
+ * `from=jetpack-connector` so Calypso returns the user to the Connectors page,
+ * and `skip_pricing` so the post-auth redirect honours redirect_after_auth
+ * instead of routing through the Calypso plans page.
+ *
+ * TEMPORARY: `skip_pricing` can be dropped once Calypso recognises
+ * `from=jetpack-connector` natively and redirects to redirectAfterAuth.
+ *
+ * @param {string} url - Calypso authorize URL.
+ * @return {string} Decorated URL (unchanged if it can't be parsed).
+ */
+function decorateAuthUrl( url ) {
+	try {
+		const parsed = new URL( url );
+		parsed.searchParams.set( 'from', 'jetpack-connector' );
+		parsed.searchParams.set( 'skip_pricing', 'true' );
+		return parsed.toString();
+	} catch {
+		return url;
+	}
+}
+
+/**
+ * Disconnect this site from WordPress.com.
+ *
+ * During an identity crisis this only clears the local tokens — the
+ * Identity_Crisis filter blocks the remote deregister call — so the original
+ * site keeps its registration.
+ *
+ * @param {string} [fallbackError] - Message used when the server provides none.
+ * @return {Promise<object|string|null>} Parsed JSON response.
+ */
+function disconnectSite( fallbackError ) {
+	return apiRequest( 'jetpack/v4/connection', {
+		method: 'POST',
+		body: { isActive: false },
+		fallbackError,
+	} );
+}
+
+/**
  * Start the Jetpack connection flow: register the site (if needed),
  * then redirect to WordPress.com for user authorization.
  *
@@ -92,22 +174,15 @@ async function startConnectionFlow( siteRegistered ) {
 		}
 		params.set( 'from', 'jetpack-connector' );
 		const qs = params.toString();
-		const authRes = await window.fetch(
-			apiRoot + 'jetpack/v4/connection/authorize_url' + ( qs ? '?' + qs : '' ),
-			{ headers: { 'X-WP-Nonce': apiNonce } }
+		const authData = await apiRequest(
+			'jetpack/v4/connection/authorize_url' + ( qs ? '?' + qs : '' ),
+			{ fallbackError: __( 'Failed to retrieve authorization URL.', 'jetpack-connection' ) }
 		);
-		if ( ! authRes.ok ) {
-			const errBody = await authRes.json().catch( () => null );
-			throw new Error(
-				errBody?.message || __( 'Failed to retrieve authorization URL.', 'jetpack-connection' )
-			);
-		}
-		const authData = await authRes.json();
 		const authorizeUrl = authData?.authorizeUrl || authData;
 		if ( typeof authorizeUrl !== 'string' || ! authorizeUrl ) {
 			throw new Error( 'No authorization URL received' );
 		}
-		window.location.href = addSkipPricing( authorizeUrl );
+		window.location.href = decorateAuthUrl( authorizeUrl );
 		return;
 	}
 
@@ -116,48 +191,17 @@ async function startConnectionFlow( siteRegistered ) {
 		body.redirect_uri = redirectUri;
 	}
 
-	const response = await window.fetch( apiRoot + 'jetpack/v4/connection/register', {
+	const result = await apiRequest( 'jetpack/v4/connection/register', {
 		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			'X-WP-Nonce': apiNonce,
-		},
-		body: JSON.stringify( body ),
+		body,
+		fallbackError: __( 'Site registration failed.', 'jetpack-connection' ),
 	} );
 
-	if ( ! response.ok ) {
-		const errBody = await response.json().catch( () => null );
-		throw new Error( errBody?.message || __( 'Site registration failed.', 'jetpack-connection' ) );
-	}
-
-	const result = await response.json();
-
-	if ( ! result.authorizeUrl ) {
+	if ( ! result?.authorizeUrl ) {
 		throw new Error( 'No authorization URL received' );
 	}
 
-	window.location.href = addSkipPricing( result.authorizeUrl );
-}
-
-/**
- * Append skip_pricing to a Calypso authorize URL so that the post-auth
- * redirect honours redirect_after_auth instead of sending the user to
- * the Calypso plans page.
- *
- * TEMPORARY: Remove once Calypso recognises `from=jetpack-connector`
- * natively and redirects to redirectAfterAuth for this flow.
- *
- * @param {string} url - Calypso authorize URL.
- * @return {string} URL with skip_pricing appended.
- */
-function addSkipPricing( url ) {
-	try {
-		const parsed = new URL( url );
-		parsed.searchParams.set( 'skip_pricing', 'true' );
-		return parsed.toString();
-	} catch {
-		return url;
-	}
+	window.location.href = decorateAuthUrl( result.authorizeUrl );
 }
 
 /**
@@ -560,25 +604,7 @@ function SiteDetailsModal( { onClose } ) {
  * @return {Promise<object|string>} Parsed JSON response.
  */
 async function postIdcAction( action, body = null ) {
-	const options = {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			'X-WP-Nonce': apiNonce,
-		},
-	};
-	if ( body ) {
-		options.body = JSON.stringify( body );
-	}
-
-	const response = await window.fetch( apiRoot + 'jetpack/v4/identity-crisis/' + action, options );
-
-	if ( ! response.ok ) {
-		const errBody = await response.json().catch( () => null );
-		throw new Error( errBody?.message || __( 'Something went wrong.', 'jetpack-connection' ) );
-	}
-
-	return response.json();
+	return apiRequest( 'jetpack/v4/identity-crisis/' + action, { method: 'POST', body } );
 }
 
 /**
@@ -673,17 +699,7 @@ function IDCPanel() {
 			if ( typeof url !== 'string' || ! url ) {
 				throw new Error( __( 'No connection URL received.', 'jetpack-connection' ) );
 			}
-			// Tag the flow as jetpack-connector so Calypso returns the user to the
-			// Connectors page, matching the card's other connection flows.
-			let authorizeUrl = url;
-			try {
-				const parsed = new URL( url );
-				parsed.searchParams.set( 'from', 'jetpack-connector' );
-				authorizeUrl = parsed.toString();
-			} catch {
-				// Use the URL as-is if it can't be parsed.
-			}
-			window.location.href = addSkipPricing( authorizeUrl );
+			window.location.href = decorateAuthUrl( url );
 		} catch ( err ) {
 			setError(
 				err?.message ||
@@ -707,46 +723,21 @@ function IDCPanel() {
 		}
 	};
 
-	// Disconnect is safe during IDC: Identity_Crisis filters out the remote
-	// WordPress.com deregister call, so only this (cloned) site's local tokens
-	// are removed — the original site keeps its registration.
 	const executeDisconnect = async () => {
 		setPendingConfirm( null );
 		setBusyAction( 'disconnect' );
 		setError( null );
 		try {
-			const response = await window.fetch( apiRoot + 'jetpack/v4/connection', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-WP-Nonce': apiNonce,
-				},
-				body: JSON.stringify( { isActive: false } ),
-			} );
-
-			if ( response.ok ) {
-				window.location.reload();
-				return;
-			}
-
-			const errBody = await response.json().catch( () => null );
-			setError(
-				errBody?.message ||
-					sprintf(
-						// translators: %s: "site" or "store".
-						__( 'Failed to disconnect the %s. Please try again.', 'jetpack-connection' ),
-						subjectNoun
-					)
-			);
-			setBusyAction( null );
-		} catch {
-			setError(
+			await disconnectSite(
 				sprintf(
 					// translators: %s: "site" or "store".
 					__( 'Failed to disconnect the %s. Please try again.', 'jetpack-connection' ),
 					subjectNoun
 				)
 			);
+			window.location.reload();
+		} catch ( err ) {
+			setError( err.message );
 			setBusyAction( null );
 		}
 	};
@@ -1066,29 +1057,12 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 		setActionError( null );
 
 		try {
-			const response = await window.fetch( apiRoot + 'jetpack/v4/connection', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-WP-Nonce': apiNonce,
-				},
-				body: JSON.stringify( { isActive: false } ),
-			} );
-
-			if ( response.ok ) {
-				window.location.reload();
-				return;
-			}
-
-			const errBody = await response.json().catch( () => null );
-			setActionError(
-				errBody?.message ||
-					__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
-			);
-		} catch {
-			setActionError(
+			await disconnectSite(
 				__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
 			);
+			window.location.reload();
+		} catch ( err ) {
+			setActionError( err.message );
 		} finally {
 			setIsDisconnecting( false );
 		}
@@ -1120,29 +1094,17 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 				body[ 'disconnect-all-users' ] = true;
 			}
 
-			const response = await window.fetch( apiRoot + 'jetpack/v4/connection/user', {
+			await apiRequest( 'jetpack/v4/connection/user', {
 				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-WP-Nonce': apiNonce,
-				},
-				body: JSON.stringify( body ),
+				body,
+				fallbackError: __(
+					'Failed to disconnect the account. Please try again.',
+					'jetpack-connection'
+				),
 			} );
-
-			if ( response.ok ) {
-				window.location.reload();
-				return;
-			}
-
-			const errBody = await response.json().catch( () => null );
-			setActionError(
-				errBody?.message ||
-					__( 'Failed to disconnect the account. Please try again.', 'jetpack-connection' )
-			);
-		} catch {
-			setActionError(
-				__( 'Failed to disconnect the account. Please try again.', 'jetpack-connection' )
-			);
+			window.location.reload();
+		} catch ( err ) {
+			setActionError( err.message );
 		} finally {
 			setIsUnlinking( false );
 		}

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -823,7 +823,12 @@ function IDCPanel() {
 
 	const whyExplanation = createElement(
 		VStack,
-		{ spacing: 2, className: 'jetpack-connector__idc-why' },
+		{
+			spacing: 2,
+			className: 'jetpack-connector__idc-why',
+			id: 'jetpack-connector-idc-why',
+			hidden: ! showWhy,
+		},
 		createElement(
 			Text,
 			{ size: 12, variant: 'muted' },
@@ -935,11 +940,12 @@ function IDCPanel() {
 				variant: 'link',
 				onClick: () => setShowWhy( value => ! value ),
 				'aria-expanded': showWhy,
+				'aria-controls': 'jetpack-connector-idc-why',
 				className: 'jetpack-connector__idc-why-toggle',
 			},
 			__( 'Why am I seeing this?', 'jetpack-connection' )
 		),
-		showWhy ? whyExplanation : null,
+		whyExplanation,
 		// A dynamic site URL in wp-config.php can keep re-triggering Safe Mode,
 		// so resolving the crisis won't stick until it's made static.
 		possibleDynamicSiteUrl

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -858,11 +858,6 @@ function IDCPanel() {
 					'jetpack-connection'
 				)
 			)
-		),
-		createElement(
-			Text,
-			{ size: 12, variant: 'muted' },
-			__( 'Choose the option below that matches your situation.', 'jetpack-connection' )
 		)
 	);
 
@@ -889,13 +884,13 @@ function IDCPanel() {
 		key: 'fresh',
 		title: sprintf(
 			// translators: %s: "site" or "store".
-			__( 'A separate %s', 'jetpack-connection' ),
+			__( 'A different %s', 'jetpack-connection' ),
 			subjectNoun
 		),
 		description: sprintf(
 			// translators: %1$s: "site" or "store" (repeated).
 			__(
-				'Connect this address on its own — restoring its previous connection if it had one, or starting a new one. The original %1$s keeps its connection.',
+				'This is a different %1$s from the one registered with WordPress.com. Give it its own connection — restoring its previous one if it had it, or starting fresh. The original %1$s is unaffected.',
 				'jetpack-connection'
 			),
 			subjectNoun
@@ -974,6 +969,11 @@ function IDCPanel() {
 			? createElement( ErrorNotice, { message: error, onDismiss: () => setError( null ) } )
 			: null,
 		createElement(
+			Text,
+			{ size: 12, variant: 'muted' },
+			__( 'Choose the option below that matches your situation.', 'jetpack-connection' )
+		),
+		createElement(
 			HStack,
 			{ spacing: 4, alignment: 'top', className: 'jetpack-connector__idc-options' },
 			...options
@@ -992,19 +992,34 @@ function IDCPanel() {
 						)
 				  )
 				: createElement(
-						Button,
-						{
-							// No isBusy here: the striped "busy" background looks
-							// odd on a link-style button, so the "Saving…" label
-							// plus the disabled state convey progress instead.
-							variant: 'link',
-							disabled: Boolean( busyAction ),
-							onClick: handleStaySafe,
-							className: 'jetpack-connector__idc-safe-mode-link',
-						},
-						busyAction === 'safe-mode'
-							? __( 'Saving…', 'jetpack-connection' )
-							: __( 'Not sure? Stay in Safe Mode', 'jetpack-connection' )
+						'span',
+						{ className: 'jetpack-connector__idc-safe-mode-group' },
+						createElement(
+							Button,
+							{
+								// No isBusy here: the striped "busy" background looks
+								// odd on a link-style button, so the "Saving…" label
+								// plus the disabled state convey progress instead.
+								variant: 'link',
+								disabled: Boolean( busyAction ),
+								onClick: handleStaySafe,
+								className: 'jetpack-connector__idc-safe-mode-link',
+							},
+							busyAction === 'safe-mode'
+								? __( 'Saving…', 'jetpack-connection' )
+								: __( 'Not sure? Stay in Safe Mode', 'jetpack-connection' )
+						),
+						createElement(
+							Text,
+							{ variant: 'muted', size: 12 },
+							createInterpolateElement( __( 'or <link>learn more</link>', 'jetpack-connection' ), {
+								link: createElement( 'a', {
+									href: 'https://jetpack.com/redirect/?source=jetpack-support-safe-mode',
+									target: '_blank',
+									rel: 'noopener noreferrer',
+								} ),
+							} )
+						)
 				  ),
 			isManagedPlatformSite
 				? null

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -823,12 +823,7 @@ function IDCPanel() {
 
 	const whyExplanation = createElement(
 		VStack,
-		{
-			spacing: 2,
-			className: 'jetpack-connector__idc-why',
-			id: 'jetpack-connector-idc-why',
-			hidden: ! showWhy,
-		},
+		{ spacing: 2, className: 'jetpack-connector__idc-why' },
 		createElement(
 			Text,
 			{ size: 12, variant: 'muted' },
@@ -945,7 +940,10 @@ function IDCPanel() {
 			},
 			__( 'Why am I seeing this?', 'jetpack-connection' )
 		),
-		whyExplanation,
+		// Wrap in a plain element so the `hidden` attribute actually hides the
+		// region: VStack renders `display: flex`, which would override `hidden`.
+		// The wrapper stays in the DOM so the toggle's aria-controls is always valid.
+		createElement( 'div', { id: 'jetpack-connector-idc-why', hidden: ! showWhy }, whyExplanation ),
 		// A dynamic site URL in wp-config.php can keep re-triggering Safe Mode,
 		// so resolving the crisis won't stick until it's made static.
 		possibleDynamicSiteUrl

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -970,7 +970,7 @@ function IDCPanel() {
 			: null,
 		createElement(
 			Text,
-			{ size: 12, variant: 'muted' },
+			{ weight: 600, size: 14, className: 'jetpack-connector__idc-choose' },
 			__( 'Choose the option below that matches your situation.', 'jetpack-connection' )
 		),
 		createElement(
@@ -1011,7 +1011,7 @@ function IDCPanel() {
 						),
 						createElement(
 							Text,
-							{ variant: 'muted', size: 12 },
+							{ variant: 'muted', size: 13 },
 							createInterpolateElement( __( 'or <link>learn more</link>', 'jetpack-connection' ), {
 								link: createElement( 'a', {
 									href: 'https://jetpack.com/redirect/?source=jetpack-support-safe-mode',

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -24,7 +24,7 @@ const registerConnector =
 const ConnectorItem = connectors.__experimentalConnectorItem || connectors.ConnectorItem;
 
 const { createElement, createInterpolateElement, useState, useEffect, useRef } = window.wp.element;
-const { __ } = window.wp.i18n;
+const { __, _x, sprintf } = window.wp.i18n;
 const { Button, Modal, Notice } = window.wp.components;
 const HStack = window.wp.components.__experimentalHStack || window.wp.components.HStack;
 const VStack = window.wp.components.__experimentalVStack || window.wp.components.VStack;
@@ -62,6 +62,17 @@ const idc = data.idc || null;
 const hasJetpackPlugin = connectedPlugins.some(
 	plugin => plugin.slug === 'jetpack' || plugin.slug.startsWith( 'jetpack-' )
 );
+// Per the Jetpack Connection language guidelines, use "store" whenever a
+// WooCommerce-family plugin is connected (Woo is the user's primary context),
+// and "site" otherwise.
+const hasWooPlugin = connectedPlugins.some( plugin => plugin.slug.startsWith( 'woocommerce' ) );
+const subjectNoun = hasWooPlugin
+	? _x(
+			'store',
+			'The thing connected to WordPress.com, in a WooCommerce context.',
+			'jetpack-connection'
+	  )
+	: _x( 'site', 'The thing connected to WordPress.com.', 'jetpack-connection' );
 
 /**
  * Start the Jetpack connection flow: register the site (if needed),
@@ -630,6 +641,7 @@ function IDCPanel() {
 	const [ isMigrated, setIsMigrated ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ pendingConfirm, setPendingConfirm ] = useState( null );
+	const [ showWhy, setShowWhy ] = useState( false );
 
 	const handleMigrate = async () => {
 		setBusyAction( 'migrate' );
@@ -640,7 +652,11 @@ function IDCPanel() {
 		} catch ( err ) {
 			setError(
 				err?.message ||
-					__( 'Failed to move the connection. Please try again.', 'jetpack-connection' )
+					sprintf(
+						// translators: %s: "site" or "store".
+						__( 'Failed to update the %s address. Please try again.', 'jetpack-connection' ),
+						subjectNoun
+					)
 			);
 		} finally {
 			setBusyAction( null );
@@ -657,7 +673,17 @@ function IDCPanel() {
 			if ( typeof url !== 'string' || ! url ) {
 				throw new Error( __( 'No connection URL received.', 'jetpack-connection' ) );
 			}
-			window.location.href = url;
+			// Tag the flow as jetpack-connector so Calypso returns the user to the
+			// Connectors page, matching the card's other connection flows.
+			let authorizeUrl = url;
+			try {
+				const parsed = new URL( url );
+				parsed.searchParams.set( 'from', 'jetpack-connector' );
+				authorizeUrl = parsed.toString();
+			} catch {
+				// Use the URL as-is if it can't be parsed.
+			}
+			window.location.href = addSkipPricing( authorizeUrl );
 		} catch ( err ) {
 			setError(
 				err?.message ||
@@ -683,7 +709,7 @@ function IDCPanel() {
 
 	// Disconnect is safe during IDC: Identity_Crisis filters out the remote
 	// WordPress.com deregister call, so only this (cloned) site's local tokens
-	// are removed — the original site keeps its connection.
+	// are removed — the original site keeps its registration.
 	const executeDisconnect = async () => {
 		setPendingConfirm( null );
 		setBusyAction( 'disconnect' );
@@ -706,21 +732,39 @@ function IDCPanel() {
 			const errBody = await response.json().catch( () => null );
 			setError(
 				errBody?.message ||
-					__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
+					sprintf(
+						// translators: %s: "site" or "store".
+						__( 'Failed to disconnect the %s. Please try again.', 'jetpack-connection' ),
+						subjectNoun
+					)
 			);
 			setBusyAction( null );
 		} catch {
-			setError( __( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' ) );
+			setError(
+				sprintf(
+					// translators: %s: "site" or "store".
+					__( 'Failed to disconnect the %s. Please try again.', 'jetpack-connection' ),
+					subjectNoun
+				)
+			);
 			setBusyAction( null );
 		}
 	};
 
 	const handleDisconnect = () => {
 		setPendingConfirm( {
-			title: __( 'Disconnect site', 'jetpack-connection' ),
-			message: __(
-				'Are you sure you want to disconnect from WordPress.com? This will affect all plugins using this connection.',
-				'jetpack-connection'
+			title: sprintf(
+				// translators: %s: "site" or "store".
+				__( 'Disconnect this %s', 'jetpack-connection' ),
+				subjectNoun
+			),
+			message: sprintf(
+				// translators: %1$s: "site" or "store".
+				__(
+					'This clears the stale connection that triggered Safe Mode, so this %1$s stops being mistaken for another. Only this %1$s is affected — the original %1$s keeps its registration and data.',
+					'jetpack-connection'
+				),
+				subjectNoun
 			),
 			onConfirm: executeDisconnect,
 		} );
@@ -733,12 +777,16 @@ function IDCPanel() {
 			createElement(
 				Text,
 				{ weight: 600, size: 14 },
-				__( 'Connection moved', 'jetpack-connection' )
+				__( 'Address updated', 'jetpack-connection' )
 			),
 			createElement(
 				Text,
 				{ variant: 'muted', size: 13 },
-				__( 'This site now uses the existing connection and all its data.', 'jetpack-connection' )
+				sprintf(
+					// translators: %s: "site" or "store".
+					__( 'WordPress.com now recognizes this %s at its new address.', 'jetpack-connection' ),
+					subjectNoun
+				)
 			),
 			createElement(
 				Button,
@@ -766,29 +814,80 @@ function IDCPanel() {
 			: createElement( 'strong', null, fallback );
 
 	const introText = hasJetpackPlugin
-		? __(
-				'Connected to <wpcom />, but now loading at <current />. Features that sync with WordPress.com — like Stats and Backups — are paused until you choose how to continue.',
+		? // translators: %s: "site" or "store".
+		  __(
+				'This %s is registered with WordPress.com at <wpcom />, but now loads at <current />. Features that sync with WordPress.com — like Stats and Backups — are paused in Safe Mode until you resolve this.',
 				'jetpack-connection'
 		  )
-		: __(
-				'Connected to <wpcom />, but now loading at <current />. Features that sync with WordPress.com are paused until you choose how to continue.',
+		: // translators: %s: "site" or "store".
+		  __(
+				'This %s is registered with WordPress.com at <wpcom />, but now loads at <current />. Features that sync with WordPress.com are paused in Safe Mode until you resolve this.',
 				'jetpack-connection'
 		  );
 
-	const intro = createInterpolateElement( introText, {
+	const intro = createInterpolateElement( sprintf( introText, subjectNoun ), {
 		wpcom: urlEl( wpcomUrl, __( 'its original address', 'jetpack-connection' ) ),
 		current: urlEl( currentUrl, __( 'this address', 'jetpack-connection' ) ),
 	} );
 
+	const whyExplanation = createElement(
+		VStack,
+		{ spacing: 2, className: 'jetpack-connector__idc-why' },
+		createElement(
+			Text,
+			{ size: 12, variant: 'muted' },
+			__( 'This can happen when:', 'jetpack-connection' )
+		),
+		createElement(
+			'ul',
+			{ className: 'jetpack-connector__idc-why-list' },
+			createElement(
+				'li',
+				null,
+				sprintf(
+					// translators: %s: "site" or "store".
+					__( "You changed your %s's address.", 'jetpack-connection' ),
+					subjectNoun
+				)
+			),
+			createElement(
+				'li',
+				null,
+				sprintf(
+					// translators: %s: "site" or "store".
+					__( 'Your %s is reachable at more than one address.', 'jetpack-connection' ),
+					subjectNoun
+				)
+			),
+			createElement(
+				'li',
+				null,
+				__(
+					'You restored or copied a database from another site that was already registered with WordPress.com.',
+					'jetpack-connection'
+				)
+			)
+		),
+		createElement(
+			Text,
+			{ size: 12, variant: 'muted' },
+			__( 'Choose the option below that matches your situation.', 'jetpack-connection' )
+		)
+	);
+
 	const migrateOption = createElement( IDCOption, {
 		key: 'migrate',
-		title: __( 'Same site, new address', 'jetpack-connection' ),
+		title: sprintf(
+			// translators: %s: "site" or "store".
+			__( 'Same %s, new address', 'jetpack-connection' ),
+			subjectNoun
+		),
 		description: __(
-			'Move the connection here. The site ID and all its connected data and features follow this address.',
+			'Update the address WordPress.com has on file. Your connection, history, and data stay the same.',
 			'jetpack-connection'
 		),
-		buttonLabel: __( 'Move connection', 'jetpack-connection' ),
-		busyLabel: __( 'Moving…', 'jetpack-connection' ),
+		buttonLabel: __( 'Update address', 'jetpack-connection' ),
+		busyLabel: __( 'Updating…', 'jetpack-connection' ),
 		isBusy: busyAction === 'migrate',
 		disabled: Boolean( busyAction ),
 		onClick: handleMigrate,
@@ -797,12 +896,20 @@ function IDCPanel() {
 
 	const freshOption = createElement( IDCOption, {
 		key: 'fresh',
-		title: __( 'A separate site', 'jetpack-connection' ),
-		description: __(
-			'Start a new connection here. The original site keeps its data.',
-			'jetpack-connection'
+		title: sprintf(
+			// translators: %s: "site" or "store".
+			__( 'A separate %s', 'jetpack-connection' ),
+			subjectNoun
 		),
-		buttonLabel: __( 'Create a fresh connection', 'jetpack-connection' ),
+		description: sprintf(
+			// translators: %1$s: "site" or "store" (repeated).
+			__(
+				'Connect this address on its own — restoring its previous connection if it had one, or starting a new one. The original %1$s keeps its connection.',
+				'jetpack-connection'
+			),
+			subjectNoun
+		),
+		buttonLabel: __( 'Connect separately', 'jetpack-connection' ),
 		busyLabel: __( 'Connecting…', 'jetpack-connection' ),
 		isBusy: busyAction === 'start-fresh',
 		disabled: Boolean( busyAction ),
@@ -822,9 +929,26 @@ function IDCPanel() {
 		createElement(
 			Text,
 			{ weight: 600, size: 14 },
-			__( 'Your site address has changed', 'jetpack-connection' )
+			sprintf(
+				// translators: %s: "site" or "store".
+				__( 'Your %s address has changed', 'jetpack-connection' ),
+				subjectNoun
+			)
 		),
 		createElement( Text, { size: 13 }, intro ),
+		// Collapsible "Why am I seeing this?" explanation keeps the panel compact
+		// while making the likely causes available to anyone who wants them.
+		createElement(
+			Button,
+			{
+				variant: 'link',
+				onClick: () => setShowWhy( value => ! value ),
+				'aria-expanded': showWhy,
+				className: 'jetpack-connector__idc-why-toggle',
+			},
+			__( 'Why am I seeing this?', 'jetpack-connection' )
+		),
+		showWhy ? whyExplanation : null,
 		// A dynamic site URL in wp-config.php can keep re-triggering Safe Mode,
 		// so resolving the crisis won't stick until it's made static.
 		possibleDynamicSiteUrl
@@ -1241,20 +1365,29 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 			};
 		}
 
+		// In Safe Mode the toggle becomes a red "Resolve" call to action that
+		// surfaces the identity-crisis options. Once expanded it reverts to a
+		// neutral "Close".
+		const toggleProps = {
+			variant: 'secondary',
+			size: 'compact',
+			onClick: () => setIsExpanded( ! isExpanded ),
+			'aria-expanded': isExpanded,
+		};
+		let toggleLabel = isExpanded
+			? __( 'Close', 'jetpack-connection' )
+			: __( 'Details', 'jetpack-connection' );
+		if ( isInSafeMode && ! isExpanded ) {
+			toggleProps.variant = 'primary';
+			toggleProps.isDestructive = true;
+			toggleLabel = __( 'Resolve', 'jetpack-connection' );
+		}
+
 		actionArea = createElement(
 			HStack,
 			{ spacing: 3, expanded: false },
 			createElement( StatusBadge, badgeProps ),
-			createElement(
-				Button,
-				{
-					variant: 'secondary',
-					size: 'compact',
-					onClick: () => setIsExpanded( ! isExpanded ),
-					'aria-expanded': isExpanded,
-				},
-				isExpanded ? __( 'Close', 'jetpack-connection' ) : __( 'Details', 'jetpack-connection' )
-			)
+			createElement( Button, toggleProps, toggleLabel )
 		);
 
 		if ( isExpanded ) {

--- a/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
+++ b/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
@@ -116,8 +116,19 @@ class REST_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function confirm_safe_mode() {
-		$updated = Jetpack_Options::update_option( 'safe_mode_confirmed', true );
-		if ( $updated ) {
+		// Read the option's true DB state, not a stale cached copy: on sites with
+		// a persistent object cache, a prior un-confirm (the admin-bar "clear
+		// confirmation" action deletes jetpack_safe_mode_confirmed) can leave a
+		// lingering cached value that would make update_option() below see the new
+		// value as unchanged and report a false failure.
+		self::flush_jetpack_option_cache( 'jetpack_safe_mode_confirmed' );
+
+		// update_option() returns false both when the write fails and when the
+		// value is already set, so treat an already-confirmed option as success.
+		if (
+			Jetpack_Options::get_option( 'safe_mode_confirmed' )
+			|| Jetpack_Options::update_option( 'safe_mode_confirmed', true )
+		) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success',
@@ -133,19 +144,30 @@ class REST_Endpoints {
 	}
 
 	/**
+	 * Flush any cached copy of a Jetpack option so a subsequent read reflects the
+	 * option's true state in the database.
+	 *
+	 * Jetpack options are stored as autoloaded `jetpack_*` WordPress options, so
+	 * bust both the individual key and the autoloaded-options cache to keep
+	 * persistent object caches from returning a stale value across requests.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option The prefixed option name (e.g. `jetpack_safe_mode_confirmed`).
+	 */
+	private static function flush_jetpack_option_cache( $option ) {
+		wp_cache_delete( $option, 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+	}
+
+	/**
 	 * Flush any cached copy of the sync_error_idc option so a subsequent read
 	 * reflects the option's true state in the database.
-	 *
-	 * The option is read via the WordPress `jetpack_sync_error_idc` option, which
-	 * is typically autoloaded — so bust both the individual key and the
-	 * autoloaded-options cache to keep persistent object caches from returning a
-	 * stale value across requests.
 	 *
 	 * @since $$next-version$$
 	 */
 	private static function flush_sync_error_idc_cache() {
-		wp_cache_delete( 'jetpack_sync_error_idc', 'options' );
-		wp_cache_delete( 'alloptions', 'options' );
+		self::flush_jetpack_option_cache( 'jetpack_sync_error_idc' );
 	}
 
 	/**

--- a/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
+++ b/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
@@ -133,6 +133,22 @@ class REST_Endpoints {
 	}
 
 	/**
+	 * Flush any cached copy of the sync_error_idc option so a subsequent read
+	 * reflects the option's true state in the database.
+	 *
+	 * The option is read via the WordPress `jetpack_sync_error_idc` option, which
+	 * is typically autoloaded — so bust both the individual key and the
+	 * autoloaded-options cache to keep persistent object caches from returning a
+	 * stale value across requests.
+	 *
+	 * @since $$next-version$$
+	 */
+	private static function flush_sync_error_idc_cache() {
+		wp_cache_delete( 'jetpack_sync_error_idc', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+	}
+
+	/**
 	 * Handles identity crisis mitigation, migrating stats and subscribers from old url to this, new url.
 	 *
 	 * @since 0.2.0
@@ -141,12 +157,28 @@ class REST_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function migrate_stats_and_subscribers() {
-		if ( Jetpack_Options::get_option( 'sync_error_idc' ) && ! Jetpack_Options::delete_option( 'sync_error_idc' ) ) {
-			return new WP_Error(
-				'error_deleting_sync_error_idc',
-				esc_html__( 'Could not delete sync error option.', 'jetpack-connection' ),
-				array( 'status' => 500 )
-			);
+		// Read the option's true DB state, not a stale cached copy: on sites with
+		// a persistent object cache, a prior successful migrate (or an IDC
+		// revalidation) may have already removed the option while a cached value
+		// lingers, which would otherwise make the delete below report a false
+		// failure.
+		self::flush_sync_error_idc_cache();
+
+		if ( Jetpack_Options::get_option( 'sync_error_idc' ) ) {
+			Jetpack_Options::delete_option( 'sync_error_idc' );
+
+			// delete_option() returns false both when the write fails and when
+			// there is nothing to delete, so re-read (cache-busted) and only treat
+			// a still-present option as a real failure.
+			self::flush_sync_error_idc_cache();
+
+			if ( Jetpack_Options::get_option( 'sync_error_idc' ) ) {
+				return new WP_Error(
+					'error_deleting_sync_error_idc',
+					esc_html__( 'Could not delete sync error option.', 'jetpack-connection' ),
+					array( 'status' => 500 )
+				);
+			}
 		}
 
 		if ( Jetpack_Options::get_option( 'migrate_for_idc' ) || Jetpack_Options::update_option( 'migrate_for_idc', true ) ) {

--- a/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
@@ -98,6 +98,7 @@ class Jetpack_Connector_Test extends TestCase {
 		wp_set_current_user( 0 );
 
 		remove_all_filters( 'jetpack_offline_mode' );
+		remove_all_filters( 'jetpack_is_in_safe_mode' );
 		StatusCache::clear();
 	}
 
@@ -260,6 +261,57 @@ class Jetpack_Connector_Test extends TestCase {
 		$data = Jetpack_Connector::get_connector_data( array() );
 
 		$this->assertTrue( $data['ssoStatus'] );
+	}
+
+	/* ── get_connector_data() — identity crisis (Safe Mode) ─────── */
+
+	/**
+	 * Test that isInSafeMode is false and no idc data is exposed when the site is not in Safe Mode.
+	 */
+	public function test_idc_data_absent_when_not_in_safe_mode() {
+		\Jetpack_Options::update_option( 'blog_token', 'test.secret' );
+		\Jetpack_Options::update_option( 'id', 12345 );
+		StatusCache::clear();
+
+		$data = Jetpack_Connector::get_connector_data( array() );
+
+		$this->assertArrayHasKey( 'isInSafeMode', $data );
+		$this->assertFalse( $data['isInSafeMode'] );
+		$this->assertArrayNotHasKey( 'idc', $data );
+	}
+
+	/**
+	 * Test that Safe Mode data is exposed when the site is in Safe Mode.
+	 */
+	public function test_idc_data_present_when_in_safe_mode() {
+		\Jetpack_Options::update_option( 'blog_token', 'test.secret' );
+		\Jetpack_Options::update_option( 'id', 12345 );
+		StatusCache::clear();
+		add_filter( 'jetpack_is_in_safe_mode', '__return_true' );
+
+		$data = Jetpack_Connector::get_connector_data( array() );
+
+		$this->assertTrue( $data['isInSafeMode'] );
+		$this->assertArrayHasKey( 'isSafeModeConfirmed', $data );
+		$this->assertArrayHasKey( 'idc', $data );
+		$this->assertArrayHasKey( 'currentUrl', $data['idc'] );
+		$this->assertArrayHasKey( 'wpcomHomeUrl', $data['idc'] );
+		$this->assertArrayHasKey( 'isDevelopmentSite', $data['idc'] );
+		$this->assertArrayHasKey( 'possibleDynamicSiteUrlDetected', $data['idc'] );
+		$this->assertNotEmpty( $data['idc']['currentUrl'] );
+	}
+
+	/**
+	 * Test that Safe Mode data is not exposed for an unregistered site.
+	 */
+	public function test_idc_data_absent_when_unregistered() {
+		StatusCache::clear();
+		add_filter( 'jetpack_is_in_safe_mode', '__return_true' );
+
+		$data = Jetpack_Connector::get_connector_data( array() );
+
+		$this->assertArrayNotHasKey( 'isInSafeMode', $data );
+		$this->assertArrayNotHasKey( 'idc', $data );
 	}
 
 	/* ── is_connectors_screen() ────────────────────────────────── */


### PR DESCRIPTION
Closes CONNECT-247

## Proposed changes

Surfaces Jetpack Identity Crisis (Safe Mode) state and resolution options directly in the WP core Settings > Connectors card, so admins can recognize and resolve an IDC without leaving the Connectors screen. Scoped entirely to the `wordpress_com` connector — no other connectors are affected.

* **Minimized card:** when the site is in Safe Mode, the `Connected` / `Site registered` badge is replaced by an orange **Safe Mode** badge, and the card's toggle becomes a red **Resolve** call to action (instead of the neutral **Details**).
* **Expanded card:** the standard connection details are replaced by an IDC resolution panel offering the same actions as the standard Jetpack IDC screen, via the existing `jetpack/v4/identity-crisis/*` REST endpoints:
  * **Update address** (migrate) — production sites only. Updates the address WordPress.com has on file while keeping the connection, history, and data.
  * **Connect separately** (start-fresh) — connects this address on its own, restoring a previous connection if one existed. Tagged with `from=jetpack-connector` and routed through the shared auth-URL handling so Calypso returns to the Connectors page.
  * **Stay in Safe Mode** (confirm-safe-mode).
  * **Disconnect site** — reuses the standard disconnect endpoint; verified safe during IDC (the `jetpack_connection_disconnect_site_wpcom` filter prevents deregistering the original/production site, so only this site's local tokens are removed).
* **Development/staging sites** are only offered the **Connect separately** option (no **Update address**), matching `ScreenMain` in `@automattic/jetpack-idc`.
* Copy follows the Jetpack Connection language guidelines: it uses "store" when a WooCommerce-family plugin is connected and "site" otherwise, and frames the site as "registered with WordPress.com". Paused features are described generically ("features that sync with WordPress.com"); the familiar "Stats and Backups" example is shown only when a Jetpack-family plugin is connected.
* A collapsible "Why am I seeing this?" explanation lists the common causes, and a warning notice is shown when a dynamic site URL is detected in `wp-config.php` (it can keep re-triggering Safe Mode), with a link to docs.

PHP exposes the new state via `Jetpack_Connector::get_connector_data()` (`isInSafeMode`, `isSafeModeConfirmed`, and an `idc` payload with `currentUrl`, `wpcomHomeUrl`, `isDevelopmentSite`, `possibleDynamicSiteUrlDetected`), mirroring `IdentityCrisis\UI::get_initial_state_data()`.

The card's connection logic was also consolidated (behavior-preserving): a single `apiRequest()` helper handles the shared REST headers/nonce, response checks, and error/network handling; a shared `disconnectSite()` backs both detail panels; and one `decorateAuthUrl()` applies the `from`/`skip_pricing` params at every redirect point.

<img width="715" height="113" alt="Screenshot 2026-06-10 at 13 44 18" src="https://github.com/user-attachments/assets/81f44746-6185-4ea0-849f-340b638ae110" />
<img width="718" height="587" alt="Screenshot 2026-06-11 at 13 57 21" src="https://github.com/user-attachments/assets/45a50ab4-cdea-4357-a744-4fb9d9426b32" />

<img width="677" height="715" alt="Screenshot 2026-06-11 at 14 00 49" src="https://github.com/user-attachments/assets/27c8dc15-63a9-4b0c-8b90-d3cc999b5528" />


## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No new tracking. The card calls existing identity-crisis and connection REST endpoints already used by the standard Jetpack IDC UI.

## Testing instructions

* You will need two JN test sites. Connect both sites to WordPress.com, then trigger an Identity Crisis (e.g. via the Jetpack Debug Helper's IDC simulator on one of them using the URL of the other one. I recommend you load this branch on both sites.
* Go to **Settings > Connectors** (WP 7.0+ core screen, or the Gutenberg plugin's Connectors page).
* Confirm the Jetpack connection card shows an orange **Safe Mode** badge and a red **Resolve** button.
* Click **Resolve** and confirm the IDC panel appears with:
  * On a production site: **Update address** (primary) and **Connect separately**.
  * On a development/staging site (`WP_ENVIRONMENT_TYPE=development|staging`): only **Connect separately** (no **Update address**).
  * A **Disconnect site** option (hidden on WoA/VIP), and a **Stay in Safe Mode** link.
  * A collapsible **Why am I seeing this?** explanation.
* Confirm the two option buttons stay bottom-aligned even when their descriptions differ in length (and that the options stack on narrow screens).


* Exercise each action and confirm it behaves correctly
	* **Stay in Safe Mode** reloads and adds the Jetpack Safe Mode badge in the master bar. 
	* **Connect separately** redirects to the connect flow. The site should connect using same blog id. The other site stays connected. Reactivate IDC spoofing with same conditions. If IDC doesn't show up, wait for 15 minutes.
	* Disable IDC spoofing. IDC screen should remain active. Use **Disconnect site** button. The other site stays connected. Reconnect.
	* Use Debug tools broken token utilities on the second site to copy blog token and blog id to the first site (in that order). This will trigger real IDC (not just spoofing). On the first site, use **Update address** and confirm it shows a confirmation and then a success state. Blog RC page should show the change for both ids.

Let me know if testing gets wonky. There are different layers of caching involved so it can be hard to test.