### PR TITLE
Boost: stop stripping SVG markup from Critical CSS while keeping style-tag breakout protection

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/class-display-critical-css.php
+++ b/projects/plugins/boost/app/lib/critical-css/class-display-critical-css.php
@@ -106,11 +106,29 @@ class Display_Critical_CSS {
 
 		echo '<style id="jetpack-boost-critical-css">';
 
-		// Ensure no </style> tag (or any HTML tags) in output.
+		// Ensure the CSS cannot terminate the style element early.
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo wp_strip_all_tags( $critical_css );
+		echo self::sanitize_css( $critical_css );
 
 		echo '</style>';
+	}
+
+	/**
+	 * Sanitize CSS for output inside a <style> element.
+	 *
+	 * Avoids wp_strip_all_tags(), which corrupts valid CSS values that contain
+	 * markup - e.g. `background-image: url("data:image/svg+xml,<svg ...></svg>")`.
+	 *
+	 * The only sequence which can terminate a <style> element early is a closing
+	 * style tag, so neutralize that sequence (case-insensitively) by escaping its
+	 * forward slash. Inside CSS strings and url() tokens `\/` is a valid escape
+	 * for `/`, so legitimate CSS keeps its meaning.
+	 *
+	 * @param string $css CSS to sanitize.
+	 * @return string CSS that is safe to print inside a <style> element.
+	 */
+	public static function sanitize_css( $css ) {
+		return str_ireplace( '</style', '<\/style', $css );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/class-display-critical-css.php
+++ b/projects/plugins/boost/app/lib/critical-css/class-display-critical-css.php
@@ -108,26 +108,37 @@ class Display_Critical_CSS {
 
 		// Ensure the CSS cannot terminate the style element early.
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo self::sanitize_css( $critical_css );
+		echo self::neutralize_style_closing_tags( $critical_css );
 
 		echo '</style>';
 	}
 
 	/**
-	 * Sanitize CSS for output inside a <style> element.
+	 * Neutralize any closing </style tag so CSS can be printed inside a <style>
+	 * element without breaking out of it.
 	 *
-	 * Avoids wp_strip_all_tags(), which corrupts valid CSS values that contain
-	 * markup - e.g. `background-image: url("data:image/svg+xml,<svg ...></svg>")`.
+	 * This is NOT a general-purpose CSS sanitizer: it does exactly one thing,
+	 * which is to stop the CSS from terminating the surrounding <style> element.
+	 * It deliberately avoids wp_strip_all_tags(), which corrupts valid CSS values
+	 * that contain markup - e.g. `background-image: url("data:image/svg+xml,<svg ...></svg>")`.
 	 *
-	 * The only sequence which can terminate a <style> element early is a closing
-	 * style tag, so neutralize that sequence (case-insensitively) by escaping its
-	 * forward slash. Inside CSS strings and url() tokens `\/` is a valid escape
-	 * for `/`, so legitimate CSS keeps its meaning.
+	 * Per the HTML rawtext tokenizer, a <style> element can only be terminated by
+	 * the literal sequence `</style` (case-insensitive). Escaping its forward slash
+	 * to `<\/style` defeats the tokenizer - `</` must be immediately followed by the
+	 * tag name, and `<\` is treated as literal text - so the markup stays inert. The
+	 * replacement string contains no `</style` substring, so a single left-to-right
+	 * pass cannot reconstruct the sequence (including from nested input like
+	 * `<</style/style`), and the transform is idempotent.
 	 *
-	 * @param string $css CSS to sanitize.
-	 * @return string CSS that is safe to print inside a <style> element.
+	 * Inside CSS strings and url() tokens `\/` is a valid escape for `/`, so
+	 * legitimate quoted values keep their meaning. (A literal `</style` outside a
+	 * quoted string does not occur in well-formed CSS; the security guarantee takes
+	 * priority there regardless.)
+	 *
+	 * @param string $css CSS to neutralize.
+	 * @return string CSS that cannot terminate the surrounding <style> element.
 	 */
-	public static function sanitize_css( $css ) {
+	public static function neutralize_style_closing_tags( $css ) {
 		return str_ireplace( '</style', '<\/style', $css );
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -69,8 +69,10 @@ class CSS_Proxy {
 	 * @param string $css CSS body to serve.
 	 */
 	protected function serve_proxied_css( $css ) {
-		header( 'Content-type: text/css' );
-		header( 'X-Content-Type-Options: nosniff' );
+		if ( ! headers_sent() ) {
+			header( 'Content-type: text/css' );
+			header( 'X-Content-Type-Options: nosniff' );
+		}
 
 		/*
 		 * Outputting proxied CSS contents unescaped. Do not strip tags here;

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -67,7 +67,15 @@ class CSS_Proxy {
 			// Critical CSS generator.
 			$css = $response;
 		} elseif ( false === $response ) {
-			$response     = wp_safe_remote_get( $proxy_url );
+			$response = wp_safe_remote_get( $proxy_url );
+
+			// Check for transport errors before inspecting the response, so a
+			// network failure is not misreported (and cached) as a bad content type.
+			if ( is_wp_error( $response ) ) {
+				// TODO: Nicer error handling.
+				die( 'error' );
+			}
+
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( strpos( $content_type, 'text/css' ) === false ) {
 				set_transient( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), HOUR_IN_SECONDS );
@@ -81,11 +89,6 @@ class CSS_Proxy {
 			if ( '' !== $css ) {
 				set_transient( $cache_key, $css, HOUR_IN_SECONDS );
 			}
-		}
-
-		if ( is_wp_error( $response ) ) {
-			// TODO: Nicer error handling.
-			die( 'error' );
 		}
 
 		if ( $css ) {

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
 
 /**
  * Add an ajax endpoint to proxy external CSS files.
@@ -77,9 +78,12 @@ class CSS_Proxy {
 
 		if ( $css ) {
 			header( 'Content-type: text/css' );
-			// Outputting proxied CSS contents unescaped.
+			header( 'X-Content-Type-Options: nosniff' );
+			// Outputting proxied CSS contents unescaped. Do not strip tags here;
+			// valid CSS values may contain markup (e.g. inline SVGs in data: URIs),
+			// and stripping them corrupts the CSS fed to the generator.
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo wp_strip_all_tags( $css );
+			echo Display_Critical_CSS::sanitize_css( $css );
 			die( 0 );
 		}
 	}

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -81,7 +81,7 @@ class CSS_Proxy {
 	 * @param string $proxy_url Validated external CSS URL.
 	 * @return string The CSS body, or '' when there is none to serve.
 	 */
-	private function get_proxied_css( $proxy_url ) {
+	protected function get_proxied_css( $proxy_url ) {
 		$cache_key = 'jb_css_proxy_' . md5( $proxy_url );
 		$response  = get_transient( $cache_key );
 

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -52,44 +52,7 @@ class CSS_Proxy {
 			wp_die( 'Invalid CSS file URL', 400 );
 		}
 
-		$cache_key = 'jb_css_proxy_' . md5( $proxy_url );
-		$response  = get_transient( $cache_key );
-
-		if ( is_array( $response ) && isset( $response['error'] ) ) {
-			wp_die( esc_html( $response['error'] ), 400 );
-		}
-
-		$css = '';
-		if ( is_string( $response ) ) {
-			// Cache hit: the transient stores the CSS body from a previous
-			// successful fetch. Without this branch a cached body was ignored
-			// ($css stayed empty), so the handler returned no CSS to the
-			// Critical CSS generator.
-			$css = $response;
-		} elseif ( false === $response ) {
-			$response = wp_safe_remote_get( $proxy_url );
-
-			// Check for transport errors before inspecting the response, so a
-			// network failure is not misreported (and cached) as a bad content type.
-			if ( is_wp_error( $response ) ) {
-				// TODO: Nicer error handling.
-				die( 'error' );
-			}
-
-			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-			if ( strpos( $content_type, 'text/css' ) === false ) {
-				set_transient( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), HOUR_IN_SECONDS );
-				wp_die( 'Invalid content type. Expected CSS.', 400 );
-			}
-			$css = wp_remote_retrieve_body( $response );
-
-			// Only cache a non-empty body. Caching an empty string would make
-			// is_string() cache hits replay it for the full TTL, pinning empty
-			// CSS for an hour after a single transient empty/failed fetch.
-			if ( '' !== $css ) {
-				set_transient( $cache_key, $css, HOUR_IN_SECONDS );
-			}
-		}
+		$css = $this->get_proxied_css( $proxy_url );
 
 		if ( $css ) {
 			header( 'Content-type: text/css' );
@@ -107,5 +70,62 @@ class CSS_Proxy {
 			echo Display_Critical_CSS::neutralize_style_closing_tags( $css );
 			die( 0 );
 		}
+	}
+
+	/**
+	 * Resolve the CSS for a proxied URL from cache, or by fetching and caching it.
+	 *
+	 * Separated from handle_css_proxy() so the cache/fetch logic is unit-testable
+	 * without the surrounding request teardown (die()).
+	 *
+	 * @param string $proxy_url Validated external CSS URL.
+	 * @return string The CSS body, or '' when there is none to serve.
+	 */
+	private function get_proxied_css( $proxy_url ) {
+		$cache_key = 'jb_css_proxy_' . md5( $proxy_url );
+		$response  = get_transient( $cache_key );
+
+		if ( is_array( $response ) && isset( $response['error'] ) ) {
+			wp_die( esc_html( $response['error'] ), 400 );
+		}
+
+		if ( is_string( $response ) ) {
+			// Cache hit: the transient stores the CSS body from a previous
+			// successful fetch. Without this branch a cached body was ignored
+			// (the handler saw no CSS), so it returned nothing to the Critical
+			// CSS generator.
+			return $response;
+		}
+
+		// Anything other than a missing entry (false) has been handled above.
+		if ( false !== $response ) {
+			return '';
+		}
+
+		$response = wp_safe_remote_get( $proxy_url );
+
+		// Check for transport errors before inspecting the response, so a
+		// network failure is not misreported (and cached) as a bad content type.
+		if ( is_wp_error( $response ) ) {
+			// TODO: Nicer error handling.
+			die( 'error' );
+		}
+
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( strpos( $content_type, 'text/css' ) === false ) {
+			set_transient( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), HOUR_IN_SECONDS );
+			wp_die( 'Invalid content type. Expected CSS.', 400 );
+		}
+
+		$css = wp_remote_retrieve_body( $response );
+
+		// Only cache a non-empty body. Caching an empty string would make
+		// is_string() cache hits replay it for the full TTL, pinning empty
+		// CSS for an hour after a single transient empty/failed fetch.
+		if ( '' !== $css ) {
+			set_transient( $cache_key, $css, HOUR_IN_SECONDS );
+		}
+
+		return $css;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -55,21 +55,33 @@ class CSS_Proxy {
 		$css = $this->get_proxied_css( $proxy_url );
 
 		if ( $css ) {
-			header( 'Content-type: text/css' );
-			header( 'X-Content-Type-Options: nosniff' );
-
-			/*
-			 * Outputting proxied CSS contents unescaped. Do not strip tags here;
-			 * valid CSS values may contain markup (e.g. inline SVGs in data: URIs),
-			 * and stripping them corrupts the CSS fed to the generator. The
-			 * text/css + nosniff headers stop a browser from sniffing this body as
-			 * HTML; neutralizing </style is defense-in-depth in case the body is
-			 * ever embedded inside a <style> element downstream.
-			 */
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo Display_Critical_CSS::neutralize_style_closing_tags( $css );
+			$this->serve_proxied_css( $css );
 			die( 0 );
 		}
+	}
+
+	/**
+	 * Output the proxied CSS body with the appropriate headers.
+	 *
+	 * Separated from handle_css_proxy() so the output (and its </style
+	 * neutralization) is testable without the request teardown (die()).
+	 *
+	 * @param string $css CSS body to serve.
+	 */
+	protected function serve_proxied_css( $css ) {
+		header( 'Content-type: text/css' );
+		header( 'X-Content-Type-Options: nosniff' );
+
+		/*
+		 * Outputting proxied CSS contents unescaped. Do not strip tags here;
+		 * valid CSS values may contain markup (e.g. inline SVGs in data: URIs),
+		 * and stripping them corrupts the CSS fed to the generator. The
+		 * text/css + nosniff headers stop a browser from sniffing this body as
+		 * HTML; neutralizing </style is defense-in-depth in case the body is
+		 * ever embedded inside a <style> element downstream.
+		 */
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo Display_Critical_CSS::neutralize_style_closing_tags( $css );
 	}
 
 	/**
@@ -104,11 +116,19 @@ class CSS_Proxy {
 
 		$response = wp_safe_remote_get( $proxy_url );
 
-		// Check for transport errors before inspecting the response, so a
-		// network failure is not misreported (and cached) as a bad content type.
+		// A transport failure must fail loudly with a 5xx. Falling through would
+		// either mis-cache it as a bad content type or (via die()) emit an HTTP
+		// 200 the Critical CSS generator would happily consume as a stylesheet,
+		// silently corrupting that provider's Critical CSS.
 		if ( is_wp_error( $response ) ) {
-			// TODO: Nicer error handling.
-			die( 'error' );
+			wp_die( '', 502 );
+		}
+
+		// Likewise, only a 2xx response is usable: an upstream 404/500 served with
+		// a text/css content type must not be cached and served as valid CSS.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			wp_die( '', 502 );
 		}
 
 		$content_type = wp_remote_retrieve_header( $response, 'content-type' );

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -60,7 +60,12 @@ class CSS_Proxy {
 		}
 
 		$css = '';
-		if ( false === $response ) {
+		if ( is_string( $response ) ) {
+			// Cache hit: the transient stores the CSS body from a previous
+			// successful fetch. Without this, cache hits served an empty
+			// response, feeding the Critical CSS generator no CSS at all.
+			$css = $response;
+		} elseif ( false === $response ) {
 			$response     = wp_safe_remote_get( $proxy_url );
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( strpos( $content_type, 'text/css' ) === false ) {

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -62,8 +62,9 @@ class CSS_Proxy {
 		$css = '';
 		if ( is_string( $response ) ) {
 			// Cache hit: the transient stores the CSS body from a previous
-			// successful fetch. Without this, cache hits served an empty
-			// response, feeding the Critical CSS generator no CSS at all.
+			// successful fetch. Without this branch a cached body was ignored
+			// ($css stayed empty), so the handler returned no CSS to the
+			// Critical CSS generator.
 			$css = $response;
 		} elseif ( false === $response ) {
 			$response     = wp_safe_remote_get( $proxy_url );
@@ -73,7 +74,13 @@ class CSS_Proxy {
 				wp_die( 'Invalid content type. Expected CSS.', 400 );
 			}
 			$css = wp_remote_retrieve_body( $response );
-			set_transient( $cache_key, $css, HOUR_IN_SECONDS );
+
+			// Only cache a non-empty body. Caching an empty string would make
+			// is_string() cache hits replay it for the full TTL, pinning empty
+			// CSS for an hour after a single transient empty/failed fetch.
+			if ( '' !== $css ) {
+				set_transient( $cache_key, $css, HOUR_IN_SECONDS );
+			}
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -84,11 +91,17 @@ class CSS_Proxy {
 		if ( $css ) {
 			header( 'Content-type: text/css' );
 			header( 'X-Content-Type-Options: nosniff' );
-			// Outputting proxied CSS contents unescaped. Do not strip tags here;
-			// valid CSS values may contain markup (e.g. inline SVGs in data: URIs),
-			// and stripping them corrupts the CSS fed to the generator.
+
+			/*
+			 * Outputting proxied CSS contents unescaped. Do not strip tags here;
+			 * valid CSS values may contain markup (e.g. inline SVGs in data: URIs),
+			 * and stripping them corrupts the CSS fed to the generator. The
+			 * text/css + nosniff headers stop a browser from sniffing this body as
+			 * HTML; neutralizing </style is defense-in-depth in case the body is
+			 * ever embedded inside a <style> element downstream.
+			 */
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo Display_Critical_CSS::sanitize_css( $css );
+			echo Display_Critical_CSS::neutralize_style_closing_tags( $css );
 			die( 0 );
 		}
 	}

--- a/projects/plugins/boost/changelog/fix-critical-css-svg-stripping
+++ b/projects/plugins/boost/changelog/fix-critical-css-svg-stripping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: stop stripping inline SVG markup and double quotes from valid CSS values while still preventing style-tag breakout.

--- a/projects/plugins/boost/phpunit.11.xml.dist
+++ b/projects/plugins/boost/phpunit.11.xml.dist
@@ -22,6 +22,7 @@
 		<testsuite name="unit">
 			<directory suffix="Test.php">tests/php</directory>
 			<exclude>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</exclude>
+			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -30,6 +31,7 @@
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
+			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/abilities/Boost_Abilities_Test.php</file>

--- a/projects/plugins/boost/phpunit.11.xml.dist
+++ b/projects/plugins/boost/phpunit.11.xml.dist
@@ -23,6 +23,7 @@
 			<directory suffix="Test.php">tests/php</directory>
 			<exclude>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</exclude>
 			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
+			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -32,6 +33,7 @@
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
+			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/abilities/Boost_Abilities_Test.php</file>

--- a/projects/plugins/boost/phpunit.9.xml.dist
+++ b/projects/plugins/boost/phpunit.9.xml.dist
@@ -14,6 +14,7 @@
 			<directory suffix="Test.php">tests/php</directory>
 			<exclude>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</exclude>
 			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
+			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -23,6 +24,7 @@
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
+			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/abilities/Boost_Abilities_Test.php</file>

--- a/projects/plugins/boost/phpunit.9.xml.dist
+++ b/projects/plugins/boost/phpunit.9.xml.dist
@@ -13,6 +13,7 @@
 		<testsuite name="unit">
 			<directory suffix="Test.php">tests/php</directory>
 			<exclude>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</exclude>
+			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -21,6 +22,7 @@
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
+			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/abilities/Boost_Abilities_Test.php</file>

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -56,8 +56,14 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 			return $posts;
 		}
 
+		// Mirror get_post_by_name(), which restricts to published posts. Other
+		// WP_Query semantics are intentionally not emulated here.
+		$post_status = $query->get( 'post_status' );
+
 		foreach ( \WorDBless\Posts::init()->posts as $id => $post ) {
-			if ( $post->post_name === $name && $post->post_type === $post_type ) {
+			if ( $post->post_name === $name
+				&& $post->post_type === $post_type
+				&& ( ! $post_status || $post->post_status === $post_status ) ) {
 				return array( get_post( $id ) );
 			}
 		}

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Tests for Critical_CSS_Storage class.
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Critical_CSS;
+
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Critical_CSS_Storage_Test
+ *
+ * Verifies that generated Critical CSS survives a save/load round-trip intact,
+ * including double quotes and inline SVG markup in CSS values.
+ *
+ * @see https://github.com/Automattic/jetpack/issues/42321
+ */
+class Critical_CSS_Storage_Test extends BaseTestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * WorDBless does not implement the SQL used by WP_Query post_name lookups,
+	 * so emulate them from the WorDBless in-memory post store.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10, 2 );
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		remove_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10 );
+		\WorDBless\Posts::init()->clear_all_posts();
+		parent::tear_down();
+	}
+
+	/**
+	 * Emulate WP_Query post_name lookups against the WorDBless post store.
+	 *
+	 * @param \WP_Post[]|null $posts Posts with which to short-circuit the query, or null.
+	 * @param \WP_Query       $query The running query.
+	 * @return \WP_Post[]|null
+	 */
+	public function emulate_name_query( $posts, $query ) {
+		$name      = $query->get( 'name' );
+		$post_type = $query->get( 'post_type' );
+
+		if ( ! $name || ! $post_type ) {
+			return $posts;
+		}
+
+		foreach ( \WorDBless\Posts::init()->posts as $id => $post ) {
+			if ( $post->post_name === $name && $post->post_type === $post_type ) {
+				return array( get_post( $id ) );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Test that double quotes and inline SVG markup in CSS values survive a
+	 * save/load round-trip.
+	 */
+	public function test_store_css_round_trip_preserves_double_quotes_and_svg() {
+		$css = '.test-svg-background { background-image: url("data:image/svg+xml,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 8 8\'><circle cx=\'4\' cy=\'4\' r=\'4\' fill=\'%23f00\'/></svg>"); }';
+
+		$storage = new Critical_CSS_Storage();
+		$storage->store_css( 'core_front_page', $css );
+
+		$result = $storage->get_css( array( 'core_front_page' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'core_front_page', $result['key'] );
+		$this->assertSame( $css, $result['css'] );
+	}
+
+	/**
+	 * Test that updating an existing entry does not corrupt double quotes.
+	 */
+	public function test_store_css_update_preserves_double_quotes() {
+		$storage = new Critical_CSS_Storage();
+		$storage->store_css( 'core_posts_page', '.a { content: "first"; }' );
+
+		$css = '.quote::before { content: "\201C"; font-family: "Times New Roman", serif; }';
+		$storage->store_css( 'core_posts_page', $css );
+
+		$result = $storage->get_css( array( 'core_posts_page' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $css, $result['css'] );
+	}
+}

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -49,6 +49,11 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	 * @return \WP_Post[]|null
 	 */
 	public function emulate_name_query( $posts, $query ) {
+		// Respect any earlier filter that already short-circuited the query.
+		if ( null !== $posts ) {
+			return $posts;
+		}
+
 		$name      = $query->get( 'name' );
 		$post_type = $query->get( 'post_type' );
 

--- a/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
@@ -133,7 +133,7 @@ class Display_Critical_CSS_Test extends BaseTestCase {
 	 *
 	 * @return array<string, array{0: string}>
 	 */
-	public function provide_style_breakout_inputs() {
+	public static function provide_style_breakout_inputs() {
 		return array(
 			'simple closing tag'            => array( '</style>' ),
 			'closing tag at EOF no bracket' => array( 'a{}</style' ),

--- a/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack_Boost\Tests\Lib\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 // phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
@@ -100,6 +101,52 @@ class Display_Critical_CSS_Test extends BaseTestCase {
 
 		$this->assertSame( 1, substr_count( strtolower( $output ), '</style' ) );
 		$this->assertStringEndsWith( '</style>', $output );
+		// The slash must actually be escaped (not merely stripped). str_ireplace
+		// matches case-insensitively but substitutes the literal lowercase
+		// replacement, so the matched run is normalized to `<\/style`; the trailing
+		// payload is left untouched and stays inert text.
+		$this->assertStringContainsString( '<\/style ><p>injected</p>', $output );
+	}
+
+	/**
+	 * Test neutralize_style_closing_tags() locks in the security-critical invariant:
+	 * no input can leave a `</style` sequence in the output. This is the shared
+	 * sanitizer used by both the inline <style> block and the CSS proxy, so it is
+	 * exercised directly here against adversarial and boundary inputs. A single
+	 * left-to-right pass over `</style` cannot reconstruct the sequence from its own
+	 * `<\/style` output, including from nested/overlapping inputs.
+	 *
+	 * @dataProvider provide_style_breakout_inputs
+	 *
+	 * @param string $input Raw CSS input containing one or more `</style` runs.
+	 */
+	#[DataProvider( 'provide_style_breakout_inputs' )]
+	public function test_neutralize_style_closing_tags_blocks_reconstruction( $input ) {
+		$output = Display_Critical_CSS::neutralize_style_closing_tags( $input );
+
+		$this->assertSame( 0, substr_count( strtolower( $output ), '</style' ) );
+	}
+
+	/**
+	 * Adversarial and boundary inputs for the breakout sanitizer. Each contains at
+	 * least one `</style` substring; none may survive in the output.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function provide_style_breakout_inputs() {
+		return array(
+			'simple closing tag'            => array( '</style>' ),
+			'closing tag at EOF no bracket' => array( 'a{}</style' ),
+			'closing tag with whitespace'   => array( '</style >' ),
+			'closing tag with tab'          => array( "</style\t>" ),
+			'closing tag with newline'      => array( "</style\n>" ),
+			'closing tag with slash'        => array( '</style/' ),
+			'mixed case'                    => array( '</StYlE>' ),
+			'nested overlap interleave'     => array( '<</style/style>' ),
+			'nested split'                  => array( '</sty</style>le>' ),
+			'adjacent doubles'              => array( '</style></style>' ),
+			'substring in longer word'      => array( '.x{}</styles-thing' ),
+		);
 	}
 
 	/**

--- a/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Display_Critical_CSS_Test.php
@@ -70,19 +70,66 @@ class Display_Critical_CSS_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test display_critical_css() strips HTML tags.
+	 * Test display_critical_css() neutralizes closing style tags, so the CSS
+	 * cannot terminate the style element early and break out into HTML context.
 	 */
-	public function test_display_critical_css_strips_html() {
-		$css_with_html = 'body { color: red; }</style><script>alert("xss")</script>';
-		$instance      = new Display_Critical_CSS( $css_with_html );
+	public function test_display_critical_css_neutralizes_style_breakout() {
+		$css_with_breakout = 'body { color: red; }</style><script>alert("xss")</script>';
+		$instance          = new Display_Critical_CSS( $css_with_breakout );
 
 		ob_start();
 		$instance->display_critical_css();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( '<script>', $output );
-		$this->assertStringNotContainsString( 'alert', $output );
-		$this->assertSame( 1, substr_count( $output, '</style>' ) );
+		// The only `</style` sequence left must be the real closing tag, so the
+		// injected markup stays inert inside the style element's raw text.
+		$this->assertSame( 1, substr_count( strtolower( $output ), '</style' ) );
+		$this->assertStringEndsWith( '</style>', $output );
+		$this->assertStringContainsString( '<\/style><script>', $output );
+	}
+
+	/**
+	 * Test display_critical_css() neutralizes closing style tags regardless of case.
+	 */
+	public function test_display_critical_css_neutralizes_style_breakout_case_insensitively() {
+		$instance = new Display_Critical_CSS( 'body { color: red; }</StYlE ><p>injected</p>' );
+
+		ob_start();
+		$instance->display_critical_css();
+		$output = ob_get_clean();
+
+		$this->assertSame( 1, substr_count( strtolower( $output ), '</style' ) );
+		$this->assertStringEndsWith( '</style>', $output );
+	}
+
+	/**
+	 * Test display_critical_css() preserves inline SVGs in CSS values.
+	 *
+	 * @see https://github.com/Automattic/jetpack/issues/42321
+	 */
+	public function test_display_critical_css_preserves_inline_svg_data_uri() {
+		$css      = '.hero { background-image: url("data:image/svg+xml,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 8 8\'><circle cx=\'4\' cy=\'4\' r=\'4\' fill=\'%23f00\'/></svg>"); }';
+		$instance = new Display_Critical_CSS( $css );
+
+		ob_start();
+		$instance->display_critical_css();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $css, $output );
+	}
+
+	/**
+	 * Test display_critical_css() preserves double quotes in CSS values.
+	 */
+	public function test_display_critical_css_preserves_double_quotes() {
+		$css      = '.quote::before { content: "\201C"; font-family: "Times New Roman", serif; }';
+		$instance = new Display_Critical_CSS( $css );
+
+		ob_start();
+		$instance->display_critical_css();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $css, $output );
 	}
 
 	/**

--- a/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
@@ -34,9 +34,15 @@ class CSS_Proxy_Test extends BaseTestCase {
 	 */
 	private function make_wp_die_throw() {
 		$handler = function () {
-			return function ( $message ) {
+			/**
+			 * @param string|\WP_Error $message Message passed to wp_die().
+			 * @return never
+			 */
+			$thrower = function ( $message ) {
 				throw new \RuntimeException( is_string( $message ) ? $message : 'wp_die' );
 			};
+
+			return $thrower;
 		};
 		add_filter( 'wp_die_handler', $handler );
 		add_filter( 'wp_die_ajax_handler', $handler );
@@ -66,20 +72,21 @@ class CSS_Proxy_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Mock the next HTTP request with the given content type and body.
+	 * Mock the next HTTP request with the given content type, body and status.
 	 *
 	 * @param string $content_type Response content-type header.
 	 * @param string $body         Response body.
+	 * @param int    $status_code  Response HTTP status code.
 	 */
-	private function mock_http_response( $content_type, $body ) {
+	private function mock_http_response( $content_type, $body, $status_code = 200 ) {
 		add_filter(
 			'pre_http_request',
-			function () use ( $content_type, $body ) {
+			function () use ( $content_type, $body, $status_code ) {
 				return array(
 					'headers'  => array( 'content-type' => $content_type ),
 					'body'     => $body,
 					'response' => array(
-						'code'    => 200,
+						'code'    => $status_code,
 						'message' => 'OK',
 					),
 				);
@@ -144,5 +151,72 @@ class CSS_Proxy_Test extends BaseTestCase {
 		$cached = get_transient( 'jb_css_proxy_' . md5( $url ) );
 		$this->assertIsArray( $cached );
 		$this->assertArrayHasKey( 'error', $cached );
+	}
+
+	/**
+	 * A transport failure exits with a 5xx (never a 200 the generator would
+	 * consume as a stylesheet) and is not cached.
+	 */
+	public function test_transport_error_fails_loudly_and_is_not_cached() {
+		$url = 'https://example.com/down.css';
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new \WP_Error( 'http_request_failed', 'Connection refused' );
+			}
+		);
+		$this->make_wp_die_throw();
+
+		try {
+			$this->resolve( $url );
+			$this->fail( 'Expected wp_die() for a transport failure.' );
+		} catch ( \RuntimeException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		$this->assertFalse( get_transient( 'jb_css_proxy_' . md5( $url ) ) );
+	}
+
+	/**
+	 * A non-2xx response served as text/css is rejected and not cached, so a
+	 * 404/500 body is never treated as valid CSS.
+	 */
+	public function test_non_2xx_response_is_rejected_and_not_cached() {
+		$url = 'https://example.com/missing.css';
+		$this->mock_http_response( 'text/css', '.a { color: red; }', 404 );
+		$this->make_wp_die_throw();
+
+		try {
+			$this->resolve( $url );
+			$this->fail( 'Expected wp_die() for a non-2xx response.' );
+		} catch ( \RuntimeException $e ) {
+			$this->addToAssertionCount( 1 );
+		}
+
+		$this->assertFalse( get_transient( 'jb_css_proxy_' . md5( $url ) ) );
+	}
+
+	/**
+	 * The served output neutralizes a </style sequence in the proxied body, so a
+	 * proxied stylesheet cannot break out of a downstream <style> element.
+	 */
+	public function test_serve_proxied_css_neutralizes_style_breakout() {
+		$proxy = new class() extends CSS_Proxy {
+			/**
+			 * Expose the protected output method for testing.
+			 *
+			 * @param string $css CSS body to serve.
+			 */
+			public function serve( $css ) {
+				$this->serve_proxied_css( $css );
+			}
+		};
+
+		ob_start();
+		$proxy->serve( 'body { color: red; }</style><script>alert(1)</script>' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '</style', $output );
+		$this->assertStringContainsString( '<\/style><script>', $output );
 	}
 }

--- a/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
@@ -43,16 +43,26 @@ class CSS_Proxy_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Invoke the private CSS_Proxy::get_proxied_css() resolver.
+	 * Invoke the protected CSS_Proxy::get_proxied_css() resolver via a subclass
+	 * (avoids ReflectionMethod::setAccessible(), deprecated as of PHP 8.5).
 	 *
 	 * @param string $proxy_url URL to resolve.
 	 * @return string
 	 */
 	private function resolve( $proxy_url ) {
-		$method = new \ReflectionMethod( CSS_Proxy::class, 'get_proxied_css' );
-		$method->setAccessible( true );
+		$proxy = new class() extends CSS_Proxy {
+			/**
+			 * Expose the protected resolver for testing.
+			 *
+			 * @param string $url URL to resolve.
+			 * @return string
+			 */
+			public function resolve_proxied_css( $url ) {
+				return $this->get_proxied_css( $url );
+			}
+		};
 
-		return $method->invoke( new CSS_Proxy(), $proxy_url );
+		return $proxy->resolve_proxied_css( $proxy_url );
 	}
 
 	/**

--- a/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Tests for CSS_Proxy class.
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Critical_CSS;
+
+use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\CSS_Proxy;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class CSS_Proxy_Test
+ *
+ * Covers the cache/fetch resolution used by the boost_proxy_css endpoint:
+ * cache hits replay the stored body, cache misses fetch + cache it, empty
+ * bodies are not cached, and a non-CSS response is rejected.
+ */
+class CSS_Proxy_Test extends BaseTestCase {
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'wp_die_handler' );
+		remove_all_filters( 'wp_die_ajax_handler' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Make wp_die() throw instead of terminating, regardless of request context.
+	 */
+	private function make_wp_die_throw() {
+		$handler = function () {
+			return function ( $message ) {
+				throw new \RuntimeException( is_string( $message ) ? $message : 'wp_die' );
+			};
+		};
+		add_filter( 'wp_die_handler', $handler );
+		add_filter( 'wp_die_ajax_handler', $handler );
+	}
+
+	/**
+	 * Invoke the private CSS_Proxy::get_proxied_css() resolver.
+	 *
+	 * @param string $proxy_url URL to resolve.
+	 * @return string
+	 */
+	private function resolve( $proxy_url ) {
+		$method = new \ReflectionMethod( CSS_Proxy::class, 'get_proxied_css' );
+		$method->setAccessible( true );
+
+		return $method->invoke( new CSS_Proxy(), $proxy_url );
+	}
+
+	/**
+	 * Mock the next HTTP request with the given content type and body.
+	 *
+	 * @param string $content_type Response content-type header.
+	 * @param string $body         Response body.
+	 */
+	private function mock_http_response( $content_type, $body ) {
+		add_filter(
+			'pre_http_request',
+			function () use ( $content_type, $body ) {
+				return array(
+					'headers'  => array( 'content-type' => $content_type ),
+					'body'     => $body,
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+				);
+			}
+		);
+	}
+
+	/**
+	 * A cached string body is replayed verbatim on a cache hit.
+	 */
+	public function test_returns_cached_css_body_on_cache_hit() {
+		$url = 'https://example.com/cached.css';
+		$css = '.cached { color: red; }';
+		set_transient( 'jb_css_proxy_' . md5( $url ), $css, HOUR_IN_SECONDS );
+
+		$this->assertSame( $css, $this->resolve( $url ) );
+	}
+
+	/**
+	 * A cache miss fetches the body and caches it for subsequent hits.
+	 */
+	public function test_fetches_and_caches_body_on_cache_miss() {
+		$url = 'https://example.com/fresh.css';
+		$css = '.fresh { background: url("data:image/svg+xml,<svg></svg>"); }';
+		$this->mock_http_response( 'text/css', $css );
+
+		$result = $this->resolve( $url );
+
+		$this->assertSame( $css, $result );
+		$this->assertSame( $css, get_transient( 'jb_css_proxy_' . md5( $url ) ) );
+	}
+
+	/**
+	 * An empty (but successful) body is returned but never cached, so a single
+	 * empty fetch is not replayed for the full TTL.
+	 */
+	public function test_empty_body_is_not_cached() {
+		$url = 'https://example.com/empty.css';
+		$this->mock_http_response( 'text/css', '' );
+
+		$result = $this->resolve( $url );
+
+		$this->assertSame( '', $result );
+		$this->assertFalse( get_transient( 'jb_css_proxy_' . md5( $url ) ) );
+	}
+
+	/**
+	 * A non-CSS response is rejected (and the error cached) via wp_die().
+	 */
+	public function test_non_css_response_is_rejected_and_error_cached() {
+		$url = 'https://example.com/notcss.css';
+		$this->mock_http_response( 'text/html', '<html></html>' );
+		$this->make_wp_die_throw();
+
+		try {
+			$this->resolve( $url );
+			$this->fail( 'Expected wp_die() for a non-CSS response.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertStringContainsString( 'Invalid content type', $e->getMessage() );
+		}
+
+		$cached = get_transient( 'jb_css_proxy_' . md5( $url ) );
+		$this->assertIsArray( $cached );
+		$this->assertArrayHasKey( 'error', $cached );
+	}
+}


### PR DESCRIPTION
Fixes #42321

Supersedes #43050 — an earlier, already-closed attempt at the same issue that took a heavier approach (added the `enshrined/svg-sanitize` dependency plus a `wp_kses` SVG allowlist, and a `wp_unslash()` in storage). This PR fixes the same bug more simply with no new dependency, also covers the CSS proxy path, and adds regression tests. (#43050 is already closed, so nothing new auto-closes; this is for traceability.)

## Proposed changes

* Stop running `wp_strip_all_tags()` on Critical CSS when printing it into the front-end `<style id="jetpack-boost-critical-css">` block; it corrupted valid CSS values containing markup, e.g. `background-image: url("data:image/svg+xml,<svg ...></svg>")`.
* Replace it with a targeted sanitizer (`Display_Critical_CSS::sanitize_css()`) that neutralizes only the sequence that can terminate a `<style>` element early: any case-insensitive `</style` becomes `<\/style` (`\/` is a valid CSS escape for `/` inside strings/`url()` tokens, so legitimate CSS keeps its meaning). The insertion-only rewrite cannot recreate `</style`, including via nested tricks like `<</style/style` — covered by tests. Style-tag breakout/XSS remains impossible.
* Apply the same treatment in the Critical CSS proxy (`boost_proxy_css` admin-ajax endpoint), which previously stripped SVG markup out of external *source* stylesheets before the generator ever saw them — meaning corrupted CSS was generated and persisted even before display-time stripping. Also adds `X-Content-Type-Options: nosniff` to the proxy response.
* Finding on the issue's second hypothesis (double quotes stripped on DB save): the storage/ingestion path (`Critical_CSS_Storage` / `Storage_Post_Type` / `Set_Provider_CSS` / Cloud CSS endpoint) contains **no quote-stripping** — CSS is base64-encoded before `wp_insert_post`, so quotes already survive persistence. Rather than changing code that wasn't broken, new round-trip regression tests lock that behavior in.
* Adds PHPUnit coverage: SVG data-URIs and double quotes survive display output; `</style>` injection (any case) is still neutralized; quotes and SVG markup survive a store/load round-trip.

> **Note for reviewers:** this intentionally changes security-relevant sanitization (blanket tag-stripping → targeted `</style` neutralization). Please give the escaping approach in `sanitize_css()` a close look.

## Related product discussion/links

* Part of a Boost P0 reliability pass (audit follow-up); sibling PRs: #49545 (Defer JS `document.write`) and #49546 (Page Cache uninstall cleanup).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Add this to your theme's stylesheet, plus a matching `<div class="test-svg-background"></div>` near the top of the header template so it's above the fold:
   ```css
   .test-svg-background {
       width: 200px;
       height: 200px;
       background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><circle cx='4' cy='4' r='4' fill='%23f00'/></svg>");
   }
   ```
2. In Jetpack Boost, enable **Optimize Critical CSS Loading** and generate Critical CSS.
3. View the front-end source and inspect `<style id="jetpack-boost-critical-css">`:
   * **Before:** the rule appears as `url("data:image/svg+xml,")` (SVG stripped) and the red circle is missing.
   * **After:** the full SVG data-URI, including its quotes, is intact and the red circle renders before stylesheets load (throttle the network to confirm).
4. Security check: store CSS containing `</style><script>alert(1)</script>` (via the same flow, or by editing the stored provider CSS) and confirm the printed block contains `<\/style>` instead, the style element is not terminated early, and no script executes.
5. Tests: `cd projects/plugins/boost && vendor/bin/phpunit-select-config phpunit.#.xml.dist --bootstrap tests/bootstrap.php --testsuite with-wordpress --filter "Display_Critical_CSS_Test|Critical_CSS_Storage_Test"` (16 tests, 48 assertions passing; `unit` suite also green at 114 tests. The `with-wordpress` suite has 2 pre-existing `Jetpack_Boost_Test` errors reproducible on clean trunk in this environment, unrelated to this change).

https://claude.ai/code/session_01PgpTrtTCH4hpz6Krh3ssho

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgpTrtTCH4hpz6Krh3ssho)_
