### PR TITLE
Podcast: dedicated settings endpoint

### DIFF
--- a/projects/packages/podcast/.phan/config.php
+++ b/projects/packages/podcast/.phan/config.php
@@ -17,5 +17,11 @@ return make_phan_config(
 		'exclude_file_regex' => array(
 			'build/',
 		),
+		'parse_file_list'    => array(
+			// DO NOT add references to files in other packages like this. This is the
+			// Jetpack plugin core-api loader, referenced only so Phan knows the
+			// `wpcom_rest_api_v2_load_plugin()` function — same as publicize/videopress.
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/core-api/load-wpcom-endpoints.php', // function wpcom_rest_api_v2_load_plugin
+		),
 	)
 );

--- a/projects/packages/podcast/.phan/config.php
+++ b/projects/packages/podcast/.phan/config.php
@@ -18,9 +18,6 @@ return make_phan_config(
 			'build/',
 		),
 		'parse_file_list'    => array(
-			// DO NOT add references to files in other packages like this. This is the
-			// Jetpack plugin core-api loader, referenced only so Phan knows the
-			// `wpcom_rest_api_v2_load_plugin()` function — same as publicize/videopress.
 			__DIR__ . '/../../../plugins/jetpack/_inc/lib/core-api/load-wpcom-endpoints.php', // function wpcom_rest_api_v2_load_plugin
 		),
 	)

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,3 +1,4 @@
 Significance: minor
 Type: changed
-Comment: The podcast settings screen now loads and saves through the Podcast package's own REST endpoint instead of WordPress core's general settings API. This keeps podcast options out of the shared core settings response and makes saving work the same way on self-hosted sites.
+
+The podcast settings screen now loads and saves through the Podcast package's own REST endpoint instead of WordPress core's general settings API. This keeps podcast options out of the shared core settings response and makes saving work the same way on self-hosted sites.

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,0 +1,3 @@
+Significance: minor
+Type: changed
+Comment: Podcast settings now read/write through a dedicated jetpack/v4/podcast/settings REST endpoint owned by the package, instead of core /wp/v2/settings. The schema and sanitizers stay the single source of truth in the package, so the feature works unchanged on self-hosted sites.

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,3 +1,3 @@
 Significance: minor
 Type: changed
-Comment: Podcast settings now read/write through a dedicated jetpack/v4/podcast/settings REST endpoint owned by the package, instead of core /wp/v2/settings. The schema and sanitizers stay the single source of truth in the package, so the feature works unchanged on self-hosted sites.
+Comment: The podcast settings screen now loads and saves through the Podcast package's own REST endpoint instead of WordPress core's general settings API. This keeps podcast options out of the shared core settings response and makes saving work the same way on self-hosted sites.

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Podcast: load and save site settings through the package's own jetpack/v4 REST endpoint instead of WordPress core's general settings API, keeping podcast options out of the shared core settings response and working the same on self-hosted sites.
+Podcast: add a dedicated jetpack/v4 REST endpoint for site settings and load/save them through it from the dashboard, working the same on self-hosted sites.

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Podcast: add a dedicated jetpack/v4 REST endpoint for site settings and load/save them through it from the dashboard, working the same on self-hosted sites.
+Podcast: add a dedicated wpcom/v2 REST endpoint for site settings and load/save them through it from the dashboard, reachable on Simple, WoA, and self-hosted from a single definition.

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-The podcast settings screen now loads and saves through the Podcast package's own REST endpoint instead of WordPress core's general settings API. This keeps podcast options out of the shared core settings response and makes saving work the same way on self-hosted sites.
+Podcast: load and save site settings through the package's own jetpack/v4 REST endpoint instead of WordPress core's general settings API, keeping podcast options out of the shared core settings response and working the same on self-hosted sites.

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -27,6 +27,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { usePodcastSettings } from '../../dashboard/hooks/use-podcast-settings';
 import metadata from './block.json';
 import { microphone } from './icons';
 import { getValidatedAttributes } from './util/get-validated-attributes';
@@ -214,10 +215,11 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 	);
 
 	// Source the show-level cover from the same REST surface the dashboard
-	// reads: /wp/v2/settings exposes `podcasting_image` (registered in
-	// class-settings.php). No more localized window globals.
-	const [ siteShowCover ] = useEntityProp< string >( 'root', 'site', 'podcasting_image' );
-	const showCoverUrl = siteShowCover || '';
+	// reads: the package's `jetpack/v4/podcast/settings` endpoint. Requires
+	// `manage_options`, so for non-admin editors the fetch 403s and the cover
+	// resolves empty — identical to the prior `/wp/v2/settings` behavior.
+	const { data: podcastSettings } = usePodcastSettings();
+	const showCoverUrl = podcastSettings?.podcasting_image || '';
 
 	const postAuthor = useSelect(
 		select => {

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -214,10 +214,9 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		postId
 	);
 
-	// Source the show-level cover from the same REST surface the dashboard
-	// reads: the package's `jetpack/v4/podcast/settings` endpoint. Requires
+	// Show-level cover from the package settings endpoint. It requires
 	// `manage_options`, so for non-admin editors the fetch 403s and the cover
-	// resolves empty — identical to the prior `/wp/v2/settings` behavior.
+	// resolves empty.
 	const { data: podcastSettings } = usePodcastSettings();
 	const showCoverUrl = podcastSettings?.podcasting_image || '';
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -214,9 +214,6 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		postId
 	);
 
-	// Show-level cover from the package settings endpoint. It requires
-	// `manage_options`, so for non-admin editors the fetch 403s and the cover
-	// resolves empty.
 	const { data: podcastSettings } = usePodcastSettings();
 	const showCoverUrl = podcastSettings?.podcasting_image || '';
 

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -54,7 +54,8 @@ class Podcast {
 		Podcast_Settings_Endpoint::init();
 
 		// Register the `podcasting_*` options. The SPA reads/writes them through
-		// Podcast_Settings_Endpoint, deliberately not core `/wp/v2/settings`.
+		// Podcast_Settings_Endpoint; they also stay in core `/wp/v2/settings` via
+		// `show_in_rest` for now, removed in a follow-up.
 		Settings::register();
 
 		// Wire the RSS feed customizations (`<itunes:*>` + `<podcast:*>` tags,

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -51,11 +51,12 @@ class Podcast {
 		Posts_To_Podcast_Endpoint::init();
 		Podcast_Stats_Endpoint::init();
 		Podcast_Distribution_Endpoint::init();
+		Podcast_Settings_Endpoint::init();
 
-		// Register the `podcasting_*` option schema so the SPA can read/write
-		// via `/wp/v2/settings`. On Simple, the legacy WPCOM site-settings
-		// filters in the wpcom mu-plugin remain authoritative for
-		// `/rest/v1.4/sites/{id}/settings`; this is the non-Simple equivalent.
+		// Register the `podcasting_*` option schema (defaults + sanitizers) and
+		// opt them into Jetpack Sync. The SPA reads/writes them through the
+		// package's own `jetpack/v4/podcast/settings` endpoint — deliberately
+		// not core `/wp/v2/settings` — so this works the same on self-hosted.
 		Settings::register();
 
 		// Wire the RSS feed customizations (`<itunes:*>` + `<podcast:*>` tags,

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -53,10 +53,8 @@ class Podcast {
 		Podcast_Distribution_Endpoint::init();
 		Podcast_Settings_Endpoint::init();
 
-		// Register the `podcasting_*` option schema (defaults + sanitizers) and
-		// opt them into Jetpack Sync. The SPA reads/writes them through the
-		// package's own `jetpack/v4/podcast/settings` endpoint — deliberately
-		// not core `/wp/v2/settings` — so this works the same on self-hosted.
+		// Register the `podcasting_*` options. The SPA reads/writes them through
+		// Podcast_Settings_Endpoint, deliberately not core `/wp/v2/settings`.
 		Settings::register();
 
 		// Wire the RSS feed customizations (`<itunes:*>` + `<podcast:*>` tags,

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -53,9 +53,6 @@ class Podcast {
 		Podcast_Distribution_Endpoint::init();
 		Podcast_Settings_Endpoint::init();
 
-		// Register the `podcasting_*` options. The SPA reads/writes them through
-		// Podcast_Settings_Endpoint; they also stay in core `/wp/v2/settings` via
-		// `show_in_rest` for now, removed in a follow-up.
 		Settings::register();
 
 		// Wire the RSS feed customizations (`<itunes:*>` + `<podcast:*>` tags,

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -8,10 +8,11 @@
 namespace Automattic\Jetpack\Podcast;
 
 /**
- * Registers the `podcasting_*` options so each `sanitize_callback` runs on
- * {@see update_option()} writes. REST exposure lives on the dedicated
- * {@see Podcast_Settings_Endpoint} (`jetpack/v4/podcast/settings`); these keys
- * are deliberately kept out of core `/wp/v2/settings`.
+ * Registers the `podcasting_*` options with their `sanitize_callback`s and
+ * `show_in_rest` so they keep appearing in core `/wp/v2/settings`. The dashboard
+ * now reads and writes them through the dedicated {@see Podcast_Settings_Endpoint}
+ * (`jetpack/v4/podcast/settings`); the core exposure stays for now and is removed
+ * in a follow-up once WPCOM's settings-controller test is decoupled.
  *
  * Array-shaped options merge against stored values on sanitize, not replace —
  * the SPA can PATCH partial entries without losing the rest.
@@ -125,6 +126,7 @@ class Settings {
 					'type'              => $type,
 					'default'           => $default,
 					'sanitize_callback' => $sanitize,
+					'show_in_rest'      => true,
 				)
 			);
 		}
@@ -136,6 +138,13 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'default' => '',
+						'format'  => 'uri',
+					),
+				),
 			)
 		);
 
@@ -146,6 +155,7 @@ class Settings {
 				'type'              => 'boolean',
 				'default'           => false,
 				'sanitize_callback' => array( __CLASS__, 'sanitize_explicit' ),
+				'show_in_rest'      => true,
 			)
 		);
 
@@ -156,6 +166,7 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_email',
+				'show_in_rest'      => true,
 			)
 		);
 
@@ -166,8 +177,12 @@ class Settings {
 				'type'              => 'integer',
 				'default'           => 0,
 				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
 			)
 		);
+
+		$podcatcher_keys = array_keys( self::SHOW_URL_HOSTS );
+		$empty_map       = array_fill_keys( $podcatcher_keys, '' );
 
 		register_setting(
 			self::OPTIONS_GROUP,
@@ -176,6 +191,20 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_urls' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'default'    => $empty_map,
+						'properties' => array_fill_keys(
+							$podcatcher_keys,
+							array(
+								'type'      => 'string',
+								'format'    => 'uri',
+								'maxLength' => self::SHOW_URL_MAX_LENGTH,
+							)
+						),
+					),
+				),
 			)
 		);
 
@@ -186,6 +215,19 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_states' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'default'    => $empty_map,
+						'properties' => array_fill_keys(
+							$podcatcher_keys,
+							array(
+								'type' => 'string',
+								'enum' => array( '', 'pending', 'active' ),
+							)
+						),
+					),
+				),
 			)
 		);
 	}

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -198,7 +198,7 @@ class Settings {
 	 * @return array<string, mixed>
 	 */
 	public static function get_all(): array {
-		$empty_map   = self::empty_podcatcher_map();
+		$empty_map   = array_fill_keys( array_keys( self::SHOW_URL_HOSTS ), '' );
 		$show_urls   = (array) get_option( 'podcasting_show_urls', array() );
 		$show_states = (array) get_option( 'podcasting_show_states', array() );
 
@@ -244,16 +244,6 @@ class Settings {
 			'podcasting_show_urls'   => array( 'type' => 'object' ),
 			'podcasting_show_states' => array( 'type' => 'object' ),
 		);
-	}
-
-	/**
-	 * Map of every podcatcher key => '' — the padding baseline for the show URL
-	 * and show state objects.
-	 *
-	 * @return array<string, string>
-	 */
-	public static function empty_podcatcher_map(): array {
-		return array_fill_keys( array_keys( self::SHOW_URL_HOSTS ), '' );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Podcast;
  * Registers the `podcasting_*` options with their `sanitize_callback`s and
  * `show_in_rest` so they keep appearing in core `/wp/v2/settings`. The dashboard
  * now reads and writes them through the dedicated {@see Podcast_Settings_Endpoint}
- * (`jetpack/v4/podcast/settings`); the core exposure stays for now and is removed
+ * (`wpcom/v2/podcast/settings`); the core exposure stays for now and is removed
  * in a follow-up once WPCOM's settings-controller test is decoupled.
  *
  * Array-shaped options merge against stored values on sanitize, not replace —

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Podcast settings: option schema, REST exposure, and sync opt-in.
+ * Podcast settings: option schema, sanitizers, and Jetpack Sync opt-in.
  *
  * @package automattic/jetpack-podcast
  */
@@ -8,9 +8,10 @@
 namespace Automattic\Jetpack\Podcast;
 
 /**
- * Registers the `podcasting_*` options for `/wp/v2/settings` exposure on
- * Atomic. Simple stays on WPCOM's `site_settings_endpoint_get` filter in the
- * wpcom mu-plugin.
+ * Registers the `podcasting_*` options so each `sanitize_callback` runs on
+ * {@see update_option()} writes. REST exposure lives on the dedicated
+ * {@see Podcast_Settings_Endpoint} (`jetpack/v4/podcast/settings`); these keys
+ * are deliberately kept out of core `/wp/v2/settings`.
  *
  * Array-shaped options merge against stored values on sanitize, not replace —
  * the SPA can PATCH partial entries without losing the rest.
@@ -124,7 +125,6 @@ class Settings {
 					'type'              => $type,
 					'default'           => $default,
 					'sanitize_callback' => $sanitize,
-					'show_in_rest'      => true,
 				)
 			);
 		}
@@ -136,13 +136,6 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_url_raw',
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'    => 'string',
-						'default' => '',
-						'format'  => 'uri',
-					),
-				),
 			)
 		);
 
@@ -153,7 +146,6 @@ class Settings {
 				'type'              => 'boolean',
 				'default'           => false,
 				'sanitize_callback' => array( __CLASS__, 'sanitize_explicit' ),
-				'show_in_rest'      => true,
 			)
 		);
 
@@ -164,7 +156,6 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_email',
-				'show_in_rest'      => true,
 			)
 		);
 
@@ -175,12 +166,8 @@ class Settings {
 				'type'              => 'integer',
 				'default'           => 0,
 				'sanitize_callback' => 'absint',
-				'show_in_rest'      => true,
 			)
 		);
-
-		$podcatcher_keys = array_keys( self::SHOW_URL_HOSTS );
-		$empty_map       = array_fill_keys( $podcatcher_keys, '' );
 
 		register_setting(
 			self::OPTIONS_GROUP,
@@ -189,20 +176,6 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_urls' ),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'       => 'object',
-						'default'    => $empty_map,
-						'properties' => array_fill_keys(
-							$podcatcher_keys,
-							array(
-								'type'      => 'string',
-								'format'    => 'uri',
-								'maxLength' => self::SHOW_URL_MAX_LENGTH,
-							)
-						),
-					),
-				),
 			)
 		);
 
@@ -213,21 +186,74 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_states' ),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'       => 'object',
-						'default'    => $empty_map,
-						'properties' => array_fill_keys(
-							$podcatcher_keys,
-							array(
-								'type' => 'string',
-								'enum' => array( '', 'pending', 'active' ),
-							)
-						),
-					),
-				),
 			)
 		);
+	}
+
+	/**
+	 * Stable, fully-padded settings payload for the REST endpoint. Every
+	 * `OPTION_NAMES` key is present; the two podcatcher maps are padded to all
+	 * known directories with empty strings so the SPA always sees a fixed shape.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_all(): array {
+		$empty_map   = self::empty_podcatcher_map();
+		$show_urls   = (array) get_option( 'podcasting_show_urls', array() );
+		$show_states = (array) get_option( 'podcasting_show_states', array() );
+
+		return array(
+			'podcasting_category_id' => (int) get_option( 'podcasting_category_id', 0 ),
+			'podcasting_title'       => (string) get_option( 'podcasting_title', '' ),
+			'podcasting_talent_name' => (string) get_option( 'podcasting_talent_name', '' ),
+			'podcasting_summary'     => (string) get_option( 'podcasting_summary', '' ),
+			'podcasting_copyright'   => (string) get_option( 'podcasting_copyright', '' ),
+			'podcasting_explicit'    => self::sanitize_explicit( get_option( 'podcasting_explicit', false ) ),
+			'podcasting_image'       => self::raw_show_image_url(),
+			'podcasting_image_id'    => (int) get_option( 'podcasting_image_id', 0 ),
+			'podcasting_category_1'  => (string) get_option( 'podcasting_category_1', '' ),
+			'podcasting_category_2'  => (string) get_option( 'podcasting_category_2', '' ),
+			'podcasting_category_3'  => (string) get_option( 'podcasting_category_3', '' ),
+			'podcasting_email'       => (string) get_option( 'podcasting_email', '' ),
+			'podcasting_show_urls'   => array_merge( $empty_map, array_intersect_key( $show_urls, $empty_map ) ),
+			'podcasting_show_states' => array_merge( $empty_map, array_intersect_key( $show_states, $empty_map ) ),
+		);
+	}
+
+	/**
+	 * Per-key type map for the endpoint's update args. Type coercion only — the
+	 * registered `sanitize_callback`s do the real validation on write, so a single
+	 * bad field can't 400 the whole partial patch.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function rest_schema_properties(): array {
+		return array(
+			'podcasting_category_id' => array( 'type' => 'integer' ),
+			'podcasting_title'       => array( 'type' => 'string' ),
+			'podcasting_talent_name' => array( 'type' => 'string' ),
+			'podcasting_summary'     => array( 'type' => 'string' ),
+			'podcasting_copyright'   => array( 'type' => 'string' ),
+			'podcasting_explicit'    => array( 'type' => array( 'boolean', 'string' ) ),
+			'podcasting_image'       => array( 'type' => 'string' ),
+			'podcasting_image_id'    => array( 'type' => 'integer' ),
+			'podcasting_category_1'  => array( 'type' => 'string' ),
+			'podcasting_category_2'  => array( 'type' => 'string' ),
+			'podcasting_category_3'  => array( 'type' => 'string' ),
+			'podcasting_email'       => array( 'type' => 'string' ),
+			'podcasting_show_urls'   => array( 'type' => 'object' ),
+			'podcasting_show_states' => array( 'type' => 'object' ),
+		);
+	}
+
+	/**
+	 * Map of every podcatcher key => '' — the padding baseline for the show URL
+	 * and show state objects.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function empty_podcatcher_map(): array {
+		return array_fill_keys( array_keys( self::SHOW_URL_HOSTS ), '' );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -14,8 +14,6 @@ use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Throwable;
 use WP_Post;
 use WP_Query;
-use WP_REST_Request;
-use WP_REST_Response;
 use WP_User;
 
 /**
@@ -43,7 +41,7 @@ class Tracks {
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
 
-		add_filter( 'rest_request_after_callbacks', array( __CLASS__, 'record_settings_saved' ), 10, 3 );
+		add_action( 'jetpack_podcast_settings_saved', array( __CLASS__, 'record_settings_saved' ) );
 	}
 
 	/**
@@ -262,34 +260,14 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcasting_settings_saved` when a `/wp/v2/settings` write
-	 * touches any podcasting option. Pass-through filter on the response.
+	 * Emit `wpcom_podcasting_settings_saved` after a podcast settings write.
 	 *
-	 * @param mixed                 $response Pass-through.
-	 * @param array                 $handler  Route handler.
-	 * @param WP_REST_Request|mixed $request  Request object.
-	 * @return mixed
+	 * Fired off the `jetpack_podcast_settings_saved` action that
+	 * {@see Podcast_Settings_Endpoint::update_item()} triggers, so it's agnostic
+	 * to the REST transport — the endpoint already gates on a touched option.
 	 */
-	public static function record_settings_saved( $response, $handler, $request ) {
-		unset( $handler );
-
+	public static function record_settings_saved(): void {
 		try {
-			if ( ! $request instanceof WP_REST_Request || '/wp/v2/settings' !== $request->get_route() ) {
-				return $response;
-			}
-			if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true ) ) {
-				return $response;
-			}
-
-			$params = (array) $request->get_params();
-			if ( empty( array_intersect_key( $params, array_flip( Settings::OPTION_NAMES ) ) ) ) {
-				return $response;
-			}
-
-			if ( $response instanceof WP_REST_Response && $response->is_error() ) {
-				return $response;
-			}
-
 			// Skip user-supplied free-text fields — keep PII out of tracks.
 			$pii   = array( 'podcasting_email', 'podcasting_talent_name' );
 			$state = array();
@@ -303,8 +281,6 @@ class Tracks {
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Tracks is best-effort.
 		}
-
-		return $response;
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -264,7 +264,7 @@ class Tracks {
 	 *
 	 * Fired off the `jetpack_podcast_settings_saved` action that
 	 * {@see Podcast_Settings_Endpoint::update_item()} triggers, so it's agnostic
-	 * to the REST transport — the endpoint already gates on a touched option.
+	 * to the REST transport — the endpoint already gates on a saved option.
 	 */
 	public static function record_settings_saved(): void {
 		try {

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/use-submit.ts
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/use-submit.ts
@@ -1,8 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { refreshPodcastSettings } from '../../../hooks/use-podcast-settings';
 
 // Stable shape from
 // wpcom: wp-content/rest-api-plugins/endpoints/podcast-distribution.php.
@@ -61,8 +60,8 @@ export function extractRejectionReasons( pcc: unknown ): string[] {
  * State + dispatcher for the Pocket Casts feed submission.
  *
  * Calls the wpcom relay; the relay persists `podcasting_show_states.pocketcasts`
- * on the server for pending/active/rejected, so we drop the core-data cache on
- * those responses to keep the SPA in sync.
+ * on the server for pending/active/rejected, so we refresh the shared settings
+ * cache on those responses to keep the SPA in sync.
  *
  * @return `{ submit, isSubmitting, result, errorMessage }` — `result.state`
  * is the discriminator the UI switches on.
@@ -71,7 +70,6 @@ export function usePocketCastsSubmit(): SubmitState & { submit: () => void } {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const [ result, setResult ] = useState< PocketCastsSubmitResponse | null >( null );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
-	const { invalidateResolution } = useDispatch( coreStore );
 
 	const submit = useCallback( () => {
 		setIsSubmitting( true );
@@ -88,9 +86,7 @@ export function usePocketCastsSubmit(): SubmitState & { submit: () => void } {
 							__( 'We couldn’t reach Pocket Casts right now. Please try again.', 'jetpack-podcast' )
 					);
 				} else {
-					// Endpoint persists `podcasting_show_states` for pending/active/rejected;
-					// drop the core-data cache so the next settings read picks it up.
-					invalidateResolution( 'getEntityRecord', [ 'root', 'site', undefined ] );
+					refreshPodcastSettings();
 				}
 			} )
 			.catch( () => {
@@ -101,7 +97,7 @@ export function usePocketCastsSubmit(): SubmitState & { submit: () => void } {
 			.finally( () => {
 				setIsSubmitting( false );
 			} );
-	}, [ invalidateResolution ] );
+	}, [] );
 
 	return { submit, isSubmitting, result, errorMessage };
 }

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -110,9 +110,8 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// Module-level cache + subscriber set so every mounted consumer shares one
-// fetch and one source of truth. A save updates the cache and notifies all
-// subscribers, mirroring the cross-component refresh core-data gave us before.
+// Module-level cache + subscribers so every mounted consumer shares one fetch.
+// A save updates the cache and notifies all consumers, keeping them in sync.
 let cache: PodcastSettings | undefined;
 let inflight: Promise< PodcastSettings > | undefined;
 const subscribers = new Set< ( next: PodcastSettings ) => void >();
@@ -148,7 +147,7 @@ interface MutateCallbacks {
  * Backed by a shared module-level cache so multiple consumers issue a single
  * request and stay in sync after a save.
  *
- * @return `{ data, isLoading }` matching the prior TanStack-shaped contract.
+ * @return `{ data, isLoading }`.
  */
 export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoading: boolean } {
 	const [ data, setData ] = useState< PodcastSettings | undefined >( cache );
@@ -193,7 +192,7 @@ export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoa
  * record, which refreshes the shared cache. Snackbars are dispatched here so
  * callers don't have to wire them up.
  *
- * @return `{ mutate, mutateAsync, isPending }` matching the prior TanStack-shaped contract.
+ * @return `{ mutate, mutateAsync, isPending }`.
  */
 export function useUpdatePodcastSettings(): {
 	mutate: ( updates: PodcastSettingsUpdate, callbacks?: MutateCallbacks ) => void;

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -1,6 +1,6 @@
-import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -12,6 +12,10 @@ import type {
 	PodcastShowUrls,
 	PodcatcherId,
 } from '../types';
+
+// Package-owned endpoint — deliberately not core /wp/v2/settings, which is
+// shape-guarded on WPCOM and would re-bloat the core settings response.
+const SETTINGS_PATH = '/jetpack/v4/podcast/settings';
 
 const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_category_id',
@@ -106,6 +110,30 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
+// Module-level cache + subscriber set so every mounted consumer shares one
+// fetch and one source of truth. A save updates the cache and notifies all
+// subscribers, mirroring the cross-component refresh core-data gave us before.
+let cache: PodcastSettings | undefined;
+let inflight: Promise< PodcastSettings > | undefined;
+const subscribers = new Set< ( next: PodcastSettings ) => void >();
+
+const publish = ( next: PodcastSettings ): PodcastSettings => {
+	cache = next;
+	subscribers.forEach( notify => notify( next ) );
+	return next;
+};
+
+const loadSettings = (): Promise< PodcastSettings > => {
+	if ( ! inflight ) {
+		inflight = apiFetch( { path: SETTINGS_PATH } )
+			.then( raw => publish( pickPodcastFields( raw as Record< string, unknown > ) ) )
+			.finally( () => {
+				inflight = undefined;
+			} );
+	}
+	return inflight;
+};
+
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;
@@ -115,29 +143,55 @@ interface MutateCallbacks {
 }
 
 /**
- * Read the current `podcasting_*` options out of the core-data 'site' entity.
+ * Read the current `podcasting_*` settings from the package's REST endpoint.
  *
- * Matches the Forms / VideoPress pattern. On WPCOM Simple/Atomic the package's
- * `register_setting()` calls route through the standard WP REST settings
- * controller, so `/wp/v2/settings` exposes the keys here directly.
+ * Backed by a shared module-level cache so multiple consumers issue a single
+ * request and stay in sync after a save.
  *
  * @return `{ data, isLoading }` matching the prior TanStack-shaped contract.
  */
 export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoading: boolean } {
-	const { record, hasResolved } = useEntityRecord< Record< string, unknown > >( 'root', 'site' );
-	// Memoised so the derived object identity is stable across renders. Without
-	// this, every render builds a new `data` object, breaking reference checks
-	// downstream (Settings' isDirty was permanently true on `podcasting_show_urls`).
-	const data = useMemo( () => ( record ? pickPodcastFields( record ) : undefined ), [ record ] );
-	return { data, isLoading: ! hasResolved };
+	const [ data, setData ] = useState< PodcastSettings | undefined >( cache );
+	const [ isLoading, setIsLoading ] = useState( cache === undefined );
+
+	useEffect( () => {
+		let active = true;
+		const notify = ( next: PodcastSettings ) => {
+			if ( active ) {
+				setData( next );
+			}
+		};
+		subscribers.add( notify );
+
+		if ( cache === undefined ) {
+			// Settle loading on both paths — a 403 (e.g. a non-admin opening the
+			// episode block) must not leave the consumer spinning forever.
+			const settle = () => {
+				if ( active ) {
+					setIsLoading( false );
+				}
+			};
+			loadSettings().then( settle, settle );
+		} else {
+			setData( cache );
+			setIsLoading( false );
+		}
+
+		return () => {
+			active = false;
+			subscribers.delete( notify );
+		};
+	}, [] );
+
+	return { data, isLoading };
 }
 
 /**
- * Save a partial settings update through core-data.
+ * Save a partial settings update through the package's REST endpoint.
  *
  * The server merges the patch into the stored settings and returns the full
- * record, which core-data uses to refresh the cache. Snackbars are dispatched
- * here so callers don't have to wire them up.
+ * record, which refreshes the shared cache. Snackbars are dispatched here so
+ * callers don't have to wire them up.
  *
  * @return `{ mutate, mutateAsync, isPending }` matching the prior TanStack-shaped contract.
  */
@@ -149,33 +203,28 @@ export function useUpdatePodcastSettings(): {
 	) => Promise< PodcastSettings >;
 	isPending: boolean;
 } {
-	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const isPending = useSelect(
-		select => !! select( coreStore ).isSavingEntityRecord( 'root', 'site', undefined ),
-		[]
-	);
+	const [ isPending, setIsPending ] = useState( false );
 
 	const mutateAsync = useCallback(
 		async (
 			updates: PodcastSettingsUpdate,
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
+			setIsPending( true );
 			try {
-				const record = await saveEntityRecord(
-					'root',
-					'site',
-					updates as Record< string, unknown >
-				);
-				if ( ! record ) {
-					throw new Error( 'save returned no record' );
-				}
+				const raw = await apiFetch( {
+					path: SETTINGS_PATH,
+					method: 'PUT',
+					data: updates as Record< string, unknown >,
+				} );
+				const record = publish( pickPodcastFields( raw as Record< string, unknown > ) );
 				if ( ! silent ) {
 					createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
 						type: 'snackbar',
 					} );
 				}
-				return pickPodcastFields( record as Record< string, unknown > );
+				return record;
 			} catch ( error ) {
 				if ( ! silent ) {
 					createErrorNotice(
@@ -184,9 +233,11 @@ export function useUpdatePodcastSettings(): {
 					);
 				}
 				throw error;
+			} finally {
+				setIsPending( false );
 			}
 		},
-		[ saveEntityRecord, createSuccessNotice, createErrorNotice ]
+		[ createSuccessNotice, createErrorNotice ]
 	);
 
 	const mutate = useCallback(

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -134,9 +134,7 @@ const setState = ( next: SettingsState ): void => {
 	listeners.forEach( listener => listener() );
 };
 
-// Fetch the settings and hand them to every reader. A non-admin (e.g. opening
-// the episode block) gets a 403; we just stop loading and leave the data empty
-// rather than spin forever.
+// A non-admin (e.g. opening the episode block) gets a 403; leave the data empty.
 const fetchSettings = (): Promise< void > =>
 	apiFetch( { path: SETTINGS_PATH } )
 		.then( raw =>
@@ -144,8 +142,6 @@ const fetchSettings = (): Promise< void > =>
 		)
 		.catch( () => setState( { data: state.data, isLoading: false } ) );
 
-// Run the one-time initial fetch on the first mount; later mounts reuse the
-// result already in the store.
 const ensureFetched = (): void => {
 	if ( hasFetched ) {
 		return;
@@ -154,12 +150,7 @@ const ensureFetched = (): void => {
 	fetchSettings();
 };
 
-/**
- * Re-fetch the settings after an out-of-band server write (e.g. the Pocket Casts
- * relay persisting `podcasting_show_states`). Updates every mounted reader.
- *
- * @return Resolves once the shared store has been refreshed.
- */
+// Refresh after an out-of-band write (e.g. the Pocket Casts relay).
 export const refreshPodcastSettings = (): Promise< void > => fetchSettings();
 
 interface MutateCallbacks {
@@ -171,8 +162,7 @@ interface MutateCallbacks {
 }
 
 /**
- * Read the current `podcasting_*` settings from the shared store, fetching them
- * once on first use.
+ * Read the settings from the shared store, fetching once on first use.
  *
  * @return `{ data, isLoading }`.
  */
@@ -182,11 +172,8 @@ export function usePodcastSettings(): SettingsState {
 }
 
 /**
- * Save a partial settings update through the package's REST endpoint.
- *
- * The server merges the patch into the stored settings and returns the full
- * record, which updates the shared store. Snackbars are dispatched here so
- * callers don't have to wire them up.
+ * Save a partial update; the server returns the full record and updates the
+ * shared store. Snackbars dispatch here unless `silent`.
  *
  * @return `{ mutate, mutateAsync, isPending }`.
  */

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -18,17 +18,13 @@ import type {
 	PodcatcherId,
 } from '../types';
 
-// Package-owned endpoint registered as a core-data entity, so the dashboard and
-// the block editor read/write through the standard store — with caching, dedup,
-// and save state for free — the same on self-hosted Jetpack as on WPCOM,
-// independent of core /wp/v2/settings. Mirrors Publicize's jetpack/v4 settings
-// entity.
+// The package endpoint as a core-data entity (à la Publicize's jetpack/v4
+// settings), so the dashboard and block editor share one store.
 const ENTITY_KIND = 'jetpack/v4';
 const ENTITY_NAME = 'podcast/settings';
 
-// Register at module load: the getEntityRecord resolver bails if the entity is
-// unknown when it first runs, so this can't wait for an effect. Singleton record
-// (no id) — reads, writes, and saving state all key off the entity name alone.
+// Register at module load — the getEntityRecord resolver bails if the entity is
+// unknown on first read, so it can't wait for an effect.
 if (
 	! dataSelect( coreStore )
 		.getEntitiesConfig( ENTITY_KIND )
@@ -137,8 +133,7 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// Refresh after an out-of-band write (e.g. the Pocket Casts relay): drop the
-// cached resolution so mounted readers re-fetch. Imperative, so it can't use a hook.
+// Invalidate after an out-of-band write (e.g. the Pocket Casts relay) so readers re-fetch.
 export const refreshPodcastSettings = (): void => {
 	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
@@ -146,16 +141,12 @@ export const refreshPodcastSettings = (): void => {
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;
-	// Suppress the hook's built-in success/error snackbars when the caller
-	// owns its own user-visible feedback (e.g. a modal with an inline Notice).
+	// Suppress the built-in snackbars when the caller shows its own feedback.
 	silent?: boolean;
 }
 
 /**
- * Read the settings off the core-data entity, resolving (fetching) on first use.
- *
- * A non-admin (e.g. opening the episode block) gets a 403, so `data` stays
- * undefined and the cover resolves empty.
+ * Read the settings off the core-data entity, resolving on first use.
  *
  * @return `{ data, isLoading }`.
  */
@@ -170,17 +161,15 @@ export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoa
 			select( coreStore ).hasFinishedResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] ),
 		[]
 	);
-	// Memoised on the record identity so derived `data` is stable across renders;
-	// without it every render rebuilds `data`, breaking downstream reference checks
-	// (Settings' isDirty stayed permanently true on `podcasting_show_urls`).
+	// Memoise on record identity to keep `data` referentially stable; otherwise
+	// downstream reference checks break (Settings' isDirty stuck on show_urls).
 	const data = useMemo( () => ( record ? pickPodcastFields( record ) : undefined ), [ record ] );
 	return { data, isLoading: ! hasResolved };
 }
 
 /**
- * Save a partial update through the entity. The server merges the patch and
- * returns the full record, which core-data caches so every reader refreshes.
- * Snackbars dispatch here unless `silent`.
+ * Save a partial update through the entity; the server returns the full merged
+ * record. Snackbars dispatch here unless `silent`.
  *
  * @return `{ mutate, mutateAsync, isPending }`.
  */
@@ -205,8 +194,6 @@ export function useUpdatePodcastSettings(): {
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
 			try {
-				// Singleton record (no id), so this POSTs the partial patch to the
-				// entity baseURL; the server merges and returns the full record.
 				const record = await saveEntityRecord(
 					ENTITY_KIND,
 					ENTITY_NAME,
@@ -239,7 +226,7 @@ export function useUpdatePodcastSettings(): {
 			updates: PodcastSettingsUpdate,
 			{ onSuccess, onError, silent = false }: MutateCallbacks = {}
 		) => {
-			// Default no-op keeps the rejection from going uncaught when no `onError` is passed.
+			// No-op onError keeps the rejection from going uncaught.
 			mutateAsync( updates, { silent } ).then( onSuccess, onError ?? ( () => {} ) );
 		},
 		[ mutateAsync ]

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -1,6 +1,11 @@
-import apiFetch from '@wordpress/api-fetch';
-import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useState, useSyncExternalStore } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import {
+	dispatch as dataDispatch,
+	select as dataSelect,
+	useDispatch,
+	useSelect,
+} from '@wordpress/data';
+import { useCallback, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -13,9 +18,32 @@ import type {
 	PodcatcherId,
 } from '../types';
 
-// Package-owned endpoint, so the dashboard reads/writes the same way on
-// self-hosted Jetpack as on WPCOM, independent of core /wp/v2/settings.
+// Package-owned endpoint registered as a core-data entity, so the dashboard and
+// the block editor read/write through the standard store — with caching, dedup,
+// and save state for free — the same on self-hosted Jetpack as on WPCOM,
+// independent of core /wp/v2/settings. Mirrors Publicize's jetpack/v4 settings
+// entity.
 const SETTINGS_PATH = '/jetpack/v4/podcast/settings';
+const ENTITY_KIND = 'jetpack/v4';
+const ENTITY_NAME = 'podcast/settings';
+
+// Register at module load: the getEntityRecord resolver bails if the entity is
+// unknown when it first runs, so this can't wait for an effect. Singleton record
+// (no id) — reads, writes, and saving state all key off the entity name alone.
+if (
+	! dataSelect( coreStore )
+		.getEntitiesConfig( ENTITY_KIND )
+		.some( ( { name } ) => name === ENTITY_NAME )
+) {
+	dataDispatch( coreStore ).addEntities( [
+		{
+			kind: ENTITY_KIND,
+			name: ENTITY_NAME,
+			baseURL: SETTINGS_PATH,
+			label: __( 'Podcast settings', 'jetpack-podcast' ),
+		},
+	] );
+}
 
 const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_category_id',
@@ -110,48 +138,11 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// Shared store so every reader fetches once and a save updates them together.
-interface SettingsState {
-	data: PodcastSettings | undefined;
-	isLoading: boolean;
-}
-
-let state: SettingsState = { data: undefined, isLoading: true };
-let hasFetched = false;
-const listeners = new Set< () => void >();
-
-const getState = (): SettingsState => state;
-
-const subscribe = ( listener: () => void ): ( () => void ) => {
-	listeners.add( listener );
-	return () => {
-		listeners.delete( listener );
-	};
+// Refresh after an out-of-band write (e.g. the Pocket Casts relay): drop the
+// cached resolution so mounted readers re-fetch. Imperative, so it can't use a hook.
+export const refreshPodcastSettings = (): void => {
+	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
-
-const setState = ( next: SettingsState ): void => {
-	state = next;
-	listeners.forEach( listener => listener() );
-};
-
-// A non-admin (e.g. opening the episode block) gets a 403; leave the data empty.
-const fetchSettings = (): Promise< void > =>
-	apiFetch( { path: SETTINGS_PATH } )
-		.then( raw =>
-			setState( { data: pickPodcastFields( raw as Record< string, unknown > ), isLoading: false } )
-		)
-		.catch( () => setState( { data: state.data, isLoading: false } ) );
-
-const ensureFetched = (): void => {
-	if ( hasFetched ) {
-		return;
-	}
-	hasFetched = true;
-	fetchSettings();
-};
-
-// Refresh after an out-of-band write (e.g. the Pocket Casts relay).
-export const refreshPodcastSettings = (): Promise< void > => fetchSettings();
 
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
@@ -162,18 +153,35 @@ interface MutateCallbacks {
 }
 
 /**
- * Read the settings from the shared store, fetching once on first use.
+ * Read the settings off the core-data entity, resolving (fetching) on first use.
+ *
+ * A non-admin (e.g. opening the episode block) gets a 403, so `data` stays
+ * undefined and the cover resolves empty.
  *
  * @return `{ data, isLoading }`.
  */
-export function usePodcastSettings(): SettingsState {
-	useEffect( ensureFetched, [] );
-	return useSyncExternalStore( subscribe, getState );
+export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoading: boolean } {
+	const record = useSelect(
+		select =>
+			select( coreStore ).getEntityRecord< Record< string, unknown > >( ENTITY_KIND, ENTITY_NAME ),
+		[]
+	);
+	const hasResolved = useSelect(
+		select =>
+			select( coreStore ).hasFinishedResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] ),
+		[]
+	);
+	// Memoised on the record identity so derived `data` is stable across renders;
+	// without it every render rebuilds `data`, breaking downstream reference checks
+	// (Settings' isDirty stayed permanently true on `podcasting_show_urls`).
+	const data = useMemo( () => ( record ? pickPodcastFields( record ) : undefined ), [ record ] );
+	return { data, isLoading: ! hasResolved };
 }
 
 /**
- * Save a partial update; the server returns the full record and updates the
- * shared store. Snackbars dispatch here unless `silent`.
+ * Save a partial update through the entity. The server merges the patch and
+ * returns the full record, which core-data caches so every reader refreshes.
+ * Snackbars dispatch here unless `silent`.
  *
  * @return `{ mutate, mutateAsync, isPending }`.
  */
@@ -185,29 +193,35 @@ export function useUpdatePodcastSettings(): {
 	) => Promise< PodcastSettings >;
 	isPending: boolean;
 } {
+	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const [ isPending, setIsPending ] = useState( false );
+	const isPending = useSelect(
+		select => !! select( coreStore ).isSavingEntityRecord( ENTITY_KIND, ENTITY_NAME, undefined ),
+		[]
+	);
 
 	const mutateAsync = useCallback(
 		async (
 			updates: PodcastSettingsUpdate,
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
-			setIsPending( true );
 			try {
-				const raw = await apiFetch( {
-					path: SETTINGS_PATH,
-					method: 'PUT',
-					data: updates as Record< string, unknown >,
-				} );
-				const saved = pickPodcastFields( raw as Record< string, unknown > );
-				setState( { data: saved, isLoading: false } );
+				// Singleton record (no id), so this POSTs the partial patch to the
+				// entity baseURL; the server merges and returns the full record.
+				const record = await saveEntityRecord(
+					ENTITY_KIND,
+					ENTITY_NAME,
+					updates as Record< string, unknown >
+				);
+				if ( ! record ) {
+					throw new Error( 'save returned no record' );
+				}
 				if ( ! silent ) {
 					createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
 						type: 'snackbar',
 					} );
 				}
-				return saved;
+				return pickPodcastFields( record as Record< string, unknown > );
 			} catch ( error ) {
 				if ( ! silent ) {
 					createErrorNotice(
@@ -216,11 +230,9 @@ export function useUpdatePodcastSettings(): {
 					);
 				}
 				throw error;
-			} finally {
-				setIsPending( false );
 			}
 		},
-		[ createSuccessNotice, createErrorNotice ]
+		[ saveEntityRecord, createSuccessNotice, createErrorNotice ]
 	);
 
 	const mutate = useCallback(

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -13,8 +13,8 @@ import type {
 	PodcatcherId,
 } from '../types';
 
-// Package-owned endpoint — deliberately not core /wp/v2/settings, which is
-// shape-guarded on WPCOM and would re-bloat the core settings response.
+// Package-owned endpoint, so the dashboard reads/writes the same way on
+// self-hosted Jetpack as on WPCOM, independent of core /wp/v2/settings.
 const SETTINGS_PATH = '/jetpack/v4/podcast/settings';
 
 const PODCAST_KEYS: Array< keyof PodcastSettings > = [

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -23,7 +23,6 @@ import type {
 // and save state for free — the same on self-hosted Jetpack as on WPCOM,
 // independent of core /wp/v2/settings. Mirrors Publicize's jetpack/v4 settings
 // entity.
-const SETTINGS_PATH = '/jetpack/v4/podcast/settings';
 const ENTITY_KIND = 'jetpack/v4';
 const ENTITY_NAME = 'podcast/settings';
 
@@ -39,7 +38,7 @@ if (
 		{
 			kind: ENTITY_KIND,
 			name: ENTITY_NAME,
-			baseURL: SETTINGS_PATH,
+			baseURL: `/${ ENTITY_KIND }/${ ENTITY_NAME }`,
 			label: __( 'Podcast settings', 'jetpack-podcast' ),
 		},
 	] );

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState, useSyncExternalStore } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -110,41 +110,62 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// Module-level cache + subscribers so every mounted consumer shares one fetch.
-// A save updates the cache and notifies all consumers, keeping them in sync.
-let cache: PodcastSettings | undefined;
-let inflight: Promise< PodcastSettings > | undefined;
-const subscribers = new Set< ( next: PodcastSettings ) => void >();
+// One shared copy of the settings for the whole dashboard. The settings screen,
+// the episode block, and the validation checks all read from here, so the data
+// is fetched once and a save (or refresh) updates every reader at the same time.
+// `useSyncExternalStore` is React's built-in way to subscribe a component to a
+// plain module value like this — and because it needs no Context provider, the
+// episode block (which renders outside the dashboard's React tree) can share it.
+interface SettingsState {
+	data: PodcastSettings | undefined;
+	isLoading: boolean;
+}
 
-const publish = ( next: PodcastSettings ): PodcastSettings => {
-	cache = next;
-	subscribers.forEach( notify => notify( next ) );
-	return next;
+let state: SettingsState = { data: undefined, isLoading: true };
+let hasFetched = false;
+const listeners = new Set< () => void >();
+
+const getState = (): SettingsState => state;
+
+const subscribe = ( listener: () => void ): ( () => void ) => {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
 };
 
-const loadSettings = (): Promise< PodcastSettings > => {
-	if ( ! inflight ) {
-		inflight = apiFetch( { path: SETTINGS_PATH } )
-			.then( raw => publish( pickPodcastFields( raw as Record< string, unknown > ) ) )
-			.finally( () => {
-				inflight = undefined;
-			} );
+const setState = ( next: SettingsState ): void => {
+	state = next;
+	listeners.forEach( listener => listener() );
+};
+
+// Fetch the settings and hand them to every reader. A non-admin (e.g. opening
+// the episode block) gets a 403; we just stop loading and leave the data empty
+// rather than spin forever.
+const fetchSettings = (): Promise< void > =>
+	apiFetch( { path: SETTINGS_PATH } )
+		.then( raw =>
+			setState( { data: pickPodcastFields( raw as Record< string, unknown > ), isLoading: false } )
+		)
+		.catch( () => setState( { data: state.data, isLoading: false } ) );
+
+// Run the one-time initial fetch on the first mount; later mounts reuse the
+// result already in the store.
+const ensureFetched = (): void => {
+	if ( hasFetched ) {
+		return;
 	}
-	return inflight;
+	hasFetched = true;
+	fetchSettings();
 };
 
 /**
- * Re-fetch settings and refresh the shared cache after an out-of-band server
- * write (e.g. the Pocket Casts relay persisting `podcasting_show_states`).
+ * Re-fetch the settings after an out-of-band server write (e.g. the Pocket Casts
+ * relay persisting `podcasting_show_states`). Updates every mounted reader.
  *
- * @return Resolves once the shared cache has been refreshed.
+ * @return Resolves once the shared store has been refreshed.
  */
-export const refreshPodcastSettings = (): Promise< void > =>
-	apiFetch( { path: SETTINGS_PATH } )
-		.then( raw => {
-			publish( pickPodcastFields( raw as Record< string, unknown > ) );
-		} )
-		.catch( () => {} );
+export const refreshPodcastSettings = (): Promise< void > => fetchSettings();
 
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
@@ -155,54 +176,21 @@ interface MutateCallbacks {
 }
 
 /**
- * Read the current `podcasting_*` settings from the package's REST endpoint.
- *
- * Backed by a shared module-level cache so multiple consumers issue a single
- * request and stay in sync after a save.
+ * Read the current `podcasting_*` settings from the shared store, fetching them
+ * once on first use.
  *
  * @return `{ data, isLoading }`.
  */
-export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoading: boolean } {
-	const [ data, setData ] = useState< PodcastSettings | undefined >( cache );
-	const [ isLoading, setIsLoading ] = useState( cache === undefined );
-
-	useEffect( () => {
-		let active = true;
-		const notify = ( next: PodcastSettings ) => {
-			if ( active ) {
-				setData( next );
-			}
-		};
-		subscribers.add( notify );
-
-		if ( cache === undefined ) {
-			// Settle loading on both paths — a 403 (e.g. a non-admin opening the
-			// episode block) must not leave the consumer spinning forever.
-			const settle = () => {
-				if ( active ) {
-					setIsLoading( false );
-				}
-			};
-			loadSettings().then( settle, settle );
-		} else {
-			setData( cache );
-			setIsLoading( false );
-		}
-
-		return () => {
-			active = false;
-			subscribers.delete( notify );
-		};
-	}, [] );
-
-	return { data, isLoading };
+export function usePodcastSettings(): SettingsState {
+	useEffect( ensureFetched, [] );
+	return useSyncExternalStore( subscribe, getState );
 }
 
 /**
  * Save a partial settings update through the package's REST endpoint.
  *
  * The server merges the patch into the stored settings and returns the full
- * record, which refreshes the shared cache. Snackbars are dispatched here so
+ * record, which updates the shared store. Snackbars are dispatched here so
  * callers don't have to wire them up.
  *
  * @return `{ mutate, mutateAsync, isPending }`.
@@ -230,13 +218,14 @@ export function useUpdatePodcastSettings(): {
 					method: 'PUT',
 					data: updates as Record< string, unknown >,
 				} );
-				const record = publish( pickPodcastFields( raw as Record< string, unknown > ) );
+				const saved = pickPodcastFields( raw as Record< string, unknown > );
+				setState( { data: saved, isLoading: false } );
 				if ( ! silent ) {
 					createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
 						type: 'snackbar',
 					} );
 				}
-				return record;
+				return saved;
 			} catch ( error ) {
 				if ( ! silent ) {
 					createErrorNotice(

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -18,14 +18,9 @@ import type {
 	PodcatcherId,
 } from '../types';
 
-// The package endpoint as a core-data entity (à la Publicize's wpcom/v2
-// entities), so the dashboard and block editor share one store. wpcom/v2 is the
-// namespace the public-api proxy forwards on Simple/WoA; jetpack/v4 is not.
 const ENTITY_KIND = 'wpcom/v2';
 const ENTITY_NAME = 'podcast/settings';
 
-// Register at module load — the getEntityRecord resolver bails if the entity is
-// unknown on first read, so it can't wait for an effect.
 if (
 	! dataSelect( coreStore )
 		.getEntitiesConfig( ENTITY_KIND )
@@ -134,7 +129,6 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// Invalidate after an out-of-band write (e.g. the Pocket Casts relay) so readers re-fetch.
 export const refreshPodcastSettings = (): void => {
 	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
@@ -142,7 +136,8 @@ export const refreshPodcastSettings = (): void => {
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;
-	// Suppress the built-in snackbars when the caller shows its own feedback.
+	// Suppress the hook's built-in success/error snackbars when the caller
+	// owns its own user-visible feedback (e.g. a modal with an inline Notice).
 	silent?: boolean;
 }
 
@@ -162,8 +157,9 @@ export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoa
 			select( coreStore ).hasFinishedResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] ),
 		[]
 	);
-	// Memoise on record identity to keep `data` referentially stable; otherwise
-	// downstream reference checks break (Settings' isDirty stuck on show_urls).
+	// Memoised so the derived object identity is stable across renders. Without
+	// this, every render builds a new `data` object, breaking reference checks
+	// downstream (Settings' isDirty was permanently true on `podcasting_show_urls`).
 	const data = useMemo( () => ( record ? pickPodcastFields( record ) : undefined ), [ record ] );
 	return { data, isLoading: ! hasResolved };
 }
@@ -227,7 +223,7 @@ export function useUpdatePodcastSettings(): {
 			updates: PodcastSettingsUpdate,
 			{ onSuccess, onError, silent = false }: MutateCallbacks = {}
 		) => {
-			// No-op onError keeps the rejection from going uncaught.
+			// Default no-op keeps the rejection from going uncaught when no `onError` is passed.
 			mutateAsync( updates, { silent } ).then( onSuccess, onError ?? ( () => {} ) );
 		},
 		[ mutateAsync ]

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -110,12 +110,7 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 	return out as unknown as PodcastSettings;
 };
 
-// One shared copy of the settings for the whole dashboard. The settings screen,
-// the episode block, and the validation checks all read from here, so the data
-// is fetched once and a save (or refresh) updates every reader at the same time.
-// `useSyncExternalStore` is React's built-in way to subscribe a component to a
-// plain module value like this — and because it needs no Context provider, the
-// episode block (which renders outside the dashboard's React tree) can share it.
+// Shared store so every reader fetches once and a save updates them together.
 interface SettingsState {
 	data: PodcastSettings | undefined;
 	isLoading: boolean;

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -18,9 +18,10 @@ import type {
 	PodcatcherId,
 } from '../types';
 
-// The package endpoint as a core-data entity (à la Publicize's jetpack/v4
-// settings), so the dashboard and block editor share one store.
-const ENTITY_KIND = 'jetpack/v4';
+// The package endpoint as a core-data entity (à la Publicize's wpcom/v2
+// entities), so the dashboard and block editor share one store. wpcom/v2 is the
+// namespace the public-api proxy forwards on Simple/WoA; jetpack/v4 is not.
+const ENTITY_KIND = 'wpcom/v2';
 const ENTITY_NAME = 'podcast/settings';
 
 // Register at module load — the getEntityRecord resolver bails if the entity is

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -133,6 +133,19 @@ const loadSettings = (): Promise< PodcastSettings > => {
 	return inflight;
 };
 
+/**
+ * Re-fetch settings and refresh the shared cache after an out-of-band server
+ * write (e.g. the Pocket Casts relay persisting `podcasting_show_states`).
+ *
+ * @return Resolves once the shared cache has been refreshed.
+ */
+export const refreshPodcastSettings = (): Promise< void > =>
+	apiFetch( { path: SETTINGS_PATH } )
+		.then( raw => {
+			publish( pickPodcastFields( raw as Record< string, unknown > ) );
+		} )
+		.catch( () => {} );
+
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -97,13 +97,17 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 			if ( null === $value ) {
 				continue;
 			}
-			update_option( $name, $value );
-			$saved = true;
+			// Only count a write that actually changed the stored value, so the
+			// action (and its Tracks event) skips no-ops and failed writes,
+			// matching WordPress's own `update_option_*` semantics.
+			if ( update_option( $name, $value ) ) {
+				$saved = true;
+			}
 		}
 
 		if ( $saved ) {
 			/**
-			 * Fires after a podcast settings write saves at least one option.
+			 * Fires after a podcast settings write changes at least one option.
 			 *
 			 * @since $$next-version$$
 			 */

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -33,16 +33,15 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the endpoint through the WPCOM REST API v2 framework when present
-	 * (Simple/WoA/Jetpack plugin), falling back to a bare instance otherwise so the
-	 * package degrades gracefully if the core-api loader isn't loaded.
+	 * Register the endpoint through the WPCOM REST API v2 framework. The loader
+	 * ships with the Jetpack plugin core-api, present in every context Podcast runs
+	 * in (Simple/WoA today, the Jetpack plugin once Podcast moves there); guarded so
+	 * the package no-ops rather than fatals if it's somehow absent.
 	 */
 	public static function init() {
 		if ( function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 			wpcom_rest_api_v2_load_plugin( self::class );
-			return;
 		}
-		new self();
 	}
 
 	/**

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -21,23 +21,10 @@ use WP_REST_Server;
 class Podcast_Settings_Endpoint extends WP_REST_Controller {
 
 	/**
-	 * Whether `init()` has wired its hooks.
-	 *
-	 * @var bool
-	 */
-	private static $initialized = false;
-
-	/**
-	 * Wire up routes. Idempotent.
+	 * Register the REST routes on `rest_api_init`.
 	 */
 	public static function init() {
-		if ( self::$initialized ) {
-			return;
-		}
-		self::$initialized = true;
-
-		$instance = new self();
-		add_action( 'rest_api_init', array( $instance, 'register_routes' ) );
+		add_action( 'rest_api_init', array( new self(), 'register_routes' ) );
 	}
 
 	/**
@@ -103,7 +90,7 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$touched = false;
+		$saved = false;
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$value = $request->get_param( $name );
@@ -111,12 +98,12 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 				continue;
 			}
 			update_option( $name, $value );
-			$touched = true;
+			$saved = true;
 		}
 
-		if ( $touched ) {
+		if ( $saved ) {
 			/**
-			 * Fires after a podcast settings write touches at least one option.
+			 * Fires after a podcast settings write saves at least one option.
 			 *
 			 * @since $$next-version$$
 			 */

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -14,19 +14,11 @@ use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Package-owned REST surface for the `podcasting_*` options the dashboard SPA
- * reads and writes. Replaces the previous reliance on core `/wp/v2/settings`
- * (and, on Simple, the legacy WPCOM v1.x site-settings filters): the schema and
- * sanitizers live entirely in {@see Settings}, so this works unchanged on
- * self-hosted Jetpack — it's pure option read/write with no wpcom backend.
- *
- * Storage stays as `wp_options`; each `register_setting()` sanitizer fires on
- * write because {@see update_option()} runs the `sanitize_option_{$name}` filter.
+ * Reads and writes the `podcasting_*` options for the dashboard SPA over its own
+ * `jetpack/v4/podcast/settings` route. Schema and sanitizers live in {@see Settings},
+ * so it works the same on self-hosted Jetpack with no wpcom backend.
  */
 class Podcast_Settings_Endpoint extends WP_REST_Controller {
-
-	const REST_NAMESPACE = 'jetpack/v4';
-	const REST_BASE      = 'podcast/settings';
 
 	/**
 	 * Whether `init()` has wired its hooks.
@@ -51,18 +43,13 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	/**
 	 * Register the GET (full record) + writable (partial patch) routes.
 	 *
-	 * Update args are top-level type coercion only — the registered
-	 * `sanitize_callback`s do the real validation when {@see update_option()}
-	 * fires `sanitize_option_{$name}`. Strict per-field schema validation here
-	 * would 400 a whole patch on one bad field; the SPA relies on silent-drop.
+	 * Update args only coerce top-level types — the registered `sanitize_callback`s
+	 * do the real validation on write, so one bad field can't 400 the whole patch.
 	 */
 	public function register_routes() {
-		$this->namespace = self::REST_NAMESPACE;
-		$this->rest_base = self::REST_BASE;
-
 		register_rest_route(
-			$this->namespace,
-			$this->rest_base,
+			'jetpack/v4',
+			'podcast/settings',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -129,11 +116,7 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 
 		if ( $touched ) {
 			/**
-			 * Fires after a podcast settings write through the REST endpoint.
-			 *
-			 * Transport-agnostic replacement for the old `/wp/v2/settings`
-			 * response hook; {@see Tracks} listens here to emit the aggregate
-			 * `wpcom_podcasting_settings_saved` event.
+			 * Fires after a podcast settings write touches at least one option.
 			 *
 			 * @since $$next-version$$
 			 */

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -114,9 +114,6 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 			if ( null === $value ) {
 				continue;
 			}
-			// Only count a write that actually changed the stored value, so the
-			// action (and its Tracks event) skips no-ops and failed writes,
-			// matching WordPress's own `update_option_*` semantics.
 			if ( update_option( $name, $value ) ) {
 				$saved = true;
 			}

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -15,16 +15,34 @@ use WP_REST_Server;
 
 /**
  * Reads and writes the `podcasting_*` options for the dashboard SPA over its own
- * `jetpack/v4/podcast/settings` route. Schema and sanitizers live in {@see Settings},
- * so it works the same on self-hosted Jetpack with no wpcom backend.
+ * `wpcom/v2/podcast/settings` route. Schema and sanitizers live in {@see Settings}.
+ *
+ * Registered through the WPCOM REST API v2 plugin framework
+ * ({@see wpcom_rest_api_v2_load_plugin()}), so a single definition is reachable on
+ * Simple and WoA via the `public-api.wordpress.com` proxy and, once Podcast ships in
+ * the Jetpack plugin, same-origin on self-hosted sites — no per-platform relay.
  */
 class Podcast_Settings_Endpoint extends WP_REST_Controller {
 
 	/**
-	 * Register the REST routes on `rest_api_init`.
+	 * Wire the routes onto `rest_api_init`. The framework instantiates this once.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the endpoint through the WPCOM REST API v2 framework when present
+	 * (Simple/WoA/Jetpack plugin), falling back to a bare instance otherwise so the
+	 * package degrades gracefully if the core-api loader isn't loaded.
 	 */
 	public static function init() {
-		add_action( 'rest_api_init', array( new self(), 'register_routes' ) );
+		if ( function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
+			wpcom_rest_api_v2_load_plugin( self::class );
+			return;
+		}
+		new self();
 	}
 
 	/**
@@ -35,7 +53,7 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			'jetpack/v4',
+			$this->namespace,
 			'podcast/settings',
 			array(
 				array(

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Dedicated REST endpoint for `podcasting_*` site settings.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Package-owned REST surface for the `podcasting_*` options the dashboard SPA
+ * reads and writes. Replaces the previous reliance on core `/wp/v2/settings`
+ * (and, on Simple, the legacy WPCOM v1.x site-settings filters): the schema and
+ * sanitizers live entirely in {@see Settings}, so this works unchanged on
+ * self-hosted Jetpack — it's pure option read/write with no wpcom backend.
+ *
+ * Storage stays as `wp_options`; each `register_setting()` sanitizer fires on
+ * write because {@see update_option()} runs the `sanitize_option_{$name}` filter.
+ */
+class Podcast_Settings_Endpoint extends WP_REST_Controller {
+
+	const REST_NAMESPACE = 'jetpack/v4';
+	const REST_BASE      = 'podcast/settings';
+
+	/**
+	 * Whether `init()` has wired its hooks.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
+	 * Wire up routes. Idempotent.
+	 */
+	public static function init() {
+		if ( self::$initialized ) {
+			return;
+		}
+		self::$initialized = true;
+
+		$instance = new self();
+		add_action( 'rest_api_init', array( $instance, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the GET (full record) + writable (partial patch) routes.
+	 *
+	 * Update args are top-level type coercion only — the registered
+	 * `sanitize_callback`s do the real validation when {@see update_option()}
+	 * fires `sanitize_option_{$name}`. Strict per-field schema validation here
+	 * would 400 a whole patch on one bad field; the SPA relies on silent-drop.
+	 */
+	public function register_routes() {
+		$this->namespace = self::REST_NAMESPACE;
+		$this->rest_base = self::REST_BASE;
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+					'args'                => Settings::rest_schema_properties(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Site admins only — same gate as the wp-admin Podcast dashboard.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function permission_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to manage podcast settings for this site.', 'jetpack-podcast' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET — the full, padded settings record.
+	 *
+	 * @param WP_REST_Request $request Unused.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		unset( $request );
+		return rest_ensure_response( Settings::get_all() );
+	}
+
+	/**
+	 * PUT/POST/PATCH — apply a partial patch and return the full merged record.
+	 *
+	 * Only keys actually present in the request are written, so absent keys can
+	 * never clobber stored values. Array-shaped options merge on sanitize.
+	 *
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		$touched = false;
+
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$value = $request->get_param( $name );
+			if ( null === $value ) {
+				continue;
+			}
+			update_option( $name, $value );
+			$touched = true;
+		}
+
+		if ( $touched ) {
+			/**
+			 * Fires after a podcast settings write through the REST endpoint.
+			 *
+			 * Transport-agnostic replacement for the old `/wp/v2/settings`
+			 * response hook; {@see Tracks} listens here to emit the aggregate
+			 * `wpcom_podcasting_settings_saved` event.
+			 *
+			 * @since $$next-version$$
+			 */
+			do_action( 'jetpack_podcast_settings_saved' );
+		}
+
+		return rest_ensure_response( Settings::get_all() );
+	}
+}

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -22,7 +22,7 @@ use WP_REST_Response;
 #[UsesClass( Settings::class )]
 class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 
-	const ROUTE = '/jetpack/v4/podcast/settings';
+	const ROUTE = '/wpcom/v2/podcast/settings';
 
 	/**
 	 * Admin user id (passes `manage_options`).
@@ -43,9 +43,9 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
-		// Register on rest_api_init so register_rest_route isn't called "incorrectly";
-		// WorDBless resets hooks between tests, so wire a fresh instance each setUp.
-		add_action( 'rest_api_init', array( new Podcast_Settings_Endpoint(), 'register_routes' ) );
+		// The constructor wires register_routes onto rest_api_init; WorDBless resets
+		// hooks between tests, so instantiate a fresh endpoint each setUp.
+		new Podcast_Settings_Endpoint();
 		do_action( 'rest_api_init' );
 
 		// Wire the option sanitizers (sanitize_option_* filters) so update_option()

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -43,14 +43,10 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
-		// The constructor wires register_routes onto rest_api_init; WorDBless resets
-		// hooks between tests, so instantiate a fresh endpoint each setUp.
 		// @phan-suppress-next-line PhanNoopNew -- constructor self-registers on rest_api_init.
 		new Podcast_Settings_Endpoint();
 		do_action( 'rest_api_init' );
 
-		// Wire the option sanitizers (sanitize_option_* filters) so update_option()
-		// merges array patches and enforces the show-state downgrade guard.
 		Settings::register_settings();
 
 		self::$admin_id      = wp_insert_user(
@@ -124,7 +120,6 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		// Sibling preserved, new entry merged in.
 		$this->assertSame( 'https://podcasts.apple.com/show/1', $data['podcasting_show_urls']['apple'] );
 		$this->assertSame( 'https://open.spotify.com/show/abc', $data['podcasting_show_urls']['spotify'] );
 	}
@@ -208,7 +203,6 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 		$response = $this->put_settings( array( 'podcasting_title' => 'Nope' ) );
 
 		$this->assertSame( 403, $response->get_status() );
-		// The write never ran.
 		$this->assertSame( '', get_option( 'podcasting_title', '' ) );
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -8,6 +8,7 @@ namespace Automattic\Jetpack\Podcast\Tests;
 use Automattic\Jetpack\Podcast\Podcast_Settings_Endpoint;
 use Automattic\Jetpack\Podcast\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use WorDBless\BaseTestCase;
 use WorDBless\Users as WorDBless_Users;
 use WP_REST_Request;
@@ -15,8 +16,10 @@ use WP_REST_Response;
 
 /**
  * @covers \Automattic\Jetpack\Podcast\Podcast_Settings_Endpoint
+ * @uses \Automattic\Jetpack\Podcast\Settings
  */
 #[CoversClass( Podcast_Settings_Endpoint::class )]
+#[UsesClass( Settings::class )]
 class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 
 	const ROUTE = '/jetpack/v4/podcast/settings';

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Podcast_Settings_Endpoint;
+use Automattic\Jetpack\Podcast\Settings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\Podcast_Settings_Endpoint
+ */
+#[CoversClass( Podcast_Settings_Endpoint::class )]
+class Podcast_Settings_Endpoint_Test extends BaseTestCase {
+
+	const ROUTE = '/jetpack/v4/podcast/settings';
+
+	/**
+	 * Admin user id (passes `manage_options`).
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Subscriber user id (fails `manage_options`).
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		// Register on rest_api_init (not directly) so register_rest_route isn't
+		// called "incorrectly". WorDBless resets hooks between tests, so add the
+		// callback fresh each setUp rather than relying on the static init() guard.
+		add_action( 'rest_api_init', array( new Podcast_Settings_Endpoint(), 'register_routes' ) );
+		do_action( 'rest_api_init' );
+
+		// Wire the option sanitizers (sanitize_option_* filters) so update_option()
+		// merges array patches and enforces the show-state downgrade guard.
+		Settings::register_settings();
+
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'pod_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'pod_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	protected function tearDown(): void {
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			delete_option( $name );
+		}
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		WorDBless_Users::init()->clear_all_users();
+		parent::tearDown();
+	}
+
+	private function get_settings(): WP_REST_Response {
+		return rest_do_request( new WP_REST_Request( 'GET', self::ROUTE ) );
+	}
+
+	private function put_settings( array $body ): WP_REST_Response {
+		$request = new WP_REST_Request( 'PUT', self::ROUTE );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( $body, JSON_UNESCAPED_SLASHES ) );
+		return rest_do_request( $request );
+	}
+
+	public function test_get_returns_full_padded_record() {
+		update_option( 'podcasting_title', 'My Show' );
+
+		$response = $this->get_settings();
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$this->assertArrayHasKey( $name, $data, "$name should be present in the response" );
+		}
+		$this->assertSame( 'My Show', $data['podcasting_title'] );
+		$this->assertSame(
+			array_keys( Settings::SHOW_URL_HOSTS ),
+			array_keys( $data['podcasting_show_urls'] )
+		);
+	}
+
+	public function test_put_merges_partial_patch_and_returns_full_record() {
+		update_option(
+			'podcasting_show_urls',
+			array( 'apple' => 'https://podcasts.apple.com/show/1' )
+		);
+
+		$response = $this->put_settings(
+			array( 'podcasting_show_urls' => array( 'spotify' => 'https://open.spotify.com/show/abc' ) )
+		);
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		// Sibling preserved, new entry merged in.
+		$this->assertSame( 'https://podcasts.apple.com/show/1', $data['podcasting_show_urls']['apple'] );
+		$this->assertSame( 'https://open.spotify.com/show/abc', $data['podcasting_show_urls']['spotify'] );
+	}
+
+	public function test_put_does_not_clobber_absent_keys() {
+		update_option( 'podcasting_title', 'Keep Me' );
+		update_option( 'podcasting_summary', 'Keep Me Too' );
+
+		$this->put_settings( array( 'podcasting_title' => 'Changed' ) );
+
+		$this->assertSame( 'Changed', get_option( 'podcasting_title' ) );
+		$this->assertSame( 'Keep Me Too', get_option( 'podcasting_summary' ) );
+	}
+
+	public function test_put_refuses_active_to_pending_downgrade() {
+		update_option( 'podcasting_show_states', array( 'apple' => 'active' ) );
+
+		$response = $this->put_settings(
+			array( 'podcasting_show_states' => array( 'apple' => 'pending' ) )
+		);
+
+		$data = $response->get_data();
+		$this->assertSame( 'active', $data['podcasting_show_states']['apple'] );
+	}
+
+	public function test_put_fires_settings_saved_action_when_an_option_is_touched() {
+		$fired = 0;
+		add_action(
+			'jetpack_podcast_settings_saved',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		$this->put_settings( array( 'podcasting_title' => 'Hooked' ) );
+
+		$this->assertSame( 1, $fired );
+	}
+
+	public function test_put_skips_action_when_no_recognized_option_present() {
+		$fired = 0;
+		add_action(
+			'jetpack_podcast_settings_saved',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		$response = $this->put_settings( array( 'not_a_podcasting_key' => 'whatever' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $fired );
+	}
+
+	public function test_get_denied_for_users_without_manage_options() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertSame( 403, $this->get_settings()->get_status() );
+	}
+
+	public function test_put_denied_for_users_without_manage_options() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$response = $this->put_settings( array( 'podcasting_title' => 'Nope' ) );
+
+		$this->assertSame( 403, $response->get_status() );
+		// The write never ran.
+		$this->assertSame( '', get_option( 'podcasting_title', '' ) );
+	}
+}

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -45,6 +45,7 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 		$wp_rest_server = new \WP_REST_Server();
 		// The constructor wires register_routes onto rest_api_init; WorDBless resets
 		// hooks between tests, so instantiate a fresh endpoint each setUp.
+		// @phan-suppress-next-line PhanNoopNew -- constructor self-registers on rest_api_init.
 		new Podcast_Settings_Endpoint();
 		do_action( 'rest_api_init' );
 

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -163,6 +163,23 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 		$this->assertSame( 1, $fired );
 	}
 
+	public function test_put_skips_action_when_value_unchanged() {
+		update_option( 'podcasting_title', 'Same' );
+
+		$fired = 0;
+		add_action(
+			'jetpack_podcast_settings_saved',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		$response = $this->put_settings( array( 'podcasting_title' => 'Same' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $fired );
+	}
+
 	public function test_put_skips_action_when_no_recognized_option_present() {
 		$fired = 0;
 		add_action(

--- a/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Settings_Endpoint_Test.php
@@ -40,9 +40,8 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new \WP_REST_Server();
-		// Register on rest_api_init (not directly) so register_rest_route isn't
-		// called "incorrectly". WorDBless resets hooks between tests, so add the
-		// callback fresh each setUp rather than relying on the static init() guard.
+		// Register on rest_api_init so register_rest_route isn't called "incorrectly";
+		// WorDBless resets hooks between tests, so wire a fresh instance each setUp.
 		add_action( 'rest_api_init', array( new Podcast_Settings_Endpoint(), 'register_routes' ) );
 		do_action( 'rest_api_init' );
 
@@ -147,7 +146,7 @@ class Podcast_Settings_Endpoint_Test extends BaseTestCase {
 		$this->assertSame( 'active', $data['podcasting_show_states']['apple'] );
 	}
 
-	public function test_put_fires_settings_saved_action_when_an_option_is_touched() {
+	public function test_put_fires_settings_saved_action_when_an_option_is_saved() {
 		$fired = 0;
 		add_action(
 			'jetpack_podcast_settings_saved',

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -50,6 +50,22 @@ class Settings_Test extends BaseTestCase {
 		delete_option( 'podcasting_show_urls' );
 	}
 
+	public function test_rest_schema_properties_types_every_option() {
+		$schema = Settings::rest_schema_properties();
+
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$this->assertArrayHasKey( $name, $schema, "$name should have an update arg schema" );
+			$this->assertArrayHasKey( 'type', $schema[ $name ], "$name schema should declare a type" );
+		}
+
+		$this->assertSame( 'integer', $schema['podcasting_category_id']['type'] );
+		$this->assertSame( 'integer', $schema['podcasting_image_id']['type'] );
+		$this->assertSame( 'object', $schema['podcasting_show_urls']['type'] );
+		$this->assertSame( 'object', $schema['podcasting_show_states']['type'] );
+		// Explicit accepts the stored boolean or the stringy form the SPA may send.
+		$this->assertSame( array( 'boolean', 'string' ), $schema['podcasting_explicit']['type'] );
+	}
+
 	public function test_register_adds_options_to_jetpack_sync_whitelist() {
 		Settings::register();
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -39,7 +39,6 @@ class Settings_Test extends BaseTestCase {
 		$this->assertSame( 'My Show', $all['podcasting_title'] );
 		$this->assertIsBool( $all['podcasting_explicit'] );
 
-		// Both podcatcher maps are padded to every known directory.
 		$expected_keys = array_keys( Settings::SHOW_URL_HOSTS );
 		$this->assertSame( $expected_keys, array_keys( $all['podcasting_show_urls'] ) );
 		$this->assertSame( $expected_keys, array_keys( $all['podcasting_show_states'] ) );
@@ -62,7 +61,6 @@ class Settings_Test extends BaseTestCase {
 		$this->assertSame( 'integer', $schema['podcasting_image_id']['type'] );
 		$this->assertSame( 'object', $schema['podcasting_show_urls']['type'] );
 		$this->assertSame( 'object', $schema['podcasting_show_states']['type'] );
-		// Explicit accepts the stored boolean or the stringy form the SPA may send.
 		$this->assertSame( array( 'boolean', 'string' ), $schema['podcasting_explicit']['type'] );
 	}
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -64,15 +64,6 @@ class Settings_Test extends BaseTestCase {
 		delete_option( 'podcasting_show_urls' );
 	}
 
-	public function test_empty_podcatcher_map_covers_all_directories_with_empty_strings() {
-		$map = Settings::empty_podcatcher_map();
-
-		$this->assertSame( array_keys( Settings::SHOW_URL_HOSTS ), array_keys( $map ) );
-		foreach ( $map as $value ) {
-			$this->assertSame( '', $value );
-		}
-	}
-
 	public function test_register_adds_options_to_jetpack_sync_whitelist() {
 		Settings::register();
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -15,14 +15,61 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Settings::class )]
 class Settings_Test extends BaseTestCase {
 
-	public function test_register_settings_exposes_every_option_to_rest() {
+	public function test_register_settings_registers_every_option() {
 		Settings::register_settings();
 
 		$registered = get_registered_settings();
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$this->assertArrayHasKey( $name, $registered, "$name should be registered" );
-			$this->assertNotEmpty( $registered[ $name ]['show_in_rest'], "$name should declare show_in_rest" );
+		}
+	}
+
+	/**
+	 * The options must NOT leak into core `/wp/v2/settings`; REST exposure lives
+	 * on the dedicated Podcast_Settings_Endpoint instead. This is what ends the
+	 * wpcom core settings-controller test churn.
+	 */
+	public function test_register_settings_keeps_options_out_of_core_rest() {
+		Settings::register_settings();
+
+		$registered = get_registered_settings();
+
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$this->assertEmpty( $registered[ $name ]['show_in_rest'], "$name must not set show_in_rest" );
+		}
+	}
+
+	public function test_get_all_returns_every_option_key_with_padded_maps() {
+		update_option( 'podcasting_title', 'My Show' );
+		update_option( 'podcasting_show_urls', array( 'apple' => 'https://podcasts.apple.com/show/1' ) );
+
+		$all = Settings::get_all();
+
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$this->assertArrayHasKey( $name, $all, "$name should be present in get_all()" );
+		}
+
+		$this->assertSame( 'My Show', $all['podcasting_title'] );
+		$this->assertIsBool( $all['podcasting_explicit'] );
+
+		// Both podcatcher maps are padded to every known directory.
+		$expected_keys = array_keys( Settings::SHOW_URL_HOSTS );
+		$this->assertSame( $expected_keys, array_keys( $all['podcasting_show_urls'] ) );
+		$this->assertSame( $expected_keys, array_keys( $all['podcasting_show_states'] ) );
+		$this->assertSame( 'https://podcasts.apple.com/show/1', $all['podcasting_show_urls']['apple'] );
+		$this->assertSame( '', $all['podcasting_show_urls']['spotify'] );
+
+		delete_option( 'podcasting_title' );
+		delete_option( 'podcasting_show_urls' );
+	}
+
+	public function test_empty_podcatcher_map_covers_all_directories_with_empty_strings() {
+		$map = Settings::empty_podcatcher_map();
+
+		$this->assertSame( array_keys( Settings::SHOW_URL_HOSTS ), array_keys( $map ) );
+		foreach ( $map as $value ) {
+			$this->assertSame( '', $value );
 		}
 	}
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -15,28 +15,14 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Settings::class )]
 class Settings_Test extends BaseTestCase {
 
-	public function test_register_settings_registers_every_option() {
+	public function test_register_settings_exposes_every_option_to_rest() {
 		Settings::register_settings();
 
 		$registered = get_registered_settings();
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$this->assertArrayHasKey( $name, $registered, "$name should be registered" );
-		}
-	}
-
-	/**
-	 * The options must NOT leak into core `/wp/v2/settings`; REST exposure lives
-	 * on the dedicated Podcast_Settings_Endpoint instead. This is what ends the
-	 * wpcom core settings-controller test churn.
-	 */
-	public function test_register_settings_keeps_options_out_of_core_rest() {
-		Settings::register_settings();
-
-		$registered = get_registered_settings();
-
-		foreach ( Settings::OPTION_NAMES as $name ) {
-			$this->assertEmpty( $registered[ $name ]['show_in_rest'], "$name must not set show_in_rest" );
+			$this->assertNotEmpty( $registered[ $name ]['show_in_rest'], "$name should declare show_in_rest" );
 		}
 	}
 

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -297,8 +297,6 @@ class Tracks_Test extends BaseTestCase {
 		update_option( 'podcasting_email', 'host@example.com' );
 		update_option( 'podcasting_talent_name', 'Jane Host' );
 
-		// No-arg recorder, fired off the `jetpack_podcast_settings_saved` action
-		// that Podcast_Settings_Endpoint::update_item() triggers.
 		Tracks::record_settings_saved();
 
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -308,4 +308,12 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'podcasting_email', $events[0]['properties'] );
 		$this->assertArrayNotHasKey( 'podcasting_talent_name', $events[0]['properties'] );
 	}
+
+	public function test_init_wires_settings_saved_recorder() {
+		Tracks::init();
+
+		$this->assertNotFalse(
+			has_action( 'jetpack_podcast_settings_saved', array( Tracks::class, 'record_settings_saved' ) )
+		);
+	}
 }

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WorDBless\Posts as WorDBless_Posts;
 use WorDBless\Users as WorDBless_Users;
-use WP_REST_Request;
-use WP_REST_Response;
 use WP_Term;
 
 /**
@@ -294,15 +292,14 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
 	}
 
-	public function test_settings_saved_emits_after_settings_rest_write() {
+	public function test_settings_saved_emits_snapshot_with_pii_redacted() {
 		update_option( 'podcasting_title', 'New Title' );
 		update_option( 'podcasting_email', 'host@example.com' );
 		update_option( 'podcasting_talent_name', 'Jane Host' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
-		$request->set_param( 'podcasting_title', 'New Title' );
-
-		Tracks::record_settings_saved( new WP_REST_Response( array(), 200 ), array(), $request );
+		// No-arg recorder, fired off the `jetpack_podcast_settings_saved` action
+		// that Podcast_Settings_Endpoint::update_item() triggers.
+		Tracks::record_settings_saved();
 
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
 		$this->assertCount( 1, $events );
@@ -310,27 +307,5 @@ class Tracks_Test extends BaseTestCase {
 		// PII is redacted from the payload.
 		$this->assertArrayNotHasKey( 'podcasting_email', $events[0]['properties'] );
 		$this->assertArrayNotHasKey( 'podcasting_talent_name', $events[0]['properties'] );
-	}
-
-	public function test_settings_saved_skips_settings_writes_without_podcasting_fields() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
-		$request->set_param( 'title', 'New Site Title' );
-
-		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
-
-		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
-	}
-
-	public function test_settings_saved_suppressed_when_response_is_an_error() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
-		$request->set_param( 'podcasting_title', 'New Title' );
-
-		Tracks::record_settings_saved(
-			new WP_REST_Response( array( 'code' => 'rest_forbidden' ), 403 ),
-			array(),
-			$request
-		);
-
-		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
 	}
 }


### PR DESCRIPTION
## Proposed changes

Podcast **site settings** (title, cover, categories, distribution links, etc.) used to load and save through WordPress's shared `/wp/v2/settings` endpoint. This PR gives them their **own dedicated endpoint** — `wpcom/v2/podcast/settings` — and points the Podcast dashboard and the Podcast Episode block at it.

What changes:

* **New endpoint.** Returns all podcast settings on read. On write it only saves the fields you actually send, so changing one field never wipes the others; the array-shaped settings (distribution links/states) merge rather than replace.
* **Self-contained.** It reads and writes the `podcasting_*` options directly with no WordPress.com relay, so one definition works the same on Simple, WoA, and a plain self-hosted Jetpack site.
* **Dashboard + block** now read and write through a standard core-data store entity (the same approach Publicize uses) instead of `/wp/v2/settings`.
* **Analytics.** The existing "settings saved" event now fires off a new internal action when a save actually changes a value, instead of off the `/wp/v2/settings` REST response. Same event, same properties, same PII redaction — no new tracking.

This PR is **purely additive**: the `podcasting_*` options still appear in `/wp/v2/settings` exactly as before, so nothing existing breaks. Actually retiring that old exposure is a deliberate, separate follow-up.

## Does this pull request change what data or activity we track or use?

No new data. The `wpcom_podcasting_settings_saved` event keeps the same properties and the same PII redaction (`podcasting_email` / `podcasting_talent_name`). What moved is its trigger: it now fires from the new endpoint when a save actually changes a setting, rather than from any `/wp/v2/settings` write. Dashboard saves are still tracked the same; unchanged ("no-op") saves no longer emit the event.

## Testing instructions

* Open the Podcast dashboard **Settings** tab — the form should load.
* Change one field and save — expect the success snackbar, the value to persist, and other fields to stay intact (a partial save must not blank them).
* Toggle a distribution link, reload, and confirm it sticks.
* Confirm `/wp/v2/settings` still lists the `podcasting_*` keys (unchanged by this PR).
* On a plain self-hosted Jetpack site (no WordPress.com connection), confirm settings still load and save.
* From `projects/packages/podcast`, run `composer test-php` — all tests pass.
