### PR TITLE
Cookie Consent: PHP backend + module enqueue

### DIFF
--- a/projects/packages/cookie-consent/.phan/config.php
+++ b/projects/packages/cookie-consent/.phan/config.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'exclude_file_regex' => array(
+			'build/',
+		),
+	)
+);

--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-php
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-php
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the cookie-consent PHP backend: banner/CCPA controls, Interactivity module enqueue, and consent log REST controller.

--- a/projects/packages/cookie-consent/src/ccpa-content.php
+++ b/projects/packages/cookie-consent/src/ccpa-content.php
@@ -2,7 +2,7 @@
 /**
  * CCPA Opt-Out Page Content Template
  *
- * @package ciab-next
+ * @package automattic/jetpack-cookie-consent
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,39 +11,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'We value your privacy and want you to feel in control of your personal information. Like most websites, we use cookies and similar tools to improve your shopping experience and show you relevant ads. Sometimes we share this information with trusted partners to do so.', 'ciab' ); ?></p>
+<p><?php echo esc_html__( 'We value your privacy and want you to feel in control of your personal information. Like most websites, we use cookies and similar tools to improve your shopping experience and show you relevant ads. Sometimes we share this information with trusted partners to do so.', 'jetpack-cookie-consent' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Some U.S. state laws consider this kind of data sharing a sale or sharing of personal information. Depending on where you live, you may have the right to opt out.', 'ciab' ); ?></p>
+<p><?php echo esc_html__( 'Some U.S. state laws consider this kind of data sharing a sale or sharing of personal information. Depending on where you live, you may have the right to opt out.', 'jetpack-cookie-consent' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading"><?php echo esc_html__( 'How to Opt Out', 'ciab' ); ?></h2>
+<h2 class="wp-block-heading"><?php echo esc_html__( 'How to Opt Out', 'jetpack-cookie-consent' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:list -->
 <ul class="wp-block-list">
-<li><?php echo esc_html__( 'Browser Opt-Out: Click the Opt Out button below to stop your browser from sharing this data.', 'ciab' ); ?></li>
-<li><?php echo esc_html__( 'Account Opt-Out: To apply this choice to your customer account, check the box and enter your email.', 'ciab' ); ?></li>
-<li><?php echo esc_html__( 'Automatic Opt-Out: If you use a browser with Global Privacy Control (GPC) turned on, we will recognize it and respect your choice automatically.', 'ciab' ); ?></li>
+<li><?php echo esc_html__( 'Browser Opt-Out: Click the Opt Out button below to stop your browser from sharing this data.', 'jetpack-cookie-consent' ); ?></li>
+<li><?php echo esc_html__( 'Account Opt-Out: To apply this choice to your customer account, check the box and enter your email.', 'jetpack-cookie-consent' ); ?></li>
+<li><?php echo esc_html__( 'Automatic Opt-Out: If you use a browser with Global Privacy Control (GPC) turned on, we will recognize it and respect your choice automatically.', 'jetpack-cookie-consent' ); ?></li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Your preferences will only affect how we use your information for personalized ads and similar activities. It will not affect how we use your information for other purposes, like security or site functionality.', 'ciab' ); ?></p>
+<p><?php echo esc_html__( 'Your preferences will only affect how we use your information for personalized ads and similar activities. It will not affect how we use your information for other purposes, like security or site functionality.', 'jetpack-cookie-consent' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Click the Opt Out button to stop this browser from sharing personal data.', 'ciab' ); ?></p>
+<p><?php echo esc_html__( 'Click the Opt Out button to stop this browser from sharing personal data.', 'jetpack-cookie-consent' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:group {"lock":{"move":false,"remove":true},"className":"wc-ccpa-opt-out-section"} -->
-<div class="wp-block-group wc-ccpa-opt-out-section">
+<!-- wp:group {"lock":{"move":false,"remove":true},"className":"jetpack-cookie-consent-ccpa-opt-out-section"} -->
+<div class="wp-block-group jetpack-cookie-consent-ccpa-opt-out-section">
 	<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
 	<div class="wp-block-buttons">
-		<!-- wp:button {"tagName":"button","lock":{"move":false,"remove":true},"className":"wc-ccpa-opt-out-button"} -->
-		<div class="wp-block-button wc-ccpa-opt-out-button"><button type="button" class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Opt Out', 'ciab' ); ?></button></div>
+		<!-- wp:button {"tagName":"button","lock":{"move":false,"remove":true},"className":"jetpack-cookie-consent-ccpa-opt-out-button"} -->
+		<div class="wp-block-button jetpack-cookie-consent-ccpa-opt-out-button"><button type="button" class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Opt Out', 'jetpack-cookie-consent' ); ?></button></div>
 		<!-- /wp:button -->
 	</div>
 	<!-- /wp:buttons -->

--- a/projects/packages/cookie-consent/src/ccpa-content.php
+++ b/projects/packages/cookie-consent/src/ccpa-content.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CCPA Opt-Out Page Content Template
+ *
+ * @package ciab-next
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html__( 'We value your privacy and want you to feel in control of your personal information. Like most websites, we use cookies and similar tools to improve your shopping experience and show you relevant ads. Sometimes we share this information with trusted partners to do so.', 'ciab' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html__( 'Some U.S. state laws consider this kind of data sharing a sale or sharing of personal information. Depending on where you live, you may have the right to opt out.', 'ciab' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading"><?php echo esc_html__( 'How to Opt Out', 'ciab' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<li><?php echo esc_html__( 'Browser Opt-Out: Click the Opt Out button below to stop your browser from sharing this data.', 'ciab' ); ?></li>
+<li><?php echo esc_html__( 'Account Opt-Out: To apply this choice to your customer account, check the box and enter your email.', 'ciab' ); ?></li>
+<li><?php echo esc_html__( 'Automatic Opt-Out: If you use a browser with Global Privacy Control (GPC) turned on, we will recognize it and respect your choice automatically.', 'ciab' ); ?></li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html__( 'Your preferences will only affect how we use your information for personalized ads and similar activities. It will not affect how we use your information for other purposes, like security or site functionality.', 'ciab' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html__( 'Click the Opt Out button to stop this browser from sharing personal data.', 'ciab' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group {"lock":{"move":false,"remove":true},"className":"wc-ccpa-opt-out-section"} -->
+<div class="wp-block-group wc-ccpa-opt-out-section">
+	<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
+	<div class="wp-block-buttons">
+		<!-- wp:button {"tagName":"button","lock":{"move":false,"remove":true},"className":"wc-ccpa-opt-out-button"} -->
+		<div class="wp-block-button wc-ccpa-opt-out-button"><button type="button" class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Opt Out', 'ciab' ); ?></button></div>
+		<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -167,6 +167,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_consent_log' ),
 					'permission_callback' => '__return_true', // Allow unauthenticated access.
@@ -209,6 +210,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_consent_logs' ),
 					'permission_callback' => array( $this, 'check_read_permission' ),

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -47,7 +47,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	private const TABLE_NAME = 'jetpack_consent_logs';
+	private const TABLE_NAME = 'jetpack_cookie_consent_logs';
 
 	/**
 	 * Database version.
@@ -82,7 +82,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	private const DB_VERSION_OPTION = 'jetpack_cookie_consent_log_db_version';
+	private const DB_VERSION_OPTION = 'jetpack_cookie_consent_consent_log_db_version';
 
 	/**
 	 * Initialize the controller: create the table, schedule cleanup,
@@ -260,7 +260,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 * @return bool
 	 */
 	public function check_read_permission() {
-		return current_user_can( 'manage_options' );
+		return current_user_can( 'manage_privacy_options' );
 	}
 
 	/**

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -1,0 +1,603 @@
+<?php
+/**
+ * Consent Log controller for CIAB Admin.
+ * Handles cookie consent logging for GDPR compliance.
+ *
+ * @package ciab-next
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Consent Log controller class.
+ */
+class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/next';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'consent-log';
+
+	/**
+	 * Database table name (without prefix).
+	 *
+	 * @var string
+	 */
+	private const TABLE_NAME = 'wc_consent_logs';
+
+	/**
+	 * Database version.
+	 *
+	 * @var string
+	 */
+	private const DB_VERSION = '0.0.1';
+
+	/**
+	 * Default retention period in days.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_RETENTION_DAYS = 30;
+
+	/**
+	 * Default consent types.
+	 *
+	 * @var array
+	 */
+	private const DEFAULT_CONSENT_TYPES = array( 'functional', 'analytics', 'marketing' );
+
+	/**
+	 * Cleanup cron hook name.
+	 *
+	 * @var string
+	 */
+	private const CLEANUP_HOOK = 'wc_next_cleanup_consent_logs';
+
+	/**
+	 * Cleanup cron group.
+	 *
+	 * @var string
+	 */
+	private const CLEANUP_GROUP = 'wc_next_consent_logs';
+
+	/**
+	 * Get the full table name with WordPress prefix.
+	 *
+	 * @return string
+	 */
+	private function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Create or upgrade the database table if needed.
+	 */
+	public function maybe_create_table() {
+		$installed_version = get_option( 'wc_next_consent_log_db_version', '0' );
+
+		if ( version_compare( $installed_version, self::DB_VERSION, '<' ) ) {
+			$this->create_table();
+			update_option( 'wc_next_consent_log_db_version', self::DB_VERSION );
+		}
+	}
+
+	/**
+	 * Create the consent logs database table.
+	 */
+	private function create_table() {
+		global $wpdb;
+		$table_name      = $this->get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			consent_id varchar(36) DEFAULT NULL,
+			event_type varchar(50) NOT NULL,
+			customer_id bigint(20) UNSIGNED NOT NULL DEFAULT 0,
+			ip_address varchar(45) DEFAULT NULL,
+			url text DEFAULT NULL,
+			consent_types longtext DEFAULT NULL,
+			date_created datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+			date_created_gmt datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+			PRIMARY KEY (id),
+			KEY consent_id (consent_id),
+			KEY customer_id (customer_id),
+			KEY event_type (event_type),
+			KEY date_created_gmt (date_created_gmt)
+		) {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		// Create consent log.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_consent_log' ),
+					'permission_callback' => '__return_true', // Allow unauthenticated access.
+					'args'                => array(
+						'consent_id'    => array(
+							'type'              => 'string',
+							'description'       => __( 'Optional unique consent identifier (UUID v4 format).', 'ciab' ),
+							'validate_callback' => array( $this, 'validate_uuid' ),
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'event_type'    => array(
+							'type'              => 'string',
+							'description'       => __( 'Type of consent event: accept_all, accept_selected, reject_all, auto_granted, or opt-out.', 'ciab' ),
+							'required'          => true,
+							'enum'              => array( 'accept_all', 'accept_selected', 'reject_all', 'auto_granted', 'opt-out' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'url'           => array(
+							'type'              => 'string',
+							'description'       => __( 'URL where consent was given.', 'ciab' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'esc_url_raw',
+						),
+						'consent_types' => array(
+							'type'              => 'object',
+							'description'       => __( 'Consent status for different cookie types (e.g., {"functional": true, "analytics": false, "marketing": true}).', 'ciab' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => array( $this, 'sanitize_consent_types' ),
+						),
+					),
+				),
+				'schema' => array( $this, 'get_create_consent_schema' ),
+			)
+		);
+
+		// Get consent logs (admin only).
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_consent_logs' ),
+					'permission_callback' => array( $this, 'check_read_permission' ),
+					'args'                => array(
+						'customer_id' => array(
+							'type'              => 'integer',
+							'description'       => __( 'Filter by WordPress user ID.', 'ciab' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'absint',
+						),
+						'before'      => array(
+							'type'              => 'string',
+							'format'            => 'date-time',
+							'description'       => __( 'Filter logs created before this date (ISO 8601 format).', 'ciab' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'after'       => array(
+							'type'              => 'string',
+							'format'            => 'date-time',
+							'description'       => __( 'Filter logs created after this date (ISO 8601 format).', 'ciab' ),
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'page'        => array(
+							'type'              => 'integer',
+							'description'       => __( 'Current page of the collection.', 'ciab' ),
+							'default'           => 1,
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'absint',
+						),
+						'per_page'    => array(
+							'type'              => 'integer',
+							'description'       => __( 'Maximum number of items to return (max 100).', 'ciab' ),
+							'default'           => 50,
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_consent_logs_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check read permission for consent logs.
+	 *
+	 * @return bool
+	 */
+	public function check_read_permission() {
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- manage_woocommerce is a WooCommerce capability.
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Validate UUID format.
+	 *
+	 * @param mixed           $value   The value to validate.
+	 * @param WP_REST_Request $request The request object.
+	 * @param string          $param   The parameter name.
+	 * @return bool|WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate_uuid( $value, $request, $param ) {
+		// Allow empty values since consent_id is optional.
+		if ( empty( $value ) ) {
+			return true;
+		}
+
+		// Use WordPress built-in UUID validation.
+		if ( ! wp_is_uuid( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf(
+					/* translators: %s: parameter name */
+					__( '%s must be a valid UUID format.', 'ciab' ),
+					$param
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitize consent types object.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 * @return array|null
+	 */
+	public function sanitize_consent_types( $value ) {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		/**
+		 * Filter the allowed consent types.
+		 *
+		 * @param array $allowed_types Array of allowed consent type keys.
+		 */
+		$allowed_types = apply_filters(
+			'ciab_next_allowed_consent_types',
+			self::DEFAULT_CONSENT_TYPES
+		);
+
+		$sanitized = array();
+		foreach ( $value as $key => $status ) {
+			$sanitized_key = sanitize_key( $key );
+			// Only allow types in the allowed list.
+			if ( in_array( $sanitized_key, $allowed_types, true ) ) {
+				$sanitized[ $sanitized_key ] = rest_sanitize_boolean( $status );
+			}
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Create a consent log entry.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_consent_log( WP_REST_Request $request ) {
+		global $wpdb;
+
+		// Generate UUID if consent_id is not provided.
+		$consent_id = $request->get_param( 'consent_id' );
+		if ( empty( $consent_id ) ) {
+			$consent_id = wp_generate_uuid4();
+		}
+
+		$current_time_gmt   = gmdate( 'Y-m-d H:i:s' );
+		$current_time_local = wp_date( 'Y-m-d H:i:s' );
+
+		// Get consent types and encode as JSON.
+		$consent_types = $request->get_param( 'consent_types' );
+		$consent_json  = ! empty( $consent_types ) ? wp_json_encode( $consent_types ) : null;
+
+		$data = array(
+			'consent_id'       => $consent_id,
+			'event_type'       => $request->get_param( 'event_type' ),
+			'customer_id'      => get_current_user_id(),
+			'ip_address'       => $this->get_client_ip(),
+			'url'              => $request->get_param( 'url' ),
+			'consent_types'    => $consent_json,
+			'date_created'     => $current_time_local,
+			'date_created_gmt' => $current_time_gmt,
+		);
+
+		$result = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$this->get_table_name(),
+			$data,
+			array( '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( false === $result ) {
+			return new WP_Error(
+				'database_error',
+				__( 'Failed to create consent log.', 'ciab' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( array( 'consent_id' => $consent_id ) );
+	}
+
+	/**
+	 * Get consent logs with filtering and pagination.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_consent_logs( WP_REST_Request $request ) {
+		global $wpdb;
+		$table_name = $this->get_table_name();
+
+		// Build WHERE clause.
+		$where  = array( '1=1' );
+		$values = array();
+
+		if ( $request->get_param( 'customer_id' ) ) {
+			$where[]  = 'customer_id = %d';
+			$values[] = $request->get_param( 'customer_id' );
+		}
+
+		if ( $request->get_param( 'after' ) ) {
+			$where[]  = 'date_created_gmt >= %s';
+			$values[] = gmdate( 'Y-m-d H:i:s', strtotime( $request->get_param( 'after' ) ) );
+		}
+
+		if ( $request->get_param( 'before' ) ) {
+			$where[]  = 'date_created_gmt <= %s';
+			$values[] = gmdate( 'Y-m-d H:i:s', strtotime( $request->get_param( 'before' ) ) );
+		}
+
+		// Pagination.
+		$page     = $request->get_param( 'page' );
+		$per_page = min( $request->get_param( 'per_page' ), 100 ); // Max 100 per page.
+		$offset   = ( $page - 1 ) * $per_page;
+
+		// Count total.
+		$where_clause = implode( ' AND ', $where );
+		$count_query  = "SELECT COUNT(*) FROM {$table_name} WHERE {$where_clause}";
+		if ( ! empty( $values ) ) {
+			$count_query = $wpdb->prepare( $count_query, ...$values ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		$total = (int) $wpdb->get_var( $count_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// Get records.
+		$query    = "SELECT * FROM {$table_name} WHERE {$where_clause} ORDER BY date_created_gmt DESC LIMIT %d OFFSET %d";
+		$values[] = $per_page;
+		$values[] = $offset;
+		$results  = $wpdb->get_results( $wpdb->prepare( $query, ...$values ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$response = rest_ensure_response( $results );
+		$response->header( 'X-WP-Total', (string) $total );
+		$response->header( 'X-WP-TotalPages', (string) ceil( $total / $per_page ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get client IP address from server variables.
+	 *
+	 * @return string|null
+	 */
+	private function get_client_ip() {
+		$ip_keys = array(
+			'HTTP_CF_CONNECTING_IP', // Cloudflare.
+			'HTTP_X_FORWARDED_FOR',  // Proxy.
+			'HTTP_X_REAL_IP',        // Nginx proxy.
+			'REMOTE_ADDR',           // Direct connection.
+		);
+
+		foreach ( $ip_keys as $key ) {
+			if ( ! empty( $_SERVER[ $key ] ) ) {
+				$ip = sanitize_text_field( wp_unslash( $_SERVER[ $key ] ) );
+				// Handle multiple IPs (X-Forwarded-For can contain multiple IPs).
+				if ( strpos( $ip, ',' ) !== false ) {
+					$ip = trim( explode( ',', $ip )[0] );
+				}
+				if ( filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+					return $ip;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the schema for the create consent endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_create_consent_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'create_consent_log',
+			'type'       => 'object',
+			'properties' => array(
+				'consent_id' => array(
+					'description' => __( 'The unique consent identifier.', 'ciab' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the schema for the get consent logs endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_consent_logs_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'consent_logs',
+			'type'    => 'array',
+			'items'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'               => array(
+						'description' => __( 'The consent log ID.', 'ciab' ),
+						'type'        => 'integer',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'consent_id'       => array(
+						'description' => __( 'The unique consent identifier.', 'ciab' ),
+						'type'        => 'string',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'event_type'       => array(
+						'description' => __( 'Type of consent event.', 'ciab' ),
+						'type'        => 'string',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'customer_id'      => array(
+						'description' => __( 'The WordPress user ID.', 'ciab' ),
+						'type'        => 'integer',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'ip_address'       => array(
+						'description' => __( 'The client IP address.', 'ciab' ),
+						'type'        => 'string',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'url'              => array(
+						'description' => __( 'URL where consent was given.', 'ciab' ),
+						'type'        => 'string',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'consent_types'    => array(
+						'description' => __( 'Consent status for different cookie types as JSON string.', 'ciab' ),
+						'type'        => 'string',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'date_created'     => array(
+						'description' => __( 'Date created in local time.', 'ciab' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+					'date_created_gmt' => array(
+						'description' => __( 'Date created in GMT.', 'ciab' ),
+						'type'        => 'string',
+						'format'      => 'date-time',
+						'context'     => array( 'view' ),
+						'readonly'    => true,
+					),
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Cleanup expired consent logs (older than retention period).
+	 * Deletes in batches to avoid performance issues with large datasets.
+	 */
+	public function cleanup_expired_logs() {
+		global $wpdb;
+
+		/**
+		 * Filters the retention period for consent logs.
+		 *
+		 * @param int $retention_days The retention period in days.
+		 */
+		$retention_days = filter_var( apply_filters( 'ciab_next_consent_log_retention_days', self::DEFAULT_RETENTION_DAYS ), FILTER_VALIDATE_INT );
+
+		if ( false === $retention_days || $retention_days <= 0 ) {
+			$retention_days = self::DEFAULT_RETENTION_DAYS;
+		}
+
+		// Calculate cutoff date in UTC.
+		$cutoff_timestamp = time() - ( $retention_days * DAY_IN_SECONDS );
+		$cutoff_date      = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
+
+		$table_name    = $this->get_table_name();
+		$batch_size    = 1000;
+		$total_deleted = 0;
+
+		// Delete in batches until all expired records are removed.
+		do {
+			$deleted = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					'DELETE FROM %i WHERE date_created_gmt < %s LIMIT %d',
+					$table_name,
+					$cutoff_date,
+					$batch_size
+				)
+			);
+
+			$total_deleted += $deleted;
+
+			// Avoid infinite loop in case of errors.
+			if ( false === $deleted ) {
+				break;
+			}
+		} while ( $deleted === $batch_size );
+	}
+
+	/**
+	 * Schedule daily cleanup action using Action Scheduler.
+	 */
+	public function schedule_cleanup() {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
+			return;
+		}
+
+		// Only schedule if not already scheduled.
+		if ( false === as_next_scheduled_action( self::CLEANUP_HOOK, array(), self::CLEANUP_GROUP ) ) {
+			as_schedule_recurring_action(
+				time(),
+				DAY_IN_SECONDS,
+				self::CLEANUP_HOOK,
+				array(),
+				self::CLEANUP_GROUP
+			);
+		}
+	}
+
+	/**
+	 * Unschedule cleanup action.
+	 * This method can be called on plugin deactivation.
+	 */
+	public function unschedule_cleanup() {
+		if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+			return;
+		}
+
+		as_unschedule_all_actions( self::CLEANUP_HOOK, array(), self::CLEANUP_GROUP );
+	}
+}

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -346,7 +346,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 
 		// Get consent types and encode as JSON.
 		$consent_types = $request->get_param( 'consent_types' );
-		$consent_json  = ! empty( $consent_types ) ? wp_json_encode( $consent_types ) : null;
+		$consent_json  = ! empty( $consent_types ) ? wp_json_encode( $consent_types, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : null;
 
 		$data = array(
 			'consent_id'       => $consent_id,
@@ -581,9 +581,8 @@ class Consent_Log_Controller extends WP_REST_Controller {
 		$cutoff_timestamp = time() - ( $retention_days * DAY_IN_SECONDS );
 		$cutoff_date      = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
 
-		$table_name    = $this->get_table_name();
-		$batch_size    = 1000;
-		$total_deleted = 0;
+		$table_name = $this->get_table_name();
+		$batch_size = 1000;
 
 		// Delete in batches until all expired records are removed.
 		do {
@@ -595,8 +594,6 @@ class Consent_Log_Controller extends WP_REST_Controller {
 					$batch_size
 				)
 			);
-
-			$total_deleted += $deleted;
 
 			// Avoid infinite loop in case of errors.
 			if ( false === $deleted ) {

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -1,24 +1,39 @@
 <?php
 /**
- * Consent Log controller for CIAB Admin.
+ * Consent Log REST controller.
  * Handles cookie consent logging for GDPR compliance.
  *
- * @package ciab-next
+ * @package automattic/jetpack-cookie-consent
  */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * REST API Consent Log controller class.
  */
-class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
+class Consent_Log_Controller extends WP_REST_Controller {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Consent_Log_Controller
+	 */
+	private static $instance = null;
 
 	/**
 	 * Endpoint namespace.
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/next';
+	protected $namespace = 'jetpack/v4/cookie-consent';
 
 	/**
 	 * Route base.
@@ -32,7 +47,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	private const TABLE_NAME = 'wc_consent_logs';
+	private const TABLE_NAME = 'jetpack_consent_logs';
 
 	/**
 	 * Database version.
@@ -60,14 +75,36 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 	 *
 	 * @var string
 	 */
-	private const CLEANUP_HOOK = 'wc_next_cleanup_consent_logs';
+	private const CLEANUP_HOOK = 'jetpack_cookie_consent_cleanup_consent_logs';
 
 	/**
-	 * Cleanup cron group.
+	 * Database version option name.
 	 *
 	 * @var string
 	 */
-	private const CLEANUP_GROUP = 'wc_next_consent_logs';
+	private const DB_VERSION_OPTION = 'jetpack_cookie_consent_log_db_version';
+
+	/**
+	 * Initialize the controller: create the table, schedule cleanup,
+	 * register REST routes, and wire the cleanup cron callback.
+	 *
+	 * @return Consent_Log_Controller
+	 */
+	public static function init() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		$instance = self::$instance;
+
+		$instance->maybe_create_table();
+		$instance->schedule_cleanup();
+
+		add_action( 'rest_api_init', array( $instance, 'register_routes' ) );
+		add_action( self::CLEANUP_HOOK, array( $instance, 'cleanup_expired_logs' ) );
+
+		return $instance;
+	}
 
 	/**
 	 * Get the full table name with WordPress prefix.
@@ -83,11 +120,11 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 	 * Create or upgrade the database table if needed.
 	 */
 	public function maybe_create_table() {
-		$installed_version = get_option( 'wc_next_consent_log_db_version', '0' );
+		$installed_version = get_option( self::DB_VERSION_OPTION, '0' );
 
 		if ( version_compare( $installed_version, self::DB_VERSION, '<' ) ) {
 			$this->create_table();
-			update_option( 'wc_next_consent_log_db_version', self::DB_VERSION );
+			update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 		}
 	}
 
@@ -136,13 +173,13 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 					'args'                => array(
 						'consent_id'    => array(
 							'type'              => 'string',
-							'description'       => __( 'Optional unique consent identifier (UUID v4 format).', 'ciab' ),
+							'description'       => __( 'Optional unique consent identifier (UUID v4 format).', 'jetpack-cookie-consent' ),
 							'validate_callback' => array( $this, 'validate_uuid' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'event_type'    => array(
 							'type'              => 'string',
-							'description'       => __( 'Type of consent event: accept_all, accept_selected, reject_all, auto_granted, or opt-out.', 'ciab' ),
+							'description'       => __( 'Type of consent event: accept_all, accept_selected, reject_all, auto_granted, or opt-out.', 'jetpack-cookie-consent' ),
 							'required'          => true,
 							'enum'              => array( 'accept_all', 'accept_selected', 'reject_all', 'auto_granted', 'opt-out' ),
 							'validate_callback' => 'rest_validate_request_arg',
@@ -150,13 +187,13 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 						),
 						'url'           => array(
 							'type'              => 'string',
-							'description'       => __( 'URL where consent was given.', 'ciab' ),
+							'description'       => __( 'URL where consent was given.', 'jetpack-cookie-consent' ),
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'esc_url_raw',
 						),
 						'consent_types' => array(
 							'type'              => 'object',
-							'description'       => __( 'Consent status for different cookie types (e.g., {"functional": true, "analytics": false, "marketing": true}).', 'ciab' ),
+							'description'       => __( 'Consent status for different cookie types (e.g., {"functional": true, "analytics": false, "marketing": true}).', 'jetpack-cookie-consent' ),
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => array( $this, 'sanitize_consent_types' ),
 						),
@@ -178,34 +215,34 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 					'args'                => array(
 						'customer_id' => array(
 							'type'              => 'integer',
-							'description'       => __( 'Filter by WordPress user ID.', 'ciab' ),
+							'description'       => __( 'Filter by WordPress user ID.', 'jetpack-cookie-consent' ),
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 						'before'      => array(
 							'type'              => 'string',
 							'format'            => 'date-time',
-							'description'       => __( 'Filter logs created before this date (ISO 8601 format).', 'ciab' ),
+							'description'       => __( 'Filter logs created before this date (ISO 8601 format).', 'jetpack-cookie-consent' ),
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'after'       => array(
 							'type'              => 'string',
 							'format'            => 'date-time',
-							'description'       => __( 'Filter logs created after this date (ISO 8601 format).', 'ciab' ),
+							'description'       => __( 'Filter logs created after this date (ISO 8601 format).', 'jetpack-cookie-consent' ),
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'page'        => array(
 							'type'              => 'integer',
-							'description'       => __( 'Current page of the collection.', 'ciab' ),
+							'description'       => __( 'Current page of the collection.', 'jetpack-cookie-consent' ),
 							'default'           => 1,
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 						'per_page'    => array(
 							'type'              => 'integer',
-							'description'       => __( 'Maximum number of items to return (max 100).', 'ciab' ),
+							'description'       => __( 'Maximum number of items to return (max 100).', 'jetpack-cookie-consent' ),
 							'default'           => 50,
 							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
@@ -223,8 +260,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 	 * @return bool
 	 */
 	public function check_read_permission() {
-		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- manage_woocommerce is a WooCommerce capability.
-		return current_user_can( 'manage_woocommerce' );
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -247,7 +283,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 				'rest_invalid_param',
 				sprintf(
 					/* translators: %s: parameter name */
-					__( '%s must be a valid UUID format.', 'ciab' ),
+					__( '%s must be a valid UUID format.', 'jetpack-cookie-consent' ),
 					$param
 				),
 				array( 'status' => 400 )
@@ -274,7 +310,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 		 * @param array $allowed_types Array of allowed consent type keys.
 		 */
 		$allowed_types = apply_filters(
-			'ciab_next_allowed_consent_types',
+			'jetpack_cookie_consent_allowed_consent_types',
 			self::DEFAULT_CONSENT_TYPES
 		);
 
@@ -332,7 +368,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 		if ( false === $result ) {
 			return new WP_Error(
 				'database_error',
-				__( 'Failed to create consent log.', 'ciab' ),
+				__( 'Failed to create consent log.', 'jetpack-cookie-consent' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -436,7 +472,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'consent_id' => array(
-					'description' => __( 'The unique consent identifier.', 'ciab' ),
+					'description' => __( 'The unique consent identifier.', 'jetpack-cookie-consent' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
@@ -461,56 +497,56 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 				'type'       => 'object',
 				'properties' => array(
 					'id'               => array(
-						'description' => __( 'The consent log ID.', 'ciab' ),
+						'description' => __( 'The consent log ID.', 'jetpack-cookie-consent' ),
 						'type'        => 'integer',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'consent_id'       => array(
-						'description' => __( 'The unique consent identifier.', 'ciab' ),
+						'description' => __( 'The unique consent identifier.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'event_type'       => array(
-						'description' => __( 'Type of consent event.', 'ciab' ),
+						'description' => __( 'Type of consent event.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'customer_id'      => array(
-						'description' => __( 'The WordPress user ID.', 'ciab' ),
+						'description' => __( 'The WordPress user ID.', 'jetpack-cookie-consent' ),
 						'type'        => 'integer',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'ip_address'       => array(
-						'description' => __( 'The client IP address.', 'ciab' ),
+						'description' => __( 'The client IP address.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'url'              => array(
-						'description' => __( 'URL where consent was given.', 'ciab' ),
+						'description' => __( 'URL where consent was given.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'consent_types'    => array(
-						'description' => __( 'Consent status for different cookie types as JSON string.', 'ciab' ),
+						'description' => __( 'Consent status for different cookie types as JSON string.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'date_created'     => array(
-						'description' => __( 'Date created in local time.', 'ciab' ),
+						'description' => __( 'Date created in local time.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'format'      => 'date-time',
 						'context'     => array( 'view' ),
 						'readonly'    => true,
 					),
 					'date_created_gmt' => array(
-						'description' => __( 'Date created in GMT.', 'ciab' ),
+						'description' => __( 'Date created in GMT.', 'jetpack-cookie-consent' ),
 						'type'        => 'string',
 						'format'      => 'date-time',
 						'context'     => array( 'view' ),
@@ -535,7 +571,7 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 		 *
 		 * @param int $retention_days The retention period in days.
 		 */
-		$retention_days = filter_var( apply_filters( 'ciab_next_consent_log_retention_days', self::DEFAULT_RETENTION_DAYS ), FILTER_VALIDATE_INT );
+		$retention_days = filter_var( apply_filters( 'jetpack_cookie_consent_log_retention_days', self::DEFAULT_RETENTION_DAYS ), FILTER_VALIDATE_INT );
 
 		if ( false === $retention_days || $retention_days <= 0 ) {
 			$retention_days = self::DEFAULT_RETENTION_DAYS;
@@ -570,34 +606,23 @@ class Next_Admin_Consent_Log_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Schedule daily cleanup action using Action Scheduler.
+	 * Schedule daily cleanup event using WP-Cron.
 	 */
 	public function schedule_cleanup() {
-		if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
-			return;
-		}
-
 		// Only schedule if not already scheduled.
-		if ( false === as_next_scheduled_action( self::CLEANUP_HOOK, array(), self::CLEANUP_GROUP ) ) {
-			as_schedule_recurring_action(
-				time(),
-				DAY_IN_SECONDS,
-				self::CLEANUP_HOOK,
-				array(),
-				self::CLEANUP_GROUP
-			);
+		if ( ! wp_next_scheduled( self::CLEANUP_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CLEANUP_HOOK );
 		}
 	}
 
 	/**
-	 * Unschedule cleanup action.
+	 * Unschedule cleanup event.
 	 * This method can be called on plugin deactivation.
 	 */
 	public function unschedule_cleanup() {
-		if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
-			return;
+		$timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CLEANUP_HOOK );
 		}
-
-		as_unschedule_all_actions( self::CLEANUP_HOOK, array(), self::CLEANUP_GROUP );
 	}
 }

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -407,9 +407,10 @@ class Consent_Log_Controller extends WP_REST_Controller {
 			$values[] = gmdate( 'Y-m-d H:i:s', strtotime( $request->get_param( 'before' ) ) );
 		}
 
-		// Pagination.
-		$page     = $request->get_param( 'page' );
-		$per_page = min( $request->get_param( 'per_page' ), 100 ); // Max 100 per page.
+		// Pagination. Clamp to safe lower bounds so per_page=0 can't divide by zero
+		// and page=0 can't produce a negative OFFSET.
+		$page     = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page = max( 1, min( (int) $request->get_param( 'per_page' ), 100 ) ); // 1-100 per page.
 		$offset   = ( $page - 1 ) * $per_page;
 
 		// Count total.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -167,10 +167,9 @@ class Cookie_Consent {
 	 * Exclude CCPA page from get_pages() results
 	 *
 	 * @param WP_Post[] $pages Array of page objects.
-	 * @param array     $args  Array of get_pages() arguments.
 	 * @return WP_Post[] Filtered array of page objects.
 	 */
-	public static function exclude_ccpa_from_get_pages( $pages, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public static function exclude_ccpa_from_get_pages( $pages ) {
 		if ( is_admin() ) {
 			// In admin, include the CCPA page in the results.
 			return $pages;
@@ -284,20 +283,17 @@ class Cookie_Consent {
 	/**
 	 * Set attributes for hooked footer navigation links (Privacy Policy and CCPA)
 	 *
-	 * @param array|null $hooked_block      The hooked block, or null to suppress.
-	 * @param string     $hooked_block_type The hooked block type name.
-	 * @param string     $relative_position The relative position of the hooked block.
-	 * @param array      $anchor_block      The anchor block.
+	 * @param array|null $hooked_block The hooked block, or null to suppress.
 	 * @return array|null Modified hooked block.
 	 */
-	public static function set_footer_navigation_link_attributes( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public static function set_footer_navigation_link_attributes( $hooked_block ) {
 		// Track which blocks we've processed.
 		static $privacy_policy_processed     = false;
 		static $ccpa_processed               = false;
 		static $manage_preferences_processed = false;
 
 		// Has the hooked block been suppressed by a previous filter?
-		if ( is_null( $hooked_block ) ) {
+		if ( null === $hooked_block ) {
 			return $hooked_block;
 		}
 
@@ -591,13 +587,13 @@ class Cookie_Consent {
 		);
 
 		// Register and enqueue the Interactivity API script module built by webpack.
-		$asset_file   = __DIR__ . '/../build/modules/cookie-consent/index.asset.php';
-		$asset        = file_exists( $asset_file ) ? require $asset_file : array(
+		$asset_file = __DIR__ . '/../build/modules/cookie-consent/index.asset.php';
+		$asset      = file_exists( $asset_file ) ? require $asset_file : array(
 			'dependencies' => array( '@wordpress/interactivity' ),
 			'version'      => self::PACKAGE_VERSION,
 		);
-		$module_url   = plugins_url( 'build/modules/cookie-consent/index.js', __DIR__ );
-		$module_id    = '@automattic/jetpack-cookie-consent';
+		$module_url = plugins_url( 'build/modules/cookie-consent/index.js', __DIR__ );
+		$module_id  = '@automattic/jetpack-cookie-consent';
 
 		wp_register_script_module(
 			$module_id,
@@ -627,7 +623,8 @@ class Cookie_Consent {
 					array(
 						'apiUrl'      => rest_url( 'jetpack/v4/cookie-consent/consent-log' ),
 						'eventPrefix' => $config['event_prefix'],
-					)
+					),
+					JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 				)
 			),
 			array( 'id' => 'jetpack-cookie-consent-config' )
@@ -674,17 +671,13 @@ class Cookie_Consent {
 			return;
 		}
 
-		// Check for preview query parameter.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$force_preview = isset( $_GET['preview_cookie_consent'] ) && '1' === $_GET['preview_cookie_consent'];
-
 		// Always render the banner/modal HTML so the "Manage Privacy Preferences" footer link
 		// can reopen the modal after consent has been set. The banner visibility is controlled
 		// client-side via Interactivity API directives (showBanner starts as false).
 		$template_path = plugin_dir_path( __FILE__ ) . 'cookie-banner-content.php';
 		if ( file_exists( $template_path ) ) {
-			// Get config for template.
-			$config = self::get_config();
+			// Get config for template (consumed by cookie-banner-content.php via include scope).
+			$config = self::get_config(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			ob_start();
 			include $template_path;
 			$html = ob_get_clean();

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -28,69 +28,61 @@ class Cookie_Consent {
 	const PACKAGE_VERSION = '0.1.0-alpha';
 
 	/**
-	 * Instance of this class
+	 * Whether the class has been initialized.
 	 *
-	 * @var Cookie_Consent
+	 * @var bool
 	 */
-	private static $instance = null;
+	private static $initialized = false;
 
 	/**
-	 * Get singleton instance
+	 * Initialize the package. Idempotent; safe to call multiple times.
 	 *
-	 * @return Cookie_Consent
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	/**
-	 * Initialize the package.
-	 *
-	 * Public entry point a consumer calls to activate cookie consent. Boots the
-	 * front-end controls (banner, CCPA flow, enqueue) and the consent log REST
-	 * controller (table creation, cron scheduling, route registration).
-	 *
-	 * @return Cookie_Consent
+	 * Public entry point a consumer calls to activate cookie consent. Registers
+	 * the front-end controls (banner, CCPA flow, enqueue) and boots the consent
+	 * log REST controller (table creation, cron scheduling, route registration).
 	 */
 	public static function init() {
-		$instance = self::get_instance();
-		Consent_Log_Controller::init();
-		return $instance;
-	}
+		if ( self::$initialized ) {
+			return;
+		}
+		self::$initialized = true;
 
-	/**
-	 * Constructor
-	 */
-	private function __construct() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
-		add_action( 'wp_footer', array( $this, 'render_banner' ), 999 );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+		add_action( 'wp_footer', array( __CLASS__, 'render_banner' ), 999 );
+
+		// Create the CCPA opt-out page once (guarded), now that the Atomic
+		// garden_site_provisioning hook is no longer available in this context.
+		add_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );
 
 		// Prevent CCPA and Privacy Policy page deletion.
-		add_filter( 'map_meta_cap', array( $this, 'prevent_privacy_pages_deletion' ), 10, 4 );
+		add_filter( 'map_meta_cap', array( __CLASS__, 'prevent_privacy_pages_deletion' ), 10, 4 );
 
 		// Hook Privacy Policy and CCPA links into navigation blocks using Block Hooks API.
-		add_filter( 'hooked_block_types', array( $this, 'register_footer_navigation_links' ), 10, 4 );
-		add_filter( 'hooked_block_core/navigation-link', array( $this, 'set_footer_navigation_link_attributes' ), 10, 4 );
-		add_filter( 'render_block_core/navigation-link', array( $this, 'add_ccpa_interactivity_directives' ), 10, 2 );
-		add_filter( 'render_block_core/navigation-link', array( $this, 'add_gdpr_manage_preferences_directives' ), 10, 2 );
+		add_filter( 'hooked_block_types', array( __CLASS__, 'register_footer_navigation_links' ), 10, 4 );
+		add_filter( 'hooked_block_core/navigation-link', array( __CLASS__, 'set_footer_navigation_link_attributes' ), 10, 4 );
+		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_ccpa_interactivity_directives' ), 10, 2 );
+		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_gdpr_manage_preferences_directives' ), 10, 2 );
 
 		// Add Interactivity API directive to CCPA opt-out button.
-		add_filter( 'render_block_core/button', array( $this, 'add_ccpa_button_directive' ), 10, 2 );
+		add_filter( 'render_block_core/button', array( __CLASS__, 'add_ccpa_button_directive' ), 10, 2 );
 
 		// Add Interactivity API directives to CCPA group block and inject snackbar.
-		add_filter( 'render_block_core/group', array( $this, 'add_ccpa_group_directives' ), 10, 2 );
+		add_filter( 'render_block_core/group', array( __CLASS__, 'add_ccpa_group_directives' ), 10, 2 );
 
 		// Exclude CCPA page from page-list block using get_pages filter.
-		add_filter( 'get_pages', array( $this, 'exclude_ccpa_from_get_pages' ), 10, 2 );
+		add_filter( 'get_pages', array( __CLASS__, 'exclude_ccpa_from_get_pages' ), 10, 2 );
+
+		// Register the CCPA page id setting for REST access.
+		add_action( 'rest_api_init', array( __CLASS__, 'register_ccpa_page_setting' ) );
+
+		// Consent log REST controller: table, cron cleanup, routes.
+		Consent_Log_Controller::init();
 	}
 
 	/**
 	 * Create CCPA opt-out page if it doesn't exist
 	 */
-	public function maybe_create_ccpa_page() {
+	public static function maybe_create_ccpa_page() {
 		// Check if we've already created the page (by ID, since slug can be changed).
 		$page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		if ( $page_id && get_post( $page_id ) ) {
@@ -113,7 +105,7 @@ class Cookie_Consent {
 		}
 
 		// Build the page content with blocks.
-		$content = $this->get_ccpa_page_content();
+		$content = self::get_ccpa_page_content();
 
 		// Create the page without content first.
 		$page_id = wp_insert_post(
@@ -140,11 +132,26 @@ class Cookie_Consent {
 	}
 
 	/**
+	 * Register the CCPA page id setting for REST API access.
+	 */
+	public static function register_ccpa_page_setting() {
+		register_setting(
+			'general',
+			'jetpack_cookie_consent_ccpa_page_id',
+			array(
+				'show_in_rest' => true,
+				'type'         => 'integer',
+				'description'  => __( 'CCPA opt-out page ID', 'jetpack-cookie-consent' ),
+			)
+		);
+	}
+
+	/**
 	 * Get CCPA page content in block format
 	 *
 	 * @return string Page content with WordPress blocks
 	 */
-	private function get_ccpa_page_content() {
+	private static function get_ccpa_page_content() {
 		$template_path = plugin_dir_path( __FILE__ ) . 'ccpa-content.php';
 
 		if ( ! file_exists( $template_path ) ) {
@@ -163,7 +170,7 @@ class Cookie_Consent {
 	 * @param array     $args  Array of get_pages() arguments.
 	 * @return WP_Post[] Filtered array of page objects.
 	 */
-	public function exclude_ccpa_from_get_pages( $pages, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public static function exclude_ccpa_from_get_pages( $pages, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( is_admin() ) {
 			// In admin, include the CCPA page in the results.
 			return $pages;
@@ -193,7 +200,7 @@ class Cookie_Consent {
 	 * @param array  $args    Additional arguments.
 	 * @return array Modified capabilities.
 	 */
-	public function prevent_privacy_pages_deletion( $caps, $cap, $user_id, $args ) {
+	public static function prevent_privacy_pages_deletion( $caps, $cap, $user_id, $args ) {
 		// Only intercept delete_post capability checks.
 		if ( 'delete_post' !== $cap ) {
 			return $caps;
@@ -225,7 +232,7 @@ class Cookie_Consent {
 	 * @param WP_Block_Template|array $context            The block template, template part, or pattern.
 	 * @return array Modified array of hooked block types.
 	 */
-	public function register_footer_navigation_links( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+	public static function register_footer_navigation_links( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
 		// Only hook to navigation blocks.
 		if ( 'core/navigation' !== $anchor_block_type ) {
 			return $hooked_block_types;
@@ -283,7 +290,7 @@ class Cookie_Consent {
 	 * @param array      $anchor_block      The anchor block.
 	 * @return array|null Modified hooked block.
 	 */
-	public function set_footer_navigation_link_attributes( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public static function set_footer_navigation_link_attributes( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// Track which blocks we've processed.
 		static $privacy_policy_processed     = false;
 		static $ccpa_processed               = false;
@@ -359,7 +366,7 @@ class Cookie_Consent {
 	 * @param array  $block         The full block, including name and attributes.
 	 * @return string Modified block content.
 	 */
-	public function add_ccpa_interactivity_directives( $block_content, $block ) {
+	public static function add_ccpa_interactivity_directives( $block_content, $block ) {
 		// Check if this is our CCPA link by looking for our metadata marker.
 		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'jetpack-cookie-consent-ccpa-privacy-link' !== $block['attrs']['metadata']['name'] ) {
 			return $block_content;
@@ -389,7 +396,7 @@ class Cookie_Consent {
 	 * @param array  $block         The full block, including name and attributes.
 	 * @return string Modified block content.
 	 */
-	public function add_gdpr_manage_preferences_directives( $block_content, $block ) {
+	public static function add_gdpr_manage_preferences_directives( $block_content, $block ) {
 		// Check if this is our manage preferences link by looking for our metadata marker.
 		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'jetpack-cookie-consent-gdpr-manage-preferences-link' !== $block['attrs']['metadata']['name'] ) {
 			return $block_content;
@@ -423,7 +430,7 @@ class Cookie_Consent {
 	 * @param array  $block         The full block, including name and attributes.
 	 * @return string Modified block content.
 	 */
-	public function add_ccpa_button_directive( $block_content, $block ) {
+	public static function add_ccpa_button_directive( $block_content, $block ) {
 		// Check if this button has the CCPA opt-out class.
 		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'jetpack-cookie-consent-ccpa-opt-out-button' ) ) {
 			return $block_content;
@@ -448,7 +455,7 @@ class Cookie_Consent {
 	 * @param array  $block         The full block, including name and attributes.
 	 * @return string Modified block content.
 	 */
-	public function add_ccpa_group_directives( $block_content, $block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public static function add_ccpa_group_directives( $block_content, $block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// Check if this group block has the CCPA opt-out section class.
 		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'jetpack-cookie-consent-ccpa-opt-out-section' ) ) {
 			return $block_content;
@@ -490,7 +497,7 @@ class Cookie_Consent {
 	 *
 	 * @return array Configuration array
 	 */
-	private function get_config() {
+	private static function get_config() {
 		$default_config = array(
 			'geo_api_url'         => 'https://public-api.wordpress.com/geo/',
 			'geo_cookie_duration' => 6 * HOUR_IN_SECONDS, // 6 hours.
@@ -564,7 +571,7 @@ class Cookie_Consent {
 	/**
 	 * Enqueue scripts and styles
 	 */
-	public function enqueue_assets() {
+	public static function enqueue_assets() {
 		// Don't load in admin.
 		if ( is_admin() ) {
 			return;
@@ -573,7 +580,7 @@ class Cookie_Consent {
 		// Load Automattic Tracks (w.js) for analytics.
 		// External script, version managed by Automattic - no version needed.
 		wp_enqueue_script(
-			'automattic-tracks',
+			'jetpack-cookie-consent-tracks',
 			'https://stats.wp.com/w.js',
 			array(),
 			gmdate( 'YW' ),
@@ -610,7 +617,7 @@ class Cookie_Consent {
 		);
 
 		// Resolve the configured Tracks event prefix once so it can be shared below.
-		$config = $this->get_config();
+		$config = self::get_config();
 
 		// Pass REST API URL and Tracks event prefix to the module via global config.
 		wp_print_inline_script_tag(
@@ -652,7 +659,7 @@ class Cookie_Consent {
 	 *
 	 * @return bool True if consent has been set
 	 */
-	private function has_consent_set() {
+	private static function has_consent_set() {
 		// Check if any WP Consent API cookie exists.
 		// If user has made a choice, at least one of these should be set.
 		return isset( $_COOKIE['wp_consent_functional'] );
@@ -661,7 +668,7 @@ class Cookie_Consent {
 	/**
 	 * Render the cookie consent banner
 	 */
-	public function render_banner() {
+	public static function render_banner() {
 		// Don't render in admin.
 		if ( is_admin() ) {
 			return;
@@ -677,7 +684,7 @@ class Cookie_Consent {
 		$template_path = plugin_dir_path( __FILE__ ) . 'cookie-banner-content.php';
 		if ( file_exists( $template_path ) ) {
 			// Get config for template.
-			$config = $this->get_config();
+			$config = self::get_config();
 			ob_start();
 			include $template_path;
 			$html = ob_get_clean();

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -587,19 +587,21 @@ class Cookie_Consent {
 		);
 
 		// Register and enqueue the Interactivity API script module built by webpack.
+		// Only the build version is read from the asset file; module dependencies are
+		// declared explicitly. Script modules may only depend on other script modules,
+		// so the asset file's `dependencies` (which can include classic scripts such as
+		// `wp-polyfill`) must not be forwarded to wp_register_script_module().
 		$asset_file = __DIR__ . '/../build/modules/cookie-consent/index.asset.php';
-		$asset      = file_exists( $asset_file ) ? require $asset_file : array(
-			'dependencies' => array( '@wordpress/interactivity' ),
-			'version'      => self::PACKAGE_VERSION,
-		);
+		$asset      = file_exists( $asset_file ) ? require $asset_file : array();
+		$version    = isset( $asset['version'] ) ? $asset['version'] : self::PACKAGE_VERSION;
 		$module_url = plugins_url( 'build/modules/cookie-consent/index.js', __DIR__ );
 		$module_id  = '@automattic/jetpack-cookie-consent';
 
 		wp_register_script_module(
 			$module_id,
 			$module_url,
-			$asset['dependencies'],
-			$asset['version']
+			array( '@wordpress/interactivity' ),
+			$version
 		);
 		wp_enqueue_script_module( $module_id );
 
@@ -609,7 +611,7 @@ class Cookie_Consent {
 			'jetpack-cookie-consent',
 			$style_url,
 			array(),
-			$asset['version']
+			$version
 		);
 
 		// Resolve the configured Tracks event prefix once so it can be shared below.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -1,0 +1,701 @@
+<?php
+/**
+ * Shoppers Privacy Controls
+ *
+ * GDPR-compliant shoppers privacy controls implementation using WordPress Interactivity API.
+ *
+ * @package ciab-next
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Cookie Consent class
+ */
+class CIAB_Next_Shoppers_Privacy {
+
+	/**
+	 * Instance of this class
+	 *
+	 * @var CIAB_Next_Shoppers_Privacy
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get singleton instance
+	 *
+	 * @return CIAB_Next_Shoppers_Privacy
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	private function __construct() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_footer', array( $this, 'render_banner' ), 999 );
+		// Run one-time setup during site provisioning (priority 15 to run after WC setup).
+		add_action( 'garden_site_provisioning', array( $this, 'maybe_create_ccpa_page' ), 15 );
+		// TODO: Uncomment once legal team provides final privacy policy copy.
+		// For the time being, we want to use default WordPress content.
+		// See: https://linear.app/a8c/issue/ARC-1031/privacy-policy-update-copy-of-privacy-policy.
+		// add_action( 'garden_site_provisioning', array( $this, 'maybe_update_privacy_policy_content' ), 15 );.
+
+		// Prevent CCPA and Privacy Policy page deletion.
+		add_filter( 'map_meta_cap', array( $this, 'prevent_privacy_pages_deletion' ), 10, 4 );
+
+		// Hook Privacy Policy and CCPA links into navigation blocks using Block Hooks API.
+		add_filter( 'hooked_block_types', array( $this, 'register_footer_navigation_links' ), 10, 4 );
+		add_filter( 'hooked_block_core/navigation-link', array( $this, 'set_footer_navigation_link_attributes' ), 10, 4 );
+		add_filter( 'render_block_core/navigation-link', array( $this, 'add_ccpa_interactivity_directives' ), 10, 2 );
+		add_filter( 'render_block_core/navigation-link', array( $this, 'add_gdpr_manage_preferences_directives' ), 10, 2 );
+
+		// Add Interactivity API directive to CCPA opt-out button.
+		add_filter( 'render_block_core/button', array( $this, 'add_ccpa_button_directive' ), 10, 2 );
+
+		// Add Interactivity API directives to CCPA group block and inject snackbar.
+		add_filter( 'render_block_core/group', array( $this, 'add_ccpa_group_directives' ), 10, 2 );
+
+		// Exclude CCPA page from page-list block using get_pages filter.
+		add_filter( 'get_pages', array( $this, 'exclude_ccpa_from_get_pages' ), 10, 2 );
+	}
+
+	/**
+	 * Create CCPA opt-out page if it doesn't exist
+	 */
+	public function maybe_create_ccpa_page() {
+		// Check if we've already created the page (by ID, since slug can be changed).
+		$page_id = get_option( 'wc_ccpa_page_id' );
+		if ( $page_id && get_post( $page_id ) ) {
+			return;
+		}
+
+		// If we have a stale page ID (option exists but post doesn't), clear it.
+		if ( $page_id && ! get_post( $page_id ) ) {
+			delete_option( 'wc_ccpa_page_id' );
+		}
+
+		// Fallback: check if page exists by slug (for backwards compatibility).
+		$page_slug = 'your-privacy-choices';
+		$page      = get_page_by_path( $page_slug );
+
+		// If page exists by slug, save its ID and we're done.
+		if ( $page ) {
+			update_option( 'wc_ccpa_page_id', $page->ID );
+			return;
+		}
+
+		// Build the page content with blocks.
+		$content = $this->get_ccpa_page_content();
+
+		// Create the page without content first.
+		$page_id = wp_insert_post(
+			array(
+				'post_title'     => __( 'Your Privacy Choices', 'ciab' ),
+				'post_name'      => $page_slug,
+				'post_status'    => 'publish',
+				'post_type'      => 'page',
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			)
+		);
+
+		// Store the page ID and update with content to create a first revision.
+		if ( $page_id && ! is_wp_error( $page_id ) ) {
+			update_option( 'wc_ccpa_page_id', $page_id );
+			wp_update_post(
+				array(
+					'ID'           => $page_id,
+					'post_content' => $content,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Get CCPA page content in block format
+	 *
+	 * @return string Page content with WordPress blocks
+	 */
+	private function get_ccpa_page_content() {
+		$template_path = plugin_dir_path( __FILE__ ) . 'ccpa-content.php';
+
+		if ( ! file_exists( $template_path ) ) {
+			return '';
+		}
+
+		ob_start();
+		include $template_path;
+		return ob_get_clean();
+	}
+
+	/**
+	 * Update the Privacy Policy page content if it's in pristine state
+	 *
+	 * This method checks if the Privacy Policy page exists and if it's in pristine state
+	 * (no edits beyond the initial creation). If so, it updates the content with
+	 * CIAB-specific privacy policy content.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function maybe_update_privacy_policy_content() {
+		$page_id = get_option( 'wp_page_for_privacy_policy' );
+
+		if ( ! $page_id ) {
+			return false;
+		}
+
+		// Check if we've already updated this page.
+		$already_updated = get_post_meta( $page_id, '_ciab_privacy_policy_updated', true );
+		if ( $already_updated ) {
+			return false;
+		}
+
+		// Check if the page is in pristine state using WordPress core APIs.
+		$revisions   = wp_get_post_revisions( $page_id );
+		$is_pristine = count( $revisions ) <= 1;
+
+		if ( ! $is_pristine ) {
+			return false;
+		}
+
+		// TODO: Update the content once provided by legal team
+		// https://linear.app/a8c/issue/ARC-1031/privacy-policy-update-copy-of-privacy-policy.
+		$new_content = '<!-- wp:paragraph --><p>
+		   Custom CIAB Privacy Policy
+		   </p><!-- /wp:paragraph -->';
+
+		// Update the page content.
+		$result = wp_update_post(
+			array(
+				'ID'           => $page_id,
+				'post_content' => $new_content,
+			),
+			true
+		);
+
+		if ( is_wp_error( $result ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					'CIAB Next: Failed to update Privacy Policy page. Error: ' . $result->get_error_message()
+				);
+			}
+			return false;
+		}
+
+		// Mark the page as updated to avoid re-updating on subsequent loads.
+		update_post_meta( $page_id, '_ciab_privacy_policy_updated', '1' );
+
+		return true;
+	}
+
+	/**
+	 * Exclude CCPA page from get_pages() results
+	 *
+	 * @param WP_Post[] $pages Array of page objects.
+	 * @param array     $args  Array of get_pages() arguments.
+	 * @return WP_Post[] Filtered array of page objects.
+	 */
+	public function exclude_ccpa_from_get_pages( $pages, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( is_admin() ) {
+			// In admin, include the CCPA page in the results.
+			return $pages;
+		}
+
+		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+
+		if ( ! $ccpa_page_id || empty( $pages ) ) {
+			return $pages;
+		}
+
+		// Filter out the CCPA page from the results.
+		return array_filter(
+			$pages,
+			function ( $page ) use ( $ccpa_page_id ) {
+				return (int) $page->ID !== (int) $ccpa_page_id;
+			}
+		);
+	}
+
+	/**
+	 * Prevent CCPA and Privacy Policy pages from being deleted
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability being checked.
+	 * @param int    $user_id User ID.
+	 * @param array  $args    Additional arguments.
+	 * @return array Modified capabilities.
+	 */
+	public function prevent_privacy_pages_deletion( $caps, $cap, $user_id, $args ) {
+		// Only intercept delete_post capability checks.
+		if ( 'delete_post' !== $cap ) {
+			return $caps;
+		}
+
+		$post_id = isset( $args[0] ) ? (int) $args[0] : 0;
+
+		// Prevent deletion of CCPA page.
+		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+		if ( $ccpa_page_id && $post_id === (int) $ccpa_page_id ) {
+			return array( 'do_not_allow' );
+		}
+
+		// Prevent deletion of Privacy Policy page.
+		$privacy_policy_page_id = function_exists( 'wc_privacy_policy_page_id' ) ? wc_privacy_policy_page_id() : get_option( 'wp_page_for_privacy_policy' );
+		if ( $privacy_policy_page_id && $post_id === (int) $privacy_policy_page_id ) {
+			return array( 'do_not_allow' );
+		}
+
+		return $caps;
+	}
+
+	/**
+	 * Register Privacy Policy and CCPA navigation links as hooked blocks
+	 *
+	 * @param array                   $hooked_block_types Array of hooked block types.
+	 * @param string                  $relative_position  The relative position.
+	 * @param string                  $anchor_block_type  The anchor block type.
+	 * @param WP_Block_Template|array $context            The block template, template part, or pattern.
+	 * @return array Modified array of hooked block types.
+	 */
+	public function register_footer_navigation_links( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+		// Only hook to navigation blocks.
+		if ( 'core/navigation' !== $anchor_block_type ) {
+			return $hooked_block_types;
+		}
+
+		// Only hook as last child.
+		if ( 'last_child' !== $relative_position ) {
+			return $hooked_block_types;
+		}
+
+		// Only hook in footer template parts.
+		if ( ! is_array( $context ) || ! str_contains( $context['slug'], '/footer' ) ) {
+			return $hooked_block_types;
+		}
+
+		// Check which pages exist and register appropriate blocks.
+		$privacy_policy_exists = false;
+		$ccpa_page_exists      = false;
+
+		// Check Privacy Policy page.
+		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
+		if ( $privacy_policy_page_id ) {
+			$page = get_post( $privacy_policy_page_id );
+			if ( $page && 'publish' === $page->post_status ) {
+				$privacy_policy_exists = true;
+			}
+		}
+
+		// Check CCPA page.
+		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+		if ( $ccpa_page_id && get_post( $ccpa_page_id ) ) {
+			$ccpa_page_exists = true;
+		}
+
+		// Register one block for each page that exists.
+		if ( $privacy_policy_exists ) {
+			$hooked_block_types[] = 'core/navigation-link';
+		}
+		if ( $ccpa_page_exists ) {
+			$hooked_block_types[] = 'core/navigation-link';
+		}
+
+		// Register GDPR "Manage Privacy Preferences" link (visibility handled client-side).
+		$hooked_block_types[] = 'core/navigation-link';
+
+		return $hooked_block_types;
+	}
+
+	/**
+	 * Set attributes for hooked footer navigation links (Privacy Policy and CCPA)
+	 *
+	 * @param array|null $hooked_block      The hooked block, or null to suppress.
+	 * @param string     $hooked_block_type The hooked block type name.
+	 * @param string     $relative_position The relative position of the hooked block.
+	 * @param array      $anchor_block      The anchor block.
+	 * @return array|null Modified hooked block.
+	 */
+	public function set_footer_navigation_link_attributes( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// Track which blocks we've processed.
+		static $privacy_policy_processed     = false;
+		static $ccpa_processed               = false;
+		static $manage_preferences_processed = false;
+
+		// Has the hooked block been suppressed by a previous filter?
+		if ( is_null( $hooked_block ) ) {
+			return $hooked_block;
+		}
+
+		// If another filter already set metadata, skip this block.
+		if ( isset( $hooked_block['attrs']['metadata']['name'] ) ) {
+			return $hooked_block;
+		}
+
+		// Check which pages exist (same logic as registration).
+		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
+		$privacy_policy_exists  = false;
+		if ( $privacy_policy_page_id ) {
+			$page = get_post( $privacy_policy_page_id );
+			if ( $page && 'publish' === $page->post_status ) {
+				$privacy_policy_exists = true;
+			}
+		}
+
+		$ccpa_page_id     = get_option( 'wc_ccpa_page_id' );
+		$ccpa_page_exists = $ccpa_page_id && get_post( $ccpa_page_id );
+
+		// Process Privacy Policy first (if it exists and hasn't been processed).
+		if ( $privacy_policy_exists && ! $privacy_policy_processed ) {
+			$hooked_block['attrs']['url']      = get_permalink( $privacy_policy_page_id );
+			$hooked_block['attrs']['label']    = get_the_title( $privacy_policy_page_id );
+			$hooked_block['attrs']['kind']     = 'custom';
+			$hooked_block['attrs']['metadata'] = array(
+				'name' => 'wc-privacy-policy-link',
+			);
+			$privacy_policy_processed          = true;
+			return $hooked_block;
+		}
+
+		// Process CCPA next (if it exists and hasn't been processed).
+		if ( $ccpa_page_exists && ! $ccpa_processed ) {
+			$hooked_block['attrs']['url']      = get_permalink( $ccpa_page_id );
+			$hooked_block['attrs']['label']    = get_the_title( $ccpa_page_id );
+			$hooked_block['attrs']['kind']     = 'custom';
+			$hooked_block['attrs']['metadata'] = array(
+				'name' => 'wc-ccpa-privacy-link',
+			);
+			$ccpa_processed                    = true;
+			return $hooked_block;
+		}
+
+		// Process GDPR "Manage Privacy Preferences" link last.
+		if ( ! $manage_preferences_processed ) {
+			$hooked_block['attrs']['url']      = '#manage-preferences';
+			$hooked_block['attrs']['label']    = __( 'Manage Privacy Preferences', 'ciab' );
+			$hooked_block['attrs']['kind']     = 'custom';
+			$hooked_block['attrs']['metadata'] = array(
+				'name' => 'wc-gdpr-manage-preferences-link',
+			);
+			$manage_preferences_processed      = true;
+			return $hooked_block;
+		}
+
+		// If we get here, all have been processed or don't exist.
+		return $hooked_block;
+	}
+
+	/**
+	 * Add Interactivity API directives to the CCPA navigation link for conditional rendering
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public function add_ccpa_interactivity_directives( $block_content, $block ) {
+		// Check if this is our CCPA link by looking for our metadata marker.
+		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'wc-ccpa-privacy-link' !== $block['attrs']['metadata']['name'] ) {
+			return $block_content;
+		}
+
+		// Use WP_HTML_Tag_Processor to safely add Interactivity API directives.
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the first <li> tag (the navigation item wrapper).
+		if ( $tags->next_tag( 'li' ) ) {
+			// Add Interactivity API directives to the <li>.
+			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-context', '{"isCcpaRegion": false}' );
+			$tags->set_attribute( 'data-wp-class--wc-ccpa-privacy-link-hidden', '!state.isCcpaRegion' );
+			$tags->set_attribute( 'data-wp-init', 'callbacks.init' );
+
+			return $tags->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Add Interactivity API directives to the GDPR "Manage Privacy Preferences" link
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public function add_gdpr_manage_preferences_directives( $block_content, $block ) {
+		// Check if this is our manage preferences link by looking for our metadata marker.
+		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'wc-gdpr-manage-preferences-link' !== $block['attrs']['metadata']['name'] ) {
+			return $block_content;
+		}
+
+		// Use WP_HTML_Tag_Processor to safely add Interactivity API directives.
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the first <li> tag (the navigation item wrapper).
+		if ( $tags->next_tag( 'li' ) ) {
+			// Add Interactivity API directives to the <li>.
+			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-context', '{"isGdprManageLink": false}' );
+			$tags->set_attribute( 'data-wp-class--wc-gdpr-manage-link-hidden', '!context.isGdprManageLink' );
+			$tags->set_attribute( 'data-wp-init', 'callbacks.init' );
+			$tags->add_class( 'wc-gdpr-manage-link-hidden' );
+		}
+
+		// Find the <a> tag and add click handler.
+		if ( $tags->next_tag( 'a' ) ) {
+			$tags->set_attribute( 'data-wp-on--click', 'actions.openManagePreferences' );
+		}
+
+		return $tags->get_updated_html();
+	}
+
+	/**
+	 * Add Interactivity API directive to CCPA opt-out button
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public function add_ccpa_button_directive( $block_content, $block ) {
+		// Check if this button has the CCPA opt-out class.
+		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'wc-ccpa-opt-out-button' ) ) {
+			return $block_content;
+		}
+
+		// Use WP_HTML_Tag_Processor to safely add the directive.
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the button element with the wp-block-button__link class.
+		if ( $tags->next_tag( array( 'class_name' => 'wp-block-button__link' ) ) ) {
+			$tags->set_attribute( 'data-wp-on--click', 'actions.optOut' );
+			return $tags->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Add Interactivity API directives to CCPA group block and inject snackbar
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public function add_ccpa_group_directives( $block_content, $block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		// Check if this group block has the CCPA opt-out section class.
+		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'wc-ccpa-opt-out-section' ) ) {
+			return $block_content;
+		}
+
+		// Use WP_HTML_Tag_Processor to add Interactivity API directives.
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+
+		// Find the group div.
+		if ( $tags->next_tag( array( 'class_name' => 'wp-block-group' ) ) ) {
+			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-context', '{"showSnackbar": false}' );
+			$block_content = $tags->get_updated_html();
+		}
+
+		// Build the snackbar HTML.
+		$snackbar_html = sprintf(
+			'<div class="wc-ccpa-snackbar" data-wp-bind--hidden="!state.showSnackbar">
+				<div class="wc-ccpa-snackbar__content">
+					<span>%s</span>
+					<button type="button" class="wc-ccpa-snackbar__dismiss" data-wp-on--click="actions.dismissSnackbar" aria-label="%s">×</button>
+				</div>
+			</div>',
+			esc_html__( 'Your browser has been successfully opted out from sharing personal data.', 'ciab' ),
+			esc_attr__( 'Dismiss', 'ciab' )
+		);
+
+		// Insert the snackbar inside the group block (before the closing </div>).
+		$closing_tag_pos = strrpos( $block_content, '</div>' );
+		if ( false !== $closing_tag_pos ) {
+			$block_content = substr_replace( $block_content, $snackbar_html, $closing_tag_pos, 0 );
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Get configuration with filters
+	 *
+	 * @return array Configuration array
+	 */
+	private function get_config() {
+		$default_config = array(
+			'geo_api_url'         => 'https://public-api.wordpress.com/geo/',
+			'geo_cookie_duration' => 6 * HOUR_IN_SECONDS, // 6 hours.
+			'country_code_cookie' => 'country_code',
+			'region_cookie'       => 'region',
+			'cookie_policy_url'   => 'https://automattic.com/cookies/',
+			'gdpr_countries'      => array(
+				// European Member countries.
+				'AT', // Austria.
+				'BE', // Belgium.
+				'BG', // Bulgaria.
+				'CY', // Cyprus.
+				'CZ', // Czech Republic.
+				'DE', // Germany.
+				'DK', // Denmark.
+				'EE', // Estonia.
+				'ES', // Spain.
+				'FI', // Finland.
+				'FR', // France.
+				'GR', // Greece.
+				'HR', // Croatia.
+				'HU', // Hungary.
+				'IE', // Ireland.
+				'IT', // Italy.
+				'LT', // Lithuania.
+				'LU', // Luxembourg.
+				'LV', // Latvia.
+				'MT', // Malta.
+				'NL', // Netherlands.
+				'PL', // Poland.
+				'PT', // Portugal.
+				'RO', // Romania.
+				'SE', // Sweden.
+				'SI', // Slovenia.
+				'SK', // Slovakia.
+				'GB', // United Kingdom.
+				// Single Market Countries that GDPR applies to.
+				'CH', // Switzerland.
+				'IS', // Iceland.
+				'LI', // Liechtenstein.
+				'NO', // Norway.
+			),
+			'ccpa_regions'        => array(
+				/* US regions/states that are treated like California for Do Not Sell requests. */
+				'california',
+				'utah',
+				'virginia',
+				'colorado',
+				'connecticut',
+				'texas',
+				'tennessee',
+				'oregon',
+				'new jersey',
+				'montana',
+				'iowa',
+				'indiana',
+				'delaware',
+			),
+			'show_on_error'       => true, // Show banner if geolocation fails.
+		);
+
+		/**
+		 * Filter cookie consent configuration
+		 *
+		 * @param array $config Configuration array
+		 */
+		return apply_filters( 'ciab_next_shoppers_privacy_config', $default_config );
+	}
+
+	/**
+	 * Enqueue scripts and styles
+	 */
+	public function enqueue_assets() {
+		// Don't load in admin.
+		if ( is_admin() ) {
+			return;
+		}
+
+		// Load Automattic Tracks (w.js) for analytics.
+		// External script, version managed by Automattic - no version needed.
+		wp_enqueue_script(
+			'automattic-tracks',
+			'https://stats.wp.com/w.js',
+			array(),
+			gmdate( 'YW' ),
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
+
+		wp_enqueue_script_module( '@ciab-next/shoppers-privacy' );
+
+		// Pass REST API URL to the module via global config.
+		wp_print_inline_script_tag(
+			sprintf(
+				'window.wcConsentLoggerConfig = %s;',
+				wp_json_encode(
+					array(
+						'apiUrl' => rest_url( 'wc/next/consent-log' ),
+					)
+				)
+			),
+			array( 'id' => 'wc-consent-logger-config' )
+		);
+
+		// Check for preview query parameter.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$force_preview = isset( $_GET['preview_cookie_consent'] ) && '1' === $_GET['preview_cookie_consent'];
+
+		// Pass configuration to frontend using wp_interactivity_config.
+		$config = $this->get_config();
+		wp_interactivity_config(
+			'cookie-consent',
+			array(
+				'geoApiUrl'         => $config['geo_api_url'],
+				'geoCookieDuration' => $config['geo_cookie_duration'],
+				'countryCodeCookie' => $config['country_code_cookie'],
+				'regionCookie'      => $config['region_cookie'],
+				'cookiePolicyUrl'   => $config['cookie_policy_url'],
+				'gdprCountries'     => $config['gdpr_countries'],
+				'ccpaRegions'       => $config['ccpa_regions'],
+				'showOnError'       => $config['show_on_error'],
+				'forcePreview'      => $force_preview,
+			)
+		);
+	}
+
+	/**
+	 * Check if consent has been set
+	 *
+	 * @return bool True if consent has been set
+	 */
+	private function has_consent_set() {
+		// Check if any WP Consent API cookie exists.
+		// If user has made a choice, at least one of these should be set.
+		return isset( $_COOKIE['wp_consent_functional'] );
+	}
+
+	/**
+	 * Render the cookie consent banner
+	 */
+	public function render_banner() {
+		// Don't render in admin.
+		if ( is_admin() ) {
+			return;
+		}
+
+		// Check for preview query parameter.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$force_preview = isset( $_GET['preview_cookie_consent'] ) && '1' === $_GET['preview_cookie_consent'];
+
+		// Always render the banner/modal HTML so the "Manage Privacy Preferences" footer link
+		// can reopen the modal after consent has been set. The banner visibility is controlled
+		// client-side via Interactivity API directives (showBanner starts as false).
+		$template_path = plugin_dir_path( __FILE__ ) . 'cookie-banner-content.php';
+		if ( file_exists( $template_path ) ) {
+			// Get config for template.
+			$config = $this->get_config();
+			ob_start();
+			include $template_path;
+			$html = ob_get_clean();
+			// Process directives and output.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo wp_interactivity_process_directives( $html );
+		}
+	}
+}

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -1,11 +1,15 @@
 <?php
 /**
- * Shoppers Privacy Controls
+ * Cookie Consent
  *
- * GDPR-compliant shoppers privacy controls implementation using WordPress Interactivity API.
+ * GDPR-compliant cookie consent controls implementation using the WordPress Interactivity API.
  *
- * @package ciab-next
+ * @package automattic/jetpack-cookie-consent
  */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use WP_HTML_Tag_Processor;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,19 +18,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Cookie Consent class
  */
-class CIAB_Next_Shoppers_Privacy {
+class Cookie_Consent {
+
+	/**
+	 * Package version.
+	 *
+	 * @var string
+	 */
+	const PACKAGE_VERSION = '0.1.0-alpha';
 
 	/**
 	 * Instance of this class
 	 *
-	 * @var CIAB_Next_Shoppers_Privacy
+	 * @var Cookie_Consent
 	 */
 	private static $instance = null;
 
 	/**
 	 * Get singleton instance
 	 *
-	 * @return CIAB_Next_Shoppers_Privacy
+	 * @return Cookie_Consent
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -36,17 +47,26 @@ class CIAB_Next_Shoppers_Privacy {
 	}
 
 	/**
+	 * Initialize the package.
+	 *
+	 * Public entry point a consumer calls to activate cookie consent. Boots the
+	 * front-end controls (banner, CCPA flow, enqueue) and the consent log REST
+	 * controller (table creation, cron scheduling, route registration).
+	 *
+	 * @return Cookie_Consent
+	 */
+	public static function init() {
+		$instance = self::get_instance();
+		Consent_Log_Controller::init();
+		return $instance;
+	}
+
+	/**
 	 * Constructor
 	 */
 	private function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'wp_footer', array( $this, 'render_banner' ), 999 );
-		// Run one-time setup during site provisioning (priority 15 to run after WC setup).
-		add_action( 'garden_site_provisioning', array( $this, 'maybe_create_ccpa_page' ), 15 );
-		// TODO: Uncomment once legal team provides final privacy policy copy.
-		// For the time being, we want to use default WordPress content.
-		// See: https://linear.app/a8c/issue/ARC-1031/privacy-policy-update-copy-of-privacy-policy.
-		// add_action( 'garden_site_provisioning', array( $this, 'maybe_update_privacy_policy_content' ), 15 );.
 
 		// Prevent CCPA and Privacy Policy page deletion.
 		add_filter( 'map_meta_cap', array( $this, 'prevent_privacy_pages_deletion' ), 10, 4 );
@@ -72,14 +92,14 @@ class CIAB_Next_Shoppers_Privacy {
 	 */
 	public function maybe_create_ccpa_page() {
 		// Check if we've already created the page (by ID, since slug can be changed).
-		$page_id = get_option( 'wc_ccpa_page_id' );
+		$page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		if ( $page_id && get_post( $page_id ) ) {
 			return;
 		}
 
 		// If we have a stale page ID (option exists but post doesn't), clear it.
 		if ( $page_id && ! get_post( $page_id ) ) {
-			delete_option( 'wc_ccpa_page_id' );
+			delete_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		}
 
 		// Fallback: check if page exists by slug (for backwards compatibility).
@@ -88,7 +108,7 @@ class CIAB_Next_Shoppers_Privacy {
 
 		// If page exists by slug, save its ID and we're done.
 		if ( $page ) {
-			update_option( 'wc_ccpa_page_id', $page->ID );
+			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page->ID );
 			return;
 		}
 
@@ -98,7 +118,7 @@ class CIAB_Next_Shoppers_Privacy {
 		// Create the page without content first.
 		$page_id = wp_insert_post(
 			array(
-				'post_title'     => __( 'Your Privacy Choices', 'ciab' ),
+				'post_title'     => __( 'Your Privacy Choices', 'jetpack-cookie-consent' ),
 				'post_name'      => $page_slug,
 				'post_status'    => 'publish',
 				'post_type'      => 'page',
@@ -109,7 +129,7 @@ class CIAB_Next_Shoppers_Privacy {
 
 		// Store the page ID and update with content to create a first revision.
 		if ( $page_id && ! is_wp_error( $page_id ) ) {
-			update_option( 'wc_ccpa_page_id', $page_id );
+			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
 			wp_update_post(
 				array(
 					'ID'           => $page_id,
@@ -137,66 +157,6 @@ class CIAB_Next_Shoppers_Privacy {
 	}
 
 	/**
-	 * Update the Privacy Policy page content if it's in pristine state
-	 *
-	 * This method checks if the Privacy Policy page exists and if it's in pristine state
-	 * (no edits beyond the initial creation). If so, it updates the content with
-	 * CIAB-specific privacy policy content.
-	 *
-	 * @return bool True on success, false on failure.
-	 */
-	public function maybe_update_privacy_policy_content() {
-		$page_id = get_option( 'wp_page_for_privacy_policy' );
-
-		if ( ! $page_id ) {
-			return false;
-		}
-
-		// Check if we've already updated this page.
-		$already_updated = get_post_meta( $page_id, '_ciab_privacy_policy_updated', true );
-		if ( $already_updated ) {
-			return false;
-		}
-
-		// Check if the page is in pristine state using WordPress core APIs.
-		$revisions   = wp_get_post_revisions( $page_id );
-		$is_pristine = count( $revisions ) <= 1;
-
-		if ( ! $is_pristine ) {
-			return false;
-		}
-
-		// TODO: Update the content once provided by legal team
-		// https://linear.app/a8c/issue/ARC-1031/privacy-policy-update-copy-of-privacy-policy.
-		$new_content = '<!-- wp:paragraph --><p>
-		   Custom CIAB Privacy Policy
-		   </p><!-- /wp:paragraph -->';
-
-		// Update the page content.
-		$result = wp_update_post(
-			array(
-				'ID'           => $page_id,
-				'post_content' => $new_content,
-			),
-			true
-		);
-
-		if ( is_wp_error( $result ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-					'CIAB Next: Failed to update Privacy Policy page. Error: ' . $result->get_error_message()
-				);
-			}
-			return false;
-		}
-
-		// Mark the page as updated to avoid re-updating on subsequent loads.
-		update_post_meta( $page_id, '_ciab_privacy_policy_updated', '1' );
-
-		return true;
-	}
-
-	/**
 	 * Exclude CCPA page from get_pages() results
 	 *
 	 * @param WP_Post[] $pages Array of page objects.
@@ -209,7 +169,7 @@ class CIAB_Next_Shoppers_Privacy {
 			return $pages;
 		}
 
-		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 
 		if ( ! $ccpa_page_id || empty( $pages ) ) {
 			return $pages;
@@ -242,13 +202,13 @@ class CIAB_Next_Shoppers_Privacy {
 		$post_id = isset( $args[0] ) ? (int) $args[0] : 0;
 
 		// Prevent deletion of CCPA page.
-		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		if ( $ccpa_page_id && $post_id === (int) $ccpa_page_id ) {
 			return array( 'do_not_allow' );
 		}
 
 		// Prevent deletion of Privacy Policy page.
-		$privacy_policy_page_id = function_exists( 'wc_privacy_policy_page_id' ) ? wc_privacy_policy_page_id() : get_option( 'wp_page_for_privacy_policy' );
+		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
 		if ( $privacy_policy_page_id && $post_id === (int) $privacy_policy_page_id ) {
 			return array( 'do_not_allow' );
 		}
@@ -295,7 +255,7 @@ class CIAB_Next_Shoppers_Privacy {
 		}
 
 		// Check CCPA page.
-		$ccpa_page_id = get_option( 'wc_ccpa_page_id' );
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		if ( $ccpa_page_id && get_post( $ccpa_page_id ) ) {
 			$ccpa_page_exists = true;
 		}
@@ -349,7 +309,7 @@ class CIAB_Next_Shoppers_Privacy {
 			}
 		}
 
-		$ccpa_page_id     = get_option( 'wc_ccpa_page_id' );
+		$ccpa_page_id     = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		$ccpa_page_exists = $ccpa_page_id && get_post( $ccpa_page_id );
 
 		// Process Privacy Policy first (if it exists and hasn't been processed).
@@ -358,7 +318,7 @@ class CIAB_Next_Shoppers_Privacy {
 			$hooked_block['attrs']['label']    = get_the_title( $privacy_policy_page_id );
 			$hooked_block['attrs']['kind']     = 'custom';
 			$hooked_block['attrs']['metadata'] = array(
-				'name' => 'wc-privacy-policy-link',
+				'name' => 'jetpack-cookie-consent-privacy-policy-link',
 			);
 			$privacy_policy_processed          = true;
 			return $hooked_block;
@@ -370,7 +330,7 @@ class CIAB_Next_Shoppers_Privacy {
 			$hooked_block['attrs']['label']    = get_the_title( $ccpa_page_id );
 			$hooked_block['attrs']['kind']     = 'custom';
 			$hooked_block['attrs']['metadata'] = array(
-				'name' => 'wc-ccpa-privacy-link',
+				'name' => 'jetpack-cookie-consent-ccpa-privacy-link',
 			);
 			$ccpa_processed                    = true;
 			return $hooked_block;
@@ -379,10 +339,10 @@ class CIAB_Next_Shoppers_Privacy {
 		// Process GDPR "Manage Privacy Preferences" link last.
 		if ( ! $manage_preferences_processed ) {
 			$hooked_block['attrs']['url']      = '#manage-preferences';
-			$hooked_block['attrs']['label']    = __( 'Manage Privacy Preferences', 'ciab' );
+			$hooked_block['attrs']['label']    = __( 'Manage Privacy Preferences', 'jetpack-cookie-consent' );
 			$hooked_block['attrs']['kind']     = 'custom';
 			$hooked_block['attrs']['metadata'] = array(
-				'name' => 'wc-gdpr-manage-preferences-link',
+				'name' => 'jetpack-cookie-consent-gdpr-manage-preferences-link',
 			);
 			$manage_preferences_processed      = true;
 			return $hooked_block;
@@ -401,7 +361,7 @@ class CIAB_Next_Shoppers_Privacy {
 	 */
 	public function add_ccpa_interactivity_directives( $block_content, $block ) {
 		// Check if this is our CCPA link by looking for our metadata marker.
-		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'wc-ccpa-privacy-link' !== $block['attrs']['metadata']['name'] ) {
+		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'jetpack-cookie-consent-ccpa-privacy-link' !== $block['attrs']['metadata']['name'] ) {
 			return $block_content;
 		}
 
@@ -411,9 +371,9 @@ class CIAB_Next_Shoppers_Privacy {
 		// Find the first <li> tag (the navigation item wrapper).
 		if ( $tags->next_tag( 'li' ) ) {
 			// Add Interactivity API directives to the <li>.
-			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-interactive', 'jetpack/cookie-consent' );
 			$tags->set_attribute( 'data-wp-context', '{"isCcpaRegion": false}' );
-			$tags->set_attribute( 'data-wp-class--wc-ccpa-privacy-link-hidden', '!state.isCcpaRegion' );
+			$tags->set_attribute( 'data-wp-class--jetpack-cookie-consent-ccpa-privacy-link-hidden', '!state.isCcpaRegion' );
 			$tags->set_attribute( 'data-wp-init', 'callbacks.init' );
 
 			return $tags->get_updated_html();
@@ -431,7 +391,7 @@ class CIAB_Next_Shoppers_Privacy {
 	 */
 	public function add_gdpr_manage_preferences_directives( $block_content, $block ) {
 		// Check if this is our manage preferences link by looking for our metadata marker.
-		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'wc-gdpr-manage-preferences-link' !== $block['attrs']['metadata']['name'] ) {
+		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'jetpack-cookie-consent-gdpr-manage-preferences-link' !== $block['attrs']['metadata']['name'] ) {
 			return $block_content;
 		}
 
@@ -441,11 +401,11 @@ class CIAB_Next_Shoppers_Privacy {
 		// Find the first <li> tag (the navigation item wrapper).
 		if ( $tags->next_tag( 'li' ) ) {
 			// Add Interactivity API directives to the <li>.
-			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-interactive', 'jetpack/cookie-consent' );
 			$tags->set_attribute( 'data-wp-context', '{"isGdprManageLink": false}' );
-			$tags->set_attribute( 'data-wp-class--wc-gdpr-manage-link-hidden', '!context.isGdprManageLink' );
+			$tags->set_attribute( 'data-wp-class--jetpack-cookie-consent-gdpr-manage-link-hidden', '!context.isGdprManageLink' );
 			$tags->set_attribute( 'data-wp-init', 'callbacks.init' );
-			$tags->add_class( 'wc-gdpr-manage-link-hidden' );
+			$tags->add_class( 'jetpack-cookie-consent-gdpr-manage-link-hidden' );
 		}
 
 		// Find the <a> tag and add click handler.
@@ -465,7 +425,7 @@ class CIAB_Next_Shoppers_Privacy {
 	 */
 	public function add_ccpa_button_directive( $block_content, $block ) {
 		// Check if this button has the CCPA opt-out class.
-		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'wc-ccpa-opt-out-button' ) ) {
+		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'jetpack-cookie-consent-ccpa-opt-out-button' ) ) {
 			return $block_content;
 		}
 
@@ -490,7 +450,7 @@ class CIAB_Next_Shoppers_Privacy {
 	 */
 	public function add_ccpa_group_directives( $block_content, $block ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		// Check if this group block has the CCPA opt-out section class.
-		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'wc-ccpa-opt-out-section' ) ) {
+		if ( ! isset( $block['attrs']['className'] ) || false === strpos( $block['attrs']['className'], 'jetpack-cookie-consent-ccpa-opt-out-section' ) ) {
 			return $block_content;
 		}
 
@@ -499,21 +459,21 @@ class CIAB_Next_Shoppers_Privacy {
 
 		// Find the group div.
 		if ( $tags->next_tag( array( 'class_name' => 'wp-block-group' ) ) ) {
-			$tags->set_attribute( 'data-wp-interactive', 'cookie-consent' );
+			$tags->set_attribute( 'data-wp-interactive', 'jetpack/cookie-consent' );
 			$tags->set_attribute( 'data-wp-context', '{"showSnackbar": false}' );
 			$block_content = $tags->get_updated_html();
 		}
 
 		// Build the snackbar HTML.
 		$snackbar_html = sprintf(
-			'<div class="wc-ccpa-snackbar" data-wp-bind--hidden="!state.showSnackbar">
-				<div class="wc-ccpa-snackbar__content">
+			'<div class="jetpack-cookie-consent-ccpa-snackbar" data-wp-bind--hidden="!state.showSnackbar">
+				<div class="jetpack-cookie-consent-ccpa-snackbar__content">
 					<span>%s</span>
-					<button type="button" class="wc-ccpa-snackbar__dismiss" data-wp-on--click="actions.dismissSnackbar" aria-label="%s">×</button>
+					<button type="button" class="jetpack-cookie-consent-ccpa-snackbar__dismiss" data-wp-on--click="actions.dismissSnackbar" aria-label="%s">×</button>
 				</div>
 			</div>',
-			esc_html__( 'Your browser has been successfully opted out from sharing personal data.', 'ciab' ),
-			esc_attr__( 'Dismiss', 'ciab' )
+			esc_html__( 'Your browser has been successfully opted out from sharing personal data.', 'jetpack-cookie-consent' ),
+			esc_attr__( 'Dismiss', 'jetpack-cookie-consent' )
 		);
 
 		// Insert the snackbar inside the group block (before the closing </div>).
@@ -590,6 +550,7 @@ class CIAB_Next_Shoppers_Privacy {
 				'delaware',
 			),
 			'show_on_error'       => true, // Show banner if geolocation fails.
+			'event_prefix'        => 'jetpack', // Tracks event name prefix; set to 'woocommerceanalytics' for Unified Analytics continuity.
 		);
 
 		/**
@@ -597,7 +558,7 @@ class CIAB_Next_Shoppers_Privacy {
 		 *
 		 * @param array $config Configuration array
 		 */
-		return apply_filters( 'ciab_next_shoppers_privacy_config', $default_config );
+		return apply_filters( 'jetpack_cookie_consent_config', $default_config );
 	}
 
 	/**
@@ -622,19 +583,47 @@ class CIAB_Next_Shoppers_Privacy {
 			)
 		);
 
-		wp_enqueue_script_module( '@ciab-next/shoppers-privacy' );
+		// Register and enqueue the Interactivity API script module built by webpack.
+		$asset_file   = __DIR__ . '/../build/modules/cookie-consent/index.asset.php';
+		$asset        = file_exists( $asset_file ) ? require $asset_file : array(
+			'dependencies' => array( '@wordpress/interactivity' ),
+			'version'      => self::PACKAGE_VERSION,
+		);
+		$module_url   = plugins_url( 'build/modules/cookie-consent/index.js', __DIR__ );
+		$module_id    = '@automattic/jetpack-cookie-consent';
 
-		// Pass REST API URL to the module via global config.
+		wp_register_script_module(
+			$module_id,
+			$module_url,
+			$asset['dependencies'],
+			$asset['version']
+		);
+		wp_enqueue_script_module( $module_id );
+
+		// Enqueue the module's compiled styles.
+		$style_url = plugins_url( 'build/modules/cookie-consent/index.css', __DIR__ );
+		wp_enqueue_style(
+			'jetpack-cookie-consent',
+			$style_url,
+			array(),
+			$asset['version']
+		);
+
+		// Resolve the configured Tracks event prefix once so it can be shared below.
+		$config = $this->get_config();
+
+		// Pass REST API URL and Tracks event prefix to the module via global config.
 		wp_print_inline_script_tag(
 			sprintf(
-				'window.wcConsentLoggerConfig = %s;',
+				'window.jetpackCookieConsentConfig = %s;',
 				wp_json_encode(
 					array(
-						'apiUrl' => rest_url( 'wc/next/consent-log' ),
+						'apiUrl'      => rest_url( 'jetpack/v4/cookie-consent/consent-log' ),
+						'eventPrefix' => $config['event_prefix'],
 					)
 				)
 			),
-			array( 'id' => 'wc-consent-logger-config' )
+			array( 'id' => 'jetpack-cookie-consent-config' )
 		);
 
 		// Check for preview query parameter.
@@ -642,9 +631,8 @@ class CIAB_Next_Shoppers_Privacy {
 		$force_preview = isset( $_GET['preview_cookie_consent'] ) && '1' === $_GET['preview_cookie_consent'];
 
 		// Pass configuration to frontend using wp_interactivity_config.
-		$config = $this->get_config();
 		wp_interactivity_config(
-			'cookie-consent',
+			'jetpack/cookie-consent',
 			array(
 				'geoApiUrl'         => $config['geo_api_url'],
 				'geoCookieDuration' => $config['geo_cookie_duration'],

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -243,7 +243,7 @@ class Cookie_Consent {
 		}
 
 		// Only hook in footer template parts.
-		if ( ! is_array( $context ) || ! str_contains( $context['slug'], '/footer' ) ) {
+		if ( ! is_array( $context ) || ! isset( $context['slug'] ) || ! str_contains( $context['slug'], '/footer' ) ) {
 			return $hooked_block_types;
 		}
 

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -166,8 +166,8 @@ class Cookie_Consent {
 	/**
 	 * Exclude CCPA page from get_pages() results
 	 *
-	 * @param WP_Post[] $pages Array of page objects.
-	 * @return WP_Post[] Filtered array of page objects.
+	 * @param \WP_Post[] $pages Array of page objects.
+	 * @return \WP_Post[] Filtered array of page objects.
 	 */
 	public static function exclude_ccpa_from_get_pages( $pages ) {
 		if ( is_admin() ) {
@@ -215,7 +215,7 @@ class Cookie_Consent {
 
 		// Prevent deletion of Privacy Policy page.
 		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
-		if ( $privacy_policy_page_id && $post_id === (int) $privacy_policy_page_id ) {
+		if ( $privacy_policy_page_id && $post_id === $privacy_policy_page_id ) {
 			return array( 'do_not_allow' );
 		}
 
@@ -228,7 +228,7 @@ class Cookie_Consent {
 	 * @param array                   $hooked_block_types Array of hooked block types.
 	 * @param string                  $relative_position  The relative position.
 	 * @param string                  $anchor_block_type  The anchor block type.
-	 * @param WP_Block_Template|array $context            The block template, template part, or pattern.
+	 * @param \WP_Block_Template|array $context            The block template, template part, or pattern.
 	 * @return array Modified array of hooked block types.
 	 */
 	public static function register_footer_navigation_links( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -593,7 +593,7 @@ class Cookie_Consent {
 		// `wp-polyfill`) must not be forwarded to wp_register_script_module().
 		$asset_file = __DIR__ . '/../build/modules/cookie-consent/index.asset.php';
 		$asset      = file_exists( $asset_file ) ? require $asset_file : array();
-		$version    = isset( $asset['version'] ) ? $asset['version'] : self::PACKAGE_VERSION;
+		$version    = $asset['version'] ?? self::PACKAGE_VERSION;
 		$module_url = plugins_url( 'build/modules/cookie-consent/index.js', __DIR__ );
 		$module_id  = '@automattic/jetpack-cookie-consent';
 

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -225,9 +225,9 @@ class Cookie_Consent {
 	/**
 	 * Register Privacy Policy and CCPA navigation links as hooked blocks
 	 *
-	 * @param array                   $hooked_block_types Array of hooked block types.
-	 * @param string                  $relative_position  The relative position.
-	 * @param string                  $anchor_block_type  The anchor block type.
+	 * @param array                    $hooked_block_types Array of hooked block types.
+	 * @param string                   $relative_position  The relative position.
+	 * @param string                   $anchor_block_type  The anchor block type.
 	 * @param \WP_Block_Template|array $context            The block template, template part, or pattern.
 	 * @return array Modified array of hooked block types.
 	 */

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -54,14 +54,14 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 			<div class="jetpack-cookie-consent__banner-actions">
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.acceptAll"
 				>
 					<?php echo esc_html__( 'Accept', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.rejectAll"
 				>
 					<?php echo esc_html__( 'Reject', 'jetpack-cookie-consent' ); ?>
@@ -249,7 +249,7 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 			<div class="jetpack-cookie-consent__modal-footer">
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.savePreferences"
 				>
 					<?php echo esc_html__( 'Save preferences', 'jetpack-cookie-consent' ); ?>

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -2,7 +2,7 @@
 /**
  * Cookie Consent Banner Template
  *
- * @package woocommerce-next
+ * @package automattic/jetpack-cookie-consent
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div
-	data-wp-interactive="cookie-consent"
+	data-wp-interactive="jetpack/cookie-consent"
 	data-wp-context='{
 		"showBanner": false,
 		"showModal": false,
@@ -23,52 +23,52 @@ if ( ! defined( 'ABSPATH' ) ) {
 		"textExpanded": false
 	}'
 	data-wp-init="callbacks.init"
-	class="wc-cookie-consent"
+	class="jetpack-cookie-consent"
 >
 	<!-- Banner -->
 	<div
-		class="wc-cookie-consent__banner"
-		data-wp-class--wc-cookie-consent__banner--visible="state.showBanner"
+		class="jetpack-cookie-consent__banner"
+		data-wp-class--jetpack-cookie-consent__banner--visible="state.showBanner"
 		role="dialog"
 		aria-labelledby="cookie-consent-title"
 		aria-describedby="cookie-consent-description"
 	>
-		<div class="wc-cookie-consent__banner-inner">
+		<div class="jetpack-cookie-consent__banner-inner">
 
-			<div class="wc-cookie-consent__banner-content">
-				<h2 id="cookie-consent-title" class="wc-cookie-consent__banner-title">
-					<?php echo esc_html__( 'Use of your personal data', 'ciab' ); ?>
+			<div class="jetpack-cookie-consent__banner-content">
+				<h2 id="cookie-consent-title" class="jetpack-cookie-consent__banner-title">
+					<?php echo esc_html__( 'Use of your personal data', 'jetpack-cookie-consent' ); ?>
 				</h2>
-				<p id="cookie-consent-description" class="wc-cookie-consent__banner-description">
+				<p id="cookie-consent-description" class="jetpack-cookie-consent__banner-description">
 					<?php
 					echo esc_html__(
 						'We and our partners process your personal data (such as browsing data, IP Addresses, cookie information, and other unique identifiers) based on your consent and/or our legitimate interest to optimize our website, marketing activities, and your user experience.',
-						'ciab'
+						'jetpack-cookie-consent'
 					);
 					?>
 				</p>
 			</div>
-			<div class="wc-cookie-consent__banner-actions">
+			<div class="jetpack-cookie-consent__banner-actions">
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.acceptAll"
 				>
-					<?php echo esc_html__( 'Accept', 'ciab' ); ?>
+					<?php echo esc_html__( 'Accept', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.rejectAll"
 				>
-					<?php echo esc_html__( 'Reject', 'ciab' ); ?>
+					<?php echo esc_html__( 'Reject', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.openModal"
 				>
-					<?php echo esc_html__( 'Customize', 'ciab' ); ?>
+					<?php echo esc_html__( 'Customize', 'jetpack-cookie-consent' ); ?>
 				</button>
 			</div>
 		</div>
@@ -76,60 +76,60 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<!-- Modal Overlay-->
 	<div
-		class="wc-cookie-consent__modal-overlay"
+		class="jetpack-cookie-consent__modal-overlay"
 		data-wp-bind--hidden="!state.showModal"
 		data-wp-on--click="actions.closeModal"
 		role="presentation"
 	></div>
 	<div
-		class="wc-cookie-consent__modal"
+		class="jetpack-cookie-consent__modal"
 		data-wp-bind--hidden="!state.showModal"
-		data-wp-class--wc-cookie-consent__modal--visible="state.showModal"
+		data-wp-class--jetpack-cookie-consent__modal--visible="state.showModal"
 		data-wp-on--keydown="actions.onModalKeyDown"
 		role="dialog"
 		aria-labelledby="cookie-consent-modal-title"
 		aria-modal="true"
 	>
-		<div class="wc-cookie-consent__modal-header">
-			<h3 id="cookie-consent-modal-title" class="wc-cookie-consent__modal-title">
-				<?php echo esc_html__( 'Customize preferences', 'ciab' ); ?>
+		<div class="jetpack-cookie-consent__modal-header">
+			<h3 id="cookie-consent-modal-title" class="jetpack-cookie-consent__modal-title">
+				<?php echo esc_html__( 'Customize preferences', 'jetpack-cookie-consent' ); ?>
 			</h3>
 			<button
 				type="button"
-				class="wc-cookie-consent__modal-close"
+				class="jetpack-cookie-consent__modal-close"
 				data-wp-on--click="actions.closeModal"
-				aria-label="<?php echo esc_attr__( 'Close modal', 'ciab' ); ?>"
+				aria-label="<?php echo esc_attr__( 'Close modal', 'jetpack-cookie-consent' ); ?>"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 					<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
 				</svg>
 			</button>
 		</div>
-		<div class="wc-cookie-consent__modal-content">
-			<div class="wc-cookie-consent__modal-body">
-				<p class="wc-cookie-consent__modal-description">
+		<div class="jetpack-cookie-consent__modal-content">
+			<div class="jetpack-cookie-consent__modal-body">
+				<p class="jetpack-cookie-consent__modal-description">
 					<?php
 					echo esc_html__(
 						'Your privacy is critically important to us. We and our partners use, store, and process your personal data to optimize our website such as by improving security or conducting analytics, marketing activities to help deliver relevant marketing or content, and your user experience such as by remembering your account name, language settings, or cart information, where applicable. You can customize your cookie settings below. Learn more in our',
-						'ciab'
+						'jetpack-cookie-consent'
 					);
 					?>
-					<a href="<?php echo esc_url( get_privacy_policy_url() ); ?>" class="wc-cookie-consent__link">
-						<?php echo esc_html__( 'Privacy Policy', 'ciab' ); ?>
+					<a href="<?php echo esc_url( get_privacy_policy_url() ); ?>" class="jetpack-cookie-consent__link">
+						<?php echo esc_html__( 'Privacy Policy', 'jetpack-cookie-consent' ); ?>
 					</a>
-					<?php echo esc_html__( 'and', 'ciab' ); ?>
-					<a href="<?php echo esc_url( $config['cookie_policy_url'] ); ?>" class="wc-cookie-consent__link">
-						<?php echo esc_html__( 'Cookie Policy', 'ciab' ); ?>
+					<?php echo esc_html__( 'and', 'jetpack-cookie-consent' ); ?>
+					<a href="<?php echo esc_url( $config['cookie_policy_url'] ); ?>" class="jetpack-cookie-consent__link">
+						<?php echo esc_html__( 'Cookie Policy', 'jetpack-cookie-consent' ); ?>
 					</a>.
 				</p>
 
-				<div class="wc-cookie-consent__category-controls">
+				<div class="jetpack-cookie-consent__category-controls">
 					<button
 						type="button"
-						class="wc-cookie-consent__description-toggle"
-						data-wp-class--wc-cookie-consent__description-toggle--expanded="context.textExpanded"
+						class="jetpack-cookie-consent__description-toggle"
+						data-wp-class--jetpack-cookie-consent__description-toggle--expanded="context.textExpanded"
 						data-wp-on--click="actions.toggleDescription"
-						aria-label="<?php echo esc_attr__( 'Toggle category description', 'ciab' ); ?>"
+						aria-label="<?php echo esc_attr__( 'Toggle category description', 'jetpack-cookie-consent' ); ?>"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 25 25" fill="none">
 							<path d="M18 12.5319L12.5 16.9319L7 12.5319L7.9 11.3319L12.5 14.9319L17 11.3319L18 12.5319Z" fill="#1E1E1E"/>
@@ -137,9 +137,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</button>
 
 					<!-- Required Cookies -->
-					<div class="wc-cookie-consent__category">
-						<div class="wc-cookie-consent__category-header">
-							<div class="wc-cookie-consent__category-checkbox wc-cookie-consent__category-checkbox--disabled">
+					<div class="jetpack-cookie-consent__category">
+						<div class="jetpack-cookie-consent__category-header">
+							<div class="jetpack-cookie-consent__category-checkbox jetpack-cookie-consent__category-checkbox--disabled">
 								<input
 									type="checkbox"
 									id="cookie-required"
@@ -147,35 +147,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 									disabled
 								/>
 								<label for="cookie-required">
-									<span class="wc-cookie-consent__category-checkbox-icon"></span>
-									<span class="wc-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Required', 'ciab' ); ?>
-										<span class="wc-cookie-consent__category-badge">
-											<?php echo esc_html__( 'Always active', 'ciab' ); ?>
+									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
+									<span class="jetpack-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Required', 'jetpack-cookie-consent' ); ?>
+										<span class="jetpack-cookie-consent__category-badge">
+											<?php echo esc_html__( 'Always active', 'jetpack-cookie-consent' ); ?>
 										</span>
 									</span>
 								</label>
 							</div>
 						</div>
-						<div class="wc-cookie-consent__category-content">
-							<p data-wp-bind--hidden="context.textExpanded" class="wc-cookie-consent__category-text">
+						<div class="jetpack-cookie-consent__category-content">
+							<p data-wp-bind--hidden="context.textExpanded" class="jetpack-cookie-consent__category-text">
 								<?php
 								echo esc_html(
 									wp_trim_words(
 										__(
 											'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
-											'ciab'
+											'jetpack-cookie-consent'
 										),
 										25
 									)
 								);
 								?>
 							</p>
-							<p data-wp-bind--hidden="!context.textExpanded" class="wc-cookie-consent__category-text">
+							<p data-wp-bind--hidden="!context.textExpanded" class="jetpack-cookie-consent__category-text">
 								<?php
 								echo esc_html__(
 									'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
-									'ciab'
+									'jetpack-cookie-consent'
 								);
 								?>
 							</p>
@@ -183,9 +183,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 
 					<!-- Analytics Cookies -->
-					<div class="wc-cookie-consent__category">
-						<div class="wc-cookie-consent__category-header">
-							<div class="wc-cookie-consent__category-checkbox">
+					<div class="jetpack-cookie-consent__category">
+						<div class="jetpack-cookie-consent__category-header">
+							<div class="jetpack-cookie-consent__category-checkbox">
 								<input
 									type="checkbox"
 									id="cookie-analytics"
@@ -193,19 +193,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 									data-wp-on--change="actions.toggleAnalytics"
 								/>
 								<label for="cookie-analytics">
-									<span class="wc-cookie-consent__category-checkbox-icon"></span>
-									<span class="wc-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Analytics', 'ciab' ); ?>
+									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
+									<span class="jetpack-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Analytics', 'jetpack-cookie-consent' ); ?>
 									</span>
 								</label>
 							</div>
 						</div>
-						<div class="wc-cookie-consent__category-content">
-							<p class="wc-cookie-consent__category-text">
+						<div class="jetpack-cookie-consent__category-content">
+							<p class="jetpack-cookie-consent__category-text">
 								<?php
 								echo esc_html__(
 									'These cookies allow us to optimize performance by collecting information on how users interact with our websites.',
-									'ciab'
+									'jetpack-cookie-consent'
 								);
 								?>
 							</p>
@@ -213,9 +213,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 
 					<!-- Advertising Cookies -->
-					<div class="wc-cookie-consent__category">
-						<div class="wc-cookie-consent__category-header">
-							<div class="wc-cookie-consent__category-checkbox">
+					<div class="jetpack-cookie-consent__category">
+						<div class="jetpack-cookie-consent__category-header">
+							<div class="jetpack-cookie-consent__category-checkbox">
 								<input
 									type="checkbox"
 									id="cookie-advertising"
@@ -223,19 +223,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 									data-wp-on--change="actions.toggleAdvertising"
 								/>
 								<label for="cookie-advertising">
-									<span class="wc-cookie-consent__category-checkbox-icon"></span>
-									<span class="wc-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Advertising', 'ciab' ); ?>
+									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
+									<span class="jetpack-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Advertising', 'jetpack-cookie-consent' ); ?>
 									</span>
 								</label>
 							</div>
 						</div>
-						<div class="wc-cookie-consent__category-content">
-							<p class="wc-cookie-consent__category-text">
+						<div class="jetpack-cookie-consent__category-content">
+							<p class="jetpack-cookie-consent__category-text">
 								<?php
 								echo esc_html__(
 									'These cookies are set by us and our advertising partners to provide you with relevant content and to understand that content\'s effectiveness.',
-									'ciab'
+									'jetpack-cookie-consent'
 								);
 								?>
 							</p>
@@ -243,27 +243,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 				</div>
 			</div>
-			<div class="wc-cookie-consent__modal-footer">
+			<div class="jetpack-cookie-consent__modal-footer">
 				<button
 					type="button"
-					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.savePreferences"
 				>
-					<?php echo esc_html__( 'Save preferences', 'ciab' ); ?>
+					<?php echo esc_html__( 'Save preferences', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.acceptAll"
 				>
-					<?php echo esc_html__( 'Accept all', 'ciab' ); ?>
+					<?php echo esc_html__( 'Accept all', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.rejectAll"
 				>
-					<?php echo esc_html__( 'Reject all', 'ciab' ); ?>
+					<?php echo esc_html__( 'Reject all', 'jetpack-cookie-consent' ); ?>
 				</button>
 			</div>
 		</div>

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Cookie Consent Banner Template
+ *
+ * @package woocommerce-next
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<div
+	data-wp-interactive="cookie-consent"
+	data-wp-context='{
+		"showBanner": false,
+		"showModal": false,
+		"categories": {
+			"required": true,
+			"analytics": true,
+			"advertising": false
+		},
+		"textExpanded": false
+	}'
+	data-wp-init="callbacks.init"
+	class="wc-cookie-consent"
+>
+	<!-- Banner -->
+	<div
+		class="wc-cookie-consent__banner"
+		data-wp-class--wc-cookie-consent__banner--visible="state.showBanner"
+		role="dialog"
+		aria-labelledby="cookie-consent-title"
+		aria-describedby="cookie-consent-description"
+	>
+		<div class="wc-cookie-consent__banner-inner">
+
+			<div class="wc-cookie-consent__banner-content">
+				<h2 id="cookie-consent-title" class="wc-cookie-consent__banner-title">
+					<?php echo esc_html__( 'Use of your personal data', 'ciab' ); ?>
+				</h2>
+				<p id="cookie-consent-description" class="wc-cookie-consent__banner-description">
+					<?php
+					echo esc_html__(
+						'We and our partners process your personal data (such as browsing data, IP Addresses, cookie information, and other unique identifiers) based on your consent and/or our legitimate interest to optimize our website, marketing activities, and your user experience.',
+						'ciab'
+					);
+					?>
+				</p>
+			</div>
+			<div class="wc-cookie-consent__banner-actions">
+				<button
+					type="button"
+					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					data-wp-on--click="actions.acceptAll"
+				>
+					<?php echo esc_html__( 'Accept', 'ciab' ); ?>
+				</button>
+				<button
+					type="button"
+					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					data-wp-on--click="actions.rejectAll"
+				>
+					<?php echo esc_html__( 'Reject', 'ciab' ); ?>
+				</button>
+				<button
+					type="button"
+					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					data-wp-on--click="actions.openModal"
+				>
+					<?php echo esc_html__( 'Customize', 'ciab' ); ?>
+				</button>
+			</div>
+		</div>
+	</div>
+
+	<!-- Modal Overlay-->
+	<div
+		class="wc-cookie-consent__modal-overlay"
+		data-wp-bind--hidden="!state.showModal"
+		data-wp-on--click="actions.closeModal"
+		role="presentation"
+	></div>
+	<div
+		class="wc-cookie-consent__modal"
+		data-wp-bind--hidden="!state.showModal"
+		data-wp-class--wc-cookie-consent__modal--visible="state.showModal"
+		data-wp-on--keydown="actions.onModalKeyDown"
+		role="dialog"
+		aria-labelledby="cookie-consent-modal-title"
+		aria-modal="true"
+	>
+		<div class="wc-cookie-consent__modal-header">
+			<h3 id="cookie-consent-modal-title" class="wc-cookie-consent__modal-title">
+				<?php echo esc_html__( 'Customize preferences', 'ciab' ); ?>
+			</h3>
+			<button
+				type="button"
+				class="wc-cookie-consent__modal-close"
+				data-wp-on--click="actions.closeModal"
+				aria-label="<?php echo esc_attr__( 'Close modal', 'ciab' ); ?>"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+					<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
+				</svg>
+			</button>
+		</div>
+		<div class="wc-cookie-consent__modal-content">
+			<div class="wc-cookie-consent__modal-body">
+				<p class="wc-cookie-consent__modal-description">
+					<?php
+					echo esc_html__(
+						'Your privacy is critically important to us. We and our partners use, store, and process your personal data to optimize our website such as by improving security or conducting analytics, marketing activities to help deliver relevant marketing or content, and your user experience such as by remembering your account name, language settings, or cart information, where applicable. You can customize your cookie settings below. Learn more in our',
+						'ciab'
+					);
+					?>
+					<a href="<?php echo esc_url( get_privacy_policy_url() ); ?>" class="wc-cookie-consent__link">
+						<?php echo esc_html__( 'Privacy Policy', 'ciab' ); ?>
+					</a>
+					<?php echo esc_html__( 'and', 'ciab' ); ?>
+					<a href="<?php echo esc_url( $config['cookie_policy_url'] ); ?>" class="wc-cookie-consent__link">
+						<?php echo esc_html__( 'Cookie Policy', 'ciab' ); ?>
+					</a>.
+				</p>
+
+				<div class="wc-cookie-consent__category-controls">
+					<button
+						type="button"
+						class="wc-cookie-consent__description-toggle"
+						data-wp-class--wc-cookie-consent__description-toggle--expanded="context.textExpanded"
+						data-wp-on--click="actions.toggleDescription"
+						aria-label="<?php echo esc_attr__( 'Toggle category description', 'ciab' ); ?>"
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 25 25" fill="none">
+							<path d="M18 12.5319L12.5 16.9319L7 12.5319L7.9 11.3319L12.5 14.9319L17 11.3319L18 12.5319Z" fill="#1E1E1E"/>
+						</svg>
+					</button>
+
+					<!-- Required Cookies -->
+					<div class="wc-cookie-consent__category">
+						<div class="wc-cookie-consent__category-header">
+							<div class="wc-cookie-consent__category-checkbox wc-cookie-consent__category-checkbox--disabled">
+								<input
+									type="checkbox"
+									id="cookie-required"
+									checked
+									disabled
+								/>
+								<label for="cookie-required">
+									<span class="wc-cookie-consent__category-checkbox-icon"></span>
+									<span class="wc-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Required', 'ciab' ); ?>
+										<span class="wc-cookie-consent__category-badge">
+											<?php echo esc_html__( 'Always active', 'ciab' ); ?>
+										</span>
+									</span>
+								</label>
+							</div>
+						</div>
+						<div class="wc-cookie-consent__category-content">
+							<p data-wp-bind--hidden="context.textExpanded" class="wc-cookie-consent__category-text">
+								<?php
+								echo esc_html(
+									wp_trim_words(
+										__(
+											'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
+											'ciab'
+										),
+										25
+									)
+								);
+								?>
+							</p>
+							<p data-wp-bind--hidden="!context.textExpanded" class="wc-cookie-consent__category-text">
+								<?php
+								echo esc_html__(
+									'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
+									'ciab'
+								);
+								?>
+							</p>
+						</div>
+					</div>
+
+					<!-- Analytics Cookies -->
+					<div class="wc-cookie-consent__category">
+						<div class="wc-cookie-consent__category-header">
+							<div class="wc-cookie-consent__category-checkbox">
+								<input
+									type="checkbox"
+									id="cookie-analytics"
+									data-wp-bind--checked="context.categories.analytics"
+									data-wp-on--change="actions.toggleAnalytics"
+								/>
+								<label for="cookie-analytics">
+									<span class="wc-cookie-consent__category-checkbox-icon"></span>
+									<span class="wc-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Analytics', 'ciab' ); ?>
+									</span>
+								</label>
+							</div>
+						</div>
+						<div class="wc-cookie-consent__category-content">
+							<p class="wc-cookie-consent__category-text">
+								<?php
+								echo esc_html__(
+									'These cookies allow us to optimize performance by collecting information on how users interact with our websites.',
+									'ciab'
+								);
+								?>
+							</p>
+						</div>
+					</div>
+
+					<!-- Advertising Cookies -->
+					<div class="wc-cookie-consent__category">
+						<div class="wc-cookie-consent__category-header">
+							<div class="wc-cookie-consent__category-checkbox">
+								<input
+									type="checkbox"
+									id="cookie-advertising"
+									data-wp-bind--checked="context.categories.advertising"
+									data-wp-on--change="actions.toggleAdvertising"
+								/>
+								<label for="cookie-advertising">
+									<span class="wc-cookie-consent__category-checkbox-icon"></span>
+									<span class="wc-cookie-consent__category-label-text">
+										<?php echo esc_html__( 'Advertising', 'ciab' ); ?>
+									</span>
+								</label>
+							</div>
+						</div>
+						<div class="wc-cookie-consent__category-content">
+							<p class="wc-cookie-consent__category-text">
+								<?php
+								echo esc_html__(
+									'These cookies are set by us and our advertising partners to provide you with relevant content and to understand that content\'s effectiveness.',
+									'ciab'
+								);
+								?>
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="wc-cookie-consent__modal-footer">
+				<button
+					type="button"
+					class="wc-block-components-button wp-element-button wc-cookie-consent__button wc-cookie-consent__button--primary"
+					data-wp-on--click="actions.savePreferences"
+				>
+					<?php echo esc_html__( 'Save preferences', 'ciab' ); ?>
+				</button>
+				<button
+					type="button"
+					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					data-wp-on--click="actions.acceptAll"
+				>
+					<?php echo esc_html__( 'Accept all', 'ciab' ); ?>
+				</button>
+				<button
+					type="button"
+					class="wc-cookie-consent__button wc-cookie-consent__button--secondary"
+					data-wp-on--click="actions.rejectAll"
+				>
+					<?php echo esc_html__( 'Reject all', 'ciab' ); ?>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -51,14 +51,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="jetpack-cookie-consent__banner-actions">
 				<button
 					type="button"
-					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.acceptAll"
 				>
 					<?php echo esc_html__( 'Accept', 'jetpack-cookie-consent' ); ?>
 				</button>
 				<button
 					type="button"
-					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.rejectAll"
 				>
 					<?php echo esc_html__( 'Reject', 'jetpack-cookie-consent' ); ?>
@@ -246,7 +246,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<div class="jetpack-cookie-consent__modal-footer">
 				<button
 					type="button"
-					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
+					class="wc-block-components-button wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.savePreferences"
 				>
 					<?php echo esc_html__( 'Save preferences', 'jetpack-cookie-consent' ); ?>

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -8,6 +8,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+// $config is supplied by Cookie_Consent::render_banner() when this template is included.
+$config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_policy_url' => '' );
 ?>
 
 <div


### PR DESCRIPTION

Part of **WOOA7S-1533** — migrating CIAB `shoppers-privacy` into the standalone, plugin-agnostic `cookie-consent` package. This is **PR 3 of 3**: the PHP backend (main class, consent-log REST controller, templates) and the module enqueue, **decoupled from WooCommerce** so the package runs on any WordPress site.

## Proposed changes

Verbatim-copy → rebrand → decouple commit discipline.

**Stack** (PR1 + PR2 have merged into `trunk`; this PR now targets `trunk`):

1. ~~PR1 — scaffold (#49509)~~ ✅ merged
2. ~~PR2 — frontend module (#49510)~~ ✅ merged
3. **PR3 — PHP backend + module enqueue** ← _this PR_ (now targets `trunk`)

| Commit                                      | What to review                                                                                                                                                                                                                                 |
| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| copy verbatim                               | byte-identical to upstream `class-shoppers-privacy.php`, `api/consent-log.php`, and the two content templates                                                                                                                                  |
| namespace + rebrand + decouple (main class) | `Automattic\Jetpack\CookieConsent\Cookie_Consent`; text domain, options, filters, store ns, CSS markers → `jetpack(_cookie_consent)_*`; `wc_privacy_policy_page_id()` → core `wp_page_for_privacy_policy` option                               |
| controller → jetpack REST + WP-Cron         | `extends \WP_REST_Controller` (was `WC_REST_Controller`); REST ns `jetpack/v4/cookie-consent`; table `jetpack_cookie_consent_logs`; Action Scheduler → wp-cron daily cleanup; read cap `manage_privacy_options`                                |
| rebrand templates                           | classes/markers + `data-wp-interactive="jetpack/cookie-consent"` + text domain                                                                                                                                                                 |
| align with spec (fixups)                    | static `init()` + `$initialized` guard (no singleton/autoload side effects); init-time guarded CCPA page creation (Atomic `garden_site_provisioning` dropped); `register_ccpa_page_setting`; module enqueue by handle+URL+`.asset.php` version |
| phpcs + phan fixups                         | add `.phan/config.php`; guard the `$config` template variable so the banner template passes PHPCS                                                                                                                                              |

**Notes for reviewers**

- **Decouple from WooCommerce** is intentional: no `WC_*` base class, no Action Scheduler, no `manage_woocommerce`; the package targets Jetpack / Woo Pro / standalone alike.
- The consent-log controller keeps upstream's two-call `register_rest_route` pattern (CREATABLE + READABLE for the same route) — faithful to upstream; WP merges the handlers.
- `Cookie_Consent::init()` is the entry point; **no consumer wires it yet**, so this is safe to land without affecting any site.
- No automated tests — matches the upstream source (no tests) per the migration design.

## Related product discussion/links

- Linear: **WOOA7S-1533**

## Does this pull request change what data or activity we track or use?

Yes — once a consumer activates the package and calls `Cookie_Consent::init()`, consent events are logged to a custom `jetpack_cookie_consent_logs` table (`consent_id`, `event_type`, `ip_address`, page `url`, `consent_types`, timestamp), with a wp-cron job pruning old rows; the frontend may also fire Automattic Tracks events (configurable prefix, default `jetpack`). The stored IP address is PII, so the **"[Status] Needs Privacy Updates"** label likely applies before this ships behind a real consumer. **No consumer wires `init()` in this PR**, so nothing is collected at runtime yet.

## Testing instructions

The **`test/cookie-consent-49511`** branch is this PR (`add/cookie-consent-php`) plus a small test bootstrap mu-plugin that wires `Cookie_Consent::init()` — the package itself ships no consumer, so this is what lets you exercise the feature end-to-end.

1. `git checkout test/cookie-consent-49511`
2. Build the package: `jetpack build packages/cookie-consent` (emits the module JS + LTR/RTL CSS into `build/`).
3. Activate the bootstrap by **symlinking** it into your site's `mu-plugins/` (symlink, not copy, so `__DIR__` still resolves back into the package and finds its autoloader):
   ```sh
   ln -s "$PWD/projects/packages/cookie-consent/tools/test-bootstrap-mu-plugin.php" \
     /path/to/wp-content/mu-plugins/cookie-consent-test.php
   ```
4. Make the built assets web-reachable by symlinking the package into `wp-content/plugins/` as `jetpack-cookie-consent` — loaded standalone from the monorepo, `plugins_url()` can't resolve the package's asset URLs, and the bootstrap rewrites them to this symlink (a real consuming plugin bundling the package in its `jetpack_vendor/` wouldn't need this):
   ```sh
   ln -s "$PWD/projects/packages/cookie-consent" \
     /path/to/wp-content/plugins/jetpack-cookie-consent
   ```

Then verify:

- **Banner / REST** — load any frontend page; the consent banner/modal renders (GDPR region). Accept / reject / customize → a `POST` to `/wp-json/jetpack/v4/cookie-consent/consent-log` records the choice and `localStorage.jetpack_cookie_consent_id` is set.
- **DB table** — the log table is created on init and rows are written on each choice:
  ```sh
  wp db query "SHOW TABLES LIKE '%jetpack_cookie_consent_logs'"
  wp db query "SELECT id, consent_id, event_type, ip_address, url, consent_types, date_created_gmt \
    FROM wp_jetpack_cookie_consent_logs ORDER BY id DESC LIMIT 5"
  ```
  (adjust the `wp_` prefix to your install.)
- **WP-Cron** — a daily cleanup event is scheduled on init:
  ```sh
  wp cron event list | grep jetpack_cookie_consent_cleanup_consent_logs
  wp cron event run jetpack_cookie_consent_cleanup_consent_logs   # prune old rows on demand
  ```

When done, remove the mu-plugin symlink — the package ships without a consumer.

**Static checks:** all four PHP files pass `php -l`, `jetpack build packages/cookie-consent` succeeds, and typecheck is clean (`tsgo --noEmit` from within `projects/packages/cookie-consent`). PHPCS, eslint, and stylelint run at the monorepo root / in CI.


