### PR TITLE
Account Protection: Add min/max password length filters

### DIFF
--- a/projects/packages/account-protection/changelog/add-account-protection-add_password_length_filters
+++ b/projects/packages/account-protection/changelog/add-account-protection-add_password_length_filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add `jetpack_account_protection_validation_min_length` and `jetpack_account_protection_validation_max_length` filters.

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -70,7 +70,12 @@ class Validation_Service {
 			),
 			'invalid_length'     => array(
 				'status'  => null,
-				'message' => __( 'Between 6 and 150 characters', 'jetpack-account-protection' ),
+				'message' => sprintf(
+					/* translators: %1$d is the minimum password length, %2$d is the maximum password length. */
+					__( 'Between %1$d and %2$d characters', 'jetpack-account-protection' ),
+					$this->get_min_length(),
+					$this->get_max_length()
+				),
 				'info'    => null,
 			),
 			'leaked'             => array(
@@ -148,7 +153,12 @@ class Validation_Service {
 		}
 
 		if ( $this->is_invalid_length( $password ) ) {
-			$errors[] = __( '<strong>Error:</strong> The password must be between 6 and 150 characters.', 'jetpack-account-protection' );
+			$errors[] = sprintf(
+				/* translators: %1$d is the minimum password length, %2$d is the maximum password length. */
+				__( '<strong>Error:</strong> The password must be between %1$d and %2$d characters.', 'jetpack-account-protection' ),
+				$this->get_min_length(),
+				$this->get_max_length()
+			);
 		}
 
 		if ( $this->is_leaked_password( $password ) ) {
@@ -189,7 +199,43 @@ class Validation_Service {
 	 */
 	public function is_invalid_length( string $password ): bool {
 		$length = strlen( $password );
-		return $length < Config::VALIDATION_SERVICE_MIN_LENGTH || $length > Config::VALIDATION_SERVICE_MAX_LENGTH;
+		return $length < $this->get_min_length() || $length > $this->get_max_length();
+	}
+
+	/**
+	 * Get the minimum allowed password length.
+	 *
+	 * @return int The minimum allowed password length.
+	 */
+	public function get_min_length(): int {
+		/**
+		 * Filters the minimum allowed password length for Account Protection.
+		 *
+		 * The default is a floor: values below it are ignored, so the filter can only
+		 * make the requirement stricter, never weaker.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $min_length The minimum allowed password length.
+		 */
+		$min_length = (int) apply_filters( 'jetpack_account_protection_validation_min_length', Config::VALIDATION_SERVICE_MIN_LENGTH );
+		return max( Config::VALIDATION_SERVICE_MIN_LENGTH, $min_length );
+	}
+
+	/**
+	 * Get the maximum allowed password length.
+	 *
+	 * @return int The maximum allowed password length.
+	 */
+	public function get_max_length(): int {
+		/**
+		 * Filters the maximum allowed password length for Account Protection.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $max_length The maximum allowed password length.
+		 */
+		return (int) apply_filters( 'jetpack_account_protection_validation_max_length', Config::VALIDATION_SERVICE_MAX_LENGTH );
 	}
 
 	/**

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -195,7 +195,7 @@ class Validation_Service {
 	 *
 	 * @param string $password The password to check.
 	 *
-	 * @return bool True if the password is between 6 and 150 characters, false otherwise.
+	 * @return bool True if the password is between get_min_length() and get_max_length() characters, false otherwise.
 	 */
 	public function is_invalid_length( string $password ): bool {
 		$length = strlen( $password );

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -212,7 +212,7 @@ class Validation_Service {
 		 * Filters the minimum allowed password length for Account Protection.
 		 *
 		 * The default is a floor: values below it are ignored, so the filter can only
-		 * make the requirement stricter, never weaker.
+		 * raise the minimum, never lower it.
 		 *
 		 * @since $$next-version$$
 		 *
@@ -231,11 +231,15 @@ class Validation_Service {
 		/**
 		 * Filters the maximum allowed password length for Account Protection.
 		 *
+		 * The default is a floor: values below it are ignored, so the filter can only
+		 * raise the maximum, never lower it.
+		 *
 		 * @since $$next-version$$
 		 *
 		 * @param int $max_length The maximum allowed password length.
 		 */
-		return (int) apply_filters( 'jetpack_account_protection_validation_max_length', Config::VALIDATION_SERVICE_MAX_LENGTH );
+		$max_length = (int) apply_filters( 'jetpack_account_protection_validation_max_length', Config::VALIDATION_SERVICE_MAX_LENGTH );
+		return max( Config::VALIDATION_SERVICE_MAX_LENGTH, $max_length );
 	}
 
 	/**

--- a/projects/packages/account-protection/tests/php/Validation_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Validation_Service_Test.php
@@ -204,6 +204,51 @@ class Validation_Service_Test extends BaseTestCase {
 		$this->assertTrue( $validation_service->is_invalid_length( $long_password ) );
 	}
 
+	public function test_min_length_is_filterable() {
+		$password           = 'abcdef';
+		$validation_service = new Validation_Service( $this->get_connection_manager() );
+		$this->assertSame( 6, $validation_service->get_min_length() );
+
+		$callback = function () {
+			return 16;
+		};
+		add_filter( 'jetpack_account_protection_validation_min_length', $callback );
+
+		$this->assertSame( 16, $validation_service->get_min_length() );
+		$this->assertTrue( $validation_service->is_invalid_length( $password ) );
+
+		remove_filter( 'jetpack_account_protection_validation_min_length', $callback );
+	}
+
+	public function test_min_length_cannot_be_filtered_below_default() {
+		$password = 'asdf';
+
+		$validation_service = new Validation_Service( $this->get_connection_manager() );
+
+		$callback = function () {
+			return 4;
+		};
+		add_filter( 'jetpack_account_protection_validation_min_length', $callback );
+		$this->assertSame( 6, $validation_service->get_min_length() );
+		$this->assertTrue( $validation_service->is_invalid_length( $password ) );
+		remove_filter( 'jetpack_account_protection_validation_min_length', $callback );
+	}
+
+	public function test_max_length_is_filterable() {
+		$password = str_repeat( 'a', 21 );
+
+		$validation_service = new Validation_Service( $this->get_connection_manager() );
+		$this->assertSame( 150, $validation_service->get_max_length() );
+
+		$callback = function () {
+			return 20;
+		};
+		add_filter( 'jetpack_account_protection_validation_max_length', $callback );
+		$this->assertSame( 20, $validation_service->get_max_length() );
+		$this->assertTrue( $validation_service->is_invalid_length( $password ) );
+		remove_filter( 'jetpack_account_protection_validation_max_length', $callback );
+	}
+
 	public function test_returns_true_if_password_matches_user_data() {
 		$user             = new \WP_User();
 		$user->user_email = 'example@wordpress.com';

--- a/projects/packages/account-protection/tests/php/Validation_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Validation_Service_Test.php
@@ -235,17 +235,31 @@ class Validation_Service_Test extends BaseTestCase {
 	}
 
 	public function test_max_length_is_filterable() {
-		$password = str_repeat( 'a', 21 );
+		$password = str_repeat( 'a', 172 );
 
 		$validation_service = new Validation_Service( $this->get_connection_manager() );
 		$this->assertSame( 150, $validation_service->get_max_length() );
 
 		$callback = function () {
-			return 20;
+			return 200;
 		};
 		add_filter( 'jetpack_account_protection_validation_max_length', $callback );
-		$this->assertSame( 20, $validation_service->get_max_length() );
-		$this->assertTrue( $validation_service->is_invalid_length( $password ) );
+		$this->assertSame( 200, $validation_service->get_max_length() );
+		$this->assertFalse( $validation_service->is_invalid_length( $password ) );
+		remove_filter( 'jetpack_account_protection_validation_max_length', $callback );
+	}
+
+	public function test_max_length_cannot_be_filtered_below_default() {
+		$password = str_repeat( 'a', 127 );
+
+		$validation_service = new Validation_Service( $this->get_connection_manager() );
+
+		$callback = function () {
+			return 100;
+		};
+		add_filter( 'jetpack_account_protection_validation_max_length', $callback );
+		$this->assertSame( 150, $validation_service->get_max_length() );
+		$this->assertFalse( $validation_service->is_invalid_length( $password ) );
 		remove_filter( 'jetpack_account_protection_validation_max_length', $callback );
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This adds `jetpack_account_protection_validation_min_length` and `jetpack_account_protection_validation_max_length` filters.

I kept the default min as a floor. Increasing the minimum is commendable, but if they're decreasing it, they're undermining the purpose of this feature, and they may as well just disable it.

I also considered adding a check for the min not being greater than the max, but that gets complicated, as then the min might need to override the max (e.g. `max( $this->get_min_length(), $max_length )` and it's cleaner to just have the end user properly configure it.

<img width="1552" height="626" alt="image" src="https://github.com/user-attachments/assets/5ff4dfb7-d180-4b37-af10-a9e9adcf4f9f" />

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1781008175498479-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Is CI happy?
* Does it work?

Example snippet:
```
$callback_min = function () { return 16; };
$callback_max = function () { return 17; };
add_filter( 'jetpack_account_protection_validation_min_length', $callback_min );
add_filter( 'jetpack_account_protection_validation_min_length', $callback_max );
```