### PR TITLE
Forms: fix fatal TypeError in Post_To_Url when hiddenFields is not an object array

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-692-post-to-url-hidden-fields-fatal
+++ b/projects/packages/forms/changelog/fix-forms-692-post-to-url-hidden-fields-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post to URL: prevent a fatal TypeError when a form's legacy hiddenFields attribute is stored as a name => value map or JSON string instead of an array of objects.

--- a/projects/packages/forms/changelog/fix-forms-692-post-to-url-hidden-fields-fatal
+++ b/projects/packages/forms/changelog/fix-forms-692-post-to-url-hidden-fields-fatal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Post to URL: prevent a fatal TypeError when a form's legacy hiddenFields attribute is stored as a name => value map or JSON string instead of an array of objects.
+Post to URL: Prevent a fatal TypeError when a form's legacy hiddenFields attribute is stored as a name => value map or JSON string instead of an array of objects.

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -168,9 +168,26 @@ class Post_To_Url {
 			$fields['lead_source'] = $entry_values['entry_permalink'];
 		}
 
-		$hidden_fields = (array) ( $form->attributes['hiddenFields'] ?? array() );
-		foreach ( $hidden_fields as $hidden_field ) {
-			$fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] );
+		// `hiddenFields` is a legacy attribute that may appear in a few shapes on forms
+		// in the wild: an array of `{ name, value }` objects (its original design), an
+		// associative `name => value` map, or a JSON-encoded string. Iterating it blindly
+		// and accessing `['name']`/`['value']` on a non-array element fatals on PHP 8 with
+		// "Cannot access offset of type string on string", so normalize defensively.
+		$hidden_fields = $form->attributes['hiddenFields'] ?? array();
+		if ( is_string( $hidden_fields ) ) {
+			$decoded       = json_decode( $hidden_fields, true );
+			$hidden_fields = is_array( $decoded ) ? $decoded : array();
+		}
+		foreach ( (array) $hidden_fields as $key => $hidden_field ) {
+			if ( is_array( $hidden_field ) ) {
+				// Original `{ name, value }` object shape.
+				if ( isset( $hidden_field['name'] ) ) {
+					$fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] ?? '' );
+				}
+			} elseif ( ! is_int( $key ) ) {
+				// Associative `name => value` shape.
+				$fields[ $key ] = sanitize_text_field( (string) $hidden_field );
+			}
 		}
 
 		return $fields;

--- a/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
+++ b/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Unit Tests for Post_To_Url.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Post_To_Url
+ *
+ * @covers Automattic\Jetpack\Forms\Service\Post_To_Url
+ */
+#[CoversClass( Post_To_Url::class )]
+class Post_To_Url_Test extends BaseTestCase {
+
+	/**
+	 * Invoke the private get_form_data method on the singleton.
+	 *
+	 * @param Contact_Form $form         The form instance.
+	 * @param array        $entry_values The feedback entry values.
+	 * @return array The gathered form data.
+	 */
+	private function invoke_get_form_data( $form, $entry_values = array() ) {
+		$instance = Post_To_Url::init();
+		$method   = new \ReflectionMethod( Post_To_Url::class, 'get_form_data' );
+		$method->setAccessible( true );
+		return $method->invoke( $instance, $form, $entry_values );
+	}
+
+	/**
+	 * The hiddenFields attribute as an array of `{ name, value }` objects (the original design shape).
+	 */
+	public function test_get_form_data_hidden_fields_object_shape() {
+		$form = $this->create_mock_form(
+			array(
+				'hiddenFields' => array(
+					array(
+						'name'  => 'campaign',
+						'value' => 'summer',
+					),
+					array(
+						'name'  => 'ref',
+						'value' => 'newsletter',
+					),
+				),
+			)
+		);
+
+		$data = $this->invoke_get_form_data( $form );
+
+		$this->assertSame( 'summer', $data['campaign'] );
+		$this->assertSame( 'newsletter', $data['ref'] );
+	}
+
+	/**
+	 * Regression test for FORMS-692: hiddenFields stored as an associative
+	 * `name => value` map must not fatal with "Cannot access offset of type
+	 * string on string" on PHP 8.
+	 */
+	public function test_get_form_data_hidden_fields_associative_shape() {
+		$form = $this->create_mock_form(
+			array(
+				'hiddenFields' => array(
+					'campaign' => 'summer',
+					'ref'      => 'newsletter',
+				),
+			)
+		);
+
+		$data = $this->invoke_get_form_data( $form );
+
+		$this->assertSame( 'summer', $data['campaign'] );
+		$this->assertSame( 'newsletter', $data['ref'] );
+	}
+
+	/**
+	 * The hiddenFields attribute stored as a JSON-encoded string should be decoded, not fatal.
+	 */
+	public function test_get_form_data_hidden_fields_json_string_shape() {
+		$form = $this->create_mock_form(
+			array(
+				'hiddenFields' => '{"campaign":"summer","ref":"newsletter"}',
+			)
+		);
+
+		$data = $this->invoke_get_form_data( $form );
+
+		$this->assertSame( 'summer', $data['campaign'] );
+		$this->assertSame( 'newsletter', $data['ref'] );
+	}
+
+	/**
+	 * Empty / missing / malformed hiddenFields should be ignored without fatal.
+	 */
+	public function test_get_form_data_hidden_fields_empty_or_malformed() {
+		foreach ( array( null, '', 'not json', array() ) as $value ) {
+			$form = $this->create_mock_form( array( 'hiddenFields' => $value ) );
+			$data = $this->invoke_get_form_data( $form );
+			$this->assertSame( array(), $data, 'Malformed hiddenFields should yield no fields.' );
+		}
+	}
+
+	/**
+	 * Salesforce organizationId is mapped to the `oid` field and lead_source is set.
+	 */
+	public function test_get_form_data_salesforce_oid_mapping() {
+		$form = $this->create_mock_form(
+			array(
+				'salesforceData' => array( 'organizationId' => '00D000000000001' ),
+			)
+		);
+
+		$data = $this->invoke_get_form_data( $form, array( 'entry_permalink' => 'https://example.com/entry' ) );
+
+		$this->assertSame( '00D000000000001', $data['oid'] );
+		$this->assertSame( 'https://example.com/entry', $data['lead_source'] );
+	}
+
+	/**
+	 * Create a mock Contact_Form with the given attributes (no parent constructor).
+	 *
+	 * @param array $attributes Form attributes.
+	 * @return Contact_Form
+	 */
+	private function create_mock_form( $attributes ) {
+		return new class( $attributes ) extends Contact_Form {
+			/**
+			 * Constructor.
+			 *
+			 * @param array $attributes Form attributes.
+			 */
+			public function __construct( $attributes ) {
+				// Don't call parent constructor - just set properties directly.
+				$this->attributes = $attributes;
+				$this->fields     = array();
+			}
+		};
+	}
+}

--- a/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
+++ b/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
@@ -98,6 +98,31 @@ class Post_To_Url_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A hiddenFields string that is not valid JSON, or whose JSON does not decode to an
+	 * array (number, string, bool, null, or a JSON array of scalars), must be ignored
+	 * without fataling rather than partially processed.
+	 */
+	public function test_get_form_data_hidden_fields_malformed_json_string() {
+		$malformed = array(
+			'truncated object'      => '{"campaign":',
+			'truncated array'       => '[{"name":"a"',
+			'unquoted garbage'      => 'not json at all',
+			'trailing comma'        => '{"a":"b",}',
+			'json number'           => '123',
+			'json bare string'      => '"justastring"',
+			'json boolean'          => 'true',
+			'json null literal'     => 'null',
+			'json array of scalars' => '["a","b","c"]',
+		);
+
+		foreach ( $malformed as $label => $value ) {
+			$form = $this->create_mock_form( array( 'hiddenFields' => $value ) );
+			$data = $this->invoke_get_form_data( $form );
+			$this->assertSame( array(), $data, "Malformed hiddenFields ({$label}) should yield no fields." );
+		}
+	}
+
+	/**
 	 * Empty / missing / malformed hiddenFields should be ignored without fatal.
 	 */
 	public function test_get_form_data_hidden_fields_empty_or_malformed() {

--- a/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
+++ b/projects/packages/forms/tests/php/service/Post_To_Url_Test.php
@@ -29,7 +29,9 @@ class Post_To_Url_Test extends BaseTestCase {
 	private function invoke_get_form_data( $form, $entry_values = array() ) {
 		$instance = Post_To_Url::init();
 		$method   = new \ReflectionMethod( Post_To_Url::class, 'get_form_data' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method->invoke( $instance, $form, $entry_values );
 	}
 


### PR DESCRIPTION
## Proposed changes

Fixes a fatal `TypeError: Cannot access offset of type string on string` (PHP 8) reported from `Post_To_Url` in production (FORMS-692).

`Post_To_Url::get_form_data()` iterates the legacy `hiddenFields` form attribute assuming it is an **array of `{ name, value }` objects**, accessing `$hidden_field['name']` / `$hidden_field['value']` on each element:

```php
$hidden_fields = (array) ( $form->attributes['hiddenFields'] ?? array() );
foreach ( $hidden_fields as $hidden_field ) {
    $fields[ $hidden_field['name'] ] = sanitize_text_field( $hidden_field['value'] );
}
```

`hiddenFields` is a legacy attribute with no current editor UI (a half-shipped Salesforce Web-to-Lead feature). On real forms it is commonly stored in a different shape — an associative `name => value` map (the same shape used by this package's own test fixtures), or occasionally a JSON string. In those cases each iterated element is a *string*, so `$hidden_field['name']` fatals on PHP 8.

The hook only runs for Salesforce-enabled forms (it bails unless `salesforceData.organizationId` is set), so the crash is sporadic but real.

This PR normalizes `hiddenFields` to handle every shape forms carry in the wild without fataling:

* Array of `{ name, value }` objects (original design) — unchanged behavior
* Associative `name => value` map — now mapped correctly
* JSON-encoded string — decoded then handled
* Empty / `null` / malformed — skipped silently

Note: `get_setup()` performs a similar offset access but inside `empty()`, which suppresses the TypeError, so it is not a crash site (verified against PHP 8.4).

## Related product discussion/links

* FORMS-692

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated: a new `Post_To_Url_Test` covers all `hiddenFields` shapes plus the Salesforce `oid` mapping.

```
cd projects/packages/forms
composer phpunit -- --filter Post_To_Url_Test
```

All 5 cases pass. Reverting the fix makes the associative-map and JSON-string cases fatal with the reported error.

Manual:
1. Add a Contact Form block with Salesforce enabled (set a `salesforceData.organizationId`).
2. On a form whose stored attributes include `hiddenFields` as an associative `name => value` map (e.g. `{ "campaign": "summer" }`), submit the form.
3. Before this change the submission fatals in `class-post-to-url.php`; after, it posts to Salesforce with the hidden fields included and no fatal.
