### PR TITLE
Write: use progress cursor on Save buttons while saving

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-4006-save-button-cursor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-4006-save-button-cursor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: show progress cursor (instead of not-allowed) on Save buttons while a save is in flight.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -188,7 +188,7 @@
 
 .bw-btn:disabled {
 	opacity: 0.5;
-	cursor: not-allowed;
+	cursor: progress;
 }
 
 .bw-btn-draft {


### PR DESCRIPTION
Fixes [RSM-4006](https://linear.app/a8c/issue/RSM-4006/save-button-shows-no-entry-cursor-when-clicked-but-save-still)

## Proposed changes
* While a save is in flight in the Write editor, the Save Draft and Publish buttons get `disabled` (via `data-wp-bind--disabled="state.isSaving"`). The shared `.bw-btn:disabled` rule was applying `cursor: not-allowed`, which is the affordance for "this action is forbidden" — wrong for an in-flight save that is actually succeeding. Switched to `cursor: progress` to match the existing `.bw-upload-zone.bw-uploading` precedent.

## Related product discussion/links
* [RSM-4006](https://linear.app/a8c/issue/RSM-4006/save-button-shows-no-entry-cursor-when-clicked-but-save-still)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open a Write editor draft (`/write` on a WP.com site running this build).
* Type something to make the draft dirty.
* Click **Save draft** (or **Publish** / **Update**).
* While the save is in flight, hover the button: the cursor should now show the "progress" / busy indicator (platform-dependent — typically an arrow with a spinner) instead of the "no entry" / forbidden cursor.
* The save itself should complete normally.

Note: the in-flight window is brief — easiest to observe on a slow network (devtools → Network → Slow 3G) or on a longer post.