### PR TITLE
JS test coverage for projects using `node --test`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@ AGENTS.md              production-exclude
 babel.config.js        production-exclude
 babel.config.[cm]js    production-exclude
 .babelrc               production-exclude
+.c8rc.json             production-exclude
 CLAUDE.md              production-exclude
 composer.lock          production-exclude
 eslint.config.mjs      production-exclude

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -122,7 +122,6 @@ We use `composer.json` to hold metadata about projects. Much of our generic tool
   * `.scripts.skip-test-php-coverage`: Run before `.scripts.test-php-coverage` in CI. If it exits with code 3, the test run will be skipped.
 * `.scripts.test-js-coverage`: If the package contains any JavaScript tests, this must run the necessary commands to generate a JS coverage report. See [Code coverage](#code-coverage) for details.
   * `.scripts.skip-test-js-coverage`: Run before `.scripts.test-js-coverage` in CI. If it exits with code 3, the test run will be skipped.
-* `.scripts.test-e2e`: If the package contains any E2E tests, this must run the necessary commands. See [E2E tests](#e2e-tests) for details.
 * `.scripts.test-js`: If the package contains any JavaScript tests, this must run the necessary commands. See [JavaScript tests](#javascript-tests) for details.
   * `.scripts.skip-test-js`: Run before `.scripts.test-js` in CI. If it exits with code 3, the test run will be skipped.
 * `.scripts.test-php`: If the package contains any PHPUnit tests, this must run the necessary commands. See [PHP tests](#php-tests) for details.
@@ -296,6 +295,8 @@ If a project contains JavaScript tests, it must define `.scripts.test-js` in `co
 
 JavaScript tests should use `jest`, not `mocha`/`chai`/`sinon`. For React testing, use `@testing-library/react` rather than `enzyme`.
 
+JavaScript tests may alternatively use `node --test`, along with `c8` for coverage.
+
 ### TypeScript type checking
 
 If a project contains TypeScript code, it should define `.scripts.typecheck` in `package.json` to run `tsgo` in a manner that will check types without building. The CI environment will run `pnpm install` beforehand, but if `composer install` or a build step is required before running tests the necessary commands for that should also be included in `.scripts.typecheck`.
@@ -303,12 +304,6 @@ If a project contains TypeScript code, it should define `.scripts.typecheck` in 
 Note the ideal configuration for a TypeScript project using `tsgo` to build will have two tsconfig files:
 * `tsconfig.json` will be used for linting and type checking all code in the project. It will set `include` to reference all TS files and TS-containing subdirs
 * `tsconfig.build.json` will be used for the build (by passing `--project tsconfig.build.json` to `tsgo`). This will extend `tsconfig.json` to override `include` to specify only the entry point files.
-
-### E2E tests
-
-**This is not implemented yet!**
-
-If a project contains end-to-end tests, it must define `.scripts.test-e2e` in `composer.json` to run the tests. If a build step is required before running tests, the necessary commands for that should also be included.
 
 ### Code coverage
 
@@ -319,6 +314,22 @@ Output should be written to the path specified via the `COVERAGE_DIR` environmen
 For PHP tests, you'll probably run PHPUnit as `php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php "$COVERAGE_DIR/php.cov"`. If you have multiple runs (e.g. unit and integration), be sure to write the `php.cov` files to separate subdirectories of `$COVERAGE_DIR`.
 
 For JS tests, you'll probably have a `test` script in package.json that runs `jest` with any needed options, and then a `test-js-coverage` script that does `pnpm run test --coverage`. If you have multiple runs (e.g. unit and integration), be sure each run writes to a different subdirectory of `$COVERAGE_DIR`.
+
+For JS tests using `node --test`, your `test-js-coverage` will likely look like `c8 --report-dir="$COVERAGE_DIR" --temp-directory="$ARTIFACTS_DIR/v8" pnpm run test`, along with a `.c8rc.json` like the following.
+
+<details><summary>Sample `.c8rc.json`</summary>
+
+```json
+{
+	"reporter": [ "json" ],
+	"all": true,
+	"include": [ "src", "index.js" ]
+}
+```
+
+</details>
+
+If you're using any other JS test runner for some reason, you'll want to have the `test-js-coverage` command write reports to `$COVERAGE_DIR/**.json` in a format compatible with Istanbul's `json` reporter, in whatever manner that can be accomplished with your chosen test runner.
 
 There's no need to be concerned about collisions with other projects' coverage files, as a separate directory is used per project. The coverage files are also automatically copied to `ARTIFACTS_DIR`.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3089,6 +3089,9 @@ importers:
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.29.0)
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       package-directory:
         specifier: ^8.1.0
         version: 8.2.0
@@ -5042,6 +5045,9 @@ importers:
       browserslist:
         specifier: ^4.24.0
         version: 4.28.2
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       webpack:
         specifier: ^5.104.1
         version: 5.105.2(webpack-cli@6.0.1)
@@ -7681,6 +7687,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -12042,6 +12052,16 @@ packages:
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
+
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -19890,6 +19910,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@blazediff/core@1.9.1': {}
 
@@ -29028,6 +29050,20 @@ snapshots:
   bytes@3.1.2: {}
 
   bytestreamjs@2.0.1: {}
+
+  c8@11.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   cac@6.7.14: {}
 

--- a/projects/packages/jetpack-mu-wpcom/.c8rc.json
+++ b/projects/packages/jetpack-mu-wpcom/.c8rc.json
@@ -1,0 +1,6 @@
+{
+	"reporter": [ "json" ],
+	"all": true,
+	"include": [ "src" ],
+	"exclude": [ "src/build", "src/build-module", "**/*.d.ts", "**/test{,s}" ]
+}

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable JS test coverage using `c8`
+
+

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -46,6 +46,7 @@
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
 		"test-js": "pnpm run test",
+		"test-js-coverage": "pnpm run test-coverage",
 		"test-php": "@composer phpunit",
 		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"",
 		"build-production": "pnpm run build-production-js",

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -23,6 +23,7 @@
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
 		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs",
+		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"
 	},
@@ -115,6 +116,7 @@
 		"@types/react-dom": "18.3.7",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"babel-plugin-transform-rename-properties": "0.1.0",
+		"c8": "^11.0.0",
 		"package-directory": "^8.1.0",
 		"sass-embedded": "1.97.3",
 		"sass-loader": "16.0.5",

--- a/projects/packages/wp-build-polyfills/.c8rc.json
+++ b/projects/packages/wp-build-polyfills/.c8rc.json
@@ -1,0 +1,5 @@
+{
+	"reporter": [ "json" ],
+	"all": true,
+	"include": [ "bin", "src", "*.js" ]
+}

--- a/projects/packages/wp-build-polyfills/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/packages/wp-build-polyfills/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable JS test coverage using `c8`
+
+

--- a/projects/packages/wp-build-polyfills/composer.json
+++ b/projects/packages/wp-build-polyfills/composer.json
@@ -40,6 +40,10 @@
 		"test-js": [
 			"pnpm run build",
 			"pnpm run test"
+		],
+		"test-js-coverage": [
+			"pnpm run build",
+			"pnpm run test-coverage"
 		]
 	},
 	"config": {

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -19,7 +19,8 @@
 		"build": "pnpm run clean && webpack && node bin/validate-boot-asset.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
 		"clean": "rm -rf build/",
-		"test": "node --test 'tests/js/**/*.test.js'"
+		"test": "node --test 'tests/js/**/*.test.js'",
+		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
@@ -37,6 +38,7 @@
 		"@wordpress/theme": "^0.15.0",
 		"@wordpress/ui": "^0.13.0",
 		"browserslist": "^4.24.0",
+		"c8": "^11.0.0",
 		"webpack": "^5.104.1",
 		"webpack-cli": "^6.0.1"
 	},

--- a/projects/plugins/backup/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/backup/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Lock file update
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1981,7 +1981,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -2027,6 +2027,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [

--- a/projects/plugins/jetpack/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/jetpack/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Lock file update
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3880,7 +3880,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -3926,6 +3926,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Lock file update
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1308,7 +1308,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "370824ff914142adb36b88b2070396f96836d43b"
+                "reference": "17cf4ffb6db2e468d015f3840acf680595023045"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1366,6 +1366,9 @@
                 ],
                 "test-js": [
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "test-php": [
                     "@composer phpunit"
@@ -2161,7 +2164,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -2207,6 +2210,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [

--- a/projects/plugins/social/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/social/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Lock file update
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -2124,7 +2124,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -2170,6 +2170,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [

--- a/projects/plugins/videopress/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/videopress/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Lock file update
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1862,7 +1862,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -1908,6 +1908,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [

--- a/projects/plugins/wpcomsh/changelog/update-enable-coverage-for-projects-using-node---test
+++ b/projects/plugins/wpcomsh/changelog/update-enable-coverage-for-projects-using-node---test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Lock file update
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1495,7 +1495,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "370824ff914142adb36b88b2070396f96836d43b"
+                "reference": "17cf4ffb6db2e468d015f3840acf680595023045"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1553,6 +1553,9 @@
                 ],
                 "test-js": [
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "test-php": [
                     "@composer phpunit"
@@ -2413,7 +2416,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "0a2f5b88f7c6792cd06a0533d66d3867f8d15aac"
+                "reference": "3f3fcbaa85914479f57f85c64247b824101cf185"
             },
             "require": {
                 "php": ">=7.2"
@@ -2459,6 +2462,10 @@
                 "test-js": [
                     "pnpm run build",
                     "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
                 ]
             },
             "license": [


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We have two projects so far that are using `node --test` rather than `jest` for testing. To get coverage for those projects, `c8` works reasonably well.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1780596341054369-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* `packages/jetpack-mu-wpcom` and `packages/wp-build-polyfills` reporting coverage now?