### PR TITLE
Sync WooCommerce module: Start syncing customer account detail changes stored in user meta

### DIFF
--- a/projects/packages/sync/changelog/add-woocommerce-customer-updated-props-sync
+++ b/projects/packages/sync/changelog/add-woocommerce-customer-updated-props-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Send WooCommerce customer account detail updates.

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -104,6 +104,13 @@ class WooCommerce extends Module {
 	private $customer_meta_updates = array();
 
 	/**
+	 * User IDs deleted during the current request.
+	 *
+	 * @var array
+	 */
+	private $deleted_user_ids = array();
+
+	/**
 	 * The table name.
 	 *
 	 * @access public
@@ -239,6 +246,8 @@ class WooCommerce extends Module {
 		add_action( 'added_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
 		add_action( 'updated_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
 		add_action( 'deleted_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
+		add_action( 'delete_user', array( $this, 'action_delete_user' ), 10, 1 );
+		add_action( 'wpmu_delete_user', array( $this, 'action_delete_user' ), 10, 1 );
 		add_action( 'shutdown', array( $this, 'action_customer_meta_updates' ) );
 		add_action( 'jetpack_updated_woo_customer_meta', $callable, 10, 2 );
 	}
@@ -337,6 +346,10 @@ class WooCommerce extends Module {
 			return;
 		}
 
+		if ( 'deleted_user_meta' === current_action() && isset( $this->deleted_user_ids[ $customer_id ] ) ) {
+			return;
+		}
+
 		$updated_props = $this->get_customer_detail_props( array( $meta_key ) );
 		if ( empty( $updated_props ) ) {
 			return;
@@ -352,6 +365,21 @@ class WooCommerce extends Module {
 	}
 
 	/**
+	 * Mark a deleted user so customer meta cleanup does not sync as profile changes.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function action_delete_user( $user_id ) {
+		$customer_id = (int) $user_id;
+		if ( $customer_id <= 0 ) {
+			return;
+		}
+
+		$this->deleted_user_ids[ $customer_id ] = true;
+		unset( $this->customer_meta_updates[ $customer_id ] );
+	}
+
+	/**
 	 * Send batched WooCommerce customer meta updates.
 	 */
 	public function action_customer_meta_updates() {
@@ -363,6 +391,10 @@ class WooCommerce extends Module {
 		$this->customer_meta_updates = array();
 
 		foreach ( $customer_meta_updates as $customer_id => $updated_props ) {
+			if ( isset( $this->deleted_user_ids[ (int) $customer_id ] ) ) {
+				continue;
+			}
+
 			/**
 			 * Fires when WooCommerce customer details stored in user meta are updated.
 			 *

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -350,18 +350,22 @@ class WooCommerce extends Module {
 			return;
 		}
 
-		$updated_props = $this->get_customer_detail_props( array( $meta_key ) );
-		if ( empty( $updated_props ) ) {
+		if ( ! is_string( $meta_key ) && ! is_numeric( $meta_key ) ) {
 			return;
 		}
+
+		$meta_key = sanitize_key( (string) $meta_key );
+		if ( ! isset( self::$customer_detail_meta_key_to_prop[ $meta_key ] ) ) {
+			return;
+		}
+
+		$updated_prop = self::$customer_detail_meta_key_to_prop[ $meta_key ];
 
 		if ( ! isset( $this->customer_meta_updates[ $customer_id ] ) ) {
 			$this->customer_meta_updates[ $customer_id ] = array();
 		}
 
-		foreach ( $updated_props as $prop ) {
-			$this->customer_meta_updates[ $customer_id ][ $prop ] = true;
-		}
+		$this->customer_meta_updates[ $customer_id ][ $updated_prop ] = true;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -129,6 +129,7 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_customer_object_updated_props', array( $this, 'filter_customer_updated_props' ) );
 		add_filter( 'jetpack_sync_whitelisted_comment_types', array( $this, 'add_review_comment_types' ) );
 
 		// Blacklist Action Scheduler comment types.
@@ -194,6 +195,9 @@ class WooCommerce extends Module {
 		add_action( 'woocommerce_new_webhook', $callable, 10, 1 );
 		add_action( 'woocommerce_webhook_deleted', $callable, 10, 2 );
 		add_action( 'woocommerce_webhook_updated', $callable, 10, 1 );
+
+		// Customers.
+		add_action( 'woocommerce_customer_object_updated_props', $callable, 10, 2 );
 	}
 
 	/**
@@ -240,6 +244,78 @@ class WooCommerce extends Module {
 		// Make sure we always have all the data - prior to WooCommerce 3.0 we only have the user supplied data in the second argument and not the full details.
 		$args[1] = $this->build_order_item( $args[0] );
 		return $args;
+	}
+
+	/**
+	 * Replace the customer object with a minimal user object before enqueueing.
+	 *
+	 * @param array $args Hook arguments.
+	 * @return array|false Minimal user object and changed prop names, or false when invalid.
+	 */
+	public function filter_customer_updated_props( $args ) {
+		if (
+			! is_array( $args )
+			|| ! isset( $args[0] )
+			|| ! isset( $args[1] )
+			|| ! is_object( $args[0] )
+			|| ! is_callable( array( $args[0], 'get_id' ) )
+			|| ! is_array( $args[1] )
+		) {
+			return false;
+		}
+
+		$customer_id = (int) $args[0]->get_id();
+		if ( $customer_id <= 0 ) {
+			return false;
+		}
+
+		$updated_props = array();
+		foreach ( $args[1] as $prop ) {
+			if ( ! is_string( $prop ) && ! is_numeric( $prop ) ) {
+				continue;
+			}
+
+			$prop = sanitize_key( (string) $prop );
+			if ( '' === $prop ) {
+				continue;
+			}
+
+			$updated_props[] = $prop;
+		}
+
+		$updated_props = array_values( array_unique( $updated_props ) );
+		if ( empty( $updated_props ) ) {
+			return false;
+		}
+
+		return array( $this->build_minimal_customer_user_object( $customer_id ), $updated_props );
+	}
+
+	/**
+	 * Build a minimal WP_User-shaped object for Activity Log.
+	 *
+	 * @param int $customer_id Customer user ID.
+	 * @return object Minimal user object.
+	 */
+	private function build_minimal_customer_user_object( $customer_id ) {
+		$user_data = (object) array(
+			'ID'           => $customer_id,
+			'display_name' => '',
+			'user_login'   => '',
+			'user_email'   => '',
+		);
+
+		$user = get_userdata( $customer_id );
+		if ( $user ) {
+			$user_data->display_name = (string) $user->display_name;
+			$user_data->user_login   = (string) $user->user_login;
+			$user_data->user_email   = (string) $user->user_email;
+		}
+
+		return (object) array(
+			'ID'   => $customer_id,
+			'data' => $user_data,
+		);
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -315,24 +315,21 @@ class WooCommerce extends Module {
 			return false;
 		}
 
-		$args[0]->ID       = $customer_id;
-		$args[0]->data->ID = $customer_id;
-
 		$updated_props = $this->get_customer_detail_props( $args[1] );
 		if ( empty( $updated_props ) ) {
 			return false;
 		}
 
-		return array( $args[0], $updated_props );
+		return array( $this->build_minimal_customer_user_object( $customer_id ), $updated_props );
 	}
 
 	/**
 	 * Track updated WooCommerce customer meta props for syncing.
 	 *
-	 * @param int    $meta_id  ID of the meta object.
-	 * @param int    $user_id  User ID.
-	 * @param string $meta_key Meta key.
-	 * @param mixed  $value    Meta value.
+	 * @param int|array $meta_id  ID of the meta object, or IDs for deleted meta.
+	 * @param int       $user_id  User ID.
+	 * @param string    $meta_key Meta key.
+	 * @param mixed     $value    Meta value.
 	 */
 	public function maybe_sync_customer_meta_update( $meta_id, $user_id, $meta_key, $value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$customer_id = (int) $user_id;

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -56,6 +56,38 @@ class WooCommerce extends Module {
 	);
 
 	/**
+	 * Mapping between WooCommerce customer detail user meta keys and customer prop names.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
+	private static $customer_detail_meta_key_to_prop = array(
+		'paying_customer'     => 'is_paying_customer',
+		'billing_first_name'  => 'billing_first_name',
+		'billing_last_name'   => 'billing_last_name',
+		'billing_company'     => 'billing_company',
+		'billing_address_1'   => 'billing_address_1',
+		'billing_address_2'   => 'billing_address_2',
+		'billing_city'        => 'billing_city',
+		'billing_state'       => 'billing_state',
+		'billing_postcode'    => 'billing_postcode',
+		'billing_country'     => 'billing_country',
+		'billing_email'       => 'billing_email',
+		'billing_phone'       => 'billing_phone',
+		'shipping_first_name' => 'shipping_first_name',
+		'shipping_last_name'  => 'shipping_last_name',
+		'shipping_company'    => 'shipping_company',
+		'shipping_address_1'  => 'shipping_address_1',
+		'shipping_address_2'  => 'shipping_address_2',
+		'shipping_city'       => 'shipping_city',
+		'shipping_state'      => 'shipping_state',
+		'shipping_postcode'   => 'shipping_postcode',
+		'shipping_country'    => 'shipping_country',
+		'shipping_phone'      => 'shipping_phone',
+	);
+
+	/**
 	 * Name of the order item database table.
 	 *
 	 * @access private
@@ -63,6 +95,13 @@ class WooCommerce extends Module {
 	 * @var string
 	 */
 	private $order_item_table_name;
+
+	/**
+	 * Customer detail meta changes to sync at the end of the request.
+	 *
+	 * @var array
+	 */
+	private $customer_meta_updates = array();
 
 	/**
 	 * The table name.
@@ -129,7 +168,7 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
-		add_filter( 'jetpack_sync_before_enqueue_woocommerce_customer_object_updated_props', array( $this, 'filter_customer_updated_props' ) );
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_updated_woo_customer_meta', array( $this, 'filter_customer_updated_meta' ) );
 		add_filter( 'jetpack_sync_whitelisted_comment_types', array( $this, 'add_review_comment_types' ) );
 
 		// Blacklist Action Scheduler comment types.
@@ -197,7 +236,11 @@ class WooCommerce extends Module {
 		add_action( 'woocommerce_webhook_updated', $callable, 10, 1 );
 
 		// Customers.
-		add_action( 'woocommerce_customer_object_updated_props', $callable, 10, 2 );
+		add_action( 'added_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
+		add_action( 'updated_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
+		add_action( 'deleted_user_meta', array( $this, 'maybe_sync_customer_meta_update' ), 10, 4 );
+		add_action( 'shutdown', array( $this, 'action_customer_meta_updates' ) );
+		add_action( 'jetpack_updated_woo_customer_meta', $callable, 10, 2 );
 	}
 
 	/**
@@ -247,48 +290,121 @@ class WooCommerce extends Module {
 	}
 
 	/**
-	 * Replace the customer object with a minimal user object before enqueueing.
+	 * Validate the minimal customer meta update payload before enqueueing.
 	 *
 	 * @param array $args Hook arguments.
 	 * @return array|false Minimal user object and changed prop names, or false when invalid.
 	 */
-	public function filter_customer_updated_props( $args ) {
+	public function filter_customer_updated_meta( $args ) {
 		if (
 			! is_array( $args )
 			|| ! isset( $args[0] )
 			|| ! isset( $args[1] )
 			|| ! is_object( $args[0] )
-			|| ! is_callable( array( $args[0], 'get_id' ) )
+			|| ! isset( $args[0]->data )
+			|| ! is_object( $args[0]->data )
+			|| ! isset( $args[0]->data->ID )
+			|| ! is_numeric( $args[0]->data->ID )
 			|| ! is_array( $args[1] )
 		) {
 			return false;
 		}
 
-		$customer_id = (int) $args[0]->get_id();
+		$customer_id = (int) $args[0]->data->ID;
 		if ( $customer_id <= 0 ) {
 			return false;
 		}
 
+		$args[0]->ID       = $customer_id;
+		$args[0]->data->ID = $customer_id;
+
+		$updated_props = $this->get_customer_detail_props( $args[1] );
+		if ( empty( $updated_props ) ) {
+			return false;
+		}
+
+		return array( $args[0], $updated_props );
+	}
+
+	/**
+	 * Track updated WooCommerce customer meta props for syncing.
+	 *
+	 * @param int    $meta_id  ID of the meta object.
+	 * @param int    $user_id  User ID.
+	 * @param string $meta_key Meta key.
+	 * @param mixed  $value    Meta value.
+	 */
+	public function maybe_sync_customer_meta_update( $meta_id, $user_id, $meta_key, $value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$customer_id = (int) $user_id;
+		if ( $customer_id <= 0 ) {
+			return;
+		}
+
+		$updated_props = $this->get_customer_detail_props( array( $meta_key ) );
+		if ( empty( $updated_props ) ) {
+			return;
+		}
+
+		if ( ! isset( $this->customer_meta_updates[ $customer_id ] ) ) {
+			$this->customer_meta_updates[ $customer_id ] = array();
+		}
+
+		foreach ( $updated_props as $prop ) {
+			$this->customer_meta_updates[ $customer_id ][ $prop ] = true;
+		}
+	}
+
+	/**
+	 * Send batched WooCommerce customer meta updates.
+	 */
+	public function action_customer_meta_updates() {
+		if ( empty( $this->customer_meta_updates ) ) {
+			return;
+		}
+
+		$customer_meta_updates       = $this->customer_meta_updates;
+		$this->customer_meta_updates = array();
+
+		foreach ( $customer_meta_updates as $customer_id => $updated_props ) {
+			/**
+			 * Fires when WooCommerce customer details stored in user meta are updated.
+			 *
+			 * @param object $customer      Minimal WP_User-shaped customer object.
+			 * @param array  $updated_props Updated customer detail prop names.
+			 */
+			do_action(
+				'jetpack_updated_woo_customer_meta',
+				$this->build_minimal_customer_user_object( (int) $customer_id ),
+				array_keys( $updated_props )
+			);
+		}
+	}
+
+	/**
+	 * Retrieve whitelisted WooCommerce customer detail props.
+	 *
+	 * @param array $props Customer detail meta keys or prop names.
+	 * @return array Customer detail prop names.
+	 */
+	private function get_customer_detail_props( $props ) {
 		$updated_props = array();
-		foreach ( $args[1] as $prop ) {
+		foreach ( $props as $prop ) {
 			if ( ! is_string( $prop ) && ! is_numeric( $prop ) ) {
 				continue;
 			}
 
 			$prop = sanitize_key( (string) $prop );
-			if ( '' === $prop ) {
+			if ( isset( self::$customer_detail_meta_key_to_prop[ $prop ] ) ) {
+				$updated_props[] = self::$customer_detail_meta_key_to_prop[ $prop ];
 				continue;
 			}
 
-			$updated_props[] = $prop;
+			if ( in_array( $prop, self::$customer_detail_meta_key_to_prop, true ) ) {
+				$updated_props[] = $prop;
+			}
 		}
 
-		$updated_props = array_values( array_unique( $updated_props ) );
-		if ( empty( $updated_props ) ) {
-			return false;
-		}
-
-		return array( $this->build_minimal_customer_user_object( $customer_id ), $updated_props );
+		return array_values( array_unique( $updated_props ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-sync-woo-customer-props-updated
+++ b/projects/plugins/jetpack/changelog/add-sync-woo-customer-props-updated
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -152,6 +152,39 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertEmpty( $foo_events );
 	}
 
+	public function test_customer_updated_props_are_synced_without_customer_data() {
+		$user_id  = wp_insert_user(
+			array(
+				'user_login' => 'test_customer',
+				'user_email' => 'customer@example.com',
+				'user_pass'  => 'test',
+			)
+		);
+		$customer = new WC_Customer( $user_id );
+
+		$customer->set_billing_email( 'updated@example.com' );
+		$customer->set_billing_city( 'San Francisco' );
+		$customer->save();
+
+		$this->sender->do_sync();
+
+		$customer_updated_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_customer_object_updated_props' );
+
+		$this->assertTrue( (bool) $customer_updated_event );
+		$this->assertIsObject( $customer_updated_event->args[0] );
+		$this->assertNotInstanceOf( 'WC_Customer', $customer_updated_event->args[0] );
+		$this->assertEquals( $user_id, $customer_updated_event->args[0]->ID );
+		$this->assertEquals( $user_id, $customer_updated_event->args[0]->data->ID );
+		$this->assertEquals( 'test_customer', $customer_updated_event->args[0]->data->user_login );
+		$this->assertEquals( 'customer@example.com', $customer_updated_event->args[0]->data->user_email );
+		$this->assertContains( 'billing_email', $customer_updated_event->args[1] );
+		$this->assertContains( 'billing_city', $customer_updated_event->args[1] );
+
+		$encoded_event_args = wp_json_encode( $customer_updated_event->args, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+		$this->assertStringNotContainsString( 'updated@example.com', $encoded_event_args );
+		$this->assertStringNotContainsString( 'San Francisco', $encoded_event_args );
+	}
+
 	public function test_approving_a_review_is_synced() {
 		$post_id    = self::factory()->post->create();
 		$review_ids = self::factory()->comment->create_post_comments(

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -195,6 +195,23 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertFalse( (bool) $this->server_event_storage->get_most_recent_event( 'jetpack_updated_woo_customer_meta' ) );
 	}
 
+	public function test_customer_meta_deletes_from_user_deletion_are_not_synced_as_customer_details() {
+		$user_id = $this->create_test_customer_user( 'test_customer_deleted', 'deleted-customer@example.com' );
+
+		update_user_meta( $user_id, 'billing_email', 'deleted-customer@example.com' );
+
+		$this->flush_customer_meta_updates();
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+
+		wp_delete_user( $user_id );
+
+		$this->flush_customer_meta_updates();
+		$this->sender->do_sync();
+
+		$this->assertFalse( (bool) $this->server_event_storage->get_most_recent_event( 'jetpack_updated_woo_customer_meta' ) );
+	}
+
 	public function test_customer_meta_filter_rebuilds_minimal_customer_object() {
 		$user_id            = $this->create_test_customer_user( 'test_customer_extra_data', 'extra-customer@example.com' );
 		$woocommerce_module = $this->get_woocommerce_module();

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Modules\WooCommerce as WooCommerce_Module;
 use PHPUnit\Framework\Attributes\Group;
 
 require_once __DIR__ . '/Jetpack_Sync_TestBase.php';
@@ -152,23 +153,17 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertEmpty( $foo_events );
 	}
 
-	public function test_customer_updated_props_are_synced_without_customer_data() {
-		$user_id  = wp_insert_user(
-			array(
-				'user_login' => 'test_customer',
-				'user_email' => 'customer@example.com',
-				'user_pass'  => 'test',
-			)
-		);
-		$customer = new WC_Customer( $user_id );
+	public function test_customer_meta_updates_are_synced_without_customer_data() {
+		$user_id = $this->create_test_customer_user( 'test_customer', 'customer@example.com' );
 
-		$customer->set_billing_email( 'updated@example.com' );
-		$customer->set_billing_city( 'San Francisco' );
-		$customer->save();
+		update_user_meta( $user_id, 'billing_email', 'updated@example.com' );
+		update_user_meta( $user_id, 'billing_city', 'San Francisco' );
+		update_user_meta( $user_id, 'paying_customer', '1' );
 
+		$this->flush_customer_meta_updates();
 		$this->sender->do_sync();
 
-		$customer_updated_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_customer_object_updated_props' );
+		$customer_updated_event = $this->server_event_storage->get_most_recent_event( 'jetpack_updated_woo_customer_meta' );
 
 		$this->assertTrue( (bool) $customer_updated_event );
 		$this->assertIsObject( $customer_updated_event->args[0] );
@@ -179,10 +174,60 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertEquals( 'customer@example.com', $customer_updated_event->args[0]->data->user_email );
 		$this->assertContains( 'billing_email', $customer_updated_event->args[1] );
 		$this->assertContains( 'billing_city', $customer_updated_event->args[1] );
+		$this->assertContains( 'is_paying_customer', $customer_updated_event->args[1] );
+		$this->assertNotContains( 'paying_customer', $customer_updated_event->args[1] );
 
 		$encoded_event_args = wp_json_encode( $customer_updated_event->args, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 		$this->assertStringNotContainsString( 'updated@example.com', $encoded_event_args );
 		$this->assertStringNotContainsString( 'San Francisco', $encoded_event_args );
+	}
+
+	public function test_non_customer_meta_updates_are_not_synced_as_customer_details() {
+		$user_id = $this->create_test_customer_user( 'test_customer_untracked_meta', 'untracked-customer@example.com' );
+
+		update_user_meta( $user_id, 'session_tokens', 'secret' );
+		update_user_meta( $user_id, 'first_name', 'Ada' );
+		update_user_meta( $user_id, 'last_name', 'Lovelace' );
+
+		$this->flush_customer_meta_updates();
+		$this->sender->do_sync();
+
+		$this->assertFalse( (bool) $this->server_event_storage->get_most_recent_event( 'jetpack_updated_woo_customer_meta' ) );
+	}
+
+	/**
+	 * Create a customer user for WooCommerce sync tests.
+	 *
+	 * @param string $user_login User login.
+	 * @param string $user_email User email.
+	 * @return int User ID.
+	 */
+	private function create_test_customer_user( $user_login, $user_email ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $user_login,
+				'user_email' => $user_email,
+				'user_pass'  => 'test',
+			)
+		);
+
+		if ( is_wp_error( $user_id ) ) {
+			$this->fail( $user_id->get_error_message() );
+		}
+
+		return (int) $user_id;
+	}
+
+	/**
+	 * Flush pending customer meta updates.
+	 */
+	private function flush_customer_meta_updates() {
+		$woocommerce_module = Modules::get_module( 'woocommerce' );
+		if ( ! $woocommerce_module instanceof WooCommerce_Module ) {
+			$this->fail( 'WooCommerce sync module is not available.' );
+		}
+
+		$woocommerce_module->action_customer_meta_updates();
 	}
 
 	public function test_approving_a_review_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -195,6 +195,44 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertFalse( (bool) $this->server_event_storage->get_most_recent_event( 'jetpack_updated_woo_customer_meta' ) );
 	}
 
+	public function test_customer_meta_filter_rebuilds_minimal_customer_object() {
+		$user_id            = $this->create_test_customer_user( 'test_customer_extra_data', 'extra-customer@example.com' );
+		$woocommerce_module = $this->get_woocommerce_module();
+
+		$filtered_args = $woocommerce_module->filter_customer_updated_meta(
+			array(
+				(object) array(
+					'ID'              => $user_id,
+					'extra_top_level' => 'secret',
+					'data'            => (object) array(
+						'ID'                => $user_id,
+						'user_login'        => 'injected_login',
+						'user_email'        => 'injected@example.com',
+						'billing_address_1' => '123 Secret St',
+					),
+				),
+				array( 'billing_email' ),
+			)
+		);
+
+		if ( ! is_array( $filtered_args ) ) {
+			$this->fail( 'Customer meta filter returned an invalid payload.' );
+		}
+
+		$customer = $filtered_args[0];
+		if ( ! is_object( $customer ) || ! isset( $customer->data ) || ! is_object( $customer->data ) ) {
+			$this->fail( 'Customer meta filter did not return a minimal customer object.' );
+		}
+
+		$this->assertEquals( $user_id, $customer->ID );
+		$this->assertEquals( $user_id, $customer->data->ID );
+		$this->assertEquals( 'test_customer_extra_data', $customer->data->user_login );
+		$this->assertEquals( 'extra-customer@example.com', $customer->data->user_email );
+		$this->assertObjectNotHasProperty( 'extra_top_level', $customer );
+		$this->assertObjectNotHasProperty( 'billing_address_1', $customer->data );
+		$this->assertSame( array( 'billing_email' ), $filtered_args[1] );
+	}
+
 	/**
 	 * Create a customer user for WooCommerce sync tests.
 	 *
@@ -219,15 +257,24 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 	}
 
 	/**
-	 * Flush pending customer meta updates.
+	 * Retrieve the WooCommerce sync module.
+	 *
+	 * @return WooCommerce_Module WooCommerce sync module.
 	 */
-	private function flush_customer_meta_updates() {
+	private function get_woocommerce_module() {
 		$woocommerce_module = Modules::get_module( 'woocommerce' );
 		if ( ! $woocommerce_module instanceof WooCommerce_Module ) {
 			$this->fail( 'WooCommerce sync module is not available.' );
 		}
 
-		$woocommerce_module->action_customer_meta_updates();
+		return $woocommerce_module;
+	}
+
+	/**
+	 * Flush pending customer meta updates.
+	 */
+	private function flush_customer_meta_updates() {
+		$this->get_woocommerce_module()->action_customer_meta_updates();
 	}
 
 	public function test_approving_a_review_is_synced() {


### PR DESCRIPTION
Related to ACTLOG-53

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add WooCommerce Sync handling for customer account detail changes stored in user meta.
* Listen for `added_user_meta`, `updated_user_meta`, and `deleted_user_meta`, batch tracked customer meta changes per user for the request, and emit a custom `jetpack_updated_woo_customer_meta` Sync action on `shutdown`.
* Send a minimal `WP_User`-shaped customer object as arg 0 and sanitized changed WooCommerce customer prop names as arg 1.
* Map tracked WooCommerce user meta keys to customer prop names, including `paying_customer` to `is_paying_customer`.
* Ignore unrelated or already-covered user meta such as `session_tokens`, `first_name`, and `last_name`.
* Skip customer meta cleanup from `delete_user`/`wpmu_delete_user` flows so deleting a customer does not also enqueue a customer detail update.
* Validate the payload before enqueueing so invalid customer objects, empty prop lists, untracked props, and overfull customer objects are not synced.
* Add Sync test coverage for tracked customer meta updates, untracked user meta updates, filter hardening, and user-deletion cleanup.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* ACTLOG-53
* Requires the WPCOM receiver/display counterpart for end-to-end Activity Log rendering.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. This introduces a new Sync action for WooCommerce customer account detail updates.

The synced payload includes:
* A minimal user object: local user ID, display name, login, and email.
* Sanitized changed prop names, such as `billing_email`, `shipping_city`, or `is_paying_customer`.

The synced payload does not include:
* Raw billing, shipping, phone, or address values.
* The full `WC_Customer` object.
* Session tokens or unrelated user meta.
* Customer meta cleanup triggered by deleting the corresponding WordPress user.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

### Automated

From a Jetpack checkout with the Docker test environment installed:

```bash
JETPACK_TEST_WOOCOMMERCE=1 jp docker phpunit jetpack -- --filter=Jetpack_Sync_WooCommerce_Test
```

Expected:
* `test_customer_meta_updates_are_synced_without_customer_data` passes.
* `test_non_customer_meta_updates_are_not_synced_as_customer_details` passes.
* `test_customer_meta_filter_rebuilds_minimal_customer_object` passes.
* `test_customer_meta_deletes_from_user_deletion_are_not_synced_as_customer_details` passes.

### Manual

1. Apply this Jetpack branch to a connected test site with WooCommerce active.
2. Apply the WPCOM receiver/display counterpart to the sandbox used for Activity Log testing: 222803-ghe-Automattic/wpcom
3. Create or use a WooCommerce customer associated with a WordPress user.
4. Update tracked WooCommerce customer fields from `wp-admin/user-edit.php`, such as billing email, billing city, shipping city, or billing phone.
5. Update tracked WooCommerce customer fields from the customer's My Account address screens.
6. Trigger or wait for Sync processing.
7. Inspect the synced `jetpack_updated_woo_customer_meta` action.
8. Confirm arg 0 is a minimal user object, not a full `WC_Customer`.
9. Confirm arg 1 contains changed prop names, such as `billing_email` and `shipping_city`.
10. Confirm the payload does not include the raw updated billing or shipping values.
11. Confirm the WPCOM Activity Log entry lists the modified fields once the receiver/display counterpart is applied.
12. Update unrelated user meta, such as `first_name`, `last_name`, or session-token data, and confirm it does not produce `jetpack_updated_woo_customer_meta`.
13. Delete a WooCommerce customer user that has tracked customer meta and confirm the deletion cleanup does not produce `jetpack_updated_woo_customer_meta`.
