### PR TITLE
Beta: Allow non-WP.org plugins to have their stable versions installed from GitHub

### DIFF
--- a/projects/plugins/beta/changelog/add-beta-install_stable_self
+++ b/projects/plugins/beta/changelog/add-beta-install_stable_self
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Allow stable versions of non-WP.org plugins to be installed.

--- a/projects/plugins/beta/src/admin/branch-card.template.php
+++ b/projects/plugins/beta/src/admin/branch-card.template.php
@@ -27,13 +27,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 		// translators: Translates the `More info` link. %1$s: URL. %2$s: PR number.
 		$more_info[] = sprintf( __( '<a target="_blank" rel="external noopener noreferrer" href="%1$s">more info #%2$s</a>', 'jetpack-beta' ), $branch->plugin_url, $branch->pr );
 	} elseif ( 'release' === $branch->source ) {
-		$data_attr   = sprintf( 'data-release="%s"', esc_attr( $branch->version ) );
-		$more_info[] = sprintf(
-			// translators: Which release is being selected.
-			__( 'Public release (%1$s) <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%2$s" target="_blank" rel="">available on WordPress.org</a>', 'jetpack-beta' ),
-			esc_html( $branch->version ),
-			esc_attr( $branch->version )
-		);
+		$data_attr = sprintf( 'data-release="%s"', esc_attr( $branch->version ) );
+		if ( isset( $branch->plugin_url ) ) {
+			$more_info[] = sprintf(
+				// translators: Which release is being selected. %1$s: Version number. %2$s: GitHub release URL.
+				__( 'Public release (%1$s) <a href="%2$s" target="_blank">available on GitHub</a>', 'jetpack-beta' ),
+				esc_html( $branch->version ),
+				esc_url( $branch->plugin_url )
+			);
+		} else {
+			$more_info[] = sprintf(
+				// translators: Which release is being selected. %1$s: Version number. %2$s: GitHub release URL.
+				__( 'Public release (%1$s) <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%2$s" target="_blank" rel="">available on WordPress.org</a>', 'jetpack-beta' ),
+				esc_html( $branch->version ),
+				esc_attr( $branch->version )
+			);
+		}
 	} elseif ( 'rc' === $branch->source || 'trunk' === $branch->source || 'unknown' === $branch->source && $branch->version ) {
 		$more_info[] = sprintf(
 			// translators: %s: Version number.

--- a/projects/plugins/beta/src/admin/plugin-manage.template.php
+++ b/projects/plugins/beta/src/admin/plugin-manage.template.php
@@ -18,8 +18,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-$manifest   = $plugin->get_manifest( true );
+$manifest = $plugin->get_manifest( true );
+
+// For unpublished plugins get_wporg_data() is a no-op returning an empty object.
+// @todo Refactor everywhere to use a generic plugin data object instead of `$wporg_data`.
 $wporg_data = $plugin->get_wporg_data( true );
+
+// Refresh plugin details from GitHub.
+if ( $plugin->is_unpublished() ) {
+	$plugin->get_latest_github_release( true );
+}
 
 $existing_branch = null;
 if ( file_exists( $plugin->plugin_path() ) ) {

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -442,17 +442,22 @@ class Plugin {
 	 * Used in place of WordPress.org data for unpublished plugins.
 	 *
 	 * @param bool $no_cache Set true to bypass the transients cache.
-	 * @return object Object with plugin data.
-	 * @throws PluginDataException If the data cannot be fetched or is invalid.
+	 * @return object|null Object with plugin data, or null if no usable release exists.
+	 * @throws PluginDataException If the data cannot be fetched.
 	 */
 	public function get_latest_github_release( $no_cache = false ) {
 		$url     = sprintf( 'https://api.github.com/repos/%s/releases/latest', $this->mirror );
 		$release = Utils::get_remote_data( $url, "github_latest_$this->slug", $no_cache );
-		if ( ! is_object( $release ) || ! isset( $release->tag_name ) || ! isset( $release->assets[0]->browser_download_url ) ) {
+		if ( $release === false ) {
 			throw new PluginDataException(
 				// translators: %s: Plugin slug.
 				sprintf( __( 'Failed to download GitHub release data for plugin \'%s\'. Check your Internet connection.', 'jetpack-beta' ), $this->slug )
 			);
+		}
+
+		// A repo with no releases returns a 404 body. Let's treat that as "no stable version".
+		if ( ! is_object( $release ) || ! isset( $release->tag_name ) || ! isset( $release->assets[0]->browser_download_url ) ) {
+			return null;
 		}
 
 		return (object) array(
@@ -949,6 +954,13 @@ class Plugin {
 				$which = 'stable';
 				if ( $this->unpublished ) {
 					$info = $this->get_latest_github_release();
+					if ( ! $info ) {
+						return new WP_Error(
+							'stable_url_missing',
+							// translators: %s: Plugin slug.
+							sprintf( __( 'No stable download URL is available for %s.', 'jetpack-beta' ), $this->plugin_slug() )
+						);
+					}
 				} else {
 					$wporg_data = $this->get_wporg_data();
 					if ( ! isset( $wporg_data->download_link ) ) {
@@ -1020,7 +1032,7 @@ class Plugin {
 				$which = 'stable';
 				if ( $this->unpublished ) {
 					$info = $this->get_latest_github_release();
-					if ( $info->version !== $id ) {
+					if ( ! $info || $info->version !== $id ) {
 						return new WP_Error(
 							'release_missing',
 							// translators: %1$s: Version number. %2$s: Plugin slug.

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -376,6 +376,15 @@ class Plugin {
 	}
 
 	/**
+	 * Is this plugin unpublished (i.e. not in the WordPress Plugin Directory)?
+	 *
+	 * @return bool
+	 */
+	public function is_unpublished() {
+		return $this->unpublished;
+	}
+
+	/**
 	 * Get the manifest data (i.e. branches) for the plugin.
 	 *
 	 * @param bool $no_cache Set true to bypass the transients cache.
@@ -425,6 +434,33 @@ class Plugin {
 			$this->wporg_data = $data;
 		}
 		return $this->wporg_data;
+	}
+
+	/**
+	 * Get info from the latest GitHub release of the plugin's mirror repo.
+	 *
+	 * Used in place of WordPress.org data for unpublished plugins.
+	 *
+	 * @param bool $no_cache Set true to bypass the transients cache.
+	 * @return object Object with plugin data.
+	 * @throws PluginDataException If the data cannot be fetched or is invalid.
+	 */
+	public function get_latest_github_release( $no_cache = false ) {
+		$url     = sprintf( 'https://api.github.com/repos/%s/releases/latest', $this->mirror );
+		$release = Utils::get_remote_data( $url, "github_latest_$this->slug", $no_cache );
+		if ( ! is_object( $release ) || ! isset( $release->tag_name ) || ! isset( $release->assets[0]->browser_download_url ) ) {
+			throw new PluginDataException(
+				// translators: %s: Plugin slug.
+				sprintf( __( 'Failed to download GitHub release data for plugin \'%s\'. Check your Internet connection.', 'jetpack-beta' ), $this->slug )
+			);
+		}
+
+		return (object) array(
+			'download_url' => $release->assets[0]->browser_download_url,
+			'version'      => ltrim( $release->tag_name, 'v' ),
+			'update_date'  => date_create( $release->published_at, timezone_open( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
+			'plugin_url'   => $release->html_url,
+		);
 	}
 
 	/**
@@ -910,22 +946,26 @@ class Plugin {
 		// Get the info based on the source.
 		switch ( $source ) {
 			case 'stable':
-				$which      = 'stable';
-				$wporg_data = $this->get_wporg_data();
-				if ( ! isset( $wporg_data->download_link ) ) {
-					return new WP_Error(
-						'stable_url_missing',
-						// translators: %s: Plugin slug.
-						sprintf( __( 'No stable download URL is available for %s.', 'jetpack-beta' ), $this->plugin_slug() )
+				$which = 'stable';
+				if ( $this->unpublished ) {
+					$info = $this->get_latest_github_release();
+				} else {
+					$wporg_data = $this->get_wporg_data();
+					if ( ! isset( $wporg_data->download_link ) ) {
+						return new WP_Error(
+							'stable_url_missing',
+							// translators: %s: Plugin slug.
+							sprintf( __( 'No stable download URL is available for %s.', 'jetpack-beta' ), $this->plugin_slug() )
+						);
+					}
+					$info = (object) array(
+						'download_url' => $wporg_data->download_link,
+						'version'      => $wporg_data->version,
+						'update_date'  => date_create( $wporg_data->last_updated, timezone_open( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
 					);
 				}
-				$info   = (object) array(
-					'download_url' => $wporg_data->download_link,
-					'version'      => $wporg_data->version,
-					'update_date'  => date_create( $wporg_data->last_updated, timezone_open( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
-				);
 				$source = 'release';
-				$id     = $wporg_data->version;
+				$id     = $info->version;
 				break;
 
 			// Master case remains purely for back-compatibility (in case anyone has bookmarked URLs).
@@ -977,7 +1017,18 @@ class Plugin {
 				break;
 
 			case 'release':
-				$which      = 'stable';
+				$which = 'stable';
+				if ( $this->unpublished ) {
+					$info = $this->get_latest_github_release();
+					if ( $info->version !== $id ) {
+						return new WP_Error(
+							'release_missing',
+							// translators: %1$s: Version number. %2$s: Plugin slug.
+							sprintf( __( 'Version %1$s does not exist for %2$s.', 'jetpack-beta' ), $id, $this->plugin_slug() )
+						);
+					}
+					break;
+				}
 				$wporg_data = $this->get_wporg_data();
 				if ( ! isset( $wporg_data->versions->{$id} ) ) {
 					return new WP_Error(


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
When wanting to install plugins that are not in WP.org, there's no way to install the latest stable release.

This PR adds this functionality, pulling from GitHub (e.g. `https://api.github.com/repos/Automattic/jetpack-beta/releases/latest`).

The existing code is quite scattered and WP.org-centric. A refactor with generic objects populated from either source would be ideal, but that's out of scope.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://github.com/Automattic/jetpack/pull/48490#issuecomment-4408512948

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Ensure the stable release works for both source types.
