### PR TITLE
WOOA7S-1497: add Videos widget backed by Jetpack Stats

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-videos-widget
+++ b/projects/packages/premium-analytics/changelog/add-pa-videos-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a Videos dashboard widget showing the most played videos via the Jetpack Stats API (through the stats-admin proxy).

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -54,6 +54,7 @@ const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
 const STATS_FOLLOWERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/followers';
 const STATS_SUBSCRIBERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/subscribers';
 const STATS_EMAIL_SUMMARY_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/emails/summary';
+const STATS_VIDEO_PLAYS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/video-plays';
 const WP_SETTINGS_PATH = '/wp/v2/settings';
 
 const coreSettingsMock = {
@@ -603,6 +604,83 @@ function buildEmailSummaryResponse() {
 	return { posts };
 }
 
+/**
+ * Read a query-string parameter from a (possibly relative) apiFetch request
+ * path.
+ *
+ * @param requestPath - The request path, with or without a query string.
+ * @param key         - The parameter name to read.
+ * @return The decoded value, or undefined when absent.
+ */
+function getQueryParam( requestPath: string, key: string ): string | undefined {
+	const query = requestPath.split( '?' )[ 1 ];
+
+	return query ? new URLSearchParams( query ).get( key ) ?? undefined : undefined;
+}
+
+/**
+ * Scale factor for play counts based on how recent the requested window ends,
+ * so the primary (recent) period reads higher than the comparison (earlier)
+ * period and the widget shows period-over-period growth. Recent windows return
+ * the full count; windows ~30+ days back taper to ~70%.
+ *
+ * @param endDate - The window's end date (YYYY-MM-DD), or undefined for "today".
+ * @return A multiplier in the range [0.7, 1].
+ */
+function playsFactorForWindow( endDate: string | undefined ): number {
+	if ( ! endDate ) {
+		return 1;
+	}
+
+	const end = new Date( `${ endDate }T00:00:00` ).getTime();
+
+	if ( Number.isNaN( end ) ) {
+		return 1;
+	}
+
+	const daysAgo = Math.max( 0, ( Date.now() - end ) / ( 24 * 60 * 60 * 1000 ) );
+
+	return 1 - Math.min( daysAgo / 30, 1 ) * 0.3;
+}
+
+/**
+ * Builds a mock Stats "video-plays" response so the Videos widget renders a
+ * populated leaderboard in Storybook. The shape matches what
+ * `sanitizeStatsVideoPlaysResponse` reads (`days.<date>.plays[]`), and play
+ * counts scale by how recent the requested window is so the comparison period
+ * reads lower than the primary one.
+ *
+ * @param requestPath - The request path, used to read the window's end date.
+ * @return Raw video-plays response.
+ */
+function buildVideoPlaysResponse( requestPath: string ) {
+	const endDate = getQueryParam( requestPath, 'end_date' ) ?? getQueryParam( requestPath, 'date' );
+	const date = endDate ?? new Date().toISOString().slice( 0, 10 );
+	const factor = playsFactorForWindow( endDate );
+	const videos = [
+		{ post_id: 101, title: 'Getting Started Walkthrough', plays: 3820 },
+		{ post_id: 102, title: 'Product Launch Highlights', plays: 2640 },
+		{ post_id: 103, title: 'Customer Story: Acme Co.', plays: 1980 },
+		{ post_id: 104, title: 'How-To: Advanced Settings', plays: 1410 },
+		{ post_id: 105, title: 'Behind the Scenes', plays: 980 },
+		{ post_id: 106, title: 'Weekly Recap', plays: 540 },
+		{ post_id: 107, title: '', plays: 320 },
+	];
+	const rows = videos.map( video => ( {
+		post_id: video.post_id,
+		title: video.title,
+		url: `https://example.com/video/${ video.post_id }/`,
+		plays: Math.round( video.plays * factor ),
+		impressions: Math.round( video.plays * factor * 1.8 ),
+		watch_time: Math.round( video.plays * factor * 12 ),
+		retention_rate: 60,
+	} ) );
+
+	// `summary.plays` feeds the summarized path (multi-day ranges set
+	// `summarize=1`); `days.<date>.plays` covers the single-day path.
+	return { date, period: 'day', summary: { plays: rows }, days: { [ date ]: { plays: rows } } };
+}
+
 const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
 
@@ -623,6 +701,10 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 
 	if ( requestPath.startsWith( STATS_EMAIL_SUMMARY_PATH ) ) {
 		return buildEmailSummaryResponse();
+	}
+
+	if ( requestPath.startsWith( STATS_VIDEO_PLAYS_PATH ) ) {
+		return buildVideoPlaysResponse( requestPath );
 	}
 
 	if ( ! requestPath.startsWith( API_BASE ) ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { differenceInCalendarDays, isValid, parseISO } from 'date-fns';
 /**
  * Internal dependencies
  */
@@ -632,15 +633,16 @@ function playsFactorForWindow( endDate: string | undefined ): number {
 		return 1;
 	}
 
-	// Parse as UTC so the scaling (and therefore the mocked counts) stay stable
-	// regardless of the machine's timezone.
-	const end = new Date( `${ endDate }T00:00:00Z` ).getTime();
+	const end = parseISO( endDate );
 
-	if ( Number.isNaN( end ) ) {
+	if ( ! isValid( end ) ) {
 		return 1;
 	}
 
-	const daysAgo = Math.max( 0, ( Date.now() - end ) / ( 24 * 60 * 60 * 1000 ) );
+	// `differenceInCalendarDays` counts whole calendar days between the two
+	// dates, so the scaling (and the mocked counts) stay stable regardless of
+	// the machine's timezone.
+	const daysAgo = Math.max( 0, differenceInCalendarDays( new Date(), end ) );
 
 	return 1 - Math.min( daysAgo / 30, 1 ) * 0.3;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -632,7 +632,9 @@ function playsFactorForWindow( endDate: string | undefined ): number {
 		return 1;
 	}
 
-	const end = new Date( `${ endDate }T00:00:00` ).getTime();
+	// Parse as UTC so the scaling (and therefore the mocked counts) stay stable
+	// regardless of the machine's timezone.
+	const end = new Date( `${ endDate }T00:00:00Z` ).getTime();
 
 	if ( Number.isNaN( end ) ) {
 		return 1;

--- a/projects/packages/premium-analytics/widgets/videos/__tests__/build-video-plays-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/videos/__tests__/build-video-plays-data.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Internal dependencies
+ */
+import { buildVideoPlaysData } from '../build-video-plays-data';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+type VideoSeed = {
+	id?: string | number;
+	label?: string;
+	plays: number;
+};
+
+/**
+ * Builds a single normalized video-plays item from a compact seed.
+ *
+ * @param seed       - The video seed.
+ * @param seed.id    - Stable post ID (omitted when testing label fallback).
+ * @param seed.label - Display label (defaults to `Video`).
+ * @param seed.plays - Play count for the period.
+ * @return A normalized video-plays item.
+ */
+function makeVideo( { id, label = 'Video', plays }: VideoSeed ): StatsVideoPlaysItem {
+	return {
+		id,
+		label,
+		plays,
+		impressions: 0,
+		watch_time: 0,
+		retention_rate: 0,
+		link: null,
+		actions: [],
+		children: null,
+	};
+}
+
+/**
+ * Builds a normalized video-plays report. The Stats query layer summarizes
+ * multi-day ranges server-side, so the report carries a single data point of
+ * per-video totals — which is what the widget consumes.
+ *
+ * @param videos - The videos for the period, already ranked by the API.
+ * @return A normalized video-plays report.
+ */
+function makeReport( videos: VideoSeed[] ): StatsNormalizedReport< StatsVideoPlaysItem > {
+	return {
+		summary: { date_start: '2024-01-01', date_end: '2024-01-31' },
+		data: [
+			{
+				time_interval: '2024-01-01',
+				date_start: '2024-01-01',
+				date_end: '2024-01-31',
+				items: videos.map( makeVideo ),
+			},
+		],
+	};
+}
+
+describe( 'buildVideoPlaysData', () => {
+	it( 'returns an empty array when the primary report is undefined', () => {
+		expect( buildVideoPlaysData( undefined, undefined ) ).toEqual( [] );
+	} );
+
+	it( 'returns an empty array when the primary report has no videos', () => {
+		expect( buildVideoPlaysData( makeReport( [] ), undefined ) ).toEqual( [] );
+	} );
+
+	it( 'maps a single video into leaderboard data', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [ { id: 1, label: 'Intro', plays: 10 } ] ),
+			undefined
+		);
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ] ).toMatchObject( {
+			id: '1',
+			label: 'Intro',
+			currentValue: 10,
+			previousValue: 0,
+			currentShare: 100,
+			previousShare: 0,
+			// No comparison value, so the video reads as newly appeared.
+			delta: 100,
+		} );
+	} );
+
+	it( 'falls back to a translated label when the API omits a title', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [ { id: 1, label: '', plays: 5 } ] ),
+			undefined
+		);
+
+		expect( result[ 0 ].label ).toBe( 'Untitled video' );
+	} );
+
+	it( 'preserves the order the API returns videos in', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [
+				{ id: 2, label: 'B', plays: 20 },
+				{ id: 3, label: 'C', plays: 12 },
+				{ id: 1, label: 'A', plays: 5 },
+			] ),
+			undefined
+		);
+
+		expect( result.map( video => video.label ) ).toEqual( [ 'B', 'C', 'A' ] );
+	} );
+
+	it( 'aligns comparison values by video ID', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [ { id: 1, label: 'Intro', plays: 150 } ] ),
+			makeReport( [ { id: 1, label: 'Intro (renamed)', plays: 100 } ] )
+		);
+
+		expect( result[ 0 ] ).toMatchObject( {
+			currentValue: 150,
+			previousValue: 100,
+			delta: 50,
+		} );
+	} );
+
+	it( 'treats videos missing from the comparison period as zero', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [
+				{ id: 1, label: 'Intro', plays: 10 },
+				{ id: 2, label: 'Outro', plays: 8 },
+			] ),
+			makeReport( [ { id: 1, label: 'Intro', plays: 5 } ] )
+		);
+
+		const outro = result.find( video => video.label === 'Outro' );
+		expect( outro ).toMatchObject( { previousValue: 0, delta: 100 } );
+	} );
+
+	it( 'aligns by label when the API omits IDs', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [ { label: 'Intro', plays: 150 } ] ),
+			makeReport( [ { label: 'Intro', plays: 100 } ] )
+		);
+
+		expect( result[ 0 ] ).toMatchObject( {
+			id: 'Intro',
+			previousValue: 100,
+			delta: 50,
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/videos/__tests__/build-video-plays-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/videos/__tests__/build-video-plays-data.test.ts
@@ -8,18 +8,20 @@ type VideoSeed = {
 	id?: string | number;
 	label?: string;
 	plays: number;
+	link?: string | null;
 };
 
 /**
  * Builds a single normalized video-plays item from a compact seed.
  *
  * @param seed       - The video seed.
- * @param seed.id    - Stable post ID (omitted when testing label fallback).
+ * @param seed.id    - Stable post ID (omitted when testing the link/label fallback).
  * @param seed.label - Display label (defaults to `Video`).
  * @param seed.plays - Play count for the period.
+ * @param seed.link  - Video URL (used as the alignment key when `id` is absent).
  * @return A normalized video-plays item.
  */
-function makeVideo( { id, label = 'Video', plays }: VideoSeed ): StatsVideoPlaysItem {
+function makeVideo( { id, label = 'Video', plays, link = null }: VideoSeed ): StatsVideoPlaysItem {
 	return {
 		id,
 		label,
@@ -27,7 +29,7 @@ function makeVideo( { id, label = 'Video', plays }: VideoSeed ): StatsVideoPlays
 		impressions: 0,
 		watch_time: 0,
 		retention_rate: 0,
-		link: null,
+		link,
 		actions: [],
 		children: null,
 	};
@@ -142,5 +144,23 @@ describe( 'buildVideoPlaysData', () => {
 			previousValue: 100,
 			delta: 50,
 		} );
+	} );
+
+	it( 'keys untitled, id-less videos by link so they do not collapse', () => {
+		const result = buildVideoPlaysData(
+			makeReport( [
+				{ label: '', plays: 20, link: 'https://example.com/a/' },
+				{ label: '', plays: 12, link: 'https://example.com/b/' },
+			] ),
+			undefined
+		);
+
+		expect( result ).toHaveLength( 2 );
+		expect( result.map( video => video.id ) ).toEqual( [
+			'https://example.com/a/',
+			'https://example.com/b/',
+		] );
+		// Both share the "Untitled video" label but remain distinct rows.
+		expect( result.every( video => video.label === 'Untitled video' ) ).toBe( true );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
@@ -23,14 +23,19 @@ function getVideoLabel( video: StatsVideoPlaysItem ) {
 
 /**
  * Resolve the key used to align a video across the primary and comparison
- * periods. Prefers the stable post ID and falls back to the display label when
- * the API omits one.
+ * periods, and to identify its leaderboard row. Prefers the stable post ID,
+ * then the video URL, and only falls back to the display label when the API
+ * omits both — so multiple untitled videos don't collapse onto one key.
  *
  * @param video - The video-plays item.
  * @return The alignment key.
  */
 function getVideoKey( video: StatsVideoPlaysItem ) {
-	return video.id != null ? String( video.id ) : getVideoLabel( video );
+	if ( video.id != null ) {
+		return String( video.id );
+	}
+
+	return video.link || getVideoLabel( video );
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import {
+	calculateDelta,
+	type LeaderboardChartData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+/**
+ * Resolve a display label for a video, falling back to a translated
+ * "Untitled video" label when the API provides none.
+ *
+ * @param video - The video-plays item.
+ * @return The video's display label.
+ */
+function getVideoLabel( video: StatsVideoPlaysItem ) {
+	return typeof video.label === 'string' && video.label
+		? video.label
+		: __( 'Untitled video', 'jetpack-premium-analytics' );
+}
+
+/**
+ * Resolve the key used to align a video across the primary and comparison
+ * periods. Prefers the stable post ID and falls back to the display label when
+ * the API omits one.
+ *
+ * @param video - The video-plays item.
+ * @return The alignment key.
+ */
+function getVideoKey( video: StatsVideoPlaysItem ) {
+	return video.id != null ? String( video.id ) : getVideoLabel( video );
+}
+
+/**
+ * Flatten a normalized video-plays report into its per-video items. The Stats
+ * query layer summarizes multi-day ranges server-side and the endpoint returns
+ * videos already ranked and limited by `max`, so the report carries a single
+ * data point of per-video totals — mirroring how the Authors widget reads its
+ * report.
+ *
+ * @param report - The normalized video-plays report, or undefined while loading.
+ * @return The per-video items for the period.
+ */
+function toVideoItems(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): StatsVideoPlaysItem[] {
+	return report?.data.flatMap( point => point.items ) ?? [];
+}
+
+/**
+ * Builds leaderboard chart data for the Videos widget.
+ *
+ * Transforms Jetpack Stats video-plays data into the format required by
+ * LeaderboardChart, with comparison values aligned by video (videos missing
+ * from the comparison period count as zero).
+ *
+ * @param primary    - Primary period video-plays report
+ * @param comparison - Comparison period video-plays report
+ * @return Processed data ready for the LeaderboardChart component
+ */
+export function buildVideoPlaysData(
+	primary: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
+	comparison: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): LeaderboardChartData {
+	const videos = toVideoItems( primary );
+
+	if ( videos.length === 0 ) {
+		return [];
+	}
+
+	const comparisonPlays = new Map(
+		toVideoItems( comparison ).map( video => [ getVideoKey( video ), video.plays ] )
+	);
+
+	// Share each value against the largest of either period so the overlay bars
+	// stay proportional; `1` guards against division by zero.
+	const maxValue = Math.max(
+		...videos.map( video =>
+			Math.max( video.plays, comparisonPlays.get( getVideoKey( video ) ) ?? 0 )
+		),
+		1
+	);
+
+	return videos.map( video => {
+		const key = getVideoKey( video );
+		const currentValue = video.plays;
+		const previousValue = comparisonPlays.get( key ) ?? 0;
+
+		return {
+			id: key,
+			label: getVideoLabel( video ),
+			currentValue,
+			previousValue,
+			currentShare: ( currentValue / maxValue ) * 100,
+			previousShare: ( previousValue / maxValue ) * 100,
+			delta: calculateDelta( currentValue, previousValue ),
+		};
+	} );
+}

--- a/projects/packages/premium-analytics/widgets/videos/package.json
+++ b/projects/packages/premium-analytics/widgets/videos/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-videos",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/videos/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videos/render.tsx
@@ -22,6 +22,7 @@ import { useMemo } from 'react';
 import { buildVideoPlaysData } from './build-video-plays-data';
 import type { VideosAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
 const DEFAULT_MAX = 7;
 
@@ -29,10 +30,17 @@ const DEFAULT_MAX = 7;
 // `reportParams`; the widget's own settings come from `VideosAttributes`.
 type VideosRenderAttributes = VideosAttributes & Partial< ReportParamsFieldAttributes >;
 
-const toPositiveInt = ( value: string | number | undefined, fallback: number ) => {
+type VideosRenderProps = WidgetRenderProps< VideosRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+// Resolve the `max` attribute to the row count requested from Stats. Per the
+// Stats widget contract `max = 0` means "all rows", so it passes through; only
+// negative or non-numeric values fall back to the default.
+const toMaxRows = ( value: string | number | undefined, fallback: number ) => {
 	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
 
-	return Number.isFinite( parsed ) && parsed > 0 ? parsed : fallback;
+	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
 };
 
 type VideosLeaderboardProps = {
@@ -168,12 +176,13 @@ function VideosReport( { max }: { max: number } ) {
  *
  * @param props            - Render props.
  * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error handler.
  * @return The rendered Videos widget.
  */
-export default function Videos( { attributes = {} }: WidgetRenderProps< VideosRenderAttributes > ) {
+export default function Videos( { attributes = {}, setError }: VideosRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes }>
-			<VideosReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
+		<WidgetRoot attributes={ attributes } setError={ setError }>
+			<VideosReport max={ toMaxRows( attributes.max, DEFAULT_MAX ) } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/videos/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videos/render.tsx
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	formatLegendLabels,
+	useWidgetError,
+	useWidgetRootContext,
+	type LeaderboardChartData,
+	type LegendLabels,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { buildVideoPlaysData } from './build-video-plays-data';
+import type { VideosAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+const DEFAULT_MAX = 7;
+
+// The dashboard injects its date range and comparison state through
+// `reportParams`; the widget's own settings come from `VideosAttributes`.
+type VideosRenderAttributes = VideosAttributes & Partial< ReportParamsFieldAttributes >;
+
+const toPositiveInt = ( value: string | number | undefined, fallback: number ) => {
+	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
+
+	return Number.isFinite( parsed ) && parsed > 0 ? parsed : fallback;
+};
+
+type VideosLeaderboardProps = {
+	/**
+	 * Leaderboard rows to render, already built from the video-plays report.
+	 * When omitted, the empty state is shown (unless `isLoading` is set).
+	 */
+	data?: LeaderboardChartData;
+	/**
+	 * When `true`, the initial loading overlay is rendered instead of the chart.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, a loading overlay is layered over the chart while data
+	 * refetches in the background.
+	 */
+	isRefetching?: boolean;
+	/**
+	 * When `true`, render each row's previous-period delta next to its value.
+	 */
+	withComparison?: boolean;
+	/**
+	 * Custom legend labels for the current/comparison periods.
+	 */
+	legendLabels?: LegendLabels;
+};
+
+/**
+ * Presentational leaderboard for the Videos widget. Renders the site's most
+ * played videos and is responsible only for the loading, empty, and populated
+ * states.
+ *
+ * @param props                - Component props.
+ * @param props.data           - Leaderboard rows to render.
+ * @param props.isLoading      - Whether to render the initial loading overlay.
+ * @param props.isRefetching   - Whether to layer a loading overlay over the chart.
+ * @param props.withComparison - Whether to render previous-period deltas.
+ * @param props.legendLabels   - Custom labels for the current/comparison periods.
+ * @return The rendered leaderboard.
+ */
+function VideosLeaderboard( {
+	data = [],
+	isLoading = false,
+	isRefetching = false,
+	withComparison = false,
+	legendLabels,
+}: VideosLeaderboardProps ) {
+	if ( isLoading ) {
+		return <WidgetLoadingOverlay />;
+	}
+
+	return (
+		<>
+			<LeaderboardChart
+				data={ data }
+				withComparison={ withComparison }
+				legendLabels={ legendLabels }
+				dataFormat={ {
+					type: 'number',
+					options: { useMultipliers: false, decimals: 0 },
+				} }
+				emptyStateIcon={ video }
+				emptyStateText={ __(
+					'Learn which videos your visitors watch most to understand what keeps them engaged.',
+					'jetpack-premium-analytics'
+				) }
+			/>
+			{ isRefetching && <WidgetLoadingOverlay /> }
+		</>
+	);
+}
+
+/**
+ * Fetches the video-plays report through the Jetpack Stats hook, builds the
+ * leaderboard rows, and hands them to the presentational `VideosLeaderboard`.
+ *
+ * @param props     - Component props.
+ * @param props.max - Maximum number of videos to display.
+ * @return The widget content.
+ */
+function VideosReport( { max }: { max: number } ) {
+	const { reportParams } = useWidgetRootContext();
+	const statsParams = useMemo( () => ( { ...reportParams, max } ), [ reportParams, max ] );
+
+	const {
+		primary,
+		comparison,
+		hasComparison,
+		isLoading,
+		isFetching,
+		hasData,
+		isError,
+		error,
+		refetch,
+	} = useStatsVideoPlays( statsParams );
+
+	// `primary.isPending` also covers the brief window where the query is disabled
+	// while the report params resolve (isLoading is false there).
+	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
+	const isRefetching = isFetching && hasData;
+	const primaryData = primary.data;
+	const comparisonData = comparison.data;
+
+	const chartData = useMemo(
+		() => buildVideoPlaysData( primaryData, comparisonData ),
+		[ primaryData, comparisonData ]
+	);
+
+	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const hasError = useWidgetError( isError, error, refetch );
+	if ( hasError ) {
+		return null;
+	}
+
+	return (
+		<VideosLeaderboard
+			data={ chartData }
+			isLoading={ isInitialLoading }
+			isRefetching={ isRefetching }
+			withComparison={ hasComparison }
+			legendLabels={ legendLabels }
+		/>
+	);
+}
+
+/**
+ * Videos widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client, chart theme, and the report
+ * params consumed by the inner leaderboard — resolved from the dashboard date
+ * range via context, the same way the other Stats widgets read them.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @return The rendered Videos widget.
+ */
+export default function Videos( { attributes = {} }: WidgetRenderProps< VideosRenderAttributes > ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<VideosReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/videos/stories/videos-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videos/stories/videos-widget.stories.tsx
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import VideosRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const VIDEOS_RENDER_MODULE = 'storybook/videos';
+
+const DEFAULT_MAX = 7;
+
+// Widget-specific story control: toggles the previous-period comparison.
+interface VideosStoryControls {
+	withComparison: boolean;
+}
+
+/**
+ * Render the data-connected Videos widget with report params derived from the
+ * `withComparison` control, so the close-up stories exercise the real data flow
+ * (served by `registerReportMocks`).
+ *
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether to request the previous-period comparison.
+ * @return The rendered widget.
+ */
+function renderVideos( { withComparison }: VideosStoryControls ) {
+	return (
+		<VideosRender
+			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Close-up canvas so the leaderboard fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '360px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Videos',
+	component: VideosRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Dashboard widget showing the site's most played videos as a leaderboard, sourced from the Jetpack Stats `video-plays` module via `useStatsVideoPlays`, with optional period-over-period comparison. In Storybook the data is served by `registerReportMocks`.",
+			},
+		},
+	},
+} satisfies Meta< VideosStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< VideosStoryControls >;
+
+/**
+ * The widget on its own, current period only.
+ */
+export const Default: Story = {
+	render: renderVideos,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Same close-up with each video's period-over-period delta (green for gains,
+ * red for losses) driven by the mocked comparison window.
+ */
+export const WithComparison: Story = {
+	render: renderVideos,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface VideosDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		VideosStoryControls {}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness, so
+ * it appears exactly as it does in product, inheriting the size / edit-mode /
+ * host-environment controls.
+ *
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether to request the previous-period comparison.
+ * @return The widget mounted in the dashboard harness.
+ */
+function VideosDashboardStory( { withComparison, ...dashboardArgs }: VideosDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ VIDEOS_RENDER_MODULE }
+			renderComponent={ VideosRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< VideosDashboardStoryProps > = {
+	render: args => <VideosDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/videos/widget.json
+++ b/projects/packages/premium-analytics/widgets/videos/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/videos",
+	"title": "Videos",
+	"description": "Most played videos, sourced from Jetpack Stats.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/videos/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videos/widget.ts
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+
+/**
+ * Configurable attributes for the Videos widget. Mirrors the `attributes`
+ * declared on the widget definition below; the host passes the selected values
+ * through to `render.tsx`.
+ */
+export type VideosAttributes = {
+	/**
+	 * Maximum number of videos to show. Maps to the WPCOM stats `max` param.
+	 */
+	max?: number;
+};
+
+/**
+ * Widget type definition.
+ */
+export default {
+	name: 'jpa/videos',
+	title: __( 'Videos', 'jetpack-premium-analytics' ),
+	icon: video,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Maximum videos', 'jetpack-premium-analytics' ),
+			type: 'integer' as const,
+		},
+	],
+	example: {
+		attributes: {
+			max: '7',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/videos/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videos/widget.ts
@@ -11,9 +11,11 @@ import { video } from '@wordpress/icons';
  */
 export type VideosAttributes = {
 	/**
-	 * Maximum number of videos to show. Maps to the WPCOM stats `max` param.
+	 * Maximum number of videos to show; `0` means all. Maps to the WPCOM stats
+	 * `max` param. Integer form controls can serialize the value to a string, so
+	 * the render entry accepts either.
 	 */
-	max?: number;
+	max?: string | number;
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/videos/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videos/widget.ts
@@ -32,7 +32,7 @@ export default {
 	],
 	example: {
 		attributes: {
-			max: '7',
+			max: 7,
 		},
 	},
 };


### PR DESCRIPTION
## Proposed changes

Ports the Videos widget from the Jetpack Stats module into the Premium Analytics dashboard, backed by the Jetpack Stats API.

<img width="2782" height="860" alt="Google Chrome -2026-06-30 at 20 19 41@2x" src="https://github.com/user-attachments/assets/5528f316-680f-4016-bcfa-23f936e6dff2" />


* **data package**: adds a `stats-fetch` API client that goes through the stats-admin proxy (`/jetpack/v4/stats-app/sites/{blog_id}/stats/{resource}`), plus `statsQuery`/`statsVideoPlaysQuery` query builders and `useStatsVideoPlays`/`useStatsBlogId` hooks. The blog ID is resolved once from `/jetpack/v4/connection/data` and cached for the page lifetime; queries use `skipToken` while the blog ID or report date is unresolved.
* **widgets-toolkit**: adds `VideosWidget` (leaderboard chart of most played videos with comparison support) and a `buildVideoPlaysData` helper, with loading/refetching overlays and empty/error states.
* **premium-analytics plugin**: registers the `jpa/videos` dashboard widget (render entry, `widget.json`, `widget.ts` with a configurable `max` attribute). The render entry defaults to an all-time report range until the host can pass the site launch date.
* **chart empty state**: centers the empty state across the full widget width instead of the chart column.
* **query client provider**: adds a `withDevtools` prop so React Query devtools render once at the page level instead of per widget.
* **icons**: adds a `video` icon used for the chart empty state.

Note: the diff also carries the "add dynamic widget registry and REST endpoint" commit until the base branch catches up with it.

## Related product discussion/links

* WOOA7S-1497

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a Jetpack-connected site with the Premium Analytics plugin active, ideally one with VideoPress/video traffic.
* Go to the Premium Analytics dashboard and open the widget picker.
* Add the **Videos** widget.
* Verify it renders a leaderboard of the most played videos, sourced from Jetpack Stats (check the network tab for requests to `/jetpack/v4/stats-app/sites/{blog_id}/stats/video-plays`).
* Change the `Maximum videos` attribute and verify the list respects the limit.
* On a site with no video plays, verify the empty state copy renders centered across the widget instead of the chart.