### PR TITLE
Newsletter: add subscribers via the WP.com subscriber import flow

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/empty-state.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/empty-state.tsx
@@ -60,7 +60,7 @@ export default function SubscribersEmptyState( {
 			<EmptyState.Description>
 				{ createInterpolateElement(
 					__(
-						'<link>Turn your site visitors into subscribers</link> or bring readers in by inviting them by email. They’ll get a confirmation message and start receiving your posts.',
+						'<link>Turn your site visitors into subscribers</link> or bring readers in by adding their emails. They’ll start receiving your posts right away.',
 						'jetpack-newsletter'
 					),
 					{

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -3,8 +3,11 @@ import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button, Dialog, Notice, Stack, Tabs, Text } from '@wordpress/ui';
 import { useAddSubscribersMutation } from '../../data/use-add-subscribers-mutation';
+import { isJobInProgress, isJobStale, useImportJobs } from '../../data/use-import-jobs';
+import { useResetImportMutation } from '../../data/use-reset-import-mutation';
 import { extractEmailsFromCsv } from '../../lib/csv-parse';
 import { recordTracksEvent } from '../../lib/tracks';
+import type { ImportJob } from '../../data/types';
 
 type Props = {
 	isOpen: boolean;
@@ -82,9 +85,86 @@ function InvalidEntriesNotice( { invalid }: { invalid: string[] } ): JSX.Element
 	);
 }
 
+/**
+ * Status notice shown while WP.com is running an import for this site (one import runs per site
+ * at a time, so the form below is disabled). The stale variant mirrors Calypso's
+ * `StaleImportJobsNotice`: after 24 hours a stuck job gets a "Cancel import" escape hatch — or,
+ * when a previous job was already cancelled, a pointer to support.
+ *
+ * @param props      - Component props.
+ * @param props.jobs - Import jobs, newest first.
+ * @return Notice element, or null when no import is running.
+ */
+function ImportStatusNotice( { jobs }: { jobs: ImportJob[] } ): JSX.Element | null {
+	const resetMutation = useResetImportMutation();
+	const handleCancelImport = useCallback( () => resetMutation.mutate(), [ resetMutation ] );
+
+	if ( ! jobs.some( isJobInProgress ) ) {
+		return null;
+	}
+
+	// Each variant carries a `key` (remount instead of reusing the previous variant's hook
+	// state) and an explicit string `spokenMessage` — Notice.Root otherwise renderToString()s
+	// its children mid-render, which corrupts hook order when they include action buttons.
+	if ( ! jobs.some( job => isJobStale( job ) ) ) {
+		const inProgressMessage = __(
+			'Your subscribers are being imported. This may take a few minutes. You can close this window and we’ll notify you when the import is complete.',
+			'jetpack-newsletter'
+		);
+		return (
+			<Notice.Root key="import-in-progress" intent="info" spokenMessage={ inProgressMessage }>
+				<Notice.Description>{ inProgressMessage }</Notice.Description>
+			</Notice.Root>
+		);
+	}
+
+	// Mirrors Calypso: once a reset has already been tried (the previous job shows as
+	// cancelled), another "Cancel import" is unlikely to help — point at support instead.
+	if ( jobs[ 1 ]?.status === 'cancelled' ) {
+		const contactSupportMessage = __(
+			'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.',
+			'jetpack-newsletter'
+		);
+		return (
+			<Notice.Root
+				key="import-stale-support"
+				intent="warning"
+				spokenMessage={ contactSupportMessage }
+			>
+				<Notice.Description>{ contactSupportMessage }</Notice.Description>
+				<Notice.Actions>
+					<Notice.ActionLink
+						href="https://jetpack.com/support/newsletter/import-subscribers/"
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ __( 'Learn more', 'jetpack-newsletter' ) }
+					</Notice.ActionLink>
+				</Notice.Actions>
+			</Notice.Root>
+		);
+	}
+
+	const staleMessage = __(
+		'Your recent import is taking longer than expected to complete. Please cancel your import and try again.',
+		'jetpack-newsletter'
+	);
+	return (
+		<Notice.Root key="import-stale" intent="warning" spokenMessage={ staleMessage }>
+			<Notice.Description>{ staleMessage }</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionButton onClick={ handleCancelImport } loading={ resetMutation.isPending }>
+					{ __( 'Cancel import', 'jetpack-newsletter' ) }
+				</Notice.ActionButton>
+			</Notice.Actions>
+		</Notice.Root>
+	);
+}
+
 type SubmitButtonProps = {
 	count: number;
 	isPending: boolean;
+	disabled?: boolean;
 	onClick: () => void;
 };
 
@@ -95,10 +175,11 @@ type SubmitButtonProps = {
  * @param props           - Component props.
  * @param props.count     - Number of valid emails to import.
  * @param props.isPending - Whether the underlying mutation is in flight.
+ * @param props.disabled  - Whether submitting is blocked (an import is already running).
  * @param props.onClick   - Submit handler.
  * @return Submit button.
  */
-function SubmitButton( { count, isPending, onClick }: SubmitButtonProps ): JSX.Element {
+function SubmitButton( { count, isPending, disabled, onClick }: SubmitButtonProps ): JSX.Element {
 	const label =
 		count > 0
 			? sprintf(
@@ -108,7 +189,11 @@ function SubmitButton( { count, isPending, onClick }: SubmitButtonProps ): JSX.E
 			  )
 			: __( 'Add subscribers', 'jetpack-newsletter' );
 	return (
-		<Button onClick={ onClick } loading={ isPending } disabled={ isPending || count === 0 }>
+		<Button
+			onClick={ onClick }
+			loading={ isPending }
+			disabled={ disabled || isPending || count === 0 }
+		>
 			{ label }
 		</Button>
 	);
@@ -116,6 +201,8 @@ function SubmitButton( { count, isPending, onClick }: SubmitButtonProps ): JSX.E
 
 type AddTabProps = {
 	mutation: ReturnType< typeof useAddSubscribersMutation >;
+	// True while WP.com is already running an import — submitting would be rejected upstream.
+	importInProgress: boolean;
 	onClose: () => void;
 };
 
@@ -123,12 +210,13 @@ type AddTabProps = {
  * Manual entry tab. Plain textarea + same forgiving comma/semicolon/whitespace parser the
  * original modal shipped with.
  *
- * @param props          - Component props.
- * @param props.mutation - Shared add-subscribers mutation handle.
- * @param props.onClose  - Close handler invoked after a successful submit.
+ * @param props                  - Component props.
+ * @param props.mutation         - Shared add-subscribers mutation handle.
+ * @param props.importInProgress - Whether an import is already running.
+ * @param props.onClose          - Close handler invoked after a successful submit.
  * @return Tab body.
  */
-function ManualTab( { mutation, onClose }: AddTabProps ): JSX.Element {
+function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.Element {
 	const [ value, setValue ] = useState( '' );
 
 	// Submit button reflects the *live* value so the user never has to wait to submit — typing one
@@ -188,6 +276,7 @@ function ManualTab( { mutation, onClose }: AddTabProps ): JSX.Element {
 				<SubmitButton
 					count={ valid.length }
 					isPending={ mutation.isPending }
+					disabled={ importInProgress }
 					onClick={ handleSubmit }
 				/>
 			</Stack>
@@ -201,12 +290,13 @@ function ManualTab( { mutation, onClose }: AddTabProps ): JSX.Element {
  * parser tolerates CSVs from Substack, Beehiiv, Mailchimp, Ghost, Patreon, Kit and Medium because
  * it just pulls email-shaped substrings out of the raw text.
  *
- * @param props          - Component props.
- * @param props.mutation - Shared add-subscribers mutation handle.
- * @param props.onClose  - Close handler invoked after a successful submit.
+ * @param props                  - Component props.
+ * @param props.mutation         - Shared add-subscribers mutation handle.
+ * @param props.importInProgress - Whether an import is already running.
+ * @param props.onClose          - Close handler invoked after a successful submit.
  * @return Tab body.
  */
-function UploadTab( { mutation, onClose }: AddTabProps ): JSX.Element {
+function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.Element {
 	const fileInputRef = useRef< HTMLInputElement | null >( null );
 	const [ fileName, setFileName ] = useState< string | null >( null );
 	const [ emails, setEmails ] = useState< string[] >( [] );
@@ -287,6 +377,7 @@ function UploadTab( { mutation, onClose }: AddTabProps ): JSX.Element {
 				<SubmitButton
 					count={ emails.length }
 					isPending={ mutation.isPending }
+					disabled={ importInProgress }
 					onClick={ handleSubmit }
 				/>
 			</Stack>
@@ -342,6 +433,7 @@ function SubstackTab(): JSX.Element {
 export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.Element | null {
 	const mutation = useAddSubscribersMutation();
 	const [ tab, setTab ] = useState< TabValue >( 'manual' );
+	const importJobsQuery = useImportJobs( isOpen );
 
 	const handleOpenChange = useCallback(
 		( nextOpen: boolean ) => {
@@ -364,6 +456,9 @@ export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.E
 		return null;
 	}
 
+	const importJobs = importJobsQuery.data ?? [];
+	const importInProgress = importJobs.some( isJobInProgress );
+
 	return (
 		<Dialog.Root open onOpenChange={ handleOpenChange }>
 			<Dialog.Popup>
@@ -372,26 +467,37 @@ export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.E
 					<Dialog.CloseIcon />
 				</Dialog.Header>
 				<Dialog.Content>
-					<Tabs.Root
-						value={ tab }
-						onValueChange={ handleTabChange }
-						render={ <Stack direction="column" gap="lg" /> }
-					>
-						<Tabs.List variant="minimal">
-							<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
-							<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
-							<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>
-						</Tabs.List>
-						<Tabs.Panel value="manual">
-							<ManualTab mutation={ mutation } onClose={ onClose } />
-						</Tabs.Panel>
-						<Tabs.Panel value="upload">
-							<UploadTab mutation={ mutation } onClose={ onClose } />
-						</Tabs.Panel>
-						<Tabs.Panel value="substack">
-							<SubstackTab />
-						</Tabs.Panel>
-					</Tabs.Root>
+					<Stack direction="column" gap="lg">
+						<ImportStatusNotice jobs={ importJobs } />
+						<Tabs.Root
+							value={ tab }
+							onValueChange={ handleTabChange }
+							render={ <Stack direction="column" gap="lg" /> }
+						>
+							<Tabs.List variant="minimal">
+								<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
+								<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
+								<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>
+							</Tabs.List>
+							<Tabs.Panel value="manual">
+								<ManualTab
+									mutation={ mutation }
+									importInProgress={ importInProgress }
+									onClose={ onClose }
+								/>
+							</Tabs.Panel>
+							<Tabs.Panel value="upload">
+								<UploadTab
+									mutation={ mutation }
+									importInProgress={ importInProgress }
+									onClose={ onClose }
+								/>
+							</Tabs.Panel>
+							<Tabs.Panel value="substack">
+								<SubstackTab />
+							</Tabs.Panel>
+						</Tabs.Root>
+					</Stack>
 				</Dialog.Content>
 			</Dialog.Popup>
 		</Dialog.Root>

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -1,5 +1,11 @@
 import { TextareaControl } from '@wordpress/components';
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button, Dialog, Notice, Stack, Tabs, Text } from '@wordpress/ui';
 import { useAddSubscribersMutation } from '../../data/use-add-subscribers-mutation';
@@ -16,7 +22,49 @@ type Props = {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// Help-center articles for exporting a subscriber list from each supported platform, linked from
+// the CSV upload tab the same way Calypso links them.
+const PLATFORM_EXPORT_URLS = {
+	beehiiv: 'https://www.beehiiv.com/support/article/12234988536215-how-to-export-subscribers',
+	ghost: 'https://ghost.org/help/exports/#members',
+	kit: 'https://help.kit.com/en/articles/2502489-how-to-export-subscribers-in-kit',
+	mailchimp: 'https://mailchimp.com/help/view-export-contacts/',
+	medium: 'https://help.medium.com/hc/en-us/articles/360059837393-Email-subscriptions',
+	patreon:
+		'https://support.patreon.com/hc/en-gb/articles/360004385971-How-do-I-manage-my-members#h_01EQGYDNF2J3XR12ABBMTZPSQM',
+};
+
 type TabValue = 'manual' | 'upload' | 'substack';
+
+/**
+ * Consent + large-import notice shown under both the manual and CSV entry forms, mirroring the copy
+ * Calypso shows on its own Add Subscribers flow.
+ *
+ * @return Two-paragraph notice.
+ */
+function ImportConsentNotice(): JSX.Element {
+	return (
+		// Match the muted gray of the WordPress control "help" text the notice sits beneath.
+		<Stack
+			direction="column"
+			gap="xs"
+			style={ { color: 'var(--wpds-color-fg-content-neutral-weak)' } }
+		>
+			<Text variant="body-sm">
+				{ __(
+					'Imports of more than 10,000 subscribers will go through a manual review before being added to your site.',
+					'jetpack-newsletter'
+				) }
+			</Text>
+			<Text variant="body-sm">
+				{ __(
+					'By clicking “Add subscribers,” you represent that you’ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.',
+					'jetpack-newsletter'
+				) }
+			</Text>
+		</Stack>
+	);
+}
 
 /**
  * Calypso's Substack importer wizard. We don't reimplement the multi-step Stripe / paid-plan
@@ -271,6 +319,7 @@ function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 				rows={ 6 }
 				placeholder="reader@example.com&#10;another@example.com"
 			/>
+			<ImportConsentNotice />
 			<InvalidEntriesNotice invalid={ invalid } />
 			<Stack direction="row" justify="end" gap="sm">
 				<SubmitButton
@@ -341,9 +390,21 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 	return (
 		<Stack direction="column" gap="md">
 			<Text variant="body-md">
-				{ __(
-					'Upload a CSV from Substack, Beehiiv, Mailchimp, Ghost, Patreon, Kit or Medium. We’ll pick the email column for you and import each address.',
-					'jetpack-newsletter'
+				{ createInterpolateElement(
+					__(
+						'Upload a CSV file with your existing subscribers list from platforms like <beehiiv>Beehiiv</beehiiv>, <ghost>Ghost</ghost>, <kit>Kit</kit>, <mailchimp>Mailchimp</mailchimp>, <medium>Medium</medium>, <patreon>Patreon</patreon>, and many others.',
+						'jetpack-newsletter'
+					),
+					{
+						beehiiv: <a href={ PLATFORM_EXPORT_URLS.beehiiv } target="_blank" rel="noreferrer" />,
+						ghost: <a href={ PLATFORM_EXPORT_URLS.ghost } target="_blank" rel="noreferrer" />,
+						kit: <a href={ PLATFORM_EXPORT_URLS.kit } target="_blank" rel="noreferrer" />,
+						mailchimp: (
+							<a href={ PLATFORM_EXPORT_URLS.mailchimp } target="_blank" rel="noreferrer" />
+						),
+						medium: <a href={ PLATFORM_EXPORT_URLS.medium } target="_blank" rel="noreferrer" />,
+						patreon: <a href={ PLATFORM_EXPORT_URLS.patreon } target="_blank" rel="noreferrer" />,
+					}
 				) }
 			</Text>
 			<input
@@ -353,6 +414,7 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 				onChange={ handleFileChange }
 				disabled={ mutation.isPending }
 			/>
+			<ImportConsentNotice />
 			{ readError ? (
 				<Notice.Root intent="error">
 					<Notice.Description>{ readError }</Notice.Description>

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -93,7 +93,7 @@ type SubmitButtonProps = {
  * disables itself when the user has nothing to submit.
  *
  * @param props           - Component props.
- * @param props.count     - Number of valid emails to invite.
+ * @param props.count     - Number of valid emails to import.
  * @param props.isPending - Whether the underlying mutation is in flight.
  * @param props.onClick   - Submit handler.
  * @return Submit button.
@@ -102,8 +102,8 @@ function SubmitButton( { count, isPending, onClick }: SubmitButtonProps ): JSX.E
 	const label =
 		count > 0
 			? sprintf(
-					// translators: %d: number of subscribers to invite.
-					_n( 'Invite %d subscriber', 'Invite %d subscribers', count, 'jetpack-newsletter' ),
+					// translators: %d: number of subscribers to add.
+					_n( 'Add %d subscriber', 'Add %d subscribers', count, 'jetpack-newsletter' ),
 					count
 			  )
 			: __( 'Add subscribers', 'jetpack-newsletter' );
@@ -131,7 +131,7 @@ type AddTabProps = {
 function ManualTab( { mutation, onClose }: AddTabProps ): JSX.Element {
 	const [ value, setValue ] = useState( '' );
 
-	// Submit button reflects the *live* value so the user never has to wait to invite — typing one
+	// Submit button reflects the *live* value so the user never has to wait to submit — typing one
 	// valid email enables the CTA right away.
 	const { valid } = useMemo( () => partitionEmails( splitEntries( value ) ), [ value ] );
 
@@ -174,7 +174,7 @@ function ManualTab( { mutation, onClose }: AddTabProps ): JSX.Element {
 				__nextHasNoMarginBottom
 				label={ __( 'Email addresses', 'jetpack-newsletter' ) }
 				help={ __(
-					'Enter one email per line. Subscribers receive an invitation by email.',
+					'Enter one email per line. We’ll automatically clean duplicate, incomplete, outdated, or spammy emails.',
 					'jetpack-newsletter'
 				) }
 				value={ value }
@@ -252,7 +252,7 @@ function UploadTab( { mutation, onClose }: AddTabProps ): JSX.Element {
 		<Stack direction="column" gap="md">
 			<Text variant="body-md">
 				{ __(
-					'Upload a CSV from Substack, Beehiiv, Mailchimp, Ghost, Patreon, Kit or Medium. We’ll pick the email column for you and send each address an invitation.',
+					'Upload a CSV from Substack, Beehiiv, Mailchimp, Ghost, Patreon, Kit or Medium. We’ll pick the email column for you and import each address.',
 					'jetpack-newsletter'
 				) }
 			</Text>
@@ -327,7 +327,7 @@ function SubstackTab(): JSX.Element {
 }
 
 /**
- * Modal that invites new subscribers by email. Three tabs — manual entry, CSV upload, and a
+ * Modal that imports new subscribers by email. Three tabs — manual entry, CSV upload, and a
  * Substack importer hand-off — share a single `useAddSubscribersMutation` so the snackbar
  * feedback + dashboard cache invalidation behave identically across tabs. (Calypso also has a
  * "Migrate from another WordPress.com site" flow; we don't ship it from inside the in-admin

--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -2,6 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import type {
 	AddSubscribersResponse,
+	ImportJob,
 	RemoveSubscriberPayload,
 	RemoveSubscriberResponse,
 	SubscriberDetails,
@@ -79,6 +80,33 @@ export function addSubscribers( emails: string[] ): Promise< AddSubscribersRespo
 		path: '/wpcom/v2/subscribers/add',
 		method: 'POST',
 		data: { emails },
+	} );
+}
+
+/**
+ * Fetch the site's subscriber import jobs, newest first. Used by the Add Subscribers modal to
+ * detect an in-flight or stale import — WP.com runs one import per site at a time.
+ *
+ * @return Import jobs.
+ */
+export function fetchImportJobs(): Promise< ImportJob[] > {
+	return apiFetch< ImportJob[] >( {
+		path: '/wpcom/v2/subscribers/import',
+		method: 'GET',
+	} );
+}
+
+/**
+ * Cancel stuck (pending / importing) subscriber import jobs, mirroring Calypso's stale-import
+ * "Cancel import" action (`useSubscriberImportStatusReset`). The proxy forwards to
+ * `/sites/{id}/subscribers/import/reset_state`.
+ *
+ * @return WP.com response with the number of jobs reset.
+ */
+export function resetImportState(): Promise< { reset_count?: number } > {
+	return apiFetch( {
+		path: '/wpcom/v2/subscribers/import/reset-state',
+		method: 'POST',
 	} );
 }
 

--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -66,11 +66,13 @@ export function removeSubscriber(
 }
 
 /**
- * Send "follower" invitations to a list of email addresses, mirroring Calypso's
- * `addSubscribers` action. The proxy forwards to `/sites/{id}/invites/new`.
+ * Import a list of email addresses as subscribers, mirroring Calypso's Add Subscribers modal
+ * (`importCsvSubscribers`). The proxy forwards to `/sites/{id}/subscribers/import`, which starts
+ * an async job — no invitation email is sent; WP.com emails a "Subscriber import completed"
+ * summary when the job finishes.
  *
- * @param emails - Email addresses to invite.
- * @return WP.com response.
+ * @param emails - Email addresses to import.
+ * @return WP.com response carrying the import job id.
  */
 export function addSubscribers( emails: string[] ): Promise< AddSubscribersResponse > {
 	return apiFetch< AddSubscribersResponse >( {

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -99,8 +99,8 @@ export type RemoveSubscriberResponse = {
 };
 
 export type AddSubscribersResponse = {
-	sent?: string[];
-	errors?: Record< string, string >;
+	// Async import job id returned by `/sites/{id}/subscribers/import`.
+	upload_id?: number;
 	[ key: string ]: unknown;
 };
 

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -104,6 +104,17 @@ export type AddSubscribersResponse = {
 	[ key: string ]: unknown;
 };
 
+export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed' | 'cancelled';
+
+export type ImportJob = {
+	id: number;
+	status: ImportJobStatus;
+	// WP.com sends counts as numeric strings (e.g. `"1"`).
+	email_count?: number | string;
+	scheduled_at?: string;
+	[ key: string ]: unknown;
+};
+
 export type SubscriberCountry = {
 	code: string;
 	name: string;

--- a/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
@@ -6,8 +6,9 @@ import { addSubscribers } from './api';
 import type { AddSubscribersResponse } from './types';
 
 /**
- * Add-subscribers mutation. POSTs `emails` to the proxy, then invalidates the subscribers list
- * cache so the table reflects the new follower invitations.
+ * Add-subscribers mutation. POSTs `emails` to the proxy, which starts an async WP.com import
+ * job, then invalidates the subscribers list cache. Fast imports show up on the refetch; larger
+ * ones land once WP.com finishes the job and sends its "Subscriber import completed" email.
  *
  * @return React-Query mutation handle.
  */
@@ -22,8 +23,13 @@ export function useAddSubscribersMutation() {
 
 			createSuccessNotice(
 				sprintf(
-					// translators: %d: number of email invitations sent.
-					_n( 'Sent %d invitation.', 'Sent %d invitations.', emails.length, 'jetpack-newsletter' ),
+					// translators: %d: number of email addresses being imported.
+					_n(
+						'Importing %d subscriber. This may take a few minutes.',
+						'Importing %d subscribers. This may take a few minutes.',
+						emails.length,
+						'jetpack-newsletter'
+					),
 					emails.length
 				),
 				{ type: 'snackbar' }

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-jobs.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-jobs.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchImportJobs } from './api';
+import type { ImportJob } from './types';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const ACTIVE_POLL_INTERVAL_MS = 5000;
+
+/**
+ * Whether an import job is still running. WP.com refuses to start a new import while any job is
+ * in one of these states.
+ *
+ * @param job - Import job.
+ * @return Whether the job is pending or importing.
+ */
+export function isJobInProgress( job: ImportJob ): boolean {
+	return job.status === 'pending' || job.status === 'importing';
+}
+
+/**
+ * Whether an in-progress job has been running long enough to be considered stuck — same
+ * 24-hour threshold as Calypso's `useHasStaleImportJobs`. Stale jobs block new imports until
+ * the user resets them.
+ *
+ * @param job - Import job.
+ * @param now - Current timestamp in ms (injectable for tests).
+ * @return Whether the job is stale.
+ */
+export function isJobStale( job: ImportJob, now: number = Date.now() ): boolean {
+	if ( ! isJobInProgress( job ) || ! job.scheduled_at ) {
+		return false;
+	}
+	return now - new Date( job.scheduled_at ).getTime() > DAY_IN_MS;
+}
+
+/**
+ * Import-jobs query for the Add Subscribers modal. Polls while a job is in progress so the
+ * "import in progress" notice clears itself when WP.com finishes the job; the key shares the
+ * `[ 'subscribers' ]` prefix so starting an import (which invalidates that prefix) refetches it.
+ *
+ * @param enabled - Whether the query should run (modal open).
+ * @return React-Query result with the jobs list, newest first.
+ */
+export function useImportJobs( enabled: boolean ) {
+	return useQuery< ImportJob[], Error >( {
+		queryKey: [ 'subscribers', 'import-jobs' ],
+		queryFn: fetchImportJobs,
+		enabled,
+		refetchInterval: query =>
+			query.state.data?.some( isJobInProgress ) ? ACTIVE_POLL_INTERVAL_MS : false,
+	} );
+}

--- a/projects/packages/newsletter/_inc/subscribers/data/use-reset-import-mutation.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-reset-import-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { resetImportState } from './api';
+
+/**
+ * Reset-import mutation. Cancels stuck import jobs via the proxy, then invalidates the
+ * import-jobs query so the stale-import notice clears and the form re-enables.
+ *
+ * @return React-Query mutation handle.
+ */
+export function useResetImportMutation() {
+	const queryClient = useQueryClient();
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	return useMutation< { reset_count?: number }, Error, void >( {
+		mutationFn: resetImportState,
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'import-jobs' ] } );
+			createSuccessNotice( __( 'Import cancelled.', 'jetpack-newsletter' ), {
+				type: 'snackbar',
+			} );
+		},
+		onError: error => {
+			createErrorNotice( error.message, { type: 'snackbar' } );
+		},
+	} );
+}

--- a/projects/packages/newsletter/changelog/update-newsletter-add-subscribers-import
+++ b/projects/packages/newsletter/changelog/update-newsletter-add-subscribers-import
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Subscribers dashboard (Newsletter modernization, behind a feature flag): add subscribers through the async WP.com subscriber import instead of follower invitations, matching Calypso, and surface in-progress / stale imports in the modal with a cancel action.

--- a/projects/packages/newsletter/tests/import-job-helpers.test.ts
+++ b/projects/packages/newsletter/tests/import-job-helpers.test.ts
@@ -1,0 +1,52 @@
+import { isJobInProgress, isJobStale } from '../_inc/subscribers/data/use-import-jobs';
+import type { ImportJob } from '../_inc/subscribers/data/types';
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+const NOW = new Date( '2026-06-10T12:00:00' ).getTime();
+
+const job = ( overrides: Partial< ImportJob > ): ImportJob => ( {
+	id: 1,
+	status: 'pending',
+	...overrides,
+} );
+
+describe( 'isJobInProgress', () => {
+	it.each( [ 'pending', 'importing' ] as const )( 'is true for %s jobs', status => {
+		expect( isJobInProgress( job( { status } ) ) ).toBe( true );
+	} );
+
+	it.each( [ 'imported', 'failed', 'cancelled' ] as const )( 'is false for %s jobs', status => {
+		expect( isJobInProgress( job( { status } ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'isJobStale', () => {
+	// `scheduled_at` arrives in WP.com's space-separated format with no timezone marker
+	// (e.g. `2026-06-10 18:08:55`), which `new Date()` parses as local time — so format these
+	// fixtures in local time too, keeping the test independent of the runner's TZ.
+	const scheduledHoursAgo = ( hours: number ): string => {
+		const d = new Date( NOW - hours * HOUR_IN_MS );
+		const pad = ( n: number ) => String( n ).padStart( 2, '0' );
+		return `${ d.getFullYear() }-${ pad( d.getMonth() + 1 ) }-${ pad( d.getDate() ) } ${ pad(
+			d.getHours()
+		) }:${ pad( d.getMinutes() ) }:${ pad( d.getSeconds() ) }`;
+	};
+
+	it( 'is false while an in-progress job is under the 24h threshold', () => {
+		expect( isJobStale( job( { scheduled_at: scheduledHoursAgo( 23 ) } ), NOW ) ).toBe( false );
+	} );
+
+	it( 'is true once an in-progress job passes the 24h threshold', () => {
+		expect( isJobStale( job( { scheduled_at: scheduledHoursAgo( 25 ) } ), NOW ) ).toBe( true );
+	} );
+
+	it( 'is false for completed jobs no matter how old', () => {
+		expect(
+			isJobStale( job( { status: 'imported', scheduled_at: scheduledHoursAgo( 100 ) } ), NOW )
+		).toBe( false );
+	} );
+
+	it( 'is false when the job has no scheduled_at to compare against', () => {
+		expect( isJobStale( job( {} ), NOW ) ).toBe( false );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -148,6 +148,30 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/subscribers/import',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_import_jobs' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/subscribers/import/reset-state',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'reset_import_state' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/subscribers/totals',
 			array(
 				array(
@@ -586,6 +610,66 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 				'subscribers_add_failed',
 				$this->get_wpcom_error_message( $body, __( 'Could not add subscribers.', 'jetpack' ) ),
 				array( 'status' => $status >= 400 ? $status : 400 )
+			);
+		}
+
+		return rest_ensure_response( $body );
+	}
+
+	/**
+	 * Proxy GET /wpcom/v2/sites/{blog_id}/subscribers/import — the site's subscriber import jobs,
+	 * newest first. The dashboard polls this while the Add Subscribers modal is open so it can
+	 * show the "import in progress" / stale-import notices (WP.com runs one import per site at a
+	 * time).
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_import_jobs() {
+		$blog_id = Connection_Manager::get_site_id();
+
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		return $this->wpcom_get( sprintf( '/sites/%d/subscribers/import', (int) $blog_id ) );
+	}
+
+	/**
+	 * POST /wpcom/v2/subscribers/import/reset-state — cancel stuck (pending / importing)
+	 * subscriber import jobs, mirroring Calypso's stale-import "Cancel import" action
+	 * (`useSubscriberImportStatusReset`). Proxies to the wpcom
+	 * `/sites/{blog_id}/subscribers/import/reset_state` endpoint and returns its
+	 * `{ reset_count }` body.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function reset_import_state() {
+		$blog_id = Connection_Manager::get_site_id();
+
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$response = Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/subscribers/import/reset_state', (int) $blog_id ),
+			'2',
+			array( 'method' => 'POST' ),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status >= 400 ) {
+			return new WP_Error(
+				'subscribers_reset_import_failed',
+				$this->get_wpcom_error_message( $body, __( 'Could not cancel the import.', 'jetpack' ) ),
+				array( 'status' => $status )
 			);
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -515,8 +515,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	}
 
 	/**
-	 * Add subscribers by email — proxies to `/sites/{blog_id}/invites/new` (v1.1) which sends a
-	 * "follower" invitation email per address. Mirrors Calypso's `addSubscribers` action.
+	 * Add subscribers by email — proxies to `/sites/{blog_id}/subscribers/import` (v2), the same
+	 * async import job Calypso's Add Subscribers modal starts. Addresses are imported directly as
+	 * subscribers (no invitation email); WP.com processes the job in the background and emails the
+	 * importing user a "Subscriber import completed" summary when it finishes.
 	 *
 	 * @param WP_REST_Request $request Request.
 	 * @return WP_REST_Response|WP_Error
@@ -546,23 +548,28 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 			);
 		}
 
+		// JSON body, not the form encoding Calypso submits: WP.com's Jetpack signature verifier
+		// canonicalizes `application/x-www-form-urlencoded` bodies differently from the Jetpack
+		// client (it re-encodes the parsed array as JSON before hashing), so a form-encoded POST
+		// fails the body-hash check and arrives unauthenticated (user 0) — surfacing as a 401
+		// `invalid_capabilities`. JSON bodies hash identically on both sides, and the endpoint
+		// reads its params from either encoding. `parse_only => false` runs the import rather
+		// than only validating the payload.
 		$response = Client::wpcom_json_api_request_as_user(
-			sprintf( '/sites/%d/invites/new', (int) $blog_id ),
-			'1.1',
+			sprintf( '/sites/%d/subscribers/import', (int) $blog_id ),
+			'2',
 			array(
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),
 			),
 			wp_json_encode(
 				array(
-					'invitees'    => $emails,
-					'role'        => 'follower',
-					'source'      => 'jetpack-subscribers-dashboard',
-					'is_external' => false,
+					'emails'     => $emails,
+					'parse_only' => false,
 				),
 				JSON_UNESCAPED_SLASHES
 			),
-			'rest'
+			'wpcom'
 		);
 
 		if ( is_wp_error( $response ) ) {
@@ -572,11 +579,13 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 		$status = (int) wp_remote_retrieve_response_code( $response );
 		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		if ( $status >= 400 ) {
+		// A successful import start carries the async job id as `upload_id`. Mirror Calypso, which
+		// treats any response without one as a failure even when the HTTP status is 2xx.
+		if ( $status >= 400 || ! is_array( $body ) || empty( $body['upload_id'] ) ) {
 			return new WP_Error(
 				'subscribers_add_failed',
-				is_array( $body ) && isset( $body['message'] ) ? $body['message'] : __( 'Could not add subscribers.', 'jetpack' ),
-				array( 'status' => $status )
+				$this->get_wpcom_error_message( $body, __( 'Could not add subscribers.', 'jetpack' ) ),
+				array( 'status' => $status >= 400 ? $status : 400 )
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/update-newsletter-add-subscribers-import
+++ b/projects/plugins/jetpack/changelog/update-newsletter-add-subscribers-import
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Subscribers (Newsletter modernization, behind a feature flag): proxy the add-subscribers action to the async wpcom /sites/{id}/subscribers/import (v2) endpoint instead of /invites/new, matching Calypso's import flow, and add import-jobs / reset-state proxy routes for the modal's in-progress and stale-import notices.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -285,6 +285,42 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	}
 
 	/**
+	 * `/subscribers/import/reset-state` forwards to the wpcom
+	 * `/sites/{blog_id}/subscribers/import/reset_state` (v2) endpoint — Calypso's stale-import
+	 * "Cancel import" action — and returns its `{ reset_count }` body verbatim.
+	 */
+	public function test_reset_import_state_forwards_and_returns_body() {
+		$captured_url = '';
+		$filter       = function ( $preempt, $parsed_args, $url ) use ( &$captured_url ) {
+			$captured_url = $url;
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'reset_count' => 1 ), JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request  = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/import/reset-state' );
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'reset_count' => 1 ), $response->get_data() );
+		$this->assertStringContainsString(
+			'/wpcom/v2/sites/' . static::$blog_id . '/subscribers/import/reset_state',
+			$captured_url
+		);
+	}
+
+	/**
 	 * `/subscribers/remove` rejects payloads with no identifiers at all — protects WP.com from
 	 * receiving a no-op cascade.
 	 */

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -190,6 +190,101 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	}
 
 	/**
+	 * `/subscribers/add` forwards to the async wpcom `/sites/{blog_id}/subscribers/import` (v2)
+	 * endpoint — the same import job Calypso's Add Subscribers modal starts, which imports the
+	 * addresses directly instead of sending invitation emails — and returns its `{ upload_id }`
+	 * body verbatim.
+	 */
+	public function test_add_forwards_to_import_endpoint_and_returns_body() {
+		$captured = array(
+			'url'  => '',
+			'body' => '',
+		);
+		$filter   = function ( $preempt, $parsed_args, $url ) use ( &$captured ) {
+			$captured['url']  = $url;
+			$captured['body'] = $parsed_args['body'] ?? null;
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'upload_id' => 4242 ), JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/add' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array( 'emails' => array( 'reader@example.com', 'not-an-email', 'second@example.com' ) ),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'upload_id' => 4242 ), $response->get_data() );
+
+		$this->assertStringContainsString(
+			'/wpcom/v2/sites/' . static::$blog_id . '/subscribers/import',
+			$captured['url']
+		);
+
+		// JSON body (form encoding would fail the Jetpack body-hash signature check WP.com-side):
+		// only the valid emails survive sanitization, and `parse_only` is false so WP.com runs
+		// the import instead of a dry run.
+		$sent = (array) json_decode( (string) $captured['body'], true );
+		$this->assertSame( array( 'reader@example.com', 'second@example.com' ), $sent['emails'] );
+		$this->assertFalse( $sent['parse_only'] );
+	}
+
+	/**
+	 * The import endpoint can report a failure inside a 2xx response (e.g. a subscriber limit);
+	 * any body without an `upload_id` maps to a WP_Error carrying the upstream message.
+	 */
+	public function test_add_maps_missing_upload_id_to_wp_error() {
+		$filter = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode(
+					array(
+						'code'    => 'subscriber_import_limit_reached',
+						'message' => 'Import limit reached.',
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/add' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'emails' => array( 'reader@example.com' ) ), JSON_UNESCAPED_SLASHES ) );
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'subscribers_add_failed', $response->get_data()['code'] );
+		$this->assertSame( 'Import limit reached.', $response->get_data()['message'] );
+	}
+
+	/**
 	 * `/subscribers/remove` rejects payloads with no identifiers at all — protects WP.com from
 	 * receiving a no-op cascade.
 	 */


### PR DESCRIPTION
Fixes #

## Proposed changes

* **Add subscribers now runs the WP.com subscriber import instead of sending invitations**, matching Calypso's Add Subscribers modal. The `/wpcom/v2/subscribers/add` proxy forwards to `/sites/{blog_id}/subscribers/import` (wpcom/v2, as the current user) with `{ emails, parse_only: false }` instead of `/sites/{blog_id}/invites/new` (v1.1). Addresses are imported directly — no invitation email; WP.com emails the importing user a "Subscriber import completed" summary when the async job finishes. Success is detected by the returned `upload_id`, mirroring Calypso (the endpoint can report failures such as subscriber limits inside a 2xx response).
  * The body is sent as JSON deliberately: WP.com's Jetpack signature verifier re-encodes `application/x-www-form-urlencoded` bodies as JSON before hashing, so a form-encoded POST fails the body-hash check, arrives as user 0, and surfaces as a misleading `invalid_capabilities` 401. JSON bodies hash identically on both sides (verified live against the import endpoint).
* **The modal surfaces in-progress and stale imports**, mirroring Calypso (WP.com runs one import per site at a time):
  * while a job is `pending`/`importing`: an info notice and disabled submit buttons; the modal polls the job list every 5s so the notice clears itself when the job completes
  * after Calypso's 24-hour stale threshold: a warning notice with a **Cancel import** action wired to the new `POST /wpcom/v2/subscribers/import/reset-state` proxy (or a support pointer when a previous job was already cancelled)
* Modal/notice copy updated from invitation semantics to import semantics ("Add N subscribers", "Importing N subscribers…", etc.).
* Each notice variant passes an explicit string `spokenMessage` and a distinct `key`: `@wordpress/ui`'s `Notice.Root` otherwise `renderToString()`s its children mid-render, which corrupts React hook order when the children include action buttons and the mounted notice switches variants (this crashed the dashboard during live testing; to be reported upstream).

All routes remain gated behind the `rsm_jetpack_ui_modernization_newsletter` feature flag.

## Related product discussion/links

* #48365

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable the modernized dashboard: `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );` and `add_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_true' );`
* Go to **Newsletter → Subscribers** in wp-admin, click **Add subscribers**, enter an email address you control, and submit.
  * Expect the "Importing 1 subscriber. This may take a few minutes." snackbar (not "Sent 1 invitation").
  * The address should **not** receive an invitation email; once the WP.com job completes, the subscriber appears in the list and the *importing admin* receives a "Subscriber import completed" email.
  * Reopen the modal while the job is still running: an info notice shows and the submit buttons are disabled until it finishes.
* To exercise the stale-import notices without waiting 24 hours, paste this in the browser console on the Subscribers page, then open the modal:

  <details><summary>Console mock for notice states</summary>

  ```js
  const orig = window.fetch;
  window.__jobs = [ { id: 1, status: 'pending', scheduled_at: '2020-01-01 00:00:00' } ];
  window.fetch = ( input, init ) => {
  	const url = typeof input === 'string' ? input : input.url;
  	const method = ( init?.method || 'GET' ).toUpperCase();
  	if ( url.includes( 'subscribers/import' ) && ! url.includes( 'reset-state' ) && method === 'GET' ) {
  		return Promise.resolve( new Response( JSON.stringify( window.__jobs ), { status: 200, headers: { 'Content-Type': 'application/json' } } ) );
  	}
  	if ( url.includes( 'reset-state' ) && method === 'POST' ) {
  		window.__jobs = [ { ...window.__jobs[ 0 ], status: 'cancelled' } ];
  		return Promise.resolve( new Response( JSON.stringify( { reset_count: 1 } ), { status: 200, headers: { 'Content-Type': 'application/json' } } ) );
  	}
  	return orig( input, init );
  };
  ```

  * With the stale `pending` job above: warning notice with a **Cancel import** button; clicking it clears the notice, re-enables the form, and shows the "Import cancelled." snackbar.
  * Set `window.__jobs[0].scheduled_at` to a recent timestamp instead: info notice ("Your subscribers are being imported…").
  * Add a second job `{ id: 2, status: 'cancelled' }` after the stale one: support-pointer variant with a "Learn more" link.
  * Restore with `window.fetch = orig`.

  </details>

* PHP: `jp docker phpunit jetpack -- --filter WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test` (20 tests). JS: `pnpm test` in `projects/packages/newsletter` (67 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1070" height="881" alt="Screenshot from 2026-06-10 18-44-32" src="https://github.com/user-attachments/assets/c6ae7068-46e5-4a26-9f80-955c0e3eca3f" />
<img width="1070" height="881" alt="Screenshot from 2026-06-10 18-43-44" src="https://github.com/user-attachments/assets/84a6a202-7844-4860-af78-75d7ffd6eba0" />
