### PR TITLE
Newsletter: hide Comp action when the site has no paid plans

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
@@ -225,16 +225,6 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 								</Notice.Description>
 							</Notice.Root>
 						) : null }
-						{ ! productsQuery.isLoading && products.length === 0 && ! productsQuery.isError ? (
-							<Notice.Root intent="info">
-								<Notice.Description>
-									{ __(
-										'You don’t have any paid newsletter plans configured on this site yet.',
-										'jetpack-newsletter'
-									) }
-								</Notice.Description>
-							</Notice.Root>
-						) : null }
 						{ allComped ? (
 							<Notice.Root intent="info">
 								<Notice.Description>

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -2,6 +2,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
+import { useMembershipsProducts } from '../data/use-memberships-products';
 import { useSubscriberRemoveMutation } from '../data/use-subscriber-remove-mutation';
 import { useSubscribers } from '../data/use-subscribers';
 import {
@@ -91,6 +92,20 @@ export default function SubscribersDataViews( {
 
 	const { data, isLoading, error } = useSubscribers( queryParams );
 	const removeMutation = useSubscriberRemoveMutation();
+
+	// Fetch the site's paid products once for the whole table (not per row) so the "Comp a
+	// subscription" action can be hidden when there's nothing to comp onto — otherwise it opens a
+	// dead-end modal that only reports "no paid plans". The Subscribers tab is already gated behind
+	// a WordPress.com connection, so the proxied request is safe to fire eagerly.
+	const { data: membershipsProducts, isError: membershipsProductsError } =
+		useMembershipsProducts( true );
+	const hasPaidProducts = ( membershipsProducts?.length ?? 0 ) > 0;
+	// Offer the action when we know there's a paid product to comp onto, OR when we couldn't
+	// determine it because the products request errored. Failing open on error preserves the
+	// capability and lets the modal surface the fetch error, rather than silently removing the
+	// action on a transient failure. It stays hidden only while the request is still loading and
+	// when the site genuinely has zero paid products (the dead-end case this fix targets).
+	const canShowCompAction = hasPaidProducts || membershipsProductsError;
 
 	// Fired off `onChangeView` rather than per-control handlers because DataViews owns
 	// the controls — we diff the previous view against the next to mirror Calypso's
@@ -216,11 +231,13 @@ export default function SubscribersDataViews( {
 			{
 				id: 'comp',
 				label: __( 'Comp a subscription', 'jetpack-newsletter' ),
-				// We need a wpcom user id to attach the comp to (Calypso's
-				// `hasUncompedPlans` also checks the plans list, but that requires the site's
-				// products to be loaded — we let the modal handle the "all comped" /
-				// "no paid plans" edge cases instead).
-				isEligible: ( subscriber: Subscriber ) => !! subscriber.user_id,
+				// Needs a wpcom user id to attach the comp to, plus a paid product to comp onto —
+				// otherwise the modal is a dead-end that only reports "no paid plans".
+				// `canShowCompAction` comes from a single table-level fetch (see above: true when
+				// products exist or the fetch errored, false while loading or on a genuinely empty
+				// site), so this stays cheap per row. The modal still handles the per-subscriber
+				// "already comped on every plan" edge case.
+				isEligible: ( subscriber: Subscriber ) => !! subscriber.user_id && canShowCompAction,
 				callback: ( items: Subscriber[] ) => {
 					const target = items[ 0 ];
 					if ( ! target ) {
@@ -261,7 +278,7 @@ export default function SubscribersDataViews( {
 				},
 			},
 		],
-		[ onViewSubscriber ]
+		[ onViewSubscriber, canShowCompAction ]
 	);
 
 	const handleConfirmRemoval = useCallback( async () => {

--- a/projects/packages/newsletter/_inc/subscribers/data/use-memberships-products.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-memberships-products.ts
@@ -4,9 +4,10 @@ import type { MembershipsProduct } from './api';
 
 /**
  * Fetch the paid newsletter / membership products configured on this site. Lazy — only runs
- * when the consumer asks for it (the Comp modal needs it; nothing else does).
+ * when the consumer asks for it. The Subscribers table fetches it to decide whether to offer the
+ * "Comp a subscription" action; the Comp modal reuses the same cached result.
  *
- * @param enabled - Whether the request should run (typically `true` once the modal is open).
+ * @param enabled - Whether the request should run.
  * @return React Query handle.
  */
 export function useMembershipsProducts( enabled: boolean ) {

--- a/projects/packages/newsletter/changelog/change-newsletter-comp-gate-paid-plans
+++ b/projects/packages/newsletter/changelog/change-newsletter-comp-gate-paid-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers: Hide the "Comp a subscription" action when the site has no paid newsletter plans.


### PR DESCRIPTION
Part of #49485 - NL06

## Proposed changes

On a site with **no paid newsletter plans**, the Subscribers tab no longer offers the **"Comp a subscription"** action. Previously the action appeared for any subscriber with a WordPress.com user id and then opened a modal that only reported "you don't have any paid plans" — a dead end.

* The site's membership products are now fetched **once at the Subscribers table level** (via the existing `useMembershipsProducts` hook, hoisted out of the Comp modal) and the action's `isEligible` is gated on whether any paid product exists. The per-row check reuses that single result, so **no per-row network requests** are introduced.
* While products are still loading / unknown, the action stays hidden — preferring "no dead-end" over a momentary availability flicker.
* On a site **with** paid plans, behavior is unchanged: the action shows for subscribers with a wpcom user id, and the modal still handles the per-subscriber "already comped on every plan" edge case.
* Removed the now-unreachable "no paid newsletter plans configured" info notice from the Comp modal (the modal can no longer open in that state). The Comp request flow itself is untouched.

## Related product discussion/links

* Reference issue: #49485

## Does this pull request change what data or activity we track or use?

No. No new tracking. The same `useMembershipsProducts` request that the Comp modal already made now also runs when the Subscribers table mounts (one extra fetch per page load on a connection-gated tab, deduped via the shared React Query cache the modal already used).

## Testing instructions

This change is on the modernized Subscribers dashboard, which is behind a feature flag and requires a WordPress.com connection (the membership-products request is proxied to WordPress.com), so it needs a connected newsletter site to verify the two states.

**No paid plans (the fix):**
1. On a connected site with the modernized Subscribers dashboard enabled and **no** paid newsletter products configured, open the Subscribers tab.
2. Open a subscriber row's action menu (and select a row for the bulk-action menu).
3. Confirm **"Comp a subscription" does not appear** in either menu. The other actions (View, Remove comp where applicable, Remove subscriber) are unaffected.

**With paid plans (unchanged):**
1. On a connected site that **has** at least one paid newsletter product, open the Subscribers tab.
2. For a subscriber with a WordPress.com user id, confirm **"Comp a subscription" still appears** and opens the working Comp modal.

**No extra per-row requests:**
* With the Network tab open while scrolling the subscribers table, confirm only a single `memberships/products` request fires for the page (not one per row).

