### PR TITLE
jetpack: More unique temp file name in WPCOM_REST_API_V2_Endpoint_External_Media_Test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-WPCOM_REST_API_V2_Endpoint_External_Media_Test-tmp-file
+++ b/projects/plugins/jetpack/changelog/fix-WPCOM_REST_API_V2_Endpoint_External_Media_Test-tmp-file
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Test fix, no change to plugin functionality.
+
+

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_External_Media_Test.php
@@ -54,6 +54,8 @@ class WPCOM_REST_API_V2_Endpoint_External_Media_Test extends Jetpack_REST_TestCa
 	public function set_up() {
 		parent::set_up();
 
+		$this->image_name = 'example_image-' . getmypid() . '-' . uniqid();
+
 		wp_set_current_user( static::$user_id );
 
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We've seen a few CI failures that seem likely to be due to concurrent runs of the tests interfering with each other. Avoid that by adding the PID and a uniqid to the "example_image" filename used by the test.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1780585303689119-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?