### PR TITLE
Daily Writing Prompt: load the widget on connected self-hosted sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-writing-prompt-widget-self-hosted
+++ b/projects/plugins/jetpack/changelog/add-writing-prompt-widget-self-hosted
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Daily Writing Prompt: load the dashboard widget on connected self-hosted Jetpack sites.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -68,6 +68,13 @@ if ( is_admin() ) {
 	// Initialize Newsletter Settings (always-loaded so the settings page URL works even when module is inactive).
 	\Automattic\Jetpack\Newsletter\Settings::init();
 
+	// Register the Daily Writing Prompt dashboard widget. It fetches prompts from
+	// WordPress.com (via the Jetpack proxy), so it only makes sense once the site
+	// is connected and able to reach WordPress.com.
+	if ( Jetpack::is_connection_ready() && ! ( new \Automattic\Jetpack\Status() )->is_offline_mode() ) {
+		\Automattic\Jetpack\Newsletter\Writing_Prompt_Widget::init();
+	}
+
 	\Automattic\Jetpack\Plugin\Jetpack_Script_Data::configure();
 }
 


### PR DESCRIPTION
Fixes CM-823

## Proposed changes

* Registers the Daily Writing Prompt dashboard widget from the Jetpack plugin's `load-jetpack.php`, so it now loads on self-hosted Jetpack sites and not only for WordPress.com-connected users via `jetpack-mu-wpcom`.
* The widget is gated on a ready WordPress.com connection **and** the site not being in offline/development mode, because it fetches prompts from WordPress.com through the Jetpack proxy and cannot load them otherwise.
* wpcom is unaffected (`load-jetpack.php` does not run there); Simple/Atomic continue to load the widget through the existing `jetpack-mu-wpcom` path.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a self-hosted site running this branch, connect Jetpack to WordPress.com.
* Go to **wp-admin → Dashboard** and confirm the **Daily Writing Prompt** widget appears in the side column and loads today's prompt. On a non-wpcom site, the Reader link should open in a new tab.
* Disconnect Jetpack (or enable offline mode, e.g. `define( 'JETPACK_DEV_DEBUG', true );`) and reload the Dashboard: the widget should no longer be registered.

