### PR TITLE
Newsletter: point Substack importer button to site-setup importer flow

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -463,7 +463,7 @@ function SubstackTab(): JSX.Element {
 	const importUrl = getSubstackImportUrl( hostname );
 
 	const handleOpen = useCallback( () => {
-		window.open( importUrl, '_blank', 'noopener,noreferrer' );
+		window.location.href = importUrl;
 	}, [ importUrl ] );
 
 	return (

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -74,7 +74,11 @@ function ImportConsentNotice(): JSX.Element {
  * @return Absolute URL.
  */
 function getSubstackImportUrl( hostname: string ): string {
-	return `https://wordpress.com/import/newsletter/substack/${ encodeURIComponent( hostname ) }`;
+	const params = new URLSearchParams( {
+		ref: 'wp-admin-importers-list-direct-importer',
+		siteSlug: hostname,
+	} );
+	return `https://wordpress.com/setup/site-setup/importerSubstack?${ params.toString() }`;
 }
 
 /**

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -75,7 +75,7 @@ function ImportConsentNotice(): JSX.Element {
  */
 function getSubstackImportUrl( hostname: string ): string {
 	const params = new URLSearchParams( {
-		ref: 'wp-admin-importers-list-direct-importer',
+		ref: 'wp-admin-newsletter-ui',
 		siteSlug: hostname,
 	} );
 	return `https://wordpress.com/setup/site-setup/importerSubstack?${ params.toString() }`;

--- a/projects/packages/newsletter/changelog/update-substack-importer-link
+++ b/projects/packages/newsletter/changelog/update-substack-importer-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Subscribers: link the Substack importer button to the WordPress.com site-setup importer flow
+Subscribers: link the Substack importer button to the WordPress.com site-setup importer flow.

--- a/projects/packages/newsletter/changelog/update-substack-importer-link
+++ b/projects/packages/newsletter/changelog/update-substack-importer-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Subscribers: link the Substack importer button to the WordPress.com site-setup importer flow


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/pull/111580 

## Proposed changes
* Update the "Open Substack importer" button in the Subscribers → Add subscribers modal (Substack tab) to link to the WordPress.com site-setup importer flow:
  `https://wordpress.com/setup/site-setup/importerSubstack?ref=wp-admin-newsletter-ui&siteSlug={site}`
* Previously the button linked to the legacy `https://wordpress.com/import/newsletter/substack/{site}` path.
* The link points at the generic importer entry (it lands on the default first step of the guided wizard) rather than jumping into a specific sub-step.
* Uses the `ref=wp-admin-newsletter-ui` entry point so the importer's Back button returns to the Newsletter UI. The matching Calypso handling is in Automattic/wp-calypso#111580 (without it, Back falls back to the importer list).

## Related product discussion/links
* Companion Calypso PR: Automattic/wp-calypso#111580

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a Jetpack-connected site, enable the modernized wp-admin Subscribers UI (both filters default off):
  ```php
  add_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_true' );
  add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );
  ```
* Go to **Jetpack → Subscribers** in wp-admin.
* Click **Add subscribers**, then open the **Substack** tab.
* Click **Open Substack importer** and confirm it opens  `https://wordpress.com/setup/site-setup/importerSubstack?ref=wp-admin-newsletter-ui&siteSlug=<your-site>`.
* (End-to-end Back behavior requires Automattic/wp-calypso#111580 to be deployed.)
