### PR TITLE
Boost: let admins test extra Concatenate JS/CSS excludes per-request via GET parameters

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -193,7 +193,7 @@ function jetpack_boost_enqueued_to_absolute_url( $url ) {
 }
 
 /**
- * Get the list of JS slugs to exclude from minification.
+ * Get the list of JS handles to exclude from minification.
  *
  * Administrators can append extra handles for the current request only via the
  * `jb-minify-js-excludes` GET parameter (comma-separated handles). See
@@ -207,7 +207,7 @@ function jetpack_boost_page_optimize_js_exclude_list() {
 }
 
 /**
- * Get the list of CSS slugs to exclude from minification.
+ * Get the list of CSS handles to exclude from minification.
  *
  * Administrators can append extra handles for the current request only via the
  * `jb-minify-css-excludes` GET parameter (comma-separated handles). See

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -194,16 +194,94 @@ function jetpack_boost_enqueued_to_absolute_url( $url ) {
 
 /**
  * Get the list of JS slugs to exclude from minification.
+ *
+ * Administrators can append extra handles for the current request only via the
+ * `jb-minify-js-excludes` GET parameter (comma-separated handles). See
+ * jetpack_boost_page_optimize_merge_debug_excludes() for details.
  */
 function jetpack_boost_page_optimize_js_exclude_list() {
-	return jetpack_boost_ds_get( 'minify_js_excludes' );
+	return jetpack_boost_page_optimize_merge_debug_excludes(
+		jetpack_boost_ds_get( 'minify_js_excludes' ),
+		'jb-minify-js-excludes'
+	);
 }
 
 /**
  * Get the list of CSS slugs to exclude from minification.
+ *
+ * Administrators can append extra handles for the current request only via the
+ * `jb-minify-css-excludes` GET parameter (comma-separated handles). See
+ * jetpack_boost_page_optimize_merge_debug_excludes() for details.
  */
 function jetpack_boost_page_optimize_css_exclude_list() {
-	return jetpack_boost_ds_get( 'minify_css_excludes' );
+	return jetpack_boost_page_optimize_merge_debug_excludes(
+		jetpack_boost_ds_get( 'minify_css_excludes' ),
+		'jb-minify-css-excludes'
+	);
+}
+
+/**
+ * Debugging aid: merge per-request exclude handles from a GET parameter into a
+ * saved concatenate/minify exclude list.
+ *
+ * Lets administrators test "would excluding handle X fix this page?" by loading
+ * the page with e.g. `?jb-minify-js-excludes=jquery-core,my-plugin-script`
+ * without editing the saved settings, and without needing a staging site.
+ *
+ * Safety properties:
+ * - Only honored for logged-in users with the `manage_options` capability. The
+ *   exclude lists are read while scripts/styles are printed (wp_head/wp_footer),
+ *   i.e. within normal WordPress runtime where capability APIs are loaded; the
+ *   function_exists() check makes this a no-op anywhere they are not.
+ * - Each handle is sanitized: only lowercase alphanumerics, dash, underscore and
+ *   dot are accepted, anything else is ignored entirely.
+ * - The merged list is never persisted — nothing is written to the data sync
+ *   store or options; the merge only affects the current request.
+ * - No Page Cache interaction: logged-in users always bypass Boost's page cache
+ *   (Request::is_cacheable() returns false), so pages rendered with these debug
+ *   parameters are neither served from nor written to the cache.
+ *
+ * @since $$next-version$$
+ *
+ * @param array  $excludes  The saved exclude list.
+ * @param string $param     The GET parameter to read extra handles from.
+ *
+ * @return array The exclude list, with any valid per-request handles appended.
+ */
+function jetpack_boost_page_optimize_merge_debug_excludes( $excludes, $param ) {
+	if ( ! is_array( $excludes ) ) {
+		$excludes = array();
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only debugging parameter; capability-gated below and never persisted.
+	if ( ! isset( $_GET[ $param ] ) || ! is_string( $_GET[ $param ] ) ) {
+		return $excludes;
+	}
+
+	// Only administrators may use the debug parameters.
+	if ( ! function_exists( 'current_user_can' ) || ! current_user_can( 'manage_options' ) ) {
+		return $excludes;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Each handle is validated against a strict allowlist below.
+	$raw_handles = explode( ',', wp_unslash( $_GET[ $param ] ) );
+
+	$extra_handles = array();
+	foreach ( $raw_handles as $handle ) {
+		$handle = strtolower( trim( $handle ) );
+
+		// sanitize_key()-style allowlist (plus dots, which are common in handles).
+		// Handles containing any other character are ignored entirely.
+		if ( $handle !== '' && preg_match( '/^[a-z0-9_.\-]+$/', $handle ) ) {
+			$extra_handles[] = $handle;
+		}
+	}
+
+	if ( empty( $extra_handles ) ) {
+		return $excludes;
+	}
+
+	return array_values( array_unique( array_merge( $excludes, $extra_handles ) ) );
 }
 
 /**

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -278,12 +278,8 @@ function jetpack_boost_page_optimize_merge_debug_excludes( $excludes, $param ) {
 	$raw_value = wp_unslash( $_GET[ $param ] );
 
 	// Bound the work: a real debug session never needs more than a handful of
-	// handles, so ignore absurdly long values outright and cap the number of
-	// handles actually processed.
-	if ( strlen( $raw_value ) > 2000 ) {
-		return $excludes;
-	}
-
+	// handles, so process at most the first 100. The excess is dropped rather
+	// than discarding the whole value, so a partial list still applies.
 	$raw_handles = array_slice( explode( ',', $raw_value ), 0, 100 );
 
 	$extra_handles = array();

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -278,12 +278,13 @@ function jetpack_boost_page_optimize_merge_debug_excludes( $excludes, $param ) {
 	$raw_value = wp_unslash( $_GET[ $param ] );
 
 	// Bound the work: a real debug session never needs more than a handful of
-	// handles, so ignore absurdly long values outright.
+	// handles, so ignore absurdly long values outright and cap the number of
+	// handles actually processed.
 	if ( strlen( $raw_value ) > 2000 ) {
 		return $excludes;
 	}
 
-	$raw_handles = explode( ',', $raw_value );
+	$raw_handles = array_slice( explode( ',', $raw_value ), 0, 100 );
 
 	$extra_handles = array();
 	foreach ( $raw_handles as $handle ) {

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -243,7 +243,7 @@ function jetpack_boost_page_optimize_css_exclude_list() {
  *
  * @since $$next-version$$
  *
- * @param array  $excludes  The saved exclude list.
+ * @param mixed  $excludes  The saved exclude list; non-array values are treated as an empty list.
  * @param string $param     The GET parameter to read extra handles from.
  *
  * @return array The exclude list, with any valid per-request handles appended.

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -229,17 +229,28 @@ function jetpack_boost_page_optimize_css_exclude_list() {
  * without editing the saved settings, and without needing a staging site.
  *
  * Safety properties:
- * - Only honored for logged-in users with the `manage_options` capability. The
- *   exclude lists are read while scripts/styles are printed (wp_head/wp_footer),
- *   i.e. within normal WordPress runtime where capability APIs are loaded; the
- *   function_exists() check makes this a no-op anywhere they are not.
- * - Each handle is sanitized: only lowercase alphanumerics, dash, underscore and
- *   dot are accepted, anything else is ignored entirely.
+ * - Only honored for logged-in users with the `manage_options` capability.
+ *   current_user_can() is available during normal page rendering (the exclude
+ *   lists are read while scripts/styles are printed at wp_head/wp_footer); the
+ *   function_exists() guard defensively no-ops in any pre-WordPress context
+ *   (e.g. the page-cache layer) where it is not yet loaded.
+ * - Each handle is validated against a strict allowlist (alphanumerics, dash,
+ *   underscore and dot); anything else is ignored entirely. Case is preserved
+ *   because script/style handles are matched case-sensitively downstream.
+ * - The number of handles processed is capped to bound the work this debug aid
+ *   can be made to do per request.
  * - The merged list is never persisted — nothing is written to the data sync
  *   store or options; the merge only affects the current request.
  * - No Page Cache interaction: logged-in users always bypass Boost's page cache
  *   (Request::is_cacheable() returns false), so pages rendered with these debug
  *   parameters are neither served from nor written to the cache.
+ *
+ * Residual note: changing the exclude list changes concatenate-bundle membership,
+ * so each distinct combination an admin renders generates its own concat-path
+ * transient (and static file when static minification is on), just like any new
+ * page does. These are reclaimed by the normal Cleanup_Stored_Paths schedule.
+ * The parameter is intentionally nonce-free so it can be shared as a plain URL,
+ * so this stays capability-gated rather than CSRF-gated.
  *
  * @since $$next-version$$
  *
@@ -264,15 +275,27 @@ function jetpack_boost_page_optimize_merge_debug_excludes( $excludes, $param ) {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Each handle is validated against a strict allowlist below.
-	$raw_handles = explode( ',', wp_unslash( $_GET[ $param ] ) );
+	$raw_value = wp_unslash( $_GET[ $param ] );
+
+	// Bound the work: a real debug session never needs more than a handful of
+	// handles, so ignore absurdly long values outright.
+	if ( strlen( $raw_value ) > 2000 ) {
+		return $excludes;
+	}
+
+	$raw_handles = explode( ',', $raw_value );
 
 	$extra_handles = array();
 	foreach ( $raw_handles as $handle ) {
-		$handle = strtolower( trim( $handle ) );
+		$handle = trim( $handle );
 
-		// sanitize_key()-style allowlist (plus dots, which are common in handles).
-		// Handles containing any other character are ignored entirely.
-		if ( $handle !== '' && preg_match( '/^[a-z0-9_.\-]+$/', $handle ) ) {
+		/*
+		 * Allowlist of characters valid in script/style handles. Case is preserved
+		 * (not lowercased) because handles are matched case-sensitively downstream,
+		 * so lowercasing would silently fail to exclude a handle registered with
+		 * uppercase letters. Handles containing any other character are ignored.
+		 */
+		if ( $handle !== '' && preg_match( '/^[a-zA-Z0-9_.\-]+$/', $handle ) ) {
 			$extra_handles[] = $handle;
 		}
 	}

--- a/projects/plugins/boost/changelog/add-minify-excludes-debug-params
+++ b/projects/plugins/boost/changelog/add-minify-excludes-debug-params
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Concatenate JS/CSS: allow administrators to test additional exclude handles per-request via jb-minify-js-excludes / jb-minify-css-excludes GET parameters, without changing saved settings.
+Concatenate JS/CSS: allow administrators to test additional exclude handles per-request via jb-minify-js-excludes / jb-minify-css-excludes GET parameters, without changing saved settings. The parameters are ignored for non-administrators.

--- a/projects/plugins/boost/changelog/add-minify-excludes-debug-params
+++ b/projects/plugins/boost/changelog/add-minify-excludes-debug-params
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Concatenate JS/CSS: allow administrators to test additional exclude handles per-request via jb-minify-js-excludes / jb-minify-css-excludes GET parameters, without changing saved settings.

--- a/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
+++ b/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
@@ -10,6 +10,7 @@
 	* [JavaScript unit tests and e2e tests](#javascript-e2e-tests)
 	* [Linting Jetpack Boost's PHP code](#linting-jetpack-boost-php-code)
 	* [Linting Jetpack Boost's JavaScript code](#linting-jetpack-boost-javascript-code)
+* [Debugging Concatenate JS/CSS exclusions](#debugging-concatenate-jscss-exclusions)
 
 # Prerequisite
 
@@ -93,3 +94,19 @@ To automatically fix some JavaScript related issues, you can run:
   pnpm lint:fix
   ``` 
 
+
+# Debugging Concatenate JS/CSS exclusions
+
+When concatenation breaks a page, you can test whether excluding a specific script or style handle fixes it — without editing the saved exclude lists — by appending one of these GET parameters to the page URL:
+
+* `jb-minify-js-excludes` — comma-separated script handles to additionally exclude from JS concatenation for that request.
+* `jb-minify-css-excludes` — comma-separated style handles to additionally exclude from CSS concatenation for that request.
+
+For example: `https://example.com/some-page/?jb-minify-js-excludes=jquery-core,my-plugin-script`.
+
+Notes:
+
+* The parameters only work for logged-in users with the `manage_options` capability (administrators); for everyone else they are ignored.
+* Handles may only contain lowercase alphanumerics, dashes, underscores and dots; anything else is discarded.
+* Nothing is persisted — the merged exclude list only applies to the current request. To make an exclusion permanent, add it in Boost's Advanced Settings.
+* This does not interact with Boost's Page Cache: logged-in users are never served cached pages, nor are their page views written to the cache.

--- a/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
+++ b/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
@@ -107,6 +107,6 @@ For example: `https://example.com/some-page/?jb-minify-js-excludes=jquery-core,m
 Notes:
 
 * The parameters only work for logged-in users with the `manage_options` capability (administrators); for everyone else they are ignored.
-* Handles may only contain lowercase alphanumerics, dashes, underscores and dots; anything else is discarded.
+* Handles may only contain alphanumerics, dashes, underscores and dots; anything else is discarded. Case is preserved, so enter the handle exactly as registered (handles are matched case-sensitively).
 * Nothing is persisted — the merged exclude list only applies to the current request. To make an exclusion permanent, add it in Boost's Advanced Settings.
 * This does not interact with Boost's Page Cache: logged-in users are never served cached pages, nor are their page views written to the cache.

--- a/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
@@ -141,6 +141,27 @@ class Debug_Excludes_Test extends Base_TestCase {
 		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
 	}
 
+	public function test_number_of_handles_processed_is_capped() {
+		// Even within the length limit, only the first 100 handles are processed so
+		// the per-asset parse stays bounded.
+		$handles                       = array_map(
+			static function ( $i ) {
+				return sprintf( 'h%03d', $i );
+			},
+			range( 1, 150 )
+		);
+		$_GET['jb-minify-js-excludes'] = implode( ',', $handles );
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$result = jetpack_boost_page_optimize_js_exclude_list();
+
+		// Two saved handles + the first 100 requested handles.
+		$this->assertCount( 102, $result );
+		$this->assertContains( 'h100', $result );
+		$this->assertNotContains( 'h101', $result );
+	}
+
 	public function test_overlong_param_is_ignored() {
 		// A debug session never needs thousands of characters; oversized values
 		// are dropped wholesale so the parser cannot be made to do unbounded work.

--- a/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
@@ -109,15 +109,46 @@ class Debug_Excludes_Test extends Base_TestCase {
 		);
 	}
 
-	public function test_handles_are_lowercased_and_trimmed() {
+	public function test_handles_are_trimmed_but_case_is_preserved() {
+		// Handles are matched case-sensitively downstream, so an uppercase handle
+		// must be preserved verbatim (after trimming) rather than lowercased —
+		// lowercasing would silently fail to exclude it.
 		$_GET['jb-minify-js-excludes'] = '  My-Plugin-Script  ';
 
 		Functions\when( 'current_user_can' )->justReturn( true );
 
 		$this->assertSame(
-			array( 'jquery', 'jquery-core', 'my-plugin-script' ),
+			array( 'jquery', 'jquery-core', 'My-Plugin-Script' ),
 			jetpack_boost_page_optimize_js_exclude_list()
 		);
+	}
+
+	public function test_saved_list_returned_unchanged_when_all_handles_invalid() {
+		// Param is present, is a string, and the user is an admin, but every handle
+		// is rejected by the allowlist — the saved list must come back untouched.
+		$_GET['jb-minify-js-excludes'] = '<script>, ../../etc/passwd,    ';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+	}
+
+	public function test_saved_list_returned_when_param_is_empty_string() {
+		$_GET['jb-minify-js-excludes'] = '';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+	}
+
+	public function test_overlong_param_is_ignored() {
+		// A debug session never needs thousands of characters; oversized values
+		// are dropped wholesale so the parser cannot be made to do unbounded work.
+		$_GET['jb-minify-js-excludes'] = str_repeat( 'a', 2001 );
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
 	}
 
 	public function test_duplicate_handles_are_not_added_twice() {

--- a/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
+
+use Automattic\Jetpack_Boost\Tests\Base_TestCase;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\After;
+
+/**
+ * Tests for the per-request concatenate/minify exclude debug GET parameters
+ * (`jb-minify-js-excludes` / `jb-minify-css-excludes`).
+ *
+ * @package Automattic\Jetpack_Boost\Tests\Lib\Minify
+ */
+class Debug_Excludes_Test extends Base_TestCase {
+
+	const SAVED_JS_EXCLUDES  = array( 'jquery', 'jquery-core' );
+	const SAVED_CSS_EXCLUDES = array( 'admin-bar' );
+
+	protected function set_up() {
+		parent::set_up();
+		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
+
+		// Note: wp_unslash() is provided by tests/bootstrap.php.
+		Functions\when( 'jetpack_boost_ds_get' )->alias(
+			function ( $key ) {
+				if ( 'minify_js_excludes' === $key ) {
+					return self::SAVED_JS_EXCLUDES;
+				}
+				if ( 'minify_css_excludes' === $key ) {
+					return self::SAVED_CSS_EXCLUDES;
+				}
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * @after
+	 */
+	#[After]
+	protected function clean_up_get_superglobal() {
+		unset( $_GET['jb-minify-js-excludes'], $_GET['jb-minify-css-excludes'] );
+	}
+
+	public function test_saved_list_returned_when_param_absent() {
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+		$this->assertSame( self::SAVED_CSS_EXCLUDES, jetpack_boost_page_optimize_css_exclude_list() );
+	}
+
+	public function test_js_handles_merged_for_administrators() {
+		$_GET['jb-minify-js-excludes'] = 'my-plugin-script, another_script.v2';
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_options' )
+			->andReturn( true );
+
+		$this->assertSame(
+			array( 'jquery', 'jquery-core', 'my-plugin-script', 'another_script.v2' ),
+			jetpack_boost_page_optimize_js_exclude_list()
+		);
+	}
+
+	public function test_css_handles_merged_for_administrators() {
+		$_GET['jb-minify-css-excludes'] = 'my-theme-style';
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_options' )
+			->andReturn( true );
+
+		$this->assertSame(
+			array( 'admin-bar', 'my-theme-style' ),
+			jetpack_boost_page_optimize_css_exclude_list()
+		);
+	}
+
+	public function test_params_ignored_without_manage_options_capability() {
+		$_GET['jb-minify-js-excludes']  = 'my-plugin-script';
+		$_GET['jb-minify-css-excludes'] = 'my-theme-style';
+
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+		$this->assertSame( self::SAVED_CSS_EXCLUDES, jetpack_boost_page_optimize_css_exclude_list() );
+	}
+
+	public function test_invalid_handles_are_ignored_entirely() {
+		$_GET['jb-minify-js-excludes'] = implode(
+			',',
+			array(
+				'valid-handle',
+				'<script>alert(1)</script>',
+				'../../etc/passwd',
+				'foo bar',
+				'handle"quote',
+				'',
+				'   ',
+				'ok_handle.min',
+			)
+		);
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame(
+			array( 'jquery', 'jquery-core', 'valid-handle', 'ok_handle.min' ),
+			jetpack_boost_page_optimize_js_exclude_list()
+		);
+	}
+
+	public function test_handles_are_lowercased_and_trimmed() {
+		$_GET['jb-minify-js-excludes'] = '  My-Plugin-Script  ';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame(
+			array( 'jquery', 'jquery-core', 'my-plugin-script' ),
+			jetpack_boost_page_optimize_js_exclude_list()
+		);
+	}
+
+	public function test_duplicate_handles_are_not_added_twice() {
+		$_GET['jb-minify-js-excludes'] = 'jquery-core,jquery-core,new-handle';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame(
+			array( 'jquery', 'jquery-core', 'new-handle' ),
+			jetpack_boost_page_optimize_js_exclude_list()
+		);
+	}
+
+	public function test_non_string_param_is_ignored() {
+		$_GET['jb-minify-js-excludes'] = array( 'my-plugin-script' );
+
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+	}
+
+	public function test_merged_list_is_never_persisted() {
+		$_GET['jb-minify-js-excludes'] = 'my-plugin-script';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\expect( 'jetpack_boost_ds_set' )->never();
+		Functions\expect( 'update_option' )->never();
+
+		jetpack_boost_page_optimize_js_exclude_list();
+
+		// The saved list, as seen by the data sync store, is untouched.
+		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_ds_get( 'minify_js_excludes' ) );
+	}
+
+	public function test_helper_handles_non_array_saved_list() {
+		$_GET['jb-minify-js-excludes'] = 'my-plugin-script';
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertSame(
+			array( 'my-plugin-script' ),
+			jetpack_boost_page_optimize_merge_debug_excludes( null, 'jb-minify-js-excludes' )
+		);
+	}
+}

--- a/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Debug_Excludes_Test.php
@@ -141,9 +141,9 @@ class Debug_Excludes_Test extends Base_TestCase {
 		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
 	}
 
-	public function test_number_of_handles_processed_is_capped() {
-		// Even within the length limit, only the first 100 handles are processed so
-		// the per-asset parse stays bounded.
+	public function test_number_of_js_handles_processed_is_capped() {
+		// Only the first 100 handles are processed so the per-asset parse stays
+		// bounded; the excess is dropped without discarding the partial list.
 		$handles                       = array_map(
 			static function ( $i ) {
 				return sprintf( 'h%03d', $i );
@@ -162,14 +162,23 @@ class Debug_Excludes_Test extends Base_TestCase {
 		$this->assertNotContains( 'h101', $result );
 	}
 
-	public function test_overlong_param_is_ignored() {
-		// A debug session never needs thousands of characters; oversized values
-		// are dropped wholesale so the parser cannot be made to do unbounded work.
-		$_GET['jb-minify-js-excludes'] = str_repeat( 'a', 2001 );
+	public function test_number_of_css_handles_processed_is_capped() {
+		$handles                        = array_map(
+			static function ( $i ) {
+				return sprintf( 'h%03d', $i );
+			},
+			range( 1, 150 )
+		);
+		$_GET['jb-minify-css-excludes'] = implode( ',', $handles );
 
 		Functions\when( 'current_user_can' )->justReturn( true );
 
-		$this->assertSame( self::SAVED_JS_EXCLUDES, jetpack_boost_page_optimize_js_exclude_list() );
+		$result = jetpack_boost_page_optimize_css_exclude_list();
+
+		// One saved handle + the first 100 requested handles.
+		$this->assertCount( 101, $result );
+		$this->assertContains( 'h100', $result );
+		$this->assertNotContains( 'h101', $result );
 	}
 
 	public function test_duplicate_handles_are_not_added_twice() {


### PR DESCRIPTION
Fixes #31682

## Proposed changes

* Adds two debug-only GET parameters for the Concatenate JS/CSS (minify) modules: `jb-minify-js-excludes` and `jb-minify-css-excludes`, each accepting comma-separated script/style handles.
* For logged-in administrators (`manage_options`), the listed handles are appended to the respective saved exclude list **for that request only**, letting support/developers test "would excluding handle X fix this page?" without editing settings or needing a staging copy.
* Handles are validated against a strict allowlist (alphanumerics, dash, underscore, dot); anything else is discarded. Case is preserved, since script/style handles are matched case-sensitively downstream. At most the first 100 handles are processed (excess is dropped, not the whole value), and nothing is ever persisted to the data-sync store.
* The merge lives in `jetpack_boost_page_optimize_merge_debug_excludes()` in `functions-helpers.php`, called from the two exclude-list readers consumed by `Concatenate_JS::do_items()` / `Concatenate_CSS::do_items()` — which run during normal WordPress runtime (`wp_head`/`wp_footer`), so `current_user_can()` is reliably available (with a `function_exists` guard as belt-and-braces; the pre-WordPress `_jb_static` service path never reads exclude lists).
* **No Page Cache interaction:** logged-in users always bypass Boost's page cache — `Request::is_cacheable()` returns `false` on both the serve and the write paths — and GET parameters are part of the cache key anyway, so these parameters can neither hit nor poison cached pages.
* The parameter is intentionally nonce-free so it can be shared as a plain URL; it stays capability-gated rather than CSRF-gated. Rendering distinct exclude combinations generates the usual concat-path cache artifacts, reclaimed by the normal `Cleanup_Stored_Paths` schedule.
* Adds unit tests covering merge, sanitization, case preservation, capability gating, dedup, the all-invalid / empty-string / handle-cap branches, non-string params, and non-persistence, plus a short "Debugging Concatenate JS/CSS exclusions" section in the development guide.

## Related product discussion/links

* Part of the Boost exclusion-UX workstream (audit follow-up); siblings: #49545, #49546, #49547, #49554.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable Concatenate JS in Jetpack Boost and visit a front-end page as an administrator; confirm scripts are served via concatenated `/_jb_static/??…` URLs.
2. Reload with `?jb-minify-js-excludes=jquery-core` appended. Confirm `jquery-core` is now served as a standalone `<script>` tag (with `WP_DEBUG` on you'll see `<!-- No Concat JS jquery-core => Excluded option -->`), while other scripts remain concatenated. Repeat with `?jb-minify-css-excludes=<style-handle>` for CSS.
3. Reload without the parameter — the handle is concatenated again, and the saved exclude list in Boost's settings is unchanged (nothing persisted).
4. Open the same URL with the parameter in a logged-out/incognito window — the parameter has no effect.
5. Try `?jb-minify-js-excludes=<script>alert(1)</script>` — the invalid handle is ignored and the page renders normally.
6. Unit tests: run the Boost PHP unit suite (`jp test php plugins/boost`); the `Debug_Excludes_Test` cases exercise this feature.

