### PR TITLE
Jetpack AI Sidebar: only enqueue on WordPress.com Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/stop-jetpack-ai-sidebar-enqueue-non-simple
+++ b/projects/plugins/jetpack/changelog/stop-jetpack-ai-sidebar-enqueue-non-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Sidebar: only enqueue on WordPress.com Simple sites; skip Atomic and self-hosted Jetpack, where it is not surfaced via Calypso.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -45,12 +45,15 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to the Jetpack AI Sidebar Preview gate. Use this filter as
-		 * a host-level kill switch for the whole sidebar entrypoint.
+		 * Defaults to the Jetpack AI Sidebar Preview gate, limited to WordPress.com
+		 * Simple sites: on Atomic and self-hosted Jetpack the sidebar is not surfaced
+		 * via Calypso, so its scripts are not enqueued here. Use this filter as a
+		 * host-level kill switch, or to opt a non-Simple site back in (e.g. for testing).
 		 *
 		 * @param bool $enabled Whether the AI sidebar is enabled.
 		 */
-		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', self::is_jetpack_ai_sidebar_preview_enabled() ) ) {
+		$is_enabled = self::is_jetpack_ai_sidebar_preview_enabled() && ( new Host() )->is_wpcom_simple();
+		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', $is_enabled ) ) {
 			return;
 		}
 
@@ -61,8 +64,9 @@ class Jetpack_AI_Sidebar {
 
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
-		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
-		// post editor on WordPress.com and Atomic sites.
+		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the post
+		// editor. Reached on WordPress.com Simple by default; Atomic and self-hosted
+		// only when jetpack_ai_sidebar_enabled is forced on (see the gate above).
 		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Load AM from CDN if not already present.

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\AiAssistantPlugin;
 use Automattic\Jetpack\Extensions\AiAssistantPlugin\Jetpack_AI_Sidebar;
 use Automattic\Jetpack\Status\Cache as Status_Cache;
@@ -81,6 +82,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_enabled' );
 		remove_all_filters( 'jetpack_offline_mode' );
 		Status_Cache::clear();
+		Constants::clear_single_constant( 'IS_WPCOM' );
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( 'jetpack_offline_mode' );
@@ -236,9 +238,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that init() registers hooks by default for AI Editorial Review.
+	 * Test that init() registers hooks by default on WordPress.com Simple sites.
 	 */
 	public function test_init_registers_hooks_by_default() {
+		Constants::set_constant( 'IS_WPCOM', true );
 		Jetpack_AI_Sidebar::init();
 
 		$this->assertNotFalse(
@@ -259,6 +262,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that init() does nothing when the sidebar gate is explicitly disabled.
 	 */
 	public function test_init_does_nothing_when_filter_is_false() {
+		Constants::set_constant( 'IS_WPCOM', true );
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 
@@ -276,6 +280,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that init() does nothing when the preview gate is disabled.
 	 */
 	public function test_init_does_nothing_when_preview_gate_is_false() {
+		Constants::set_constant( 'IS_WPCOM', true );
 		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 
@@ -295,6 +300,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_init_registers_hooks_when_preview_is_enabled_without_ai_editorial_review() {
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+		Constants::set_constant( 'IS_WPCOM', true );
 		Jetpack_AI_Sidebar::init();
 
 		$this->assertNotFalse(
@@ -333,6 +339,29 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
 			'maybe_enqueue_abilities_script should be hooked when filter is true.'
+		);
+	}
+
+	/**
+	 * Test that init() registers nothing on non-Simple sites by default, and that
+	 * the jetpack_ai_sidebar_enabled filter can still force it on (e.g. for testing).
+	 */
+	public function test_init_skips_when_not_simple_unless_filter_forced() {
+		// No IS_WPCOM constant => not a Simple site: the gate keeps init() inert.
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should not be hooked on non-Simple sites by default.'
+		);
+
+		// Forcing the kill-switch filter opts a non-Simple site back in.
+		$this->enable_sidebar();
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should be hooked when the filter forces enablement on a non-Simple site.'
 		);
 	}
 
@@ -1043,6 +1072,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_full_flow_with_default_enabled() {
 		$this->set_block_editor_screen();
+		Constants::set_constant( 'IS_WPCOM', true );
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
 
@@ -1056,6 +1086,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test full flow: filter disabled, init, verify no provider registered.
 	 */
 	public function test_full_flow_with_filter_disabled() {
+		Constants::set_constant( 'IS_WPCOM', true );
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 


### PR DESCRIPTION
## Proposed changes

* Gate the Jetpack AI Sidebar entrypoint to WordPress.com Simple sites. On Atomic and self-hosted Jetpack, `init()` now returns early, so the sidebar is not enqueued or registered — no provider registration, no Agents Manager CDN enqueue, no abilities script, no post-editor enabling, and no preview-data patch.
* The new default is `is_jetpack_ai_sidebar_preview_enabled() && Host::is_wpcom_simple()`, still passed through the existing `jetpack_ai_sidebar_enabled` filter. Overriding that filter (`__return_true`) still force-enables non-Simple sites for testing.
* Site type is read via `Host::is_wpcom_simple()`, matching the host checks already used elsewhere in this file.

This is a hygiene change: the AI Sidebar is no longer surfaced on Atomic/self-hosted via Calypso, so there is no reason to enqueue its scripts there.

## Related product discussion/links

NA

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com Simple site, open the post editor and confirm the Jetpack AI Sidebar behaves exactly as before (its provider and scripts still load).
* On an Atomic or self-hosted Jetpack site, open the post editor and confirm the sidebar is no longer enqueued: no `jetpack-ai-sidebar.provider.mjs` is registered and the sidebar scripts are not loaded.
* On an Atomic or self-hosted site, add `add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );` and confirm the sidebar can still be force-enabled (the override path is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
