### PR TITLE
Notifications: gate v3 panel behind hosting-dashboard-opt-in preference

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notifications-v3-hosting-dashboard-gate
+++ b/projects/plugins/jetpack/changelog/update-notifications-v3-hosting-dashboard-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Notifications: gate the v3 panel behind the hosting dashboard opt-in instead of a query parameter.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -195,9 +195,8 @@ class Jetpack_Notifications {
 
 		$third_party_cookie_check_iframe = '<span style="display:none;"><iframe class="jetpack-notes-cookie-check" src="https://widgets.wp.com/3rd-party-cookie-check/index.html"></iframe></span>';
 
-		// Opt into the v3 notifications panel/iframe via the `notifications=v3` query parameter.
-		$notifications_version = sanitize_key( wp_unslash( $_GET['notifications'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$panel_id              = 'v3' === $notifications_version ? 'wpnt-notes-panel3' : 'wpnt-notes-panel2';
+		// Use the v3 notifications panel/iframe for users who have opted into the hosting dashboard.
+		$panel_id = self::has_hosting_dashboard_opt_in() ? 'wpnt-notes-panel3' : 'wpnt-notes-panel2';
 
 		$title = self::get_notes_markup();
 
@@ -216,6 +215,21 @@ class Jetpack_Notifications {
 				'href'   => 'https://wordpress.com/reader/notifications',
 			)
 		);
+	}
+
+	/**
+	 * Whether the current user has opted into the hosting dashboard, which also enables the v3 notifications panel.
+	 *
+	 * @return bool
+	 */
+	private static function has_hosting_dashboard_opt_in() {
+		if ( ! function_exists( 'get_user_attribute' ) ) {
+			return false;
+		}
+
+		$preferences = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
+
+		return 'opt-in' === ( $preferences['hosting-dashboard-opt-in']['value'] ?? null );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Replaces the `notifications=v3` query-parameter gate (added in #49514) with a check on the current user's `calypso_preferences['hosting-dashboard-opt-in']` value. When that value is `'opt-in'`, the notifications admin-bar item renders `#wpnt-notes-panel3` (v3 panel/iframe); otherwise it renders `#wpnt-notes-panel2`.
* Mirrors the gate used by the wpcom admin-bar "All Sites" logo, so a user who opted into the hosting dashboard gets the v3 notifications experience automatically — no URL flag required.
* Guards `get_user_attribute()` with `function_exists()` so self-hosted Jetpack sites (where the function and the preference don't exist) safely fall back to the v2 panel.

## Related product discussion/links
* Follow-up to #49514.

## Does this pull request change what data or activity we track or use?
No. It reads an existing user preference (`calypso_preferences`) to decide which notifications panel markup to render.

## Testing instructions
* On a WoA/Atomic site (where `get_user_attribute()` and `calypso_preferences` are available):
  * As a user **without** the hosting dashboard opt-in, load any admin page and inspect the notifications admin-bar item — the panel div should be `#wpnt-notes-panel2`.
  * Set the user's `calypso_preferences['hosting-dashboard-opt-in']['value']` to `opt-in`, reload, and confirm the panel div is now `#wpnt-notes-panel3` and clicking the bell opens the v3 panel (iframe `https://widgets.wp.com/notifications/app/`) in a browser that allows third-party cookies.
* On a self-hosted Jetpack site, confirm the notifications bell still renders `#wpnt-notes-panel2` and is unaffected.
