### PR TITLE
Premium Analytics: extend the API proxy to cover Stats-Admin endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST: Extend the analytics API proxy to forward the Stats dashboard endpoints (stats, subscribers, dashboard modules, WordAds, purchases, and more) under the jetpack-premium-analytics/v1 namespace, ahead of deprecating the stats-admin package.
+REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1 (allowed-prefix + write-method allowlist; caller passes the WPCOM API version), ahead of deprecating the stats-admin package. The analytics data now lives under the `analytics/` prefix on this route instead of the dedicated `proxy/` route.

--- a/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1, shaped as `proxy/v<version>/<prefix>/<subpath>` (e.g. `proxy/v1.1/wordads/earnings`) — the `proxy/` segment marks a transparent WPCOM forward, the WPCOM API version is in the path, and an allowed-prefix + write-method allowlist bounds the blog token. Ahead of deprecating the stats-admin package.
+REST: Serve the whole analytics and stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1, shaped as `proxy/v<version>/<prefix>/<subpath>` (for example `proxy/v1.1/wordads/earnings`). The `proxy/` segment marks a transparent WordPress.com forward, the WordPress.com API version lives in the path, and an allowed-prefix plus write-method allowlist bounds the blog token. This lays the groundwork for deprecating the stats-admin package.

--- a/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1, shaped as `proxy/v<version>/<prefix>/<subpath>` (e.g. `proxy/v1.1/wordads/earnings`) — the `proxy/` segment marks a transparent WPCOM forward, the WPCOM API version is in the path, and an allowed-prefix + write-method allowlist bound the blog token. Ahead of deprecating the stats-admin package.
+REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1, shaped as `proxy/v<version>/<prefix>/<subpath>` (e.g. `proxy/v1.1/wordads/earnings`) — the `proxy/` segment marks a transparent WPCOM forward, the WPCOM API version is in the path, and an allowed-prefix + write-method allowlist bounds the blog token. Ahead of deprecating the stats-admin package.

--- a/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Extend the analytics API proxy to forward the Stats dashboard endpoints (stats, subscribers, dashboard modules, WordAds, purchases, and more) under the jetpack-premium-analytics/v1 namespace, ahead of deprecating the stats-admin package.

--- a/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoints-to-api-proxy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1 (allowed-prefix + write-method allowlist; caller passes the WPCOM API version), ahead of deprecating the stats-admin package. The analytics data now lives under the `analytics/` prefix on this route instead of the dedicated `proxy/` route.
+REST: Serve the whole analytics + Stats surface through one endpoint-agnostic proxy under jetpack-premium-analytics/v1, shaped as `proxy/v<version>/<prefix>/<subpath>` (e.g. `proxy/v1.1/wordads/earnings`) — the `proxy/` segment marks a transparent WPCOM forward, the WPCOM API version is in the path, and an allowed-prefix + write-method allowlist bound the blog token. Ahead of deprecating the stats-admin package.

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -71,22 +71,40 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private const FORWARDED_HEADERS = array( 'x-wp-total', 'x-wp-totalpages' );
 
 	/**
-	 * Per-prefix configuration — the single source of truth for everything the proxy needs to
-	 * know about a top-level resource group. The keys are also the security boundary: the route
-	 * only matches these prefixes, so the blog token can never be driven against the whole WPCOM
-	 * site API. Adding or changing an endpoint group is a one-entry edit here, not a sweep across
-	 * the permission / write / cache / path methods, all of which read from this table.
+	 * Per-prefix configuration — the single source of truth for every proxied endpoint group.
+	 * The route regex, permission check, write gate, cache-busting, and path builder all read
+	 * from this table, so an endpoint group is defined here and nowhere else.
 	 *
-	 * Per entry:
-	 *  - `capability` (string, required) Capability that grants access; `manage_options` always
-	 *                  grants too, so `analytics` (capability `manage_options`) stays admin-only.
-	 *  - `writes`     (string[])  Sub-paths a non-GET (POST) may reach. Trailing `/` = this prefix
-	 *                  and any sub-path; no trailing `/` = that exact endpoint only. Absent =
-	 *                  read-only.
-	 *  - `cache_bust` (bool)      Whether a successful write invalidates the matching read cache.
-	 *  - `path`       (string)    A printf template (`%d` = blog ID) for endpoints not scoped under
-	 *                  `/sites/<id>/` (e.g. `upgrades`). A prefix with a fixed `path` takes no
-	 *                  sub-path. Absent = `/sites/<id>/<endpoint>`.
+	 * The keys double as the security boundary: a request is only routed (and the blog token only
+	 * forwarded) if its first path segment is a key here — so the proxy can never be driven
+	 * against the whole WPCOM site API. Keep keys lowercase; they are matched case-insensitively.
+	 *
+	 * A request maps to `proxy/v<version>/<key>/<sub-path>` →
+	 * `/sites/<blog-id>/<key>/<sub-path>` (the caller chooses `<version>`; the base is derived).
+	 *
+	 * Fields per entry:
+	 *  - `capability` (string, required) Capability granting access. `manage_options` is always
+	 *                  also accepted, so a value of `manage_options` means "admins only". A
+	 *                  missing/unknown value fails closed (denies).
+	 *  - `writes`     (string[], optional) Sub-paths reachable with POST (the only write verb).
+	 *                  Each matcher: trailing `/` = that sub-path and anything under it; no
+	 *                  trailing `/` = that exact endpoint only. Omit for a read-only group.
+	 *  - `cache_bust` (bool, optional) If true, a successful POST clears the matching read cache.
+	 *                  Only meaningful alongside `writes`.
+	 *  - `path`       (string, optional) printf template (`%d` = blog id) for groups NOT under
+	 *                  `/sites/<id>/` (e.g. `upgrades` → `/upgrades?site=%d`). A group with a
+	 *                  fixed `path` takes no sub-path. Omit for the normal `/sites/<id>/<key>/…`.
+	 *
+	 * Maintaining endpoints (this table is the only edit needed for a pass-through endpoint):
+	 *  - ADD a group:   add a key with at least `capability`. Reads work immediately at
+	 *                   `proxy/v<version>/<key>/<sub-path>`. The frontend picks the WPCOM version.
+	 *  - ALLOW writes:  add `writes` (and `cache_bust` if a write should freshen a cached read).
+	 *  - CHANGE access: edit `capability` (e.g. tighten a group to `manage_options`).
+	 *  - REMOVE a group: delete its key — the route stops matching it and it 404s.
+	 *  - Cover it with a row in `data_endpoint_matrix()` (capability / writable / WPCOM path).
+	 *  - NOTE: this is for transparent WPCOM forwards only. Endpoints needing local processing
+	 *    (DB reads, body rewrites, the Notices class, …) are NOT proxied — they get their own
+	 *    routes outside `proxy/`; do not add them here.
 	 *
 	 * @var array<string, array<string, mixed>>
 	 */

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -17,10 +17,16 @@ use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Forwards an authenticated dashboard request to the WPCOM analytics endpoint for the
- * connected site's blog ID, caches the successful response in a short-lived transient,
- * and returns it. Lets the extracted frontend's data layer talk to WPCOM without each
- * call leaving the WordPress origin.
+ * Forwards an authenticated dashboard request to the WPCOM endpoint for the connected
+ * site's blog ID, caches the successful response in a short-lived transient, and returns
+ * it. Lets the extracted frontend's data layer talk to WPCOM without each call leaving the
+ * WordPress origin.
+ *
+ * Two route families share one forwarding core:
+ *  - the analytics catch-all (`proxy/<endpoint>` → `/sites/<id>/analytics/<endpoint>`); and
+ *  - the Stats routes (declared in {@see get_stats_routes()}), which re-expose the
+ *    `stats-admin` package's WPCOM pass-through endpoints under this namespace, minus the
+ *    blog ID in the URL.
  */
 class Api_Proxy_Controller extends WP_REST_Controller {
 
@@ -77,7 +83,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the proxy route. The trailing capture group is the target analytics path.
+	 * Register the analytics catch-all and the Stats pass-through routes.
 	 *
 	 * @return void
 	 */
@@ -104,6 +110,110 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+
+		foreach ( $this->get_stats_routes() as $route ) {
+			register_rest_route(
+				$this->namespace,
+				'/' . $route['route'],
+				array(
+					'methods'             => $route['methods'],
+					'callback'            => function ( WP_REST_Request $request ) use ( $route ) {
+						return $this->handle_stats_request( $request, $route );
+					},
+					'permission_callback' => $this->permission_callback_for( $route['permission'] ?? 'stats' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * The Stats endpoints to re-expose, mirroring `stats-admin` minus the `/sites/<id>` URL
+	 * segment. Each entry is a thin description the shared forwarder turns into a WPCOM call:
+	 *
+	 *  - `route`      Relative route regex; `%s` captures (named `subpath`) act as whitelists.
+	 *  - `wpcom`      Path relative to `/sites/<id>/`; a `%s` is filled from the `subpath` param.
+	 *  - `build`      Optional callable( int $site_id ): string for paths not under `/sites/<id>/`.
+	 *  - `methods`    Allowed HTTP verbs (defaults handled per entry).
+	 *  - `version`    WPCOM API version. Defaults to '2'.
+	 *  - `base`       WPCOM API base ('rest' | 'wpcom'). Defaults to 'wpcom'.
+	 *  - `permission` 'stats' (default) or 'wordads'.
+	 *  - `cache`      Whether GET responses may be cached. Defaults to true.
+	 *
+	 * The single `stats/(?P<subpath>.+)` route absorbs every `/sites/<id>/stats/*` endpoint
+	 * (per-resource stats, single post/video, email stats, UTM, devices, location views, and
+	 * referrer-spam list/new/delete) the same way the analytics catch-all works.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_stats_routes(): array {
+		$read  = WP_REST_Server::READABLE;
+		$write = WP_REST_Server::EDITABLE;
+
+		return array(
+			array(
+				'route'   => 'stats',
+				'wpcom'   => 'stats',
+				'methods' => $read,
+				'version' => '1.1',
+				'base'    => 'rest',
+			),
+			array(
+				'route'   => 'stats/(?P<subpath>.+)',
+				'wpcom'   => 'stats/%s',
+				'methods' => $read . ',' . $write,
+				'version' => '1.1',
+				'base'    => 'rest',
+			),
+			array(
+				'route'   => 'subscribers/counts',
+				'wpcom'   => 'subscribers/counts',
+				'methods' => $read,
+			),
+			array(
+				'route'   => 'site-has-never-published-post',
+				'wpcom'   => 'site-has-never-published-post',
+				'methods' => $read,
+			),
+			array(
+				'route'   => 'jetpack-stats/usage',
+				'wpcom'   => 'jetpack-stats/usage',
+				'methods' => $read,
+				'cache'   => false,
+			),
+			array(
+				'route'   => 'jetpack-stats-dashboard/modules',
+				'wpcom'   => 'jetpack-stats-dashboard/modules',
+				'methods' => $read . ',' . $write,
+			),
+			array(
+				'route'   => 'jetpack-stats-dashboard/module-settings',
+				'wpcom'   => 'jetpack-stats-dashboard/module-settings',
+				'methods' => $read . ',' . $write,
+			),
+			array(
+				'route'   => 'commercial-classification',
+				'wpcom'   => 'commercial-classification',
+				'methods' => $write,
+			),
+			array(
+				'route'      => 'wordads/(?P<subpath>earnings|stats)',
+				'wpcom'      => 'wordads/%s',
+				'methods'    => $read,
+				'version'    => '1.1',
+				'base'       => 'rest',
+				'permission' => 'wordads',
+			),
+			array(
+				'route'   => 'purchases',
+				'methods' => $read,
+				'version' => '1.2',
+				'base'    => 'rest',
+				'cache'   => false,
+				'build'   => static function ( int $site_id ): string {
+					return sprintf( '/upgrades?site=%d', $site_id );
+				},
+			),
+		);
 	}
 
 	/**
@@ -113,6 +223,40 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Administrators, or users who can view stats, may reach the Stats data.
+	 *
+	 * @return bool
+	 */
+	public function check_stats_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Administrators, or users who can manage WordAds, may reach the WordAds data.
+	 *
+	 * @return bool
+	 */
+	public function check_wordads_permission(): bool {
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown
+		return current_user_can( 'manage_options' ) || current_user_can( 'activate_wordads' );
+	}
+
+	/**
+	 * Map a route's permission key to its callback.
+	 *
+	 * @param string $permission Permission key ('stats' | 'wordads').
+	 *
+	 * @return callable
+	 */
+	private function permission_callback_for( string $permission ): callable {
+		if ( 'wordads' === $permission ) {
+			return array( $this, 'check_wordads_permission' );
+		}
+
+		return array( $this, 'check_stats_permission' );
 	}
 
 	/**
@@ -134,17 +278,87 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Serve a cached payload when available, otherwise fetch from WPCOM and cache it.
+	 * Proxy the analytics catch-all to `/sites/<id>/analytics/<endpoint>`.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function handle_proxy_request( WP_REST_Request $request ) {
-		$cache_key = $this->get_cache_key( $request );
-		$cached    = get_transient( $cache_key );
-		if ( false !== $cached ) {
-			return $this->build_response( $cached );
+		$path = sprintf(
+			'/sites/%d/analytics/%s',
+			(int) Jetpack_Options::get_option( 'id' ),
+			(string) $request->get_param( 'endpoint' )
+		);
+
+		return $this->forward( $request, $path, array() );
+	}
+
+	/**
+	 * Proxy a declared Stats route to its WPCOM endpoint.
+	 *
+	 * @param WP_REST_Request      $request Request object.
+	 * @param array<string, mixed> $route   The matched route description.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function handle_stats_request( WP_REST_Request $request, array $route ) {
+		return $this->forward(
+			$request,
+			$this->build_stats_path( $request, $route ),
+			array(
+				'version' => $route['version'] ?? '2',
+				'base'    => $route['base'] ?? 'wpcom',
+				'cache'   => $route['cache'] ?? true,
+			)
+		);
+	}
+
+	/**
+	 * Resolve a Stats route to its WPCOM path (without the forwarded query string).
+	 *
+	 * @param WP_REST_Request      $request Request object.
+	 * @param array<string, mixed> $route   The matched route description.
+	 *
+	 * @return string
+	 */
+	private function build_stats_path( WP_REST_Request $request, array $route ): string {
+		$site_id = (int) Jetpack_Options::get_option( 'id' );
+
+		if ( isset( $route['build'] ) ) {
+			return ( $route['build'] )( $site_id );
+		}
+
+		$relative = $route['wpcom'];
+		if ( str_contains( $relative, '%s' ) ) {
+			$relative = sprintf( $relative, (string) $request->get_param( 'subpath' ) );
+		}
+
+		return sprintf( '/sites/%d/%s', $site_id, $relative );
+	}
+
+	/**
+	 * Serve a cached payload when available, otherwise forward to WPCOM and cache the result.
+	 *
+	 * @param WP_REST_Request      $request    Request object.
+	 * @param string               $wpcom_path WPCOM path without the forwarded query string.
+	 * @param array<string, mixed> $opts       version | base | cache overrides.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function forward( WP_REST_Request $request, string $wpcom_path, array $opts ) {
+		$version   = $opts['version'] ?? '2';
+		$base      = $opts['base'] ?? 'wpcom';
+		$method    = strtoupper( $request->get_method() );
+		$is_read   = 'GET' === $method;
+		$cacheable = $is_read && ( $opts['cache'] ?? true );
+
+		$cache_key = $cacheable ? $this->get_cache_key( $request, $wpcom_path ) : null;
+		if ( null !== $cache_key ) {
+			$cached = get_transient( $cache_key );
+			if ( false !== $cached ) {
+				return $this->build_response( $cached );
+			}
 		}
 
 		if ( ! ( new Manager( self::SLUG ) )->is_connected() ) {
@@ -155,16 +369,23 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			);
 		}
 
+		$args = array(
+			'method'  => $method,
+			'timeout' => self::API_TIMEOUT,
+		);
+		$body = null;
+		if ( ! $is_read ) {
+			$body            = $request->get_body();
+			$args['headers'] = array( 'Content-Type' => 'application/json' );
+		}
+
 		try {
 			$response = Client::wpcom_json_api_request_as_blog(
-				$this->build_endpoint_url( $request ),
-				'2',
-				array(
-					'method'  => 'GET',
-					'timeout' => self::API_TIMEOUT,
-				),
-				null,
-				'wpcom'
+				$this->append_forwarded_params( $request, $wpcom_path ),
+				$version,
+				$args,
+				$body,
+				$base
 			);
 		} catch ( \Exception $e ) {
 			return new WP_Error(
@@ -183,25 +404,6 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		}
 
 		return $this->cache_and_build_response( $response, $cache_key );
-	}
-
-	/**
-	 * Build the WPCOM analytics path for the connected blog from the request.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return string
-	 */
-	protected function build_endpoint_url( WP_REST_Request $request ): string {
-		$site_id      = (int) Jetpack_Options::get_option( 'id' );
-		$endpoint_url = sprintf( '/sites/%d/analytics/%s', $site_id, (string) $request->get_param( 'endpoint' ) );
-
-		$params = $this->get_forwarded_params( $request );
-		if ( ! empty( $params ) ) {
-			$endpoint_url .= '?' . http_build_query( $params );
-		}
-
-		return $endpoint_url;
 	}
 
 	/**
@@ -228,14 +430,14 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Cache a successful (200) response and return it to the caller.
+	 * Cache a successful (200) response when a cache key is given, and return it to the caller.
 	 *
-	 * @param array  $http_response Raw response from the Jetpack client.
-	 * @param string $cache_key     Transient key for this request signature.
+	 * @param array       $http_response Raw response from the Jetpack client.
+	 * @param string|null $cache_key     Transient key, or null to skip caching.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function cache_and_build_response( array $http_response, string $cache_key ) {
+	private function cache_and_build_response( array $http_response, ?string $cache_key ) {
 		$status = (int) wp_remote_retrieve_response_code( $http_response );
 		$data   = json_decode( wp_remote_retrieve_body( $http_response ), false );
 
@@ -254,7 +456,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			'headers' => $this->extract_forwarded_headers( wp_remote_retrieve_headers( $http_response ) ),
 		);
 
-		if ( 200 === $status ) {
+		if ( null !== $cache_key && 200 === $status ) {
 			set_transient( $cache_key, $payload, self::CACHE_TTL );
 		}
 
@@ -300,7 +502,26 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Query params to forward to WPCOM, minus the WordPress routing param.
+	 * Append the forwarded query params to a WPCOM path, choosing the right separator.
+	 *
+	 * @param WP_REST_Request $request    Request object.
+	 * @param string          $wpcom_path WPCOM path that may already carry a query string.
+	 *
+	 * @return string
+	 */
+	private function append_forwarded_params( WP_REST_Request $request, string $wpcom_path ): string {
+		$params = $this->get_forwarded_params( $request );
+		if ( empty( $params ) ) {
+			return $wpcom_path;
+		}
+
+		$separator = str_contains( $wpcom_path, '?' ) ? '&' : '?';
+
+		return $wpcom_path . $separator . http_build_query( $params );
+	}
+
+	/**
+	 * Query params to forward to WPCOM, minus the WordPress routing params.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -315,16 +536,17 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Build the transient key from the request signature (endpoint + forwarded params).
+	 * Build the transient key from the request signature (target path + forwarded params).
 	 *
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request    Request object.
+	 * @param string          $wpcom_path WPCOM path without the forwarded query string.
 	 *
 	 * @return string
 	 */
-	private function get_cache_key( WP_REST_Request $request ): string {
+	private function get_cache_key( WP_REST_Request $request, string $wpcom_path ): string {
 		$params = $this->get_forwarded_params( $request );
 		ksort( $params );
-		$signature = (string) $request->get_param( 'endpoint' ) . '|' . (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES );
+		$signature = $wpcom_path . '|' . (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES );
 
 		return self::CACHE_PREFIX . md5( $signature );
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -461,12 +461,39 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Mirror stats-admin: a successful write invalidates the matching (param-less) read cache.
-		if ( ! $is_read && ( $opts['bust_on_write'] ?? false ) && 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
-			delete_transient( $this->cache_key_for( $wpcom_path, $version, $base, array() ) );
-		}
+		$this->maybe_bust_read_cache( $response, ! $is_read, $opts, $wpcom_path, $version, $base );
 
 		return $this->cache_and_build_response( $response, $cache_key );
+	}
+
+	/**
+	 * Mirror stats-admin: a successful write invalidates the matching (param-less) read cache, so
+	 * the next GET reflects the change instead of serving the cached pre-write value. It busts only
+	 * when the request was a write, the prefix opted in (`bust_on_write`), and WPCOM returned 200.
+	 *
+	 * This is a pure function of the response and route context — it takes the raw client response
+	 * rather than reaching out to WPCOM itself, so the full bust decision is unit-testable without
+	 * a live connection.
+	 *
+	 * @param array                $http_response Raw response from the Jetpack client.
+	 * @param bool                 $is_write      Whether the request used a write (non-GET) method.
+	 * @param array<string, mixed> $opts          Forwarding opts (reads `bust_on_write`).
+	 * @param string               $wpcom_path    WPCOM path without the forwarded query string.
+	 * @param string               $version       WPCOM API version.
+	 * @param string               $base          WPCOM API base.
+	 *
+	 * @return void
+	 */
+	private function maybe_bust_read_cache( array $http_response, bool $is_write, array $opts, string $wpcom_path, string $version, string $base ): void {
+		if ( ! $is_write || empty( $opts['bust_on_write'] ) ) {
+			return;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $http_response ) ) {
+			return;
+		}
+
+		delete_transient( $this->cache_key_for( $wpcom_path, $version, $base, array() ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -213,9 +213,14 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Confine a data endpoint to a relative sub-path, rejecting traversal (`..`) and schemes
-	 * (`:`). The allowed top-level prefix is already enforced by the route regex; commas are
-	 * permitted since stats sub-paths legitimately contain them (UTM params).
+	 * Confine a data endpoint to a relative sub-path under an allowed prefix, rejecting traversal
+	 * (`..`) and schemes (`:`). Commas are permitted since stats sub-paths legitimately contain
+	 * them (UTM params).
+	 *
+	 * The prefix is re-checked here, not just in the route regex: WP's `get_param()` prefers
+	 * GET/JSON/POST over the URL route capture, so a caller could otherwise shadow the matched
+	 * `endpoint` with `?endpoint=…` and escape the allowlist. This runs against the same
+	 * `get_param()` value the handler forwards, so it closes the hole whichever source wins.
 	 *
 	 * @param mixed $value Raw endpoint param.
 	 *
@@ -228,7 +233,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		return (bool) preg_match( '#^[\w.,/-]+$#', $value );
+		if ( ! preg_match( '#^[\w.,/-]+$#', $value ) ) {
+			return false;
+		}
+
+		return in_array( strtolower( explode( '/', $value )[0] ), self::ALLOWED_PREFIXES, true );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -326,8 +326,9 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private function build_data_path( string $endpoint ): string {
 		$site_id = (int) Jetpack_Options::get_option( 'id' );
 
-		// `upgrades` (purchases) is the one endpoint not scoped under `/sites/<id>/`.
-		if ( 'upgrades' === $endpoint ) {
+		// `upgrades` (purchases) is the one endpoint not scoped under `/sites/<id>/`. Match the
+		// trailing-slash variant the validator tolerates so it can't fall through to /sites/.
+		if ( 'upgrades' === rtrim( $endpoint, '/' ) ) {
 			return sprintf( '/upgrades?site=%d', $site_id );
 		}
 

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -71,34 +71,47 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private const FORWARDED_HEADERS = array( 'x-wp-total', 'x-wp-totalpages' );
 
 	/**
-	 * Top-level resource groups the data proxy may reach under `/sites/<id>/` (plus the
-	 * site-less `upgrades`). This is the security boundary: the route only matches these
-	 * prefixes, so the blog token can never be driven against the whole WPCOM site API.
+	 * Per-prefix configuration — the single source of truth for everything the proxy needs to
+	 * know about a top-level resource group. The keys are also the security boundary: the route
+	 * only matches these prefixes, so the blog token can never be driven against the whole WPCOM
+	 * site API. Adding or changing an endpoint group is a one-entry edit here, not a sweep across
+	 * the permission / write / cache / path methods, all of which read from this table.
 	 *
-	 * @var string[]
-	 */
-	private const ALLOWED_PREFIXES = array(
-		'analytics',
-		'stats',
-		'wordads',
-		'subscribers',
-		'jetpack-stats',
-		'jetpack-stats-dashboard',
-		'commercial-classification',
-		'upgrades',
-	);
-
-	/**
-	 * Sub-paths the data proxy may reach with a non-GET (write) method. Everything else is
-	 * read-only — reads can only surface this site's own data, but writes are confined to the
-	 * few endpoints the dashboard legitimately mutates.
+	 * Per entry:
+	 *  - `capability` (string, required) Capability that grants access; `manage_options` always
+	 *                  grants too, so `analytics` (capability `manage_options`) stays admin-only.
+	 *  - `writes`     (string[])  Sub-paths a non-GET (POST) may reach. Trailing `/` = this prefix
+	 *                  and any sub-path; no trailing `/` = that exact endpoint only. Absent =
+	 *                  read-only.
+	 *  - `cache_bust` (bool)      Whether a successful write invalidates the matching read cache.
+	 *  - `path`       (string)    A printf template (`%d` = blog ID) for endpoints not scoped under
+	 *                  `/sites/<id>/` (e.g. `upgrades`). A prefix with a fixed `path` takes no
+	 *                  sub-path. Absent = `/sites/<id>/<endpoint>`.
 	 *
-	 * @var string[]
+	 * @var array<string, array<string, mixed>>
 	 */
-	private const WRITE_PREFIXES = array(
-		'jetpack-stats-dashboard/',
-		'commercial-classification',
-		'stats/referrers/spam/',
+	private const PREFIX_CONFIG = array(
+		'analytics'                 => array( 'capability' => 'manage_options' ),
+		'stats'                     => array(
+			'capability' => 'view_stats',
+			'writes'     => array( 'stats/referrers/spam/' ),
+		),
+		'wordads'                   => array( 'capability' => 'activate_wordads' ),
+		'subscribers'               => array( 'capability' => 'view_stats' ),
+		'jetpack-stats'             => array( 'capability' => 'view_stats' ),
+		'jetpack-stats-dashboard'   => array(
+			'capability' => 'view_stats',
+			'writes'     => array( 'jetpack-stats-dashboard/' ),
+			'cache_bust' => true,
+		),
+		'commercial-classification' => array(
+			'capability' => 'view_stats',
+			'writes'     => array( 'commercial-classification' ),
+		),
+		'upgrades'                  => array(
+			'capability' => 'view_stats',
+			'path'       => '/upgrades?site=%d',
+		),
 	);
 
 	/**
@@ -153,7 +166,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Regex alternation of the allowed prefixes, used to anchor the data route.
+	 * Regex alternation of the allowed prefixes (the {@see PREFIX_CONFIG} keys), used to anchor
+	 * the data route.
 	 *
 	 * @return string
 	 */
@@ -164,60 +178,41 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				static function ( string $prefix ): string {
 					return preg_quote( $prefix, '#' );
 				},
-				self::ALLOWED_PREFIXES
+				array_keys( self::PREFIX_CONFIG )
 			)
 		);
 	}
 
 	/**
-	 * Permission for the data proxy: analytics needs `manage_options`, WordAds needs the WordAds
-	 * capability, and the rest the general stats capability.
+	 * The {@see PREFIX_CONFIG} entry for an endpoint's top-level prefix, or null if not allowed.
+	 *
+	 * @param string $endpoint The endpoint value (`get_param('endpoint')`).
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function config_for( string $endpoint ): ?array {
+		$prefix = strtolower( explode( '/', $endpoint )[0] );
+
+		return self::PREFIX_CONFIG[ $prefix ] ?? null;
+	}
+
+	/**
+	 * Permission for the data proxy: the prefix's configured capability grants access, and
+	 * `manage_options` always does (so `analytics`, whose capability is `manage_options`, stays
+	 * admin-only). The capability comes from {@see PREFIX_CONFIG}.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return bool
 	 */
 	public function check_data_permission( WP_REST_Request $request ): bool {
-		// WordPress matches REST routes case-insensitively, so classify case-insensitively too.
-		$endpoint = strtolower( (string) $request->get_param( 'endpoint' ) );
-
-		if ( str_starts_with( $endpoint, 'analytics' ) ) {
-			return $this->check_permission();
+		$config = $this->config_for( (string) $request->get_param( 'endpoint' ) );
+		if ( null === $config ) {
+			return false;
 		}
 
-		if ( str_starts_with( $endpoint, 'wordads' ) ) {
-			return $this->check_wordads_permission();
-		}
-
-		return $this->check_stats_permission();
-	}
-
-	/**
-	 * Only site administrators may reach the premium analytics data.
-	 *
-	 * @return bool
-	 */
-	public function check_permission(): bool {
-		return current_user_can( 'manage_options' );
-	}
-
-	/**
-	 * Administrators, or users who can view stats, may reach the Stats data.
-	 *
-	 * @return bool
-	 */
-	public function check_stats_permission(): bool {
-		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
-	}
-
-	/**
-	 * Administrators, or users who can manage WordAds, may reach the WordAds data.
-	 *
-	 * @return bool
-	 */
-	public function check_wordads_permission(): bool {
-		// phpcs:ignore WordPress.WP.Capabilities.Unknown
-		return current_user_can( 'manage_options' ) || current_user_can( 'activate_wordads' );
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- capability is from the PREFIX_CONFIG allowlist.
+		return current_user_can( 'manage_options' ) || current_user_can( $config['capability'] );
 	}
 
 	/**
@@ -245,15 +240,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		$prefix = strtolower( explode( '/', $value )[0] );
-		if ( ! in_array( $prefix, self::ALLOWED_PREFIXES, true ) ) {
+		$config = $this->config_for( $value );
+		if ( null === $config ) {
 			return false;
 		}
 
-		// `upgrades` is the site-less purchases endpoint — it takes no sub-path, so reject
-		// `upgrades/<anything>` (which build_data_path() would otherwise mis-route under /sites/).
-		if ( 'upgrades' === $prefix && 'upgrades' !== rtrim( strtolower( $value ), '/' ) ) {
-			return false;
+		// A prefix with a fixed `path` (e.g. site-less `upgrades`) takes no sub-path, so reject
+		// `<prefix>/<anything>` — build_data_path() ignores sub-paths there and would mis-route.
+		if ( isset( $config['path'] ) ) {
+			$prefix = strtolower( explode( '/', $value )[0] );
+			if ( $prefix !== rtrim( strtolower( $value ), '/' ) ) {
+				return false;
+			}
 		}
 
 		return true;
@@ -326,17 +324,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private function build_data_path( string $endpoint ): string {
 		$site_id = (int) Jetpack_Options::get_option( 'id' );
 
-		// `upgrades` (purchases) is the one endpoint not scoped under `/sites/<id>/`. Match the
-		// trailing-slash variant the validator tolerates so it can't fall through to /sites/.
-		if ( 'upgrades' === rtrim( $endpoint, '/' ) ) {
-			return sprintf( '/upgrades?site=%d', $site_id );
+		// A prefix with a fixed `path` (e.g. site-less `upgrades`) is not scoped under /sites/<id>/.
+		$config = $this->config_for( $endpoint );
+		if ( null !== $config && isset( $config['path'] ) ) {
+			return sprintf( $config['path'], $site_id );
 		}
 
 		return sprintf( '/sites/%d/%s', $site_id, $endpoint );
 	}
 
 	/**
-	 * Whether a non-GET method may be forwarded for this endpoint.
+	 * Whether a non-GET method may be forwarded for this endpoint, per the prefix's `writes`.
+	 * A `writes` entry ending in `/` matches that sub-path prefix; otherwise it matches exactly.
 	 *
 	 * @param string $endpoint The validated sub-path.
 	 *
@@ -344,12 +343,13 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function is_write_allowed( string $endpoint ): bool {
 		$endpoint = strtolower( $endpoint );
-		foreach ( self::WRITE_PREFIXES as $prefix ) {
-			// Honor the WRITE_PREFIXES convention: a trailing slash means "this prefix and any
-			// sub-path"; no trailing slash means "this exact endpoint only".
-			$matches = str_ends_with( $prefix, '/' )
-				? str_starts_with( $endpoint, $prefix )
-				: $endpoint === $prefix;
+		$config   = $this->config_for( $endpoint );
+
+		foreach ( $config['writes'] ?? array() as $matcher ) {
+			$matcher = strtolower( $matcher );
+			$matches = str_ends_with( $matcher, '/' )
+				? str_starts_with( $endpoint, $matcher )
+				: $endpoint === $matcher;
 			if ( $matches ) {
 				return true;
 			}
@@ -366,7 +366,9 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return bool
 	 */
 	private function busts_cache( string $endpoint ): bool {
-		return str_starts_with( strtolower( $endpoint ), 'jetpack-stats-dashboard/' );
+		$config = $this->config_for( $endpoint );
+
+		return ! empty( $config['cache_bust'] );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -204,7 +204,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return bool
 	 */
 	public function check_data_permission( WP_REST_Request $request ): bool {
-		if ( str_starts_with( (string) $request->get_param( 'endpoint' ), 'wordads' ) ) {
+		// WordPress matches REST routes case-insensitively, so classify case-insensitively too.
+		if ( str_starts_with( strtolower( (string) $request->get_param( 'endpoint' ) ), 'wordads' ) ) {
 			return $this->check_wordads_permission();
 		}
 
@@ -304,8 +305,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function handle_data_request( WP_REST_Request $request ) {
 		$endpoint = (string) $request->get_param( 'endpoint' );
+		$method   = strtoupper( $request->get_method() );
 
-		if ( 'GET' !== strtoupper( $request->get_method() ) && ! $this->is_write_allowed( $endpoint ) ) {
+		// Reads are open across the allowed prefixes; only POST may mutate, and only the
+		// few endpoints on the write allowlist. Everything else is rejected locally.
+		if ( 'GET' !== $method && ! ( 'POST' === $method && $this->is_write_allowed( $endpoint ) ) ) {
 			return new WP_Error(
 				'rest_read_only',
 				__( 'This endpoint is read-only.', 'jetpack-premium-analytics' ),
@@ -353,6 +357,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return bool
 	 */
 	private function is_write_allowed( string $endpoint ): bool {
+		$endpoint = strtolower( $endpoint );
 		foreach ( self::WRITE_PREFIXES as $prefix ) {
 			if ( $endpoint === $prefix || str_starts_with( $endpoint, $prefix ) ) {
 				return true;
@@ -370,7 +375,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return bool
 	 */
 	private function busts_cache( string $endpoint ): bool {
-		return str_starts_with( $endpoint, 'jetpack-stats-dashboard/' );
+		return str_starts_with( strtolower( $endpoint ), 'jetpack-stats-dashboard/' );
 	}
 
 	/**
@@ -564,8 +569,9 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Query params to forward to WPCOM, minus the WordPress routing params and the proxy's own
-	 * control param (`version`).
+	 * Query params to forward to WPCOM, minus the WordPress routing params, the proxy's own
+	 * control param (`version`), and `site` (the proxy pins the site itself, so a caller-supplied
+	 * `site` must not reach the `upgrades` query string).
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -573,8 +579,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		// Drop the params WordPress adds for its own routing, plus the proxy's own version selector.
-		unset( $params['rest_route'], $params['_locale'], $params['version'] );
+		unset( $params['rest_route'], $params['_locale'], $params['version'], $params['site'] );
 
 		return is_array( $params ) ? $params : array();
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -23,10 +23,13 @@ use WP_REST_Server;
  * WordPress origin.
  *
  * Two route families share one forwarding core:
- *  - the analytics catch-all (`proxy/<endpoint>` → `/sites/<id>/analytics/<endpoint>`); and
- *  - the Stats routes (declared in {@see get_stats_routes()}), which re-expose the
- *    `stats-admin` package's WPCOM pass-through endpoints under this namespace, minus the
- *    blog ID in the URL.
+ *  - the analytics catch-all (`proxy/<endpoint>` → `/sites/<id>/analytics/<endpoint>`, v2); and
+ *  - an agnostic data proxy that re-exposes the `stats-admin` package's WPCOM pass-through
+ *    endpoints under this namespace, minus the blog ID in the URL. Rather than registering
+ *    each endpoint, it accepts any sub-path under an allowed top-level prefix (see
+ *    {@see ALLOWED_PREFIXES}) and lets the caller pick the WPCOM API `version`; the proxy
+ *    stays endpoint-agnostic while the prefix allowlist + write policy keep the blast radius
+ *    of the blog token bounded.
  */
 class Api_Proxy_Controller extends WP_REST_Controller {
 
@@ -65,6 +68,36 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private const FORWARDED_HEADERS = array( 'x-wp-total', 'x-wp-totalpages' );
 
 	/**
+	 * Top-level resource groups the data proxy may reach under `/sites/<id>/` (plus the
+	 * site-less `upgrades`). This is the security boundary: the route only matches these
+	 * prefixes, so the blog token can never be driven against the whole WPCOM site API.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_PREFIXES = array(
+		'stats',
+		'wordads',
+		'subscribers',
+		'jetpack-stats',
+		'jetpack-stats-dashboard',
+		'commercial-classification',
+		'upgrades',
+	);
+
+	/**
+	 * Sub-paths the data proxy may reach with a non-GET (write) method. Everything else is
+	 * read-only — reads can only surface this site's own data, but writes are confined to the
+	 * few endpoints the dashboard legitimately mutates.
+	 *
+	 * @var string[]
+	 */
+	private const WRITE_PREFIXES = array(
+		'jetpack-stats-dashboard/',
+		'commercial-classification',
+		'stats/referrers/spam/',
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -83,7 +116,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the analytics catch-all and the Stats pass-through routes.
+	 * Register the analytics catch-all and the agnostic data proxy.
 	 *
 	 * @return void
 	 */
@@ -111,117 +144,45 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			)
 		);
 
-		foreach ( $this->get_stats_routes() as $route ) {
-			$config = array(
-				'methods'             => $route['methods'],
-				'callback'            => function ( WP_REST_Request $request ) use ( $route ) {
-					return $this->handle_stats_request( $request, $route );
-				},
-				'permission_callback' => $this->permission_callback_for( $route['permission'] ?? 'stats' ),
-			);
-			if ( isset( $route['args'] ) ) {
-				$config['args'] = $route['args'];
-			}
-
-			register_rest_route( $this->namespace, '/' . $route['route'], $config );
-		}
-	}
-
-	/**
-	 * The Stats endpoints to re-expose, mirroring `stats-admin` minus the `/sites/<id>` URL
-	 * segment. Each entry is a thin description the shared forwarder turns into a WPCOM call:
-	 *
-	 *  - `route`      Relative route regex; `%s` captures (named `subpath`) act as whitelists.
-	 *  - `wpcom`      Path relative to `/sites/<id>/`; a `%s` is filled from the `subpath` param.
-	 *  - `build`      Optional callable( int $site_id ): string for paths not under `/sites/<id>/`.
-	 *  - `methods`    Allowed HTTP verbs (defaults handled per entry).
-	 *  - `version`    WPCOM API version. Defaults to '2'.
-	 *  - `base`       WPCOM API base ('rest' | 'wpcom'). Defaults to 'wpcom'.
-	 *  - `permission` 'stats' (default) or 'wordads'.
-	 *  - `cache`      Whether GET responses may be cached. Defaults to true.
-	 *
-	 * The single `stats/(?P<subpath>.+)` route absorbs every `/sites/<id>/stats/*` endpoint
-	 * (per-resource stats, single post/video, email stats, UTM, devices, location views, and
-	 * referrer-spam list/new/delete) the same way the analytics catch-all works.
-	 *
-	 * @return array<int, array<string, mixed>>
-	 */
-	private function get_stats_routes(): array {
-		$read  = WP_REST_Server::READABLE;
-		$write = WP_REST_Server::EDITABLE;
-
-		return array(
+		register_rest_route(
+			$this->namespace,
+			'/(?P<endpoint>(?:' . $this->allowed_prefix_pattern() . ')(?:/.*)?)',
 			array(
-				'route'   => 'stats',
-				'wpcom'   => 'stats',
-				'methods' => $read,
-				'version' => '1.1',
-				'base'    => 'rest',
-			),
-			array(
-				'route'   => 'stats/(?P<subpath>.+)',
-				'wpcom'   => 'stats/%s',
-				'methods' => $read . ',' . $write,
-				'version' => '1.1',
-				'base'    => 'rest',
-				'args'    => array(
-					'subpath' => array(
-						'validate_callback' => array( $this, 'validate_subpath' ),
+				'methods'             => WP_REST_Server::READABLE . ',' . WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'handle_data_request' ),
+				'permission_callback' => array( $this, 'check_data_permission' ),
+				'args'                => array(
+					'endpoint' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => array( $this, 'validate_data_endpoint' ),
+					),
+					'version'  => array(
+						'description'       => __( 'WPCOM API version to forward to (e.g. 1.1, 1.2, 2).', 'jetpack-premium-analytics' ),
+						'type'              => 'string',
+						'default'           => '2',
+						'validate_callback' => array( $this, 'validate_version' ),
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
-			),
-			array(
-				'route'   => 'subscribers/counts',
-				'wpcom'   => 'subscribers/counts',
-				'methods' => $read,
-			),
-			array(
-				'route'   => 'site-has-never-published-post',
-				'wpcom'   => 'site-has-never-published-post',
-				'methods' => $read,
-			),
-			array(
-				'route'   => 'jetpack-stats/usage',
-				'wpcom'   => 'jetpack-stats/usage',
-				'methods' => $read,
-				'cache'   => false,
-			),
-			array(
-				'route'         => 'jetpack-stats-dashboard/modules',
-				'wpcom'         => 'jetpack-stats-dashboard/modules',
-				'methods'       => $read . ',' . $write,
-				'bust_on_write' => true,
-			),
-			array(
-				'route'         => 'jetpack-stats-dashboard/module-settings',
-				'wpcom'         => 'jetpack-stats-dashboard/module-settings',
-				'methods'       => $read . ',' . $write,
-				'bust_on_write' => true,
-			),
-			array(
-				'route'   => 'commercial-classification',
-				'wpcom'   => 'commercial-classification',
-				'methods' => $write,
-			),
-			array(
-				'route'      => 'wordads/(?P<subpath>earnings|stats)',
-				'wpcom'      => 'wordads/%s',
-				'methods'    => $read,
-				'version'    => '1.1',
-				'base'       => 'rest',
-				'permission' => 'wordads',
-			),
-			array(
-				'route'   => 'purchases',
-				'methods' => $read,
-				'version' => '1.2',
-				'base'    => 'rest',
-				'cache'   => false,
-				'build'   => static function ( int $site_id ): string {
-					return sprintf( '/upgrades?site=%d', $site_id );
+			)
+		);
+	}
+
+	/**
+	 * Regex alternation of the allowed prefixes, used to anchor the data route.
+	 *
+	 * @return string
+	 */
+	private function allowed_prefix_pattern(): string {
+		return implode(
+			'|',
+			array_map(
+				static function ( string $prefix ): string {
+					return preg_quote( $prefix, '#' );
 				},
-			),
+				self::ALLOWED_PREFIXES
+			)
 		);
 	}
 
@@ -232,6 +193,22 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Permission for the data proxy: WordAds endpoints need the WordAds capability, the rest
+	 * the general stats capability.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return bool
+	 */
+	public function check_data_permission( WP_REST_Request $request ): bool {
+		if ( str_starts_with( (string) $request->get_param( 'endpoint' ), 'wordads' ) ) {
+			return $this->check_wordads_permission();
+		}
+
+		return $this->check_stats_permission();
 	}
 
 	/**
@@ -254,22 +231,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Map a route's permission key to its callback.
-	 *
-	 * @param string $permission Permission key ('stats' | 'wordads').
-	 *
-	 * @return callable
-	 */
-	private function permission_callback_for( string $permission ): callable {
-		if ( 'wordads' === $permission ) {
-			return array( $this, 'check_wordads_permission' );
-		}
-
-		return array( $this, 'check_stats_permission' );
-	}
-
-	/**
-	 * Confine the endpoint to a relative analytics sub-path so it cannot escape the
+	 * Confine the analytics endpoint to a relative sub-path so it cannot escape the
 	 * `/sites/<id>/analytics/` prefix via traversal (`..`), an absolute path, or a scheme.
 	 *
 	 * @param mixed $value Raw endpoint param.
@@ -287,22 +249,33 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Confine a Stats sub-path to a relative segment so it cannot escape `/sites/<id>/stats/`
-	 * via traversal (`..`) or an absolute path. Broader than {@see validate_endpoint()}, since
-	 * Stats sub-paths legitimately contain commas (e.g. the UTM params list).
+	 * Confine a data endpoint to a relative sub-path, rejecting traversal (`..`). Broader than
+	 * {@see validate_endpoint()} since stats sub-paths legitimately contain commas (UTM params).
+	 * The allowed top-level prefix is already enforced by the route regex.
 	 *
-	 * @param mixed $value Raw subpath param.
+	 * @param mixed $value Raw endpoint param.
 	 *
 	 * @return bool
 	 */
-	public function validate_subpath( $value ): bool {
+	public function validate_data_endpoint( $value ): bool {
 		$value = (string) $value;
 
-		if ( '' === $value || str_starts_with( $value, '/' ) || str_contains( $value, '..' ) ) {
+		if ( str_contains( $value, '..' ) ) {
 			return false;
 		}
 
 		return (bool) preg_match( '#^[\w.,/-]+$#', $value );
+	}
+
+	/**
+	 * A WPCOM API version is one or two dot-separated numbers (e.g. `2`, `1.1`).
+	 *
+	 * @param mixed $value Raw version param.
+	 *
+	 * @return bool
+	 */
+	public function validate_version( $value ): bool {
+		return (bool) preg_match( '#^[0-9]+(\.[0-9]+)?$#', (string) $value );
 	}
 
 	/**
@@ -323,47 +296,81 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Proxy a declared Stats route to its WPCOM endpoint.
+	 * Proxy a data request to its WPCOM endpoint, at the caller-chosen API version.
 	 *
-	 * @param WP_REST_Request      $request Request object.
-	 * @param array<string, mixed> $route   The matched route description.
+	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function handle_stats_request( WP_REST_Request $request, array $route ) {
+	public function handle_data_request( WP_REST_Request $request ) {
+		$endpoint = (string) $request->get_param( 'endpoint' );
+
+		if ( 'GET' !== strtoupper( $request->get_method() ) && ! $this->is_write_allowed( $endpoint ) ) {
+			return new WP_Error(
+				'rest_read_only',
+				__( 'This endpoint is read-only.', 'jetpack-premium-analytics' ),
+				array( 'status' => 405 )
+			);
+		}
+
+		$version = (string) $request->get_param( 'version' );
+
 		return $this->forward(
 			$request,
-			$this->build_stats_path( $request, $route ),
+			$this->build_data_path( $endpoint ),
 			array(
-				'version'       => $route['version'] ?? '2',
-				'base'          => $route['base'] ?? 'wpcom',
-				'cache'         => $route['cache'] ?? true,
-				'bust_on_write' => $route['bust_on_write'] ?? false,
+				// WPCOM exposes v2 under the `wpcom` base and v1.x under the `rest` base.
+				'version'       => $version,
+				'base'          => '2' === $version ? 'wpcom' : 'rest',
+				'bust_on_write' => $this->busts_cache( $endpoint ),
 			)
 		);
 	}
 
 	/**
-	 * Resolve a Stats route to its WPCOM path (without the forwarded query string).
+	 * Build the WPCOM path for a data endpoint.
 	 *
-	 * @param WP_REST_Request      $request Request object.
-	 * @param array<string, mixed> $route   The matched route description.
+	 * @param string $endpoint The validated, allowed sub-path.
 	 *
 	 * @return string
 	 */
-	private function build_stats_path( WP_REST_Request $request, array $route ): string {
+	private function build_data_path( string $endpoint ): string {
 		$site_id = (int) Jetpack_Options::get_option( 'id' );
 
-		if ( isset( $route['build'] ) ) {
-			return ( $route['build'] )( $site_id );
+		// `upgrades` (purchases) is the one endpoint not scoped under `/sites/<id>/`.
+		if ( 'upgrades' === $endpoint ) {
+			return sprintf( '/upgrades?site=%d', $site_id );
 		}
 
-		$relative = $route['wpcom'] ?? '';
-		if ( str_contains( $relative, '%s' ) ) {
-			$relative = sprintf( $relative, (string) $request->get_param( 'subpath' ) );
+		return sprintf( '/sites/%d/%s', $site_id, $endpoint );
+	}
+
+	/**
+	 * Whether a non-GET method may be forwarded for this endpoint.
+	 *
+	 * @param string $endpoint The validated sub-path.
+	 *
+	 * @return bool
+	 */
+	private function is_write_allowed( string $endpoint ): bool {
+		foreach ( self::WRITE_PREFIXES as $prefix ) {
+			if ( $endpoint === $prefix || str_starts_with( $endpoint, $prefix ) ) {
+				return true;
+			}
 		}
 
-		return sprintf( '/sites/%d/%s', $site_id, $relative );
+		return false;
+	}
+
+	/**
+	 * Whether a successful write to this endpoint should invalidate the matching read cache.
+	 *
+	 * @param string $endpoint The validated sub-path.
+	 *
+	 * @return bool
+	 */
+	private function busts_cache( string $endpoint ): bool {
+		return str_starts_with( $endpoint, 'jetpack-stats-dashboard/' );
 	}
 
 	/**
@@ -371,7 +378,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request      $request    Request object.
 	 * @param string               $wpcom_path WPCOM path without the forwarded query string.
-	 * @param array<string, mixed> $opts       version | base | cache overrides.
+	 * @param array<string, mixed> $opts       version | base | bust_on_write | cache overrides.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
@@ -380,9 +387,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		$base      = $opts['base'] ?? 'wpcom';
 		$method    = strtoupper( $request->get_method() );
 		$is_read   = 'GET' === $method;
-		$cacheable = $is_read && ( $opts['cache'] ?? true );
+		$cacheable = $is_read
+			&& ( $opts['cache'] ?? true )
+			&& null === $request->get_param( 'force_refresh' );
 
-		$cache_key = $cacheable ? $this->get_cache_key( $request, $wpcom_path ) : null;
+		$cache_key = $cacheable ? $this->cache_key_for( $wpcom_path, $version, $base, $this->get_forwarded_params( $request ) ) : null;
 		if ( null !== $cache_key ) {
 			$cached = get_transient( $cache_key );
 			if ( false !== $cached ) {
@@ -434,14 +443,14 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 
 		// Mirror stats-admin: a successful write invalidates the matching (param-less) read cache.
 		if ( ! $is_read && ( $opts['bust_on_write'] ?? false ) && 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
-			delete_transient( $this->cache_key_for( $wpcom_path, array() ) );
+			delete_transient( $this->cache_key_for( $wpcom_path, $version, $base, array() ) );
 		}
 
 		return $this->cache_and_build_response( $response, $cache_key );
 	}
 
 	/**
-	 * Schema for the proxy endpoint.
+	 * Schema for the analytics proxy endpoint.
 	 *
 	 * @return array
 	 */
@@ -555,7 +564,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Query params to forward to WPCOM, minus the WordPress routing params.
+	 * Query params to forward to WPCOM, minus the WordPress routing params and the proxy's own
+	 * control param (`version`).
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -563,35 +573,26 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		// Drop the params WordPress adds for its own routing — they're meaningless to WPCOM.
-		unset( $params['rest_route'], $params['_locale'] );
+		// Drop the params WordPress adds for its own routing, plus the proxy's own version selector.
+		unset( $params['rest_route'], $params['_locale'], $params['version'] );
 
 		return is_array( $params ) ? $params : array();
 	}
 
 	/**
-	 * Build the transient key from the request signature (target path + forwarded params).
-	 *
-	 * @param WP_REST_Request $request    Request object.
-	 * @param string          $wpcom_path WPCOM path without the forwarded query string.
-	 *
-	 * @return string
-	 */
-	private function get_cache_key( WP_REST_Request $request, string $wpcom_path ): string {
-		return $this->cache_key_for( $wpcom_path, $this->get_forwarded_params( $request ) );
-	}
-
-	/**
-	 * Transient key for a target path and a set of forwarded params (order-independent).
+	 * Transient key for a target path + API version/base + forwarded params (order-independent).
+	 * Version and base are part of the key so the same path at different versions doesn't collide.
 	 *
 	 * @param string $wpcom_path WPCOM path without the forwarded query string.
+	 * @param string $version    WPCOM API version.
+	 * @param string $base       WPCOM API base.
 	 * @param array  $params     Forwarded query params.
 	 *
 	 * @return string
 	 */
-	private function cache_key_for( string $wpcom_path, array $params ): string {
+	private function cache_key_for( string $wpcom_path, string $version, string $base, array $params ): string {
 		ksort( $params );
-		$signature = $wpcom_path . '|' . (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES );
+		$signature = implode( '|', array( $wpcom_path, $version, $base, (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES ) ) );
 
 		return self::CACHE_PREFIX . md5( $signature );
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -22,14 +22,12 @@ use WP_REST_Server;
  * it. Lets the extracted frontend's data layer talk to WPCOM without each call leaving the
  * WordPress origin.
  *
- * Two route families share one forwarding core:
- *  - the analytics catch-all (`proxy/<endpoint>` → `/sites/<id>/analytics/<endpoint>`, v2); and
- *  - an agnostic data proxy that re-exposes the `stats-admin` package's WPCOM pass-through
- *    endpoints under this namespace, minus the blog ID in the URL. Rather than registering
- *    each endpoint, it accepts any sub-path under an allowed top-level prefix (see
- *    {@see ALLOWED_PREFIXES}) and lets the caller pick the WPCOM API `version`; the proxy
- *    stays endpoint-agnostic while the prefix allowlist + write policy keep the blast radius
- *    of the blog token bounded.
+ * One agnostic route serves the whole surface (analytics + the re-exposed `stats-admin`
+ * endpoints), minus the blog ID in the URL. Rather than registering each endpoint, it
+ * accepts any sub-path under an allowed top-level prefix (see {@see ALLOWED_PREFIXES}) and
+ * lets the caller pick the WPCOM API `version` (the base is derived: v2 → wpcom, v1.x →
+ * rest). The proxy stays endpoint-agnostic while the prefix allowlist + write-method policy
+ * keep the blast radius of the blog token bounded.
  */
 class Api_Proxy_Controller extends WP_REST_Controller {
 
@@ -75,6 +73,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @var string[]
 	 */
 	private const ALLOWED_PREFIXES = array(
+		'analytics',
 		'stats',
 		'wordads',
 		'subscribers',
@@ -102,7 +101,6 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->namespace = self::SLUG . '/v1';
-		$this->rest_base = 'proxy';
 	}
 
 	/**
@@ -116,34 +114,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the analytics catch-all and the agnostic data proxy.
+	 * Register the agnostic data proxy route.
 	 *
 	 * @return void
 	 */
 	public function register_routes(): void {
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<endpoint>.*)',
-			array(
-				array(
-					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'handle_proxy_request' ),
-					'permission_callback' => array( $this, 'check_permission' ),
-					'args'                => array(
-						'endpoint' => array(
-							'description'       => __( 'The analytics sub-path to proxy.', 'jetpack-premium-analytics' ),
-							'type'              => 'string',
-							'required'          => true,
-							'validate_callback' => array( $this, 'validate_endpoint' ),
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
 		register_rest_route(
 			$this->namespace,
 			'/(?P<endpoint>(?:' . $this->allowed_prefix_pattern() . ')(?:/.*)?)',
@@ -187,17 +162,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Only site administrators may reach the analytics data.
-	 *
-	 * @return bool
-	 */
-	public function check_permission(): bool {
-		return current_user_can( 'manage_options' );
-	}
-
-	/**
-	 * Permission for the data proxy: WordAds endpoints need the WordAds capability, the rest
-	 * the general stats capability.
+	 * Permission for the data proxy: analytics needs `manage_options`, WordAds needs the WordAds
+	 * capability, and the rest the general stats capability.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -205,11 +171,26 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function check_data_permission( WP_REST_Request $request ): bool {
 		// WordPress matches REST routes case-insensitively, so classify case-insensitively too.
-		if ( str_starts_with( strtolower( (string) $request->get_param( 'endpoint' ) ), 'wordads' ) ) {
+		$endpoint = strtolower( (string) $request->get_param( 'endpoint' ) );
+
+		if ( str_starts_with( $endpoint, 'analytics' ) ) {
+			return $this->check_permission();
+		}
+
+		if ( str_starts_with( $endpoint, 'wordads' ) ) {
 			return $this->check_wordads_permission();
 		}
 
 		return $this->check_stats_permission();
+	}
+
+	/**
+	 * Only site administrators may reach the premium analytics data.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -232,27 +213,9 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Confine the analytics endpoint to a relative sub-path so it cannot escape the
-	 * `/sites/<id>/analytics/` prefix via traversal (`..`), an absolute path, or a scheme.
-	 *
-	 * @param mixed $value Raw endpoint param.
-	 *
-	 * @return bool
-	 */
-	public function validate_endpoint( $value ): bool {
-		$value = (string) $value;
-
-		if ( str_starts_with( $value, '/' ) || str_contains( $value, '..' ) || str_contains( $value, ':' ) ) {
-			return false;
-		}
-
-		return (bool) preg_match( '#^[A-Za-z0-9._/-]+$#', $value );
-	}
-
-	/**
-	 * Confine a data endpoint to a relative sub-path, rejecting traversal (`..`). Broader than
-	 * {@see validate_endpoint()} since stats sub-paths legitimately contain commas (UTM params).
-	 * The allowed top-level prefix is already enforced by the route regex.
+	 * Confine a data endpoint to a relative sub-path, rejecting traversal (`..`) and schemes
+	 * (`:`). The allowed top-level prefix is already enforced by the route regex; commas are
+	 * permitted since stats sub-paths legitimately contain them (UTM params).
 	 *
 	 * @param mixed $value Raw endpoint param.
 	 *
@@ -277,23 +240,6 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	public function validate_version( $value ): bool {
 		return (bool) preg_match( '#^[0-9]+(\.[0-9]+)?$#', (string) $value );
-	}
-
-	/**
-	 * Proxy the analytics catch-all to `/sites/<id>/analytics/<endpoint>`.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function handle_proxy_request( WP_REST_Request $request ) {
-		$path = sprintf(
-			'/sites/%d/analytics/%s',
-			(int) Jetpack_Options::get_option( 'id' ),
-			(string) $request->get_param( 'endpoint' )
-		);
-
-		return $this->forward( $request, $path, array() );
 	}
 
 	/**
@@ -452,29 +398,6 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		}
 
 		return $this->cache_and_build_response( $response, $cache_key );
-	}
-
-	/**
-	 * Schema for the analytics proxy endpoint.
-	 *
-	 * @return array
-	 */
-	public function get_item_schema(): array {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'proxy',
-			'type'       => 'object',
-			'properties' => array(
-				'endpoint' => array(
-					'description' => __( 'The remote analytics endpoint to proxy.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'required'    => true,
-				),
-			),
-		);
-
-		return $this->add_additional_fields_schema( $schema );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -212,8 +212,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			return false;
 		}
 
+		// Fall back to `do_not_allow` so a config entry missing `capability` fails closed.
+		$capability = $config['capability'] ?? 'do_not_allow';
+
 		// phpcs:ignore WordPress.WP.Capabilities.Unknown -- capability is from the PREFIX_CONFIG allowlist.
-		return current_user_can( 'manage_options' ) || current_user_can( $config['capability'] );
+		return current_user_can( 'manage_options' ) || current_user_can( $capability );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -112,17 +112,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		);
 
 		foreach ( $this->get_stats_routes() as $route ) {
-			register_rest_route(
-				$this->namespace,
-				'/' . $route['route'],
-				array(
-					'methods'             => $route['methods'],
-					'callback'            => function ( WP_REST_Request $request ) use ( $route ) {
-						return $this->handle_stats_request( $request, $route );
-					},
-					'permission_callback' => $this->permission_callback_for( $route['permission'] ?? 'stats' ),
-				)
+			$config = array(
+				'methods'             => $route['methods'],
+				'callback'            => function ( WP_REST_Request $request ) use ( $route ) {
+					return $this->handle_stats_request( $request, $route );
+				},
+				'permission_callback' => $this->permission_callback_for( $route['permission'] ?? 'stats' ),
 			);
+			if ( isset( $route['args'] ) ) {
+				$config['args'] = $route['args'];
+			}
+
+			register_rest_route( $this->namespace, '/' . $route['route'], $config );
 		}
 	}
 
@@ -163,6 +164,12 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				'methods' => $read . ',' . $write,
 				'version' => '1.1',
 				'base'    => 'rest',
+				'args'    => array(
+					'subpath' => array(
+						'validate_callback' => array( $this, 'validate_subpath' ),
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
 			),
 			array(
 				'route'   => 'subscribers/counts',
@@ -181,14 +188,16 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				'cache'   => false,
 			),
 			array(
-				'route'   => 'jetpack-stats-dashboard/modules',
-				'wpcom'   => 'jetpack-stats-dashboard/modules',
-				'methods' => $read . ',' . $write,
+				'route'         => 'jetpack-stats-dashboard/modules',
+				'wpcom'         => 'jetpack-stats-dashboard/modules',
+				'methods'       => $read . ',' . $write,
+				'bust_on_write' => true,
 			),
 			array(
-				'route'   => 'jetpack-stats-dashboard/module-settings',
-				'wpcom'   => 'jetpack-stats-dashboard/module-settings',
-				'methods' => $read . ',' . $write,
+				'route'         => 'jetpack-stats-dashboard/module-settings',
+				'wpcom'         => 'jetpack-stats-dashboard/module-settings',
+				'methods'       => $read . ',' . $write,
+				'bust_on_write' => true,
 			),
 			array(
 				'route'   => 'commercial-classification',
@@ -278,6 +287,25 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Confine a Stats sub-path to a relative segment so it cannot escape `/sites/<id>/stats/`
+	 * via traversal (`..`) or an absolute path. Broader than {@see validate_endpoint()}, since
+	 * Stats sub-paths legitimately contain commas (e.g. the UTM params list).
+	 *
+	 * @param mixed $value Raw subpath param.
+	 *
+	 * @return bool
+	 */
+	public function validate_subpath( $value ): bool {
+		$value = (string) $value;
+
+		if ( '' === $value || str_starts_with( $value, '/' ) || str_contains( $value, '..' ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '#^[\w.,/-]+$#', $value );
+	}
+
+	/**
 	 * Proxy the analytics catch-all to `/sites/<id>/analytics/<endpoint>`.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -307,9 +335,10 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			$request,
 			$this->build_stats_path( $request, $route ),
 			array(
-				'version' => $route['version'] ?? '2',
-				'base'    => $route['base'] ?? 'wpcom',
-				'cache'   => $route['cache'] ?? true,
+				'version'       => $route['version'] ?? '2',
+				'base'          => $route['base'] ?? 'wpcom',
+				'cache'         => $route['cache'] ?? true,
+				'bust_on_write' => $route['bust_on_write'] ?? false,
 			)
 		);
 	}
@@ -329,7 +358,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			return ( $route['build'] )( $site_id );
 		}
 
-		$relative = $route['wpcom'];
+		$relative = $route['wpcom'] ?? '';
 		if ( str_contains( $relative, '%s' ) ) {
 			$relative = sprintf( $relative, (string) $request->get_param( 'subpath' ) );
 		}
@@ -364,7 +393,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		if ( ! ( new Manager( self::SLUG ) )->is_connected() ) {
 			return new WP_Error(
 				'no_connection',
-				__( 'Please connect Jetpack to load analytics data.', 'jetpack-premium-analytics' ),
+				__( 'Please connect Jetpack to load your data.', 'jetpack-premium-analytics' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -390,7 +419,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		} catch ( \Exception $e ) {
 			return new WP_Error(
 				'api_error',
-				__( 'Error processing the analytics request.', 'jetpack-premium-analytics' ),
+				__( 'Error processing the request.', 'jetpack-premium-analytics' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -398,9 +427,14 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
 				'api_error',
-				__( 'Error communicating with the analytics service.', 'jetpack-premium-analytics' ),
+				__( 'Error communicating with the data service.', 'jetpack-premium-analytics' ),
 				array( 'status' => 500 )
 			);
+		}
+
+		// Mirror stats-admin: a successful write invalidates the matching (param-less) read cache.
+		if ( ! $is_read && ( $opts['bust_on_write'] ?? false ) && 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
+			delete_transient( $this->cache_key_for( $wpcom_path, array() ) );
 		}
 
 		return $this->cache_and_build_response( $response, $cache_key );
@@ -445,7 +479,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		if ( 200 === $status && null === $data && JSON_ERROR_NONE !== json_last_error() ) {
 			return new WP_Error(
 				'api_error',
-				__( 'The analytics service returned an unreadable response.', 'jetpack-premium-analytics' ),
+				__( 'The data service returned an unreadable response.', 'jetpack-premium-analytics' ),
 				array( 'status' => 502 )
 			);
 		}
@@ -544,7 +578,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_cache_key( WP_REST_Request $request, string $wpcom_path ): string {
-		$params = $this->get_forwarded_params( $request );
+		return $this->cache_key_for( $wpcom_path, $this->get_forwarded_params( $request ) );
+	}
+
+	/**
+	 * Transient key for a target path and a set of forwarded params (order-independent).
+	 *
+	 * @param string $wpcom_path WPCOM path without the forwarded query string.
+	 * @param array  $params     Forwarded query params.
+	 *
+	 * @return string
+	 */
+	private function cache_key_for( string $wpcom_path, array $params ): string {
 		ksort( $params );
 		$signature = $wpcom_path . '|' . (string) wp_json_encode( $params, JSON_UNESCAPED_SLASHES );
 

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -22,12 +22,17 @@ use WP_REST_Server;
  * it. Lets the extracted frontend's data layer talk to WPCOM without each call leaving the
  * WordPress origin.
  *
- * One agnostic route serves the whole surface (analytics + the re-exposed `stats-admin`
- * endpoints), minus the blog ID in the URL. Rather than registering each endpoint, it
- * accepts any sub-path under an allowed top-level prefix (see {@see ALLOWED_PREFIXES}) and
- * lets the caller pick the WPCOM API `version` (the base is derived: v2 → wpcom, v1.x →
- * rest). The proxy stays endpoint-agnostic while the prefix allowlist + write-method policy
- * keep the blast radius of the blog token bounded.
+ * One agnostic route serves the whole pass-through surface (analytics + the re-exposed
+ * `stats-admin` endpoints), minus the blog ID in the URL:
+ *
+ *     proxy/v<version>/<prefix>/<subpath>   e.g. proxy/v1.1/wordads/earnings
+ *
+ * The `proxy/` segment marks a transparent WPCOM forward (future local endpoints live
+ * elsewhere under the namespace). Rather than registering each endpoint, it accepts any
+ * sub-path under an allowed top-level prefix (see {@see ALLOWED_PREFIXES}); the caller picks
+ * the WPCOM API `version` in the path (the base is derived: v2 → wpcom, v1.x → rest). The
+ * proxy stays endpoint-agnostic while the prefix allowlist + write-method policy keep the
+ * blast radius of the blog token bounded.
  */
 class Api_Proxy_Controller extends WP_REST_Controller {
 
@@ -119,9 +124,13 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @return void
 	 */
 	public function register_routes(): void {
+		// proxy/v<version>/<prefix>/<subpath> — the `proxy/` segment marks a transparent WPCOM
+		// pass-through (local endpoints live elsewhere under the namespace), the version is part
+		// of the path (matching WPCOM's own `rest/v1.1` / `wpcom/v2` structure), and the prefix
+		// allowlist is anchored into the route.
 		register_rest_route(
 			$this->namespace,
-			'/(?P<endpoint>(?:' . $this->allowed_prefix_pattern() . ')(?:/.*)?)',
+			'/proxy/v(?P<version>[0-9]+(?:\.[0-9]+)?)/(?P<endpoint>(?:' . $this->allowed_prefix_pattern() . ')(?:/.*)?)',
 			array(
 				'methods'             => WP_REST_Server::READABLE . ',' . WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'handle_data_request' ),
@@ -135,9 +144,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 					'version'  => array(
 						'description'       => __( 'WPCOM API version to forward to (e.g. 1.1, 1.2, 2).', 'jetpack-premium-analytics' ),
 						'type'              => 'string',
-						'default'           => '2',
+						'required'          => true,
 						'validate_callback' => array( $this, 'validate_version' ),
-						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
 			)
@@ -501,9 +509,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Query params to forward to WPCOM, minus the WordPress routing params, the proxy's own
-	 * control param (`version`), and `site` (the proxy pins the site itself, so a caller-supplied
-	 * `site` must not reach the `upgrades` query string).
+	 * Query params to forward to WPCOM, minus the WordPress routing params and `site` (the proxy
+	 * pins the site itself, so a caller-supplied `site` must not reach the `upgrades` query string).
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -511,7 +518,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		unset( $params['rest_route'], $params['_locale'], $params['version'], $params['site'] );
+		unset( $params['rest_route'], $params['_locale'], $params['site'] );
 
 		return is_array( $params ) ? $params : array();
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -29,10 +29,10 @@ use WP_REST_Server;
  *
  * The `proxy/` segment marks a transparent WPCOM forward (future local endpoints live
  * elsewhere under the namespace). Rather than registering each endpoint, it accepts any
- * sub-path under an allowed top-level prefix (see {@see ALLOWED_PREFIXES}); the caller picks
- * the WPCOM API `version` in the path (the base is derived: v2 → wpcom, v1.x → rest). The
- * proxy stays endpoint-agnostic while the prefix allowlist + write-method policy keep the
- * blast radius of the blog token bounded.
+ * sub-path under an allowed top-level prefix (see {@see PREFIX_CONFIG}); the caller picks the
+ * WPCOM API `version` in the path (the base is derived: v2 → wpcom, v1.x → rest). The proxy
+ * stays endpoint-agnostic while the prefix allowlist + write-method policy keep the blast
+ * radius of the blog token bounded.
  */
 class Api_Proxy_Controller extends WP_REST_Controller {
 
@@ -91,24 +91,25 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * @var array<string, array<string, mixed>>
 	 */
 	private const PREFIX_CONFIG = array(
-		'analytics'                 => array( 'capability' => 'manage_options' ),
-		'stats'                     => array(
+		'analytics'                     => array( 'capability' => 'manage_options' ),
+		'stats'                         => array(
 			'capability' => 'view_stats',
 			'writes'     => array( 'stats/referrers/spam/' ),
 		),
-		'wordads'                   => array( 'capability' => 'activate_wordads' ),
-		'subscribers'               => array( 'capability' => 'view_stats' ),
-		'jetpack-stats'             => array( 'capability' => 'view_stats' ),
-		'jetpack-stats-dashboard'   => array(
+		'wordads'                       => array( 'capability' => 'activate_wordads' ),
+		'subscribers'                   => array( 'capability' => 'view_stats' ),
+		'site-has-never-published-post' => array( 'capability' => 'view_stats' ),
+		'jetpack-stats'                 => array( 'capability' => 'view_stats' ),
+		'jetpack-stats-dashboard'       => array(
 			'capability' => 'view_stats',
 			'writes'     => array( 'jetpack-stats-dashboard/' ),
 			'cache_bust' => true,
 		),
-		'commercial-classification' => array(
+		'commercial-classification'     => array(
 			'capability' => 'view_stats',
 			'writes'     => array( 'commercial-classification' ),
 		),
-		'upgrades'                  => array(
+		'upgrades'                      => array(
 			'capability' => 'view_stats',
 			'path'       => '/upgrades?site=%d',
 		),

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -345,7 +345,12 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	private function is_write_allowed( string $endpoint ): bool {
 		$endpoint = strtolower( $endpoint );
 		foreach ( self::WRITE_PREFIXES as $prefix ) {
-			if ( $endpoint === $prefix || str_starts_with( $endpoint, $prefix ) ) {
+			// Honor the WRITE_PREFIXES convention: a trailing slash means "this prefix and any
+			// sub-path"; no trailing slash means "this exact endpoint only".
+			$matches = str_ends_with( $prefix, '/' )
+				? str_starts_with( $endpoint, $prefix )
+				: $endpoint === $prefix;
+			if ( $matches ) {
 				return true;
 			}
 		}
@@ -533,10 +538,10 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 
 	/**
 	 * Query params to forward to WPCOM, minus the WordPress routing params, the proxy's own
-	 * control/routing captures (`endpoint`, `version` — which a caller could also pass as query
-	 * params since `get_param()` prefers GET), and `site` (the proxy pins the site itself, so a
-	 * caller-supplied `site` must not reach the `upgrades` query string). Dropping the control
-	 * params also keeps them out of the cache key.
+	 * control params (`endpoint`, `version`, `force_refresh` — which a caller could also pass as
+	 * query params since `get_param()` prefers GET), and `site` (the proxy pins the site itself,
+	 * so a caller-supplied `site` must not reach the `upgrades` query string). Dropping the
+	 * control params also keeps them out of the cache key.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -544,7 +549,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		unset( $params['rest_route'], $params['_locale'], $params['site'], $params['endpoint'], $params['version'] );
+		unset( $params['rest_route'], $params['_locale'], $params['site'], $params['endpoint'], $params['version'], $params['force_refresh'] );
 
 		return is_array( $params ) ? $params : array();
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -245,7 +245,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		return in_array( strtolower( explode( '/', $value )[0] ), self::ALLOWED_PREFIXES, true );
+		$prefix = strtolower( explode( '/', $value )[0] );
+		if ( ! in_array( $prefix, self::ALLOWED_PREFIXES, true ) ) {
+			return false;
+		}
+
+		// `upgrades` is the site-less purchases endpoint — it takes no sub-path, so reject
+		// `upgrades/<anything>` (which build_data_path() would otherwise mis-route under /sites/).
+		if ( 'upgrades' === $prefix && 'upgrades' !== rtrim( strtolower( $value ), '/' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -286,12 +297,23 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			$request,
 			$this->build_data_path( $endpoint ),
 			array(
-				// WPCOM exposes v2 under the `wpcom` base and v1.x under the `rest` base.
 				'version'       => $version,
-				'base'          => '2' === $version ? 'wpcom' : 'rest',
+				'base'          => $this->base_for_version( $version ),
 				'bust_on_write' => $this->busts_cache( $endpoint ),
 			)
 		);
+	}
+
+	/**
+	 * The WPCOM API base for a version: v2 lives under `wpcom`, v1.x under `rest`. Derived from
+	 * the major component so dotted forms (e.g. `2.0`) map correctly.
+	 *
+	 * @param string $version WPCOM API version.
+	 *
+	 * @return string
+	 */
+	private function base_for_version( string $version ): string {
+		return 2 === (int) $version ? 'wpcom' : 'rest';
 	}
 
 	/**
@@ -509,8 +531,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Query params to forward to WPCOM, minus the WordPress routing params and `site` (the proxy
-	 * pins the site itself, so a caller-supplied `site` must not reach the `upgrades` query string).
+	 * Query params to forward to WPCOM, minus the WordPress routing params, the proxy's own
+	 * control/routing captures (`endpoint`, `version` — which a caller could also pass as query
+	 * params since `get_param()` prefers GET), and `site` (the proxy pins the site itself, so a
+	 * caller-supplied `site` must not reach the `upgrades` query string). Dropping the control
+	 * params also keeps them out of the cache key.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -518,7 +543,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 */
 	private function get_forwarded_params( WP_REST_Request $request ): array {
 		$params = $request->get_query_params();
-		unset( $params['rest_route'], $params['_locale'], $params['site'] );
+		unset( $params['rest_route'], $params['_locale'], $params['site'], $params['endpoint'], $params['version'] );
 
 		return is_array( $params ) ? $params : array();
 	}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -237,6 +237,8 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		// view_stats reaches the stats data but not WordAds.
 		$this->assertTrue( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'stats/top-posts' ) ) );
 		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
+		// WordPress routes case-insensitively — a mixed-case WordAds path must still hit the WordAds gate.
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'WordAds/earnings' ) ) );
 	}
 
 	public function test_stats_permission_granted_for_view_stats_capability() {
@@ -316,6 +318,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 			'commercial class.' => array( 'commercial-classification', true ),
 			'spam new'          => array( 'stats/referrers/spam/new', true ),
 			'spam delete'       => array( 'stats/referrers/spam/delete', true ),
+			'mixed case write'  => array( 'JETPACK-STATS-DASHBOARD/modules', true ),
 			'stats read'        => array( 'stats/top-posts', false ),
 			'subscribers read'  => array( 'subscribers/counts', false ),
 			'usage read'        => array( 'jetpack-stats/usage', false ),
@@ -329,6 +332,43 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'rest_read_only', $response->get_error_code() );
 		$this->assertSame( 405, $response->get_error_data()['status'] );
+	}
+
+	public function test_put_to_write_endpoint_returns_405() {
+		// Only POST may mutate — PUT/PATCH on a write-allowed endpoint is still rejected locally.
+		$response = $this->controller->handle_data_request( $this->build_data_request( 'PUT', 'jetpack-stats-dashboard/modules' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'rest_read_only', $response->get_error_code() );
+		$this->assertSame( 405, $response->get_error_data()['status'] );
+	}
+
+	public function test_post_to_write_endpoint_passes_the_method_gate() {
+		// A POST to a write-allowed endpoint clears the gate and reaches the connection check.
+		$response = $this->controller->handle_data_request( $this->build_data_request( 'POST', 'jetpack-stats-dashboard/modules' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'no_connection', $response->get_error_code() );
+	}
+
+	public function test_forwarded_params_drop_caller_supplied_site() {
+		// `site` is the proxy's own path-scoping param for `upgrades`; a caller must not set it.
+		$request  = $this->build_data_request(
+			'GET',
+			'upgrades',
+			array(
+				'site'   => '999',
+				'period' => 'year',
+			)
+		);
+		$accessor = function ( WP_REST_Request $req ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->get_forwarded_params( $req );
+		};
+
+		$forwarded = $accessor->call( $this->controller, $request );
+		$this->assertArrayNotHasKey( 'site', $forwarded );
+		$this->assertArrayHasKey( 'period', $forwarded );
 	}
 
 	public function test_validate_data_endpoint_accepts_commas_and_rejects_traversal() {

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -305,6 +305,44 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertSame( 200, $response->get_status() );
 	}
 
+	public function test_stats_wildcard_route_validates_subpath() {
+		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/stats/(?P<subpath>.+)'][0];
+		$this->assertSame(
+			array( $this->controller, 'validate_subpath' ),
+			$route['args']['subpath']['validate_callback']
+		);
+	}
+
+	public function test_validate_subpath_accepts_real_stats_subpaths() {
+		$this->assertTrue( $this->controller->validate_subpath( 'top-posts' ) );
+		$this->assertTrue( $this->controller->validate_subpath( 'post/123' ) );
+		$this->assertTrue( $this->controller->validate_subpath( 'opens/emails/123/rate' ) );
+		// UTM params arrive comma-separated — must be allowed.
+		$this->assertTrue( $this->controller->validate_subpath( 'utm/utm_campaign,utm_source,utm_medium' ) );
+	}
+
+	/**
+	 * @dataProvider data_invalid_subpaths
+	 *
+	 * @param string $subpath A subpath that must be rejected.
+	 */
+	#[DataProvider( 'data_invalid_subpaths' )]
+	public function test_validate_subpath_rejects_traversal_and_absolute( string $subpath ) {
+		$this->assertFalse( $this->controller->validate_subpath( $subpath ) );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public static function data_invalid_subpaths(): array {
+		return array(
+			'parent traversal' => array( '../../purchases' ),
+			'absolute path'    => array( '/sites/1/purchases' ),
+			'scheme injection' => array( 'http://evil.test/' ),
+			'empty'            => array( '' ),
+		);
+	}
+
 	/**
 	 * Build a proxy request with the endpoint capture and forwarded query params set.
 	 *

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -424,6 +424,95 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Exhaustive behavior matrix: every WPCOM-proxy endpoint the controller exposes must still
+	 * validate, resolve to the same capability tier + method policy + WPCOM path it did before the
+	 * config refactor (and as the originating stats-admin controller forwarded it).
+	 *
+	 * @dataProvider data_endpoint_matrix
+	 *
+	 * @param string $endpoint   The endpoint sub-path (after proxy/v<version>/).
+	 * @param string $capability The capability that gates it.
+	 * @param bool   $writable   Whether a POST is permitted.
+	 * @param string $wpcom_path The expected WPCOM path (with %d for the site id).
+	 */
+	#[DataProvider( 'data_endpoint_matrix' )]
+	public function test_endpoint_behavior_matrix( string $endpoint, string $capability, bool $writable, string $wpcom_path ) {
+		$site_id = (int) \Jetpack_Options::get_option( 'id' );
+
+		$resolve = function ( string $e ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
+			$cfg = $this->config_for( $e );
+			return array(
+				// @phan-suppress-next-line PhanUndeclaredMethod
+				'valid'      => $this->validate_data_endpoint( $e ),
+				'capability' => $cfg['capability'] ?? null,
+				// @phan-suppress-next-line PhanUndeclaredMethod
+				'writable'   => $this->is_write_allowed( $e ),
+				// @phan-suppress-next-line PhanUndeclaredMethod
+				'path'       => $this->build_data_path( $e ),
+			);
+		};
+		$got     = $resolve->call( $this->controller, $endpoint );
+
+		$this->assertTrue( $got['valid'], "$endpoint should validate" );
+		$this->assertSame( $capability, $got['capability'], "$endpoint capability" );
+		$this->assertSame( $writable, $got['writable'], "$endpoint writability" );
+		$this->assertSame( sprintf( $wpcom_path, $site_id ), $got['path'], "$endpoint WPCOM path" );
+	}
+
+	/**
+	 * Every WPCOM-proxy endpoint, with the capability / writability / path it forwarded as in
+	 * stats-admin. Reads are GET-only (writable=false); the four mutations are POST.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: bool, 3: string}>
+	 */
+	public static function data_endpoint_matrix(): array {
+		$stats   = 'view_stats';
+		$wordads = 'activate_wordads';
+		$admin   = 'manage_options';
+
+		return array(
+			// Analytics (manage_options).
+			'analytics report'     => array( 'analytics/reports/totals', $admin, false, '/sites/%d/analytics/reports/totals' ),
+
+			// Site stats + every /stats/* read family (v1.1, view_stats).
+			'site stats'           => array( 'stats', $stats, false, '/sites/%d/stats' ),
+			'stats resource'       => array( 'stats/top-posts', $stats, false, '/sites/%d/stats/top-posts' ),
+			'stats file dl'        => array( 'stats/file-downloads', $stats, false, '/sites/%d/stats/file-downloads' ),
+			'stats subscribers'    => array( 'stats/subscribers', $stats, false, '/sites/%d/stats/subscribers' ),
+			'single post stats'    => array( 'stats/post/123', $stats, false, '/sites/%d/stats/post/123' ),
+			'single video stats'   => array( 'stats/video/45', $stats, false, '/sites/%d/stats/video/45' ),
+			'email summary'        => array( 'stats/emails/summary', $stats, false, '/sites/%d/stats/emails/summary' ),
+			'email opens single'   => array( 'stats/opens/emails/12/rate', $stats, false, '/sites/%d/stats/opens/emails/12/rate' ),
+			'email clicks single'  => array( 'stats/clicks/emails/12/link', $stats, false, '/sites/%d/stats/clicks/emails/12/link' ),
+			'email time series'    => array( 'stats/opens/emails/12', $stats, false, '/sites/%d/stats/opens/emails/12' ),
+			'utm series'           => array( 'stats/utm/utm_source,utm_medium', $stats, false, '/sites/%d/stats/utm/utm_source,utm_medium' ),
+			'devices series'       => array( 'stats/devices/screensize', $stats, false, '/sites/%d/stats/devices/screensize' ),
+			'location views'       => array( 'stats/location-views/country', $stats, false, '/sites/%d/stats/location-views/country' ),
+			'referrer spam list'   => array( 'stats/referrers/spam', $stats, false, '/sites/%d/stats/referrers/spam' ),
+
+			// Stats writes (POST, v1.1, view_stats).
+			'referrer spam new'    => array( 'stats/referrers/spam/new', $stats, true, '/sites/%d/stats/referrers/spam/new' ),
+			'referrer spam delete' => array( 'stats/referrers/spam/delete', $stats, true, '/sites/%d/stats/referrers/spam/delete' ),
+
+			// v2 / wpcom endpoints (view_stats).
+			'subscribers counts'   => array( 'subscribers/counts', $stats, false, '/sites/%d/subscribers/counts' ),
+			'never published'      => array( 'site-has-never-published-post', $stats, false, '/sites/%d/site-has-never-published-post' ),
+			'plan usage'           => array( 'jetpack-stats/usage', $stats, false, '/sites/%d/jetpack-stats/usage' ),
+			'dashboard modules'    => array( 'jetpack-stats-dashboard/modules', $stats, true, '/sites/%d/jetpack-stats-dashboard/modules' ),
+			'module settings'      => array( 'jetpack-stats-dashboard/module-settings', $stats, true, '/sites/%d/jetpack-stats-dashboard/module-settings' ),
+			'commercial class.'    => array( 'commercial-classification', $stats, true, '/sites/%d/commercial-classification' ),
+
+			// WordAds (activate_wordads).
+			'wordads earnings'     => array( 'wordads/earnings', $wordads, false, '/sites/%d/wordads/earnings' ),
+			'wordads stats'        => array( 'wordads/stats', $wordads, false, '/sites/%d/wordads/stats' ),
+
+			// Purchases — site-less path (view_stats).
+			'purchases'            => array( 'upgrades', $stats, false, '/upgrades?site=%d' ),
+		);
+	}
+
+	/**
 	 * @dataProvider data_versions
 	 *
 	 * @param string $version A version string.

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -195,7 +195,14 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 		$this->assertSame( array( $this->controller, 'validate_data_endpoint' ), $args['endpoint']['validate_callback'] );
 		$this->assertSame( array( $this->controller, 'validate_version' ), $args['version']['validate_callback'] );
-		$this->assertSame( '2', $args['version']['default'] );
+		$this->assertTrue( $args['version']['required'] );
+	}
+
+	public function test_data_route_carries_proxy_and_version_path_segments() {
+		// The route is proxy/v<version>/<prefix>/<subpath>.
+		$route = $this->data_route_key();
+		$this->assertStringContainsString( 'proxy/v', $route );
+		$this->assertStringContainsString( '(?P<version>', $route );
 	}
 
 	public function test_data_route_only_matches_allowed_prefixes() {
@@ -432,12 +439,15 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 * @return WP_REST_Request
 	 */
 	private function build_data_request( string $method, string $endpoint, array $params = array(), ?string $version = null ): WP_REST_Request {
-		$request = new WP_REST_Request( $method, '/jetpack-premium-analytics/v1/' . $endpoint );
-		// The capture is a route (URL) param; `version` arrives as a query param.
-		$request->set_url_params( array( 'endpoint' => $endpoint ) );
-		if ( null !== $version ) {
-			$params['version'] = $version;
-		}
+		$version = $version ?? '2';
+		$request = new WP_REST_Request( $method, '/jetpack-premium-analytics/v1/proxy/v' . $version . '/' . $endpoint );
+		// `endpoint` and `version` are both route (URL) captures in production.
+		$request->set_url_params(
+			array(
+				'endpoint' => $endpoint,
+				'version'  => $version,
+			)
+		);
 		$request->set_query_params( $params );
 
 		return $request;

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -20,8 +20,6 @@ use WP_REST_Server;
 #[CoversClass( Api_Proxy_Controller::class )]
 class Api_Proxy_Controller_Test extends BaseTestCase {
 
-	private const ROUTE = '/jetpack-premium-analytics/v1/proxy/(?P<endpoint>.*)';
-
 	/**
 	 * Controller under test.
 	 *
@@ -42,14 +40,30 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		do_action( 'rest_api_init' );
 	}
 
-	public function test_registers_proxy_route_under_package_namespace() {
-		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( self::ROUTE, $routes );
+	public function test_legacy_proxy_route_is_no_longer_registered() {
+		$this->assertArrayNotHasKey( '/jetpack-premium-analytics/v1/proxy/(?P<endpoint>.*)', rest_get_server()->get_routes() );
 	}
 
-	public function test_route_uses_the_controllers_permission_callback() {
-		$route = rest_get_server()->get_routes()[ self::ROUTE ][0];
-		$this->assertSame( array( $this->controller, 'check_permission' ), $route['permission_callback'] );
+	public function test_analytics_is_served_by_the_data_route() {
+		// Analytics is now an allowed prefix on the single agnostic route, not a dedicated route.
+		$this->assertStringContainsString( 'analytics', $this->data_route_key() );
+	}
+
+	public function test_analytics_requires_manage_options() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_stats_only',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		// view_stats reaches stats data but NOT the premium analytics surface.
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'analytics/reports/totals' ) ) );
+		$this->assertTrue( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'stats/top-posts' ) ) );
 	}
 
 	public function test_permission_denied_without_manage_options() {
@@ -70,7 +84,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	public function test_returns_403_error_when_not_connected() {
-		$response = $this->controller->handle_proxy_request( $this->build_request( 'reports/totals' ) );
+		$response = $this->controller->handle_data_request( $this->build_request( 'reports/totals' ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'no_connection', $response->get_error_code() );
@@ -86,7 +100,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		);
 		set_transient( $this->cache_key( $request ), $payload, MINUTE_IN_SECONDS );
 
-		$response = $this->controller->handle_proxy_request( $request );
+		$response = $this->controller->handle_data_request( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
@@ -127,35 +141,6 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		);
 
 		$this->assertSame( $this->cache_key( $bare ), $this->cache_key( $routing ) );
-	}
-
-	public function test_validate_endpoint_accepts_a_relative_sub_path() {
-		$this->assertTrue( $this->controller->validate_endpoint( 'reports/totals' ) );
-	}
-
-	/**
-	 * @dataProvider data_invalid_endpoints
-	 *
-	 * @param string $endpoint An endpoint that must be rejected.
-	 */
-	#[DataProvider( 'data_invalid_endpoints' )]
-	public function test_validate_endpoint_rejects_traversal_and_scheme( string $endpoint ) {
-		$this->assertFalse( $this->controller->validate_endpoint( $endpoint ) );
-	}
-
-	/**
-	 * Endpoints that would escape the `/analytics/` prefix.
-	 *
-	 * @return array<string, string[]>
-	 */
-	public static function data_invalid_endpoints(): array {
-		return array(
-			'parent traversal' => array( '../../sites/1/posts' ),
-			'absolute path'    => array( '/sites/1/posts' ),
-			'scheme injection' => array( 'http://evil.test/' ),
-			'disallowed char'  => array( 'reports totals' ),
-			'empty'            => array( '' ),
-		);
 	}
 
 	public function test_undecodable_200_body_returns_502_and_is_not_cached() {
@@ -216,6 +201,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	public function test_data_route_only_matches_allowed_prefixes() {
 		// The route regex enumerates the allowed prefixes — a non-allowed prefix is absent.
 		$route = $this->data_route_key();
+		$this->assertStringContainsString( 'analytics', $route );
 		$this->assertStringContainsString( 'stats', $route );
 		$this->assertStringContainsString( 'commercial', $route );
 		$this->assertStringNotContainsString( 'posts', $route );
@@ -415,20 +401,15 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Build an analytics proxy request with the endpoint capture and forwarded query params set.
+	 * Build an analytics GET request on the data route (analytics is the `analytics` prefix, v2).
 	 *
-	 * @param string $endpoint The analytics endpoint to proxy.
+	 * @param string $endpoint The analytics sub-path (without the `analytics/` prefix).
 	 * @param array  $params   Forwarded query params.
 	 *
 	 * @return WP_REST_Request
 	 */
 	private function build_request( string $endpoint, array $params = array() ): WP_REST_Request {
-		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/' . $endpoint );
-		// The capture is a route (URL) param in production, not a query param.
-		$request->set_url_params( array( 'endpoint' => $endpoint ) );
-		$request->set_query_params( $params );
-
-		return $request;
+		return $this->build_data_request( 'GET', 'analytics/' . $endpoint, $params, '2' );
 	}
 
 	/**
@@ -476,18 +457,14 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 * @return string
 	 */
 	private function cache_key( WP_REST_Request $request ): string {
-		$path = sprintf(
-			'/sites/%d/analytics/%s',
-			(int) \Jetpack_Options::get_option( 'id' ),
-			(string) $request->get_param( 'endpoint' )
-		);
-
-		$accessor = function ( WP_REST_Request $req, string $wpcom_path ) {
+		$accessor = function ( WP_REST_Request $req ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
-			return $this->cache_key_for( $wpcom_path, '2', 'wpcom', $this->get_forwarded_params( $req ) );
+			$path = $this->build_data_path( (string) $req->get_param( 'endpoint' ) );
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->cache_key_for( $path, '2', 'wpcom', $this->get_forwarded_params( $req ) );
 		};
 
-		return $accessor->call( $this->controller, $request, $path );
+		return $accessor->call( $this->controller, $request );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -175,59 +175,74 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertFalse( get_transient( $this->cache_key( $request ) ) );
 	}
 
-	/**
-	 * The Stats routes that should be registered under the package namespace.
-	 *
-	 * @return array<string, array{0: string, 1: string[]}>
-	 */
-	public static function data_stats_routes(): array {
-		$ns = '/jetpack-premium-analytics/v1/';
-
-		return array(
-			'site stats'         => array( $ns . 'stats', array( 'GET' ) ),
-			'stats resource'     => array( $ns . 'stats/(?P<subpath>.+)', array( 'GET', 'POST' ) ),
-			'subscribers counts' => array( $ns . 'subscribers/counts', array( 'GET' ) ),
-			'never published'    => array( $ns . 'site-has-never-published-post', array( 'GET' ) ),
-			'plan usage'         => array( $ns . 'jetpack-stats/usage', array( 'GET' ) ),
-			'dashboard modules'  => array( $ns . 'jetpack-stats-dashboard/modules', array( 'GET', 'POST' ) ),
-			'module settings'    => array( $ns . 'jetpack-stats-dashboard/module-settings', array( 'GET', 'POST' ) ),
-			'commercial class.'  => array( $ns . 'commercial-classification', array( 'POST' ) ),
-			'wordads'            => array( $ns . 'wordads/(?P<subpath>earnings|stats)', array( 'GET' ) ),
-			'purchases'          => array( $ns . 'purchases', array( 'GET' ) ),
+	public function test_response_with_null_cache_key_is_not_cached() {
+		$response = $this->cache_and_build_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ok' => true ), JSON_UNESCAPED_SLASHES ),
+				'headers'  => array(),
+			),
+			null
 		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
 	}
 
-	/**
-	 * @dataProvider data_stats_routes
-	 *
-	 * @param string   $route            The expected route pattern.
-	 * @param string[] $expected_methods The HTTP methods the route must accept.
-	 */
-	#[DataProvider( 'data_stats_routes' )]
-	public function test_registers_stats_route( string $route, array $expected_methods ) {
-		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( $route, $routes );
+	public function test_registers_data_route_with_read_and_write_methods() {
+		$route = $this->data_route_key();
+		$this->assertNotSame( '', $route, 'The agnostic data route should be registered.' );
 
-		$methods = $routes[ $route ][0]['methods'];
-		foreach ( $expected_methods as $method ) {
-			$this->assertArrayHasKey( $method, $methods );
-		}
+		$methods = rest_get_server()->get_routes()[ $route ][0]['methods'];
+		$this->assertArrayHasKey( 'GET', $methods );
+		$this->assertArrayHasKey( 'POST', $methods );
 	}
 
-	public function test_stats_routes_use_the_stats_permission_callback() {
-		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/stats'][0];
-		$this->assertSame( array( $this->controller, 'check_stats_permission' ), $route['permission_callback'] );
+	public function test_data_route_uses_data_callbacks() {
+		$handler = rest_get_server()->get_routes()[ $this->data_route_key() ][0];
+
+		$this->assertSame( array( $this->controller, 'handle_data_request' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_data_permission' ), $handler['permission_callback'] );
 	}
 
-	public function test_wordads_route_uses_the_wordads_permission_callback() {
-		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/wordads/(?P<subpath>earnings|stats)'][0];
-		$this->assertSame( array( $this->controller, 'check_wordads_permission' ), $route['permission_callback'] );
+	public function test_data_route_validates_endpoint_and_version() {
+		$args = rest_get_server()->get_routes()[ $this->data_route_key() ][0]['args'];
+
+		$this->assertSame( array( $this->controller, 'validate_data_endpoint' ), $args['endpoint']['validate_callback'] );
+		$this->assertSame( array( $this->controller, 'validate_version' ), $args['version']['validate_callback'] );
+		$this->assertSame( '2', $args['version']['default'] );
+	}
+
+	public function test_data_route_only_matches_allowed_prefixes() {
+		// The route regex enumerates the allowed prefixes — a non-allowed prefix is absent.
+		$route = $this->data_route_key();
+		$this->assertStringContainsString( 'stats', $route );
+		$this->assertStringContainsString( 'commercial', $route );
+		$this->assertStringNotContainsString( 'posts', $route );
+		$this->assertStringNotContainsString( 'media', $route );
+	}
+
+	public function test_data_permission_dispatches_by_endpoint() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		// view_stats reaches the stats data but not WordAds.
+		$this->assertTrue( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'stats/top-posts' ) ) );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
 	}
 
 	public function test_stats_permission_granted_for_view_stats_capability() {
 		$user_id = wp_insert_user(
 			array(
-				'user_login' => 'jpa_viewer',
+				'user_login' => 'jpa_viewer2',
 				'user_pass'  => 'password',
 				'role'       => 'subscriber',
 			)
@@ -247,104 +262,120 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @dataProvider data_stats_paths
+	 * @dataProvider data_data_paths
 	 *
-	 * @param array<string, mixed> $route    The route description to resolve.
-	 * @param string               $subpath  The matched `subpath` capture, if any.
-	 * @param string               $expected The expected WPCOM path.
+	 * @param string $endpoint The validated endpoint.
+	 * @param string $expected The expected WPCOM path (with %d for the site id).
 	 */
-	#[DataProvider( 'data_stats_paths' )]
-	public function test_build_stats_path( array $route, string $subpath, string $expected ) {
-		$request = new WP_REST_Request( 'GET', '/' );
-		if ( '' !== $subpath ) {
-			$request->set_param( 'subpath', $subpath );
-		}
-
-		$accessor = function ( WP_REST_Request $req, array $r ) {
+	#[DataProvider( 'data_data_paths' )]
+	public function test_build_data_path( string $endpoint, string $expected ) {
+		$accessor = function ( string $e ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
-			return $this->build_stats_path( $req, $r );
+			return $this->build_data_path( $e );
 		};
 
-		$site_id  = (int) \Jetpack_Options::get_option( 'id' );
-		$resolved = $accessor->call( $this->controller, $request, $route );
-
-		$this->assertSame( sprintf( $expected, $site_id ), $resolved );
-	}
-
-	/**
-	 * @return array<string, array{0: array<string, mixed>, 1: string, 2: string}>
-	 */
-	public static function data_stats_paths(): array {
-		return array(
-			'wildcard subpath' => array( array( 'wpcom' => 'stats/%s' ), 'top-posts', '/sites/%d/stats/top-posts' ),
-			'wordads subpath'  => array( array( 'wpcom' => 'wordads/%s' ), 'earnings', '/sites/%d/wordads/earnings' ),
-			'static path'      => array( array( 'wpcom' => 'subscribers/counts' ), '', '/sites/%d/subscribers/counts' ),
-			'build override'   => array(
-				array(
-					'build' => static function ( int $id ): string {
-						return sprintf( '/upgrades?site=%d', $id );
-					},
-				),
-				'',
-				'/upgrades?site=%d',
-			),
-		);
-	}
-
-	public function test_response_with_null_cache_key_is_not_cached() {
-		$response = $this->cache_and_build_response(
-			array(
-				'response' => array( 'code' => 200 ),
-				'body'     => wp_json_encode( array( 'ok' => true ), JSON_UNESCAPED_SLASHES ),
-				'headers'  => array(),
-			),
-			null
-		);
-
-		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertSame( 200, $response->get_status() );
-	}
-
-	public function test_stats_wildcard_route_validates_subpath() {
-		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/stats/(?P<subpath>.+)'][0];
-		$this->assertSame(
-			array( $this->controller, 'validate_subpath' ),
-			$route['args']['subpath']['validate_callback']
-		);
-	}
-
-	public function test_validate_subpath_accepts_real_stats_subpaths() {
-		$this->assertTrue( $this->controller->validate_subpath( 'top-posts' ) );
-		$this->assertTrue( $this->controller->validate_subpath( 'post/123' ) );
-		$this->assertTrue( $this->controller->validate_subpath( 'opens/emails/123/rate' ) );
-		// UTM params arrive comma-separated — must be allowed.
-		$this->assertTrue( $this->controller->validate_subpath( 'utm/utm_campaign,utm_source,utm_medium' ) );
-	}
-
-	/**
-	 * @dataProvider data_invalid_subpaths
-	 *
-	 * @param string $subpath A subpath that must be rejected.
-	 */
-	#[DataProvider( 'data_invalid_subpaths' )]
-	public function test_validate_subpath_rejects_traversal_and_absolute( string $subpath ) {
-		$this->assertFalse( $this->controller->validate_subpath( $subpath ) );
+		$site_id = (int) \Jetpack_Options::get_option( 'id' );
+		$this->assertSame( sprintf( $expected, $site_id ), $accessor->call( $this->controller, $endpoint ) );
 	}
 
 	/**
 	 * @return array<string, string[]>
 	 */
-	public static function data_invalid_subpaths(): array {
+	public static function data_data_paths(): array {
 		return array(
-			'parent traversal' => array( '../../purchases' ),
-			'absolute path'    => array( '/sites/1/purchases' ),
-			'scheme injection' => array( 'http://evil.test/' ),
-			'empty'            => array( '' ),
+			'stats resource' => array( 'stats/top-posts', '/sites/%d/stats/top-posts' ),
+			'wordads'        => array( 'wordads/earnings', '/sites/%d/wordads/earnings' ),
+			'utm commas'     => array( 'stats/utm/utm_campaign,utm_source', '/sites/%d/stats/utm/utm_campaign,utm_source' ),
+			'purchases'      => array( 'upgrades', '/upgrades?site=%d' ),
 		);
 	}
 
 	/**
-	 * Build a proxy request with the endpoint capture and forwarded query params set.
+	 * @dataProvider data_write_endpoints
+	 *
+	 * @param string $endpoint The endpoint to check.
+	 * @param bool   $allowed  Whether a non-GET method is permitted.
+	 */
+	#[DataProvider( 'data_write_endpoints' )]
+	public function test_is_write_allowed( string $endpoint, bool $allowed ) {
+		$accessor = function ( string $e ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->is_write_allowed( $e );
+		};
+
+		$this->assertSame( $allowed, $accessor->call( $this->controller, $endpoint ) );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function data_write_endpoints(): array {
+		return array(
+			'dashboard modules' => array( 'jetpack-stats-dashboard/modules', true ),
+			'module settings'   => array( 'jetpack-stats-dashboard/module-settings', true ),
+			'commercial class.' => array( 'commercial-classification', true ),
+			'spam new'          => array( 'stats/referrers/spam/new', true ),
+			'spam delete'       => array( 'stats/referrers/spam/delete', true ),
+			'stats read'        => array( 'stats/top-posts', false ),
+			'subscribers read'  => array( 'subscribers/counts', false ),
+			'usage read'        => array( 'jetpack-stats/usage', false ),
+			'wordads read'      => array( 'wordads/earnings', false ),
+		);
+	}
+
+	public function test_write_to_read_only_endpoint_returns_405() {
+		$response = $this->controller->handle_data_request( $this->build_data_request( 'POST', 'stats/top-posts' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'rest_read_only', $response->get_error_code() );
+		$this->assertSame( 405, $response->get_error_data()['status'] );
+	}
+
+	public function test_validate_data_endpoint_accepts_commas_and_rejects_traversal() {
+		$this->assertTrue( $this->controller->validate_data_endpoint( 'stats/utm/utm_campaign,utm_source,utm_medium' ) );
+		$this->assertTrue( $this->controller->validate_data_endpoint( 'stats/opens/emails/123/rate' ) );
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'stats/../../purchases' ) );
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'stats/a:b' ) );
+	}
+
+	/**
+	 * @dataProvider data_versions
+	 *
+	 * @param string $version A version string.
+	 * @param bool   $valid   Whether it should validate.
+	 */
+	#[DataProvider( 'data_versions' )]
+	public function test_validate_version( string $version, bool $valid ) {
+		$this->assertSame( $valid, $this->controller->validate_version( $version ) );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function data_versions(): array {
+		return array(
+			'v2'        => array( '2', true ),
+			'v1.1'      => array( '1.1', true ),
+			'v1.2'      => array( '1.2', true ),
+			'word'      => array( 'latest', false ),
+			'injection' => array( '2;DROP', false ),
+			'empty'     => array( '', false ),
+		);
+	}
+
+	public function test_data_cache_key_varies_by_version() {
+		$accessor = function ( string $path, string $version ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->cache_key_for( $path, $version, '2' === $version ? 'wpcom' : 'rest', array() );
+		};
+
+		$v2  = $accessor->call( $this->controller, '/sites/0/stats/top-posts', '2' );
+		$v11 = $accessor->call( $this->controller, '/sites/0/stats/top-posts', '1.1' );
+		$this->assertNotSame( $v2, $v11 );
+	}
+
+	/**
+	 * Build an analytics proxy request with the endpoint capture and forwarded query params set.
 	 *
 	 * @param string $endpoint The analytics endpoint to proxy.
 	 * @param array  $params   Forwarded query params.
@@ -353,14 +384,52 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 */
 	private function build_request( string $endpoint, array $params = array() ): WP_REST_Request {
 		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/' . $endpoint );
-		$request->set_param( 'endpoint', $endpoint );
+		// The capture is a route (URL) param in production, not a query param.
+		$request->set_url_params( array( 'endpoint' => $endpoint ) );
 		$request->set_query_params( $params );
 
 		return $request;
 	}
 
 	/**
-	 * Compute the controller's transient cache key for an analytics request.
+	 * Build a data proxy request with the endpoint capture set.
+	 *
+	 * @param string      $method   HTTP method.
+	 * @param string      $endpoint The data endpoint to proxy.
+	 * @param array       $params   Forwarded query params.
+	 * @param string|null $version  WPCOM API version param, if any.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function build_data_request( string $method, string $endpoint, array $params = array(), ?string $version = null ): WP_REST_Request {
+		$request = new WP_REST_Request( $method, '/jetpack-premium-analytics/v1/' . $endpoint );
+		// The capture is a route (URL) param; `version` arrives as a query param.
+		$request->set_url_params( array( 'endpoint' => $endpoint ) );
+		if ( null !== $version ) {
+			$params['version'] = $version;
+		}
+		$request->set_query_params( $params );
+
+		return $request;
+	}
+
+	/**
+	 * The registered route key of the agnostic data proxy.
+	 *
+	 * @return string
+	 */
+	private function data_route_key(): string {
+		foreach ( array_keys( rest_get_server()->get_routes() ) as $key ) {
+			if ( str_contains( $key, '(?P<endpoint>' ) && str_contains( $key, 'commercial' ) ) {
+				return $key;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Compute the controller's transient cache key for an analytics request (v2 / wpcom).
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
@@ -375,7 +444,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 		$accessor = function ( WP_REST_Request $req, string $wpcom_path ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
-			return $this->get_cache_key( $req, $wpcom_path );
+			return $this->cache_key_for( $wpcom_path, '2', 'wpcom', $this->get_forwarded_params( $req ) );
 		};
 
 		return $accessor->call( $this->controller, $request, $path );

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -360,8 +360,17 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	public function test_validate_data_endpoint_accepts_commas_and_rejects_traversal() {
 		$this->assertTrue( $this->controller->validate_data_endpoint( 'stats/utm/utm_campaign,utm_source,utm_medium' ) );
 		$this->assertTrue( $this->controller->validate_data_endpoint( 'stats/opens/emails/123/rate' ) );
+		$this->assertTrue( $this->controller->validate_data_endpoint( 'analytics/reports/totals' ) );
 		$this->assertFalse( $this->controller->validate_data_endpoint( 'stats/../../purchases' ) );
 		$this->assertFalse( $this->controller->validate_data_endpoint( 'stats/a:b' ) );
+	}
+
+	public function test_validate_data_endpoint_re_enforces_the_prefix_allowlist() {
+		// WP get_param() prefers a GET/JSON/POST `endpoint` over the URL capture, so a shadowed
+		// value with a non-allowed prefix must be rejected even though the URL matched the route.
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'me/settings' ) );
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'posts' ) );
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'sites/123/users' ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -618,6 +618,133 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * @dataProvider data_cache_bust_endpoints
+	 *
+	 * @param string $endpoint The endpoint.
+	 * @param bool   $busts    Whether a successful write should invalidate the read cache.
+	 */
+	#[DataProvider( 'data_cache_bust_endpoints' )]
+	public function test_busts_cache_decision_from_config( string $endpoint, bool $busts ) {
+		$accessor = function ( string $e ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
+			return $this->busts_cache( $e );
+		};
+
+		$this->assertSame( $busts, $accessor->call( $this->controller, $endpoint ) );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function data_cache_bust_endpoints(): array {
+		return array(
+			'dashboard modules' => array( 'jetpack-stats-dashboard/modules', true ),
+			'module settings'   => array( 'jetpack-stats-dashboard/module-settings', true ),
+			'commercial class.' => array( 'commercial-classification', false ),
+			'referrer spam new' => array( 'stats/referrers/spam/new', false ),
+			'stats read'        => array( 'stats/top-posts', false ),
+		);
+	}
+
+	public function test_successful_write_busts_matching_read_cache() {
+		// A no-param GET to this dashboard read caches under this key; a 200 POST to it clears it.
+		$endpoint = 'jetpack-stats-dashboard/modules';
+		$read_key = $this->read_cache_key( $endpoint, '2' );
+		set_transient( $read_key, array( 'data' => 'stale' ), MINUTE_IN_SECONDS );
+
+		$this->invoke_bust( $endpoint, '2', true, true, 200 );
+
+		$this->assertFalse( get_transient( $read_key ), 'a 200 write to a bust endpoint clears its read cache' );
+	}
+
+	/**
+	 * @dataProvider data_non_busting_cases
+	 *
+	 * @param bool $is_write      Whether the request was a write.
+	 * @param bool $bust_on_write Whether the prefix opted into cache-busting.
+	 * @param int  $status        The WPCOM response status.
+	 */
+	#[DataProvider( 'data_non_busting_cases' )]
+	public function test_read_cache_survives_when_bust_conditions_are_not_met( bool $is_write, bool $bust_on_write, int $status ) {
+		$endpoint = 'jetpack-stats-dashboard/modules';
+		$read_key = $this->read_cache_key( $endpoint, '2' );
+		set_transient( $read_key, array( 'data' => 'keep' ), MINUTE_IN_SECONDS );
+
+		$this->invoke_bust( $endpoint, '2', $is_write, $bust_on_write, $status );
+
+		$this->assertNotFalse( get_transient( $read_key ) );
+	}
+
+	/**
+	 * @return array<string, array{0: bool, 1: bool, 2: int}>
+	 */
+	public static function data_non_busting_cases(): array {
+		return array(
+			'read request'        => array( false, true, 200 ),
+			'non-200 write'       => array( true, true, 500 ),
+			'prefix not opted in' => array( true, false, 200 ),
+		);
+	}
+
+	public function test_bust_is_scoped_to_the_written_path_and_version() {
+		// An unrelated path, and the same path at a different version, must survive a bust.
+		$other_path    = $this->read_cache_key( 'stats/top-posts', '1.1' );
+		$other_version = $this->read_cache_key( 'jetpack-stats-dashboard/modules', '1.1' );
+		set_transient( $other_path, array( 'data' => 'keep' ), MINUTE_IN_SECONDS );
+		set_transient( $other_version, array( 'data' => 'keep' ), MINUTE_IN_SECONDS );
+
+		$this->invoke_bust( 'jetpack-stats-dashboard/modules', '2', true, true, 200 );
+
+		$this->assertNotFalse( get_transient( $other_path ), 'an unrelated path must not be busted' );
+		$this->assertNotFalse( get_transient( $other_version ), 'a different version of the same path must not be busted' );
+	}
+
+	/**
+	 * Invoke the (connection-free) cache-bust decision with a synthetic response.
+	 *
+	 * @param string $endpoint      The endpoint.
+	 * @param string $version       The WPCOM API version.
+	 * @param bool   $is_write      Whether the request was a write.
+	 * @param bool   $bust_on_write Whether the prefix opted into cache-busting.
+	 * @param int    $status        The WPCOM response status.
+	 *
+	 * @return void
+	 */
+	private function invoke_bust( string $endpoint, string $version, bool $is_write, bool $bust_on_write, int $status ): void {
+		$accessor = function ( string $e, string $v, bool $w, bool $b, int $s ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
+			$this->maybe_bust_read_cache(
+				array( 'response' => array( 'code' => $s ) ),
+				$w,
+				array( 'bust_on_write' => $b ),
+				$this->build_data_path( $e ),
+				$v,
+				'2' === $v ? 'wpcom' : 'rest'
+			);
+		};
+
+		$accessor->call( $this->controller, $endpoint, $version, $is_write, $bust_on_write, $status );
+	}
+
+	/**
+	 * The param-less read cache key for an endpoint at a given version (what a no-param GET caches
+	 * under, and what a successful write to it busts).
+	 *
+	 * @param string $endpoint The endpoint.
+	 * @param string $version  The WPCOM API version.
+	 *
+	 * @return string
+	 */
+	private function read_cache_key( string $endpoint, string $version ): string {
+		$accessor = function ( string $e, string $v ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
+			return $this->cache_key_for( $this->build_data_path( $e ), $v, '2' === $v ? 'wpcom' : 'rest', array() );
+		};
+
+		return $accessor->call( $this->controller, $endpoint, $version );
+	}
+
+	/**
 	 * Build an analytics GET request on the data route (analytics is the `analytics` prefix, v2).
 	 *
 	 * @param string $endpoint The analytics sub-path (without the `analytics/` prefix).

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -307,16 +307,17 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 */
 	public static function data_write_endpoints(): array {
 		return array(
-			'dashboard modules' => array( 'jetpack-stats-dashboard/modules', true ),
-			'module settings'   => array( 'jetpack-stats-dashboard/module-settings', true ),
-			'commercial class.' => array( 'commercial-classification', true ),
-			'spam new'          => array( 'stats/referrers/spam/new', true ),
-			'spam delete'       => array( 'stats/referrers/spam/delete', true ),
-			'mixed case write'  => array( 'JETPACK-STATS-DASHBOARD/modules', true ),
-			'stats read'        => array( 'stats/top-posts', false ),
-			'subscribers read'  => array( 'subscribers/counts', false ),
-			'usage read'        => array( 'jetpack-stats/usage', false ),
-			'wordads read'      => array( 'wordads/earnings', false ),
+			'dashboard modules'  => array( 'jetpack-stats-dashboard/modules', true ),
+			'module settings'    => array( 'jetpack-stats-dashboard/module-settings', true ),
+			'commercial class.'  => array( 'commercial-classification', true ),
+			'spam new'           => array( 'stats/referrers/spam/new', true ),
+			'spam delete'        => array( 'stats/referrers/spam/delete', true ),
+			'mixed case write'   => array( 'JETPACK-STATS-DASHBOARD/modules', true ),
+			'commercial subpath' => array( 'commercial-classification/foo', false ),
+			'stats read'         => array( 'stats/top-posts', false ),
+			'subscribers read'   => array( 'subscribers/counts', false ),
+			'usage read'         => array( 'jetpack-stats/usage', false ),
+			'wordads read'       => array( 'wordads/earnings', false ),
 		);
 	}
 

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -344,14 +344,17 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertSame( 'no_connection', $response->get_error_code() );
 	}
 
-	public function test_forwarded_params_drop_caller_supplied_site() {
-		// `site` is the proxy's own path-scoping param for `upgrades`; a caller must not set it.
+	public function test_forwarded_params_drop_control_and_site_params() {
+		// `site` (path-scoping) and the `endpoint`/`version` control captures must never be
+		// forwarded to WPCOM or folded into the cache key, even if passed as query params.
 		$request  = $this->build_data_request(
 			'GET',
 			'upgrades',
 			array(
-				'site'   => '999',
-				'period' => 'year',
+				'site'     => '999',
+				'endpoint' => 'me/settings',
+				'version'  => '9',
+				'period'   => 'year',
 			)
 		);
 		$accessor = function ( WP_REST_Request $req ) {
@@ -361,6 +364,8 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 		$forwarded = $accessor->call( $this->controller, $request );
 		$this->assertArrayNotHasKey( 'site', $forwarded );
+		$this->assertArrayNotHasKey( 'endpoint', $forwarded );
+		$this->assertArrayNotHasKey( 'version', $forwarded );
 		$this->assertArrayHasKey( 'period', $forwarded );
 	}
 
@@ -378,6 +383,40 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertFalse( $this->controller->validate_data_endpoint( 'me/settings' ) );
 		$this->assertFalse( $this->controller->validate_data_endpoint( 'posts' ) );
 		$this->assertFalse( $this->controller->validate_data_endpoint( 'sites/123/users' ) );
+	}
+
+	public function test_validate_data_endpoint_rejects_upgrades_subpaths() {
+		// `upgrades` is site-less and takes no sub-path; build_data_path only handles the exact form.
+		$this->assertTrue( $this->controller->validate_data_endpoint( 'upgrades' ) );
+		$this->assertFalse( $this->controller->validate_data_endpoint( 'upgrades/foo' ) );
+	}
+
+	/**
+	 * @dataProvider data_version_bases
+	 *
+	 * @param string $version A version string.
+	 * @param string $base    The expected WPCOM base.
+	 */
+	#[DataProvider( 'data_version_bases' )]
+	public function test_base_for_version( string $version, string $base ) {
+		$accessor = function ( string $v ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->base_for_version( $v );
+		};
+
+		$this->assertSame( $base, $accessor->call( $this->controller, $version ) );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public static function data_version_bases(): array {
+		return array(
+			'v2'   => array( '2', 'wpcom' ),
+			'v2.0' => array( '2.0', 'wpcom' ),
+			'v1.1' => array( '1.1', 'rest' ),
+			'v1.2' => array( '1.2', 'rest' ),
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -68,7 +68,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 	public function test_permission_denied_without_manage_options() {
 		wp_set_current_user( 0 );
-		$this->assertFalse( $this->controller->check_permission() );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'analytics/reports/totals' ) ) );
 	}
 
 	public function test_permission_granted_for_administrator() {
@@ -80,7 +80,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 			)
 		);
 		wp_set_current_user( $admin_id );
-		$this->assertTrue( $this->controller->check_permission() );
+		$this->assertTrue( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'analytics/reports/totals' ) ) );
 	}
 
 	public function test_returns_403_error_when_not_connected() {
@@ -246,14 +246,16 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$user->add_cap( 'view_stats' );
 		wp_set_current_user( $user_id );
 
-		$this->assertTrue( $this->controller->check_stats_permission() );
-		$this->assertFalse( $this->controller->check_wordads_permission() );
+		// view_stats reaches stats, but not the WordAds (activate_wordads) or analytics (manage_options) tiers.
+		$this->assertTrue( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'stats/top-posts' ) ) );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'analytics/reports/totals' ) ) );
 	}
 
 	public function test_permissions_denied_for_anonymous_user() {
 		wp_set_current_user( 0 );
-		$this->assertFalse( $this->controller->check_stats_permission() );
-		$this->assertFalse( $this->controller->check_wordads_permission() );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'stats/top-posts' ) ) );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -278,10 +278,11 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 */
 	public static function data_data_paths(): array {
 		return array(
-			'stats resource' => array( 'stats/top-posts', '/sites/%d/stats/top-posts' ),
-			'wordads'        => array( 'wordads/earnings', '/sites/%d/wordads/earnings' ),
-			'utm commas'     => array( 'stats/utm/utm_campaign,utm_source', '/sites/%d/stats/utm/utm_campaign,utm_source' ),
-			'purchases'      => array( 'upgrades', '/upgrades?site=%d' ),
+			'stats resource'  => array( 'stats/top-posts', '/sites/%d/stats/top-posts' ),
+			'wordads'         => array( 'wordads/earnings', '/sites/%d/wordads/earnings' ),
+			'utm commas'      => array( 'stats/utm/utm_campaign,utm_source', '/sites/%d/stats/utm/utm_campaign,utm_source' ),
+			'purchases'       => array( 'upgrades', '/upgrades?site=%d' ),
+			'purchases slash' => array( 'upgrades/', '/upgrades?site=%d' ),
 		);
 	}
 

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -713,11 +713,13 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	private function invoke_bust( string $endpoint, string $version, bool $is_write, bool $bust_on_write, int $status ): void {
 		$accessor = function ( string $e, string $v, bool $w, bool $b, int $s ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
+			$path = $this->build_data_path( $e );
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call().
 			$this->maybe_bust_read_cache(
 				array( 'response' => array( 'code' => $s ) ),
 				$w,
 				array( 'bust_on_write' => $b ),
-				$this->build_data_path( $e ),
+				$path,
 				$v,
 				'2' === $v ? 'wpcom' : 'rest'
 			);

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -176,6 +176,136 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The Stats routes that should be registered under the package namespace.
+	 *
+	 * @return array<string, array{0: string, 1: string[]}>
+	 */
+	public static function data_stats_routes(): array {
+		$ns = '/jetpack-premium-analytics/v1/';
+
+		return array(
+			'site stats'         => array( $ns . 'stats', array( 'GET' ) ),
+			'stats resource'     => array( $ns . 'stats/(?P<subpath>.+)', array( 'GET', 'POST' ) ),
+			'subscribers counts' => array( $ns . 'subscribers/counts', array( 'GET' ) ),
+			'never published'    => array( $ns . 'site-has-never-published-post', array( 'GET' ) ),
+			'plan usage'         => array( $ns . 'jetpack-stats/usage', array( 'GET' ) ),
+			'dashboard modules'  => array( $ns . 'jetpack-stats-dashboard/modules', array( 'GET', 'POST' ) ),
+			'module settings'    => array( $ns . 'jetpack-stats-dashboard/module-settings', array( 'GET', 'POST' ) ),
+			'commercial class.'  => array( $ns . 'commercial-classification', array( 'POST' ) ),
+			'wordads'            => array( $ns . 'wordads/(?P<subpath>earnings|stats)', array( 'GET' ) ),
+			'purchases'          => array( $ns . 'purchases', array( 'GET' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_stats_routes
+	 *
+	 * @param string   $route            The expected route pattern.
+	 * @param string[] $expected_methods The HTTP methods the route must accept.
+	 */
+	#[DataProvider( 'data_stats_routes' )]
+	public function test_registers_stats_route( string $route, array $expected_methods ) {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( $route, $routes );
+
+		$methods = $routes[ $route ][0]['methods'];
+		foreach ( $expected_methods as $method ) {
+			$this->assertArrayHasKey( $method, $methods );
+		}
+	}
+
+	public function test_stats_routes_use_the_stats_permission_callback() {
+		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/stats'][0];
+		$this->assertSame( array( $this->controller, 'check_stats_permission' ), $route['permission_callback'] );
+	}
+
+	public function test_wordads_route_uses_the_wordads_permission_callback() {
+		$route = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/wordads/(?P<subpath>earnings|stats)'][0];
+		$this->assertSame( array( $this->controller, 'check_wordads_permission' ), $route['permission_callback'] );
+	}
+
+	public function test_stats_permission_granted_for_view_stats_capability() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->check_stats_permission() );
+		$this->assertFalse( $this->controller->check_wordads_permission() );
+	}
+
+	public function test_permissions_denied_for_anonymous_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_stats_permission() );
+		$this->assertFalse( $this->controller->check_wordads_permission() );
+	}
+
+	/**
+	 * @dataProvider data_stats_paths
+	 *
+	 * @param array<string, mixed> $route    The route description to resolve.
+	 * @param string               $subpath  The matched `subpath` capture, if any.
+	 * @param string               $expected The expected WPCOM path.
+	 */
+	#[DataProvider( 'data_stats_paths' )]
+	public function test_build_stats_path( array $route, string $subpath, string $expected ) {
+		$request = new WP_REST_Request( 'GET', '/' );
+		if ( '' !== $subpath ) {
+			$request->set_param( 'subpath', $subpath );
+		}
+
+		$accessor = function ( WP_REST_Request $req, array $r ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->build_stats_path( $req, $r );
+		};
+
+		$site_id  = (int) \Jetpack_Options::get_option( 'id' );
+		$resolved = $accessor->call( $this->controller, $request, $route );
+
+		$this->assertSame( sprintf( $expected, $site_id ), $resolved );
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, mixed>, 1: string, 2: string}>
+	 */
+	public static function data_stats_paths(): array {
+		return array(
+			'wildcard subpath' => array( array( 'wpcom' => 'stats/%s' ), 'top-posts', '/sites/%d/stats/top-posts' ),
+			'wordads subpath'  => array( array( 'wpcom' => 'wordads/%s' ), 'earnings', '/sites/%d/wordads/earnings' ),
+			'static path'      => array( array( 'wpcom' => 'subscribers/counts' ), '', '/sites/%d/subscribers/counts' ),
+			'build override'   => array(
+				array(
+					'build' => static function ( int $id ): string {
+						return sprintf( '/upgrades?site=%d', $id );
+					},
+				),
+				'',
+				'/upgrades?site=%d',
+			),
+		);
+	}
+
+	public function test_response_with_null_cache_key_is_not_cached() {
+		$response = $this->cache_and_build_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ok' => true ), JSON_UNESCAPED_SLASHES ),
+				'headers'  => array(),
+			),
+			null
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
 	 * Build a proxy request with the endpoint capture and forwarded query params set.
 	 *
 	 * @param string $endpoint The analytics endpoint to proxy.
@@ -192,31 +322,37 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Compute the controller's transient cache key for a request.
+	 * Compute the controller's transient cache key for an analytics request.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return string
 	 */
 	private function cache_key( WP_REST_Request $request ): string {
-		$accessor = function ( WP_REST_Request $req ) {
+		$path = sprintf(
+			'/sites/%d/analytics/%s',
+			(int) \Jetpack_Options::get_option( 'id' ),
+			(string) $request->get_param( 'endpoint' )
+		);
+
+		$accessor = function ( WP_REST_Request $req, string $wpcom_path ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
-			return $this->get_cache_key( $req );
+			return $this->get_cache_key( $req, $wpcom_path );
 		};
 
-		return $accessor->call( $this->controller, $request );
+		return $accessor->call( $this->controller, $request, $path );
 	}
 
 	/**
 	 * Invoke the controller's private cache_and_build_response().
 	 *
-	 * @param array  $http_response Raw HTTP response array.
-	 * @param string $cache_key     Transient key.
+	 * @param array       $http_response Raw HTTP response array.
+	 * @param string|null $cache_key     Transient key, or null to skip caching.
 	 *
 	 * @return WP_REST_Response|\WP_Error
 	 */
-	private function cache_and_build_response( array $http_response, string $cache_key ) {
-		$accessor = function ( array $resp, string $key ) {
+	private function cache_and_build_response( array $http_response, ?string $cache_key ) {
+		$accessor = function ( array $resp, ?string $key ) {
 			return $this->cache_and_build_response( $resp, $key );
 		};
 

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -660,8 +660,10 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 * @return string
 	 */
 	private function data_route_key(): string {
+		// Identify the route by its stable structural markers (the proxy/v<version>/ shape and the
+		// endpoint capture), not by any one prefix — so it survives changes to the allowlist.
 		foreach ( array_keys( rest_get_server()->get_routes() ) as $key ) {
-			if ( str_contains( $key, '(?P<endpoint>' ) && str_contains( $key, 'commercial' ) ) {
+			if ( str_contains( $key, '/proxy/v' ) && str_contains( $key, '(?P<endpoint>' ) ) {
 				return $key;
 			}
 		}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -396,6 +396,75 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Unsupported endpoints must not route at all — the request never reaches the handler and the
+	 * blog token is never forwarded. Covers other resources, foreign namespaces, prefix-extension
+	 * strings, and deep sub-paths under a non-allowed prefix.
+	 *
+	 * @dataProvider data_unsupported_paths
+	 *
+	 * @param string $path The endpoint path (after proxy/v2/).
+	 */
+	#[DataProvider( 'data_unsupported_paths' )]
+	public function test_unsupported_endpoint_is_not_routed( string $path ) {
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/v2/' . $path )
+		);
+
+		$this->assertSame( 404, $response->get_status(), "$path must not route" );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public static function data_unsupported_paths(): array {
+		return array(
+			'other resource'        => array( 'posts' ),
+			'core wp namespace'     => array( 'wp/v2/users' ),
+			'me namespace'          => array( 'me/settings' ),
+			'raw sites passthrough' => array( 'sites/1/options' ),
+			'prefix extension'      => array( 'statsfoo' ),
+			'analytics extension'   => array( 'analyticsx' ),
+			'deep unsupported path' => array( 'posts/123/revisions/456' ),
+		);
+	}
+
+	public function test_shadowed_unsupported_endpoint_is_rejected_on_dispatch() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_admin_shadow',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		// URL prefix is allowed (stats), but a shadowing ?endpoint= points outside the allowlist.
+		// Even as an admin the request is rejected before anything is forwarded.
+		foreach ( array( 'me/settings', 'posts/1', 'wp/v2/users/1/meta' ) as $shadow ) {
+			$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/v1.1/stats' );
+			$request->set_query_params( array( 'endpoint' => $shadow ) );
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertGreaterThanOrEqual( 400, $response->get_status(), "shadow $shadow must be rejected" );
+		}
+	}
+
+	public function test_permission_denies_unsupported_prefix_even_for_admin() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_admin_unsupported',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		// A prefix outside the config fails closed (config lookup misses) — admins included.
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'posts' ) ) );
+		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wp/v2/users' ) ) );
+	}
+
+	/**
 	 * @dataProvider data_version_bases
 	 *
 	 * @param string $version A version string.


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/WOOA7S-1534/premium-analytics-extend-the-api-proxy-to-cover-stats-admin-endpoints

## Proposed changes

Replaces the Premium Analytics REST proxy's per-endpoint registry with a **single endpoint-agnostic route** under `jetpack-premium-analytics/v1` that serves the whole pass-through surface — analytics **and** the re-exposed `stats-admin` WPCOM endpoints — **without the blog id in the URL**, ahead of deprecating the `stats-admin` package.

**URL shape**
```
proxy/v<version>/<prefix>/<subpath>
```
* The `proxy/` segment marks a **transparent WPCOM forward**, reserving the rest of the namespace for the future *local* endpoints (posts/notices/etc.) so the two kinds never collide.
* The **WPCOM API version is in the path** (matching WPCOM's own `rest/v1.1` vs `wpcom/v2` structure); the base is derived (`v2` → `wpcom`, `v1.x` → `rest`). Examples:
  * `GET …/v1/proxy/v2/analytics/reports/totals` → `/sites/<id>/analytics/reports/totals`
  * `GET …/v1/proxy/v1.1/stats/top-posts` → `/sites/<id>/stats/top-posts`
  * `GET …/v1/proxy/v1.1/wordads/earnings` → `/sites/<id>/wordads/earnings`
  * `GET …/v1/proxy/v1.2/upgrades` → `/upgrades?site=<id>`

**Security boundary**
* **Prefix allowlist in the route regex** — only `analytics`, `stats`, `wordads`, `subscribers`, `jetpack-stats`, `jetpack-stats-dashboard`, `commercial-classification`, `upgrades` match. **Re-enforced** on the effective `get_param('endpoint')` value in `validate_data_endpoint()` (a GET/JSON/POST `endpoint` can shadow the URL capture, so the allowlist is re-checked where the value is actually used → 400 before forwarding).
* **Write-method allowlist** — only `POST` mutates, and only `jetpack-stats-dashboard/`, `commercial-classification`, `stats/referrers/spam/`; everything else 405s. Prefix checks are case-insensitive.
* Per-capability gating (analytics → `manage_options`; WordAds → `activate_wordads`; rest → `manage_options`/`view_stats`). Blog-token-signed, server-pinned site ID, traversal guard, `site` stripped from forwarded params, `force_refresh` cache bypass, write-then-read cache invalidation, per-version cache keys.

**⚠️ Breaking (consumer-coordinated):** the dashboard data layer must call `proxy/v<version>/<prefix>/<subpath>` (analytics moves off the old dedicated `proxy/<subpath>` route). Tracked in WOOA7S-1539.

**Out of scope** (deferred — sub-issues of WOOA7S-1534): local / non-WPCOM-proxy endpoints (`posts`, `posts/<id>`, `posts/<id>/likes`, notices, `jetpack-stats/user-feedback`) and unregistering the `stats-admin` `REST_Controller`.

## Related product discussion/links

* WOOA7S-1534 — https://linear.app/a8c/issue/WOOA7S-1534/premium-analytics-extend-the-api-proxy-to-cover-stats-admin-endpoints

## Does this pull request change what data or activity we track or use?

No. This re-routes existing WPCOM analytics/stats requests through one REST namespace; the data fetched and the blog-token auth are unchanged. Permissions match the originating controllers.

## Testing instructions

* `cd projects/packages/premium-analytics && composer test-php` — 60 tests pass (route shape, prefix/version/endpoint validation incl. the `get_param` shadowing re-check, permission dispatch, write-method policy, path building, caching).
* `composer phpcs:lint -- projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php` — clean.
* On a Jetpack-connected site (admin / `view_stats` / `activate_wordads` as appropriate), confirm the routes above return the same payload as the `stats-admin` equivalents. A non-allowed prefix (e.g. `proxy/v2/posts`) 404s; a shadowed `?endpoint=me/settings` 400s; POST/PUT to a read-only endpoint 405s.


### Sample requests & responses

All requests are admin-cookie-authenticated (send `X-WP-Nonce`); the proxy signs the outbound call with the **blog token** and forwards to WPCOM. The REST response **body is the WPCOM response forwarded verbatim**, with `status` mirrored and `x-wp-total` / `x-wp-totalpages` passed through when present.

> ⚠️ The success bodies below are **representative WPCOM response shapes** (illustrative, not captured from a specific live site — a fresh test site has little stats data). The error responses come from this proxy's own code and are exact. I can capture live authed responses against a Jetpack-connected Jurassic Ninja site if useful — say the word.

#### Site stats — `GET /wp-json/jetpack-premium-analytics/v1/proxy/v1.1/stats`
```http
GET /wp-json/jetpack-premium-analytics/v1/proxy/v1.1/stats
X-WP-Nonce: <nonce>
```
```jsonc
// 200 — verbatim from WPCOM /sites/<id>/stats (v1.1)
{
  "date": "2026-06-16",
  "stats": {
    "visitors_today": 12, "views_today": 34,
    "views_best_day": "2026-06-10", "views_best_day_total": 210,
    "views": 48210, "visitors": 31002, "comments": 412, "posts": 87,
    "followers_blog": 1530, "followers_subscribers": 1290
  }
}
```

#### Top posts — `GET …/proxy/v1.1/stats/top-posts?period=day&date=2026-06-16`
```jsonc
// 200 — verbatim from WPCOM /sites/<id>/stats/top-posts (v1.1)
{
  "date": "2026-06-16",
  "days": {
    "2026-06-16": {
      "postviews": [
        { "id": 0, "href": "https://example.com/", "title": "Home page / Archives", "type": "homepage", "views": 120 },
        { "id": 41, "href": "https://example.com/hello/", "title": "Hello world", "type": "post", "views": 64 }
      ],
      "total_views": 184
    }
  }
}
```

#### UTM time-series (commas survive validation) — `GET …/proxy/v1.1/stats/utm/utm_source,utm_medium?period=month`
Returns the WPCOM `/sites/<id>/stats/utm/<params>` payload verbatim. The comma-separated params are why the endpoint validator allows `,`.

#### WordAds earnings (needs `activate_wordads`) — `GET …/proxy/v1.1/wordads/earnings`
Returns the WPCOM `/sites/<id>/wordads/earnings` payload verbatim.

#### Purchases — `GET …/proxy/v1.2/upgrades`
Forwarded to WPCOM `/upgrades?site=<id>` (the one non-`/sites/<id>/` endpoint). A caller-supplied `?site=` is stripped so it can't override the pinned site.

#### Write — `POST …/proxy/v2/jetpack-stats-dashboard/modules`
```http
POST /wp-json/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats-dashboard/modules
X-WP-Nonce: <nonce>
Content-Type: application/json

{ "modules": { "highlights": true } }
```
Forwarded as POST to WPCOM `/sites/<id>/jetpack-stats-dashboard/modules` (v2); on a 200 the matching read cache is invalidated.

---

#### Error cases (exact — from this proxy)
```jsonc
// Jetpack not connected — any endpoint
// 403
{ "code": "no_connection", "message": "Please connect Jetpack to load your data.", "data": { "status": 403 } }
```
```jsonc
// Prefix not on the allowlist — GET …/proxy/v2/posts
// 404 (no route matches)
{ "code": "rest_no_route", "message": "No route was found matching the URL and request method.", "data": { "status": 404 } }
```
```jsonc
// get_param shadowing attempt — GET …/proxy/v1.1/stats/x?endpoint=me/settings
// 400 (validator re-checks the effective prefix)
{ "code": "rest_invalid_param", "message": "Invalid parameter(s): endpoint", "data": { "status": 400, "params": { "endpoint": "Invalid parameter." } } }
```
```jsonc
// Non-POST / read-only mutation — POST …/proxy/v1.1/stats/top-posts
// 405
{ "code": "rest_read_only", "message": "This endpoint is read-only.", "data": { "status": 405 } }
```

