### PR TITLE
Cookie Consent: scaffold package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2369,6 +2369,49 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.105.2)
 
+  projects/packages/cookie-consent:
+    dependencies:
+      '@wordpress/interactivity':
+        specifier: 6.48.0
+        version: 6.48.0
+    devDependencies:
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../../js-packages/webpack-config
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
+      '@wordpress/base-styles':
+        specifier: 9.1.0
+        version: 9.1.0
+      '@wordpress/browserslist-config':
+        specifier: 6.48.0
+        version: 6.48.0
+      autoprefixer:
+        specifier: 10.4.20
+        version: 10.4.20(postcss@8.5.14)
+      postcss:
+        specifier: 8.5.14
+        version: 8.5.14
+      postcss-loader:
+        specifier: 8.2.0
+        version: 8.2.0(postcss@8.5.14)(typescript@5.9.3)(webpack@5.105.2)
+      sass-embedded:
+        specifier: 1.97.3
+        version: 1.97.3
+      sass-loader:
+        specifier: 16.0.5
+        version: 16.0.5(sass-embedded@1.97.3)(webpack@5.105.2)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      webpack:
+        specifier: 5.105.2
+        version: 5.105.2(webpack-cli@6.0.1)
+      webpack-cli:
+        specifier: 6.0.1
+        version: 6.0.1(webpack@5.105.2)
+
   projects/packages/explat:
     dependencies:
       '@automattic/explat-client':

--- a/projects/packages/cookie-consent/.gitattributes
+++ b/projects/packages/cookie-consent/.gitattributes
@@ -1,0 +1,9 @@
+# Files to include in the mirror repo, but excluded via gitignore.
+# Remember to end all directories with `/**` to properly tag every file.
+/build/**            production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+src/modules/**       production-exclude
+tools/**             production-exclude
+declarations.d.ts    production-exclude

--- a/projects/packages/cookie-consent/.gitignore
+++ b/projects/packages/cookie-consent/.gitignore
@@ -1,0 +1,6 @@
+vendor/
+node_modules/
+build/
+.cache/
+composer.lock
+.phpunit.cache/

--- a/projects/packages/cookie-consent/.phpcs.dir.xml
+++ b/projects/packages/cookie-consent/.phpcs.dir.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-cookie-consent" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-cookie-consent" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array">
+				<element value="ciab" />
+			</property>
+			<property name="new_text_domain" value="jetpack-cookie-consent" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/cookie-consent/CHANGELOG.md
+++ b/projects/packages/cookie-consent/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0-alpha - unreleased
+
+- Initial version.

--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -1,10 +1,10 @@
 # Cookie Consent
 
-Cookie Consent (`@automattic/jetpack-cookie-consent`) provides a GDPR cookie-consent banner, a CCPA "Do Not Sell/Share" opt-out flow, geolocation-based consent-model selection, WP Consent API integration, and consent logging. It is plugin-agnostic — consumable by Jetpack, Woo Pro, or a standalone plugin — and has no WooCommerce dependency.
+Cookie Consent (`@automattic/jetpack-cookie-consent`) is a plugin-agnostic package intended to provide a GDPR cookie-consent banner, a CCPA "Do Not Sell/Share" opt-out flow, geolocation-based consent-model selection, WP Consent API integration, and consent logging.
+
+This package is currently scaffold-only (no runtime behavior yet) and includes a placeholder Interactivity module entry point so the build passes; feature code is introduced in follow-up PRs.
 
 ## Usage
-
-The package has no side effects on load. A consumer activates it by calling:
 
 `\Automattic\Jetpack\CookieConsent\Cookie_Consent::init();`
 

--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -1,0 +1,23 @@
+# Cookie Consent
+
+Cookie Consent (`@automattic/jetpack-cookie-consent`) provides a GDPR cookie-consent banner, a CCPA "Do Not Sell/Share" opt-out flow, geolocation-based consent-model selection, WP Consent API integration, and consent logging. It is plugin-agnostic — consumable by Jetpack, Woo Pro, or a standalone plugin — and has no WooCommerce dependency.
+
+## Usage
+
+The package has no side effects on load. A consumer activates it by calling:
+
+`\Automattic\Jetpack\CookieConsent\Cookie_Consent::init();`
+
+Build the frontend module before use:
+
+`pnpm --filter @automattic/jetpack-cookie-consent build`
+
+## Configuration
+
+Filter `jetpack_cookie_consent_config` to override defaults (geo API URL, GDPR/CCPA region lists, cookie policy URL, and the Tracks `event_prefix`). The Tracks event prefix defaults to `jetpack`; set it to `woocommerceanalytics` to keep continuity with the WooCommerce/Unified Analytics Tracks stream.
+
+## Requirements
+
+- PHP >= 7.2
+- The WordPress Interactivity API (WP 6.5+ / Gutenberg).
+- The WP Consent API plugin (provides `window.wp_set_consent`) for writing consent state.

--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-package
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-package
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Initial version: cookie-consent package (GDPR banner, CCPA opt-out, consent logging) migrated from CIAB shoppers-privacy.
+Initial version: scaffold the cookie-consent package.

--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-package
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Initial version: cookie-consent package (GDPR banner, CCPA opt-out, consent logging) migrated from CIAB shoppers-privacy.

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -32,11 +32,7 @@
 	"prefer-stable": true,
 	"extra": {
 		"autotagger": true,
-		"mirror-repo": "Automattic/jetpack-cookie-consent",
 		"textdomain": "jetpack-cookie-consent",
-		"version-constants": {
-			"::PACKAGE_VERSION": "src/class-cookie-consent.php"
-		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"
 		},

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -31,7 +31,6 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
-		"autotagger": true,
 		"textdomain": "jetpack-cookie-consent",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -1,0 +1,47 @@
+{
+	"name": "automattic/jetpack-cookie-consent",
+	"description": "GDPR cookie-consent banner, CCPA opt-out, and consent logging for WordPress.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"pnpm run build-production"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-cookie-consent",
+		"textdomain": "jetpack-cookie-consent",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-cookie-consent.php"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"
+		},
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		}
+	}
+}

--- a/projects/packages/cookie-consent/declarations.d.ts
+++ b/projects/packages/cookie-consent/declarations.d.ts
@@ -1,0 +1,2 @@
+declare module '*.scss';
+declare module '*.css';

--- a/projects/packages/cookie-consent/eslint.config.mjs
+++ b/projects/packages/cookie-consent/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { makeBaseConfig, defineConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
+
+export default defineConfig( makeBaseConfig( import.meta.url ) );

--- a/projects/packages/cookie-consent/package.json
+++ b/projects/packages/cookie-consent/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@automattic/jetpack-cookie-consent",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"description": "GDPR cookie-consent banner, CCPA opt-out, and consent logging for WordPress.",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/cookie-consent/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Cookie Consent"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/cookie-consent"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"type": "module",
+	"scripts": {
+		"build": "pnpm run clean && pnpm run module:build",
+		"build-production": "NODE_ENV=production pnpm run build",
+		"clean": "rm -rf build/",
+		"module:build": "webpack --config ./tools/webpack.config.modules.js",
+		"module:watch": "webpack --watch --config ./tools/webpack.config.modules.js",
+		"typecheck": "tsgo --noEmit",
+		"watch": "pnpm run module:watch"
+	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
+	"dependencies": {
+		"@wordpress/interactivity": "6.48.0"
+	},
+	"devDependencies": {
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
+		"@wordpress/base-styles": "9.1.0",
+		"@wordpress/browserslist-config": "6.48.0",
+		"autoprefixer": "10.4.20",
+		"postcss": "8.5.14",
+		"postcss-loader": "8.2.0",
+		"sass-embedded": "1.97.3",
+		"sass-loader": "16.0.5",
+		"typescript": "5.9.3",
+		"webpack": "5.105.2",
+		"webpack-cli": "6.0.1"
+	}
+}

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/index.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/index.ts
@@ -1,0 +1,2 @@
+// Placeholder entry — replaced in PR2 with the real module port.
+export {};

--- a/projects/packages/cookie-consent/tools/webpack.config.modules.js
+++ b/projects/packages/cookie-consent/tools/webpack.config.modules.js
@@ -25,7 +25,6 @@ export default {
 	optimization: { ...jetpackWebpackConfig.optimization },
 	resolve: {
 		...jetpackWebpackConfig.resolve,
-		modules: [ 'node_modules' ],
 	},
 	externals: {
 		...jetpackWebpackConfig.externals,

--- a/projects/packages/cookie-consent/tools/webpack.config.modules.js
+++ b/projects/packages/cookie-consent/tools/webpack.config.modules.js
@@ -1,0 +1,60 @@
+/**
+ * Webpack configuration for building the cookie-consent Interactivity script module.
+ */
+import path from 'path';
+import jetpackWebpackConfig from '@automattic/jetpack-webpack-config/webpack';
+import autoprefixer from 'autoprefixer';
+
+const __dirname = import.meta.dirname;
+
+export default {
+	mode: jetpackWebpackConfig.mode,
+	devtool: jetpackWebpackConfig.devtool,
+	entry: {
+		'cookie-consent/index': path.join( __dirname, '../src/modules/cookie-consent/index.ts' ),
+	},
+	output: {
+		...jetpackWebpackConfig.output,
+		path: path.join( __dirname, '../build/modules' ),
+		module: true,
+		chunkFormat: 'module',
+		environment: { module: true },
+		library: { type: 'module' },
+	},
+	experiments: { outputModule: true },
+	optimization: { ...jetpackWebpackConfig.optimization },
+	resolve: {
+		...jetpackWebpackConfig.resolve,
+		modules: [ 'node_modules' ],
+	},
+	externals: {
+		...jetpackWebpackConfig.externals,
+	},
+	module: {
+		strictExportPresence: true,
+		rules: [
+			jetpackWebpackConfig.TranspileRule( { exclude: /node_modules\// } ),
+			jetpackWebpackConfig.CssRule( {
+				extensions: [ 'css', 'sass', 'scss' ],
+				extraLoaders: [
+					{
+						loader: 'postcss-loader',
+						options: { postcssOptions: { plugins: [ autoprefixer ] } },
+					},
+					{
+						loader: 'sass-loader',
+						options: { api: 'modern-compiler', sassOptions: { style: 'expanded' } },
+					},
+				],
+			} ),
+		],
+	},
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins( {
+			DependencyExtractionPlugin: true,
+			I18nLoaderPlugin: false,
+			I18nCheckPlugin: false,
+		} ),
+	],
+	watchOptions: { ...jetpackWebpackConfig.watchOptions },
+};

--- a/projects/packages/cookie-consent/tsconfig.json
+++ b/projects/packages/cookie-consent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"include": [ "src/modules", "declarations.d.ts" ]
+}


### PR DESCRIPTION

Part of **WOOA7S-1533**. Migrating the CIAB `shoppers-privacy` feature out of `next-admin`/`ciab-next` into a new standalone, plugin-agnostic Jetpack monorepo package, following the Premium Analytics extraction philosophy (portable, no CIAB deps, consumable by Jetpack / Woo Pro / standalone). This is **PR 1 of 3** — the package scaffold only.

## Proposed changes

Adds the `projects/packages/cookie-consent/` scaffold. No feature code yet, no consumer wires it up, so nothing is live until later PRs + a consumer calls `Cookie_Consent::init()`.

**Stack:**

1. **PR1 — scaffold** ← _this PR_ (targets `trunk`)
2. PR2 — frontend Interactivity module (#49510, targets PR1)
3. PR3 — PHP backend + module enqueue (#49511, targets PR2)

| File                                                                           | What to review                                                                                                                                                                                                                                                                                                                                       |
| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `composer.json`                                                                | `jetpack-library`; runtime `require` is **php >=7.2 only** (no jetpack-package deps, for portability); `extra` = textdomain, changelogger, branch-alias. `mirror-repo`/`version-constants`/`autotagger` are intentionally deferred until the public mirror repo exists (autotagger is a no-op without `mirror-repo`); they'll be added together then |
| `package.json`                                                                 | `private`; webpack-module build scripts; dep `@wordpress/interactivity`; build/lint devDeps only                                                                                                                                                                                                                                                     |
| `tools/webpack.config.modules.js`                                              | single explicit entry → `build/modules/cookie-consent/index.js`, ESM script-module output                                                                                                                                                                                                                                                            |
| `tsconfig.json` / `declarations.d.ts` / `eslint.config.mjs` / `.phpcs.dir.xml` | standard package config; text domain `jetpack-cookie-consent`                                                                                                                                                                                                                                                                                        |
| `.gitattributes` / `.gitignore`                                                | ship built JS + PHP in mirror, exclude TS source/tooling                                                                                                                                                                                                                                                                                             |
| `README.md` / `CHANGELOG.md` / `changelog/`                                    | package docs + initial changelog entry                                                                                                                                                                                                                                                                                                               |

A placeholder `src/modules/cookie-consent/index.ts` lets the build pass; it's replaced in PR2.

## Related product discussion/links

- Linear: **WOOA7S-1533**

## Does this pull request change what data or activity we track or use?

No. This PR is scaffold/config only — there is no runtime code and nothing is tracked.

## Testing instructions

- Check out the branch and run `pnpm --filter @automattic/jetpack-cookie-consent build` — the placeholder module builds to `build/modules/cookie-consent/index.js`.
- Run `jetpack test typecheck -v packages/cookie-consent` — clean. (eslint/stylelint run at the monorepo root, not as per-package scripts.)
- No runtime/site behavior to test; the package has no consumer yet.
