### PR TITLE
Podcast: restore auto-excerpt fallback for empty feed descriptions

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-feed-empty-descriptions
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-empty-descriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: fix empty episode descriptions in the feed when no excerpt is set.

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -73,7 +73,7 @@ class Customize_Feed {
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
-		add_filter( 'the_excerpt_rss', array( __CLASS__, 'filter_excerpt_to_manual_only' ) );
+		add_filter( 'the_excerpt_rss', array( __CLASS__, 'filter_episode_excerpt' ) );
 
 		// Prune RSS chrome that podcatchers don't read. Cuts payload size and
 		// keeps incidental post data (body content, gravatar URLs, image EXIF,
@@ -95,20 +95,41 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Restrict per-item `<description>` (and the `<itunes:summary>` we mirror
-	 * from it) to the post's manual excerpt — never the auto-generated one.
+	 * Episode description for `<description>` and the `<itunes:summary>` we
+	 * mirror from it: the post's manual excerpt (the block editor's "Show
+	 * notes" field) when set, otherwise the auto-generated excerpt trimmed
+	 * from the post body.
 	 *
-	 * Default WP behavior pipes the post body through `wp_trim_excerpt()` when
-	 * the post has no manual excerpt, which leaks paragraph + heading text from
-	 * below the Podcast Episode block into the description that Apple Podcasts
-	 * and Spotify present to listeners. Authors with no excerpt set should see
-	 * an empty description, not a flattened body.
+	 * Returning only the manual excerpt (empty otherwise) blanked the
+	 * descriptions Apple Podcasts and Spotify show for every episode that
+	 * never set show notes — a regression for sites relying on the
+	 * auto-generated summary. `wp_trim_excerpt()` runs the body through
+	 * `excerpt_remove_blocks()` first, so the Podcast Episode player block is
+	 * dropped and only prose (paragraphs/headings) survives — no player markup
+	 * leaks into the description.
 	 *
-	 * @return string Manual excerpt, or empty string when none is set.
+	 * Hooked to `the_excerpt_rss` and called directly for `<itunes:summary>`
+	 * so both fields always emit the same text.
+	 *
+	 * @return string Manual excerpt, or the auto-generated body excerpt when none is set.
 	 */
-	public static function filter_excerpt_to_manual_only(): string {
+	public static function filter_episode_excerpt(): string {
 		global $post;
-		return $post instanceof WP_Post ? (string) $post->post_excerpt : '';
+		if ( ! $post instanceof WP_Post ) {
+			return '';
+		}
+		if ( '' !== trim( (string) $post->post_excerpt ) ) {
+			return (string) $post->post_excerpt;
+		}
+
+		// Called twice per item (the `the_excerpt_rss` filter + the
+		// `<itunes:summary>` mirror), and `wp_trim_excerpt()` re-renders the
+		// whole body through `the_content` each time — memoize per post.
+		static $auto_excerpts = array();
+		if ( ! array_key_exists( $post->ID, $auto_excerpts ) ) {
+			$auto_excerpts[ $post->ID ] = (string) wp_trim_excerpt( '', $post );
+		}
+		return $auto_excerpts[ $post->ID ];
 	}
 
 	/**
@@ -214,10 +235,10 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Mirror what the `<description>` emits (manual excerpt, never the
-		// auto-generated body trim — see `filter_excerpt_to_manual_only()`).
-		$excerpt = self::filter_excerpt_to_manual_only();
-		if ( '' !== $excerpt ) {
+		// Mirror what the `<description>` emits — manual excerpt when set,
+		// otherwise the auto-generated body excerpt (see `filter_episode_excerpt()`).
+		$excerpt = self::filter_episode_excerpt();
+		if ( '' !== trim( $excerpt ) ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}
 

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -196,9 +196,11 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Mirror what `<description>` emits: manual excerpt, else WP's auto-generated body excerpt.
-		$excerpt = (string) get_the_excerpt( $post );
-		if ( '' !== trim( $excerpt ) ) {
+		// Re-applying `the_excerpt_rss` so `<itunes:summary>` matches whatever
+		// the item's `<description>` ends up emitting — `get_the_excerpt()`
+		// doesn't run the filter chain itself.
+		$excerpt = (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+		if ( '' !== $excerpt ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}
 

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -73,7 +73,6 @@ class Customize_Feed {
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
-		add_filter( 'the_excerpt_rss', array( __CLASS__, 'filter_episode_excerpt' ) );
 
 		// Prune RSS chrome that podcatchers don't read. Cuts payload size and
 		// keeps incidental post data (body content, gravatar URLs, image EXIF,
@@ -92,28 +91,6 @@ class Customize_Feed {
 		remove_action( 'rss2_item', 'mrss_news_item' );
 
 		Feed_Detection::detect_and_record();
-	}
-
-	/**
-	 * Episode description for `<description>` and `<itunes:summary>`: manual excerpt when set, else the auto-generated body excerpt (`wp_trim_excerpt()` drops the player block, keeping only prose).
-	 *
-	 * @return string Manual excerpt, or the auto-generated body excerpt when none is set.
-	 */
-	public static function filter_episode_excerpt(): string {
-		global $post;
-		if ( ! $post instanceof WP_Post ) {
-			return '';
-		}
-		if ( '' !== trim( (string) $post->post_excerpt ) ) {
-			return (string) $post->post_excerpt;
-		}
-
-		// Memoize: called twice per item and `wp_trim_excerpt()` re-renders the body each time.
-		static $auto_excerpts = array();
-		if ( ! array_key_exists( $post->ID, $auto_excerpts ) ) {
-			$auto_excerpts[ $post->ID ] = (string) wp_trim_excerpt( '', $post );
-		}
-		return $auto_excerpts[ $post->ID ];
 	}
 
 	/**
@@ -219,8 +196,8 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Mirror what the `<description>` emits (see `filter_episode_excerpt()`).
-		$excerpt = self::filter_episode_excerpt();
+		// Mirror what `<description>` emits: manual excerpt, else WP's auto-generated body excerpt.
+		$excerpt = (string) get_the_excerpt( $post );
 		if ( '' !== trim( $excerpt ) ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -95,21 +95,7 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Episode description for `<description>` and the `<itunes:summary>` we
-	 * mirror from it: the post's manual excerpt (the block editor's "Show
-	 * notes" field) when set, otherwise the auto-generated excerpt trimmed
-	 * from the post body.
-	 *
-	 * Returning only the manual excerpt (empty otherwise) blanked the
-	 * descriptions Apple Podcasts and Spotify show for every episode that
-	 * never set show notes — a regression for sites relying on the
-	 * auto-generated summary. `wp_trim_excerpt()` runs the body through
-	 * `excerpt_remove_blocks()` first, so the Podcast Episode player block is
-	 * dropped and only prose (paragraphs/headings) survives — no player markup
-	 * leaks into the description.
-	 *
-	 * Hooked to `the_excerpt_rss` and called directly for `<itunes:summary>`
-	 * so both fields always emit the same text.
+	 * Episode description for `<description>` and `<itunes:summary>`: manual excerpt when set, else the auto-generated body excerpt (`wp_trim_excerpt()` drops the player block, keeping only prose).
 	 *
 	 * @return string Manual excerpt, or the auto-generated body excerpt when none is set.
 	 */
@@ -122,9 +108,7 @@ class Customize_Feed {
 			return (string) $post->post_excerpt;
 		}
 
-		// Called twice per item (the `the_excerpt_rss` filter + the
-		// `<itunes:summary>` mirror), and `wp_trim_excerpt()` re-renders the
-		// whole body through `the_content` each time — memoize per post.
+		// Memoize: called twice per item and `wp_trim_excerpt()` re-renders the body each time.
 		static $auto_excerpts = array();
 		if ( ! array_key_exists( $post->ID, $auto_excerpts ) ) {
 			$auto_excerpts[ $post->ID ] = (string) wp_trim_excerpt( '', $post );
@@ -235,8 +219,7 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Mirror what the `<description>` emits — manual excerpt when set,
-		// otherwise the auto-generated body excerpt (see `filter_episode_excerpt()`).
+		// Mirror what the `<description>` emits (see `filter_episode_excerpt()`).
 		$excerpt = self::filter_episode_excerpt();
 		if ( '' !== trim( $excerpt ) ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -37,7 +37,6 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'pre_attachment_url_to_postid' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
-		remove_all_filters( 'wp_trim_excerpt' );
 		Jetpack_Options::delete_option( 'id' );
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
@@ -549,45 +548,36 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'type="application/json+chapters"', $output );
 	}
 
-	public function test_filter_episode_excerpt_returns_manual_excerpt() {
-		global $post;
-		$post = new WP_Post(
-			(object) array(
-				'ID'           => 101,
-				'post_excerpt' => 'A manually written episode summary.',
-				'post_content' => '<p>Body content that should be ignored.</p>',
+	public function test_output_item_tags_uses_manual_excerpt_for_itunes_summary() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode with Excerpt',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'Authored summary for this episode.',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /-->',
 			)
 		);
 
-		$this->assertSame(
-			'A manually written episode summary.',
-			Customize_Feed::filter_episode_excerpt()
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$output = (string) ob_get_clean();
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString(
+			'<itunes:summary>Authored summary for this episode.</itunes:summary>',
+			$output
 		);
 	}
 
 	/**
-	 * Episodes with no manual excerpt fall back to the auto-generated body excerpt (stubbed here to assert only that the fallback is taken).
+	 * No manual excerpt → `<itunes:summary>` mirrors WP's auto excerpt, which drops the player block and keeps only prose.
 	 */
-	public function test_filter_episode_excerpt_falls_back_to_auto_excerpt() {
-		global $post;
-		$post = new WP_Post(
-			(object) array(
-				'ID'           => 102,
-				'post_excerpt' => '',
-				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /--><p>Body prose that listeners should see.</p>',
-			)
-		);
-
-		add_filter( 'wp_trim_excerpt', array( $this, 'return_stub_excerpt' ) );
-
-		$this->assertSame( 'Auto-generated summary.', Customize_Feed::filter_episode_excerpt() );
-	}
-
-	/**
-	 * The real `wp_trim_excerpt()` fallback strips the Podcast Episode player block, leaking only prose into the description.
-	 */
-	public function test_filter_episode_excerpt_strips_podcast_block_from_auto_excerpt() {
-		// Real inserted post so core's `get_the_content()` has the data it needs to render.
+	public function test_output_item_tags_uses_auto_excerpt_when_no_manual_excerpt() {
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => 'Episode without Show notes',
@@ -601,73 +591,15 @@ class Customize_Feed_Test extends BaseTestCase {
 		$post = get_post( $post_id );
 		setup_postdata( $post );
 
-		$excerpt = Customize_Feed::filter_episode_excerpt();
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$output = (string) ob_get_clean();
 
 		wp_reset_postdata();
 
-		$this->assertStringContainsString( 'Body prose that listeners should see.', $excerpt );
-		$this->assertStringNotContainsString( 'podcast-episode', $excerpt );
-		$this->assertStringNotContainsString( 'mediaUrl', $excerpt );
-		$this->assertStringNotContainsString( 'example.com/ep.mp3', $excerpt );
-	}
-
-	/**
-	 * Helper for stubbing `wp_trim_excerpt` in the auto-excerpt fallback tests.
-	 *
-	 * @return string
-	 */
-	public function return_stub_excerpt(): string {
-		return 'Auto-generated summary.';
-	}
-
-	public function test_filter_episode_excerpt_handles_missing_post() {
-		global $post;
-		$post = null;
-
-		$this->assertSame( '', Customize_Feed::filter_episode_excerpt() );
-	}
-
-	public function test_output_item_tags_uses_manual_excerpt_for_itunes_summary() {
-		global $post;
-		$post = new WP_Post(
-			(object) array(
-				'ID'           => 103,
-				'post_type'    => 'post',
-				'post_title'   => 'Episode with Excerpt',
-				'post_excerpt' => 'Authored summary for this episode.',
-				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /-->',
-			)
-		);
-
-		ob_start();
-		Customize_Feed::output_item_tags();
-		$output = (string) ob_get_clean();
-
-		$this->assertStringContainsString(
-			'<itunes:summary>Authored summary for this episode.</itunes:summary>',
-			$output
-		);
-	}
-
-	public function test_output_item_tags_uses_auto_excerpt_when_no_manual_excerpt() {
-		global $post;
-		$post = new WP_Post(
-			(object) array(
-				'ID'           => 104,
-				'post_type'    => 'post',
-				'post_title'   => 'Episode without Excerpt',
-				'post_excerpt' => '',
-				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /--><p>Body content.</p>',
-			)
-		);
-
-		add_filter( 'wp_trim_excerpt', array( $this, 'return_stub_excerpt' ) );
-
-		ob_start();
-		Customize_Feed::output_item_tags();
-		$output = (string) ob_get_clean();
-
-		// No manual excerpt → auto-generated body excerpt mirrored into <itunes:summary>.
-		$this->assertStringContainsString( '<itunes:summary>Auto-generated summary.</itunes:summary>', $output );
+		$this->assertStringContainsString( '<itunes:summary>', $output );
+		$this->assertStringContainsString( 'Body prose that listeners should see.', $output );
+		$this->assertStringNotContainsString( 'mediaUrl', $output );
+		$this->assertStringNotContainsString( 'example.com/ep.mp3', $output );
 	}
 }

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -566,12 +566,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Episodes with no manual excerpt (no "Show notes") fall back to the
-	 * auto-generated body excerpt — the description Apple/Spotify showed before
-	 * the regression, rather than the empty string the leak-fix produced.
-	 *
-	 * The trimming itself is WP core's `wp_trim_excerpt()`; we stub its output
-	 * filter to assert only that the fallback is taken.
+	 * Episodes with no manual excerpt fall back to the auto-generated body excerpt (stubbed here to assert only that the fallback is taken).
 	 */
 	public function test_filter_episode_excerpt_falls_back_to_auto_excerpt() {
 		global $post;
@@ -589,15 +584,10 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The auto-excerpt fallback runs the body through WP core's real
-	 * `wp_trim_excerpt()` (no stub): `excerpt_remove_blocks()` drops the
-	 * Podcast Episode player block, leaving only the prose. This is the exact
-	 * leak the fix relies on not happening — the player markup must never reach
-	 * the description.
+	 * The real `wp_trim_excerpt()` fallback strips the Podcast Episode player block, leaking only prose into the description.
 	 */
 	public function test_filter_episode_excerpt_strips_podcast_block_from_auto_excerpt() {
-		// A real inserted post (not a bare WP_Post) so core's `get_the_content()`
-		// inside `wp_trim_excerpt()` has the post data it needs to render.
+		// Real inserted post so core's `get_the_content()` has the data it needs to render.
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => 'Episode without Show notes',
@@ -677,8 +667,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		Customize_Feed::output_item_tags();
 		$output = (string) ob_get_clean();
 
-		// No manual excerpt → the auto-generated body excerpt is mirrored into
-		// <itunes:summary>, matching what <description> emits.
+		// No manual excerpt → auto-generated body excerpt mirrored into <itunes:summary>.
 		$this->assertStringContainsString( '<itunes:summary>Auto-generated summary.</itunes:summary>', $output );
 	}
 }

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -37,6 +37,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'pre_attachment_url_to_postid' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
+		remove_all_filters( 'wp_trim_excerpt' );
 		Jetpack_Options::delete_option( 'id' );
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
@@ -548,7 +549,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'type="application/json+chapters"', $output );
 	}
 
-	public function test_filter_excerpt_to_manual_only_returns_manual_excerpt() {
+	public function test_filter_episode_excerpt_returns_manual_excerpt() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
@@ -560,28 +561,80 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertSame(
 			'A manually written episode summary.',
-			Customize_Feed::filter_excerpt_to_manual_only()
+			Customize_Feed::filter_episode_excerpt()
 		);
 	}
 
-	public function test_filter_excerpt_to_manual_only_returns_empty_when_no_manual_excerpt() {
+	/**
+	 * Episodes with no manual excerpt (no "Show notes") fall back to the
+	 * auto-generated body excerpt — the description Apple/Spotify showed before
+	 * the regression, rather than the empty string the leak-fix produced.
+	 *
+	 * The trimming itself is WP core's `wp_trim_excerpt()`; we stub its output
+	 * filter to assert only that the fallback is taken.
+	 */
+	public function test_filter_episode_excerpt_falls_back_to_auto_excerpt() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
 				'ID'           => 102,
 				'post_excerpt' => '',
-				'post_content' => '<p>Body paragraph that should NOT leak into description.</p><h2>A heading</h2>',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /--><p>Body prose that listeners should see.</p>',
 			)
 		);
 
-		$this->assertSame( '', Customize_Feed::filter_excerpt_to_manual_only() );
+		add_filter( 'wp_trim_excerpt', array( $this, 'return_stub_excerpt' ) );
+
+		$this->assertSame( 'Auto-generated summary.', Customize_Feed::filter_episode_excerpt() );
 	}
 
-	public function test_filter_excerpt_to_manual_only_handles_missing_post() {
+	/**
+	 * The auto-excerpt fallback runs the body through WP core's real
+	 * `wp_trim_excerpt()` (no stub): `excerpt_remove_blocks()` drops the
+	 * Podcast Episode player block, leaving only the prose. This is the exact
+	 * leak the fix relies on not happening — the player markup must never reach
+	 * the description.
+	 */
+	public function test_filter_episode_excerpt_strips_podcast_block_from_auto_excerpt() {
+		// A real inserted post (not a bare WP_Post) so core's `get_the_content()`
+		// inside `wp_trim_excerpt()` has the post data it needs to render.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode without Show notes',
+				'post_status'  => 'publish',
+				'post_excerpt' => '',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /--><p>Body prose that listeners should see.</p>',
+			)
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		$excerpt = Customize_Feed::filter_episode_excerpt();
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString( 'Body prose that listeners should see.', $excerpt );
+		$this->assertStringNotContainsString( 'podcast-episode', $excerpt );
+		$this->assertStringNotContainsString( 'mediaUrl', $excerpt );
+		$this->assertStringNotContainsString( 'example.com/ep.mp3', $excerpt );
+	}
+
+	/**
+	 * Helper for stubbing `wp_trim_excerpt` in the auto-excerpt fallback tests.
+	 *
+	 * @return string
+	 */
+	public function return_stub_excerpt(): string {
+		return 'Auto-generated summary.';
+	}
+
+	public function test_filter_episode_excerpt_handles_missing_post() {
 		global $post;
 		$post = null;
 
-		$this->assertSame( '', Customize_Feed::filter_excerpt_to_manual_only() );
+		$this->assertSame( '', Customize_Feed::filter_episode_excerpt() );
 	}
 
 	public function test_output_item_tags_uses_manual_excerpt_for_itunes_summary() {
@@ -606,7 +659,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 	}
 
-	public function test_output_item_tags_omits_itunes_summary_when_no_manual_excerpt() {
+	public function test_output_item_tags_uses_auto_excerpt_when_no_manual_excerpt() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
@@ -618,11 +671,14 @@ class Customize_Feed_Test extends BaseTestCase {
 			)
 		);
 
+		add_filter( 'wp_trim_excerpt', array( $this, 'return_stub_excerpt' ) );
+
 		ob_start();
 		Customize_Feed::output_item_tags();
 		$output = (string) ob_get_clean();
 
-		$this->assertStringNotContainsString( '<itunes:summary>', $output );
-		$this->assertStringNotContainsString( 'Body content', $output );
+		// No manual excerpt → the auto-generated body excerpt is mirrored into
+		// <itunes:summary>, matching what <description> emits.
+		$this->assertStringContainsString( '<itunes:summary>Auto-generated summary.</itunes:summary>', $output );
 	}
 }


### PR DESCRIPTION
Fixes PODS-166/podcast-feed-episode-descriptions-empty-when-no-manual-excerpt

## Summary

In a previous PR we removed the default WordPress excerpt. This means that the summary was no longer being shared unless a post excerpt was explicitly set. This PR reverts that change and goes back to the default WordPress excerpt method which checks the excerpt and then falls back to the post content other wise.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Pull changes
* Add an episode with a set excerpt and check the summary in the feed it should match the excerpt
* Remove the excerpt and put content in the post the content should match summary.