### PR TITLE
Premium Analytics: route data layer through the new proxy controller

### DIFF
--- a/projects/packages/premium-analytics/changelog/wire-frontend-to-proxy
+++ b/projects/packages/premium-analytics/changelog/wire-frontend-to-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Data layer: route report requests through the jetpack-premium-analytics proxy controller instead of the legacy woocommerce-analytics proxy route.

--- a/projects/packages/premium-analytics/packages/data/src/api/constants.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Constants for API endpoints
  */
-export const reportsPath = '/wc/v3/woocommerce-analytics/proxy/reports';
+export const reportsPath = '/jetpack-premium-analytics/v1/proxy/reports';

--- a/projects/packages/premium-analytics/packages/data/src/api/report-visitors-by-location-fetch/report-visitors-by-location-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/report-visitors-by-location-fetch/report-visitors-by-location-fetch.ts
@@ -36,7 +36,7 @@ export type RequestReportVisitorsByLocationParams = BaseReportParams & {
 /**
  * Fetch visitors grouped by location (country or region) for the selected period.
  *
- * This endpoint is proxied through `/wc/v3/woocommerce-analytics/proxy/reports/...`
+ * This endpoint is proxied through `/jetpack-premium-analytics/v1/proxy/reports/...`
  * and ultimately served by wpcom analytics.
  */
 export async function fetchReportVisitorsByLocation( {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -48,7 +48,7 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
  * Base path that all report requests share. Matches `reportsPath` in the data
  * package (`@jetpack-premium-analytics/data`).
  */
-const API_BASE = '/wc/v3/woocommerce-analytics/proxy/reports';
+const API_BASE = '/jetpack-premium-analytics/v1/proxy/reports';
 
 /**
  * Days of mock data to generate (covering past requests).


### PR DESCRIPTION
Fixes #

## Proposed changes
Stacked on top of #49506 (the API proxy REST controller). Now that the controller exists, this wires the dashboard data layer to it:

* Point `reportsPath` (`packages/data/src/api/constants.ts`) at `/jetpack-premium-analytics/v1/proxy/reports`, replacing the legacy `/wc/v3/woocommerce-analytics/proxy/reports` route. Every report fetcher (`products`, `orders/by-date`, `customers/new-returning`, `sessions/by-conversion-rate`, `sessions/by-location`, coupons, bookings, order-attribution, …) goes through `apiFetch` against this shared base, so the single constant covers them all.
* Move the Storybook report-mock base path (`widgets-toolkit/.../register-report-mocks.ts`) in lockstep so widget stories keep intercepting the same paths.
* Update the stale upstream-path doc comment in `report-visitors-by-location-fetch.ts`.

Out of scope: `use-product-images` (`/wc/v3/products`, hits the local store) and `report-export-fetch` (`/wc/v3/woocommerce-analytics/reports/csv-export`, the plugin's own export endpoint, not the data proxy) — neither goes through this proxy.

## Related product discussion/links
* https://linear.app/a8c/issue/WOOA7S-1438

## Does this pull request change what data or activity we track or use?
No. This redirects existing report requests from one proxy route to another; the data fetched is unchanged.

## Testing instructions
* Build the plugin (`jetpack build plugins/premium-analytics`) and load the analytics dashboard in wp-admin on a Jetpack-connected site.
* Open the network panel and confirm report requests now hit `/wp-json/jetpack-premium-analytics/v1/proxy/reports/...` (e.g. `reports/products`, `reports/orders/by-date`) instead of `/wc/v3/woocommerce-analytics/proxy/reports/...`.
* Confirm the widgets render with data — request/response shapes are unchanged from the caller's perspective (see the samples on #49506).
* Storybook: run the widgets-toolkit stories and confirm mock data still renders (the mock middleware base path moved with the constant).
