### PR TITLE
Newsletter: fix removing a subscriber in the modernized dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -785,15 +785,17 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	}
 
 	/**
-	 * Helper: POST to a v1.1 wpcom REST path as the current user.
+	 * Helper: POST to a v1.1 wpcom REST path using the blog (site) token.
 	 *
-	 * Note on caps: WP.com's followers / email-followers / memberships endpoints require the
-	 * calling user to have the `delete_followers` capability on the wpcom-side blog. That maps
-	 * 1:1 with the wpcom blog admin role, so this works on real Jetpack-connected sites where
-	 * the wp-admin admin user is also the wpcom-side blog admin. It does NOT work on environments
-	 * where the wpcom-side blog is owned by a different account than the locally-connected user
-	 * (e.g. some Jurassic Ninja test sites). We tried `as_blog` and forwarding as the connection
-	 * owner — both hit the same wpcom cap gate. The fix lives on the wpcom side, not here.
+	 * Why the blog token and not the current user: a user-token request
+	 * (`wpcom_json_api_request_as_user`) to the classic v1.1 `/rest` API arrives with no
+	 * authenticated principal — the classic API does not establish a wpcom user from the Jetpack
+	 * auth header the way the wpcom/v2 layer does, so the request runs with `get_current_user_id()
+	 * === 0`. Any `current_user_can()` gate on the wpcom side is therefore unsatisfiable. The blog
+	 * token always validates for a connected site, and the wpcom followers / email-followers /
+	 * memberships endpoints accept it via `is_jetpack_authorized_for_site()` (mirroring the
+	 * subscriber-list read endpoint, which already trusts the blog token). Authorization of the
+	 * acting admin happens locally in `permission_check()` before we ever proxy.
 	 *
 	 * Returns null on success or a WP_Error describing the failure.
 	 *
@@ -801,7 +803,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * @return WP_Error|null
 	 */
 	private function wpcom_post( $path ) {
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			$path,
 			'1.1',
 			array( 'method' => 'POST' ),
@@ -814,6 +816,15 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 		}
 
 		$status = (int) wp_remote_retrieve_response_code( $response );
+
+		// A 404 means the target is already gone — removing the wpcom follower also clears the
+		// shared blog subscription, so the email-follower step then finds nothing. Deleting a
+		// missing record is an idempotent no-op success, not an error, so don't surface it in the
+		// aggregated multi-step result.
+		if ( 404 === $status ) {
+			return null;
+		}
+
 		if ( $status >= 400 ) {
 			$body    = json_decode( wp_remote_retrieve_body( $response ), true );
 			$message = is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'WP.com call failed.', 'jetpack' );

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-delete-subscriber
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-delete-subscriber
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Subscribers (Newsletter modernization, behind a feature flag): fix removing a subscriber. Authorize the wpcom follower/email-follower/paid-cancel calls with the blog token (the user-token path resolved to no current user on the classic v1.1 API), and treat a 404 from any step as an idempotent no-op so a subscriber who is both a follower and an email subscriber no longer reports a false error after a successful removal.
+
+


### PR DESCRIPTION
Fixes #

## Proposed changes
The modernized Subscribers dashboard's **Remove subscriber** action proxies to wpcom's granular `followers/delete`, `email-followers/delete`, and `memberships/.../cancel` endpoints. Removal failed for two reasons, both fixed here in `wpcom_post()`:

* **Authorization:** the calls used `wpcom_json_api_request_as_user()` against the classic v1.1 `/rest` API, which — unlike the wpcom/v2 layer the subscriber-list read uses — doesn't establish a wpcom user from the Jetpack auth header. The request reached the endpoints with `get_current_user_id() === 0`, so their `current_user_can()` gate could never pass (changing the gated cap on the wpcom side alone was therefore insufficient). Switched to `wpcom_json_api_request_as_blog()`; wpcom now authorizes the request via `is_jetpack_authorized_for_site()`, and the proxy already enforces `manage_options` locally in `permission_check()` before proxying.
* **False-error toast:** deleting the wpcom follower also clears the *shared* underlying blog subscription, so the subsequent email-follower delete returns `404 not_following`. That 404 was aggregated as an error, producing a failure toast after a fully successful removal. A delete that finds the target already gone is an idempotent no-op success, so `wpcom_post()` now treats a `404` from any step as success.

This change is behind the off-by-default `rsm_jetpack_ui_modernization_newsletter` filter.

## Related product discussion/links
* Companion wpcom change (required): 222518-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Requires the companion wpcom change **222518-ghe-Automattic/wpcom** to be deployed/sandboxed.

* Enable the modernized dashboard: add a filter returning `true` for `rsm_jetpack_ui_modernization_newsletter`.
* Go to **Jetpack → Newsletter → Subscribers** on a Jetpack-connected site.
* Open the **⋯** Actions menu on a subscriber who is **both a `.com` follower and an email subscriber**, and choose **Remove subscriber** → confirm.
* Expected: a success toast, the row disappears, and the network response for `POST /wp-json/wpcom/v2/subscribers/remove` is `{"ok":true,"errors":[]}` (previously: `ok:false` with a "capability" error, and — after the auth fix alone — a 404 `not_following` on the email-follower step).
* Repeat for the other subscriber shapes to cover each step:
  * **Email-only** subscriber (no `.com` follower) — single email-follower delete.
  * **Paid** subscriber — exercises the memberships `cancel` step.
