### PR TITLE
Premium Analytics: add API proxy REST controller

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-api-proxy-controller
+++ b/projects/packages/premium-analytics/changelog/add-api-proxy-controller
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Add the analytics API proxy controller that forwards dashboard requests to WPCOM and briefly caches the response.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
+		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -87,6 +87,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			'/' . $this->rest_base . '/(?P<endpoint>.*)',
 			array(
 				array(
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'handle_proxy_request' ),
 					'permission_callback' => array( $this, 'check_permission' ),

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * REST controller that proxies dashboard data-layer requests to the WPCOM analytics API.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Forwards an authenticated dashboard request to the WPCOM analytics endpoint for the
+ * connected site's blog ID, caches the successful response in a short-lived transient,
+ * and returns it. Lets the extracted frontend's data layer talk to WPCOM without each
+ * call leaving the WordPress origin.
+ */
+class Api_Proxy_Controller extends WP_REST_Controller {
+
+	/**
+	 * Package slug. Also the cache-key prefix (see SLUG-derived CACHE_PREFIX) — the only
+	 * piece the source pulled from its dropped Utilities trait.
+	 */
+	private const SLUG = 'jetpack-premium-analytics';
+
+	/**
+	 * Transient key prefix, derived from the package slug.
+	 *
+	 * @var string
+	 */
+	private const CACHE_PREFIX = self::SLUG . '_proxy_';
+
+	/**
+	 * How long a successful response stays cached.
+	 *
+	 * @var int
+	 */
+	private const CACHE_TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Timeout for the outbound WPCOM request, in seconds.
+	 *
+	 * @var int
+	 */
+	private const API_TIMEOUT = 20;
+
+	/**
+	 * Response headers worth forwarding back to the dashboard.
+	 *
+	 * @var string[]
+	 */
+	private const FORWARDED_HEADERS = array( 'x-wp-total', 'x-wp-totalpages' );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = self::SLUG . '/v1';
+		$this->rest_base = 'proxy';
+	}
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the proxy route. The trailing capture group is the target analytics path.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<endpoint>.*)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_proxy_request' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Only site administrators may reach the analytics data.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Serve a cached payload when available, otherwise fetch from WPCOM and cache it.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_proxy_request( WP_REST_Request $request ) {
+		$cache_key = $this->get_cache_key( $request );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $this->build_response( $cached );
+		}
+
+		if ( ! ( new Manager( self::SLUG ) )->is_connected() ) {
+			return new WP_Error(
+				'no_connection',
+				__( 'Please connect Jetpack to load analytics data.', 'jetpack-premium-analytics' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		try {
+			$response = Client::wpcom_json_api_request_as_blog(
+				$this->build_endpoint_url( $request ),
+				'2',
+				array(
+					'method'  => 'GET',
+					'timeout' => self::API_TIMEOUT,
+				),
+				null,
+				'wpcom'
+			);
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'api_error',
+				__( 'Error processing the analytics request.', 'jetpack-premium-analytics' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'api_error',
+				__( 'Error communicating with the analytics service.', 'jetpack-premium-analytics' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $this->cache_and_build_response( $response, $cache_key );
+	}
+
+	/**
+	 * Build the WPCOM analytics path for the connected blog from the request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return string
+	 */
+	protected function build_endpoint_url( WP_REST_Request $request ): string {
+		$site_id      = (string) Jetpack_Options::get_option( 'id' );
+		$endpoint_url = sprintf( '/sites/%s/analytics/%s', $site_id, (string) $request->get_param( 'endpoint' ) );
+
+		$params = $this->get_forwarded_params( $request );
+		if ( ! empty( $params ) ) {
+			$endpoint_url .= '?' . http_build_query( $params );
+		}
+
+		return $endpoint_url;
+	}
+
+	/**
+	 * Schema for the proxy endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema(): array {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'proxy',
+			'type'       => 'object',
+			'properties' => array(
+				'endpoint' => array(
+					'description' => __( 'The remote analytics endpoint to proxy.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'required'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Cache a successful (200) response and return it to the caller.
+	 *
+	 * @param array  $http_response Raw response from the Jetpack client.
+	 * @param string $cache_key     Transient key for this request signature.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function cache_and_build_response( array $http_response, string $cache_key ): WP_REST_Response {
+		$status  = (int) wp_remote_retrieve_response_code( $http_response );
+		$headers = wp_remote_retrieve_headers( $http_response );
+
+		$payload = array(
+			'data'    => json_decode( wp_remote_retrieve_body( $http_response ), false ),
+			'status'  => $status,
+			'headers' => $this->extract_forwarded_headers( $headers ),
+		);
+
+		if ( 200 === $status ) {
+			set_transient( $cache_key, $payload, self::CACHE_TTL );
+		}
+
+		return $this->build_response( $payload );
+	}
+
+	/**
+	 * Rebuild a WP_REST_Response from a cached or freshly fetched payload.
+	 *
+	 * @param array $payload Stored payload with data, status, and headers.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function build_response( array $payload ): WP_REST_Response {
+		$response = new WP_REST_Response( $payload['data'], (int) $payload['status'] );
+
+		foreach ( (array) $payload['headers'] as $name => $value ) {
+			$response->header( $name, $value );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Keep only the response headers the dashboard needs (pagination totals).
+	 *
+	 * @param mixed $headers Response headers as returned by the HTTP API.
+	 *
+	 * @return array<string, string>
+	 */
+	private function extract_forwarded_headers( $headers ): array {
+		if ( $headers instanceof \ArrayAccess || is_array( $headers ) ) {
+			$forwarded = array();
+			foreach ( self::FORWARDED_HEADERS as $name ) {
+				if ( isset( $headers[ $name ] ) ) {
+					$forwarded[ $name ] = (string) $headers[ $name ];
+				}
+			}
+			return $forwarded;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Query params to forward to WPCOM, minus the WordPress routing param.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array
+	 */
+	private function get_forwarded_params( WP_REST_Request $request ): array {
+		$params = $request->get_query_params();
+		unset( $params['rest_route'] );
+
+		return is_array( $params ) ? $params : array();
+	}
+
+	/**
+	 * Build the transient key from the request signature (endpoint + forwarded params).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return string
+	 */
+	private function get_cache_key( WP_REST_Request $request ): string {
+		$params = $this->get_forwarded_params( $request );
+		ksort( $params );
+		$signature = (string) $request->get_param( 'endpoint' ) . '|' . (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES );
+
+		return self::CACHE_PREFIX . md5( $signature );
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -96,6 +96,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 							'description'       => __( 'The analytics sub-path to proxy.', 'jetpack-premium-analytics' ),
 							'type'              => 'string',
 							'required'          => true,
+							'validate_callback' => array( $this, 'validate_endpoint' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
@@ -112,6 +113,24 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Confine the endpoint to a relative analytics sub-path so it cannot escape the
+	 * `/sites/<id>/analytics/` prefix via traversal (`..`), an absolute path, or a scheme.
+	 *
+	 * @param mixed $value Raw endpoint param.
+	 *
+	 * @return bool
+	 */
+	public function validate_endpoint( $value ): bool {
+		$value = (string) $value;
+
+		if ( str_starts_with( $value, '/' ) || str_contains( $value, '..' ) || str_contains( $value, ':' ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '#^[A-Za-z0-9._/-]+$#', $value );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -90,6 +90,14 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'handle_proxy_request' ),
 					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => array(
+						'endpoint' => array(
+							'description'       => __( 'The analytics sub-path to proxy.', 'jetpack-premium-analytics' ),
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -165,8 +173,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	protected function build_endpoint_url( WP_REST_Request $request ): string {
-		$site_id      = (string) Jetpack_Options::get_option( 'id' );
-		$endpoint_url = sprintf( '/sites/%s/analytics/%s', $site_id, (string) $request->get_param( 'endpoint' ) );
+		$site_id      = (int) Jetpack_Options::get_option( 'id' );
+		$endpoint_url = sprintf( '/sites/%d/analytics/%s', $site_id, (string) $request->get_param( 'endpoint' ) );
 
 		$params = $this->get_forwarded_params( $request );
 		if ( ! empty( $params ) ) {
@@ -205,16 +213,25 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @param array  $http_response Raw response from the Jetpack client.
 	 * @param string $cache_key     Transient key for this request signature.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
-	private function cache_and_build_response( array $http_response, string $cache_key ): WP_REST_Response {
-		$status  = (int) wp_remote_retrieve_response_code( $http_response );
-		$headers = wp_remote_retrieve_headers( $http_response );
+	private function cache_and_build_response( array $http_response, string $cache_key ) {
+		$status = (int) wp_remote_retrieve_response_code( $http_response );
+		$data   = json_decode( wp_remote_retrieve_body( $http_response ), false );
+
+		// A 200 with an undecodable body means the upstream is degraded; don't cache garbage.
+		if ( 200 === $status && null === $data && JSON_ERROR_NONE !== json_last_error() ) {
+			return new WP_Error(
+				'api_error',
+				__( 'The analytics service returned an unreadable response.', 'jetpack-premium-analytics' ),
+				array( 'status' => 502 )
+			);
+		}
 
 		$payload = array(
-			'data'    => json_decode( wp_remote_retrieve_body( $http_response ), false ),
+			'data'    => $data,
 			'status'  => $status,
-			'headers' => $this->extract_forwarded_headers( $headers ),
+			'headers' => $this->extract_forwarded_headers( wp_remote_retrieve_headers( $http_response ) ),
 		);
 
 		if ( 200 === $status ) {
@@ -271,7 +288,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		unset( $params['rest_route'] );
+		// Drop the params WordPress adds for its own routing — they're meaningless to WPCOM.
+		unset( $params['rest_route'], $params['_locale'] );
 
 		return is_array( $params ) ? $params : array();
 	}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
 /**
@@ -59,6 +60,7 @@ class Analytics {
 		}
 
 		Sync_Status_Tracker::configure();
+		Api_Proxy_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for Api_Proxy_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller
+ */
+#[CoversClass( Api_Proxy_Controller::class )]
+class Api_Proxy_Controller_Test extends BaseTestCase {
+
+	private const ROUTE = '/jetpack-premium-analytics/v1/proxy/(?P<endpoint>.*)';
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Api_Proxy_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Set up the controller and a fresh REST server.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new Api_Proxy_Controller();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_registers_proxy_route_under_package_namespace() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+	}
+
+	public function test_route_uses_the_controllers_permission_callback() {
+		$route = rest_get_server()->get_routes()[ self::ROUTE ][0];
+		$this->assertSame( array( $this->controller, 'check_permission' ), $route['permission_callback'] );
+	}
+
+	public function test_permission_denied_without_manage_options() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+
+	public function test_permission_granted_for_administrator() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_returns_403_error_when_not_connected() {
+		$response = $this->controller->handle_proxy_request( $this->build_request( 'reports/totals' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'no_connection', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	public function test_cache_hit_serves_stored_payload_without_a_connection() {
+		$request = $this->build_request( 'reports/totals', array( 'period' => 'week' ) );
+		$payload = array(
+			'data'    => (object) array( 'orders' => 42 ),
+			'status'  => 200,
+			'headers' => array( 'x-wp-total' => '42' ),
+		);
+		set_transient( $this->cache_key( $request ), $payload, MINUTE_IN_SECONDS );
+
+		$response = $this->controller->handle_proxy_request( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 42, $response->get_data()->orders );
+		$this->assertSame( '42', $response->get_headers()['x-wp-total'] );
+	}
+
+	public function test_cache_key_ignores_query_param_order_but_not_values() {
+		$a = $this->build_request(
+			'reports/totals',
+			array(
+				'period' => 'week',
+				'fields' => 'orders',
+			)
+		);
+		$b = $this->build_request(
+			'reports/totals',
+			array(
+				'fields' => 'orders',
+				'period' => 'week',
+			)
+		);
+		$c = $this->build_request( 'reports/totals', array( 'period' => 'month' ) );
+
+		$this->assertSame( $this->cache_key( $a ), $this->cache_key( $b ) );
+		$this->assertNotSame( $this->cache_key( $a ), $this->cache_key( $c ) );
+	}
+
+	/**
+	 * Build a proxy request with the endpoint capture and forwarded query params set.
+	 *
+	 * @param string $endpoint The analytics endpoint to proxy.
+	 * @param array  $params   Forwarded query params.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function build_request( string $endpoint, array $params = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/' . $endpoint );
+		$request->set_param( 'endpoint', $endpoint );
+		$request->set_query_params( $params );
+
+		return $request;
+	}
+
+	/**
+	 * Compute the controller's transient cache key for a request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return string
+	 */
+	private function cache_key( WP_REST_Request $request ): string {
+		$accessor = function ( WP_REST_Request $req ) {
+			return $this->get_cache_key( $req );
+		};
+
+		return $accessor->call( $this->controller, $request );
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -114,6 +114,37 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertNotSame( $this->cache_key( $a ), $this->cache_key( $c ) );
 	}
 
+	public function test_cache_key_ignores_wordpress_routing_params() {
+		$bare    = $this->build_request( 'reports/totals', array( 'period' => 'week' ) );
+		$routing = $this->build_request(
+			'reports/totals',
+			array(
+				'period'     => 'week',
+				'rest_route' => '/jetpack-premium-analytics/v1/proxy/reports/totals',
+				'_locale'    => 'user',
+			)
+		);
+
+		$this->assertSame( $this->cache_key( $bare ), $this->cache_key( $routing ) );
+	}
+
+	public function test_undecodable_200_body_returns_502_and_is_not_cached() {
+		$request  = $this->build_request( 'reports/totals' );
+		$response = $this->cache_and_build_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '<html>not json</html>',
+				'headers'  => array(),
+			),
+			$this->cache_key( $request )
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'api_error', $response->get_error_code() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+		$this->assertFalse( get_transient( $this->cache_key( $request ) ) );
+	}
+
 	/**
 	 * Build a proxy request with the endpoint capture and forwarded query params set.
 	 *
@@ -143,5 +174,21 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		};
 
 		return $accessor->call( $this->controller, $request );
+	}
+
+	/**
+	 * Invoke the controller's private cache_and_build_response().
+	 *
+	 * @param array  $http_response Raw HTTP response array.
+	 * @param string $cache_key     Transient key.
+	 *
+	 * @return WP_REST_Response|\WP_Error
+	 */
+	private function cache_and_build_response( array $http_response, string $cache_key ) {
+		$accessor = function ( array $resp, string $key ) {
+			return $this->cache_and_build_response( $resp, $key );
+		};
+
+		return $accessor->call( $this->controller, $http_response, $cache_key );
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -170,6 +170,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 */
 	private function cache_key( WP_REST_Request $request ): string {
 		$accessor = function ( WP_REST_Request $req ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
 			return $this->get_cache_key( $req );
 		};
 

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\PremiumAnalytics\REST;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -126,6 +127,35 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		);
 
 		$this->assertSame( $this->cache_key( $bare ), $this->cache_key( $routing ) );
+	}
+
+	public function test_validate_endpoint_accepts_a_relative_sub_path() {
+		$this->assertTrue( $this->controller->validate_endpoint( 'reports/totals' ) );
+	}
+
+	/**
+	 * @dataProvider data_invalid_endpoints
+	 *
+	 * @param string $endpoint An endpoint that must be rejected.
+	 */
+	#[DataProvider( 'data_invalid_endpoints' )]
+	public function test_validate_endpoint_rejects_traversal_and_scheme( string $endpoint ) {
+		$this->assertFalse( $this->controller->validate_endpoint( $endpoint ) );
+	}
+
+	/**
+	 * Endpoints that would escape the `/analytics/` prefix.
+	 *
+	 * @return array<string, string[]>
+	 */
+	public static function data_invalid_endpoints(): array {
+		return array(
+			'parent traversal' => array( '../../sites/1/posts' ),
+			'absolute path'    => array( '/sites/1/posts' ),
+			'scheme injection' => array( 'http://evil.test/' ),
+			'disallowed char'  => array( 'reports totals' ),
+			'empty'            => array( '' ),
+		);
 	}
 
 	public function test_undecodable_200_body_returns_502_and_is_not_cached() {

--- a/projects/plugins/premium-analytics/changelog/add-api-proxy-controller
+++ b/projects/plugins/premium-analytics/changelog/add-api-proxy-controller
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies to bundle the analytics API proxy REST controller.
+Update package dependencies to bundle the analytics API proxy REST controller.

--- a/projects/plugins/premium-analytics/changelog/add-api-proxy-controller
+++ b/projects/plugins/premium-analytics/changelog/add-api-proxy-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies to bundle the analytics API proxy REST controller.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -597,9 +597,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "14c207f485d8aac79486e000e68fed54934d58c8"
+                "reference": "3bae8046405853284fdd3b0fa970b5dfb173cb12"
             },
             "require": {
+                "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "php": ">=7.2"
             },


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1438/pr-2-migrate-api-proxy-rest-controller-to-premium-analytics

## Why
The extracted analytics dashboard's data layer needs an authenticated, same-origin way to read WPCOM analytics for the connected site. This adds the server-side proxy that forwards those reads to WPCOM and briefly caches the result, so the dashboard can render real data without each request leaving the WordPress origin or re-authenticating.

## Proposed changes
* Add `Api_Proxy_Controller` (`src/REST/class-api-proxy-controller.php`) — a `WP_REST_Controller` that registers `GET /jetpack-premium-analytics/v1/proxy/(?P<endpoint>.*)` on `rest_api_init`.
* Forward the captured `endpoint` plus its query params to `/sites/<blog_id>/analytics/<endpoint>` via `Jetpack\Connection\Client::wpcom_json_api_request_as_blog()`, using the connected site's blog ID.
* Cache successful (`200`) responses in a 5-minute transient keyed on the request signature (endpoint + sorted query params), prefixed with the package slug. Cache hits are served without contacting WPCOM. Pagination headers (`x-wp-total`, `x-wp-totalpages`) are forwarded back.
* Gate the route on `manage_options`; return a `403 no_connection` error when Jetpack isn't connected and `500 api_error` on a transport/upstream failure.
* Wire `Api_Proxy_Controller::register()` into `Analytics::init()`; add the `automattic/jetpack-connection` runtime dependency and the `automattic/jetpack-test-environment` dev dependency.

This migrates WooCommerce Analytics' `ApiProxy`, stripping the WC-specific surface: `WC_REST_Controller` → `WP_REST_Controller`, `view_woocommerce_reports` → `manage_options`, and the `LoggerTrait` / `Utilities` / `RegistrableInterface` dependencies (the controller registers its own route). Per the issue, caching is implemented as a server-side transient (the source only set `Cache-Control` headers).

## API changes
Adds `GET /jetpack-premium-analytics/v1/proxy/<endpoint>` (admin-only), which proxies to the WPCOM analytics API for the connected blog and caches successful responses for 5 minutes.

<details>
<summary>Request</summary>

```http
GET /wp-json/jetpack-premium-analytics/v1/proxy/reports/totals?period=week
X-WP-Nonce: <nonce for a manage_options user>
```

</details>

<details>
<summary>Verification output (live, Jetpack-connected dev site — blog 254382938)</summary>

```text
## 1. Route registered
   /jetpack-premium-analytics/v1/proxy/(?P<endpoint>.*)

## 2. Cache HIT via rest_do_request (no WPCOM call)
   status: 200
   x-wp-total: 42
   body: {"orders":42,"revenue":1234.56}

## 3. Cache MISS on connected site -> forwarded to WPCOM
   blog id: 254382938 (connected: yes)
   proxied status from WPCOM: 404
   proxied body from WPCOM: {"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}
   # 404 is WPCOM's own response for this test blog (no analytics data); the proxy
   # faithfully forwards the upstream status + body. The connection check passed.

## 4. Permission gate (unauthenticated HTTP)
   HTTP 401 (manage_options required)
```

</details>

> **Note on `jp phan`:** Phan could not run locally — the host only has PHP 8.5.3, which Phan 5.5.2's bundled `var_representation_polyfill` fatals on while parsing the WordPress stubs (a `case X;` parse error). This affects every phan run in the repo on this host, not this change; `php -l` is clean on all three files and types/APIs were verified against the Connection package. CI runs phan on a pinned PHP and is the authoritative gate.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/WOOA7S-1438/pr-2-migrate-api-proxy-rest-controller-to-premium-analytics
* Parent: https://linear.app/a8c/issue/WOOA7S-1436
* Builds on the scaffolding from PR 1 (WOOA7S-1437) — no runtime dependency.

## Does this pull request change what data or activity we track or use?
No. This relays existing analytics reads from the connected site to WPCOM over the existing Jetpack blog token; it introduces no new tracking or data collection. The 5-minute transient stores only the proxied response payload.

## Testing instructions

Acceptance criteria from the issue:

- [x] `jp build packages/premium-analytics` succeeds
- [x] `jp test php packages/premium-analytics` passes (new test included — 8 tests, 14 assertions)
- [ ] `jp phan packages/premium-analytics` passes — deferred to CI (see note above; not runnable on host PHP 8.5)
- [x] `jp changelog add packages/premium-analytics` entry included
- [x] PR is <500 LoC of production code, excluding tests (~293 LoC controller)
- [x] Proxy route responds with a cached payload on a Jetpack-connected dev site



To verify locally:

* Activate the `premium-analytics` plugin on a Jetpack-connected site (requires Gutenberg active).
* Confirm the route is registered: `wp eval 'do_action("rest_api_init"); print_r(array_filter(array_keys(rest_get_server()->get_routes()), fn($r)=>str_contains($r,"premium-analytics/v1/proxy")));'`
* As a non-admin / unauthenticated, `GET /wp-json/jetpack-premium-analytics/v1/proxy/reports/totals` → `401`/`403`.
* As an admin on a connected site, the request is forwarded to `/sites/<blog_id>/analytics/reports/totals` and the upstream status + body are returned.
* Seed a transient for a request signature, repeat the request, and confirm the cached payload is returned without an outbound WPCOM call.
