### PR TITLE
Notifications: make the v3 panel the default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notifications-v3-default
+++ b/projects/plugins/jetpack/changelog/update-notifications-v3-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Notifications: use the v3 notifications panel by default.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -195,9 +195,7 @@ class Jetpack_Notifications {
 
 		$third_party_cookie_check_iframe = '<span style="display:none;"><iframe class="jetpack-notes-cookie-check" src="https://widgets.wp.com/3rd-party-cookie-check/index.html"></iframe></span>';
 
-		// Opt into the v3 notifications panel/iframe via the `notifications=v3` query parameter.
-		$notifications_version = sanitize_key( wp_unslash( $_GET['notifications'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$panel_id              = 'v3' === $notifications_version ? 'wpnt-notes-panel3' : 'wpnt-notes-panel2';
+		$panel_id = 'wpnt-notes-panel3';
 
 		$title = self::get_notes_markup();
 


### PR DESCRIPTION
DOTMSD-1294

## Proposed changes

Graduates the v3 notifications panel to the default. Previously v3 was gated behind a `notifications=v3` query parameter; this drops the opt-in and always renders the v3 panel (`wpnt-notes-panel3`).

The query-param opt-in never shipped, so its unreleased changelog entry is updated in place rather than stacking an add + remove pair.

A small follow-up will remove the now-dead v2-panel code (e.g. inlining the constant `$panel_id` and dropping its `esc_attr` wrapper).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Log in to a site with the Jetpack notifications (masterbar) module active.
* Click the notifications bell in the admin bar.
* Confirm the panel container is `wpnt-notes-panel3` (the v3 panel) without needing `?notifications=v3` in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)