### PR TITLE
Premium Analytics: route stats/* proxy endpoints to the v1.1 Stats API

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1489-proxy-stats-routing
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1489-proxy-stats-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Api_Proxy_Controller: route stats/* endpoints (e.g. stats/top-posts) to the v1.1 Stats REST API; other endpoints continue to target the v2 analytics API.

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -116,8 +116,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Confine the endpoint to a relative analytics sub-path so it cannot escape the
-	 * `/sites/<id>/analytics/` prefix via traversal (`..`), an absolute path, or a scheme.
+	 * Confine the endpoint to a relative sub-path so it cannot escape the
+	 * `/sites/<id>/` prefix via traversal (`..`), an absolute path, or a scheme.
 	 *
 	 * @param mixed $value Raw endpoint param.
 	 *
@@ -155,16 +155,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			);
 		}
 
+		$target = $this->resolve_upstream( $request );
+
 		try {
 			$response = Client::wpcom_json_api_request_as_blog(
-				$this->build_endpoint_url( $request ),
-				'2',
+				$target['path'],
+				$target['version'],
 				array(
 					'method'  => 'GET',
 					'timeout' => self::API_TIMEOUT,
 				),
 				null,
-				'wpcom'
+				$target['base']
 			);
 		} catch ( \Exception $e ) {
 			return new WP_Error(
@@ -186,22 +188,37 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Build the WPCOM analytics path for the connected blog from the request.
+	 * Resolve the upstream WPCOM request for the proxied endpoint: its path, API
+	 * version, and base.
+	 *
+	 * Most endpoints target the v2 analytics namespace (`/sites/<id>/analytics/…`).
+	 * Jetpack Stats endpoints (`stats/…`, e.g. `stats/top-posts`) instead live on
+	 * the v1.1 REST API directly under the site, so they are routed there.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return string
+	 * @return array{path: string, version: string, base: string}
 	 */
-	protected function build_endpoint_url( WP_REST_Request $request ): string {
-		$site_id      = (int) Jetpack_Options::get_option( 'id' );
-		$endpoint_url = sprintf( '/sites/%d/analytics/%s', $site_id, (string) $request->get_param( 'endpoint' ) );
+	protected function resolve_upstream( WP_REST_Request $request ): array {
+		$site_id  = (int) Jetpack_Options::get_option( 'id' );
+		$endpoint = (string) $request->get_param( 'endpoint' );
 
 		$params = $this->get_forwarded_params( $request );
-		if ( ! empty( $params ) ) {
-			$endpoint_url .= '?' . http_build_query( $params );
+		$query  = empty( $params ) ? '' : '?' . http_build_query( $params );
+
+		if ( str_starts_with( $endpoint, 'stats/' ) ) {
+			return array(
+				'path'    => sprintf( '/sites/%d/%s%s', $site_id, $endpoint, $query ),
+				'version' => '1.1',
+				'base'    => 'rest',
+			);
 		}
 
-		return $endpoint_url;
+		return array(
+			'path'    => sprintf( '/sites/%d/analytics/%s%s', $site_id, $endpoint, $query ),
+			'version' => '2',
+			'base'    => 'wpcom',
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -175,6 +175,26 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertFalse( get_transient( $this->cache_key( $request ) ) );
 	}
 
+	public function test_resolve_upstream_routes_stats_endpoints_to_the_v1_1_rest_api() {
+		\Jetpack_Options::update_option( 'id', 123 );
+
+		$target = $this->resolve_upstream( $this->build_request( 'stats/top-posts', array( 'period' => 'day' ) ) );
+
+		$this->assertSame( '/sites/123/stats/top-posts?period=day', $target['path'] );
+		$this->assertSame( '1.1', $target['version'] );
+		$this->assertSame( 'rest', $target['base'] );
+	}
+
+	public function test_resolve_upstream_routes_other_endpoints_to_the_v2_analytics_api() {
+		\Jetpack_Options::update_option( 'id', 123 );
+
+		$target = $this->resolve_upstream( $this->build_request( 'reports/totals', array( 'period' => 'week' ) ) );
+
+		$this->assertSame( '/sites/123/analytics/reports/totals?period=week', $target['path'] );
+		$this->assertSame( '2', $target['version'] );
+		$this->assertSame( 'wpcom', $target['base'] );
+	}
+
 	/**
 	 * Build a proxy request with the endpoint capture and forwarded query params set.
 	 *
@@ -185,7 +205,10 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 */
 	private function build_request( string $endpoint, array $params = array() ): WP_REST_Request {
 		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/' . $endpoint );
-		$request->set_param( 'endpoint', $endpoint );
+		// Mirror real routing: `endpoint` is the URL regex capture, query params
+		// are separate. Setting it as a query param would let set_query_params()
+		// clobber it (and would forward it upstream).
+		$request->set_url_params( array( 'endpoint' => $endpoint ) );
 		$request->set_query_params( $params );
 
 		return $request;
@@ -221,5 +244,21 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		};
 
 		return $accessor->call( $this->controller, $http_response, $cache_key );
+	}
+
+	/**
+	 * Invoke the controller's protected resolve_upstream().
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array{path: string, version: string, base: string}
+	 */
+	private function resolve_upstream( WP_REST_Request $request ): array {
+		$accessor = function ( WP_REST_Request $req ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->resolve_upstream( $req );
+		};
+
+		return $accessor->call( $this->controller, $request );
 	}
 }


### PR DESCRIPTION
### Proposed changes

The `Api_Proxy_Controller` (`jetpack-premium-analytics/v1/proxy/<endpoint>`) always forwarded to `/sites/{id}/analytics/<endpoint>` on the **v2 analytics API**. Jetpack Stats endpoints such as `stats/top-posts` live on the **v1.1 Stats REST API** (`/sites/{id}/stats/top-posts`, `rest` base), so proxying them returned a `rest_no_route` 404 from WPCOM.

This routes `stats/*` endpoints to `/sites/{id}/stats/...` on v1.1 (rest base); all other endpoints continue to target the v2 analytics namespace. The endpoint-validation guard is unchanged (still rejects traversal/absolute/scheme).

### Why

The Premium Analytics dashboard's "Top posts & pages" widget consumes the v1.1 Stats `top-posts` payload and needs to reach it through the proxy controller (which injects the blog ID + auth server-side). Without this, the widget's request 404s.

### Testing instructions

- `cd projects/packages/premium-analytics && composer phpunit -- --filter 'Api_Proxy_Controller'` — 17 passing (includes new `resolve_upstream` routing tests).
- On a Jetpack-connected site, an authenticated GET to `/wp-json/jetpack-premium-analytics/v1/proxy/stats/top-posts?period=day&date=YYYY-MM-DD&max=10&summarize=1` returns HTTP 200 with the `{summary:{postviews:[…]}}` payload (was 404 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)