### PR TITLE
Newsletter: Stop the modernized Settings spinner from flashing on every visit

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-settings-spinner-flash
+++ b/projects/packages/newsletter/changelog/fix-newsletter-settings-spinner-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: stop the modernized Settings tab from flashing a full-page loading spinner on every visit by caching resolved settings across mounts.

--- a/projects/packages/newsletter/src/settings/newsletter-settings.tsx
+++ b/projects/packages/newsletter/src/settings/newsletter-settings.tsx
@@ -55,6 +55,28 @@ function normalizeSettings( settings: Record< string, unknown > ): NewsletterSet
 	};
 }
 
+// Module-level cache of the last resolved settings. The modernized dashboard
+// renders this body inside a `Tabs.Panel` that unmounts when the visitor
+// switches to the Subscribers tab and remounts on return, so without a cache
+// every revisit re-initialized `isLoading` to true and flashed the full-page
+// spinner while re-fetching. Seeding initial state from this cache lets repeat
+// mounts paint the settings immediately; only the genuine first load (empty
+// cache) shows the spinner. The mount effect still re-fetches in the
+// background to refresh the cache, so a returning visitor sees current values
+// without the flash.
+let cachedSettings: NewsletterSettings | null = null;
+
+/**
+ * Test-only: clear the module-level settings cache so each test starts cold.
+ * The cache deliberately outlives any single component instance (that's the
+ * whole point — it survives the tab unmount/remount), which also means it
+ * leaks across tests in a file. Call this in `beforeEach` to keep cold-cache
+ * assertions order-independent.
+ */
+export function __resetNewsletterSettingsCacheForTests(): void {
+	cachedSettings = null;
+}
+
 export type NewsletterSettingsBodyProps = {
 	/**
 	 * Whether the active user has a connected WordPress.com owner account.
@@ -111,8 +133,10 @@ export function NewsletterSettingsBody( {
 	connectUrl,
 	isModernized = false,
 }: NewsletterSettingsBodyProps ): JSX.Element | null {
-	const [ data, setData ] = useState< NewsletterSettings | null >( null );
-	const [ isLoading, setIsLoading ] = useState( true );
+	// Seed from the module cache so a remount (e.g. returning to the Settings
+	// tab) paints immediately instead of flashing the full-page spinner.
+	const [ data, setData ] = useState< NewsletterSettings | null >( () => cachedSettings );
+	const [ isLoading, setIsLoading ] = useState( () => ! cachedSettings );
 	const [ error, setError ] = useState< string | null >( null );
 
 	// Subscription settings state (for manual save).
@@ -173,7 +197,9 @@ export function NewsletterSettingsBody( {
 		}
 	}, [ newsletterScriptData ] );
 
-	// Load settings on mount.
+	// Load settings on mount. When the cache is already populated (a remount)
+	// this refetch runs in the background to refresh values without a spinner —
+	// `isLoading` is only true on the genuine first load.
 	useEffect( () => {
 		fetchSettings()
 			.then( ( settings: Record< string, unknown > ) => {
@@ -183,10 +209,34 @@ export function NewsletterSettingsBody( {
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newsletter settings load error:', err );
-				setError( err.message || __( 'Failed to load settings', 'jetpack-newsletter' ) );
+				// Only surface a blocking error when there's no cached data to
+				// fall back on; a background refresh failure shouldn't blank a
+				// page that's already rendering.
+				if ( ! cachedSettings ) {
+					setError( err.message || __( 'Failed to load settings', 'jetpack-newsletter' ) );
+				}
 				setIsLoading( false );
 			} );
 	}, [] );
+
+	// Keep the module cache in sync with local state so optimistic edits,
+	// saves, and reverts all carry over to the next mount — a returning visitor
+	// sees their latest values, not a pre-save snapshot.
+	//
+	// Known caveat (low severity): this mirrors the *optimistic* `data`, so a
+	// staged-but-unsaved edit briefly survives a tab switch — on remount the
+	// visitor sees the un-persisted value while the per-section `*Changes` state
+	// has reset to `{}` (no "unsaved changes" affordance), until the background
+	// refetch overwrites it with the server value. The end state is correct
+	// (server wins) and unsaved edits were already discarded on unmount pre-cache,
+	// so this isn't a regression. The structural fix is a persisted saved-baseline
+	// to reconcile against on remount (see the stacked preview-link PR's
+	// `savedData`); tracked as a follow-up.
+	useEffect( () => {
+		if ( data ) {
+			cachedSettings = data;
+		}
+	}, [ data ] );
 
 	// Handle auto-save for newsletter toggle and email settings.
 	const handleAutoSave = useCallback(

--- a/projects/packages/newsletter/tests/settings-cache.test.jsx
+++ b/projects/packages/newsletter/tests/settings-cache.test.jsx
@@ -1,0 +1,104 @@
+// The modernized Newsletter dashboard mounts `NewsletterSettingsBody` inside a
+// `Tabs.Panel` that unmounts on tab switch and remounts on return. Without a
+// cache that remount re-flashed the full-page spinner on every visit. These
+// tests lock in the fix: the genuine first load shows a loading affordance,
+// but a later mount (cache warm) paints the settings immediately.
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteType: jest.fn( () => 'jetpack' ),
+} ) );
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: jest.fn() },
+	},
+} ) );
+
+jest.mock( '../src/settings/api', () => ( {
+	fetchSettings: jest.fn(),
+	updateSettings: jest.fn(),
+} ) );
+
+jest.mock( '../src/settings/script-data', () => ( {
+	getNewsletterScriptData: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '../src/settings/sections', () => ( {
+	EmailBylineSection: () => <div data-testid="email-byline-section" />,
+	EmailContentSection: () => <div data-testid="email-content-section" />,
+	EmailDefaultsSection: () => <div data-testid="email-defaults-section" />,
+	EmailReplyToSettingsSection: () => <div data-testid="email-reply-to-settings-section" />,
+	EmailSenderSettingsSection: () => <div data-testid="email-sender-settings-section" />,
+	LegacySubscriptionsSection: () => <div data-testid="legacy-subscriptions-section" />,
+	NewsletterCategoriesSection: () => <div data-testid="newsletter-categories-section" />,
+	NewsletterSection: () => <div data-testid="newsletter-section" />,
+	PaidNewsletterSection: () => <div data-testid="paid-newsletter-section" />,
+	SubscribeModalSection: () => <div data-testid="subscribe-modal-section" />,
+	SubscriptionsSection: () => <div data-testid="subscriptions-section" />,
+	WelcomeEmailSection: () => <div data-testid="welcome-email-section" />,
+} ) );
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { fetchSettings } from '../src/settings/api';
+import {
+	NewsletterSettingsBody,
+	__resetNewsletterSettingsCacheForTests,
+} from '../src/settings/newsletter-settings';
+
+const defaultSettings = {
+	subscriptions: true,
+	wpcom_subscription_emails_use_excerpt: 'full',
+	wpcom_newsletter_categories: [],
+	newsletter_has_active_plan: false,
+};
+
+// The full-page loading affordance is a bare `<Spinner />` with no section
+// markup; "loaded" is the first section appearing.
+const isShowingSpinner = () => screen.queryByTestId( 'newsletter-section' ) === null;
+
+describe( 'NewsletterSettingsBody loading cache', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Reset the module-level cache so every test starts cold, regardless of
+		// order — otherwise an earlier test that warms the cache would make the
+		// "genuine first load" assertion below pass for the wrong reason.
+		__resetNewsletterSettingsCacheForTests();
+		// Resolve on a microtask so the synchronous initial render still shows
+		// the loading state on a cold cache.
+		fetchSettings.mockResolvedValue( defaultSettings );
+	} );
+
+	it( 'shows the loading affordance on the genuine first load', async () => {
+		render( <NewsletterSettingsBody /> );
+
+		// Cold render: spinner first, no section yet.
+		expect( isShowingSpinner() ).toBe( true );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'newsletter-section' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'does not flash the spinner on a later mount once settings are cached', async () => {
+		// First mount warms the module cache.
+		const view = render( <NewsletterSettingsBody /> );
+		await waitFor( () => {
+			expect( screen.getByTestId( 'newsletter-section' ) ).toBeInTheDocument();
+		} );
+		view.unmount();
+
+		// Remount (e.g. returning to the Settings tab): the section is present
+		// synchronously, with no spinner-only frame in between.
+		render( <NewsletterSettingsBody /> );
+		expect( isShowingSpinner() ).toBe( false );
+		expect( screen.getByTestId( 'newsletter-section' ) ).toBeInTheDocument();
+
+		// Let the background refresh settle so its state update doesn't leak
+		// past the test as an unwrapped act() warning.
+		await waitFor( () => {
+			expect( fetchSettings ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of #49485 - NL26



## Proposed changes

The modernized Newsletter Settings page flashed a full-page loading spinner on **every** visit, including repeat ones. The dashboard mounts `NewsletterSettingsBody` inside a `Tabs.Panel` that unmounts when you switch to the Subscribers tab and remounts on return, so each revisit re-initialized `isLoading` to `true`, re-ran `fetchSettings()`, and re-rendered the bare `<Spinner />` while it loaded — a jarring flash on a page the user had already seen.

* Add a small module-level cache of the last resolved (normalized) settings in `newsletter-settings.tsx`.
* Seed the `data` / `isLoading` initial state from that cache, so a remount with a warm cache paints the settings immediately. The genuine first-ever load (cold cache) still shows the loading affordance.
* The mount effect still re-fetches in the background to keep values fresh; on a warm cache it no longer toggles a spinner. A background refresh failure no longer blanks an already-rendered page.
* Keep the cache in sync with local state (optimistic edits, saves, reverts) so a returning visitor sees their latest values, not a pre-save snapshot.
* Add `tests/settings-cache.test.jsx` locking in: cold load shows the affordance; warm remount does not flash the spinner.

No new state-management abstraction is introduced — this is a minimal, self-contained cache next to the component that owns the loading state. The legacy standalone `admin.php?page=jetpack-newsletter` route (single full-page mount, no remount) is unaffected.

## Related product discussion/links

* See linked issue.

## Does this pull request change what data or activity we track or use?

No. No new tracking, and no change to which settings are fetched or saved.

## Testing instructions

* On a site with the modernized Newsletter dashboard, open the Newsletter page and let Settings load.
* Switch to the **Subscribers** tab, then back to **Settings**.
* **Before this PR:** the full-page spinner flashes again on the return visit.
* **After this PR:** Settings render immediately with no spinner flash; only the very first load (fresh page load / empty cache) shows the loading affordance.
* Confirm settings still render correctly and saves persist across tab switches.

Automated gates run on this branch: `eslint`, `tsgo --noEmit` typecheck, and the newsletter Jest suite (60 tests) all pass; dependency-aware package build is green.


