### PR TITLE
Newsletter: fix Add plans link on subdirectory installs (use home_url slug)

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-add-plans-subdirectory-url
+++ b/projects/packages/newsletter/changelog/fix-newsletter-add-plans-subdirectory-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: fix the "Add plans" link for WordPress installs in a subdirectory by deriving the site slug from home_url instead of site_url.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -254,15 +254,13 @@ class Settings {
 		$current_user = wp_get_current_user();
 		$theme        = wp_get_theme();
 
-		$site_url     = get_site_url();
-		$site_raw_url = preg_replace( '(^https?://)', '', $site_url );
-
 		$host                   = new Host();
 		$status                 = new Status();
+		$site_suffix            = $status->get_site_suffix();
 		$blog_id                = (int) $host->get_wpcom_site_id();
 		$is_wpcom               = $host->is_wpcom_platform();
 		$is_block_theme         = wp_is_block_theme();
-		$setup_payment_plan_url = ( $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . rawurlencode( $site_raw_url );
+		$setup_payment_plan_url = ( $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . $site_suffix;
 
 		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
 
@@ -278,7 +276,7 @@ class Settings {
 			'email'                           => $current_user->user_email,
 			'gravatar'                        => get_avatar_url( $current_user->ID ),
 			'dateExample'                     => gmdate( get_option( 'date_format' ), time() ),
-			'subscriberManagementUrl'         => $this->get_subscriber_management_url( $wp_admin_subscriber_management_enabled, $is_wpcom, $site_raw_url, $blog_id ),
+			'subscriberManagementUrl'         => $this->get_subscriber_management_url( $wp_admin_subscriber_management_enabled, $is_wpcom, $site_suffix, $blog_id ),
 			'subscriberManagementEnabled'     => (bool) $wp_admin_subscriber_management_enabled,
 			'isSubscriptionSiteEditSupported' => $is_block_theme,
 			'setupPaymentPlansUrl'            => $setup_payment_plan_url,
@@ -330,11 +328,11 @@ class Settings {
 	 *
 	 * @param bool   $wp_admin_enabled Whether wp-admin subscriber management is enabled.
 	 * @param bool   $is_wpcom         Whether this is a WordPress.com site.
-	 * @param string $site_raw_url     The site URL without protocol.
+	 * @param string $site_suffix      The Calypso site suffix (home host, slashes as `::`).
 	 * @param int    $blog_id          The blog ID.
 	 * @return string The subscriber management URL.
 	 */
-	private function get_subscriber_management_url( $wp_admin_enabled, $is_wpcom, $site_raw_url, $blog_id ) {
+	private function get_subscriber_management_url( $wp_admin_enabled, $is_wpcom, $site_suffix, $blog_id ) {
 		// If wp-admin subscriber management is enabled, use the wp-admin page.
 		if ( $wp_admin_enabled ) {
 			return admin_url( 'admin.php?page=subscribers' );
@@ -342,7 +340,7 @@ class Settings {
 
 		// For wpcom sites, use the wordpress.com URL.
 		if ( $is_wpcom ) {
-			return 'https://wordpress.com/subscribers/' . $site_raw_url;
+			return 'https://wordpress.com/subscribers/' . $site_suffix;
 		}
 
 		// For Jetpack sites, use the jetpack.com redirect URL.

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -57,6 +57,8 @@ class Settings_Test extends BaseTestCase {
 
 		unset( $_GET['page'] );
 		remove_all_filters( Settings::MODERNIZATION_FILTER );
+		remove_all_filters( 'site_url' );
+		remove_all_filters( 'home_url' );
 
 		// Dequeue any scripts that may have leaked into globals during the test.
 		wp_dequeue_script( 'jp-tracks' );
@@ -199,9 +201,6 @@ class Settings_Test extends BaseTestCase {
 		add_filter( 'home_url', array( $this, 'mock_subdirectory_home_url' ) );
 
 		$data = ( new Settings() )->add_script_data( array() );
-
-		remove_filter( 'site_url', array( $this, 'mock_subdirectory_site_url' ) );
-		remove_filter( 'home_url', array( $this, 'mock_subdirectory_home_url' ) );
 
 		$this->assertSame(
 			'https://cloud.jetpack.com/monetize/payments/example.com',

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -188,6 +188,52 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Regression test for NL-695: on a WordPress install living in a subdirectory,
+	 * `site_url` includes the subdirectory path (e.g. `example.com/pages`) while
+	 * `home_url` is the bare host (e.g. `example.com`). The "Add plans" URL must be
+	 * built from the home host so Calypso receives a valid site slug, not the
+	 * subdirectory path.
+	 */
+	public function test_add_script_data_payment_url_uses_home_host_on_subdirectory_install() {
+		add_filter( 'site_url', array( $this, 'mock_subdirectory_site_url' ) );
+		add_filter( 'home_url', array( $this, 'mock_subdirectory_home_url' ) );
+
+		$data = ( new Settings() )->add_script_data( array() );
+
+		remove_filter( 'site_url', array( $this, 'mock_subdirectory_site_url' ) );
+		remove_filter( 'home_url', array( $this, 'mock_subdirectory_home_url' ) );
+
+		$this->assertSame(
+			'https://cloud.jetpack.com/monetize/payments/example.com',
+			$data['newsletter']['setupPaymentPlansUrl'],
+			'Add plans URL must use the home host, not the site_url subdirectory path.'
+		);
+		$this->assertStringNotContainsString(
+			'pages',
+			$data['newsletter']['setupPaymentPlansUrl'],
+			'Add plans URL must not leak the site_url subdirectory segment.'
+		);
+	}
+
+	/**
+	 * Mock `site_url` for a subdirectory install (WordPress lives in `/pages`).
+	 *
+	 * @return string
+	 */
+	public function mock_subdirectory_site_url() {
+		return 'https://example.com/pages';
+	}
+
+	/**
+	 * Mock `home_url` for a subdirectory install (the site is served from the root).
+	 *
+	 * @return string
+	 */
+	public function mock_subdirectory_home_url() {
+		return 'https://example.com';
+	}
+
+	/**
 	 * Reflection helper for the private static `Settings::is_modernized()`.
 	 *
 	 * Going through reflection rather than `apply_filters()` ensures we test the


### PR DESCRIPTION
Fixes NL-695

## Proposed changes
* The Newsletter "Add plans" and "Subscribers" links were built from `get_site_url()`, which on subdirectory WordPress installs includes the subdirectory path — leaking into the generated Calypso/Jetpack Cloud URL as e.g. `…/payments/example.com%2Fpages` and producing a broken link.
* This switches to `Status::get_site_suffix()`, which derives the slug from `home_url()` and is the canonical helper for Calypso URLs across the monorepo, and drops the now-redundant `rawurlencode()`.
* Adds a regression test covering a subdirectory install (`site_url` = `example.com/pages`, `home_url` = `example.com`).

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WordPress install where the site address (`home_url`) differs from the WordPress address (`site_url`) — i.e. WordPress lives in a subdirectory — go to **Jetpack → Newsletter → Paid Newsletter** in wp-admin.
* Click the **Add plans** button and confirm the destination URL is `cloud.jetpack.com/monetize/payments/<your-home-host>` with no subdirectory path or `%2F` in it.
* On a regular (non-subdirectory) install, confirm the link is unchanged.
