### PR TITLE
Newsletter: gate placement "Preview and edit" link on saved-enabled state

### DIFF
--- a/projects/packages/newsletter/changelog/change-newsletter-preview-edit-gating
+++ b/projects/packages/newsletter/changelog/change-newsletter-preview-edit-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: Only show the subscription placement "Preview and edit" link once the placement is enabled and saved.

--- a/projects/packages/newsletter/src/settings/newsletter-settings.tsx
+++ b/projects/packages/newsletter/src/settings/newsletter-settings.tsx
@@ -66,15 +66,26 @@ function normalizeSettings( settings: Record< string, unknown > ): NewsletterSet
 // without the flash.
 let cachedSettings: NewsletterSettings | null = null;
 
+// Module-level cache of the last *persisted* settings — the saved baseline,
+// as opposed to `cachedSettings` above which mirrors the optimistic (possibly
+// unsaved) `data`. Kept in sync on fetch and after every successful save, and
+// module-cached for the same reason: so a remount on tab-return knows the
+// saved state immediately instead of treating it as unknown until the
+// background refetch resolves. Consumed by the Subscriptions section to gate
+// each placement's "Preview and edit" link on whether that placement is
+// enabled *in the saved state* (an unsaved toggle previews nothing).
+let cachedSavedSettings: NewsletterSettings | null = null;
+
 /**
- * Test-only: clear the module-level settings cache so each test starts cold.
- * The cache deliberately outlives any single component instance (that's the
- * whole point — it survives the tab unmount/remount), which also means it
- * leaks across tests in a file. Call this in `beforeEach` to keep cold-cache
+ * Test-only: clear the module-level settings caches so each test starts cold.
+ * The caches deliberately outlive any single component instance (that's the
+ * whole point — they survive the tab unmount/remount), which also means they
+ * leak across tests in a file. Call this in `beforeEach` to keep cold-cache
  * assertions order-independent.
  */
 export function __resetNewsletterSettingsCacheForTests(): void {
 	cachedSettings = null;
+	cachedSavedSettings = null;
 }
 
 export type NewsletterSettingsBodyProps = {
@@ -136,6 +147,11 @@ export function NewsletterSettingsBody( {
 	// Seed from the module cache so a remount (e.g. returning to the Settings
 	// tab) paints immediately instead of flashing the full-page spinner.
 	const [ data, setData ] = useState< NewsletterSettings | null >( () => cachedSettings );
+	// Last persisted settings (saved baseline), seeded from the module cache so a
+	// remount knows the saved state without waiting on the background refetch.
+	const [ savedData, setSavedData ] = useState< NewsletterSettings | null >(
+		() => cachedSavedSettings
+	);
 	const [ isLoading, setIsLoading ] = useState( () => ! cachedSettings );
 	const [ error, setError ] = useState< string | null >( null );
 
@@ -203,7 +219,10 @@ export function NewsletterSettingsBody( {
 	useEffect( () => {
 		fetchSettings()
 			.then( ( settings: Record< string, unknown > ) => {
-				setData( normalizeSettings( settings ) );
+				const normalized = normalizeSettings( settings );
+				setData( normalized );
+				// Server truth on load is both the optimistic value and the saved baseline.
+				setSavedData( normalized );
 				setIsLoading( false );
 			} )
 			.catch( ( err: Error ) => {
@@ -237,6 +256,14 @@ export function NewsletterSettingsBody( {
 			cachedSettings = data;
 		}
 	}, [ data ] );
+
+	// Mirror the saved baseline to the module cache so it, too, survives a
+	// remount (parallel to `cachedSettings` above, but for persisted values).
+	useEffect( () => {
+		if ( savedData ) {
+			cachedSavedSettings = savedData;
+		}
+	}, [ savedData ] );
 
 	// Handle auto-save for newsletter toggle and email settings.
 	const handleAutoSave = useCallback(
@@ -277,6 +304,8 @@ export function NewsletterSettingsBody( {
 			// Save to backend.
 			updateSettings( updates )
 				.then( () => {
+					// Advance the saved baseline now that these values are persisted.
+					setSavedData( prev => ( { ...prev, ...updates } ) );
 					createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 				} )
 				.catch( ( err: Error ) => {
@@ -308,6 +337,7 @@ export function NewsletterSettingsBody( {
 
 		updateSettings( senderNameChanges )
 			.then( () => {
+				setSavedData( prev => ( { ...prev, ...senderNameChanges } ) );
 				setSenderNameChanges( {} );
 				createSuccessNotice( __( 'Sender name saved', 'jetpack-newsletter' ) );
 			} )
@@ -341,6 +371,9 @@ export function NewsletterSettingsBody( {
 
 		updateSettings( subscriptionChanges )
 			.then( () => {
+				// Advance the saved baseline so each placement's "Preview and edit"
+				// link reflects the just-saved enabled state.
+				setSavedData( prev => ( { ...prev, ...subscriptionChanges } ) );
 				setSubscriptionChanges( {} );
 				createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
 			} )
@@ -395,6 +428,8 @@ export function NewsletterSettingsBody( {
 
 		updateSettings( apiUpdates )
 			.then( () => {
+				// Merge the staged (string) values so the baseline mirrors `data`'s shape.
+				setSavedData( prev => ( { ...prev, ...newsletterCategoriesChanges } ) );
 				setNewsletterCategoriesChanges( {} );
 				createSuccessNotice( __( 'Newsletter categories saved', 'jetpack-newsletter' ) );
 			} )
@@ -428,6 +463,7 @@ export function NewsletterSettingsBody( {
 
 		updateSettings( welcomeEmailChanges )
 			.then( () => {
+				setSavedData( prev => ( { ...prev, ...welcomeEmailChanges } ) );
 				setWelcomeEmailChanges( {} );
 				createSuccessNotice( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
 			} )
@@ -459,6 +495,7 @@ export function NewsletterSettingsBody( {
 
 		updateSettings( subscribeModalChanges )
 			.then( () => {
+				setSavedData( prev => ( { ...prev, ...subscribeModalChanges } ) );
 				setSubscribeModalChanges( {} );
 				createSuccessNotice( __( 'Subscribe modal heading saved', 'jetpack-newsletter' ) );
 			} )
@@ -542,6 +579,7 @@ export function NewsletterSettingsBody( {
 
 								<SubscriptionsSection
 									data={ data }
+									savedData={ savedData }
 									onChange={ handleSubscriptionChange }
 									onSave={ saveSubscriptionSettings }
 									isSaving={ isSavingSubscriptions }

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -38,6 +38,12 @@ const PLACEMENT_SLUG_BY_KEY: Record< string, string > = {
 
 interface SubscriptionsSectionProps {
 	data: NewsletterSettings;
+	/**
+	 * Last *persisted* settings. A placement's "Preview and edit" link only
+	 * shows when the placement is enabled here (saved), not merely toggled on
+	 * in the optimistic `data` — otherwise the link opens an empty preview.
+	 */
+	savedData: NewsletterSettings | null;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
 	onSave: () => void;
 	isSaving: boolean;
@@ -60,6 +66,7 @@ interface SubscriptionsSectionProps {
  */
 export function SubscriptionsSection( {
 	data,
+	savedData,
 	onChange,
 	onSave,
 	isSaving,
@@ -230,20 +237,32 @@ export function SubscriptionsSection( {
 									{ __( 'Homepage and posts', 'jetpack-newsletter' ) }
 								</Text>
 								<div className="jetpack-newsletter-placements-grid">
-									{ placements.map( placement => (
-										<PlacementCard
-											key={ placement.key }
-											id={ `placement-${ placement.key }` }
-											name={ String( placement.key ) }
-											title={ placement.title }
-											illustration={ placement.illustration }
-											previewUrl={ placement.previewUrl }
-											checked={ Boolean( data[ placement.key ] ) }
-											onChange={ handlePlacementChange }
-											onPreviewClick={ handlePlacementPreviewClick }
-											disabled={ ! isNewsletterEnabled }
-										/>
-									) ) }
+									{ placements.map( placement => {
+										// Surface "Preview and edit" only when the placement is
+										// enabled in the SAVED state AND still shown as checked —
+										// otherwise the link opens an empty Site Editor preview.
+										// Gating on `savedData` (the persisted baseline) rather than
+										// "untouched since save" keeps the link reversible: toggle a
+										// saved-on placement off then back on and it returns, while a
+										// freshly enabled-but-unsaved placement stays linkless until
+										// the save lands.
+										const isEnabledAndSaved =
+											Boolean( data[ placement.key ] ) && Boolean( savedData?.[ placement.key ] );
+										return (
+											<PlacementCard
+												key={ placement.key }
+												id={ `placement-${ placement.key }` }
+												name={ String( placement.key ) }
+												title={ placement.title }
+												illustration={ placement.illustration }
+												previewUrl={ isEnabledAndSaved ? placement.previewUrl : undefined }
+												checked={ Boolean( data[ placement.key ] ) }
+												onChange={ handlePlacementChange }
+												onPreviewClick={ handlePlacementPreviewClick }
+												disabled={ ! isNewsletterEnabled }
+											/>
+										);
+									} ) }
 								</div>
 							</Stack>
 

--- a/projects/packages/newsletter/tests/subscriptions-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscriptions-section.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the "Preview and edit" link gating in the Subscriptions section.
+ *
+ * `@wordpress/ui` / `@wordpress/components` are stubbed to plain HTML so we can
+ * assert on the rendered links directly. The component's own visibility logic —
+ * show the per-placement link only when the placement is enabled AND saved, and
+ * only when the site supports the Site Editor link — is exercised against the
+ * real source.
+ */
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled }>
+			{ children }
+		</button>
+	),
+	Card: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
+		Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	},
+	Fieldset: {
+		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
+	},
+	Link: ( {
+		children,
+		href,
+	}: {
+		children: React.ReactNode;
+		href?: string;
+		onClick?: () => void;
+	} ) => <a href={ href }>{ children }</a>,
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Text: ( { children, id }: { children: React.ReactNode; id?: string } ) => (
+		<span id={ id }>{ children }</span>
+	),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	CheckboxControl: ( {
+		id,
+		checked,
+		onChange,
+	}: {
+		id?: string;
+		checked?: boolean;
+		onChange?: ( next: boolean ) => void;
+	} ) => (
+		<input
+			type="checkbox"
+			id={ id }
+			checked={ checked }
+			// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+			// eslint-disable-next-line react/jsx-no-bind
+			onChange={ e => onChange?.( e.target.checked ) }
+		/>
+	),
+	ToggleControl: ( { label }: { label: React.ReactNode } ) => <div>{ label }</div>,
+} ) );
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		tracks: { recordEvent: jest.fn() },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteType: jest.fn( () => 'jetpack' ),
+	getAdminUrl: jest.fn( ( p: string ) => `https://example.com/wp-admin/${ p }` ),
+} ) );
+
+jest.mock( '../src/settings/script-data', () => ( {
+	getNewsletterScriptData: jest.fn( () => ( {
+		isBlockTheme: true,
+		themeStylesheet: 'twentytwentyfive',
+		isSubscriptionSiteEditSupported: true,
+	} ) ),
+} ) );
+
+import { render, screen } from '@testing-library/react';
+import { getNewsletterScriptData } from '../src/settings/script-data';
+import { SubscriptionsSection } from '../src/settings/sections/subscriptions-section';
+import type { NewsletterSettings } from '../src/settings/types';
+
+const OVERLAY_KEY = 'jetpack_subscribe_overlay_enabled';
+
+/**
+ * Build a `NewsletterSettings`-shaped object with all placement keys present so
+ * tests can flip a single placement on/off without leaving the rest undefined.
+ *
+ * @param overrides - Subset of settings to merge over the defaults.
+ * @return Settings object ready to pass to `<SubscriptionsSection data />`.
+ */
+function buildData( overrides: Partial< NewsletterSettings > = {} ): NewsletterSettings {
+	return {
+		jetpack_subscribe_overlay_enabled: false,
+		sm_enabled: false,
+		jetpack_subscriptions_subscribe_post_end_enabled: false,
+		jetpack_subscribe_floating_button_enabled: false,
+		...overrides,
+	} as NewsletterSettings;
+}
+
+/**
+ * Render `<SubscriptionsSection>` with sensible defaults so each test only has
+ * to override the props it cares about.
+ *
+ * @param props - Prop overrides to apply on top of the defaults.
+ * @return RTL render helpers.
+ */
+function renderSection(
+	props: Partial< React.ComponentProps< typeof SubscriptionsSection > > = {}
+) {
+	const data = ( props.data as NewsletterSettings ) ?? buildData();
+	// Default the saved baseline to the displayed data, so a test that only sets
+	// `data` exercises the "enabled + saved" case. Tests that need divergence
+	// (enabled-but-unsaved, reverted-to-saved) pass `savedData` explicitly.
+	const savedData = ( props.savedData as NewsletterSettings | null | undefined ) ?? data;
+	return render(
+		<SubscriptionsSection
+			data={ data }
+			savedData={ savedData }
+			onChange={ jest.fn() }
+			onSave={ jest.fn() }
+			isSaving={ false }
+			hasChanges={ false }
+			changedKeys={ [] }
+			isNewsletterEnabled={ true }
+			{ ...props }
+		/>
+	);
+}
+
+/**
+ * Count the placement-grid "Preview and edit" links.
+ *
+ * The Navigation subgroup renders its own "Preview and edit" links — gated on
+ * site capability, not on this fix — and both target the `//index` template.
+ * Placement links never point at `//index`, so filtering those out isolates
+ * the grid links this fix controls.
+ *
+ * @return The placement-grid "Preview and edit" anchors.
+ */
+function previewLinks(): HTMLAnchorElement[] {
+	return (
+		screen.queryAllByRole( 'link', { name: 'Preview and edit' } ) as HTMLAnchorElement[]
+	 ).filter( link => ! link.getAttribute( 'href' )?.includes( '%2F%2Findex' ) );
+}
+
+describe( 'SubscriptionsSection — Preview and edit gating', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows the link for a placement that is enabled and saved', () => {
+		renderSection( {
+			data: buildData( { [ OVERLAY_KEY ]: true } ),
+			savedData: buildData( { [ OVERLAY_KEY ]: true } ),
+		} );
+		expect( previewLinks() ).toHaveLength( 1 );
+	} );
+
+	it( 'hides the link for a disabled placement', () => {
+		renderSection( {
+			data: buildData( { [ OVERLAY_KEY ]: false } ),
+			savedData: buildData( { [ OVERLAY_KEY ]: false } ),
+		} );
+		expect( previewLinks() ).toHaveLength( 0 );
+	} );
+
+	it( 'hides the link for an enabled placement that is not yet saved', () => {
+		renderSection( {
+			// Toggled on optimistically, but the saved baseline still has it off.
+			data: buildData( { [ OVERLAY_KEY ]: true } ),
+			savedData: buildData( { [ OVERLAY_KEY ]: false } ),
+		} );
+		expect( previewLinks() ).toHaveLength( 0 );
+	} );
+
+	it( 'keeps the link when a saved-on placement is toggled off then back on (reverted to saved)', () => {
+		// The regression this fix targets: gating on the saved baseline, not on
+		// "touched since save", so reverting an edit restores the link without a
+		// round-trip to the server. `changedKeys` still reports the key as dirty.
+		renderSection( {
+			data: buildData( { [ OVERLAY_KEY ]: true } ),
+			savedData: buildData( { [ OVERLAY_KEY ]: true } ),
+			changedKeys: [ OVERLAY_KEY ],
+		} );
+		expect( previewLinks() ).toHaveLength( 1 );
+	} );
+
+	it( 'hides the link when the site does not support the Site Editor link', () => {
+		( getNewsletterScriptData as jest.Mock ).mockReturnValueOnce( {
+			isBlockTheme: false,
+			themeStylesheet: '',
+			isSubscriptionSiteEditSupported: false,
+		} );
+		renderSection( {
+			data: buildData( { [ OVERLAY_KEY ]: true } ),
+			savedData: buildData( { [ OVERLAY_KEY ]: true } ),
+		} );
+		expect( previewLinks() ).toHaveLength( 0 );
+	} );
+
+	it( 'shows links only for the saved-enabled placements in a mixed grid', () => {
+		renderSection( {
+			data: buildData( {
+				jetpack_subscribe_overlay_enabled: true, // enabled + saved -> link
+				sm_enabled: true, // enabled but unsaved -> no link
+				jetpack_subscribe_floating_button_enabled: true, // enabled + saved -> link
+			} ),
+			savedData: buildData( {
+				jetpack_subscribe_overlay_enabled: true,
+				sm_enabled: false, // baseline still off
+				jetpack_subscribe_floating_button_enabled: true,
+			} ),
+		} );
+		expect( previewLinks() ).toHaveLength( 2 );
+	} );
+} );


### PR DESCRIPTION
Part of #49485 - NL08

> **Stacked on #49530** (the Settings-spinner cache). This PR is based on that branch and shares one settings-state model — review/merge #49530 first; GitHub will retarget this to `trunk` automatically once it lands. The diff here is just the placement-link change.

## Proposed changes

* In the modernized Newsletter Settings, the subscription-form placement "Preview and edit" link previously rendered whenever the site supported the Site Editor link — regardless of whether that placement was actually enabled. Clicking it for a disabled (or freshly-toggled-but-unsaved) placement opened an empty Site Editor preview.
* The link is now shown only when the placement is **enabled in the saved state** *and* still displayed as checked. Gating is done against a persisted **saved baseline** (`savedData`) rather than "untouched since save", which keeps the link **reversible**: toggle a saved-on placement off and back on and the link returns immediately, without a round-trip to the server. A freshly enabled-but-unsaved placement still stays linkless until the save lands. The existing site-capability gating (block theme / theme stylesheet / subscription-site-edit support) is preserved.
* **Why a saved baseline:** the Subscriptions section stages toggles for a manual Save — `data` is updated optimistically while the key is tracked in a pending changeset that's cleared on save. The page previously kept *no* record of the last-persisted values, so the first version of this fix had to use "key is in the pending changeset" as a proxy for "unsaved". That proxy is touch-based, not value-based: toggling a saved-on placement off then on left the key marked dirty, so the link stayed hidden until an actual save — even though the saved state never changed. This version introduces `savedData`, a persisted baseline set on load and advanced on every successful save, and gates the link on `data[ key ] && savedData[ key ]`. The baseline is module-cached (parallel to #49530's optimistic cache) so it survives the tab unmount/remount without the link blinking off on return.

This only touches the placement-card grid. The Navigation subgroup's "Preview and edit" links are intentionally out of scope here (they share the same "empty preview when unsaved" critique — a reasonable follow-up).

## Related product discussion/links

* See linked issue.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prerequisite: a site with the modernized Newsletter dashboard enabled (modernization filter on) and a block theme so the Site Editor links are eligible.

1. Go to **Jetpack → Newsletter → Settings**, and find the **Subscriptions → Homepage and posts** placement grid (the 2×2 set of selectable cards: overlay, pop-up, end-of-post block, floating button).
2. For a placement whose checkbox is **off**: confirm **no** "Preview and edit" link appears under its title.
3. Toggle a previously-off placement **on** but do **not** click **Save**: confirm the link does **not** appear while the change is unsaved.
4. Click **Save**: confirm the link now appears and opens the correct template/part in the Site Editor (not an empty preview).
5. **Reversibility check (the fix):** with that placement saved-on, toggle it **off** (link disappears), then **back on** *without saving* — confirm the link **returns** immediately.
6. Toggle a saved-on placement off and **Save**: confirm the link stays gone.
7. Switch to the **Subscribers** tab and back to **Settings**: confirm the link state is correct on return with no flicker (the saved baseline is module-cached).
8. Regression: on a site that does not support the Site Editor links (non-block theme / no subscription-site-edit support), confirm no placement shows the link regardless of enabled/saved state.

Automated coverage: `tests/subscriptions-section.test.tsx` asserts the link shows for enabled-and-saved placements (including the reverted-to-saved case) and is hidden for disabled, enabled-but-unsaved, and capability-ineligible cases (`jp test js packages/newsletter`).

