### PR TITLE
SEO: surface SEO Tools as a Plugin Search Hint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-psh-plugin-search-hint
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-psh-plugin-search-hint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-SEO: surface SEO Tools as a Plugin Search Hint when users search the plugin directory for SEO-related terms.
+SEO: Surface SEO Tools as a Plugin Search Hint when users search the plugin directory for SEO-related terms.

--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-psh-plugin-search-hint
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-psh-plugin-search-hint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SEO: surface SEO Tools as a Plugin Search Hint when users search the plugin directory for SEO-related terms.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -354,7 +354,6 @@ class Jetpack_Plugin_Search {
 				'vaultpress',
 				'videopress',
 				'search',
-				'seo-tools',
 			);
 
 			/*
@@ -366,6 +365,16 @@ class Jetpack_Plugin_Search {
 				$searchable_modules[] = 'sharing-block';
 			} else {
 				$searchable_modules[] = 'sharedaddy';
+			}
+
+			/*
+			 * Only surface the SEO Tools hint once the new Jetpack SEO admin page is
+			 * available. The page is gated behind the `rsm_jetpack_seo` feature flag,
+			 * so without this gate the hint's CTAs would point to a page that isn't
+			 * registered yet.
+			 */
+			if ( apply_filters( 'rsm_jetpack_seo', false ) ) {
+				$searchable_modules[] = 'seo-tools';
 			}
 
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -611,11 +611,12 @@ class Jetpack_Plugin_Search {
 		} elseif ( 'seo-tools' === $plugin['module'] && Jetpack::is_module_active( $plugin['module'] ) ) {
 			// Jetpack SEO has its own wp-admin page; send users there (same tab)
 			// rather than a jetpack.com doc redirect, which isn't registered for
-			// this module.
+			// this module. Reuse get_configure_url() so the destination stays in
+			// one place.
 			$links['jp_get_started'] = '<a
 				id="plugin-select-settings"
 				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
-				href="' . esc_url( admin_url( 'admin.php?page=jetpack-seo' ) ) . '"
+				href="' . esc_url( $this->get_configure_url( $plugin['module'], $plugin['configure_url'] ) ) . '"
 				data-module="' . esc_attr( $plugin['module'] ) . '"
 				data-track="get_started"
 				>' . esc_html__( 'Get started', 'jetpack' ) . '</a>';

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -518,12 +518,9 @@ class Jetpack_Plugin_Search {
 				$configure_url = Redirect::get_url( 'calypso-marketing-connections' );
 				break;
 			case 'seo-tools':
-				$configure_url = Redirect::get_url(
-					'calypso-marketing-traffic',
-					array(
-						'anchor' => 'seo',
-					)
-				);
+				// Jetpack SEO has its own wp-admin page (the new SEO home base);
+				// send users there rather than the legacy Traffic page.
+				$configure_url = admin_url( 'admin.php?page=jetpack-seo' );
 				break;
 			case 'google-analytics':
 				$configure_url = Redirect::get_url(
@@ -602,6 +599,17 @@ class Jetpack_Plugin_Search {
 				data-track="configure"
 				>' . esc_html__( 'Configure', 'jetpack' ) . '</a>';
 			// Module is active, doesn't have options to configure.
+		} elseif ( 'seo-tools' === $plugin['module'] && Jetpack::is_module_active( $plugin['module'] ) ) {
+			// Jetpack SEO has its own wp-admin page; send users there (same tab)
+			// rather than a jetpack.com doc redirect, which isn't registered for
+			// this module.
+			$links['jp_get_started'] = '<a
+				id="plugin-select-settings"
+				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
+				href="' . esc_url( admin_url( 'admin.php?page=jetpack-seo' ) ) . '"
+				data-module="' . esc_attr( $plugin['module'] ) . '"
+				data-track="get_started"
+				>' . esc_html__( 'Get started', 'jetpack' ) . '</a>';
 		} elseif ( Jetpack::is_module_active( $plugin['module'] ) ) {
 			$links['jp_get_started'] = '<a
 				id="plugin-select-settings"

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -354,6 +354,7 @@ class Jetpack_Plugin_Search {
 				'vaultpress',
 				'videopress',
 				'search',
+				'seo-tools',
 			);
 
 			/*

--- a/projects/plugins/jetpack/modules/seo-tools.php
+++ b/projects/plugins/jetpack/modules/seo-tools.php
@@ -10,7 +10,7 @@
  * Auto Activate: No
  * Module Tags: Social, Appearance
  * Feature: Traffic
- * Additional Search Queries: search engine optimization, social preview, meta description, custom title format
+ * Additional Search Queries: search engine optimization, social preview, meta description, custom title format, seo, sitemap, open graph, search engine, title tag
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
## Proposed changes

SEO Tools was missing from the Plugin Search Hints (PSH) `$searchable_modules` list, so searching the wp-admin **Plugins → Add New** directory for SEO-related terms surfaced no Jetpack SEO card — even though the `seo-tools` module already declares the metadata PSH needs (name, description, `Requires Connection: No`, `Additional Search Queries`).

- Add `seo-tools` to the PSH `$searchable_modules` list, **gated behind the `rsm_jetpack_seo` feature flag** so the hint only appears once the new Jetpack SEO page exists (that page is gated on the same flag — the two ship together).
- Enrich the `seo-tools` module header's `Additional Search Queries` with `seo, sitemap, open graph, search engine, title tag`, so those searches surface the hint.
- Point the hint's CTAs at the new **Jetpack SEO page** (`admin.php?page=jetpack-seo`): the post-enable **Configure** CTA (via `get_configure_url()`) and the **Get started** CTA shown when the module is already active. Previously these went to the legacy Traffic page and an unregistered `jetpack.com` redirect (`plugin-hint-learn-seo-tools`, a 404) respectively.

The card is dismissible, like every other PSH card. SEO Tools is a free feature (its module `plan_classes` defaults to `free`), so the hint is not plan-gated.

## Related product discussion/links

JETPACK-1725

## Screenshots


https://github.com/user-attachments/assets/649dddd7-e5e2-403e-98ff-defe0e900139


## Does this pull request change what data or activity we track or use?

No new Tracks events. PSH already records `wpa_plugin_search_term` and `wpa_plugin_search_match_found`; with this change `seo-tools` can now appear as a `feature` value in `wpa_plugin_search_match_found`. Covered by the project-wide SEO Tracks review (JETPACK-1728).

## Testing instructions

> The hint is gated behind the `rsm_jetpack_seo` feature flag — enable it (e.g. a mu-plugin `add_filter( 'rsm_jetpack_seo', '__return_true' );`) so the new SEO page exists.

1. With **SEO Tools inactive** and fewer than 3 PSH hints dismissed on the site, go to **Plugins → Add New**.
2. Search for one of the surfaced terms — `seo`, `sitemap`, `open graph`, `search engine`, or `title tag` (or an existing one like `meta description` / `social preview`).
3. Confirm a "Jetpack: SEO Tools" card appears at the top of the results, dismissible, with an **Enable** action.
4. Click **Enable**: confirm SEO Tools activates and you land on the new **Jetpack SEO** page (`admin.php?page=jetpack-seo`) — not the legacy Traffic page.
5. Search again with **SEO Tools active**: confirm the card's **Get started** CTA opens the same Jetpack SEO page (no jetpack.com 404).
6. With the flag **off**, confirm the SEO card does not appear at all.

### Test environments

<!-- Check the environments you verified. -->
- [x] wpcom Simple
- [x] wpcom Atomic
- [x] Self-hosted
- [x] Connected mode
- [ ] Offline mode
