### PR TITLE
Repo Gardening: Exclude generated lockfile PRs from description check

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-rep-gardening-exclude_generated_lockfile_PRs_from_description_check
+++ b/projects/github-actions/repo-gardening/changelog/fix-rep-gardening-exclude_generated_lockfile_PRs_from_description_check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Exclude lockfile generation PRs from description check.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
@@ -532,10 +532,7 @@ async function checkDescription(
 		return;
 	}
 
-	if (
-		ref === 'update/pnpm_and_composer_lock_files' &&
-		( author === 'matticbot' || author === 'github-actions[bot]' )
-	) {
+	if ( ref === 'update/pnpm_and_composer_lock_files' && author === 'matticbot' ) {
 		debug( `check-description: Automated lock file update, skipping` );
 		return;
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
@@ -532,6 +532,14 @@ async function checkDescription(
 		return;
 	}
 
+	if (
+		ref === 'update/pnpm_and_composer_lock_files' &&
+		( author === 'matticbot' || author === 'github-actions[bot]' )
+	) {
+		debug( `check-description: Automated lock file update, skipping` );
+		return;
+	}
+
 	debug( `check-description: start building our comment` );
 
 	// We'll add any remarks we may have about the PR to that comment body.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We recently had our first lockfile conflict resolution PR (#49512). However, repo-gardning complained about the PR description. Let's exclude that in this PR.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

This is copy/pasted from the block above for stub generation, which works fine, so barring typos, we should be good.