### PR TITLE
Social: remove unused getFailedConnections selector

### DIFF
--- a/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
@@ -71,21 +71,6 @@ export function hasConnections( state: SocialStoreState ) {
 }
 
 /**
- * Returns the failed Publicize connections.
- *
- * @param state - State object.
- * @return List of connections.
- */
-export const getFailedConnections = createSelector(
-	( state: SocialStoreState ) => {
-		const connections = getConnections( state );
-
-		return connections.filter( connection => 'broken' === connection.status );
-	},
-	( state: SocialStoreState ) => [ state.connectionData?.connections ]
-);
-
-/**
  * Returns a list of Publicize connection service names that require reauthentication from users.
  * For example, when LinkedIn switched its API from v1 to v2.
  *

--- a/projects/packages/publicize/_inc/social-store/selectors/test/connection-data.test.js
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/connection-data.test.js
@@ -1,7 +1,7 @@
 import {
 	getConnections,
 	hasConnections,
-	getFailedConnections,
+	getBrokenConnections,
 	getMustReauthConnections,
 	getEnabledConnections,
 	getDisabledConnections,
@@ -70,14 +70,14 @@ describe( 'Social store selectors: connectionData', () => {
 		} );
 	} );
 
-	describe( 'getFailedConnections', () => {
+	describe( 'getBrokenConnections', () => {
 		it( 'should return empty array if no connections', () => {
-			expect( getFailedConnections( {} ) ).toEqual( [] );
+			expect( getBrokenConnections( {} ) ).toEqual( [] );
 		} );
 
-		it( 'should return failed connections', () => {
-			const failedConnections = getFailedConnections( state );
-			expect( failedConnections ).toEqual( [ state.connectionData.connections[ 1 ] ] );
+		it( 'should return broken connections', () => {
+			const brokenConnections = getBrokenConnections( state );
+			expect( brokenConnections ).toEqual( [ state.connectionData.connections[ 1 ] ] );
 		} );
 	} );
 

--- a/projects/packages/publicize/changelog/remove-publicize-failed-connections-selector
+++ b/projects/packages/publicize/changelog/remove-publicize-failed-connections-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the unused getFailedConnections selector in favor of its duplicate getBrokenConnections


### PR DESCRIPTION
Fixes #

## Proposed changes

* Remove the unused `getFailedConnections` selector from the publicize package social store. It became an exact duplicate of `getBrokenConnections` when the old `test_success` field was replaced by `status` in #40679, and its last consumers were removed in #38350 and #47741.
* Repoint the existing `getFailedConnections` tests to `getBrokenConnections`, which is the selector actually used in production and previously had no direct test coverage.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify `getFailedConnections` is not referenced anywhere: `git grep getFailedConnections` should return nothing.
* Run the social store selector tests: `cd projects/packages/publicize && pnpm exec jest _inc/social-store/selectors/test/connection-data.test.js` — all tests should pass.
* Smoke test the editor sharing UI: with a broken social connection, the broken connection notice should still appear (it uses `getBrokenConnections`, which is unchanged).
