### PR TITLE
Write editor: image properties panel with alignment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-image-align-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-image-align-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: Add image properties panel (alt text, size, alignment, featured image) opened by an Edit pencil on each image. Adds left, center, and right alignment, replaces the inline ALT and Size buttons, and fixes the stale "align left" toolbar indicator.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1348,6 +1348,12 @@
 	padding: 0;
 	position: relative;
 	text-align: center;
+
+	/* Each figure clears any prior float so floated figures stack vertically
+	 * in the editor and a later figure's bounding box can't overlap a
+	 * floated image above it (which would otherwise break hover targeting
+	 * for the Edit pencil and other controls). */
+	clear: both;
 }
 
 /* Image size presets.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1382,6 +1382,47 @@
 	height: auto;
 }
 
+/* Image alignment.  Every image gets an explicit aligncenter / alignleft /
+ * alignright class — themes (and the published post) key off these for
+ * positioning, and we want predictable round-trip with the block editor.
+ *
+ * Float-based wrap on alignleft / alignright comes from wp-admin's core
+ * editor stylesheet which is inherited here.  We let it apply: text wraps
+ * around aligned images in the editor preview just as it will in the
+ * published post.  The rules below add fallback margin/text-align so the
+ * positioning is still correct on contexts where the core editor.css is
+ * not loaded. */
+.bw-content figure.aligncenter,
+.bw-content .bw-image-figure.aligncenter {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: center;
+}
+
+.bw-content figure.alignleft,
+.bw-content .bw-image-figure.alignleft {
+	margin-left: 0;
+	margin-right: auto;
+	text-align: left;
+}
+
+.bw-content figure.alignleft img,
+.bw-content .bw-image-figure.alignleft img {
+	margin-left: 0;
+}
+
+.bw-content figure.alignright,
+.bw-content .bw-image-figure.alignright {
+	margin-left: auto;
+	margin-right: 0;
+	text-align: right;
+}
+
+.bw-content figure.alignright img,
+.bw-content .bw-image-figure.alignright img {
+	margin-right: 0;
+}
+
 /* Center images horizontally inside the figure.  For sized figures the
  * img already fills the figure box, so this is a no-op visually; for
  * URL-pasted (non-sized) figures it centers a smaller-than-parent img. */
@@ -1390,10 +1431,17 @@
 	margin-right: auto;
 }
 
+/* The controls wrapper hugs the image, not the figure, so the floating
+ * buttons anchor to the visible image edges.  Without this, sizes where the
+ * image's natural width is smaller than the figure's CSS width (notably
+ * Medium, where a 300px image sits inside a 50%-of-content-area figure) push
+ * the bottom-left and bottom-right buttons past the image bounds. */
 .bw-content figure .bw-img-controls,
 .bw-content .bw-image-figure .bw-img-controls {
 	position: relative;
-	display: block;
+	display: inline-block;
+	max-width: 100%;
+	vertical-align: top;
 }
 
 .bw-content figure .bw-img-delete,
@@ -1435,66 +1483,11 @@
 	background: rgba(214, 54, 56, 0.85);
 }
 
-/* Alt text button */
-.bw-img-alt {
-	position: absolute;
-	bottom: 10px;
-	left: 10px;
-	padding: 4px 10px;
-	border-radius: 4px;
-	background: rgba(0, 0, 0, 0.6);
-	backdrop-filter: blur(4px);
-	color: #fff;
-	border: none;
-	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: 0.05em;
-	cursor: pointer;
-	opacity: 0;
-	transform: scale(0.8);
-	transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
-	z-index: 5;
-}
-
-.bw-img-controls:hover .bw-img-alt,
-.bw-img-controls:focus-within .bw-img-alt {
-	opacity: 1;
-	transform: scale(1);
-}
-
-.bw-img-alt:hover {
-	background: rgba(33, 113, 177, 0.85);
-}
-
-/* Alt text inline input */
-.bw-img-alt-input {
-	position: absolute;
-	bottom: 10px;
-	left: 10px;
-	right: 10px;
-	z-index: 6;
-	padding: 8px 12px;
-	border: none;
-	border-radius: 6px;
-	background: rgba(0, 0, 0, 0.7);
-	backdrop-filter: blur(8px);
-	color: #fff;
-	font-size: 13px;
-	font-family: inherit;
-	outline: none;
-	box-sizing: border-box;
-	animation: bw-fade-in 0.12s ease;
-}
-
-.bw-img-alt-input::placeholder {
-	color: rgba(255, 255, 255, 0.5);
-}
-
-/* Caption button */
+/* Caption button — leftmost bottom control. */
 .bw-img-caption-btn {
 	position: absolute;
 	bottom: 10px;
-	left: 60px;
+	left: 10px;
 	padding: 4px 10px;
 	border-radius: 4px;
 	background: rgba(0, 0, 0, 0.6);
@@ -1520,83 +1513,46 @@
 	background: rgba(33, 113, 177, 0.85);
 }
 
-/* Size button — mirrors .bw-img-caption-btn styling, sits to its right. */
-.bw-img-size {
+/* Edit (pencil) button — opens the image properties modal. Anchored to the
+ * bottom-right so it doesn't stack horizontally with Caption on narrow
+ * images (RSM-3980). */
+.bw-img-edit {
 	position: absolute;
 	bottom: 10px;
-	left: 130px;
-	padding: 4px 10px;
+	right: 10px;
+	width: 28px;
+	height: 24px;
+	padding: 0;
 	border-radius: 4px;
 	background: rgba(0, 0, 0, 0.6);
 	backdrop-filter: blur(4px);
 	color: #fff;
 	border: none;
-	font-size: 11px;
-	font-weight: 600;
 	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	opacity: 0;
 	transform: scale(0.8);
 	transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
 	z-index: 5;
 }
 
-.bw-img-controls:hover .bw-img-size,
-.bw-img-controls:focus-within .bw-img-size {
+.bw-img-edit .dashicons {
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
+}
+
+.bw-img-controls:hover .bw-img-edit,
+.bw-img-controls:focus-within .bw-img-edit {
 	opacity: 1;
 	transform: scale(1);
 }
 
-.bw-img-size:hover {
+.bw-img-edit:hover {
 	background: rgba(33, 113, 177, 0.85);
-}
-
-.bw-img-size-menu {
-	position: absolute;
-	bottom: 40px;
-	left: 130px;
-	z-index: 6;
-	background: rgba(0, 0, 0, 0.8);
-	backdrop-filter: blur(8px);
-	border-radius: 6px;
-	padding: 4px;
-	min-width: 110px;
-	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-	animation: bw-fade-in 0.12s ease;
-}
-
-.bw-img-size-menu[hidden] {
-	display: none;
-}
-
-.bw-img-size-option {
-	display: block;
-	width: 100%;
-	padding: 6px 10px 6px 24px;
-	border: none;
-	border-radius: 4px;
-	background: transparent;
-	text-align: start;
-	cursor: pointer;
-	font-family: inherit;
-	font-size: 12px;
-	color: #fff;
-	position: relative;
-	transition: background 0.1s ease;
-}
-
-.bw-img-size-option:hover {
-	background: rgba(255, 255, 255, 0.15);
-}
-
-.bw-img-size-option[aria-checked="true"] {
-	font-weight: 700;
-}
-
-.bw-img-size-option[aria-checked="true"]::before {
-	content: "✓";
-	position: absolute;
-	left: 8px;
-	font-weight: 700;
 }
 
 /* Figcaption.
@@ -1653,6 +1609,14 @@
 .bw-figure-selected {
 	outline: 3px solid var(--wp-admin-theme-color, #3858e9);
 	outline-offset: 4px;
+	border-radius: 4px;
+}
+
+/* Edit panel target: shows which figure the floating edit panel is currently
+ * pointed at, so switching panels between images is visually clear. */
+.bw-figure-editing {
+	outline: 2px solid var(--wp-admin-theme-color, #3858e9);
+	outline-offset: 6px;
 	border-radius: 4px;
 }
 
@@ -1883,6 +1847,150 @@
 	width: 16px;
 	height: 16px;
 	cursor: pointer;
+}
+
+/* ===== Image edit panel =====
+ * Non-modal floating panel docked to the bottom-right on desktop, sliding up
+ * as a full-width bottom sheet on mobile. Lets the user keep seeing the
+ * image change as size/alignment are picked. */
+.bw-image-edit-panel {
+	position: fixed;
+	bottom: 24px;
+	right: 24px;
+	z-index: 300;
+	width: 320px;
+	max-width: calc(100vw - 48px);
+	background: #fff;
+	border-radius: 12px;
+	padding: 20px 24px 24px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.06);
+	animation: bw-fade-in 0.15s ease;
+}
+
+.bw-image-edit-panel[hidden] {
+	display: none;
+}
+
+@media (max-width: 640px) {
+
+	.bw-image-edit-panel {
+		right: 0;
+		bottom: 0;
+		left: 0;
+		width: auto;
+		max-width: none;
+		border-radius: 12px 12px 0 0;
+		padding: 16px 16px max(20px, env(safe-area-inset-bottom));
+		box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.06);
+		animation: bw-slide-up 0.2s ease;
+	}
+}
+
+@keyframes bw-slide-up {
+
+	from {
+		transform: translateY(100%);
+	}
+
+	to {
+		transform: translateY(0);
+	}
+}
+
+.bw-edit-panel-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: 0 0 16px;
+	gap: 8px;
+}
+
+.bw-edit-panel-title {
+	margin: 0;
+	font-size: 15px;
+	font-weight: 600;
+	color: #1a1a1a;
+}
+
+.bw-edit-panel-close {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: #555;
+	font-size: 20px;
+	line-height: 1;
+	cursor: pointer;
+	transition: background 0.12s ease, color 0.12s ease;
+}
+
+.bw-edit-panel-close:hover,
+.bw-edit-panel-close:focus {
+	background: rgba(0, 0, 0, 0.06);
+	color: #1a1a1a;
+}
+
+.bw-edit-panel-done {
+	width: 100%;
+	margin-top: 16px;
+}
+
+/* Per-section label + radio-button row inside the edit panel. */
+.bw-edit-section {
+	margin-top: 16px;
+}
+
+.bw-edit-section[hidden] {
+	display: none;
+}
+
+.bw-edit-label {
+	display: block;
+	font-size: 12px;
+	font-weight: 600;
+	color: #555;
+	margin-bottom: 6px;
+	letter-spacing: 0.02em;
+}
+
+.bw-edit-radios {
+	display: flex;
+	gap: 4px;
+	background: #f3f4f6;
+	border-radius: 8px;
+	padding: 4px;
+}
+
+.bw-edit-size-option,
+.bw-edit-align-option {
+	flex: 1;
+	padding: 6px 10px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 13px;
+	color: #555;
+	transition: background 0.12s ease, color 0.12s ease;
+}
+
+.bw-edit-size-option:hover,
+.bw-edit-align-option:hover {
+	background: rgba(33, 113, 177, 0.08);
+}
+
+.bw-edit-size-option[aria-checked="true"],
+.bw-edit-align-option[aria-checked="true"] {
+	background: #fff;
+	color: #1a1a1a;
+	font-weight: 600;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
 /* ===== Post picker modal ===== */

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -137,6 +137,15 @@ let selectedFigure = null;
 // if the user cancels the selection (Escape, click, or typing a letter).
 let preFigureSelectionRange = null;
 
+// The figure currently open in the image properties panel. Set by editImage()
+// and cleared by closeImageModal(); changes made in the panel apply to this
+// figure live.
+let editingFigure = null;
+
+// The element that triggered the edit panel (typically the per-image Edit
+// pencil button) — focus returns here when the panel closes for a11y.
+let editTriggerEl = null;
+
 let cachedContent = null;
 
 // --- Undo/redo helpers ---
@@ -253,9 +262,7 @@ function stripRuntimeFigureControls( root ) {
 		wrapper.remove();
 	} );
 	root
-		.querySelectorAll(
-			'.bw-img-delete, .bw-img-alt, .bw-img-alt-input, .bw-img-caption-btn, .bw-img-size, .bw-img-size-menu'
-		)
+		.querySelectorAll( '.bw-img-delete, .bw-img-caption-btn, .bw-img-edit' )
 		.forEach( el => el.remove() );
 }
 
@@ -367,9 +374,13 @@ function getContent() {
 	return cachedContent;
 }
 
-// Image size presets we ship. Alignment, wide/full layouts, and custom
-// widths stay in the block editor (see RSM-3472).
+// Image size presets we ship. Wide/full layouts and custom widths stay in the
+// block editor (see RSM-3472).
 const IMAGE_SIZE_SLUGS = [ 'thumbnail', 'medium', 'large', 'full' ];
+
+// Image alignment values we ship. 'center' is the default and emits no class
+// or attribute, matching block editor behavior for unaligned images.
+const IMAGE_ALIGNS = [ 'left', 'center', 'right' ];
 
 // Cache of media library size lookups keyed by attachment ID.  Populated
 // at upload time from the API response, then again lazily when the user
@@ -462,6 +473,35 @@ function setFigureSize( fig, slug ) {
 }
 
 /**
+ * Toggle an alignment class on a figure, replacing any existing one.  Always
+ * adds one of alignleft/aligncenter/alignright so the published view centers
+ * reliably (themes key off these classes; unaligned figures don't center
+ * consistently across themes).
+ *
+ * @param {Element} fig   - The figure element.
+ * @param {string}  align - 'left', 'center', or 'right'.
+ */
+function setFigureAlignment( fig, align ) {
+	fig.classList.remove( 'alignleft', 'alignright', 'aligncenter' );
+	if ( align === 'left' ) fig.classList.add( 'alignleft' );
+	else if ( align === 'right' ) fig.classList.add( 'alignright' );
+	else fig.classList.add( 'aligncenter' );
+}
+
+/**
+ * Read the current alignment from a figure's class list. Returns 'center'
+ * when no align class is set.
+ *
+ * @param {Element} fig - The figure element.
+ * @return {string} 'left', 'center', or 'right'.
+ */
+function getFigureAlignment( fig ) {
+	if ( fig.classList.contains( 'alignleft' ) ) return 'left';
+	if ( fig.classList.contains( 'alignright' ) ) return 'right';
+	return 'center';
+}
+
+/**
  * Deselect the currently-selected figure, if any, and optionally
  * restore the cursor position saved before the figure was selected.
  *
@@ -484,22 +524,6 @@ function clearFigureSelection( restoreCursor = true ) {
 // Deselect figure on any click — don't restore the saved cursor
 // because the click itself places the caret where the user wants it.
 document.addEventListener( 'click', () => clearFigureSelection( false ) );
-
-// Close any open per-image Size dropdown on outside click.  One listener
-// total — avoids the per-figure listener accumulation that would otherwise
-// pile up as users insert / undo / redo images over a session.
-// The menu's own trigger button is its previousElementSibling; only clicks
-// on *that* button are exempt, so clicking a different image's Size button
-// still closes the menu (and lets that image's button open its own menu).
-document.addEventListener( 'click', ev => {
-	const openMenu = document.querySelector( '.bw-img-size-menu:not([hidden])' );
-	if ( ! openMenu ) return;
-	if ( openMenu.contains( ev.target ) ) return;
-	const trigger = openMenu.previousElementSibling;
-	if ( trigger && trigger.contains( ev.target ) ) return;
-	openMenu.hidden = true;
-	trigger?.setAttribute( 'aria-expanded', 'false' );
-} );
 
 /**
  * Whether the editor has anything worth saving — non-empty title, any
@@ -659,15 +683,41 @@ function createLinkFromUrl( url ) {
 }
 
 /**
- * Focus the first visible input inside a modal after it becomes visible.
- * Uses requestAnimationFrame so the element is no longer hidden.
+ * End an in-progress edit-panel session: commit changes as a discrete undo
+ * entry and reset edit-only state. Returns the trigger element that opened
+ * the panel so the caller can decide whether to return focus there.
+ *
+ * No-op when no edit session is in progress.
+ *
+ * @return {Element|null} The Edit pencil that opened the panel, or null.
+ */
+function endEditSession() {
+	if ( ! state.isEditMode ) return null;
+	const trigger = editTriggerEl;
+	if ( editingFigure ) {
+		editingFigure.classList.remove( 'bw-figure-editing' );
+	}
+	editingFigure = null;
+	editTriggerEl = null;
+	state.isEditMode = false;
+	state.editingImageAlign = 'center';
+	state.editingImageSize = '';
+	state.editingImageHasMediaId = false;
+	pushToUndoHistory();
+	return trigger;
+}
+
+/**
+ * Focus the first visible input inside the image insert overlay or the edit
+ * panel after it becomes visible. Uses requestAnimationFrame so the element
+ * is no longer hidden.
  */
 function focusModalInput() {
 	requestAnimationFrame( () => {
-		const overlay = document.querySelector( '.bw-image-overlay:not([hidden])' );
-		if ( ! overlay ) return;
-		const input = overlay.querySelector( 'input:not([hidden])' );
-		if ( input ) input.focus();
+		const target = document.querySelector(
+			'.bw-image-edit-panel:not([hidden]) input:not([hidden]), .bw-image-overlay:not([hidden]) input:not([hidden])'
+		);
+		if ( target ) target.focus();
 	} );
 }
 
@@ -1064,23 +1114,35 @@ function convertToBlocks( html ) {
 				? `<figcaption class="wp-element-caption">${ figcaption.innerHTML }</figcaption>`
 				: '';
 
-			// Read figure size class + the `wp-image-<id>` class for the
-			// media library attachment ID.  These map to core wp:image
-			// attributes so the published markup matches what the block
-			// editor would emit, and the block editor can re-open these
-			// images without surprises.
-			const imageSizeSlug = [ 'thumbnail', 'medium', 'large', 'full' ].find( s =>
-				node.classList.contains( 'size-' + s )
-			);
+			// Read figure size + alignment classes plus the `wp-image-<id>`
+			// class for the media-library attachment ID.  These map to core
+			// wp:image attributes so the published markup matches what the
+			// block editor would emit, and the block editor can re-open these
+			// images without surprises.  Center alignment is the default and
+			// emits no attribute, matching block editor behavior.
+			const imageSizeSlug = IMAGE_SIZE_SLUGS.find( s => node.classList.contains( 'size-' + s ) );
+			// Always emit an explicit align attr + class.  Without aligncenter
+			// many themes don't center the figure in the published view, and
+			// the block editor reads "no align" as "default" (which renders
+			// differently from explicit center).  Match the block editor's
+			// convention so the published post centers reliably.
+			let imageAlign = 'center';
+			if ( node.classList.contains( 'alignleft' ) ) {
+				imageAlign = 'left';
+			} else if ( node.classList.contains( 'alignright' ) ) {
+				imageAlign = 'right';
+			}
 			const mediaId = getMediaIdFromImg( img );
 
 			const imageAttrs = [];
 			if ( mediaId ) imageAttrs.push( `"id":${ mediaId }` );
 			if ( imageSizeSlug ) imageAttrs.push( `"sizeSlug":"${ imageSizeSlug }"` );
+			imageAttrs.push( `"align":"${ imageAlign }"` );
 			const imageAttrsJson = imageAttrs.length ? ` {${ imageAttrs.join( ',' ) }}` : '';
 
 			const figureClasses = [ 'wp-block-image' ];
 			if ( imageSizeSlug ) figureClasses.push( 'size-' + imageSizeSlug );
+			figureClasses.push( 'align' + imageAlign );
 
 			const imgClassAttr = mediaId ? ` class="wp-image-${ mediaId }"` : '';
 
@@ -1536,6 +1598,12 @@ function placeCursorAtEnd( el ) {
  * @param {Element} fig - The figure element to delete.
  */
 function animateAndDeleteFigure( fig ) {
+	// If the edit panel is open for this figure, close it first — the
+	// figure is about to disappear and the panel's target is gone.
+	if ( editingFigure === fig ) {
+		const { actions } = store( 'wpcom-write' );
+		actions.closeImageModal();
+	}
 	// Mark as deleting so getFigureAdjacentToCursor skips it during
 	// the animation delay (prevents rapid Backspace from re-selecting).
 	fig.dataset.bwDeleting = '';
@@ -1655,49 +1723,10 @@ function addDeleteButtons() {
 		} );
 		controls.appendChild( btn );
 
-		// Alt text button (only for images, not videos).
+		// Skip the rest (caption, edit) for non-image figures — videos use
+		// only the delete control.
 		const imgEl = controls.querySelector( 'img' );
 		if ( ! imgEl ) return;
-
-		const altBtn = document.createElement( 'button' );
-		altBtn.className = 'bw-img-alt';
-		altBtn.textContent = i18n.alt || 'ALT';
-		altBtn.contentEditable = 'false';
-		altBtn.addEventListener( 'click', e => {
-			e.preventDefault();
-			e.stopPropagation();
-
-			const existing = controls.querySelector( '.bw-img-alt-input' );
-			if ( existing ) {
-				existing.remove();
-				return;
-			}
-
-			const input = document.createElement( 'input' );
-			input.type = 'text';
-			input.className = 'bw-img-alt-input';
-			input.placeholder = i18n.describeImage || 'Describe this image...';
-			input.value = imgEl.alt || '';
-			input.contentEditable = 'false';
-			input.addEventListener( 'click', ev => ev.stopPropagation() );
-			input.addEventListener( 'keydown', ev => {
-				ev.stopPropagation();
-				if ( ev.key === 'Enter' ) {
-					imgEl.alt = input.value;
-					input.remove();
-				}
-				if ( ev.key === 'Escape' ) {
-					input.remove();
-				}
-			} );
-			input.addEventListener( 'blur', () => {
-				imgEl.alt = input.value;
-				setTimeout( () => input.remove(), 150 );
-			} );
-			controls.appendChild( input );
-			input.focus();
-		} );
-		controls.appendChild( altBtn );
 
 		// Captions saved by the editor come back from the server with class
 		// `wp-element-caption` and no `contentEditable`, so without this any
@@ -1739,113 +1768,23 @@ function addDeleteButtons() {
 		} );
 		controls.appendChild( capBtn );
 
-		// Size button + dropdown (only for media-library images: external
-		// URLs have no registered sizes to swap between).
-		const isMediaLibrary = !! getMediaIdFromImg( imgEl );
-		if ( isMediaLibrary ) {
-			const sizeBtn = document.createElement( 'button' );
-			sizeBtn.className = 'bw-img-size';
-			sizeBtn.textContent = i18n.size || 'Size';
-			sizeBtn.contentEditable = 'false';
-			sizeBtn.setAttribute( 'aria-haspopup', 'menu' );
-			sizeBtn.setAttribute( 'aria-expanded', 'false' );
-
-			const menu = document.createElement( 'div' );
-			menu.className = 'bw-img-size-menu';
-			menu.contentEditable = 'false';
-			menu.hidden = true;
-			menu.setAttribute( 'role', 'menu' );
-			const sizeOptions = [
-				[ 'thumbnail', i18n.sizeThumbnail || 'Thumbnail' ],
-				[ 'medium', i18n.sizeMedium || 'Medium' ],
-				[ 'large', i18n.sizeLarge || 'Large' ],
-				[ 'full', i18n.sizeFull || 'Full' ],
-			];
-			sizeOptions.forEach( ( [ slug, label ] ) => {
-				const opt = document.createElement( 'button' );
-				opt.className = 'bw-img-size-option';
-				opt.textContent = label;
-				opt.contentEditable = 'false';
-				opt.setAttribute( 'role', 'menuitemradio' );
-				opt.dataset.size = slug;
-				opt.tabIndex = -1;
-				opt.addEventListener( 'click', ev => {
-					ev.preventDefault();
-					ev.stopPropagation();
-					setFigureSize( fig, slug );
-					trackMediaSizeSwap( applyMediaSizeToFigure( fig, slug ) ).then( pushToUndoHistory );
-					closeSizeMenu( true );
-				} );
-				menu.appendChild( opt );
-			} );
-
-			const openSizeMenu = () => {
-				// Close any other image's open Size menu first.  sizeBtn's click
-				// handler stops propagation so the document-level outside-click
-				// listener can't do this for us.
-				document.querySelectorAll( '.bw-img-size-menu:not([hidden])' ).forEach( other => {
-					if ( other === menu ) return;
-					other.hidden = true;
-					other.previousElementSibling?.setAttribute( 'aria-expanded', 'false' );
-				} );
-				// Mark the option that matches the figure's current size class
-				// (none on figures loaded without an explicit sizeSlug).
-				const current = IMAGE_SIZE_SLUGS.find( s => fig.classList.contains( 'size-' + s ) );
-				const options = [ ...menu.querySelectorAll( '.bw-img-size-option' ) ];
-				options.forEach( opt => {
-					opt.setAttribute( 'aria-checked', opt.dataset.size === current ? 'true' : 'false' );
-				} );
-				menu.hidden = false;
-				sizeBtn.setAttribute( 'aria-expanded', 'true' );
-				// Focus the current option so arrow keys move from there.
-				const focusTarget = options.find( o => o.dataset.size === current ) || options[ 0 ];
-				focusTarget?.focus();
-			};
-			const closeSizeMenu = ( returnFocus = false ) => {
-				menu.hidden = true;
-				sizeBtn.setAttribute( 'aria-expanded', 'false' );
-				if ( returnFocus ) sizeBtn.focus();
-			};
-
-			sizeBtn.addEventListener( 'click', ev => {
-				ev.preventDefault();
-				ev.stopPropagation();
-				if ( menu.hidden ) {
-					openSizeMenu();
-				} else {
-					closeSizeMenu();
-				}
-			} );
-
-			// Arrow / Home / End / Escape navigation within the open menu.
-			menu.addEventListener( 'keydown', ev => {
-				const options = [ ...menu.querySelectorAll( '.bw-img-size-option' ) ];
-				const idx = options.indexOf( menu.ownerDocument.activeElement );
-				if ( ev.key === 'ArrowDown' ) {
-					ev.preventDefault();
-					options[ ( idx + 1 ) % options.length ]?.focus();
-				} else if ( ev.key === 'ArrowUp' ) {
-					ev.preventDefault();
-					options[ ( idx - 1 + options.length ) % options.length ]?.focus();
-				} else if ( ev.key === 'Home' ) {
-					ev.preventDefault();
-					options[ 0 ]?.focus();
-				} else if ( ev.key === 'End' ) {
-					ev.preventDefault();
-					options[ options.length - 1 ]?.focus();
-				} else if ( ev.key === 'Escape' ) {
-					ev.preventDefault();
-					closeSizeMenu( true );
-				} else if ( ev.key === 'Tab' ) {
-					// Tab out of the menu closes it.  The browser handles the
-					// focus move; we just clean up state.
-					closeSizeMenu();
-				}
-			} );
-
-			controls.appendChild( sizeBtn );
-			controls.appendChild( menu );
-		}
+		// Edit button — opens the image properties modal (alt, size, align,
+		// featured). Anchored to the bottom-right so it doesn't stack
+		// horizontally with the Caption button on narrow (Thumbnail / Medium)
+		// images (RSM-3980).
+		const editBtn = document.createElement( 'button' );
+		editBtn.className = 'bw-img-edit';
+		editBtn.innerHTML = '<span class="dashicons dashicons-edit" aria-hidden="true"></span>';
+		editBtn.contentEditable = 'false';
+		editBtn.setAttribute( 'aria-label', i18n.editImage || 'Edit image' );
+		editBtn.setAttribute( 'title', i18n.editImage || 'Edit image' );
+		editBtn.addEventListener( 'click', e => {
+			e.preventDefault();
+			e.stopPropagation();
+			const { actions } = store( 'wpcom-write' );
+			actions.editImage( fig, e.currentTarget );
+		} );
+		controls.appendChild( editBtn );
 
 		// Enter inside the figcaption exits to the next block. Attached on every
 		// figure init (not just on first caption-button click) so it survives an
@@ -2314,7 +2253,7 @@ function updateFormattingState() {
 	state.formatHeading = false;
 	state.formatQuote = false;
 	state.headingLabel = i18n.normal || 'Normal';
-	state.formatAlignLeft = true;
+	state.formatAlignLeft = false;
 	state.formatAlignCenter = false;
 	state.formatAlignRight = false;
 	state.formatAlignJustify = false;
@@ -2335,10 +2274,14 @@ function updateFormattingState() {
 				if ( node.tagName === 'BLOCKQUOTE' ) {
 					state.formatQuote = true;
 				}
-				// Detect alignment from the nearest block element.
+				// Detect alignment from the nearest block element. Only highlight
+				// a button when alignment is explicitly set — empty textAlign
+				// means "default", which is left in browsers but shouldn't show
+				// any align button as active (matches block-editor behavior and
+				// avoids misleading users when nearby figures render centered).
 				if ( /^(P|H[1-6]|DIV|BLOCKQUOTE)$/.test( node.tagName ) && node.style.textAlign ) {
 					const align = node.style.textAlign;
-					state.formatAlignLeft = align === 'left' || align === 'start' || align === '';
+					state.formatAlignLeft = align === 'left' || align === 'start';
 					state.formatAlignCenter = align === 'center';
 					state.formatAlignRight = align === 'right';
 					state.formatAlignJustify = align === 'justify';
@@ -3091,6 +3034,24 @@ const { state } = store( 'wpcom-write', {
 			inner.setAttribute( 'aria-expanded', state.showSlashMenu ? 'true' : 'false' );
 			inner.setAttribute( 'aria-activedescendant', state.slashActiveId || '' );
 		},
+
+		/**
+		 * Mirror edit-modal radio state onto aria-checked attributes so the
+		 * active option is visually marked.  Reading state.editingImageAlign
+		 * / state.editingImageSize here subscribes the watcher to those
+		 * signals; the modal's data-wp-watch wires this up.
+		 */
+		syncEditImageModalRadios() {
+			const align = state.editingImageAlign;
+			const size = state.editingImageSize;
+			if ( ! state.showImageModal || ! state.isEditMode ) return;
+			document.querySelectorAll( '.bw-edit-align-option' ).forEach( btn => {
+				btn.setAttribute( 'aria-checked', btn.value === align ? 'true' : 'false' );
+			} );
+			document.querySelectorAll( '.bw-edit-size-option' ).forEach( btn => {
+				btn.setAttribute( 'aria-checked', btn.value === size ? 'true' : 'false' );
+			} );
+		},
 	},
 	state: {
 		formatBold: false,
@@ -3112,6 +3073,18 @@ const { state } = store( 'wpcom-write', {
 		},
 		get isBlockEditorWarning() {
 			return state.unsupportedWarning === 'block-editor';
+		},
+		// True when a "true modal" overlay is open (insert image, video,
+		// post picker). Used to gate keystroke handlers — the edit panel is
+		// non-modal and intentionally not included here.
+		get hasBlockingModal() {
+			return state.showImageInsertOverlay || state.showVideoModal || state.showPostPicker;
+		},
+		// True when the centered insert overlay should be visible. The
+		// underlying state.showImageModal flag is shared between insert and
+		// edit; this getter separates them in markup bindings.
+		get showImageInsertOverlay() {
+			return state.showImageModal && ! state.isEditMode;
 		},
 		get unsupportedDescId() {
 			if ( state.unsupportedWarning === 'classic-editor' ) {
@@ -3140,11 +3113,12 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		handleTitleKeyDown( event ) {
-			// Block keystrokes while a modal overlay is open.
-			if ( state.showImageModal || state.showVideoModal || state.showPostPicker ) {
+			// Block keystrokes while a blocking overlay is open. The image
+			// edit panel is non-modal and doesn't block title editing.
+			if ( state.hasBlockingModal ) {
 				if ( event.key === 'Escape' ) {
 					const { actions: a } = store( 'wpcom-write' );
-					if ( state.showImageModal ) {
+					if ( state.showImageInsertOverlay ) {
 						a.closeImageModal();
 					} else {
 						a.closeVideoModal();
@@ -3358,15 +3332,16 @@ const { state } = store( 'wpcom-write', {
 
 		handleKeyDown( event ) {
 			// Keep savedRange current before any key changes the selection.
-			if ( ! state.showImageModal && ! state.showVideoModal && ! state.showPostPicker ) {
+			if ( ! state.hasBlockingModal ) {
 				saveSelection();
 			}
 
-			// Block all keystrokes while a modal overlay is open.
-			if ( state.showImageModal || state.showVideoModal || state.showPostPicker ) {
+			// Block all keystrokes while a blocking overlay is open. The
+			// image edit panel is non-modal and doesn't block editor input.
+			if ( state.hasBlockingModal ) {
 				if ( event.key === 'Escape' ) {
 					const { actions: a } = store( 'wpcom-write' );
-					if ( state.showImageModal ) {
+					if ( state.showImageInsertOverlay ) {
 						a.closeImageModal();
 					} else {
 						a.closeVideoModal();
@@ -4307,14 +4282,49 @@ const { state } = store( 'wpcom-write', {
 
 		toggleFeaturedImage() {
 			state.setAsFeatured = ! state.setAsFeatured;
+			// In edit mode the toggle applies to the post immediately.  The
+			// post-level featuredMediaId is the source of truth on save; we
+			// set / clear it here so the change survives modal close.
+			if ( state.isEditMode && editingFigure ) {
+				const mediaId = getMediaIdFromImg( editingFigure.querySelector( 'img' ) );
+				if ( ! mediaId ) return;
+				state.featuredMediaId = state.setAsFeatured ? mediaId : 0;
+			}
 		},
 
 		updateImageAlt() {
 			const el = getElement();
 			state.imageAlt = el.ref.value;
+			// In edit mode, apply to the figure live.  Undo coalesces all
+			// modal edits into a single history entry pushed on close.
+			if ( state.isEditMode && editingFigure ) {
+				const img = editingFigure.querySelector( 'img' );
+				if ( img ) img.alt = state.imageAlt;
+			}
+		},
+
+		setEditImageSize() {
+			const el = getElement();
+			const slug = el.ref.value;
+			if ( ! editingFigure || ! IMAGE_SIZE_SLUGS.includes( slug ) ) return;
+			state.editingImageSize = slug;
+			setFigureSize( editingFigure, slug );
+			trackMediaSizeSwap( applyMediaSizeToFigure( editingFigure, slug ) );
+		},
+
+		setEditImageAlign() {
+			const el = getElement();
+			const align = el.ref.value;
+			if ( ! editingFigure || ! IMAGE_ALIGNS.includes( align ) ) return;
+			state.editingImageAlign = align;
+			setFigureAlignment( editingFigure, align );
 		},
 
 		openImageModal() {
+			// If the edit panel is open for an existing image, end that
+			// session first so the user's changes land as a discrete undo
+			// entry before the insert overlay replaces the panel.
+			endEditSession();
 			saveSelection();
 			state.imageUrl = '';
 			state.imageAlt = '';
@@ -4326,7 +4336,52 @@ const { state } = store( 'wpcom-write', {
 			focusModalInput();
 		},
 
+		editImage( figure, triggerEl ) {
+			// `figure` and `triggerEl` are passed by the per-image Edit pencil
+			// handler — not by Interactivity bindings — so we accept them as
+			// arguments rather than reading from getElement().
+			if ( ! figure ) return;
+			const img = figure.querySelector( 'img' );
+			if ( ! img ) return;
+
+			// Switching mid-edit from one image's panel to another: commit
+			// the previous session as a discrete undo entry and clear the
+			// outline on the old figure before retargeting.
+			if ( state.isEditMode && editingFigure && editingFigure !== figure ) {
+				editingFigure.classList.remove( 'bw-figure-editing' );
+				pushToUndoHistory();
+			}
+
+			editingFigure = figure;
+			editTriggerEl = triggerEl || null;
+			figure.classList.add( 'bw-figure-editing' );
+			state.isEditMode = true;
+			state.imageAlt = img.alt || '';
+			state.editingImageAlign = getFigureAlignment( figure );
+			state.editingImageSize =
+				IMAGE_SIZE_SLUGS.find( s => figure.classList.contains( 'size-' + s ) ) || '';
+
+			const mediaId = getMediaIdFromImg( img );
+			state.editingImageHasMediaId = !! mediaId;
+			state.setAsFeatured = !! ( mediaId && state.featuredMediaId === mediaId );
+
+			state.showImageModal = true;
+			focusModalInput();
+
+			// On mobile the panel slides up as a bottom sheet that covers
+			// roughly the lower half of the viewport. Scroll the figure
+			// near the top so it stays visible while the user edits.
+			if ( window.matchMedia( '(max-width: 640px)' ).matches ) {
+				requestAnimationFrame( () => {
+					figure.scrollIntoView( { block: 'start', behavior: 'smooth' } );
+				} );
+			}
+		},
+
 		closeImageModal() {
+			// endEditSession returns the Edit pencil that opened the panel
+			// (when we were in edit mode) so we can return focus there.
+			const triggerToRefocus = endEditSession();
 			state.showImageModal = false;
 			state.imageUrl = '';
 			state.imageAlt = '';
@@ -4334,7 +4389,11 @@ const { state } = store( 'wpcom-write', {
 			state.uploadedMediaId = 0;
 			resetUploadZone();
 			restoreSelection();
-			getContent()?.focus();
+			if ( triggerToRefocus && document.contains( triggerToRefocus ) ) {
+				triggerToRefocus.focus();
+			} else {
+				getContent()?.focus();
+			}
 		},
 
 		handleImageModalKeyDown( event ) {
@@ -4410,14 +4469,14 @@ const { state } = store( 'wpcom-write', {
 				// editor and swap src to the Large-sized URL so the natural
 				// img dimensions match the default preset.
 				img.className = 'wp-image-' + state.uploadedMediaId;
-				figure.className = 'bw-image-figure size-large';
+				figure.className = 'bw-image-figure size-large aligncenter';
 				figure.appendChild( img );
 				trackMediaSizeSwap( applyMediaSizeToFigure( figure, 'large' ) );
 			} else {
 				// External URL (no media library entry, no resized files):
 				// no size preset — the per-image Size button is hidden, matching
 				// block editor behavior.
-				figure.className = 'bw-image-figure';
+				figure.className = 'bw-image-figure aligncenter';
 				figure.appendChild( img );
 			}
 
@@ -4596,6 +4655,10 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		insertImage() {
+			// Slash-menu image insert: close any open edit panel first so
+			// the in-progress edit session is committed as a discrete undo
+			// entry before the insert overlay takes over.
+			endEditSession();
 			flushUndoDebounce();
 			clearSlashText();
 			clearSlashActive();
@@ -5369,8 +5432,8 @@ async function savePost( postStatus, isAutosave = false ) {
 			p.remove();
 		}
 	} );
-	clone.querySelectorAll( '.bw-figure-selected' ).forEach( el => {
-		el.classList.remove( 'bw-figure-selected' );
+	clone.querySelectorAll( '.bw-figure-selected, .bw-figure-editing' ).forEach( el => {
+		el.classList.remove( 'bw-figure-selected', 'bw-figure-editing' );
 	} );
 	// Also strip the contenteditable attribute from figures — it's a
 	// runtime attribute that shouldn't be persisted.
@@ -5636,13 +5699,7 @@ document.addEventListener( 'keydown', event => {
 	if ( event.key?.toLowerCase() !== 's' ) return;
 	if ( ! ( event.ctrlKey || event.metaKey ) ) return;
 	if ( event.shiftKey || event.altKey ) return;
-	if (
-		state.isSaving ||
-		state.unsupportedWarning ||
-		state.showImageModal ||
-		state.showVideoModal ||
-		state.showPostPicker
-	) {
+	if ( state.isSaving || state.unsupportedWarning || state.hasBlockingModal ) {
 		return;
 	}
 
@@ -5653,6 +5710,22 @@ document.addEventListener( 'keydown', event => {
 	} else {
 		actions.saveDraft();
 	}
+} );
+
+// Escape closes the image edit panel from anywhere on the page. The panel
+// is non-modal — focus may live in the editor, the title, or anywhere
+// outside the panel itself — so it needs a global Escape handler instead
+// of relying on the panel's own keydown.  Skipped when a blocking overlay
+// is open (those handle Escape themselves) and when an active text-editing
+// surface might want Escape for its own purposes (the alt-text input
+// inside the panel uses default behavior — losing focus on Escape is OK).
+document.addEventListener( 'keydown', event => {
+	if ( event.key !== 'Escape' ) return;
+	if ( ! state.isEditMode ) return;
+	if ( state.hasBlockingModal ) return;
+	event.preventDefault();
+	const { actions } = store( 'wpcom-write' );
+	actions.closeImageModal();
 } );
 
 // File-drop safety net: .bw-content has min-height:60vh but doesn't

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1173,12 +1173,23 @@ function convertToBlocks( html ) {
 
 			const imgClassAttr = mediaId ? ` class="wp-image-${ mediaId }"` : '';
 
+			// Preserve the img's width/height attrs so the browser knows the
+			// intrinsic size in the published view.  Without them, themes
+			// that don't constrain `.size-thumbnail` etc. let the img stretch
+			// to fill its container — even when the URL points at a
+			// 150x150 resized file.  applyMediaSizeToFigure sets these on
+			// every media-library size swap; we just need to keep them.
+			const imgWidth = img.getAttribute( 'width' );
+			const imgHeight = img.getAttribute( 'height' );
+			const imgWidthAttr = imgWidth ? ` width="${ escapeAttr( imgWidth ) }"` : '';
+			const imgHeightAttr = imgHeight ? ` height="${ escapeAttr( imgHeight ) }"` : '';
+
 			blocks.push(
 				`<!-- wp:image${ imageAttrsJson } -->\n<figure class="${ figureClasses.join(
 					' '
 				) }"><img src="${ escapeAttr( src ) }" alt="${ escapeAttr(
 					alt
-				) }"${ imgClassAttr }/>${ captionHtml }</figure>\n<!-- /wp:image -->`
+				) }"${ imgClassAttr }${ imgWidthAttr }${ imgHeightAttr }/>${ captionHtml }</figure>\n<!-- /wp:image -->`
 			);
 		} else if ( tag === 'blockquote' ) {
 			// Extract citation from <cite> if present.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3063,21 +3063,36 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		/**
-		 * Mirror edit-modal radio state onto aria-checked attributes so the
-		 * active option is visually marked.  Reading state.editingImageAlign
+		 * Mirror edit-modal radio state onto aria-checked + tabindex so the
+		 * active option is visually marked AND owns the roving tab stop per
+		 * the WAI-ARIA radio pattern (only one radio per group in tab order;
+		 * arrow keys move within the group). Reading state.editingImageAlign
 		 * / state.editingImageSize here subscribes the watcher to those
-		 * signals; the modal's data-wp-watch wires this up.
+		 * signals; the panel's data-wp-watch wires this up.
 		 */
 		syncEditImageModalRadios() {
 			const align = state.editingImageAlign;
 			const size = state.editingImageSize;
 			if ( ! state.showImageModal || ! state.isEditMode ) return;
-			document.querySelectorAll( '.bw-edit-align-option' ).forEach( btn => {
-				btn.setAttribute( 'aria-checked', btn.value === align ? 'true' : 'false' );
-			} );
-			document.querySelectorAll( '.bw-edit-size-option' ).forEach( btn => {
-				btn.setAttribute( 'aria-checked', btn.value === size ? 'true' : 'false' );
-			} );
+			const sync = ( selector, activeValue ) => {
+				const options = document.querySelectorAll( selector );
+				let activeFound = false;
+				options.forEach( btn => {
+					const isActive = btn.value === activeValue;
+					btn.setAttribute( 'aria-checked', isActive ? 'true' : 'false' );
+					btn.tabIndex = isActive ? 0 : -1;
+					if ( isActive ) activeFound = true;
+				} );
+				// Keep one option tabbable even when nothing matches the
+				// current state (e.g. size: '' for non-media-library images
+				// where the section is hidden anyway, but the rule still
+				// holds — no group should be entirely untabbable).
+				if ( ! activeFound && options.length ) {
+					options[ 0 ].tabIndex = 0;
+				}
+			};
+			sync( '.bw-edit-align-option', align );
+			sync( '.bw-edit-size-option', size );
 		},
 	},
 	state: {
@@ -4345,6 +4360,49 @@ const { state } = store( 'wpcom-write', {
 			if ( ! editingFigure || ! IMAGE_ALIGNS.includes( align ) ) return;
 			state.editingImageAlign = align;
 			setFigureAlignment( editingFigure, align );
+		},
+
+		/**
+		 * Arrow / Home / End navigation within the Size and Alignment
+		 * radiogroups in the edit panel. Implements the WAI-ARIA radio
+		 * pattern: arrow keys move focus to the next/previous option AND
+		 * activate it; Home / End jump to first / last; only the active
+		 * option carries tabindex=0 so Tab moves out of the group.
+		 *
+		 * @param {KeyboardEvent} event - The keydown event.
+		 */
+		handleEditRadiogroupKeyDown( event ) {
+			const nav = [ 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End' ];
+			if ( ! nav.includes( event.key ) ) return;
+			const group = event.currentTarget;
+			const options = [ ...group.querySelectorAll( '[role="radio"]' ) ];
+			if ( ! options.length ) return;
+			event.preventDefault();
+			const current = group.ownerDocument.activeElement;
+			const idx = Math.max( 0, options.indexOf( current ) );
+			let next;
+			switch ( event.key ) {
+				case 'ArrowLeft':
+				case 'ArrowUp':
+					next = options[ ( idx - 1 + options.length ) % options.length ];
+					break;
+				case 'ArrowRight':
+				case 'ArrowDown':
+					next = options[ ( idx + 1 ) % options.length ];
+					break;
+				case 'Home':
+					next = options[ 0 ];
+					break;
+				case 'End':
+					next = options[ options.length - 1 ];
+					break;
+			}
+			if ( next ) {
+				next.focus();
+				// Activate the new option — the radio pattern selects on
+				// move (vs. menu, which moves focus without selecting).
+				next.click();
+			}
 		},
 
 		openImageModal() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -473,6 +473,33 @@ function setFigureSize( fig, slug ) {
 }
 
 /**
+ * Infer a size slug for a figure by matching the img's current src against
+ * the media library's registered sizes. Used when a figure loaded from
+ * outside Write (e.g. block-editor default insert) has no `size-X` class
+ * but the img URL matches a known preset — Write's panel should show that
+ * preset as the active selection instead of a blank state.
+ *
+ * Asynchronous because the registered sizes come from a REST request that's
+ * cached in memory after the first call.
+ *
+ * @param {Element} fig - The figure element.
+ * @return {Promise<string>} Slug ('thumbnail'/'medium'/'large'/'full') or '' when no match (custom size, external URL, etc).
+ */
+async function inferSizeFromImgSrc( fig ) {
+	const img = fig.querySelector( 'img' );
+	if ( ! img ) return '';
+	const id = getMediaIdFromImg( img );
+	if ( ! id ) return '';
+	const sizes = await fetchMediaSizes( id );
+	if ( ! sizes ) return '';
+	const src = img.src;
+	for ( const slug of IMAGE_SIZE_SLUGS ) {
+		if ( sizes[ slug ]?.source_url === src ) return slug;
+	}
+	return '';
+}
+
+/**
  * Toggle an alignment class on a figure, replacing any existing one.  Always
  * adds one of alignleft/aligncenter/alignright so the published view centers
  * reliably (themes key off these classes; unaligned figures don't center
@@ -4364,6 +4391,22 @@ const { state } = store( 'wpcom-write', {
 			const mediaId = getMediaIdFromImg( img );
 			state.editingImageHasMediaId = !! mediaId;
 			state.setAsFeatured = !! ( mediaId && state.featuredMediaId === mediaId );
+
+			// Block-editor inserts often omit `sizeSlug` even though the img
+			// src matches a registered size — so the figure has no `size-X`
+			// class and the panel would show no size as selected.  When that
+			// happens, fall back to matching the img URL against the media
+			// library's registered sizes so the panel reflects what the user
+			// actually sees.  Stamp the matched class onto the figure so the
+			// figure is self-describing and round-trips through save.
+			if ( ! state.editingImageSize && mediaId ) {
+				inferSizeFromImgSrc( figure ).then( slug => {
+					if ( slug && figure === editingFigure ) {
+						state.editingImageSize = slug;
+						setFigureSize( figure, slug );
+					}
+				} );
+			}
 
 			state.showImageModal = true;
 			focusModalInput();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -378,8 +378,11 @@ function getContent() {
 // block editor (see RSM-3472).
 const IMAGE_SIZE_SLUGS = [ 'thumbnail', 'medium', 'large', 'full' ];
 
-// Image alignment values we ship. 'center' is the default and emits no class
-// or attribute, matching block editor behavior for unaligned images.
+// Image alignment values we ship. All three are made explicit on save —
+// every image gets an `align*` class on the figure and an `align`
+// attribute in the block JSON, including center, so themes can rely on
+// the class to position the figure (many don't center unaligned figures
+// by default).
 const IMAGE_ALIGNS = [ 'left', 'center', 'right' ];
 
 // Cache of media library size lookups keyed by attachment ID.  Populated
@@ -1144,9 +1147,8 @@ function convertToBlocks( html ) {
 			// Read figure size + alignment classes plus the `wp-image-<id>`
 			// class for the media-library attachment ID.  These map to core
 			// wp:image attributes so the published markup matches what the
-			// block editor would emit, and the block editor can re-open these
-			// images without surprises.  Center alignment is the default and
-			// emits no attribute, matching block editor behavior.
+			// block editor would emit, and the block editor can re-open
+			// these images without surprises.
 			const imageSizeSlug = IMAGE_SIZE_SLUGS.find( s => node.classList.contains( 'size-' + s ) );
 			// Always emit an explicit align attr + class.  Without aligncenter
 			// many themes don't center the figure in the published view, and

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1233,20 +1233,20 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 		<div class="bw-edit-section" hidden data-wp-bind--hidden="!state.editingImageHasMediaId">
 			<div class="bw-edit-label"><?php echo esc_html__( 'Size', 'jetpack-mu-wpcom' ); ?></div>
-			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image size', 'jetpack-mu-wpcom' ); ?>">
-				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="thumbnail" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Thumbnail', 'jetpack-mu-wpcom' ); ?></button>
-				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="medium" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Medium', 'jetpack-mu-wpcom' ); ?></button>
-				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="large" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Large', 'jetpack-mu-wpcom' ); ?></button>
-				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="full" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Full', 'jetpack-mu-wpcom' ); ?></button>
+			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image size', 'jetpack-mu-wpcom' ); ?>" data-wp-on--keydown="actions.handleEditRadiogroupKeyDown">
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" tabindex="-1" value="thumbnail" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Thumbnail', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" tabindex="-1" value="medium" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Medium', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" tabindex="-1" value="large" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Large', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" tabindex="-1" value="full" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Full', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 
 		<div class="bw-edit-section">
 			<div class="bw-edit-label"><?php echo esc_html__( 'Alignment', 'jetpack-mu-wpcom' ); ?></div>
-			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image alignment', 'jetpack-mu-wpcom' ); ?>">
-				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="left" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Left', 'jetpack-mu-wpcom' ); ?></button>
-				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="center" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Center', 'jetpack-mu-wpcom' ); ?></button>
-				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="right" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Right', 'jetpack-mu-wpcom' ); ?></button>
+			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image alignment', 'jetpack-mu-wpcom' ); ?>" data-wp-on--keydown="actions.handleEditRadiogroupKeyDown">
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" tabindex="-1" value="left" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Left', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" tabindex="-1" value="center" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Center', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" tabindex="-1" value="right" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Right', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -261,9 +261,10 @@ function wpcom_write_allowed_block_attrs() {
 		// id: media-library metadata, not visible formatting.
 		// alt: preserved via HTML element, not block JSON.
 		// sizeSlug: thumbnail/medium/large/full size presets.
-		// align: left/center/right via the image properties modal.  Wide and
-		// full alignments are accepted here too — they round-trip as a
-		// centered image because Write has no wide/full preview.
+		// align: left/center/right via the image properties panel.  Wide and
+		// full alignment values are rejected by wpcom_write_has_unsupported_blocks
+		// further down (the same value check used for paragraph/heading),
+		// so posts using those bounce to the block editor.
 		'image'     => array( 'id', 'sizeSlug', 'alt', 'align' ),
 		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive' ),
 		'quote'     => array( 'align', 'citation' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -124,9 +124,8 @@ add_action(
 
 		// Pass translated strings to JavaScript for dynamic messages.
 		$write_strings = array(
-			'alt'                  => __( 'ALT', 'jetpack-mu-wpcom' ),
 			'caption'              => __( 'Caption', 'jetpack-mu-wpcom' ),
-			'describeImage'        => __( 'Describe this image...', 'jetpack-mu-wpcom' ),
+			'editImage'            => __( 'Edit image', 'jetpack-mu-wpcom' ),
 			'writeCaption'         => __( 'Write a caption...', 'jetpack-mu-wpcom' ),
 			// translators: %s is the error message from the upload failure.
 			'uploadFailed'         => __( 'Upload failed: %s', 'jetpack-mu-wpcom' ),
@@ -145,11 +144,6 @@ add_action(
 			'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
 			'heading2'             => __( 'Heading 2', 'jetpack-mu-wpcom' ),
 			'heading3'             => __( 'Heading 3', 'jetpack-mu-wpcom' ),
-			'size'                 => __( 'Size', 'jetpack-mu-wpcom' ),
-			'sizeThumbnail'        => __( 'Thumbnail', 'jetpack-mu-wpcom' ),
-			'sizeMedium'           => __( 'Medium', 'jetpack-mu-wpcom' ),
-			'sizeLarge'            => __( 'Large', 'jetpack-mu-wpcom' ),
-			'sizeFull'             => __( 'Full', 'jetpack-mu-wpcom' ),
 			'preview'              => __( 'Preview', 'jetpack-mu-wpcom' ),
 			// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
 			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
@@ -267,10 +261,10 @@ function wpcom_write_allowed_block_attrs() {
 		// id: media-library metadata, not visible formatting.
 		// alt: preserved via HTML element, not block JSON.
 		// sizeSlug: thumbnail/medium/large/full size presets.
-		// align: intentionally not in the allowlist — Write has no image-
-		// alignment UI.  Posts with any image alignment bounce to the block
-		// editor via the unsupported-content modal.
-		'image'     => array( 'id', 'sizeSlug', 'alt' ),
+		// align: left/center/right via the image properties modal.  Wide and
+		// full alignments are accepted here too — they round-trip as a
+		// centered image because Write has no wide/full preview.
+		'image'     => array( 'id', 'sizeSlug', 'alt', 'align' ),
 		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive' ),
 		'quote'     => array( 'align', 'citation' ),
 		'list'      => array( 'ordered' ),
@@ -823,59 +817,63 @@ function wpcom_write_render_admin_page() {
 	wp_interactivity_state(
 		'wpcom-write',
 		array(
-			'postsPath'           => '/wp/v2/posts',
-			'mediaPath'           => '/wp/v2/media',
-			'homeUrl'             => home_url( '/' ),
-			'adminUrl'            => admin_url(),
-			'writeUrl'            => wpcom_write_url(),
-			'editPostId'          => $edit_post_id,
-			'postStatus'          => $post_status,
-			'isPublishedPost'     => 'publish' === $post_status,
-			'title'               => $edit_title,
-			'isSaving'            => false,
-			'isPublished'         => false,
-			'message'             => '',
-			'showLinkInput'       => false,
-			'linkUrl'             => '',
-			'showImageModal'      => false,
-			'showVideoModal'      => false,
-			'videoUrl'            => '',
-			'imageAlt'            => '',
-			'setAsFeatured'       => false,
-			'featuredMediaId'     => $edit_featured_id,
-			'isUploading'         => false,
-			'categories'          => $categories_data,
-			'catLabel'            => $cat_label,
-			'existingTagIds'      => $existing_tag_ids,
-			'showCatDropdown'     => false,
-			'showHelp'            => false,
-			'showSlashMenu'       => false,
-			'slashActiveId'       => '',
-			'slashFilter'         => '',
-			'showLeaveConfirm'    => false,
-			'showHeadingMenu'     => false,
-			'showTextColorMenu'   => false,
-			'formatStrikethrough' => false,
-			'formatUnderline'     => false,
-			'formatAlignLeft'     => true,
-			'formatAlignCenter'   => false,
-			'formatAlignRight'    => false,
-			'formatAlignJustify'  => false,
-			'cannotJustify'       => false,
-			'formatOList'         => false,
-			'formatUList'         => false,
-			'insideList'          => false,
-			'showRecoveryBanner'  => false,
-			'unsupportedWarning'  => $unsupported_type,
-			'editorUrl'           => $editor_url,
-			'blockEditorUrl'      => $block_editor_url,
-			'previewUrl'          => $preview_url,
-			'showMoreMenu'        => false,
-			'recentDrafts'        => $recent_drafts,
-			'openPostError'       => $open_post_error,
-			'showPostPicker'      => '' !== $open_post_error,
-			'postPickerUrl'       => '',
-			'pendingOpenPost'     => false,
+			'postsPath'              => '/wp/v2/posts',
+			'mediaPath'              => '/wp/v2/media',
+			'homeUrl'                => home_url( '/' ),
+			'adminUrl'               => admin_url(),
+			'writeUrl'               => wpcom_write_url(),
+			'editPostId'             => $edit_post_id,
+			'postStatus'             => $post_status,
+			'isPublishedPost'        => 'publish' === $post_status,
+			'title'                  => $edit_title,
+			'isSaving'               => false,
+			'isPublished'            => false,
+			'message'                => '',
+			'showLinkInput'          => false,
+			'linkUrl'                => '',
+			'showImageModal'         => false,
+			'showVideoModal'         => false,
+			'videoUrl'               => '',
+			'imageAlt'               => '',
+			'setAsFeatured'          => false,
+			'featuredMediaId'        => $edit_featured_id,
+			'isEditMode'             => false,
+			'editingImageAlign'      => 'center',
+			'editingImageSize'       => '',
+			'editingImageHasMediaId' => false,
+			'isUploading'            => false,
+			'categories'             => $categories_data,
+			'catLabel'               => $cat_label,
+			'existingTagIds'         => $existing_tag_ids,
+			'showCatDropdown'        => false,
+			'showHelp'               => false,
+			'showSlashMenu'          => false,
+			'slashActiveId'          => '',
+			'slashFilter'            => '',
+			'showLeaveConfirm'       => false,
+			'showHeadingMenu'        => false,
+			'showTextColorMenu'      => false,
+			'formatStrikethrough'    => false,
+			'formatUnderline'        => false,
+			'formatAlignLeft'        => false,
+			'formatAlignCenter'      => false,
+			'formatAlignRight'       => false,
+			'formatAlignJustify'     => false,
+			'cannotJustify'          => false,
+			'formatOList'            => false,
+			'formatUList'            => false,
+			'insideList'             => false,
+			'showRecoveryBanner'     => false,
+			'unsupportedWarning'     => $unsupported_type,
+			'editorUrl'              => $editor_url,
+			'blockEditorUrl'         => $block_editor_url,
+			'previewUrl'             => $preview_url,
+			'showMoreMenu'           => false,
+			'recentDrafts'           => $recent_drafts,
+			'openPostError'          => $open_post_error,
+			'showPostPicker'         => '' !== $open_post_error,
+			'postPickerUrl'          => '',
+			'pendingOpenPost'        => false,
 		)
 	);
 
@@ -1174,8 +1172,8 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		</div>
 	</main>
 
-	<!-- Image modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--pointerdown="actions.handleOverlayPointerDown" data-wp-on--keydown="actions.handleImageModalKeyDown" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
+	<!-- Image insert modal: centered, blocking overlay for picking a new image. -->
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageInsertOverlay" data-wp-on--pointerdown="actions.handleOverlayPointerDown" data-wp-on--keydown="actions.handleImageModalKeyDown" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 		<div class="bw-image-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Add an image', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 			<h3><?php echo esc_html__( 'Add an image', 'jetpack-mu-wpcom' ); ?></h3>
 			<label class="bw-upload-zone" id="bw-upload-zone" data-wp-on--dragover="actions.handleDragOver" data-wp-on--dragleave="actions.handleDragLeave" data-wp-on--drop="actions.handleDrop">
@@ -1205,6 +1203,59 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			</label>
 			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertImageFromUrl" style="width:100%;margin-top:12px;"><?php echo esc_html__( 'Insert image', 'jetpack-mu-wpcom' ); ?></button>
 		</div>
+	</div>
+
+	<!-- Image edit panel: non-modal, docked bottom-right. Changes apply
+		live to the figure so the rest of the editor stays visible. -->
+	<div
+		class="bw-image-edit-panel"
+		hidden
+		data-wp-bind--hidden="!state.isEditMode"
+		role="dialog"
+		aria-modal="false"
+		aria-labelledby="bw-edit-panel-title"
+		data-wp-watch="callbacks.syncEditImageModalRadios"
+	>
+		<div class="bw-edit-panel-header">
+			<h3 id="bw-edit-panel-title" class="bw-edit-panel-title"><?php echo esc_html__( 'Edit image', 'jetpack-mu-wpcom' ); ?></h3>
+			<button class="bw-edit-panel-close" type="button" data-wp-on--click="actions.closeImageModal" aria-label="<?php echo esc_attr__( 'Close', 'jetpack-mu-wpcom' ); ?>" title="<?php echo esc_attr__( 'Close', 'jetpack-mu-wpcom' ); ?>">&times;</button>
+		</div>
+
+		<label class="bw-edit-label" for="bw-edit-alt"><?php echo esc_html__( 'Alt text', 'jetpack-mu-wpcom' ); ?></label>
+		<input
+			id="bw-edit-alt"
+			type="text"
+			class="bw-image-url-input"
+			placeholder="<?php echo esc_attr__( 'Describe this image…', 'jetpack-mu-wpcom' ); ?>"
+			data-wp-on--input="actions.updateImageAlt"
+			data-wp-bind--value="state.imageAlt"
+		/>
+
+		<div class="bw-edit-section" hidden data-wp-bind--hidden="!state.editingImageHasMediaId">
+			<div class="bw-edit-label"><?php echo esc_html__( 'Size', 'jetpack-mu-wpcom' ); ?></div>
+			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image size', 'jetpack-mu-wpcom' ); ?>">
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="thumbnail" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Thumbnail', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="medium" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Medium', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="large" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Large', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-size-option" role="radio" aria-checked="false" value="full" data-wp-on--click="actions.setEditImageSize"><?php echo esc_html__( 'Full', 'jetpack-mu-wpcom' ); ?></button>
+			</div>
+		</div>
+
+		<div class="bw-edit-section">
+			<div class="bw-edit-label"><?php echo esc_html__( 'Alignment', 'jetpack-mu-wpcom' ); ?></div>
+			<div class="bw-edit-radios" role="radiogroup" aria-label="<?php echo esc_attr__( 'Image alignment', 'jetpack-mu-wpcom' ); ?>">
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="left" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Left', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="center" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Center', 'jetpack-mu-wpcom' ); ?></button>
+				<button type="button" class="bw-edit-align-option" role="radio" aria-checked="false" value="right" data-wp-on--click="actions.setEditImageAlign"><?php echo esc_html__( 'Right', 'jetpack-mu-wpcom' ); ?></button>
+			</div>
+		</div>
+
+		<label class="bw-featured-toggle" hidden data-wp-bind--hidden="!state.editingImageHasMediaId">
+			<input type="checkbox" data-wp-on--change="actions.toggleFeaturedImage" data-wp-bind--checked="state.setAsFeatured" />
+			<span><?php echo esc_html__( 'Set as featured image', 'jetpack-mu-wpcom' ); ?></span>
+		</label>
+
+		<button class="bw-btn bw-btn-publish bw-edit-panel-done" type="button" data-wp-on--click="actions.closeImageModal"><?php echo esc_html__( 'Done', 'jetpack-mu-wpcom' ); ?></button>
 	</div>
 
 	<!-- Leave confirmation — matches @wordpress/components ConfirmDialog -->

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -801,21 +801,20 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	public function test_detect_unsupported_image_with_align() {
 		foreach ( array( 'left', 'center', 'right' ) as $align ) {
 			$content = '<!-- wp:image {"align":"' . $align . '"} --><figure class="wp-block-image align' . $align . '"><img src="test.jpg" alt=""/></figure><!-- /wp:image -->';
-			$this->assertSame(
-				'block-editor',
+			$this->assertFalse(
 				wpcom_write_detect_unsupported_content( $content ),
-				"align={$align} should bounce to block editor"
+				"align={$align} should round-trip through Write"
 			);
 		}
 	}
 
 	/**
-	 * Test that an image with align + sizeSlug returns 'block-editor'.
-	 * sizeSlug round-trips, but align triggers the unsupported modal.
+	 * Test that an image with align + sizeSlug round-trips. Both are now
+	 * supported via the image properties modal.
 	 */
 	public function test_detect_unsupported_image_with_align_and_size_slug() {
 		$content = '<!-- wp:image {"align":"center","sizeSlug":"medium","id":42} --><figure class="wp-block-image aligncenter size-medium"><img src="test.jpg" alt=""/></figure><!-- /wp:image -->';
-		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
 	}
 
 	/**
@@ -1270,7 +1269,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$js_attrs = array(
 			'embed'     => array( 'providerNameSlug', 'responsive', 'type', 'url' ),
 			'heading'   => array( 'align', 'level' ),
-			'image'     => array( 'id', 'sizeSlug' ),
+			'image'     => array( 'align', 'id', 'sizeSlug' ),
 			'list'      => array( 'ordered' ),
 			'list-item' => array(),
 			'paragraph' => array( 'align' ),


### PR DESCRIPTION
Fixes [RSM-3979](https://linear.app/a8c/issue/RSM-3979/writer-enhancement-add-left-align-and-text-wrap-options-for-images-in) and [RSM-3982](https://linear.app/a8c/issue/RSM-3982/image-alignment-indicator-shows-left-aligned-but-image-renders).

## Proposed changes
* Add an **Edit pencil** on every image in the Write editor that opens a new image properties panel — alt text, size, alignment, set-as-featured all in one surface. Replaces the inline ALT and Size buttons.
* Add **left / center / right alignment** for images. Center is now explicit (`align:"center"` + `aligncenter` class) so the published view centers reliably across themes.
* The panel is **non-modal**: it docks to the bottom-right on desktop and slides up as a full-width bottom sheet on mobile. Changes apply live so the rest of the editor stays visible and editable.
* When the panel is open, the **active figure gets a focus outline** so multi-image switching is clear.
* Fix the **indicator-state bug** where the top-toolbar Left button stayed highlighted whenever a text block had no explicit alignment (i.e. always, by default). Now only highlights when alignment is explicitly set.
* As a side effect of going from 4 inline buttons to 3 (`×`, Caption, Edit) and anchoring the new wrapper to the image bounds, the Thumbnail and Medium overflow from [RSM-3980](https://linear.app/a8c/issue/RSM-3980/writer-image-control-bar-alt-caption-size-overflows-the-image-bounds) is also addressed.

<img width="1453" height="856" alt="Screenshot 2026-06-10 at 1 57 07 PM" src="https://github.com/user-attachments/assets/0142256f-ae20-41c5-bdb0-70fa0097ef67" />


## Related product discussion/links
* Linear: [RSM-3979](https://linear.app/a8c/issue/RSM-3979/writer-enhancement-add-left-align-and-text-wrap-options-for-images-in), [RSM-3982](https://linear.app/a8c/issue/RSM-3982/image-alignment-indicator-shows-left-aligned-but-image-renders)
* Builds on [#48980](https://github.com/Automattic/jetpack/pull/48980) (size presets), which had decided alignment was an open question

## Does this pull request change what data or activity we track or use?
No. The image block's `align` attribute is added to the round-trip allowlist; no new tracking events.

## Testing instructions
**Setup**: Open any post (new or existing) in the Write editor with at least one image inserted from the media library.

**Edit panel**:
* Hover an image — the floating bar should show ×, Caption, ✎ (Edit pencil). Click the Edit pencil.
* Panel docks to bottom-right (or slides up from bottom on mobile). Alt text, Size (Thumbnail/Medium/Large/Full), Alignment (Left/Center/Right), and Set-as-featured controls are all there.
* Change the alignment and watch the image update live behind the panel. Try Medium + Left to see text wrap around it.
* Click Done, ×, or press Escape to close — focus returns to the Edit pencil.
* While the panel is open, you should still be able to type in the editor, click other paragraphs, and use Cmd/Ctrl+S to save.

**Multi-image**:
* Insert two images. Open the panel on image 1 — should see a blue outline around it. Click image 2's Edit pencil — outline jumps to image 2, panel updates.

**Insert-while-editing**:
* With the panel open, click the toolbar Image icon or type `/image`. The panel should close and the insert modal should open. The previous edit's changes are committed as a single undo entry.

**Round-trip with block editor**:
* Set Left or Right alignment, save the post, open it in the block editor — alignment should be preserved (`align:"left"` etc in the block markup).
* Conversely, open a block-editor post with a center-aligned image in Write — Center should be pre-selected in the panel.

**Indicator bug (RSM-3982)**:
* Open any post with no aligned text. Look at the top-toolbar Left alignment button — it should NOT appear highlighted. Click into different paragraphs; still not highlighted. (Before this PR, it was always highlighted.)

**Mobile**:
* In Chrome devtools, switch to a phone viewport (e.g. iPhone 14, 390×844). Open the Edit pencil — panel should slide up from the bottom edge as a full-width bottom sheet. The figure should scroll into view above the sheet.

**Accessibility**:
* Tab into the panel — focus moves through Alt, the radio groups, featured checkbox, Done. Tab again exits the panel into the document (no focus trap; intentional for non-modal dialogs).
* Press Escape from any focus position (panel, editor, title) — panel closes and focus returns to the Edit pencil.
* `role="dialog"` and `aria-modal="false"` are set on the panel; `aria-labelledby` points to the panel title.

**Known mobile caveat**: when the Alt text input is focused on iOS, the software keyboard may cover the lower portion of the bottom sheet. Tracked as polish for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)