### PR TITLE
renovate: Pin all actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,13 +102,11 @@
 		// We'll leave major updates ungrouped though, as those likely need more individualized attention.
 		{
 			extends: [ 'helpers:pinGitHubActionDigests' ],
-			matchPackageNames: [ '!actions/**' ],
 		},
 		{
 			groupName: 'GitHub Actions minor version bumps',
 			matchDepTypes: [ 'action' ],
-			matchUpdateTypes: [ 'minor', 'patch', 'pin', 'digest' ],
-			matchPackageNames: [ '!actions/**' ],
+			matchUpdateTypes: [ 'minor', 'patch', 'pin', 'digest', 'pinDigest' ],
 			schedule: [ '* 0-3 * * 1' ],
 			additionalReviewers: [ 'team:qualityops' ],
 		},


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #49456 set up renovate to pin all actions except `actions/*`. It has now come out that they intend to turn on GitHub's "require actions to be pinned" setting, which does not make an exception for those. We may as well get ahead of things and update renovate now.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
DEVPROD-1072#comment-440d38ac

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* ~~Run renovate using this branch and see what happens?~~ Merge in a fork and run renovate there.