### PR TITLE
Premium Analytics: add date range picker to the dashboard

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-date-range-picker
+++ b/projects/packages/premium-analytics/changelog/add-pa-date-range-picker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Add the date range picker with comparison support, syncing the selected range to URL search params so all widgets pick it up.

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@jetpack-premium-analytics/datetime';
 import { BaseControl } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -31,6 +31,19 @@ export type DateFiltersPanelProps = {
 	 * The current primary date range.
 	 */
 	range: DateRange;
+
+	/**
+	 * The applied (committed) preset ID. Used to label the picker's trigger
+	 * while the popover is closed, so a discarded draft shows the applied
+	 * preset. Falls back to `presetId` when omitted.
+	 */
+	appliedPresetId?: PrimaryPresetId;
+
+	/**
+	 * The applied (committed) date range. Used to label the picker's trigger
+	 * while the popover is closed. Falls back to `range` when omitted.
+	 */
+	appliedRange?: DateRange;
 
 	/**
 	 * The current comparison preset ID (e.g., 'previous-period', 'previous-month').
@@ -97,6 +110,8 @@ export type DateFiltersPanelProps = {
 export function DateFiltersPanel( {
 	presetId,
 	range,
+	appliedPresetId,
+	appliedRange,
 	comparisonPresetId,
 	onChange,
 	onComparisonChange,
@@ -129,6 +144,14 @@ export function DateFiltersPanel( {
 		return isPrimaryPreset( presetId ) ? presetId : undefined;
 	}, [ presetId ] );
 
+	// Same validation for the applied preset that labels the closed trigger.
+	const validatedAppliedPresetId = useMemo( () => {
+		if ( ! appliedPresetId ) {
+			return undefined;
+		}
+		return isPrimaryPreset( appliedPresetId ) ? appliedPresetId : undefined;
+	}, [ appliedPresetId ] );
+
 	// Validate and normalize the comparison preset ID
 	const validatedComparisonPresetId = useMemo( () => {
 		return isComparisonPresetId( comparisonPresetId ) ? comparisonPresetId : undefined;
@@ -137,8 +160,19 @@ export function DateFiltersPanel( {
 	// Derive comparison enabled state directly from validated prop
 	const comparisonEnabled = !! validatedComparisonPresetId;
 
-	// Get available presets for the current range
-	const presets = useComparisonDatePresets( range );
+	/*
+	 * Track whether the primary picker popover is open so the comparison label
+	 * mirrors it: while the picker is open it previews the draft range, but once
+	 * closed without Apply it reverts to the applied range (just like the
+	 * picker's own trigger). Without this, the comparison label would keep
+	 * showing the un-applied draft's derived range.
+	 */
+	const [ isPrimaryPickerOpen, setIsPrimaryPickerOpen ] = useState( false );
+	const comparisonSourceRange = isPrimaryPickerOpen ? range : appliedRange ?? range;
+
+	// Available comparison presets, derived from whichever primary range the
+	// picker is currently reflecting (draft while open, applied while closed).
+	const presets = useComparisonDatePresets( comparisonSourceRange );
 
 	/**
 	 * Determines the default preset ID to use when comparison is enabled.
@@ -200,12 +234,15 @@ export function DateFiltersPanel( {
 				<DateRangePopover
 					presetId={ validatedPresetId }
 					range={ range }
+					appliedPresetId={ validatedAppliedPresetId }
+					appliedRange={ appliedRange }
 					onChange={ onChange }
 					onApply={ onApply }
 					onCancel={ onCancel }
 					canApply={ canApply }
 					timeZone={ timeZone }
 					containerElement={ containerElement }
+					onOpenChange={ setIsPrimaryPickerOpen }
 				/>
 			</BaseControl>
 

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
@@ -286,6 +286,26 @@ type DateRangePopoverProps = Omit< DateRangePopoverContentProps, 'isWideScreen' 
 	 * instead of its own wrapper to determine mobile/wide layouts.
 	 */
 	containerElement?: HTMLElement | null;
+
+	/**
+	 * Applied (committed) range used to label the trigger while the popover is
+	 * closed. Defaults to `range`. Pass the committed range here so closing
+	 * without Apply shows the applied range while `range` keeps the draft.
+	 */
+	appliedRange?: DateRange;
+
+	/**
+	 * Applied (committed) preset used to label the trigger while the popover is
+	 * closed. Defaults to `presetId`.
+	 */
+	appliedPresetId?: PrimaryPresetId;
+
+	/**
+	 * Notifies the parent when the popover opens or closes, so it can mirror the
+	 * draft-while-open / applied-while-closed behavior for related controls
+	 * (e.g. the comparison label that follows the primary range).
+	 */
+	onOpenChange?: ( isOpen: boolean ) => void;
 };
 
 /**
@@ -297,14 +317,29 @@ const WIDE_CONTAINER_THRESHOLD = 780;
 export function DateRangePopover( {
 	presetId,
 	range,
+	appliedRange,
+	appliedPresetId,
 	onChange,
 	onApply,
 	onCancel,
 	canApply,
 	timeZone,
 	containerElement,
+	onOpenChange,
 }: DateRangePopoverProps ) {
 	const [ containerWidth, setContainerWidth ] = useState< number | null >( null );
+
+	// Tracks whether the popover is open, to label the trigger from the live
+	// draft while open and from the applied range while closed.
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleOpenToggle = useCallback(
+		( next: boolean ) => {
+			setIsOpen( next );
+			onOpenChange?.( next );
+		},
+		[ onOpenChange ]
+	);
 
 	// Callback to update container width
 	const handleResize = useCallback( ( entries: ResizeObserverEntry[] ) => {
@@ -328,13 +363,23 @@ export function DateRangePopover( {
 
 	const isWideScreen = containerWidth !== null && containerWidth >= WIDE_CONTAINER_THRESHOLD;
 
-	const presetLabel = getPresetLabel( presetId );
+	/*
+	 * While open, the trigger mirrors the live draft (`range`/`presetId`). While
+	 * closed, it shows the applied range so an accidental outside-click reverts
+	 * the display — the draft itself is kept and restored on reopen.
+	 */
+	const closedRange = appliedRange ?? range;
+	const closedPresetId = appliedRange ? appliedPresetId : presetId;
+	const labelRange = isOpen ? range : closedRange;
+	const labelPresetId = isOpen ? presetId : closedPresetId;
+	const presetLabel = getPresetLabel( labelPresetId );
 
 	return (
 		<Dropdown
 			popoverProps={ {
 				className: 'date-filters-panel__popover',
 			} }
+			onToggle={ handleOpenToggle }
 			renderToggle={ ( { onToggle } ) => (
 				<Button
 					className="date-filters-panel-button"
@@ -346,7 +391,7 @@ export function DateRangePopover( {
 				>
 					<Button.Icon icon={ calendar } size={ 16 } />
 					{ presetLabel && <Badge>{ presetLabel }</Badge> }
-					{ formatDateRange( range ) }
+					{ formatDateRange( labelRange ) }
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
@@ -358,6 +403,10 @@ export function DateRangePopover( {
 						onApply();
 						onClose();
 					} }
+					/*
+					 * Cancel explicitly discards the draft; an outside-click only
+					 * closes (keeping the draft for the next open).
+					 */
 					onCancel={ () => {
 						onCancel();
 						onClose();

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -8,7 +8,10 @@
 	"dependencies": {
 		"@automattic/jetpack-premium-analytics-data": "link:../../packages/data",
 		"@automattic/jetpack-script-data": "workspace:*",
+		"@jetpack-premium-analytics/data": "workspace:*",
+		"@jetpack-premium-analytics/datetime": "workspace:*",
 		"@jetpack-premium-analytics/routing": "workspace:*",
+		"@jetpack-premium-analytics/ui": "workspace:*",
 		"@wordpress/admin-ui": "2.1.0",
 		"@wordpress/api-fetch": "7.46.0",
 		"@wordpress/core-data": "7.46.0",
@@ -20,6 +23,7 @@
 		"@wordpress/ui": "0.13.0",
 		"@wordpress/widget-dashboard": "0.1.1-next.v.202606191442.0",
 		"@wordpress/widget-primitives": "0.1.1-next.v.202606191442.0",
+		"date-fns": "4.1.0",
 		"fast-deep-equal": "^3.1.3",
 		"react": "18.3.1"
 	}

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getScriptData } from '@automattic/jetpack-script-data';
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { ensureCoreSettingsReady, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { isPrimaryPreset } from '@jetpack-premium-analytics/datetime';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
@@ -25,7 +25,11 @@ type DashboardSearch = Record< string, string | undefined >;
  * Seed the default date range into the URL on first visit so the date picker
  * and the widgets share a populated search state. Defaults to the last 30 days
  * with a previous-period comparison, resolved from the shared analytics
- * defaults (`getDefaultQueryParams`).
+ * defaults (`getDefaultQueryParams`). The seed runs after
+ * `ensureCoreSettingsReady()` so the dates are encoded in the site timezone;
+ * otherwise `getDefaultQueryParams` would fall back to the browser timezone
+ * (core `site` settings not loaded yet) and the seeded `to` boundary would
+ * land on a different instant than a later Apply writes.
  *
  * Then register the widget-modules discovery entity before the stage renders,
  * so the stage's `getEntityRecords` read resolves and feeds the records to
@@ -34,7 +38,7 @@ type DashboardSearch = Record< string, string | undefined >;
  * Guarded for idempotency: beforeLoad re-runs on every navigation and preload.
  */
 export const route = {
-	beforeLoad: ( { search }: { search?: DashboardSearch } = {} ) => {
+	beforeLoad: async ( { search }: { search?: DashboardSearch } = {} ) => {
 		const connectionStatus = getScriptData()?.connection?.connectionStatus;
 
 		if ( ! connectionStatus?.isRegistered ) {
@@ -48,6 +52,9 @@ export const route = {
 
 		const params = ( search ?? {} ) as DashboardSearch;
 		if ( ! params.from || ! params.to || ! params.interval ) {
+			// Seed dates in the site timezone, not the browser's (see above).
+			await ensureCoreSettingsReady();
+
 			/*
 			 * Derive the seeded range from a supplied preset (when it maps to a
 			 * concrete range) so a `?preset=…` deep-link gets a matching
@@ -56,21 +63,39 @@ export const route = {
 			 */
 			const preset =
 				isPrimaryPreset( params.preset ) && params.preset !== 'custom' ? params.preset : undefined;
+
+			/*
+			 * Fill only the missing params: defaults first, then the
+			 * user-supplied values override them, so a partial URL (e.g. a
+			 * custom `from`/`to` without `interval`) keeps its provided
+			 * values instead of being reset to the defaults.
+			 */
+			const seeded: Record< string, unknown > = {
+				...getDefaultQueryParams( true, preset ),
+				...params,
+			};
+
+			/*
+			 * When the URL already carries a custom `from`/`to` but no valid
+			 * preset, mark the seed as `custom` so `normalizeReportParams` keeps
+			 * the supplied dates instead of recomputing them from the default
+			 * preset (which would otherwise show the widgets a different range
+			 * than the picker).
+			 */
+			if ( params.from && params.to && ! preset ) {
+				seeded.preset = 'custom';
+			}
+
 			throw redirect( {
 				to: '/',
 				replace: true,
 				/*
-				 * Fill only the missing params: defaults first, then the
-				 * user-supplied values override them, so a partial URL (e.g. a
-				 * custom `from`/`to` without `interval`) keeps its provided
-				 * values instead of being reset to the defaults.
-				 *
 				 * The router is built dynamically, so the '/' route has no
 				 * statically-typed search schema (tanstack widens it to
 				 * `never`). Cast the seeded params the same way the routing
 				 * package does when it writes the URL.
 				 */
-				search: { ...getDefaultQueryParams( true, preset ), ...params } as unknown as never,
+				search: seeded as unknown as never,
 			} );
 		}
 

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -35,6 +35,11 @@ type DashboardSearch = Record< string, string | undefined >;
  * `useWidgetTypes`. Premium Analytics serves the records from its own namespace
  * (see `src/widget-modules.php`), independent of core's `wp/v2` endpoint.
  * Guarded for idempotency: beforeLoad re-runs on every navigation and preload.
+ *
+ * That registration is one-time bootstrap setup that could move to the page's
+ * `init` module (`packages/init`) now that `@wordpress/build` supports it —
+ * registering once at boot instead of on every beforeLoad run. Left here for
+ * now (idempotency-guarded); tracked as a follow-up.
  */
 export const route = {
 	beforeLoad: async ( { search }: { search?: DashboardSearch } = {} ) => {

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { getScriptData } from '@automattic/jetpack-script-data';
-import { ensureCoreSettingsReady, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
-import { isPrimaryPreset } from '@jetpack-premium-analytics/datetime';
+import { ensureCoreSettingsReady, normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -52,39 +51,35 @@ export const route = {
 
 		const params = ( search ?? {} ) as DashboardSearch;
 		if ( ! params.from || ! params.to || ! params.interval ) {
-			// Seed dates in the site timezone, not the browser's (see above).
-			await ensureCoreSettingsReady();
-
 			/*
-			 * Derive the seeded range from a supplied preset (when it maps to a
-			 * concrete range) so a `?preset=…` deep-link gets a matching
-			 * `from`/`to`/`interval` instead of the generic last-30-days default.
-			 * `custom` has no computable range, so it falls back to the default.
+			 * Seed dates in the site timezone, not the browser's, by waiting for
+			 * core `site` settings. A rejection here (network/auth) shouldn't
+			 * error the whole page, so fall back to the default seed — matching
+			 * upstream's loader behavior. The only cost is the timezone briefly
+			 * falling back to the browser's until settings resolve.
 			 */
-			const preset =
-				isPrimaryPreset( params.preset ) && params.preset !== 'custom' ? params.preset : undefined;
+			try {
+				await ensureCoreSettingsReady();
+			} catch {
+				// Proceed with the default seed below.
+			}
 
 			/*
-			 * Fill only the missing params: defaults first, then the
-			 * user-supplied values override them, so a partial URL (e.g. a
-			 * custom `from`/`to` without `interval`) keeps its provided
-			 * values instead of being reset to the defaults.
+			 * Resolve the date params through `normalizeReportParams` — the same
+			 * resolver the widgets use — so the URL and the widgets agree on
+			 * dates, interval, preset, and comparison. A raw default spread would
+			 * force `comp: '1'` onto a custom `from`/`to` deep-link the user never
+			 * asked to compare; normalizeReportParams only applies the default
+			 * comparison on a genuinely fresh load (no `from`/`to`).
+			 *
+			 * Overlay the resolved report params onto the original search so
+			 * non-report params that may be deep-linked (e.g. `section`) survive
+			 * the seed redirect.
 			 */
 			const seeded: Record< string, unknown > = {
-				...getDefaultQueryParams( true, preset ),
 				...params,
+				...normalizeReportParams( params as Parameters< typeof normalizeReportParams >[ 0 ] ),
 			};
-
-			/*
-			 * When the URL already carries a custom `from`/`to` but no valid
-			 * preset, mark the seed as `custom` so `normalizeReportParams` keeps
-			 * the supplied dates instead of recomputing them from the default
-			 * preset (which would otherwise show the widgets a different range
-			 * than the picker).
-			 */
-			if ( params.from && params.to && ! preset ) {
-				seeded.preset = 'custom';
-			}
 
 			throw redirect( {
 				to: '/',

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getScriptData } from '@automattic/jetpack-script-data';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -11,12 +12,19 @@ import { redirect } from '@wordpress/route';
  */
 import { DASHBOARD_REST_NAMESPACE } from './hooks/constants';
 
+type DashboardSearch = Record< string, string | undefined >;
+
 /**
  * Route lifecycle for the dashboard.
  *
  * Guard:
  * - Not connected → /connect
  * - Connected but sync pending → /syncing
+ *
+ * Seed the default date range into the URL on first visit so the date picker
+ * and the widgets share a populated search state. Defaults to the last 30 days
+ * with a previous-period comparison, resolved from the shared analytics
+ * defaults (`getDefaultQueryParams`).
  *
  * Then register the widget-modules discovery entity before the stage renders,
  * so the stage's `getEntityRecords` read resolves and feeds the records to
@@ -25,7 +33,7 @@ import { DASHBOARD_REST_NAMESPACE } from './hooks/constants';
  * Guarded for idempotency: beforeLoad re-runs on every navigation and preload.
  */
 export const route = {
-	beforeLoad: () => {
+	beforeLoad: ( { search }: { search?: DashboardSearch } = {} ) => {
 		const connectionStatus = getScriptData()?.connection?.connectionStatus;
 
 		if ( ! connectionStatus?.isRegistered ) {
@@ -35,6 +43,21 @@ export const route = {
 		const syncFinished = getScriptData()?.premium_analytics?.initial_full_sync_finished ?? 0;
 		if ( ! syncFinished ) {
 			throw redirect( { to: '/syncing' } );
+		}
+
+		const params = ( search ?? {} ) as DashboardSearch;
+		if ( ! params.from || ! params.to || ! params.interval ) {
+			throw redirect( {
+				to: '/',
+				replace: true,
+				/*
+				 * The router is built dynamically, so the '/' route has no
+				 * statically-typed search schema (tanstack widens it to
+				 * `never`). Cast the seeded params the same way the routing
+				 * package does when it writes the URL.
+				 */
+				search: { ...params, ...getDefaultQueryParams( true ) } as unknown as never,
+			} );
 		}
 
 		const coreSelect = select( coreStore ) as unknown as {

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -3,6 +3,7 @@
  */
 import { getScriptData } from '@automattic/jetpack-script-data';
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { isPrimaryPreset } from '@jetpack-premium-analytics/datetime';
 import { store as coreStore } from '@wordpress/core-data';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -47,16 +48,29 @@ export const route = {
 
 		const params = ( search ?? {} ) as DashboardSearch;
 		if ( ! params.from || ! params.to || ! params.interval ) {
+			/*
+			 * Derive the seeded range from a supplied preset (when it maps to a
+			 * concrete range) so a `?preset=…` deep-link gets a matching
+			 * `from`/`to`/`interval` instead of the generic last-30-days default.
+			 * `custom` has no computable range, so it falls back to the default.
+			 */
+			const preset =
+				isPrimaryPreset( params.preset ) && params.preset !== 'custom' ? params.preset : undefined;
 			throw redirect( {
 				to: '/',
 				replace: true,
 				/*
+				 * Fill only the missing params: defaults first, then the
+				 * user-supplied values override them, so a partial URL (e.g. a
+				 * custom `from`/`to` without `interval`) keeps its provided
+				 * values instead of being reset to the defaults.
+				 *
 				 * The router is built dynamically, so the '/' route has no
 				 * statically-typed search schema (tanstack widens it to
 				 * `never`). Cast the seeded params the same way the routing
 				 * package does when it writes the URL.
 				 */
-				search: { ...params, ...getDefaultQueryParams( true ) } as unknown as never,
+				search: { ...getDefaultQueryParams( true, preset ), ...params } as unknown as never,
 			} );
 		}
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -11,3 +11,11 @@
 	padding-block-end: 24px;
 	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 }
+
+.dateFilters {
+	// Sits below the section tabs and above the widgets. The tab list already
+	// adds a bottom margin, so only pad below here to keep the spacing even.
+	// Inline padding matches the tabs and widget grid so it lines up.
+	padding-block-end: var(--wpds-dimension-gap-lg, 16px);
+	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
-import { endOfDay } from 'date-fns';
+import { endOfDay, isValid } from 'date-fns';
 import { DashboardSections } from './components';
 import {
 	DASHBOARD_NAME,
@@ -85,9 +85,25 @@ function Dashboard(): JSX.Element {
 	const presetId = useMemo( () => effective.preset ?? undefined, [ effective.preset ] );
 
 	const range = useMemo( () => {
+		/*
+		 * Parse a search-param date into a TZDate, returning `undefined` for an
+		 * unparseable value. The picker reads these straight from the URL, so a
+		 * malformed `from`/`to` (e.g. a hand-edited or under-encoded deep link
+		 * where the `+` offset decoded to a space) must not produce an invalid
+		 * Date — `formatDate` throws "Invalid time value" on one and would
+		 * white-screen the whole dashboard. `undefined` degrades gracefully.
+		 */
+		const parse = ( value?: string ) => {
+			if ( ! value ) {
+				return undefined;
+			}
+			const date = localTZDate( value );
+			return isValid( date ) ? date : undefined;
+		};
+
 		return {
-			from: effective.from ? localTZDate( effective.from ) : undefined,
-			to: effective.to ? localTZDate( effective.to ) : undefined,
+			from: parse( effective.from ),
+			to: parse( effective.to ),
 		};
 	}, [ effective.from, effective.to ] );
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,12 +1,20 @@
-import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import {
+	getSiteTimezone,
+	GlobalErrorProvider,
+	localTZDate,
+	type ReportQueryParams,
+} from '@jetpack-premium-analytics/data';
+import { encodeDateToSearchParam, useStagedSearch } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { endOfDay } from 'date-fns';
 import { DashboardSections } from './components';
 import {
 	DASHBOARD_NAME,
@@ -16,6 +24,19 @@ import {
 	useDashboardSections,
 } from './hooks';
 import styles from './stage.module.scss';
+import type {
+	ComparisonPresetId,
+	DateRange,
+	PrimaryPresetId,
+} from '@jetpack-premium-analytics/datetime';
+
+type ReportQuerySearchParams = Partial<
+	ReportQueryParams & {
+		preset?: PrimaryPresetId;
+		compare_preset?: ComparisonPresetId;
+		comp?: string;
+	}
+>;
 
 /**
  * Premium Analytics dashboard page stage component.
@@ -45,6 +66,85 @@ function Dashboard(): JSX.Element {
 
 	const [ editMode, setEditMode ] = useState( false );
 
+	/*
+	 * Date-range state lives in the URL search params. Edits are staged
+	 * locally and committed atomically on Apply (or immediately for
+	 * comparison changes), so widgets re-fetch only on commit.
+	 */
+	const { effective, stage, commit, revert, isDirty } = useStagedSearch<
+		ReportQuerySearchParams,
+		'/'
+	>( {
+		from: '/',
+	} );
+
+	const presetId = useMemo( () => effective.preset ?? undefined, [ effective.preset ] );
+
+	const range = useMemo( () => {
+		return {
+			from: effective.from ? localTZDate( effective.from ) : undefined,
+			to: effective.to ? localTZDate( effective.to ) : undefined,
+		};
+	}, [ effective.from, effective.to ] );
+
+	const onChange = useCallback(
+		( nextRange?: DateRange, nextPresetId?: PrimaryPresetId ) => {
+			if ( ! nextRange && ! nextPresetId ) {
+				return;
+			}
+
+			if ( nextRange && nextRange.from && nextRange.to ) {
+				/*
+				 * Stage `from` and `to` as ISO strings. The `to` date is
+				 * adjusted to the end of the day, since the date picker core
+				 * component sets the time to 00:00:00.
+				 */
+				stage( {
+					from: encodeDateToSearchParam( nextRange.from ),
+					to: encodeDateToSearchParam( endOfDay( nextRange.to ) ),
+				} );
+			}
+
+			if ( nextPresetId ) {
+				stage( { preset: nextPresetId } );
+			}
+		},
+		[ stage ]
+	);
+
+	const comparisonPresetId = useMemo(
+		() => effective.compare_preset ?? undefined,
+		[ effective.compare_preset ]
+	);
+
+	/**
+	 * Comparison changes commit immediately (no Apply step).
+	 */
+	const onComparisonChange = useCallback(
+		( nextComparisonRange: DateRange | undefined, nextComparisonPresetId?: ComparisonPresetId ) => {
+			stage( {
+				compare_from: encodeDateToSearchParam( nextComparisonRange?.from ),
+				compare_to: encodeDateToSearchParam( nextComparisonRange?.to ),
+				compare_preset: nextComparisonPresetId ?? undefined,
+				comp: nextComparisonRange ? '1' : undefined,
+			} );
+
+			commit();
+		},
+		[ stage, commit ]
+	);
+
+	const onApply = useCallback( () => {
+		commit();
+	}, [ commit ] );
+
+	const onCancel = useCallback( () => {
+		revert();
+	}, [ revert ] );
+
+	// Container element for the date filters panel responsive layout.
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
 	return (
 		<GlobalErrorProvider>
 			<WidgetDashboard
@@ -72,6 +172,29 @@ function Dashboard(): JSX.Element {
 						value={ activeSection }
 						onChange={ setActiveSection }
 					>
+						{ /*
+						 * The date filters drive every section, so they render once
+						 * below the section tabs and above the widgets, sharing the
+						 * URL search state across all sections.
+						 *
+						 * The wrapper div is also the responsive-measurement target:
+						 * DateFiltersPanel reads its width to pick mobile/wide layouts
+						 * instead of relying on the viewport.
+						 */ }
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel
+								presetId={ presetId }
+								range={ range }
+								comparisonPresetId={ comparisonPresetId }
+								onChange={ onChange }
+								onComparisonChange={ onComparisonChange }
+								onApply={ onApply }
+								onCancel={ onCancel }
+								canApply={ isDirty }
+								timeZone={ getSiteTimezone() }
+								containerElement={ containerElement }
+							/>
+						</div>
 						{ sections.map( section => (
 							<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
 								{ activeSection === section.id ? (

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -43,6 +43,32 @@ type ReportQuerySearchParams = Partial<
 >;
 
 /**
+ * Parse search-param dates into a picker range, dropping unparseable values to
+ * `undefined`. The picker reads these straight from the URL, so a malformed
+ * `from`/`to` (e.g. a hand-edited or under-encoded deep link where the `+`
+ * offset decoded to a space) must not become an invalid Date — `formatDate`
+ * throws "Invalid time value" on one and would white-screen the dashboard.
+ *
+ * @param {string} [from] - The `from` search param.
+ * @param {string} [to]   - The `to` search param.
+ * @return {object} The parsed range, with invalid endpoints as `undefined`.
+ */
+function toPickerRange( from?: string, to?: string ) {
+	const parse = ( value?: string ) => {
+		if ( ! value ) {
+			return undefined;
+		}
+		const date = localTZDate( value );
+		return isValid( date ) ? date : undefined;
+	};
+
+	return {
+		from: parse( from ),
+		to: parse( to ),
+	};
+}
+
+/**
  * Premium Analytics dashboard page stage component.
  *
  * @return {JSX.Element} The Premium Analytics dashboard.
@@ -75,37 +101,34 @@ function Dashboard(): JSX.Element {
 	 * locally and committed atomically on Apply (or immediately for
 	 * comparison changes), so widgets re-fetch only on commit.
 	 */
-	const { effective, stage, commit, revert, isDirty } = useStagedSearch<
+	const { committed, effective, stage, commit, revert, isDirty } = useStagedSearch<
 		ReportQuerySearchParams,
 		'/'
 	>( {
 		from: '/',
 	} );
 
+	/*
+	 * Staged preset/range are the in-progress draft: the open popover (calendar
+	 * + trigger) reflects them live as the user edits.
+	 */
 	const presetId = useMemo( () => effective.preset ?? undefined, [ effective.preset ] );
+	const range = useMemo(
+		() => toPickerRange( effective.from, effective.to ),
+		[ effective.from, effective.to ]
+	);
 
-	const range = useMemo( () => {
-		/*
-		 * Parse a search-param date into a TZDate, returning `undefined` for an
-		 * unparseable value. The picker reads these straight from the URL, so a
-		 * malformed `from`/`to` (e.g. a hand-edited or under-encoded deep link
-		 * where the `+` offset decoded to a space) must not produce an invalid
-		 * Date — `formatDate` throws "Invalid time value" on one and would
-		 * white-screen the whole dashboard. `undefined` degrades gracefully.
-		 */
-		const parse = ( value?: string ) => {
-			if ( ! value ) {
-				return undefined;
-			}
-			const date = localTZDate( value );
-			return isValid( date ) ? date : undefined;
-		};
-
-		return {
-			from: parse( effective.from ),
-			to: parse( effective.to ),
-		};
-	}, [ effective.from, effective.to ] );
+	/*
+	 * Committed preset/range are what's actually applied. The picker uses them
+	 * to label its trigger while the popover is closed, so an accidental
+	 * outside-click reverts the display to the applied range — while the staged
+	 * draft above is kept and restored when the popover reopens.
+	 */
+	const appliedPresetId = useMemo( () => committed.preset ?? undefined, [ committed.preset ] );
+	const appliedRange = useMemo(
+		() => toPickerRange( committed.from, committed.to ),
+		[ committed.from, committed.to ]
+	);
 
 	const onChange = useCallback(
 		( nextRange?: DateRange, nextPresetId?: PrimaryPresetId ) => {
@@ -152,7 +175,10 @@ function Dashboard(): JSX.Element {
 	);
 
 	/**
-	 * Comparison changes commit immediately (no Apply step).
+	 * Comparison changes commit immediately — but only when the primary date
+	 * isn't mid-edit. If a primary edit is staged but not yet applied, the
+	 * comparison change rides along and commits together on Apply, so tweaking
+	 * the comparison never commits an un-applied primary draft.
 	 */
 	const onComparisonChange = useCallback(
 		( nextComparisonRange: DateRange | undefined, nextComparisonPresetId?: ComparisonPresetId ) => {
@@ -163,9 +189,16 @@ function Dashboard(): JSX.Element {
 				comp: nextComparisonRange ? '1' : undefined,
 			} );
 
-			commit();
+			const hasPrimaryDraft =
+				effective.from !== committed.from ||
+				effective.to !== committed.to ||
+				effective.preset !== committed.preset;
+
+			if ( ! hasPrimaryDraft ) {
+				commit();
+			}
 		},
-		[ stage, commit ]
+		[ stage, commit, effective, committed ]
 	);
 
 	const onApply = useCallback( () => {
@@ -219,6 +252,8 @@ function Dashboard(): JSX.Element {
 							<DateFiltersPanel
 								presetId={ presetId }
 								range={ range }
+								appliedPresetId={ appliedPresetId }
+								appliedRange={ appliedRange }
 								comparisonPresetId={ comparisonPresetId }
 								onChange={ onChange }
 								onComparisonChange={ onComparisonChange }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -212,6 +212,21 @@ function Dashboard(): JSX.Element {
 	// Container element for the date filters panel responsive layout.
 	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
 
+	/*
+	 * Read the site timezone reactively. A fully-specified deep link skips the
+	 * seed's `ensureCoreSettingsReady()` await, so core `site` settings may not
+	 * be loaded on first paint; subscribing here re-renders with the real site
+	 * timezone once they resolve, instead of sticking with the browser fallback.
+	 */
+	const timeZone = useSelect( select => {
+		void (
+			select( coreStore ) as unknown as {
+				getEntityRecord: ( kind: string, name: string ) => unknown;
+			}
+		 ).getEntityRecord( 'root', 'site' );
+		return getSiteTimezone();
+	}, [] );
+
 	return (
 		<GlobalErrorProvider>
 			<WidgetDashboard
@@ -260,7 +275,7 @@ function Dashboard(): JSX.Element {
 								onApply={ onApply }
 								onCancel={ onCancel }
 								canApply={ isDirty }
-								timeZone={ getSiteTimezone() }
+								timeZone={ timeZone }
 								containerElement={ containerElement }
 							/>
 						</div>

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -4,7 +4,11 @@ import {
 	localTZDate,
 	type ReportQueryParams,
 } from '@jetpack-premium-analytics/data';
-import { encodeDateToSearchParam, useStagedSearch } from '@jetpack-premium-analytics/routing';
+import {
+	deriveComparisonRange,
+	encodeDateToSearchParam,
+	useStagedSearch,
+} from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
@@ -34,7 +38,7 @@ type ReportQuerySearchParams = Partial<
 	ReportQueryParams & {
 		preset?: PrimaryPresetId;
 		compare_preset?: ComparisonPresetId;
-		comp?: string;
+		comp?: '1';
 	}
 >;
 
@@ -99,17 +103,31 @@ function Dashboard(): JSX.Element {
 				 * adjusted to the end of the day, since the date picker core
 				 * component sets the time to 00:00:00.
 				 */
-				stage( {
-					from: encodeDateToSearchParam( nextRange.from ),
-					to: encodeDateToSearchParam( endOfDay( nextRange.to ) ),
-				} );
+				const from = encodeDateToSearchParam( nextRange.from );
+				const to = encodeDateToSearchParam( endOfDay( nextRange.to ) );
+				const patch: ReportQuerySearchParams = { from, to };
+
+				/*
+				 * When comparison is enabled, re-derive the comparison window
+				 * from the new primary range so widgets compare against the
+				 * matching previous period instead of the stale dates.
+				 */
+				if ( effective.comp === '1' ) {
+					const derived = deriveComparisonRange( { ...effective, from, to } );
+					if ( derived ) {
+						patch.compare_from = derived.compare_from;
+						patch.compare_to = derived.compare_to;
+					}
+				}
+
+				stage( patch );
 			}
 
 			if ( nextPresetId ) {
 				stage( { preset: nextPresetId } );
 			}
 		},
-		[ stage ]
+		[ stage, effective ]
 	);
 
 	const comparisonPresetId = useMemo(


### PR DESCRIPTION
Fixes WOOA7S-1587

## Proposed changes

<img width="1918" height="1130" alt="Google Chrome -2026-06-24 at 16 20 00@2x" src="https://github.com/user-attachments/assets/80eb48db-9b1e-4361-8f15-31cedce36354" />


Ports the date range picker from the next-woocommerce-analytics dashboard into the Premium Analytics dashboard, syncing the selected range to URL search params so every widget picks it up.

* **dashboard route**: renders the `DateFiltersPanel` (already vendored in `packages/ui`) at the top of the dashboard, wired to `useStagedSearch` from `@jetpack-premium-analytics/routing`. Date range and preset edits are staged locally and committed atomically to the URL search params on **Apply** (`from`, `to`, `preset`); the `to` date is adjusted to end-of-day since the calendar component returns midnight. Comparison changes (`compare_from`, `compare_to`, `compare_preset`, `comp`) commit immediately, matching the original dashboard behavior.
* **widgets-toolkit**: points `WidgetRoot`'s default search source at `/` (the premium-analytics dashboard route) instead of the WooCommerce Analytics route path, so widgets resolve their report params from the dashboard URL via `normalizeReportParams`. No widget changes needed — they already read params through `useWidgetRootContext()`.
* **package.json**: adds `link:packages/*` deps for the `data`/`datetime`/`formatters`/`routing`/`ui` internal packages so wp-build can resolve them from the route bundle; documents the new deps in the dashboard route's package.json; updates `pnpm-lock.yaml` accordingly.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a site with the Premium Analytics plugin active.
* Go to the **Analytics** dashboard.
* Verify the date range picker and the **Compare to** dropdown render above the widgets.
* Open the picker, choose a preset (e.g. **Last 7 days**), and click **Apply**.
* Verify the URL updates (`from`, `to` and `preset` search params inside the `p` param) and widgets re-fetch for the new range.
* Pick a custom range via the calendar or the From/To inputs and verify **Apply**/**Cancel** stage and revert correctly.
* Enable comparison via the **Compare to** dropdown and verify the `compare_from`/`compare_to`/`compare_preset`/`comp` params commit immediately without pressing Apply.
* Reload the page with the params in the URL and verify the picker restores the selected range.
