### PR TITLE
Newsletter: match subscriber row avatar fallback to the detail panel

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/cells/subscriber-identity.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/cells/subscriber-identity.tsx
@@ -23,13 +23,17 @@ export default function SubscriberIdentity( { subscriber }: Props ): JSX.Element
 	return (
 		<Stack direction="row" align="center" gap="sm" className="jetpack-newsletter__identity">
 			{ /* The display name + email are rendered as visible text right next to the avatar,
-			     so the avatar is decorative for assistive tech — wrap with aria-hidden + omit
-			     `displayName` (the shared component otherwise uses it as alt text) to avoid the
-			     screen reader announcing the name twice. */ }
+			     so the avatar is decorative for assistive tech — the `aria-hidden` wrapper
+			     removes it (and its `alt`) from the accessibility tree so the name isn't
+			     announced twice. `displayName` is still passed because the shared component
+			     forwards it as `&name=`, which the `d=initials` fallback needs to derive the
+			     initials — without it a subscriber with no Gravatar gets a generic placeholder
+			     that doesn't match the detail view's initials tile. */ }
 			{ email_address ? (
 				<span aria-hidden="true">
 					<Gravatar
 						email={ email_address }
+						displayName={ display_name }
 						size={ 32 }
 						useHovercard={ false }
 						className="jetpack-newsletter__identity-avatar"

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-gravatar
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-gravatar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: render the same initials avatar in the subscriber row and detail panel when a subscriber has no Gravatar

--- a/projects/packages/newsletter/tests/subscriber-identity.test.tsx
+++ b/projects/packages/newsletter/tests/subscriber-identity.test.tsx
@@ -1,0 +1,37 @@
+// The identity cell renders the shared Gravatar next to the subscriber name.
+// For subscribers with no real Gravatar, the `d=initials` fallback needs the
+// display name (sent as `&name=`) to compute the initials — otherwise the row
+// shows a generic placeholder that doesn't match the detail view's initials
+// tile. `@wordpress/ui` is stubbed to plain elements; the real Gravatar renders
+// so we can assert the generated `<img>` URL.
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import SubscriberIdentity from '../_inc/subscribers/components/cells/subscriber-identity';
+import type { Subscriber } from '../_inc/subscribers/data/types';
+
+const subscriber: Subscriber = {
+	user_id: 1,
+	display_name: 'henridevtest',
+	email_address: 'henridevtest@example.com',
+	subscription_status: 'subscribed',
+};
+
+describe( 'SubscriberIdentity (avatar fallback)', () => {
+	it( 'passes the display name to the Gravatar so the initials fallback matches the detail view', () => {
+		render( <SubscriberIdentity subscriber={ subscriber } /> );
+
+		// The avatar lives inside an `aria-hidden` wrapper, so include hidden
+		// elements when querying for it.
+		const img = screen.getByRole( 'img', { hidden: true } ) as HTMLImageElement;
+
+		const url = new URL( img.src );
+		expect( url.searchParams.get( 'd' ) ).toBe( 'initials' );
+		expect( url.searchParams.get( 'name' ) ).toBe( 'henridevtest' );
+	} );
+} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* The modernized Newsletter subscriber **row** rendered a different fallback avatar than the **detail panel** for subscribers with no Gravatar: the row showed a generic placeholder while the panel showed an initials tile.
* Root cause: the row omitted `displayName` on the shared `Gravatar` component (originally to avoid a duplicate screen-reader announcement). `displayName` does double duty — it's the `alt` text *and* becomes the `&name=` URL parameter that Gravatar's `d=initials` default image uses to derive the initials. Dropping it stripped `&name=`, so the row's initials fallback had nothing to render from.
* Pass `displayName` to the row's `Gravatar` again. The avatar is already wrapped in `aria-hidden="true"`, which keeps it (and its `alt`) out of the accessibility tree — so there's no double announcement, and the row now renders the same initials fallback as the detail panel.
* Added a unit test asserting the row avatar URL carries the `name=` parameter (so it matches the detail panel).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the modernized Newsletter dashboard (**Jetpack → Newsletter → Subscribers**).
* Find a subscriber who has **no** Gravatar (so the initials/placeholder fallback is used).
* Confirm the avatar shown in the subscriber **row** matches the avatar shown in the **detail panel** when you click **View** / open the inspector — both should be the same initials tile.
* Subscribers who *do* have a real Gravatar are unaffected (they were always consistent).

### Before / After

Subscriber row avatar vs. detail-panel avatar for a subscriber with no Gravatar (emails redacted). Before, the row fell back to a generic placeholder while the panel showed the initials tile; after, both render the same initials tile.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/newsletter-modernized-gravatar/before-gravatar.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/newsletter-modernized-gravatar/after-gravatar.png) |
