### PR TITLE
Blogging Prompts: update responses link wording to "View responses"

### DIFF
--- a/projects/packages/newsletter/changelog/update-blogging-prompt-responses-wording
+++ b/projects/packages/newsletter/changelog/update-blogging-prompt-responses-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Blogging prompt: update wording
+
+

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -12,7 +12,7 @@
 
 .wpcom-daily-writing-prompt--answered-users {
 
-	// The "View all responses" secondary button renders as an anchor, so it
+	// The "View responses" secondary button renders as an anchor, so it
 	// inherits wp-admin's unlayered `a { color: #2271b1 }` rule, which would
 	// otherwise beat @wordpress/ui's layered button color. Re-apply the button's
 	// own foreground color. See settings/sections/paid-newsletter-section.tsx.

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.js
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.js
@@ -88,7 +88,7 @@ export default () => {
 									/>
 								}
 							>
-								{ __( 'View all responses', 'jetpack-newsletter' ) }
+								{ __( 'View responses', 'jetpack-newsletter' ) }
 							</Button>
 						) }
 						<span>

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -80,14 +80,14 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 		mockIsWpcomPlatformSite.mockReturnValue( true );
 	} );
 
-	it( 'renders the View all responses button and avatar faces outside the footer', async () => {
+	it( 'renders the View responses button and avatar faces outside the footer', async () => {
 		mockApiFetch.mockResolvedValue( [ PROMPT_WITH_RESPONSES ] );
 
 		const { container } = render( <WritingPrompt /> );
 
 		// The responses control is a secondary button rendered as an anchor, so it
 		// carries the button role while still navigating via its href.
-		const responsesButton = await screen.findByRole( 'button', { name: /View all responses/ } );
+		const responsesButton = await screen.findByRole( 'button', { name: /View responses/ } );
 		expect( responsesButton ).toHaveAttribute( 'href', 'https://example.com/tag/dailyprompt-1' );
 		expect( responsesButton ).toHaveAttribute( 'target', '_blank' );
 		expect( screen.getAllByRole( 'img', { name: 'User avatar' } ) ).toHaveLength( 2 );
@@ -97,7 +97,7 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 		const answeredUsers = container.querySelector( '.wpcom-daily-writing-prompt--answered-users' );
 		expect( answeredUsers ).not.toBeNull();
 		expect(
-			within( answeredUsers as HTMLElement ).getByRole( 'button', { name: /View all responses/ } )
+			within( answeredUsers as HTMLElement ).getByRole( 'button', { name: /View responses/ } )
 		).toBeInTheDocument();
 
 		// The branding footer must NOT contain the responses button.
@@ -105,7 +105,7 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 		const footer = container.querySelector( '.wpcom-daily-writing-prompt--branding' );
 		expect( footer ).not.toBeNull();
 		expect(
-			within( footer as HTMLElement ).queryByRole( 'button', { name: /View all responses/ } )
+			within( footer as HTMLElement ).queryByRole( 'button', { name: /View responses/ } )
 		).not.toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/changelog/update-blogging-prompt-responses-wording
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompt-responses-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Blogging Prompt: update wording
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -26,7 +26,7 @@ const blockSettings = {
 	example: {
 		attributes: {
 			answersLink: 'https://wordpress.com/tag/dailyprompt',
-			answersLinkText: __( 'View all responses', 'jetpack' ),
+			answersLinkText: __( 'View responses', 'jetpack' ),
 			gravatars: [ { url: avatar1 }, { url: avatar2 }, { url: avatar3 } ],
 			promptLabel: __( 'Daily writing prompt', 'jetpack' ),
 			promptText: __( "What's your favorite place to visit?", 'jetpack' ),


### PR DESCRIPTION
Fixes CM-829

## Proposed changes
* Update the blogging prompt responses link wording from "View all responses" to "View responses".
* Applies the change in two places:
  * The Daily Writing Prompt widget in the `jetpack-newsletter` package (`writing-prompt.js`).
  * The Blogging Prompt block's editor example in the Jetpack plugin (`editor.js`).
* Update the related code comment in `style.scss` and the widget tests to match the new wording.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a connected site, add the Blogging Prompt block in the editor and confirm the example/preview shows a "View responses" link (no longer "View all responses").
* On a site rendering the Daily Writing Prompt widget with existing responses, confirm the responses button reads "View responses" and still links to the Reader tag page in a new tab.
* Run the newsletter package tests to confirm they pass: `jetpack docker phpunit` is not needed here — the widget has JS tests covering the button label.
