### PR TITLE
Coverage: Use multiple-merge when downloading artifacts

### DIFF
--- a/.github/files/coverage-munger/process-coverage.sh
+++ b/.github/files/coverage-munger/process-coverage.sh
@@ -50,7 +50,7 @@ if [[ -n "$TMP" ]]; then
 
 	echo "::group::Creating JS coverage summary"
 	mkdir "$TMP_DIR/js"
-	cp artifacts/js-combined.json "$TMP_DIR/js"
+	cp -v artifacts/js-combined.json "$TMP_DIR/js"
 	pnpm --filter=./.github/files/coverage-munger/ exec nyc report --no-exclude-after-remap --report-dir="$TMP_DIR" --temp-dir="$TMP_DIR/js" --reporter=json-summary
 	jq -r 'to_entries[] | select( .key != "total" ) | [ .key, .value.lines.total, .value.lines.covered ] | @tsv' "$TMP_DIR/coverage-summary.json" > "$TMP_DIR/js-summary.tsv"
 	echo '::endgroup::'
@@ -59,6 +59,7 @@ else
 	touch "$TMP_DIR/js-summary.tsv"
 fi
 
-echo "::group::Combining coverage summaries"
-sort "$TMP_DIR/php-summary.tsv" "$TMP_DIR/js-summary.tsv" > artifacts/summary.tsv
+echo "::group::Saving coverage summary"
+# Name the summary per coverage group so downloading with `merge-multiple` doesn't clobber summaries from other groups. The publish job merges them.
+cp -v "$TMP_DIR/$COVERAGE_GROUP-summary.tsv" "artifacts/summary-$COVERAGE_GROUP.tsv"
 echo '::endgroup::'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -344,18 +344,14 @@ jobs:
         with:
           pattern: 'Code coverage (*)'
           path: coverage_dl
+          merge-multiple: true # This extracts all artifacts into the same dir (but beware of file collisons, where last one wins).
 
       - name: Merge coverage artifacts
         run: |
           mkdir coverage
-          # If there's only one matching artifact, actions/download-artifact puts it directly in the specified path. If multiple, it makes subdirectories that need merging.
-          if [[ -f coverage_dl/summary.tsv ]]; then
-            mv coverage_dl/* coverage/
-          else
-            sort coverage_dl/*/summary.tsv > coverage/summary.tsv
-            rm coverage_dl/*/summary.tsv
-            mv coverage_dl/*/* coverage/
-          fi
+          sort coverage_dl/summary-*.tsv > coverage/summary.tsv
+          rm coverage_dl/summary-*.tsv
+          mv coverage_dl/* coverage/
 
       - name: Upload coverage results
         env:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In #49416 we fixed single-artifact downloads, and this iterates with a simpler solution.

Because `actions/download-artifact` has a `merge-multiple` option, we can use that to download things into the same flat directory. To avoid clobbered names, we need to rename the summary files by coverage group.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://github.com/Automattic/jetpack/pull/49416#issuecomment-4632184922

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

See #49544, which generated this run:
https://github.com/Automattic/jetpack/actions/runs/27319386035/job/80706987849