### PR TITLE
RTC: add jetpack_rtc_join Tracks event for RTC usage analytics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4237,6 +4237,9 @@ importers:
 
   projects/packages/rtc:
     dependencies:
+      '@automattic/jetpack-analytics':
+        specifier: workspace:*
+        version: link:../../js-packages/analytics
       '@wordpress/api-fetch':
         specifier: 7.48.0
         version: 7.48.0
@@ -4277,12 +4280,30 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
+      '@babel/core':
+        specifier: 7.29.0
+        version: 7.29.0
+      '@babel/preset-react':
+        specifier: 7.28.5
+        version: 7.28.5(@babel/core@7.29.0)
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@wordpress/base-styles':
         specifier: 9.1.0
         version: 9.1.0
       '@wordpress/browserslist-config':
         specifier: 6.48.0
         version: 6.48.0
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2
+      jetpack-js-tools:
+        specifier: workspace:*
+        version: link:../../../tools/js-tools
       sass-embedded:
         specifier: 1.97.3
         version: 1.97.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4246,6 +4246,9 @@ importers:
       '@wordpress/components':
         specifier: 35.0.0
         version: 35.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data':
+        specifier: 10.48.0
+        version: 10.48.0(react@18.3.1)
       '@wordpress/element':
         specifier: 8.0.0
         version: 8.0.0

--- a/projects/packages/rtc/changelog/dotcom-17555-tracks-events-rtc-join
+++ b/projects/packages/rtc/changelog/dotcom-17555-tracks-events-rtc-join
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+RTC: add a jetpack_rtc_join Tracks event recording transport and contributors when a client joins a room

--- a/projects/packages/rtc/jest.config.cjs
+++ b/projects/packages/rtc/jest.config.cjs
@@ -1,0 +1,5 @@
+const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
+
+module.exports = {
+	...baseConfig,
+};

--- a/projects/packages/rtc/package.json
+++ b/projects/packages/rtc/package.json
@@ -18,12 +18,15 @@
 		"build": "pnpm run clean && webpack",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
 		"clean": "rm -rf build/",
+		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
+		"test-coverage": "pnpm run test --coverage",
 		"watch": "pnpm run build && webpack watch"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@wordpress/api-fetch": "7.48.0",
 		"@wordpress/components": "35.0.0",
 		"@wordpress/element": "8.0.0",
@@ -39,8 +42,14 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@babel/core": "7.29.0",
+		"@babel/preset-react": "7.28.5",
+		"@jest/globals": "30.4.1",
+		"@types/jest": "30.0.0",
 		"@wordpress/base-styles": "9.1.0",
 		"@wordpress/browserslist-config": "6.48.0",
+		"jest": "30.4.2",
+		"jetpack-js-tools": "workspace:*",
 		"sass-embedded": "1.97.3",
 		"sass-loader": "16.0.5",
 		"webpack": "5.105.2",

--- a/projects/packages/rtc/package.json
+++ b/projects/packages/rtc/package.json
@@ -29,6 +29,7 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@wordpress/api-fetch": "7.48.0",
 		"@wordpress/components": "35.0.0",
+		"@wordpress/data": "10.48.0",
 		"@wordpress/element": "8.0.0",
 		"@wordpress/hooks": "4.48.0",
 		"@wordpress/i18n": "6.21.0",

--- a/projects/packages/rtc/src/js/notices/index.tsx
+++ b/projects/packages/rtc/src/js/notices/index.tsx
@@ -13,6 +13,7 @@ import './public-path';
 
 import { addFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
+import { registerJoinTracking } from '../tracking/track-join';
 import RtcAdminSomeoneWaitingNotice from './notices/rtc-admin-someone-waiting-notice';
 import { registerConnectionErrorModalFilter } from './notices/rtc-connection-error-modal-filter';
 import RtcNonAdminPostUpgradeNotice from './notices/rtc-non-admin-post-upgrade-notice';
@@ -46,6 +47,9 @@ function registerRoomLimitFilter(): void {
 		() => Number.MAX_SAFE_INTEGER
 	);
 }
+
+// Join tracking runs on every site with RTC, regardless of the room limit.
+registerJoinTracking();
 
 // Room-limit enforcement always runs (it stops polling, sends join requests).
 // The branded modals are gated behind enableLimitNotices.

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -55,15 +55,29 @@ const entityRoom = ( awareness: unknown ) => ( {
 	awareness: awareness as never,
 } );
 
-describe( 'withJoinTracking', () => {
-	beforeEach( () => recordRtcEventMock.mockClear() );
+// Mirrors SETTLE_DELAY_MS in track-join.ts.
+const SETTLE_DELAY_MS = 3000;
 
-	it( 'records a join with contributor ids when the local client is already present', async () => {
+describe( 'withJoinTracking', () => {
+	beforeEach( () => {
+		recordRtcEventMock.mockClear();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'records the settled roster a delay after the local client is present', async () => {
 		const creator = jest.fn().mockResolvedValue( makeProvider() );
 		const wrapped = withJoinTracking( creator as never );
 
 		// clientID 1 (user 7) is present, plus a second tab of user 7 and user 9.
 		await wrapped( entityRoom( fakeAwareness( { states: { 1: 7, 2: 7, 3: 9 }, clientID: 1 } ) ) );
+
+		// Nothing recorded until the settle delay elapses.
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
@@ -72,7 +86,26 @@ describe( 'withJoinTracking', () => {
 		} );
 	} );
 
-	it( 'defers recording until the local client becomes present', async () => {
+	it( 'captures peers that sync in during the settle delay', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		// The local client (user 7) joins; a peer's awareness has not synced yet.
+		const awareness = fakeAwareness( { states: { 1: 7 }, clientID: 1 } );
+		await wrapped( entityRoom( awareness ) );
+
+		// A peer syncs in before the delay elapses.
+		awareness.setState( 2, 9 );
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			contributor_count: 2,
+			contributors: [ 7, 9 ],
+		} );
+	} );
+
+	it( 'defers until the local client becomes present, then waits the delay', async () => {
 		const creator = jest.fn().mockResolvedValue( makeProvider() );
 		const wrapped = withJoinTracking( creator as never );
 
@@ -80,12 +113,16 @@ describe( 'withJoinTracking', () => {
 		const awareness = fakeAwareness( { states: {}, clientID: 1 } );
 		await wrapped( entityRoom( awareness ) );
 
+		// The delay running out while absent records nothing.
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 
 		// Core-data populates the local client's collaboratorInfo and fires a change.
 		awareness.setState( 1, 7 );
 		awareness.emitChange();
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 1,
@@ -93,38 +130,16 @@ describe( 'withJoinTracking', () => {
 		} );
 	} );
 
-	it( 'does not record on changes where only remote clients are present', async () => {
-		const creator = jest.fn().mockResolvedValue( makeProvider() );
-		const wrapped = withJoinTracking( creator as never );
-
-		// A remote peer is present but the local client (clientID 1) is not yet.
-		const awareness = fakeAwareness( { states: { 2: 9 }, clientID: 1 } );
-		await wrapped( entityRoom( awareness ) );
-		awareness.emitChange();
-
-		expect( recordRtcEventMock ).not.toHaveBeenCalled();
-
-		// Once the local client appears, the snapshot includes both.
-		awareness.setState( 1, 7 );
-		awareness.emitChange();
-
-		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
-		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
-			contributor_count: 2,
-			contributors: [ 9, 7 ],
-		} );
-	} );
-
 	it( 'records only once even if awareness changes again', async () => {
 		const creator = jest.fn().mockResolvedValue( makeProvider() );
 		const wrapped = withJoinTracking( creator as never );
 
-		const awareness = fakeAwareness( { states: {}, clientID: 1 } );
+		const awareness = fakeAwareness( { states: { 1: 7 }, clientID: 1 } );
 		await wrapped( entityRoom( awareness ) );
 
-		awareness.setState( 1, 7 );
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 		awareness.emitChange();
-		awareness.emitChange();
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -139,6 +154,7 @@ describe( 'withJoinTracking', () => {
 			ydoc: {} as never,
 			awareness: fakeAwareness( { states: { 1: 7 }, clientID: 1 } ) as never,
 		} );
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 	} );
@@ -152,6 +168,7 @@ describe( 'withJoinTracking', () => {
 			objectId: 'post-42',
 			ydoc: {} as never,
 		} );
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 	} );
@@ -163,6 +180,7 @@ describe( 'withJoinTracking', () => {
 		await wrapped(
 			entityRoom( fakeAwareness( { states: { 1: 7, 2: null, 3: 9 }, clientID: 1 } ) )
 		);
+		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 2,

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -13,42 +13,120 @@ jest.unstable_mockModule( '@wordpress/hooks', () => ( {
 
 const { withJoinTracking, registerJoinTracking } = await import( '../track-join' );
 
+type StateSpec = Record< number, number | null >;
+type FakeAwarenessOptions = { states?: StateSpec; clientID?: number };
+
 /**
- * Build a fake awareness whose getStates() returns states keyed by client id,
- * each carrying a collaboratorInfo.id (the WP user id).
+ * Build a fake awareness keyed by client id. Each entry maps a client id to a WP
+ * user id (or null for a state with no collaboratorInfo.id). `clientID` is the
+ * local client. Exposes `emitChange()` and `setState()` so tests can simulate
+ * presence appearing after provider creation.
  *
- * @param userIds - WP user IDs for each simulated client; undefined means no collaboratorInfo.id.
- * @return A fake awareness object with a getStates() method.
+ * @param options - Fake awareness options (`states` keyed by client id, `clientID` for the local client).
+ * @return A fake awareness object.
  */
-function fakeAwareness( userIds: Array< number | undefined > ) {
+function fakeAwareness( options: FakeAwarenessOptions = {} ) {
+	const { states: spec = {}, clientID = 1 } = options;
 	const states = new Map< number, { collaboratorInfo?: { id?: number } } >();
-	userIds.forEach( ( id, index ) => {
-		states.set( index, { collaboratorInfo: id === undefined ? {} : { id } } );
-	} );
-	return { getStates: () => states };
+	const set = ( key: number, id: number | null ) =>
+		states.set( key, { collaboratorInfo: id === null ? {} : { id } } );
+	Object.keys( spec ).forEach( key => set( Number( key ), spec[ Number( key ) ] ) );
+	const listeners = new Set< () => void >();
+	return {
+		clientID,
+		getStates: () => states,
+		on: ( _event: string, cb: () => void ) => {
+			listeners.add( cb );
+		},
+		off: ( _event: string, cb: () => void ) => {
+			listeners.delete( cb );
+		},
+		emitChange: () => listeners.forEach( cb => cb() ),
+		setState: set,
+	};
 }
 
 const makeProvider = () => ( { destroy: jest.fn(), on: jest.fn() } );
 
+const entityRoom = ( awareness: unknown ) => ( {
+	objectType: 'postType',
+	objectId: 'post-42',
+	ydoc: {} as never,
+	awareness: awareness as never,
+} );
+
 describe( 'withJoinTracking', () => {
 	beforeEach( () => recordRtcEventMock.mockClear() );
 
-	it( 'records a join with contributor ids for an entity room', async () => {
+	it( 'records a join with contributor ids when the local client is already present', async () => {
 		const creator = jest.fn().mockResolvedValue( makeProvider() );
 		const wrapped = withJoinTracking( creator as never );
 
-		await wrapped( {
-			objectType: 'postType',
-			objectId: 'post-42',
-			ydoc: {} as never,
-			awareness: fakeAwareness( [ 7, 7, 9 ] ) as never,
-		} );
+		// clientID 1 (user 7) is present, plus a second tab of user 7 and user 9.
+		await wrapped( entityRoom( fakeAwareness( { states: { 1: 7, 2: 7, 3: 9 }, clientID: 1 } ) ) );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 3,
 			contributors: [ 7, 7, 9 ],
 		} );
+	} );
+
+	it( 'defers recording until the local client becomes present', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		// At provider-creation time the local client has no awareness state yet.
+		const awareness = fakeAwareness( { states: {}, clientID: 1 } );
+		await wrapped( entityRoom( awareness ) );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+
+		// Core-data populates the local client's collaboratorInfo and fires a change.
+		awareness.setState( 1, 7 );
+		awareness.emitChange();
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			contributor_count: 1,
+			contributors: [ 7 ],
+		} );
+	} );
+
+	it( 'does not record on changes where only remote clients are present', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		// A remote peer is present but the local client (clientID 1) is not yet.
+		const awareness = fakeAwareness( { states: { 2: 9 }, clientID: 1 } );
+		await wrapped( entityRoom( awareness ) );
+		awareness.emitChange();
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+
+		// Once the local client appears, the snapshot includes both.
+		awareness.setState( 1, 7 );
+		awareness.emitChange();
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			contributor_count: 2,
+			contributors: [ 9, 7 ],
+		} );
+	} );
+
+	it( 'records only once even if awareness changes again', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		const awareness = fakeAwareness( { states: {}, clientID: 1 } );
+		await wrapped( entityRoom( awareness ) );
+
+		awareness.setState( 1, 7 );
+		awareness.emitChange();
+		awareness.emitChange();
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not record for a collection room (objectId === null)', async () => {
@@ -59,7 +137,7 @@ describe( 'withJoinTracking', () => {
 			objectType: 'postType',
 			objectId: null,
 			ydoc: {} as never,
-			awareness: fakeAwareness( [ 7 ] ) as never,
+			awareness: fakeAwareness( { states: { 1: 7 }, clientID: 1 } ) as never,
 		} );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
@@ -82,12 +160,9 @@ describe( 'withJoinTracking', () => {
 		const creator = jest.fn().mockResolvedValue( makeProvider() );
 		const wrapped = withJoinTracking( creator as never );
 
-		await wrapped( {
-			objectType: 'postType',
-			objectId: 'post-42',
-			ydoc: {} as never,
-			awareness: fakeAwareness( [ 7, undefined, 9 ] ) as never,
-		} );
+		await wrapped(
+			entityRoom( fakeAwareness( { states: { 1: 7, 2: null, 3: 9 }, clientID: 1 } ) )
+		);
 
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 2,
@@ -100,12 +175,9 @@ describe( 'withJoinTracking', () => {
 		const creator = jest.fn().mockResolvedValue( provider );
 		const wrapped = withJoinTracking( creator as never );
 
-		const result = await wrapped( {
-			objectType: 'postType',
-			objectId: 'post-42',
-			ydoc: {} as never,
-			awareness: fakeAwareness( [ 7 ] ) as never,
-		} );
+		const result = await wrapped(
+			entityRoom( fakeAwareness( { states: { 1: 7 }, clientID: 1 } ) )
+		);
 
 		expect( result ).toBe( provider );
 	} );

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -81,6 +81,7 @@ describe( 'withJoinTracking', () => {
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			wp_user_id: 7,
 			contributor_count: 3,
 			contributors: [ 7, 7, 9 ],
 		} );
@@ -100,6 +101,7 @@ describe( 'withJoinTracking', () => {
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			wp_user_id: 7,
 			contributor_count: 2,
 			contributors: [ 7, 9 ],
 		} );
@@ -125,6 +127,7 @@ describe( 'withJoinTracking', () => {
 		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			wp_user_id: 7,
 			contributor_count: 1,
 			contributors: [ 7 ],
 		} );
@@ -183,6 +186,7 @@ describe( 'withJoinTracking', () => {
 		jest.advanceTimersByTime( SETTLE_DELAY_MS );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			wp_user_id: 7,
 			contributor_count: 2,
 			contributors: [ 7, 9 ],
 		} );

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+
+const recordRtcEventMock = jest.fn();
+
+jest.unstable_mockModule( '../tracks', () => ( {
+	recordRtcEvent: recordRtcEventMock,
+} ) );
+
+const { withJoinTracking } = await import( '../track-join' );
+
+/**
+ * Build a fake awareness whose getStates() returns states keyed by client id,
+ * each carrying a collaboratorInfo.id (the WP user id).
+ *
+ * @param userIds - WP user IDs for each simulated client; undefined means no collaboratorInfo.id.
+ * @return A fake awareness object with a getStates() method.
+ */
+function fakeAwareness( userIds: Array< number | undefined > ) {
+	const states = new Map< number, { collaboratorInfo?: { id?: number } } >();
+	userIds.forEach( ( id, index ) => {
+		states.set( index, { collaboratorInfo: id === undefined ? {} : { id } } );
+	} );
+	return { getStates: () => states };
+}
+
+const makeProvider = () => ( { destroy: jest.fn(), on: jest.fn() } );
+
+describe( 'withJoinTracking', () => {
+	beforeEach( () => recordRtcEventMock.mockClear() );
+
+	it( 'records a join with contributor ids for an entity room', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		await wrapped( {
+			objectType: 'postType',
+			objectId: 'post-42',
+			ydoc: {} as never,
+			awareness: fakeAwareness( [ 7, 7, 9 ] ) as never,
+		} );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			contributor_count: 3,
+			contributors: [ 7, 7, 9 ],
+		} );
+	} );
+
+	it( 'does not record for a collection room (objectId === null)', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		await wrapped( {
+			objectType: 'postType',
+			objectId: null,
+			ydoc: {} as never,
+			awareness: fakeAwareness( [ 7 ] ) as never,
+		} );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record when awareness is absent', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		await wrapped( {
+			objectType: 'postType',
+			objectId: 'post-42',
+			ydoc: {} as never,
+		} );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'omits awareness states with no collaborator id', async () => {
+		const creator = jest.fn().mockResolvedValue( makeProvider() );
+		const wrapped = withJoinTracking( creator as never );
+
+		await wrapped( {
+			objectType: 'postType',
+			objectId: 'post-42',
+			ydoc: {} as never,
+			awareness: fakeAwareness( [ 7, undefined, 9 ] ) as never,
+		} );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			contributor_count: 2,
+			contributors: [ 7, 9 ],
+		} );
+	} );
+
+	it( 'returns the inner provider result', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withJoinTracking( creator as never );
+
+		const result = await wrapped( {
+			objectType: 'postType',
+			objectId: 'post-42',
+			ydoc: {} as never,
+			awareness: fakeAwareness( [ 7 ] ) as never,
+		} );
+
+		expect( result ).toBe( provider );
+	} );
+} );

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -1,12 +1,17 @@
 import { jest } from '@jest/globals';
 
 const recordRtcEventMock = jest.fn();
+const addFilterMock = jest.fn();
 
 jest.unstable_mockModule( '../tracks', () => ( {
 	recordRtcEvent: recordRtcEventMock,
 } ) );
 
-const { withJoinTracking } = await import( '../track-join' );
+jest.unstable_mockModule( '@wordpress/hooks', () => ( {
+	addFilter: addFilterMock,
+} ) );
+
+const { withJoinTracking, registerJoinTracking } = await import( '../track-join' );
 
 /**
  * Build a fake awareness whose getStates() returns states keyed by client id,
@@ -103,5 +108,33 @@ describe( 'withJoinTracking', () => {
 		} );
 
 		expect( result ).toBe( provider );
+	} );
+} );
+
+describe( 'registerJoinTracking', () => {
+	beforeEach( () => addFilterMock.mockClear() );
+
+	it( 'registers a sync.providers filter at priority 30', () => {
+		registerJoinTracking();
+
+		expect( addFilterMock ).toHaveBeenCalledWith(
+			'sync.providers',
+			'jetpack/rtc-join-tracking',
+			expect.any( Function ),
+			30
+		);
+	} );
+
+	it( 'wraps each provider creator with join tracking', () => {
+		registerJoinTracking();
+
+		const mapper = addFilterMock.mock.calls[ 0 ][ 2 ] as ( p: unknown[] ) => unknown[];
+		const creatorA = jest.fn();
+		const creatorB = jest.fn();
+		const wrapped = mapper( [ creatorA, creatorB ] );
+
+		expect( wrapped ).toHaveLength( 2 );
+		expect( wrapped[ 0 ] ).not.toBe( creatorA );
+		expect( wrapped[ 1 ] ).not.toBe( creatorB );
 	} );
 } );

--- a/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
@@ -1,10 +1,19 @@
 import { jest } from '@jest/globals';
 
 const mockRecordEvent = jest.fn();
+const mockGetCurrentPostId = jest.fn( (): number | undefined => 42 );
+const mockGetCurrentPostType = jest.fn( (): string | undefined => 'post' );
 
 jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
 	default: { tracks: { recordEvent: mockRecordEvent } },
+} ) );
+
+jest.unstable_mockModule( '@wordpress/data', () => ( {
+	select: () => ( {
+		getCurrentPostId: mockGetCurrentPostId,
+		getCurrentPostType: mockGetCurrentPostType,
+	} ),
 } ) );
 
 const { getTransport, recordRtcEvent } = await import( '../tracks' );
@@ -34,18 +43,14 @@ describe( 'getTransport', () => {
 describe( 'recordRtcEvent', () => {
 	beforeEach( () => {
 		recordEvent.mockClear();
-		( window as Record< string, unknown > ).jetpackRTC = {
-			providers: [ 'pinghub' ],
-			currentPostId: 42,
-			currentPostType: 'post',
-		};
+		( window as Record< string, unknown > ).jetpackRTC = { providers: [ 'pinghub' ] };
 	} );
 
 	afterEach( () => {
 		delete ( window as Record< string, unknown > ).jetpackRTC;
 	} );
 
-	it( 'merges transport and post context into the event properties', () => {
+	it( 'merges transport and editor post context into the event properties', () => {
 		recordRtcEvent( 'jetpack_rtc_join', { contributor_count: 2 } );
 
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
@@ -54,6 +59,19 @@ describe( 'recordRtcEvent', () => {
 			post_id: 42,
 			post_type: 'post',
 			contributor_count: 2,
+		} );
+	} );
+
+	it( 'reads post context from the editor store on http-polling (no window.jetpackRTC)', () => {
+		delete ( window as Record< string, unknown > ).jetpackRTC;
+
+		recordRtcEvent( 'jetpack_rtc_join', { contributor_count: 1 } );
+
+		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			transport: 'http-polling',
+			post_id: 42,
+			post_type: 'post',
+			contributor_count: 1,
 		} );
 	} );
 

--- a/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 const mockRecordEvent = jest.fn();
 const mockGetCurrentPostId = jest.fn( (): number | undefined => 42 );
 const mockGetCurrentPostType = jest.fn( (): string | undefined => 'post' );
+const mockGetCurrentUser = jest.fn( (): { id?: number } | undefined => ( { id: 99 } ) );
 
 jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
@@ -13,6 +14,7 @@ jest.unstable_mockModule( '@wordpress/data', () => ( {
 	select: () => ( {
 		getCurrentPostId: mockGetCurrentPostId,
 		getCurrentPostType: mockGetCurrentPostType,
+		getCurrentUser: mockGetCurrentUser,
 	} ),
 } ) );
 
@@ -56,6 +58,7 @@ describe( 'recordRtcEvent', () => {
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			transport: 'pinghub',
+			wp_user_id: 99,
 			post_id: 42,
 			post_type: 'post',
 			contributor_count: 2,
@@ -69,10 +72,17 @@ describe( 'recordRtcEvent', () => {
 
 		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			transport: 'http-polling',
+			wp_user_id: 99,
 			post_id: 42,
 			post_type: 'post',
 			contributor_count: 1,
 		} );
+	} );
+
+	it( 'includes the current user WP id as wp_user_id', () => {
+		recordRtcEvent( 'jetpack_rtc_join' );
+
+		expect( recordEvent.mock.calls[ 0 ][ 1 ] ).toMatchObject( { wp_user_id: 99 } );
 	} );
 
 	it( 'does not set blog_id (left to jpTracksContext)', () => {

--- a/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
@@ -1,4 +1,15 @@
-import { getTransport } from '../tracks';
+import { jest } from '@jest/globals';
+
+const mockRecordEvent = jest.fn();
+
+jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: mockRecordEvent } },
+} ) );
+
+const { getTransport, recordRtcEvent } = await import( '../tracks' );
+
+const recordEvent = mockRecordEvent as jest.Mock;
 
 describe( 'getTransport', () => {
 	afterEach( () => {
@@ -17,5 +28,46 @@ describe( 'getTransport', () => {
 
 	it( 'returns "http-polling" when jetpackRTC is absent', () => {
 		expect( getTransport() ).toBe( 'http-polling' );
+	} );
+} );
+
+describe( 'recordRtcEvent', () => {
+	beforeEach( () => {
+		recordEvent.mockClear();
+		( window as Record< string, unknown > ).jetpackRTC = {
+			providers: [ 'pinghub' ],
+			currentPostId: 42,
+			currentPostType: 'post',
+		};
+	} );
+
+	afterEach( () => {
+		delete ( window as Record< string, unknown > ).jetpackRTC;
+	} );
+
+	it( 'merges transport and post context into the event properties', () => {
+		recordRtcEvent( 'jetpack_rtc_join', { contributor_count: 2 } );
+
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
+			transport: 'pinghub',
+			post_id: 42,
+			post_type: 'post',
+			contributor_count: 2,
+		} );
+	} );
+
+	it( 'does not set blog_id (left to jpTracksContext)', () => {
+		recordRtcEvent( 'jetpack_rtc_join' );
+
+		const props = recordEvent.mock.calls[ 0 ][ 1 ];
+		expect( props ).not.toHaveProperty( 'blog_id' );
+	} );
+
+	it( 'never throws when analytics throws', () => {
+		recordEvent.mockImplementationOnce( () => {
+			throw new Error( 'tracks unavailable' );
+		} );
+		expect( () => recordRtcEvent( 'jetpack_rtc_join' ) ).not.toThrow();
 	} );
 } );

--- a/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
@@ -3,7 +3,6 @@ import { jest } from '@jest/globals';
 const mockRecordEvent = jest.fn();
 const mockGetCurrentPostId = jest.fn( (): number | undefined => 42 );
 const mockGetCurrentPostType = jest.fn( (): string | undefined => 'post' );
-const mockGetCurrentUser = jest.fn( (): { id?: number } | undefined => ( { id: 99 } ) );
 
 jest.unstable_mockModule( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
@@ -14,7 +13,6 @@ jest.unstable_mockModule( '@wordpress/data', () => ( {
 	select: () => ( {
 		getCurrentPostId: mockGetCurrentPostId,
 		getCurrentPostType: mockGetCurrentPostType,
-		getCurrentUser: mockGetCurrentUser,
 	} ),
 } ) );
 
@@ -58,7 +56,6 @@ describe( 'recordRtcEvent', () => {
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			transport: 'pinghub',
-			wp_user_id: 99,
 			post_id: 42,
 			post_type: 'post',
 			contributor_count: 2,
@@ -72,17 +69,10 @@ describe( 'recordRtcEvent', () => {
 
 		expect( recordEvent ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			transport: 'http-polling',
-			wp_user_id: 99,
 			post_id: 42,
 			post_type: 'post',
 			contributor_count: 1,
 		} );
-	} );
-
-	it( 'includes the current user WP id as wp_user_id', () => {
-		recordRtcEvent( 'jetpack_rtc_join' );
-
-		expect( recordEvent.mock.calls[ 0 ][ 1 ] ).toMatchObject( { wp_user_id: 99 } );
 	} );
 
 	it( 'does not set blog_id (left to jpTracksContext)', () => {

--- a/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/tracks.test.ts
@@ -1,0 +1,21 @@
+import { getTransport } from '../tracks';
+
+describe( 'getTransport', () => {
+	afterEach( () => {
+		delete ( window as Record< string, unknown > ).jetpackRTC;
+	} );
+
+	it( 'returns "pinghub" when the pinghub provider is configured', () => {
+		( window as Record< string, unknown > ).jetpackRTC = { providers: [ 'pinghub' ] };
+		expect( getTransport() ).toBe( 'pinghub' );
+	} );
+
+	it( 'returns "http-polling" when pinghub is not in the providers list', () => {
+		( window as Record< string, unknown > ).jetpackRTC = { providers: [ 'http-polling' ] };
+		expect( getTransport() ).toBe( 'http-polling' );
+	} );
+
+	it( 'returns "http-polling" when jetpackRTC is absent', () => {
+		expect( getTransport() ).toBe( 'http-polling' );
+	} );
+} );

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -24,9 +24,43 @@ function getContributorIds( awareness: Awareness ): number[] {
 }
 
 /**
+ * Whether the local client's presence has been established in awareness.
+ *
+ * The local awareness state (with collaboratorInfo) is populated by core-data
+ * shortly after the provider is created, not synchronously, so this is false
+ * at provider-creation time.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ * @return True once the local client has a collaborator id in awareness.
+ */
+function isLocalClientPresent( awareness: Awareness ): boolean {
+	const localState = awareness.getStates().get( awareness.clientID ) as
+		| CollaboratorAwarenessState
+		| undefined;
+	return typeof localState?.collaboratorInfo?.id === 'number';
+}
+
+/**
+ * Record the join event with a snapshot of the contributors currently present.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ */
+function recordJoin( awareness: Awareness ): void {
+	const contributors = getContributorIds( awareness );
+	recordRtcEvent( JOIN_EVENT, {
+		contributor_count: contributors.length,
+		contributors,
+	} );
+}
+
+/**
  * Wrap a provider creator so that joining an entity room records a
  * `jetpack_rtc_join` Tracks event. Collection rooms (objectId === null) are
  * ignored, matching the room-limit wrapper.
+ *
+ * The contributor snapshot is taken once the local client's presence is
+ * established in awareness, not at provider-creation time (when awareness is
+ * still empty), so the event always includes at least the local user.
  *
  * @param creator - The provider creator to wrap.
  * @return The wrapped provider creator.
@@ -34,12 +68,21 @@ function getContributorIds( awareness: Awareness ): number[] {
 export function withJoinTracking( creator: ProviderCreator ): ProviderCreator {
 	return async options => {
 		const result = await creator( options );
-		if ( options.objectId !== null && options.awareness ) {
-			const contributors = getContributorIds( options.awareness );
-			recordRtcEvent( JOIN_EVENT, {
-				contributor_count: contributors.length,
-				contributors,
-			} );
+		const { objectId, awareness } = options;
+		if ( objectId === null || ! awareness ) {
+			return result;
+		}
+
+		if ( isLocalClientPresent( awareness ) ) {
+			recordJoin( awareness );
+		} else {
+			const onChange = () => {
+				if ( isLocalClientPresent( awareness ) ) {
+					awareness.off( 'change', onChange );
+					recordJoin( awareness );
+				}
+			};
+			awareness.on( 'change', onChange );
 		}
 		return result;
 	};

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -37,30 +37,47 @@ function getContributorIds( awareness: Awareness ): number[] {
 }
 
 /**
- * Whether the local client's presence has been established in awareness.
+ * The local client's WordPress user id from awareness.
  *
- * The local awareness state (with collaboratorInfo) is populated by core-data
- * shortly after the provider is created, not synchronously, so this is false
- * at provider-creation time.
+ * Read from the local awareness state's `collaboratorInfo.id`, which is
+ * populated by core-data shortly after the provider is created (not
+ * synchronously). Same id-space as `contributors` (see `getContributorIds`), so
+ * it locates the recording user within the roster — on Atomic this is the
+ * site-local id, which differs from the wpcom id Tracks records as `_ui`.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ * @return The local client's WP user id, or undefined when not yet present.
+ */
+function getLocalUserId( awareness: Awareness ): number | undefined {
+	const localState = awareness.getStates().get( awareness.clientID ) as
+		| CollaboratorAwarenessState
+		| undefined;
+	return localState?.collaboratorInfo?.id;
+}
+
+/**
+ * Whether the local client's presence has been established in awareness.
  *
  * @param awareness - The Yjs awareness instance for the room.
  * @return True once the local client has a collaborator id in awareness.
  */
 function isLocalClientPresent( awareness: Awareness ): boolean {
-	const localState = awareness.getStates().get( awareness.clientID ) as
-		| CollaboratorAwarenessState
-		| undefined;
-	return typeof localState?.collaboratorInfo?.id === 'number';
+	return typeof getLocalUserId( awareness ) === 'number';
 }
 
 /**
  * Record the join event with a snapshot of the contributors currently present.
+ *
+ * `wp_user_id` is read from awareness here (guaranteed present once
+ * `isLocalClientPresent` is true) rather than from the resolver-backed
+ * `core` store, so it is always populated.
  *
  * @param awareness - The Yjs awareness instance for the room.
  */
 function recordJoin( awareness: Awareness ): void {
 	const contributors = getContributorIds( awareness );
 	recordRtcEvent( JOIN_EVENT, {
+		wp_user_id: getLocalUserId( awareness ),
 		contributor_count: contributors.length,
 		contributors,
 	} );

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -1,3 +1,4 @@
+import { addFilter } from '@wordpress/hooks';
 import { recordRtcEvent } from './tracks';
 import type { Awareness, ProviderCreator } from '@wordpress/sync';
 
@@ -42,4 +43,19 @@ export function withJoinTracking( creator: ProviderCreator ): ProviderCreator {
 		}
 		return result;
 	};
+}
+
+/**
+ * Register the join-tracking wrapper on the sync.providers filter.
+ *
+ * Runs at priority 30 so it wraps providers after the rtc package (priority 10)
+ * and the room-limit wrapper (priority 20).
+ */
+export function registerJoinTracking(): void {
+	addFilter(
+		'sync.providers',
+		'jetpack/rtc-join-tracking',
+		( providers: ProviderCreator[] ) => providers.map( withJoinTracking ),
+		30
+	);
 }

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -1,0 +1,45 @@
+import { recordRtcEvent } from './tracks';
+import type { Awareness, ProviderCreator } from '@wordpress/sync';
+
+const JOIN_EVENT = 'jetpack_rtc_join';
+
+interface CollaboratorAwarenessState {
+	collaboratorInfo?: { id?: number };
+}
+
+/**
+ * Build the contributor user-ID list from the current awareness states.
+ *
+ * A user editing in multiple tabs appears multiple times (same id); distinct
+ * users appear as distinct ids. States with no collaborator id are skipped.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ * @return The WP user IDs currently present in the room.
+ */
+function getContributorIds( awareness: Awareness ): number[] {
+	return Array.from( awareness.getStates().values() )
+		.map( state => ( state as CollaboratorAwarenessState )?.collaboratorInfo?.id )
+		.filter( ( id ): id is number => typeof id === 'number' );
+}
+
+/**
+ * Wrap a provider creator so that joining an entity room records a
+ * `jetpack_rtc_join` Tracks event. Collection rooms (objectId === null) are
+ * ignored, matching the room-limit wrapper.
+ *
+ * @param creator - The provider creator to wrap.
+ * @return The wrapped provider creator.
+ */
+export function withJoinTracking( creator: ProviderCreator ): ProviderCreator {
+	return async options => {
+		const result = await creator( options );
+		if ( options.objectId !== null && options.awareness ) {
+			const contributors = getContributorIds( options.awareness );
+			recordRtcEvent( JOIN_EVENT, {
+				contributor_count: contributors.length,
+				contributors,
+			} );
+		}
+		return result;
+	};
+}

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -37,13 +37,10 @@ function getContributorIds( awareness: Awareness ): number[] {
 }
 
 /**
- * The local client's WordPress user id from awareness.
- *
- * Read from the local awareness state's `collaboratorInfo.id`, which is
- * populated by core-data shortly after the provider is created (not
- * synchronously). Same id-space as `contributors` (see `getContributorIds`), so
- * it locates the recording user within the roster — on Atomic this is the
- * site-local id, which differs from the wpcom id Tracks records as `_ui`.
+ * The local client's WordPress user id, read from the local awareness state's
+ * `collaboratorInfo.id` (same id-space as `contributors` — see
+ * `getContributorIds`). Undefined until core-data populates it, shortly after
+ * the provider is created.
  *
  * @param awareness - The Yjs awareness instance for the room.
  * @return The local client's WP user id, or undefined when not yet present.
@@ -84,12 +81,8 @@ function recordJoin( awareness: Awareness ): void {
 }
 
 /**
- * Snapshot the join once the local client is present, after a short settle
- * delay so peers already in the room have time to sync into awareness.
- *
- * Recording at provider-creation time (when awareness is empty) yields a
- * self-only or empty roster; waiting for the local client and then a brief
- * delay lets the snapshot include the peers who were already editing.
+ * Snapshot the join once the local client is present, after `SETTLE_DELAY_MS`
+ * so peers already in the room have time to sync into awareness.
  *
  * @param awareness - The Yjs awareness instance for the room.
  */

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -22,6 +22,11 @@ interface CollaboratorAwarenessState {
  * A user editing in multiple tabs appears multiple times (same id); distinct
  * users appear as distinct ids. States with no collaborator id are skipped.
  *
+ * The ids come from awareness `collaboratorInfo.id`, i.e. the WordPress user id.
+ * On Simple sites that is the WordPress.com user id, but on Atomic/Jetpack sites
+ * it is the *site-local* WP user id (not the wpcom id used by Tracks' `_ui`), so
+ * `contributors` is only meaningful scoped to a single `blog_id`.
+ *
  * @param awareness - The Yjs awareness instance for the room.
  * @return The WP user IDs currently present in the room.
  */

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -6,9 +6,9 @@ const JOIN_EVENT = 'jetpack_rtc_join';
 
 /**
  * Delay between the local client appearing in awareness and snapshotting the
- * contributor list. Peers already in the room sync into awareness within ~1s of
- * connecting; this leaves headroom so an early joiner doesn't record a self-only
- * roster, without waiting so long that the editor may have been closed.
+ * contributor list, to give peers already in the room time to sync in. PingHub
+ * propagates awareness sub-second; HTTP-polling is slower (a poll cycle), so the
+ * roster stays best-effort there — see the limitation note on `getContributorIds`.
  */
 const SETTLE_DELAY_MS = 3000;
 
@@ -26,6 +26,13 @@ interface CollaboratorAwarenessState {
  * On Simple sites that is the WordPress.com user id, but on Atomic/Jetpack sites
  * it is the *site-local* WP user id (not the wpcom id used by Tracks' `_ui`), so
  * `contributors` is only meaningful scoped to a single `blog_id`.
+ *
+ * Limitation: this roster is best-effort. A client records only the peers it has
+ * synced when the snapshot fires. On HTTP-polling, awareness arrives on a poll
+ * cycle (up to 25s for a backgrounded tab), so a joiner can record a self-only
+ * roster even when others are editing. Derive simultaneous-editor and multi-tab
+ * counts by correlating join events (distinct/repeated `wp_user_id` on the same
+ * `post_id` within a time window), not from a single event's `contributors`.
  *
  * @param awareness - The Yjs awareness instance for the room.
  * @return The WP user IDs currently present in the room.

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -4,6 +4,14 @@ import type { Awareness, ProviderCreator } from '@wordpress/sync';
 
 const JOIN_EVENT = 'jetpack_rtc_join';
 
+/**
+ * Delay between the local client appearing in awareness and snapshotting the
+ * contributor list. Peers already in the room sync into awareness within ~1s of
+ * connecting; this leaves headroom so an early joiner doesn't record a self-only
+ * roster, without waiting so long that the editor may have been closed.
+ */
+const SETTLE_DELAY_MS = 3000;
+
 interface CollaboratorAwarenessState {
 	collaboratorInfo?: { id?: number };
 }
@@ -54,13 +62,36 @@ function recordJoin( awareness: Awareness ): void {
 }
 
 /**
+ * Snapshot the join once the local client is present, after a short settle
+ * delay so peers already in the room have time to sync into awareness.
+ *
+ * Recording at provider-creation time (when awareness is empty) yields a
+ * self-only or empty roster; waiting for the local client and then a brief
+ * delay lets the snapshot include the peers who were already editing.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ */
+function recordJoinAfterSettle( awareness: Awareness ): void {
+	let scheduled = false;
+
+	const scheduleSnapshot = (): void => {
+		if ( scheduled || ! isLocalClientPresent( awareness ) ) {
+			return;
+		}
+		scheduled = true;
+		awareness.off( 'change', scheduleSnapshot );
+		setTimeout( () => recordJoin( awareness ), SETTLE_DELAY_MS );
+	};
+
+	awareness.on( 'change', scheduleSnapshot );
+	// Handle the case where the local client is already present at creation time.
+	scheduleSnapshot();
+}
+
+/**
  * Wrap a provider creator so that joining an entity room records a
  * `jetpack_rtc_join` Tracks event. Collection rooms (objectId === null) are
  * ignored, matching the room-limit wrapper.
- *
- * The contributor snapshot is taken once the local client's presence is
- * established in awareness, not at provider-creation time (when awareness is
- * still empty), so the event always includes at least the local user.
  *
  * @param creator - The provider creator to wrap.
  * @return The wrapped provider creator.
@@ -69,20 +100,8 @@ export function withJoinTracking( creator: ProviderCreator ): ProviderCreator {
 	return async options => {
 		const result = await creator( options );
 		const { objectId, awareness } = options;
-		if ( objectId === null || ! awareness ) {
-			return result;
-		}
-
-		if ( isLocalClientPresent( awareness ) ) {
-			recordJoin( awareness );
-		} else {
-			const onChange = () => {
-				if ( isLocalClientPresent( awareness ) ) {
-					awareness.off( 'change', onChange );
-					recordJoin( awareness );
-				}
-			};
-			awareness.on( 'change', onChange );
+		if ( objectId !== null && awareness ) {
+			recordJoinAfterSettle( awareness );
 		}
 		return result;
 	};

--- a/projects/packages/rtc/src/js/tracking/tracks.ts
+++ b/projects/packages/rtc/src/js/tracking/tracks.ts
@@ -1,11 +1,15 @@
 import analytics from '@automattic/jetpack-analytics';
+import { select } from '@wordpress/data';
 
 type RtcTransport = 'pinghub' | 'http-polling';
 
 interface JetpackRtcGlobals {
 	providers?: string[];
-	currentPostId?: number;
-	currentPostType?: string;
+}
+
+interface EditorSelectors {
+	getCurrentPostId?: () => number | undefined;
+	getCurrentPostType?: () => string | undefined;
 }
 
 /**
@@ -20,11 +24,30 @@ function getRtcGlobals(): JetpackRtcGlobals {
 /**
  * Determine the active RTC transport from the providers configured by the server.
  *
+ * `window.jetpackRTC` is only injected on the PingHub path, so its absence
+ * means the built-in HTTP-polling transport is in use.
+ *
  * @return 'pinghub' when the PingHub WebSocket provider is active, otherwise 'http-polling'.
  */
 export function getTransport(): RtcTransport {
 	const { providers } = getRtcGlobals();
 	return Array.isArray( providers ) && providers.includes( 'pinghub' ) ? 'pinghub' : 'http-polling';
+}
+
+/**
+ * Read the current post context from the editor store.
+ *
+ * This is transport-agnostic: it works on both PingHub and HTTP-polling sites,
+ * unlike `window.jetpackRTC`, which the server only injects on the PingHub path.
+ *
+ * @return The current post id and type (each undefined when unavailable).
+ */
+function getPostContext(): { post_id?: number; post_type?: string } {
+	const editor = select( 'core/editor' ) as EditorSelectors | undefined;
+	return {
+		post_id: editor?.getCurrentPostId?.(),
+		post_type: editor?.getCurrentPostType?.(),
+	};
 }
 
 /**
@@ -41,12 +64,10 @@ export function recordRtcEvent(
 	eventName: string,
 	properties: Record< string, unknown > = {}
 ): void {
-	const { currentPostId, currentPostType } = getRtcGlobals();
 	try {
 		analytics.tracks.recordEvent( eventName, {
 			transport: getTransport(),
-			post_id: currentPostId,
-			post_type: currentPostType,
+			...getPostContext(),
 			...properties,
 		} );
 	} catch {

--- a/projects/packages/rtc/src/js/tracking/tracks.ts
+++ b/projects/packages/rtc/src/js/tracking/tracks.ts
@@ -12,10 +12,6 @@ interface EditorSelectors {
 	getCurrentPostType?: () => string | undefined;
 }
 
-interface CoreSelectors {
-	getCurrentUser?: () => { id?: number } | undefined;
-}
-
 /**
  * Read the server-provided RTC globals off `window`.
  *
@@ -55,21 +51,6 @@ function getPostContext(): { post_id?: number; post_type?: string } {
 }
 
 /**
- * The current user's WordPress user id.
- *
- * This is in the same id-space as the `contributors` list (the WP user id, which
- * is the WordPress.com id on Simple sites but the site-local id on Atomic), so it
- * lets the recording user be located within the room roster — useful on Atomic,
- * where `contributors` ids do not match the wpcom id Tracks records as `_ui`.
- *
- * @return The WP user id, or undefined when unavailable.
- */
-function getCurrentUserId(): number | undefined {
-	const core = select( 'core' ) as CoreSelectors | undefined;
-	return core?.getCurrentUser?.()?.id;
-}
-
-/**
  * Record an RTC Tracks event with the common properties merged in.
  *
  * `blog_id` is attached automatically by `@automattic/jetpack-analytics` from
@@ -86,7 +67,6 @@ export function recordRtcEvent(
 	try {
 		analytics.tracks.recordEvent( eventName, {
 			transport: getTransport(),
-			wp_user_id: getCurrentUserId(),
 			...getPostContext(),
 			...properties,
 		} );

--- a/projects/packages/rtc/src/js/tracking/tracks.ts
+++ b/projects/packages/rtc/src/js/tracking/tracks.ts
@@ -12,6 +12,10 @@ interface EditorSelectors {
 	getCurrentPostType?: () => string | undefined;
 }
 
+interface CoreSelectors {
+	getCurrentUser?: () => { id?: number } | undefined;
+}
+
 /**
  * Read the server-provided RTC globals off `window`.
  *
@@ -51,6 +55,21 @@ function getPostContext(): { post_id?: number; post_type?: string } {
 }
 
 /**
+ * The current user's WordPress user id.
+ *
+ * This is in the same id-space as the `contributors` list (the WP user id, which
+ * is the WordPress.com id on Simple sites but the site-local id on Atomic), so it
+ * lets the recording user be located within the room roster — useful on Atomic,
+ * where `contributors` ids do not match the wpcom id Tracks records as `_ui`.
+ *
+ * @return The WP user id, or undefined when unavailable.
+ */
+function getCurrentUserId(): number | undefined {
+	const core = select( 'core' ) as CoreSelectors | undefined;
+	return core?.getCurrentUser?.()?.id;
+}
+
+/**
  * Record an RTC Tracks event with the common properties merged in.
  *
  * `blog_id` is attached automatically by `@automattic/jetpack-analytics` from
@@ -67,6 +86,7 @@ export function recordRtcEvent(
 	try {
 		analytics.tracks.recordEvent( eventName, {
 			transport: getTransport(),
+			wp_user_id: getCurrentUserId(),
 			...getPostContext(),
 			...properties,
 		} );

--- a/projects/packages/rtc/src/js/tracking/tracks.ts
+++ b/projects/packages/rtc/src/js/tracking/tracks.ts
@@ -1,0 +1,26 @@
+type RtcTransport = 'pinghub' | 'http-polling';
+
+interface JetpackRtcGlobals {
+	providers?: string[];
+	currentPostId?: number;
+	currentPostType?: string;
+}
+
+/**
+ * Read the server-provided RTC globals off `window`.
+ *
+ * @return The `window.jetpackRTC` config, or an empty object when absent.
+ */
+function getRtcGlobals(): JetpackRtcGlobals {
+	return ( window as unknown as { jetpackRTC?: JetpackRtcGlobals } ).jetpackRTC ?? {};
+}
+
+/**
+ * Determine the active RTC transport from the providers configured by the server.
+ *
+ * @return 'pinghub' when the PingHub WebSocket provider is active, otherwise 'http-polling'.
+ */
+export function getTransport(): RtcTransport {
+	const { providers } = getRtcGlobals();
+	return Array.isArray( providers ) && providers.includes( 'pinghub' ) ? 'pinghub' : 'http-polling';
+}

--- a/projects/packages/rtc/src/js/tracking/tracks.ts
+++ b/projects/packages/rtc/src/js/tracking/tracks.ts
@@ -1,3 +1,5 @@
+import analytics from '@automattic/jetpack-analytics';
+
 type RtcTransport = 'pinghub' | 'http-polling';
 
 interface JetpackRtcGlobals {
@@ -23,4 +25,31 @@ function getRtcGlobals(): JetpackRtcGlobals {
 export function getTransport(): RtcTransport {
 	const { providers } = getRtcGlobals();
 	return Array.isArray( providers ) && providers.includes( 'pinghub' ) ? 'pinghub' : 'http-polling';
+}
+
+/**
+ * Record an RTC Tracks event with the common properties merged in.
+ *
+ * `blog_id` is attached automatically by `@automattic/jetpack-analytics` from
+ * `window.jpTracksContext`, so it is intentionally not set here. Event names
+ * must be prefixed `jetpack_` or the analytics package drops them silently.
+ *
+ * @param eventName  - Tracks event name (must start with `jetpack_`).
+ * @param properties - Event-specific properties.
+ */
+export function recordRtcEvent(
+	eventName: string,
+	properties: Record< string, unknown > = {}
+): void {
+	const { currentPostId, currentPostType } = getRtcGlobals();
+	try {
+		analytics.tracks.recordEvent( eventName, {
+			transport: getTransport(),
+			post_id: currentPostId,
+			post_type: currentPostType,
+			...properties,
+		} );
+	} catch {
+		// Telemetry must never break the editor.
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a transport-agnostic `tracking/` module to the RTC package that sends RTC usage Tracks events via `@automattic/jetpack-analytics`.
* Emit a `jetpack_rtc_join` Tracks event when a client joins an entity room, recording the active transport (`pinghub` vs `http-polling`), the post, the recording user's WP id (`wp_user_id`), the contributor count, and the collaborators' WP user IDs. The contributor snapshot is taken after a short settle delay so peers already in the room have time to sync into awareness.
* Register join tracking on the `sync.providers` filter (priority 30, after provider registration at 10 and the room-limit wrapper at 20) so it runs on every RTC site regardless of room-limit configuration — covering both Simple (WebSocket) and Atomic (HTTP-polling) sites.
* Add JS test tooling (Jest) to the RTC package, which previously had none, plus unit tests for the new module (17 tests).

This is the first of several PRs (one per event). Follow-ups will add `jetpack_rtc_blocked` and `jetpack_rtc_connection_error`, then remove the older PingHub-only `pixel()` / `logConnectionEvent()` telemetry.

Note on behaviour: the join is recorded shortly after the local client becomes present in awareness (a brief settle delay), so a client later turned away by the room limit will still emit a join before the (future) `jetpack_rtc_blocked` event; downstream analysis treats a same-session block as superseding the join.

## Related product discussion/links
* DOTCOM-17555

## Does this pull request change what data or activity we track or use?
Yes — this PR adds a new Tracks event. Adding the "[Status] Needs Privacy Updates" label.

The `jetpack_rtc_join` event is recorded in the WordPress.com block editor when a logged-in user joins a real-time collaboration room. Properties:
- `transport` — `pinghub` or `http-polling`
- `post_id`, `post_type` — the post being edited
- `wp_user_id` — the recording user's WordPress user id (see id-space note under Known limitations)
- `contributor_count` — number of collaborators present in the room
- `contributors` — array of WordPress user IDs of the collaborators present (a repeated ID indicates the same user editing in multiple tabs; distinct IDs indicate multiple simultaneous editors)

`blog_id` is attached automatically by the analytics library. No new persistent storage is introduced; the event is sent to Tracks. The purpose is to measure RTC usage on WordPress.com (how many people use it, single-user multi-tab vs. multiple simultaneous editors, and across which transport).

## Known limitations
* **`wp_user_id` / `contributors` are WordPress user IDs, not one global id-space.** On Simple sites they are WordPress.com user ids; on Atomic/Jetpack sites they are the *site-local* WP user ids, which differ from the wpcom id Tracks records as `_ui`. They are therefore only comparable within a single `blog_id`. `wp_user_id` exists so the recording user can be located within the local-id `contributors` roster on Atomic.
* **The `contributors` roster is best-effort.** A client records only the peers it has synced when the snapshot fires. On HTTP-polling, awareness arrives on a poll cycle (up to 25s for a backgrounded tab), so a joiner can record a self-only roster even when others are editing. Reconstruct simultaneous-editor and multi-tab counts by correlating join events (distinct/repeated `wp_user_id` on the same `post_id` within a time window) rather than trusting a single event's `contributors`.

## Testing instructions

Unit tests:
* `cd projects/packages/rtc && pnpm test` — 17 tests should pass.

Functional (requires a WordPress.com environment with RTC enabled — Simple or Atomic; this depends on wpcom Tracks + RTC infrastructure and cannot be fully exercised on a plain self-hosted site):
* Open a post in the block editor with the browser Network tab open.
* Confirm a `jetpack_rtc_join` Tracks beacon fires (filter the Network tab for `pixel.wp.com`) with `transport`, `wp_user_id`, `contributor_count`, and `contributors`.
* Open the same post in a second tab as the same user — confirm `wp_user_id` repeats in `contributors`.
* Open the same post as a different user — confirm `contributors` eventually contains both distinct user IDs (best-effort; on HTTP-polling a joiner's roster may be self-only — see Known limitations).
* Confirm `transport` reflects the site's transport (`pinghub` on Simple, `http-polling` on a non-edge Atomic site).
