### PR TITLE
Boost: continue Critical CSS generation when a single provider fails unexpectedly

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
@@ -181,9 +181,11 @@ async function createBrowserInterface(
 
 /**
  * Generate Critical CSS for the specified Provider Keys, sending each block
- * to the server. Per-provider errors are recorded against the offending
- * provider and do not stop the remaining providers from generating. Only
- * throws on global failures (e.g. the generator library failing to load).
+ * to the server. Per-provider generation errors are recorded against the
+ * offending provider and do not stop the remaining providers from generating.
+ * Throws only on failures that aren't tied to a single provider's generation
+ * step, e.g. the generator library failing to load, or a state-persistence
+ * callback rejecting.
  *
  * @param {Object}      providers            - Set of URLs to use for each provider key
  * @param {Viewport[]}  viewports            - Viewports to use when generating Critical CSS.
@@ -335,7 +337,10 @@ async function generateForKeys(
 				recordBoostEvent( 'critical_css_failure', eventProps );
 
 				// Record the error against this provider, and continue generating
-				// Critical CSS for the remaining providers.
+				// Critical CSS for the remaining providers. The stored type is the
+				// catch-all 'UnknownError' (a valid CriticalCssErrorType) rather than
+				// the analytics `type` above, which may be 'unknown' or some other
+				// value that isn't a recognised member.
 				await callbacks.setProviderErrors(
 					key,
 					urls.map( url => ( {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
@@ -181,7 +181,9 @@ async function createBrowserInterface(
 
 /**
  * Generate Critical CSS for the specified Provider Keys, sending each block
- * to the server. Throws on error or cancellation.
+ * to the server. Per-provider errors are recorded against the offending
+ * provider and do not stop the remaining providers from generating. Only
+ * throws on global failures (e.g. the generator library failing to load).
  *
  * @param {Object}      providers            - Set of URLs to use for each provider key
  * @param {Viewport[]}  viewports            - Viewports to use when generating Critical CSS.
@@ -312,11 +314,17 @@ async function generateForKeys(
 					recordBoostEvent( 'critical_css_url_error', eventProps );
 				}
 			} else {
+				// Swallow errors caused by cancelling the process.
+				if ( signal.aborted ) {
+					return;
+				}
+
+				stepsFailed++;
 				const stdError = standardizeError( err );
 				const type =
 					( 'type' in stdError && typeof stdError.type === 'string' && stdError.type ) || 'unknown';
 
-				// Track showstopper Critical CSS generation error.
+				// Track unexpected per-provider Critical CSS generation error.
 				const eventProps = {
 					time: Date.now() - startTime,
 					provider_key: key,
@@ -326,7 +334,17 @@ async function generateForKeys(
 
 				recordBoostEvent( 'critical_css_failure', eventProps );
 
-				throw err;
+				// Record the error against this provider, and continue generating
+				// Critical CSS for the remaining providers.
+				await callbacks.setProviderErrors(
+					key,
+					urls.map( url => ( {
+						url,
+						message: stdError.message,
+						type: 'UnknownError',
+						meta: {},
+					} ) )
+				);
 			}
 		} finally {
 			// Always increment provider index and update boundary progress,

--- a/projects/plugins/boost/changelog/fix-critical-css-provider-error-resilience
+++ b/projects/plugins/boost/changelog/fix-critical-css-provider-error-resilience
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: continue generating for remaining providers when one provider fails unexpectedly, instead of failing the whole run.


### PR DESCRIPTION
Fixes #38217

## Proposed changes

* **Critical CSS (local/browser generation):** when an unexpected error (anything other than `SuccessTargetError`) occurs while generating CSS for one provider, record it as that provider's error via the existing `set-provider-errors` data-sync action (`UnknownError` type) and continue with the remaining providers — instead of re-throwing, which unwound the whole run, set the global state to `error`, and discarded the run for all remaining providers even though completed providers' CSS was already saved server-side.
* Keep `stepsFailed` accounting so the existing `critical_css_failure` / `critical_css_success` Tracks events remain accurate; the per-provider `critical_css_failure` event is still recorded.
* Skip recording the error when generation was cancelled (`signal.aborted`), matching the previous swallow-on-abort behavior.
* **Unchanged:** `SuccessTargetError` (per-URL failures) handling, `ProviderCssSaveError` handling, and the global hard-failure path when the generator library fails to load. `isFatalError()` still reports a fatal error when *no* provider succeeded, so the all-failed UX is preserved. No PHP changes needed — `Critical_CSS_State::maybe_set_generated()` already flips overall status to `generated` once no provider is pending.

> Note: no jest test added — Boost's jest config has no module mapping for the `$lib`/`$features` aliases this module uses, so testing it would mean building new test infrastructure; flagging that as a follow-up rather than bundling it here.

## Related product discussion/links

* Part of a Boost Critical-CSS resilience pass (audit follow-up); siblings: #49545, #49546, #49547.

## Does this pull request change what data or activity we track or use?

No. (Existing Tracks events unchanged; the per-provider failure event already carried `provider_key`.)

## Testing instructions

1. Use a free-plan (local generation) site with Boost's Critical CSS module enabled, ideally with several providers (posts, pages, front page, …).
2. Simulate a failing provider — e.g. via a devtools breakpoint/override that throws inside `generateCriticalCSS` for one provider key, or by temporarily corrupting one provider's URL in the `jetpack_boost_ds_critical_css_state` option.
3. Click **Regenerate** Critical CSS in Boost admin and keep the tab open (generation runs in-browser).
4. **Confirm:** the progress bar continues past the failing provider; generation completes; the failing provider shows its error in the advanced recommendations list while the others show success.
5. Verify stored state: `jetpack_boost_ds_critical_css_state` shows the failing provider with `status: error`, the rest `success`, overall `generated`; the front end serves critical CSS for successful providers.
6. Regression checks: a per-URL failure (one 404 URL in a provider) still surfaces as a `SuccessTargetError` recommendation; blocking the `jetpack-critical-css-gen` chunk still produces the global error state; cancelling mid-run produces no spurious provider errors.

https://claude.ai/code/session_01PgpTrtTCH4hpz6Krh3ssho

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgpTrtTCH4hpz6Krh3ssho)_