### PR TITLE
VideoPress: truncate long titles and filenames in the dashboard library

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-library-title-overflow
+++ b/projects/packages/videopress/changelog/fix-videopress-library-title-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress dashboard: truncate long video titles and filenames with an ellipsis in the library grid and table, and clamp long titles in the video details breadcrumb.

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -189,7 +189,6 @@
 	// than an <a> because navigation is handled by the in-app router, not an
 	// href; styled to read as a link and inherit the cell's typography.
 	&__title-link {
-		display: inline;
 		margin: 0;
 		padding: 0;
 		border: 0;
@@ -203,6 +202,38 @@
 		&:focus-visible {
 			color: var(--wp-admin-theme-color, #3858e9);
 			text-decoration: underline;
+		}
+	}
+
+	// Truncate long titles with an ellipsis instead of letting them spill
+	// across neighbouring cards (grid) or into the next column (table).
+	// DataViews' own .dataviews-title-field truncation only targets its
+	// internal anchor/button markup, so custom renderers bring their own.
+	// `width: fit-content` keeps the button's hit area at text size while
+	// `max-width` provides the bound that makes text-overflow engage;
+	// `min-width: 0` lets the element shrink when it shares a flex row
+	// with a status pill. The full text stays reachable via the elements'
+	// `title` attribute (set in fields.tsx).
+	&__title-link,
+	&__title-text {
+		display: block;
+		width: fit-content;
+		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	// Title + status pill row: cap the row at the cell width so the title
+	// (min-width: 0 above) shrinks and ellipsizes, and keep the pill from
+	// being crushed by a long title.
+	&__title-cell {
+		min-width: 0;
+		max-width: 100%;
+
+		> :last-child {
+			flex-shrink: 0;
 		}
 	}
 
@@ -228,6 +259,20 @@
 		&__progress,
 		&__failed {
 			display: none;
+		}
+
+		// Cap the two free-text columns so a pathological title + filename
+		// can't bloat their columns (DataViews caps cells at 80ch, which
+		// lets long text shove every other column out of the viewport).
+		// 36ch keeps the default column set within a ~1440px admin screen;
+		// narrower viewports fall back to the table's horizontal scroll.
+		&__title-link,
+		&__title-text {
+			max-width: 36ch;
+		}
+
+		&__filename {
+			max-width: 30ch;
 		}
 	}
 

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -126,7 +126,12 @@ const Editor = ( {
 	return (
 		<AdminPage
 			breadcrumbs={
-				<Breadcrumbs items={ [ getParentBreadcrumbItem(), { label: video.title } ] } />
+				// display: contents wrapper — a pure scoping hook so the
+				// stylesheet can clamp long video titles in the current-item
+				// crumb (Breadcrumbs' own class names are CSS-module hashes).
+				<div className="vp-video-details__breadcrumbs">
+					<Breadcrumbs items={ [ getParentBreadcrumbItem(), { label: video.title } ] } />
+				</div>
 			}
 			actions={
 				<HeaderActions

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -38,6 +38,12 @@
 // because @wordpress/admin-ui's Breadcrumbs uses hashed CSS-module class
 // names. Long video titles are clamped so they can't crowd the header's
 // Save button; the full title remains visible in the Title field below.
+// Upstream defect this works around: Breadcrumbs ships its own
+// `li:last-child { flex-shrink: 1; min-width: 0 }` intending exactly this
+// truncation, but it never engages — the nav and the header's inner Stack
+// are flex items left at `min-width: auto`, so no width constraint ever
+// reaches the list. If that's fixed upstream, this block can shrink to
+// just the max-width cap (or go away entirely).
 .vp-video-details__breadcrumbs {
 	display: contents;
 

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -32,6 +32,23 @@
 	}
 }
 
+// Scoping hook only — display: contents removes the wrapper's box from
+// layout, so the breadcrumb list flows in the header exactly as before.
+// The current-item crumb is targeted structurally (li:last-child h1)
+// because @wordpress/admin-ui's Breadcrumbs uses hashed CSS-module class
+// names. Long video titles are clamped so they can't crowd the header's
+// Save button; the full title remains visible in the Title field below.
+.vp-video-details__breadcrumbs {
+	display: contents;
+
+	li:last-child h1 {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: min(60ch, 45vw);
+	}
+}
+
 .vp-video-details__not-found {
 	padding: 48px 24px;
 	text-align: center;

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -24,11 +24,15 @@ const TitleText = ( { item }: { item: LibraryItem } ) => {
 	const { openVideoDetails } = useUploadActions();
 	const { type, upload, title, id } = item;
 
+	// `title` attributes expose the full text on hover; the elements
+	// themselves truncate with an ellipsis (see &__title-link /
+	// &__title-text in style.scss).
 	if ( type === 'videopress' && upload.status === 'idle' ) {
 		return (
 			<button
 				type="button"
 				className="vp-library__title-link"
+				title={ title }
 				onClick={ () => openVideoDetails( id ) }
 			>
 				{ title }
@@ -36,7 +40,11 @@ const TitleText = ( { item }: { item: LibraryItem } ) => {
 		);
 	}
 
-	return <span>{ title }</span>;
+	return (
+		<span className="vp-library__title-text" title={ title }>
+			{ title }
+		</span>
+	);
 };
 
 const privacyLabel = ( privacy: LibraryItem[ 'privacy' ] ): string => {
@@ -121,7 +129,7 @@ export const libraryFields: Field< LibraryItem >[] = [
 		label: __( 'Filename', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.filename,
 		render: ( { item } ) => (
-			<Text variant="body-sm" className="vp-library__filename">
+			<Text variant="body-sm" className="vp-library__filename" title={ item.filename }>
 				{ item.filename }
 			</Text>
 		),

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -22,8 +22,10 @@ const makeActions = ( overrides: Partial< UploadActions > = {} ): UploadActions 
 const renderField = ( ui: React.ReactNode, actions: UploadActions ) =>
 	render( <UploadActionsProvider value={ actions }>{ ui }</UploadActionsProvider> );
 
-// The title cell render is whatever the exported `title` field declares.
+// The cell renders are whatever the exported field declarations provide.
 const TitleCellRender = ( libraryFields.find( f => f.id === 'title' ) as Field< LibraryItem > )
+	.render as ( args: { item: LibraryItem } ) => React.ReactNode;
+const FilenameRender = ( libraryFields.find( f => f.id === 'filename' ) as Field< LibraryItem > )
 	.render as ( args: { item: LibraryItem } ) => React.ReactNode;
 
 describe( 'ThumbnailField — grid Details access', () => {
@@ -137,9 +139,6 @@ describe( 'TitleCell — grid Details access', () => {
 
 	it( 'exposes the full filename via a title attribute (forwarded through the Text component)', () => {
 		const longName = 'a-very-long-filename-that-needs-truncation-in-the-table-layout.mov';
-		const FilenameRender = (
-			libraryFields.find( f => f.id === 'filename' ) as Field< LibraryItem >
-		 ).render as ( args: { item: LibraryItem } ) => React.ReactNode;
 		renderField( <FilenameRender item={ item( { filename: longName } ) } />, makeActions() );
 		expect( screen.getByText( longName ) ).toHaveAttribute( 'title', longName );
 	} );

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -113,4 +113,22 @@ describe( 'TitleCell — grid Details access', () => {
 		expect( screen.getByText( 'Deleting…' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Doomed' } ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'exposes the full title via a title attribute (hover affordance for truncated text)', () => {
+		const longTitle = 'A very long recording title that will be truncated with an ellipsis';
+		renderField( <TitleCellRender item={ item( { title: longTitle } ) } />, makeActions() );
+		expect( screen.getByRole( 'button', { name: longTitle } ) ).toHaveAttribute(
+			'title',
+			longTitle
+		);
+
+		renderField(
+			<TitleCellRender item={ item( { type: 'local', title: longTitle } ) } />,
+			makeActions()
+		);
+		expect( screen.getByText( longTitle, { selector: 'span' } ) ).toHaveAttribute(
+			'title',
+			longTitle
+		);
+	} );
 } );

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -114,14 +114,17 @@ describe( 'TitleCell — grid Details access', () => {
 		expect( screen.queryByRole( 'button', { name: 'Doomed' } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'exposes the full title via a title attribute (hover affordance for truncated text)', () => {
+	it( 'exposes the full title via a title attribute on the clickable variant', () => {
 		const longTitle = 'A very long recording title that will be truncated with an ellipsis';
 		renderField( <TitleCellRender item={ item( { title: longTitle } ) } />, makeActions() );
 		expect( screen.getByRole( 'button', { name: longTitle } ) ).toHaveAttribute(
 			'title',
 			longTitle
 		);
+	} );
 
+	it( 'exposes the full title via a title attribute on the plain-text variant', () => {
+		const longTitle = 'A very long recording title that will be truncated with an ellipsis';
 		renderField(
 			<TitleCellRender item={ item( { type: 'local', title: longTitle } ) } />,
 			makeActions()
@@ -130,5 +133,14 @@ describe( 'TitleCell — grid Details access', () => {
 			'title',
 			longTitle
 		);
+	} );
+
+	it( 'exposes the full filename via a title attribute (forwarded through the Text component)', () => {
+		const longName = 'a-very-long-filename-that-needs-truncation-in-the-table-layout.mov';
+		const FilenameRender = (
+			libraryFields.find( f => f.id === 'filename' ) as Field< LibraryItem >
+		 ).render as ( args: { item: LibraryItem } ) => React.ReactNode;
+		renderField( <FilenameRender item={ item( { filename: longName } ) } />, makeActions() );
+		expect( screen.getByText( longName ) ).toHaveAttribute( 'title', longName );
 	} );
 } );


### PR DESCRIPTION
Fixes VIDP-253 (CFT feedback item **VP11**, reported in #49485)

## Proposed changes

Long video titles and filenames overflowed ungracefully in the modernized VideoPress dashboard: grid cards hard-clipped titles mid-character with no ellipsis, and in the table layout a long title would render *over* the filename column's text while pushing the Duration/Uploaded/Privacy columns out of the viewport entirely. The video details page rendered the full raw title in the breadcrumb, crowding the Save button.

* **Ellipsis truncation for titles in both layouts.** DataViews' own `.dataviews-title-field` truncation only targets its internal anchor/button markup, so our custom renderers now bring their own: `display: block` + `width: fit-content` (keeps the clickable title's hit area at text size) + `max-width` bound + `min-width: 0` (lets the title shrink when it shares a flex row with a status pill, which itself gets `flex-shrink: 0`).
* **Sane table column caps.** Title text capped at 36ch and filename at 30ch in the table layout, sized so the default column set fits a ~1440px admin screen; narrower viewports fall back to the table's horizontal scroll. (DataViews' built-in 80ch cell cap still overflows once two text columns hit it.)
* **Hover affordance.** The truncating elements carry `title` attributes so the full text is reachable on hover.
* **Details-page breadcrumb clamp.** The current-item crumb (an `h1` rendered by `@wordpress/admin-ui`'s Breadcrumbs) is clamped via a `display: contents` scoping wrapper — the component's class names are hashed CSS-modules, so the wrapper gives us a stable hook with zero layout impact. The full title remains visible in the Title field directly below.

## Related product discussion/links

* VIDP-253
* CFT Feedback Inventory: #49485

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires the modernized VideoPress dashboard (`add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`) and videos with absurdly long titles/filenames — e.g. rename a video to a 130+ character unbroken string like `screen-recording-2026-06-11-at-14-23-55-final-FINAL-v2-revised-EXPORT-1080p60-high-bitrate-DO-NOT-DELETE-master-copy-approved-by-legal`.

* Go to **Jetpack → VideoPress → Library** (grid layout). Long titles under the cards should truncate with an ellipsis at the card edge instead of being hard-clipped mid-character; hovering the title shows the full text.
* Switch to the **table layout**. Long titles and filenames should each truncate with an ellipsis inside their own columns — no text overlapping the next column, and Duration / Uploaded / Privacy / Actions all visible without horizontal scrolling at a typical desktop width.
* Open the long-titled video's **details page**. The breadcrumb should show a truncated title with an ellipsis, leaving the Save button untouched; the full title still appears in the Title field.

### Screenshots (mocked media responses; 1440×900)

| | Before | After |
|---|---|---|
| Grid | ![grid before](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/before-grid.png) | ![grid after](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/after-grid.png) |
| Table | ![table before](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/before-table.png) | ![table after](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/after-table.png) |
| Details | ![details before](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/before-details.png) | ![details after](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-library-title-overflow/after-details.png) |

Unit tests: `cd projects/packages/videopress && pnpm test` (includes the `title`-attribute hover affordance on both the clickable and plain title variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
