### PR TITLE
Notifications: gate v3 panel behind a notifications=v3 query parameter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-notifications-v3-query-param
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-notifications-v3-query-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+wpcom-admin-bar: position the v3 notifications panel (#wpnt-notes-panel3) on mobile alongside the existing v2 panel.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -378,7 +378,8 @@
 					}
 				}
 
-				#wpnt-notes-panel2 {
+				#wpnt-notes-panel2,
+				#wpnt-notes-panel3 {
 					top: 46px;
 				}
 			}

--- a/projects/plugins/jetpack/changelog/add-notifications-v3-query-param
+++ b/projects/plugins/jetpack/changelog/add-notifications-v3-query-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Notifications: support a notifications=v3 query parameter to opt into the v3 notifications panel.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -195,6 +195,10 @@ class Jetpack_Notifications {
 
 		$third_party_cookie_check_iframe = '<span style="display:none;"><iframe class="jetpack-notes-cookie-check" src="https://widgets.wp.com/3rd-party-cookie-check/index.html"></iframe></span>';
 
+		// Opt into the v3 notifications panel/iframe via the `notifications=v3` query parameter.
+		$notifications_version = sanitize_key( wp_unslash( $_GET['notifications'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$panel_id              = 'v3' === $notifications_version ? 'wpnt-notes-panel3' : 'wpnt-notes-panel2';
+
 		$title = self::get_notes_markup();
 
 		// The default fallback is `en_US`. Remove underscore if present, noting that lang codes can be more than three chars.
@@ -205,7 +209,7 @@ class Jetpack_Notifications {
 				'id'     => 'notes',
 				'title'  => $title,
 				'meta'   => array(
-					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $user_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
+					'html'  => '<div id="' . esc_attr( $panel_id ) . '" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $user_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',


### PR DESCRIPTION
Related to DOTMSD-1294

## Proposed changes
* Adds a `notifications=v3` query parameter to the Notifications module that opts the admin-bar notifications panel into the v3 markup.
* When `?notifications=v3` is present, the panel container renders with `id="wpnt-notes-panel3"` (and the remote notes JS targets `#wpnt-notes-iframe3`); otherwise it keeps the existing `wpnt-notes-panel2` / `wpnt-notes-iframe2` behavior.
* The query value is unslashed and sanitized via `sanitize_key()` before use.

Note: this PR only controls the panel container `id` rendered by Jetpack. The matching `#wpnt-notes-iframe3` is created by the remote wpcom notes script (`admin-bar-v2.js` served from `s0.wp.com`); a corresponding wpcom-side change may be needed for the iframe to switch.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
* Apply this branch to a Jetpack-connected site and load the admin bar (e.g. `wp-admin`).
* Without the query parameter, inspect the Notifications panel markup and confirm the container is `<div id="wpnt-notes-panel2" ...>` (existing behavior).
* Reload the page with `?notifications=v3` appended to the URL.
* Confirm the container now renders as `<div id="wpnt-notes-panel3" ...>`.
* Verify the notifications bell still opens the panel and behaves normally in both cases.
