### PR TITLE
Backport boost 4.6.0 changes

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.6.0-beta] - 2026-06-08
+## [4.6.0] - 2026-06-09
 ### Added
 - Concatenate JS: Add a `jetpack_boost_js_minify_fallback` action that fires when JS minification is skipped in favor of the original bundle, so logging plugins can observe how often (and why) the safety net engages. [#49399]
 - Register Jetpack Boost abilities via the WordPress Abilities API (modules read/toggle, latest speed score, and page cache flush) for AI agents on WordPress 6.9+. [#48328]
@@ -956,7 +956,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
-[4.6.0-beta]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.9...4.6.0-beta
+[4.6.0]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.9...4.6.0
 [4.5.9]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.8-beta...4.5.9
 [4.5.8-beta]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.7...4.5.8-beta
 [4.5.7]: https://github.com/Automattic/jetpack-boost-production/compare/4.5.6...4.5.7

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "4.6.0-beta",
+	"version": "4.6.0",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -77,7 +77,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_6_0_beta",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_6_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50acc9fcb431e33bb8923496654d08a4",
+    "content-hash": "a6aa2dc6fafd1c01a4d73609e5e800a3",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 4.6.0-beta
+ * Version: 4.6.0
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die( 0 );
 }
 
-define( 'JETPACK_BOOST_VERSION', '4.6.0-beta' );
+define( 'JETPACK_BOOST_VERSION', '4.6.0' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 7.2
-Stable tag: 4.6.0-beta
+Stable tag: 4.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -185,7 +185,7 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 4. Historical performance tracking with the upgraded plan.
 
 == Changelog ==
-### 4.6.0-beta - 2026-06-08
+### 4.6.0 - 2026-06-09
 #### Added
 - Concatenate JS: Add a `jetpack_boost_js_minify_fallback` action that fires when JS minification is skipped in favor of the original bundle, so logging plugins can observe how often (and why) the safety net engages.
 - Register Jetpack Boost abilities via the WordPress Abilities API (modules read/toggle, latest speed score, and page cache flush) for AI agents on WordPress 6.9+.


### PR DESCRIPTION
## Proposed changes

Backports the Boost 4.6.0 stable release changes from `boost/branch-4.6.0` to trunk:

* `CHANGELOG.md`: roll the `4.6.0-beta` entry to `4.6.0` (dated 2026-06-09) and update the compare link.
* `jetpack-boost.php`: bump `Version` and `JETPACK_BOOST_VERSION` to `4.6.0`.
* `composer.json`: bump the `version` field and `autoloader-suffix` to `4.6.0` (dependency pinning intentionally excluded), with the regenerated `content-hash` in `composer.lock` — matching the shape of the 4.5.9 backport (#48065).
* `readme.txt`: bump `Stable tag` and the changelog section heading to `4.6.0`. (Also restores the `-` between version and date in the heading, which was dropped on the release branch — 4.5.9 and earlier use `### x.y.z - date`.)

Notes for reviewers:

* The change files currently in `projects/plugins/boost/changelog/` (`force-a-release`, `prerelease`, `renovate-*`) were added to trunk **after** the 4.6.0 branch cut and belong to the next release, so they are intentionally untouched.
* The release branch's pinned `composer.json`/`composer.lock`/`package.json` versions are intentionally **not** backported.
* Context: 4.6.0 was fully cut and published to WordPress.org SVN and the mirror repo, but the stable tag was never flipped (live version is still 4.5.9) because a fatal was found in the my-jetpack package (`Automattic\Jetpack\Search\Plan` class not found). The fix will land on trunk separately and 4.6.1 will be cut from trunk; this PR brings trunk's changelog/version history in line with the published 4.6.0 first so the 4.6.1 release generates a clean changelog.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify the diff matches the release commits on `boost/branch-4.6.0` (changelog roll, version bump, readme stable tag) with no change-file deletions and no dependency pinning.
* Confirm trunk's `projects/plugins/boost/CHANGELOG.md` top entry reads `## [4.6.0] - 2026-06-09` after merge.
