### PR TITLE
Daily Writing Prompt: defer connection check to dashboard setup (fix Atomic fatal)

### DIFF
--- a/projects/packages/newsletter/changelog/fix-writing-prompt-widget-early-connection-check
+++ b/projects/packages/newsletter/changelog/fix-writing-prompt-widget-early-connection-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Daily Writing Prompt: defer the connection-readiness check to dashboard setup, avoiding a fatal error on Atomic sites when the check ran before Core's pluggable functions were loaded.

--- a/projects/packages/newsletter/src/class-writing-prompt-widget.php
+++ b/projects/packages/newsletter/src/class-writing-prompt-widget.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Newsletter;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
+
 /**
  * Register and render the Daily Writing Prompt dashboard widget.
  */
@@ -50,6 +54,10 @@ class Writing_Prompt_Widget {
 			return;
 		}
 
+		if ( ! self::should_load() ) {
+			return;
+		}
+
 		wp_add_dashboard_widget(
 			'wpcom_daily_writing_prompt',
 			__( 'Daily Writing Prompt', 'jetpack-newsletter' ),
@@ -64,6 +72,31 @@ class Writing_Prompt_Widget {
 		// screen and runs before the header is printed) rather than in the render
 		// callback, so the stylesheet lands in the head like it did previously.
 		self::enqueue_assets();
+	}
+
+	/**
+	 * Whether the Daily Writing Prompt widget should load.
+	 *
+	 * The widget fetches prompts from WordPress.com through the Jetpack proxy, so
+	 * it can only load where the site is able to reach WordPress.com: on Simple
+	 * sites, or on online, connected Jetpack sites (including Atomic).
+	 *
+	 * This runs on `wp_dashboard_setup` rather than at plugin-load time so that
+	 * the connection check happens after Core's pluggable functions are loaded.
+	 * Checking the connection any earlier triggers a fatal error on Atomic.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	private static function should_load() {
+		// Simple sites can always reach WordPress.com, with no Jetpack connection involved.
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return true;
+		}
+
+		// Everywhere else the widget needs an online, connected site to fetch prompts.
+		return ( new Connection_Manager() )->is_connected() && ! ( new Status() )->is_offline_mode();
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Writing_Prompt_Widget_Test.php
+++ b/projects/packages/newsletter/tests/php/Writing_Prompt_Widget_Test.php
@@ -7,7 +7,10 @@
 
 namespace Automattic\Jetpack\Newsletter\Tests;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Newsletter\Writing_Prompt_Widget;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -34,6 +37,8 @@ class Writing_Prompt_Widget_Test extends BaseTestCase {
 		$property->setValue( null, false );
 
 		remove_all_actions( 'wp_dashboard_setup' );
+		( new Connection_Manager() )->reset_connection_status();
+		Status_Cache::clear();
 
 		$GLOBALS['wp_meta_boxes'] = array();
 	}
@@ -45,7 +50,40 @@ class Writing_Prompt_Widget_Test extends BaseTestCase {
 		wp_set_current_user( 0 );
 		unset( $GLOBALS['wp_meta_boxes'] );
 
+		remove_all_filters( 'jetpack_options' );
+		remove_all_filters( 'jetpack_offline_mode' );
+		Constants::clear_constants();
+		( new Connection_Manager() )->reset_connection_status();
+		Status_Cache::clear();
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Put the site into a state where the widget is allowed to load: not a
+	 * Simple site, online, and with a working WordPress.com connection.
+	 */
+	private function allow_widget_to_load() {
+		add_filter( 'jetpack_options', array( $this, 'mock_connection_options' ), 10, 2 );
+		( new Connection_Manager() )->reset_connection_status();
+	}
+
+	/**
+	 * Mock the Jetpack blog ID and token so the site reports as connected.
+	 *
+	 * @param mixed  $value The option value.
+	 * @param string $name  The option name.
+	 * @return mixed
+	 */
+	public function mock_connection_options( $value, $name ) {
+		switch ( $name ) {
+			case 'id':
+				return 1234;
+			case 'blog_token':
+				return 'test.blogtoken.123';
+		}
+
+		return $value;
 	}
 
 	/**
@@ -114,6 +152,7 @@ class Writing_Prompt_Widget_Test extends BaseTestCase {
 	public function test_register_widget_adds_widget_for_admin() {
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 		$this->set_current_user_admin();
+		$this->allow_widget_to_load();
 
 		Writing_Prompt_Widget::register_widget();
 
@@ -121,6 +160,49 @@ class Writing_Prompt_Widget_Test extends BaseTestCase {
 			'wpcom_daily_writing_prompt',
 			$GLOBALS['wp_meta_boxes']['dashboard']['side']['high']
 		);
+	}
+
+	/**
+	 * Test that the widget is registered on Simple sites without a Jetpack
+	 * connection, since Simple sites can always reach WordPress.com.
+	 */
+	public function test_register_widget_adds_widget_on_wpcom_simple() {
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		$this->set_current_user_admin();
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Writing_Prompt_Widget::register_widget();
+
+		$this->assertArrayHasKey(
+			'wpcom_daily_writing_prompt',
+			$GLOBALS['wp_meta_boxes']['dashboard']['side']['high']
+		);
+	}
+
+	/**
+	 * Test that the widget is not registered when the site has no ready
+	 * WordPress.com connection and is not a Simple site.
+	 */
+	public function test_register_widget_skips_without_connection() {
+		$this->set_current_user_admin();
+
+		Writing_Prompt_Widget::register_widget();
+
+		$this->assertArrayNotHasKey( 'dashboard', $GLOBALS['wp_meta_boxes'] );
+	}
+
+	/**
+	 * Test that the widget is not registered in offline mode, even with an
+	 * otherwise working connection.
+	 */
+	public function test_register_widget_skips_in_offline_mode() {
+		$this->set_current_user_admin();
+		$this->allow_widget_to_load();
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		Writing_Prompt_Widget::register_widget();
+
+		$this->assertArrayNotHasKey( 'dashboard', $GLOBALS['wp_meta_boxes'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-writing-prompt-widget-early-connection-check
+++ b/projects/plugins/jetpack/changelog/fix-writing-prompt-widget-early-connection-check
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Daily Writing Prompt: defer the connection-readiness check to dashboard setup, avoiding a fatal error on Atomic sites when the check ran before Core's pluggable functions were loaded.

--- a/projects/plugins/jetpack/changelog/fix-writing-prompt-widget-early-connection-check
+++ b/projects/plugins/jetpack/changelog/fix-writing-prompt-widget-early-connection-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Daily Writing Prompt: defer the connection-readiness check to dashboard setup, avoiding a fatal error on Atomic sites when the check ran before Core's pluggable functions were loaded.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -68,12 +68,7 @@ if ( is_admin() ) {
 	// Initialize Newsletter Settings (always-loaded so the settings page URL works even when module is inactive).
 	\Automattic\Jetpack\Newsletter\Settings::init();
 
-	// Register the Daily Writing Prompt dashboard widget. It fetches prompts from
-	// WordPress.com (via the Jetpack proxy), so it only makes sense once the site
-	// is connected and able to reach WordPress.com.
-	if ( Jetpack::is_connection_ready() && ! ( new \Automattic\Jetpack\Status() )->is_offline_mode() ) {
-		\Automattic\Jetpack\Newsletter\Writing_Prompt_Widget::init();
-	}
+	\Automattic\Jetpack\Newsletter\Writing_Prompt_Widget::init();
 
 	\Automattic\Jetpack\Plugin\Jetpack_Script_Data::configure();
 }


### PR DESCRIPTION
Fixes CM-828

## Proposed changes

PR #49491 registered the Daily Writing Prompt dashboard widget from `load-jetpack.php`, gated on `Jetpack::is_connection_ready()`. That file runs at **plugin-include time** (`wp-settings.php` → `jetpack.php`), which is **before Core loads `pluggable.php`**. On Atomic, wpcomsh hooks `jetpack_is_connection_ready` → `has_connected_owner()` → `get_connection_owner()` → `get_userdata()` — a pluggable function not yet defined — so every wp-admin request fataled:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Automattic\Jetpack\Connection\get_userdata() in .../jetpack-connection/src/class-manager.php:907
```

This PR:

* Moves the gating **into the widget class**, into a `should_load()` check run from `register_widget()` on `wp_dashboard_setup` — late enough that pluggable functions are loaded.
* Makes `load-jetpack.php` call `Writing_Prompt_Widget::init()` unconditionally, since `init()` only registers a `wp_dashboard_setup` hook (cheap and safe at include time).
* `should_load()` short-circuits to `true` on WordPress.com Simple sites (always able to reach WordPress.com, and never instantiates the connection manager there); everywhere else it requires `( new Connection_Manager() )->is_connected()` and not offline mode.
* Adds regression tests and changelog entries for the `jetpack` plugin and `jetpack-newsletter` package.

## Related product discussion/links

* CM-828 (follow-up to CM-823 / #49491)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* **Atomic (the regression):** on a WoA site running this branch, load **wp-admin**. Confirm it loads without the `get_userdata()` fatal, and the **Daily Writing Prompt** widget renders on the Dashboard.
* **Self-hosted connected:** spin up a Jurassic Ninja site, connect Jetpack, go to **wp-admin → Dashboard**, and confirm the widget appears and loads today's prompt.
* **Disconnected / offline:** disconnect Jetpack (or set `define( 'JETPACK_DEV_DEBUG', true );`) and reload the Dashboard — the widget should not be registered.
* PHPUnit: `jetpack docker phpunit jetpack-newsletter` (the `Writing_Prompt_Widget` suite covers Simple, connected, disconnected, and offline paths).