### PR TITLE
Newsletter: remove a subscriber via the consolidated wpcom/v2 endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -386,8 +386,12 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * Remove a subscriber by cancelling any paid subscriptions and deleting both the WPCOM
 	 * follower and email follower records, mirroring Calypso's `useSubscriberRemoveMutation`.
 	 *
-	 * Each underlying call is best-effort — we collect errors per step so the caller can show a
-	 * partial-failure notice instead of giving up on the first 4xx.
+	 * Proxies to the consolidated wpcom `/sites/{blog_id}/subscribers/remove` (v2) endpoint, which
+	 * runs all three steps in-process after switching to the blog and returns an aggregated
+	 * `{ ok, errors }` result. Forwarded as the current user (not the blog token): the wpcom/v2
+	 * authorization layer maps the Jetpack user token to the wpcom user, so the endpoint's
+	 * `manage_options` gate evaluates against the acting admin — unlike the classic v1.1 `/rest`
+	 * API, which left the request with no current user.
 	 *
 	 * @param WP_REST_Request $request Request.
 	 * @return WP_REST_Response|WP_Error
@@ -401,7 +405,9 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 
 		$user_id               = (int) $request->get_param( 'user_id' );
 		$email_subscription_id = (int) $request->get_param( 'email_subscription_id' );
-		$paid_subscription_ids = (array) $request->get_param( 'paid_subscription_ids' );
+		$paid_subscription_ids = array_values(
+			array_filter( array_map( 'strval', (array) $request->get_param( 'paid_subscription_ids' ) ) )
+		);
 
 		if ( ! $user_id && ! $email_subscription_id && empty( $paid_subscription_ids ) ) {
 			return new WP_Error(
@@ -411,57 +417,40 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 			);
 		}
 
-		$errors = array();
-
-		foreach ( $paid_subscription_ids as $paid_id ) {
-			$paid_id = sanitize_text_field( (string) $paid_id );
-			if ( '' === $paid_id ) {
-				continue;
-			}
-			$step_error = $this->wpcom_post(
-				sprintf( '/sites/%d/memberships/subscriptions/%s/cancel', (int) $blog_id, $paid_id )
-			);
-			if ( is_wp_error( $step_error ) ) {
-				$errors[] = array(
-					'step'  => 'cancel_paid_subscription',
-					'id'    => $paid_id,
-					'error' => $step_error->get_error_message(),
-				);
-			}
-		}
-
-		if ( $user_id ) {
-			$step_error = $this->wpcom_post(
-				sprintf( '/sites/%d/followers/%d/delete', (int) $blog_id, $user_id )
-			);
-			if ( is_wp_error( $step_error ) ) {
-				$errors[] = array(
-					'step'  => 'delete_follower',
-					'id'    => (string) $user_id,
-					'error' => $step_error->get_error_message(),
-				);
-			}
-		}
-
-		if ( $email_subscription_id ) {
-			$step_error = $this->wpcom_post(
-				sprintf( '/sites/%d/email-followers/%d/delete', (int) $blog_id, $email_subscription_id )
-			);
-			if ( is_wp_error( $step_error ) ) {
-				$errors[] = array(
-					'step'  => 'delete_email_follower',
-					'id'    => (string) $email_subscription_id,
-					'error' => $step_error->get_error_message(),
-				);
-			}
-		}
-
-		return rest_ensure_response(
+		$response = Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/subscribers/remove', (int) $blog_id ),
+			'2',
 			array(
-				'ok'     => empty( $errors ),
-				'errors' => $errors,
-			)
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json' ),
+			),
+			wp_json_encode(
+				array(
+					'user_id'               => $user_id,
+					'email_subscription_id' => $email_subscription_id,
+					'paid_subscription_ids' => $paid_subscription_ids,
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+			'wpcom'
 		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status >= 400 ) {
+			return new WP_Error(
+				'subscribers_remove_failed',
+				is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'Could not remove the subscriber.', 'jetpack' ),
+				array( 'status' => $status )
+			);
+		}
+
+		return rest_ensure_response( $body );
 	}
 
 	/**
@@ -782,45 +771,6 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 		}
 
 		return rest_ensure_response( $body );
-	}
-
-	/**
-	 * Helper: POST to a v1.1 wpcom REST path as the current user.
-	 *
-	 * Note on caps: WP.com's followers / email-followers / memberships endpoints require the
-	 * calling user to have the `delete_followers` capability on the wpcom-side blog. That maps
-	 * 1:1 with the wpcom blog admin role, so this works on real Jetpack-connected sites where
-	 * the wp-admin admin user is also the wpcom-side blog admin. It does NOT work on environments
-	 * where the wpcom-side blog is owned by a different account than the locally-connected user
-	 * (e.g. some Jurassic Ninja test sites). We tried `as_blog` and forwarding as the connection
-	 * owner — both hit the same wpcom cap gate. The fix lives on the wpcom side, not here.
-	 *
-	 * Returns null on success or a WP_Error describing the failure.
-	 *
-	 * @param string $path Path under `/rest/v1.1`.
-	 * @return WP_Error|null
-	 */
-	private function wpcom_post( $path ) {
-		$response = Client::wpcom_json_api_request_as_user(
-			$path,
-			'1.1',
-			array( 'method' => 'POST' ),
-			null,
-			'rest'
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$status = (int) wp_remote_retrieve_response_code( $response );
-		if ( $status >= 400 ) {
-			$body    = json_decode( wp_remote_retrieve_body( $response ), true );
-			$message = is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'WP.com call failed.', 'jetpack' );
-			return new WP_Error( 'wpcom_call_failed', $message, array( 'status' => $status ) );
-		}
-
-		return null;
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-delete-subscriber-v2
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-delete-subscriber-v2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Subscribers (Newsletter modernization, behind a feature flag): fix removing a subscriber by proxying to the consolidated wpcom /sites/{id}/subscribers/remove (v2) endpoint as the current user, instead of the granular v1.1 follower/email-follower/paid-cancel endpoints which authenticated no user.
+
+

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -203,6 +203,104 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	}
 
 	/**
+	 * `/subscribers/remove` forwards a single request to the consolidated wpcom
+	 * `/sites/{blog_id}/subscribers/remove` (v2) endpoint and returns its aggregated body verbatim.
+	 */
+	public function test_remove_forwards_to_consolidated_endpoint_and_returns_body() {
+		$captured = array();
+		$filter   = function ( $preempt, $parsed_args, $url ) use ( &$captured ) {
+			$captured['url']  = $url;
+			$captured['body'] = $parsed_args['body'] ?? null;
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode(
+					array(
+						'ok'     => true,
+						'errors' => array(),
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/remove' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'user_id'               => 281425227,
+					'email_subscription_id' => 943104114,
+					'paid_subscription_ids' => array( '5', '6' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'ok'     => true,
+				'errors' => array(),
+			),
+			$response->get_data()
+		);
+
+		// Single consolidated call to the site-scoped v2 route — not the old v1.1 fan-out.
+		$this->assertStringContainsString(
+			'/wpcom/v2/sites/' . static::$blog_id . '/subscribers/remove',
+			$captured['url']
+		);
+
+		$sent = json_decode( (string) $captured['body'], true );
+		$this->assertSame( 281425227, $sent['user_id'] );
+		$this->assertSame( 943104114, $sent['email_subscription_id'] );
+		$this->assertSame( array( '5', '6' ), $sent['paid_subscription_ids'] );
+	}
+
+	/**
+	 * A 4xx from the consolidated endpoint surfaces as a WP_Error carrying the upstream message.
+	 */
+	public function test_remove_maps_wpcom_error_to_wp_error() {
+		$filter = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'message' => 'Nope.' ), JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 403,
+					'message' => 'Forbidden',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/remove' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'user_id' => 123 ), JSON_UNESCAPED_SLASHES ) );
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'subscribers_remove_failed', $response->get_data()['code'] );
+		$this->assertSame( 'Nope.', $response->get_data()['message'] );
+	}
+
+	/**
 	 * `/subscribers/individual` requires either a subscription_id or a user_id — without both,
 	 * there's nothing to fetch.
 	 */

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -207,7 +207,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	 * `/sites/{blog_id}/subscribers/remove` (v2) endpoint and returns its aggregated body verbatim.
 	 */
 	public function test_remove_forwards_to_consolidated_endpoint_and_returns_body() {
-		$captured = array();
+		$captured = array(
+			'url'  => '',
+			'body' => '',
+		);
 		$filter   = function ( $preempt, $parsed_args, $url ) use ( &$captured ) {
 			$captured['url']  = $url;
 			$captured['body'] = $parsed_args['body'] ?? null;
@@ -263,7 +266,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 			$captured['url']
 		);
 
-		$sent = json_decode( (string) $captured['body'], true );
+		$sent = (array) json_decode( (string) $captured['body'], true );
 		$this->assertSame( 281425227, $sent['user_id'] );
 		$this->assertSame( 943104114, $sent['email_subscription_id'] );
 		$this->assertSame( array( '5', '6' ), $sent['paid_subscription_ids'] );


### PR DESCRIPTION
Fixes #

## Proposed changes
The modernized Subscribers dashboard's **Remove subscriber** action failed: the Jetpack proxy fanned out to wpcom's granular v1.1 `followers/delete`, `email-followers/delete`, and `memberships/.../cancel` endpoints via `wpcom_json_api_request_as_user()`. The classic v1.1 `/rest` API doesn't establish a wpcom user from the Jetpack auth header, so those requests arrived with no current user (`get_current_user_id() === 0`) and the endpoints' capability gate could never pass.

* Repoint `remove_subscriber()` at the **consolidated wpcom `/sites/{blog_id}/subscribers/remove` (v2) endpoint** with a single `as_user` call, passing `{ user_id, email_subscription_id, paid_subscription_ids }` and returning its aggregated `{ ok, errors }` body. The wpcom/v2 authorization layer maps the Jetpack user token to the wpcom user, so the endpoint's `manage_options` gate evaluates against the acting admin (verified: resolves to the connected owner with `manage_options` on the blog).
* Drop the now-unused `wpcom_post()` v1.1 helper and the three-call fan-out.
* Add tests covering the single-call forwarding and the upstream-error → `WP_Error` mapping.

This is behind the off-by-default `rsm_jetpack_ui_modernization_newsletter` filter.

## Related product discussion/links
* Companion wpcom change (required): 222673-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Requires the companion wpcom change **222673-ghe-Automattic/wpcom** (consolidated `subscribers/remove` endpoint + idempotent "already-gone" handling) to be deployed/sandboxed.

* Enable the modernized dashboard: add a filter returning `true` for `rsm_jetpack_ui_modernization_newsletter`.
* Go to **Jetpack → Newsletter → Subscribers** on a Jetpack-connected site.
* Open the **⋯** Actions menu on a subscriber and choose **Remove subscriber** → confirm. Verify across each subscriber shape:
  * **Both a `.com` follower and an email subscriber** — the case that previously failed; expect a success toast, the row disappears, and `POST /wp-json/wpcom/v2/subscribers/remove` returns `{"ok":true,"errors":[]}`.
  * **Email-only** subscriber.
  * **Paid** subscriber (exercises the membership `cancel` step).
* Confirm the request now resolves as the connected user on the wpcom side (the `manage_options` gate passes) rather than failing with a capability error.
