### PR TITLE
Docker: Force core and test suite versions to match via mu-plugin

### DIFF
--- a/tools/docker/bin/update-core.sh
+++ b/tools/docker/bin/update-core.sh
@@ -23,32 +23,26 @@ fi
 echo "Current version: $INIT_CORE_VERSION"
 echo "Target version: $TARGET_VERSION"
 
-# We could force-install, but for now just abort if we're already at our target.
-if [[ "$TARGET_VERSION" != "$INIT_CORE_VERSION" ]]; then
-	echo "Updating WordPress core to $TARGET_VERSION..."
-	echo "Please be patient; this may take some time."
+if [[ "$TARGET_VERSION" == "$INIT_CORE_VERSION" ]]; then
+	echo 'Already on requested version, but forcing update.'
+fi
+echo "Updating WordPress core to $TARGET_VERSION..."
+echo "Please be patient; this may take some time."
 
-	# Clean up old option if a previous update didn't complete. Otherwise one would get this:
-	# "Error: Another update is currently in progress."
-	wp option get core_updater.lock &>/dev/null && wp option delete core_updater.lock
+# Clean up old option if a previous update didn't complete. Otherwise one would get this:
+# "Error: Another update is currently in progress."
+wp option get core_updater.lock &>/dev/null && wp option delete core_updater.lock
 
-	wp core update --version="$TARGET_VERSION" --force
+wp core update --version="$TARGET_VERSION" --force
 
-	# If these don't match now, it means something went wrong with the update.
-	if [[ "$TARGET_VERSION" != "$(wp core version)" ]]; then
-		echo "WordPress update to $TARGET_VERSION failed!"
-		exit 1
-	fi
-
-	# Update database.
-	echo 'Updating core database.'
-	wp core update-db
+# If these don't match now, it means something went wrong with the update.
+if [[ "$TARGET_VERSION" != "$(wp core version)" ]]; then
+	echo "WordPress update to $TARGET_VERSION failed!"
+	exit 1
 fi
 
-# Update core unit tests.
-echo 'Updating core unit tests...'
-svn -q switch "https://develop.svn.wordpress.org/tags/$TARGET_VERSION/tests/phpunit/data" /tmp/wordpress-develop/tests/phpunit/data && svn -q switch "https://develop.svn.wordpress.org/tags/$TARGET_VERSION/tests/phpunit/includes" /tmp/wordpress-develop/tests/phpunit/includes || {
-	echo 'Failed to update WordPress unit tests!'
-}
+# Update database.
+echo 'Updating core database.'
+wp core update-db
 
 echo "Successfully updated WordPress from $INIT_CORE_VERSION to $TARGET_VERSION."

--- a/tools/docker/mu-plugins/.gitignore
+++ b/tools/docker/mu-plugins/.gitignore
@@ -7,3 +7,4 @@
 !jetpack-debug-helper-loader.php
 !/jetpack-debug-helper
 !offline-mode-force-wpcom-disconnect.php
+!sync_wp_test_suite_with_core_version.php

--- a/tools/docker/mu-plugins/sync_wp_test_suite_with_core_version.php
+++ b/tools/docker/mu-plugins/sync_wp_test_suite_with_core_version.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Sync WP test suite with Core version
+ * Description: When WordPress core is updated, sync the WordPress test suite to the matching version.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ *
+ * @todo Consider adding support for nightly/alpha/beta/RC?
+ */
+
+// phpcs:disable WordPress.PHP.DevelopmentFunctions
+
+/**
+ * Update the WordPress test suite to match the installed core version.
+ *
+ * @param WP_Upgrader $upgrader   Upgrader instance.
+ * @param array       $hook_extra Extra arguments.
+ */
+function jetpack_sync_phpunit_tests_with_core( $upgrader, $hook_extra ) {
+	if ( ( $hook_extra['type'] ?? '' ) !== 'core' ) {
+		return;
+	}
+
+	// Read the version fresh from disk
+	$wp_version = '';
+	require ABSPATH . WPINC . '/version.php';
+
+	// WordPress versioning has no minor 0 version.
+	$tag  = preg_replace( '/^(\d+\.\d+)\.0$/', '$1', $wp_version );
+	$base = '/tmp/wordpress-develop/tests/phpunit';
+
+	foreach ( array( 'data', 'includes' ) as $dir ) {
+		$url    = "https://develop.svn.wordpress.org/tags/$tag/tests/phpunit/$dir";
+		$cmd    = sprintf(
+			'svn -q switch --trust-server-cert --non-interactive %s %s 2>&1',
+			escapeshellarg( $url ),
+			escapeshellarg( "$base/$dir" )
+		);
+		$output = shell_exec( $cmd );
+		if ( $output ) {
+			// Error!
+			error_log( "Error while updating test suite to match core version! Error:\n$output" );
+		} else {
+			error_log( "Successfully updated test suite to match core version: svn switch $dir -> tags/$tag" );
+		}
+	}
+}
+add_action( 'upgrader_process_complete', 'jetpack_sync_phpunit_tests_with_core', 10, 2 );

--- a/tools/docker/mu-plugins/sync_wp_test_suite_with_core_version.php
+++ b/tools/docker/mu-plugins/sync_wp_test_suite_with_core_version.php
@@ -43,7 +43,7 @@ function jetpack_sync_phpunit_tests_with_core( $upgrader, $hook_extra ) {
 		$output = shell_exec( $cmd );
 		if ( $output ) {
 			// Error!
-			error_log( "Error while updating test suite to match core version! Error:\n$output" );
+			error_log( "Error while updating test suite to match core version!\n\nSVN output:\n$output" );
 		} else {
 			error_log( "Successfully updated test suite to match core version: svn switch $dir -> tags/$tag" );
 		}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Previously we relied on `jetpack docker update-core` to sync the WP test suite version with the core version (#41934). However, that doesn't account for people updating in their WP Admin dashboard.

This adds an mu-plugin called `sync_wp_test_suite_with_core_version.php` to handle this instead.

It also removes the now-redundant code from `tools/docker/bin/update-core.sh` and forces an install via `jetpack docker update-core` even if the version matches (may as well).

One caveat: beta/RC/nightlies won't work (nor did they before). On failure, it'll just log two errors to the logs right after the update completion and move on (no recurring noise), which in this iteration is probably acceptable.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1779490954982889-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Try upgrading/downgrading with `jetpack docker update-core <some-ver>`.
2. Try upgrading via the dashboard (you can use the above option to downgrade).
3. Try WordPress Beta to use a nightly and see failures.