### PR TITLE
Podcast: remove at-pressable-podcasting bridge

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-at-pressable-podcasting-bridge
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-at-pressable-podcasting-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Podcasting: drop the legacy podcasting admin-menu fallback now that the jetpack-podcast package owns the experience unconditionally.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -440,9 +440,7 @@ class Jetpack_Mu_Wpcom {
 		// Initialize the Podcast package here (rather than in
 		// load_wpcom_user_features) so feed-customization hooks register
 		// for anonymous requests too — Apple Podcasts / Spotify crawlers
-		// aren't logged in. Podcast::init() gates itself on host
-		// (Simple/WoA) and `jetpack_podcast_untangle`, so the legacy
-		// podcasting code keeps running until the flag flips.
+		// aren't logged in. Podcast::init() gates itself on host (Simple/WoA).
 		\Automattic\Jetpack\Podcast\Podcast::init();
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -10,7 +10,6 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
-use Automattic\Jetpack\Podcast\Podcast;
 use Automattic\Jetpack\Redirect;
 
 require_once __DIR__ . '/../../common/wpcom-callout.php';
@@ -276,9 +275,9 @@ function wpcom_reorder_submenu( $menu_slug, $desired_order ) {
 	$domain          = wp_parse_url( home_url(), PHP_URL_HOST );
 	$ordered_submenu = array();
 
-	// Re-add submenu items in the desired order. Dedupe because slugs in
-	// $desired_order can be substrings of one another (e.g. 'podcast' /
-	// 'podcasting'), which would otherwise match the same item twice.
+	// Re-add submenu items in the desired order. Dedupe because a slug in
+	// $desired_order can be a substring of another item's URL, which would
+	// otherwise match the same item twice.
 	foreach ( $desired_order as $submenu_slug ) {
 		foreach ( $submenu[ $menu_slug ] as $item ) {
 			$clean_url = str_replace( $domain, '', $item[2] );
@@ -410,18 +409,7 @@ function wpcom_add_jetpack_submenu() {
 		);
 	}
 
-	if ( Podcast::is_enabled() ) {
-		Podcast_Admin_Page::add_wp_admin_submenu();
-	} else {
-		add_submenu_page(
-			'jetpack',
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			'https://wordpress.com/settings/podcasting/' . $domain,
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		);
-	}
+	Podcast_Admin_Page::add_wp_admin_submenu();
 
 	if ( $is_simple_site ) {
 		// Jetpack > Newsletter.
@@ -476,7 +464,6 @@ function wpcom_add_jetpack_submenu() {
 			'subscribers',
 			'newsletter',
 			'podcast',
-			'podcasting',
 			'traffic',
 			'jetpack#/settings',
 		)
@@ -778,7 +765,6 @@ function wpcom_add_settings_menu() {
 			'crowdsignal',
 			'rating',
 			'newsletter',
-			'podcasting',
 		)
 	);
 }

--- a/projects/packages/podcast/AGENTS.md
+++ b/projects/packages/podcast/AGENTS.md
@@ -1,9 +1,9 @@
 # Podcast
 
-The wp-admin Podcast experience for the Jetpack plugin. Currently an
-empty package gated behind the `jetpack_podcast_untangle` filter
-(default off); follow-up PRs in the untangle train layer the SPA, REST
-settings, and RSS feed customization on top of this gate.
+The wp-admin Podcast experience for the Jetpack plugin: the SPA, REST
+settings, and RSS feed customization for podcasting on Simple and Atomic
+sites. The package owns the experience outright now that the legacy stack
+it replaced has been removed.
 
 ## UI primitives
 

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -2,4 +2,4 @@
 
 Hosts the wp-admin Podcast experience for the Jetpack plugin (Simple and Atomic only).
 
-The package owns the wp-admin SPA, REST integration, and feed customization, and is gated behind the `jetpack_podcast_untangle` filter (default on). The filter remains an escape hatch for forcing the legacy stack back on: filtering it off falls back to the legacy `Automattic_Podcasting` code in the wpcom mu-plugin on Simple sites. (The Atomic-side `at-pressable-podcasting` bridge has been removed.)
+The package owns the wp-admin SPA, REST integration, and feed customization for podcasting on Simple and Atomic sites. The legacy stack it replaced — the `Automattic_Podcasting` code in the wpcom mu-plugin and the Atomic-side `at-pressable-podcasting` bridge — has been removed.

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -2,4 +2,4 @@
 
 Hosts the wp-admin Podcast experience for the Jetpack plugin (Simple and Atomic only).
 
-The package is gated behind the `jetpack_podcast_untangle` filter (default off). Until the filter is flipped on, the package contributes nothing — the legacy podcasting code (`Automattic_Podcasting` in the wpcom mu-plugin and the `at-pressable-podcasting` bridge plugin) keeps running unchanged. Subsequent PRs in the untangle train layer the new wp-admin SPA, REST integration, and feed customization on top of this gate.
+The package owns the wp-admin SPA, REST integration, and feed customization, and is gated behind the `jetpack_podcast_untangle` filter (default on). The filter remains an escape hatch for forcing the legacy stack back on: filtering it off falls back to the legacy `Automattic_Podcasting` code in the wpcom mu-plugin on Simple sites. (The Atomic-side `at-pressable-podcasting` bridge has been removed.)

--- a/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
+++ b/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: removed
 
-Docs: drop references to the removed at-pressable-podcasting bridge.
+Podcast: remove the jetpack_podcast_untangle gate now that the legacy podcasting stack and at-pressable-podcasting bridge are gone; the package owns the experience unconditionally.

--- a/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
+++ b/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Docs: drop references to the removed at-pressable-podcasting bridge.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -14,10 +14,7 @@ use Automattic\Jetpack\Status\Request;
 /**
  * Registers and renders the Podcast Episode block.
  *
- * Activation is gated by the `jetpack_podcast_untangle` filter; the
- * caller (Podcast::init()) is responsible for the host gate. Each action
- * callback re-checks the filter at hook time, so a late-registered filter
- * callback still takes effect.
+ * The caller (Podcast::init()) is responsible for the host gate.
  */
 class Podcast_Episode_Block {
 
@@ -40,8 +37,7 @@ class Podcast_Episode_Block {
 	const VIEW_HANDLE = 'jetpack-podcast-episode-view';
 
 	/**
-	 * Wire the block's actions. Hooks are added unconditionally; each
-	 * callback re-checks the untangle filter and short-circuits when off.
+	 * Wire the block's actions.
 	 */
 	public static function register_hooks() {
 		add_action( 'init', array( __CLASS__, 'register_block' ), 9 );
@@ -49,17 +45,7 @@ class Podcast_Episode_Block {
 	}
 
 	/**
-	 * Whether the new podcast experience is enabled.
-	 *
-	 * Delegates to {@see Podcast::is_enabled()} so the block honors the
-	 * same default (proxied A8C requests) as the rest of the package.
-	 */
-	private static function is_enabled(): bool {
-		return Podcast::is_enabled();
-	}
-
-	/**
-	 * Register the block when the gate is open.
+	 * Register the block.
 	 *
 	 * Also registers the front-end style bundle (built separately from the
 	 * editor bundle so it actually ships on the public post page) and hands
@@ -67,10 +53,6 @@ class Podcast_Episode_Block {
 	 * enqueues it whenever the block is rendered.
 	 */
 	public static function register_block() {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
-
 		// Assets::register_script side-loads the sibling style.css and
 		// registers a style handle under the same name. The accompanying
 		// (essentially empty) style.js handle is registered too but never
@@ -118,10 +100,6 @@ class Podcast_Episode_Block {
 	 * Enqueue the bundled editor script + style from the package's dist/.
 	 */
 	public static function load_editor_scripts() {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
-
 		Assets::register_script(
 			self::EDITOR_HANDLE,
 			'../../../dist/blocks/podcast-episode/editor.js',

--- a/projects/packages/podcast/src/blocks/podcast-episode/util/register-jetpack-block.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/util/register-jetpack-block.ts
@@ -1,8 +1,7 @@
 /**
  * Lightweight `registerJetpackBlock` for this package.
  *
- * Bridges Jetpack's extension-availability gate (driven by the
- * `jetpack_podcast_untangle` PHP filter via `Jetpack_Gutenberg`) to
+ * Bridges Jetpack's extension-availability gate (via `Jetpack_Gutenberg`) to
  * `registerBlockType`. Strips paid-plan / child-block / prefix branches that
  * the full shared helper carries — this block has none of those.
  *

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -10,10 +10,7 @@ namespace Automattic\Jetpack\Podcast;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
- * Adds the "Jetpack > Podcast" wp-admin screen on Simple and Atomic when the
- * `jetpack_podcast_untangle` filter is enabled. Until that filter flips, every
- * entry point here is a no-op so the legacy podcasting experience keeps
- * running unchanged.
+ * Adds the "Jetpack > Podcast" wp-admin screen on Simple and Atomic.
  */
 class Admin_Page {
 
@@ -52,10 +49,6 @@ class Admin_Page {
 	 * parent menu exists.
 	 */
 	public static function add_wp_admin_submenu() {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
-
 		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
 		$callback        = function_exists( $wp_build_render )
 			? $wp_build_render
@@ -90,7 +83,7 @@ class Admin_Page {
 	 * before `add_wp_admin_submenu()` runs at priority 999999.
 	 */
 	public static function maybe_load_wp_build() {
-		if ( ! self::is_enabled() || ! self::is_podcast_admin_request() ) {
+		if ( ! self::is_podcast_admin_request() ) {
 			return;
 		}
 
@@ -162,13 +155,6 @@ class Admin_Page {
 			<h1>Podcast</h1>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Whether the Podcast untangle is enabled.
-	 */
-	private static function is_enabled() {
-		return Podcast::is_enabled();
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-create-ai-podcast-page.php
+++ b/projects/packages/podcast/src/class-create-ai-podcast-page.php
@@ -7,8 +7,8 @@
  * posts picker, submits the generate request, polls the job, and resumes
  * across reloads via localStorage.
  *
- * Bootstrapped from `Podcast::init()` after the Host (Simple/WoA) and
- * `jetpack_podcast_untangle` gates have already been checked upstream.
+ * Bootstrapped from `Podcast::init()` after the Host (Simple/WoA) gate has
+ * already been checked upstream.
  *
  * @package automattic/jetpack-podcast
  */

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -12,12 +12,10 @@ use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Status\Host;
 
 /**
- * Loads Jetpack Podcast on Simple and Atomic sites, gated behind the
- * `jetpack_podcast_untangle` feature filter (default on).
- *
- * If the filter is flipped off, `init()` is a no-op so the legacy
- * `Automattic_Podcasting` code in the wpcom mu-plugin keeps running on Simple
- * sites. (The Atomic-side at-pressable-podcasting bridge has been removed.)
+ * Loads Jetpack Podcast on Simple and Atomic sites. The package owns the
+ * podcasting experience outright now that the legacy stack — the wpcom
+ * mu-plugin `Automattic_Podcasting` code and the Atomic-side
+ * at-pressable-podcasting bridge — has been removed.
  */
 class Podcast {
 
@@ -33,8 +31,7 @@ class Podcast {
 	/**
 	 * Initialize the package.
 	 *
-	 * Bails on hosts other than Simple and Atomic, and again unless the
-	 * `jetpack_podcast_untangle` filter returns true.
+	 * Bails on hosts other than Simple and Atomic.
 	 */
 	public static function init() {
 		if ( self::$initialized ) {
@@ -47,9 +44,6 @@ class Podcast {
 			return;
 		}
 
-		// Wire the Podcast Episode block actions before the filter check below:
-		// each callback re-checks `jetpack_podcast_untangle` at hook time so a
-		// late-registered filter callback still takes effect.
 		Podcast_Episode_Block::register_hooks();
 
 		// Register the local REST routes before request-local rollout gates.
@@ -59,10 +53,6 @@ class Podcast {
 		Posts_To_Podcast_Endpoint::init();
 		Podcast_Stats_Endpoint::init();
 		Podcast_Distribution_Endpoint::init();
-
-		if ( ! self::is_enabled() ) {
-			return;
-		}
 
 		// Register the `podcasting_*` option schema so the SPA can read/write
 		// via `/wp/v2/settings`. On Simple, the legacy WPCOM site-settings
@@ -85,7 +75,7 @@ class Podcast {
 		}
 
 		// Posts to Podcast lives behind its own filter so the Create AI
-		// Podcast page can ship independently of the broader untangle.
+		// Podcast page can ship independently of the rest of the package.
 		//
 		// Note: no `is_admin()` guard here. The submenu must also register when
 		// Calypso builds its nav via the `wpcom/v2/admin-menu` REST endpoint,
@@ -102,9 +92,8 @@ class Podcast {
 	 * Whether the Posts to Podcast feature (Create AI Podcast page + REST
 	 * proxy) is enabled for the current request.
 	 *
-	 * Mirrors the `jetpack_podcast_untangle` pattern: defaults to true for
-	 * connected WordPress.com users, and can be flipped globally via the
-	 * `jetpack_posts_to_podcast` filter.
+	 * Defaults to true for connected WordPress.com users, and can be flipped
+	 * globally via the `jetpack_posts_to_podcast` filter.
 	 */
 	public static function is_posts_to_podcast_enabled() {
 		/**
@@ -131,23 +120,5 @@ class Podcast {
 		}
 
 		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
-	}
-
-	/**
-	 * Whether the Podcast untangle is enabled for the current request.
-	 *
-	 * Defaults to true — the new package owns the experience on Simple
-	 * and Atomic. The filter remains as an escape hatch for forcing the
-	 * legacy stack back on (rollback, test fixtures, per-site overrides).
-	 */
-	public static function is_enabled() {
-		/**
-		 * Master switch for the Podcast untangle.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param bool $enabled Whether to enable the new Podcast package.
-		 */
-		return (bool) apply_filters( 'jetpack_podcast_untangle', true );
 	}
 }

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -13,12 +13,11 @@ use Automattic\Jetpack\Status\Host;
 
 /**
  * Loads Jetpack Podcast on Simple and Atomic sites, gated behind the
- * `jetpack_podcast_untangle` feature filter.
+ * `jetpack_podcast_untangle` feature filter (default on).
  *
- * Until the filter returns true, `init()` is a no-op so the legacy podcasting
- * code (`Automattic_Podcasting` from the wpcom mu-plugin and the
- * at-pressable-podcasting bridge plugin) keeps running unchanged. Subsequent
- * PRs in the untangle train fill this in.
+ * If the filter is flipped off, `init()` is a no-op so the legacy
+ * `Automattic_Podcasting` code in the wpcom mu-plugin keeps running on Simple
+ * sites. (The Atomic-side at-pressable-podcasting bridge has been removed.)
  */
 class Podcast {
 

--- a/projects/packages/podcast/src/endpoints/class-posts-to-podcast-helper.php
+++ b/projects/packages/podcast/src/endpoints/class-posts-to-podcast-helper.php
@@ -15,16 +15,9 @@ class Posts_To_Podcast_Helper {
 	/**
 	 * Whether the Posts to Podcast feature is active for the current request.
 	 *
-	 * Inherits the package-level untangle gate so the feature only registers
-	 * when the rest of the podcast package is active.
-	 *
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		if ( ! Podcast::is_enabled() ) {
-			return false;
-		}
-
 		/**
 		 * Filter to allow disabling the Posts to Podcast feature on a per-site basis.
 		 * Defaults to true wherever the podcast package is active; flip this to false

--- a/projects/plugins/wpcomsh/changelog/remove-at-pressable-podcasting-bridge
+++ b/projects/plugins/wpcomsh/changelog/remove-at-pressable-podcasting-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Podcasting: remove the at-pressable-podcasting bridge now that the jetpack-podcast package owns the experience on every WoA site.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -5,7 +5,6 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.1",
-		"automattic/at-pressable-podcasting": "^2.0.8",
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
@@ -77,12 +76,6 @@
 			"type": "vcs",
 			"no-api": true,
 			"url": "https://github.com/Automattic/custom-fonts-typekit.git"
-		},
-		{
-			"name": "automattic/at-pressable-podcasting",
-			"type": "vcs",
-			"no-api": true,
-			"url": "https://github.com/automattic/at-pressable-podcasting.git"
 		},
 		{
 			"name": "automattic/text-media-widget-styles",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,28 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f027d03433b3a70bb6f4b28317c7a19c",
+    "content-hash": "d0871f7a7395d1ee5864c7d40d2e35df",
     "packages": [
-        {
-            "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "78780729dbf7b01e67e2a6472f8576ce8ba7f0fc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/78780729dbf7b01e67e2a6472f8576ce8ba7f0fc",
-                "reference": "78780729dbf7b01e67e2a6472f8576ce8ba7f0fc",
-                "shasum": ""
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "time": "2026-05-12T12:18:56+00:00"
-        },
         {
             "name": "automattic/block-delimiter",
             "version": "dev-trunk",

--- a/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
@@ -20,11 +20,6 @@ class WpcomshLoadedTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that any composer dependencies are loaded.
-	 *
-	 * The legacy at-pressable-podcasting vendor is intentionally gated by
-	 * `jetpack_podcast_untangle` and no longer loads when the gate is on
-	 * (which is now the default). The vendor still ships in vendor/ until
-	 * the Phase D cleanup; only the boot path is gated.
 	 */
 	public function test_composer_dependencies_loaded() {
 		$this->assertTrue( class_exists( 'Jetpack_Fonts' ), 'vendor/automattic/custom-fonts not loaded' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -122,20 +122,6 @@ if ( is_readable( $jetpack_autoloader ) ) {
 
 	return;
 }
-/**
- * Atomic-side safety net for the Podcast untangle. The package now defaults
- * the gate to true on its own, so this filter is redundant in steady state —
- * keep it as a belt-and-suspenders pin until the legacy
- * at-pressable-podcasting vendor is removed in the Phase D cleanup.
- */
-add_filter( 'jetpack_podcast_untangle', '__return_true' );
-
-if (
-	! class_exists( '\Automattic\Jetpack\Podcast\Podcast' )
-	|| ! \Automattic\Jetpack\Podcast\Podcast::is_enabled()
-) {
-	require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
-}
 require_once __DIR__ . '/vendor/automattic/custom-fonts/custom-fonts.php';
 require_once __DIR__ . '/vendor/automattic/custom-fonts-typekit/custom-fonts-typekit.php';
 require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-widget-styles.php';


### PR DESCRIPTION
## Summary

This removes the fallback of podcasting to the at-pressable-podcasting bridge. We are now fully using the Jetpack package since the untangle and this is all dead-code.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Smoke test and make sure nothing is on-fire. This _should_ all dead code.