### PR TITLE
Akismet: render the unified Jetpack header, footer and layout on Akismet admin pages

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -40,19 +40,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Akismet_Admin_Chrome {
 
 	/**
-	 * Hook suffixes of Akismet's settings page, depending on where it ends up in the menu.
-	 *
-	 * - `jetpack_page_akismet-key-config`  when Jetpack is active and Akismet is a Jetpack submenu.
-	 * - `settings_page_akismet-key-config` when Jetpack is not driving the menu (Settings submenu).
-	 *
-	 * @var string[]
-	 */
-	const PAGE_HOOK_SUFFIXES = array(
-		'jetpack_page_akismet-key-config',
-		'settings_page_akismet-key-config',
-	);
-
-	/**
 	 * The green Jetpack logo mark, sized via the `height` attribute by callers.
 	 *
 	 * @param int $height Pixel height of the logo.
@@ -178,7 +165,7 @@ class Akismet_Admin_Chrome {
 				exactly like every other unified Jetpack admin page. */
 			.jetpack-admin-page #dolly {
 				float: none;
-				text-align: right;
+				text-align: end;
 				background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 				font-style: italic;
 				color: var(--wpds-color-fg-content-neutral-weak, #87a6bc);
@@ -193,9 +180,15 @@ class Akismet_Admin_Chrome {
 			/* ── Contained layout: fixed header, scrolling middle, pinned footer ──
 				Mirrors the jetpack-admin-page-layout mixin, adapted to Akismet's
 				markup (#wpbody-content > #akismet-plugin-container > header/.akismet-lower/footer).
-				Scoped to both menu locations: jetpack_page_… and settings_page_… */
+				Scoped to both menu locations: jetpack_page_… and settings_page_…
+
+				The mixin uses physical `left`/`right` because its SCSS is compiled
+				through rtlcss, which emits a flipped stylesheet. This inline `<style>`
+				has no such build step, so it uses CSS logical properties
+				(`inset-inline-*`, `padding-inline-*`, `margin-inline`) to flip with the
+				admin menu under RTL locales. */
 			body[class*="_page_akismet-key-config"] #wpcontent {
-				padding-left: 0;
+				padding-inline-start: 0;
 			}
 			body[class*="_page_akismet-key-config"] #wpfooter {
 				display: none;
@@ -204,8 +197,8 @@ class Akismet_Admin_Chrome {
 				box-sizing: border-box;
 				position: fixed;
 				top: var(--wp-admin-bar-height, 32px);
-				left: 160px;
-				right: 0;
+				inset-inline-start: 160px;
+				inset-inline-end: 0;
 				bottom: 0;
 				width: auto;
 				padding-bottom: 0;
@@ -214,16 +207,16 @@ class Akismet_Admin_Chrome {
 				flex-direction: column;
 			}
 			body[class*="_page_akismet-key-config"].folded #wpbody-content {
-				left: 36px;
+				inset-inline-start: 36px;
 			}
 			@media (max-width: 960px) {
 				body[class*="_page_akismet-key-config"].auto-fold #wpbody-content {
-					left: 36px;
+					inset-inline-start: 36px;
 				}
 			}
 			@media (min-width: 961px) {
 				body[class*="_page_akismet-key-config"].is-nav-unification:not(.folded) #wpbody-content {
-					left: 272px;
+					inset-inline-start: 272px;
 				}
 			}
 			body[class*="_page_akismet-key-config"] #akismet-plugin-container {
@@ -260,8 +253,7 @@ class Akismet_Admin_Chrome {
 			body[class*="_page_akismet-key-config"] .akismet-lower > * {
 				box-sizing: border-box;
 				max-width: 45rem;
-				margin-left: auto;
-				margin-right: auto;
+				margin-inline: auto;
 			}
 			body[class*="_page_akismet-key-config"] .jp-akismet-footer {
 				flex-shrink: 0;
@@ -271,7 +263,7 @@ class Akismet_Admin_Chrome {
 				body[class*="_page_akismet-key-config"].folded #wpbody-content,
 				body[class*="_page_akismet-key-config"].auto-fold #wpbody-content {
 					top: var(--wp-admin-bar-height, 46px);
-					left: 0;
+					inset-inline-start: 0;
 				}
 			}
 		</style>

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Renders the unified Jetpack admin header and footer chrome on Akismet's admin pages.
+ *
+ * Akismet (5.7+) exposes two action hooks in its admin views:
+ *  - `akismet_header`: when an action is registered, it REPLACES Akismet's default masthead.
+ *  - `akismet_footer`: rendered at the bottom of every admin view; empty by default.
+ *
+ * This integration consumes those hooks from the Jetpack plugin so that Akismet's pages
+ * share the same branded header bar, standardized footer AND contained layout as the rest
+ * of the unified Jetpack admin (the `@wordpress/admin-ui` page header + `JetpackFooter` look
+ * used by My Jetpack, Protect, Social, etc.): a fixed header, an internally-scrolling middle
+ * and a footer pinned to the bottom of the viewport.
+ *
+ * The markup mirrors the admin-ui page header and `.jetpack-footer` component, and the
+ * styling is a small self-contained stylesheet (no external CSS, no JS, no build step) that
+ * reproduces the measured computed styles of those components plus the
+ * `jetpack-admin-page-layout` mixin, adapted to Akismet's markup
+ * (`#wpbody-content > #akismet-plugin-container > header / .akismet-lower / footer`). This
+ * keeps the integration resilient to the CSS-Module class hashing used by the real React
+ * components.
+ *
+ * NOTE: This class does not modify the Akismet plugin in any way. It only registers
+ * callbacks on Akismet's own action hooks.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Wires the unified Jetpack header, footer and contained layout onto Akismet's admin pages.
+ */
+class Akismet_Admin_Chrome {
+
+	/**
+	 * Hook suffixes of Akismet's settings page, depending on where it ends up in the menu.
+	 *
+	 * - `jetpack_page_akismet-key-config`  when Jetpack is active and Akismet is a Jetpack submenu.
+	 * - `settings_page_akismet-key-config` when Jetpack is not driving the menu (Settings submenu).
+	 *
+	 * @var string[]
+	 */
+	const PAGE_HOOK_SUFFIXES = array(
+		'jetpack_page_akismet-key-config',
+		'settings_page_akismet-key-config',
+	);
+
+	/**
+	 * The green Jetpack logo mark, sized via the `height` attribute by callers.
+	 *
+	 * @param int $height Pixel height of the logo.
+	 * @return string SVG markup.
+	 */
+	private function jetpack_logo( $height ) {
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" height="' . (int) $height . '" class="jp-akismet-logo" aria-hidden="true"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"></path></svg>';
+	}
+
+	/**
+	 * Register the hooks that drive the chrome.
+	 *
+	 * Safe to call unconditionally: the header/footer callbacks are only ever fired by
+	 * Akismet's own admin views, and the inline stylesheet is printed alongside the header.
+	 */
+	public function init_hooks() {
+		add_action( 'akismet_header', array( $this, 'render_header' ) );
+		add_action( 'akismet_footer', array( $this, 'render_footer' ) );
+	}
+
+	/**
+	 * The self-contained stylesheet reproducing the admin-ui page header + `.jetpack-footer`
+	 * computed styles. Printed once, alongside the header.
+	 */
+	private function print_styles() {
+		static $printed = false;
+		if ( $printed ) {
+			return;
+		}
+		$printed = true;
+		?>
+		<style id="jp-akismet-chrome-css">
+			/* ── Header (admin-ui page header look) ── */
+			.jp-akismet-header {
+				display: flex;
+				align-items: center;
+				box-sizing: border-box;
+				min-height: 72px;
+				padding: 16px 24px;
+				background: #fff;
+				/* `box-shadow` (not `border-bottom`) so the hairline never adds to the
+					box and nudges the logo/title off the admin-ui header's vertical center. */
+				box-shadow: inset 0 -1px 0 #e4e4e4;
+			}
+			.jp-akismet-header__title {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+			}
+			/* 24×24 visual slot centering the 20px logo, matching My Jetpack/Boost. */
+			.jp-akismet-header__visual {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-shrink: 0;
+				width: 24px;
+				height: 24px;
+			}
+			.jp-akismet-header__title h1 {
+				margin: 0;
+				padding: 0;
+				font-size: 15px;
+				font-weight: 500;
+				line-height: 20px;
+				color: #1e1e1e;
+			}
+			/* ── Footer (.jetpack-footer look) ── */
+			.jp-akismet-footer {
+				display: flex;
+				align-items: center;
+				flex-wrap: wrap;
+				gap: 24px;
+				box-sizing: border-box;
+				padding: 20px 24px;
+				border-top: 1px solid #e4e4e4;
+				background: #fff;
+				color: #1e1e1e;
+				font-size: 13px;
+			}
+			.jp-akismet-footer__logo {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				font-weight: 500;
+			}
+			.jp-akismet-footer__menu {
+				display: flex;
+				gap: 16px;
+			}
+			/* `#akismet-plugin-container a` is green in Akismet's own CSS; this scoped
+				selector outranks it so the footer links read as neutral grey (#707070,
+				matching My Jetpack's footer links). */
+			#akismet-plugin-container .jp-akismet-footer__menu a {
+				color: #707070;
+				text-decoration: none;
+			}
+			#akismet-plugin-container .jp-akismet-footer__menu a:hover {
+				color: #1e1e1e;
+				text-decoration: underline;
+			}
+			.jp-akismet-footer__a8c {
+				margin-inline-start: auto;
+				display: inline-flex;
+				align-items: center;
+			}
+			/* Mobile: the byline drops its right-push and wraps to its own full-width
+				row, left-aligned — matching how JetpackFooter stacks on other pages. */
+			@media (max-width: 782px) {
+				.jp-akismet-footer__a8c {
+					margin-inline-start: 0;
+					flex-basis: 100%;
+				}
+			}
+			.jp-akismet-footer__a8c svg path {
+				fill: #707070;
+			}
+
+			/* ── Hello Dolly ──
+				The `.jetpack-admin-page #dolly` treatment (right-aligned, italic,
+				WPDS colors) ships in the jetpack-components / My Jetpack admin CSS,
+				which doesn't load on Akismet's page — so without this, Dolly's lyric
+				falls back to left-aligned here. Re-declare it so Dolly lands top-right
+				exactly like every other unified Jetpack admin page. */
+			.jetpack-admin-page #dolly {
+				float: none;
+				text-align: right;
+				background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+				font-style: italic;
+				color: var(--wpds-color-fg-content-neutral-weak, #87a6bc);
+				border-bottom: none;
+			}
+			@media (max-width: 659px) {
+				.jetpack-admin-page #dolly {
+					display: none;
+				}
+			}
+
+			/* ── Contained layout: fixed header, scrolling middle, pinned footer ──
+				Mirrors the jetpack-admin-page-layout mixin, adapted to Akismet's
+				markup (#wpbody-content > #akismet-plugin-container > header/.akismet-lower/footer).
+				Scoped to both menu locations: jetpack_page_… and settings_page_… */
+			body[class*="_page_akismet-key-config"] #wpcontent {
+				padding-left: 0;
+			}
+			body[class*="_page_akismet-key-config"] #wpfooter {
+				display: none;
+			}
+			body[class*="_page_akismet-key-config"] #wpbody-content {
+				box-sizing: border-box;
+				position: fixed;
+				top: var(--wp-admin-bar-height, 32px);
+				left: 160px;
+				right: 0;
+				bottom: 0;
+				width: auto;
+				padding-bottom: 0;
+				overflow: hidden;
+				display: flex;
+				flex-direction: column;
+			}
+			body[class*="_page_akismet-key-config"].folded #wpbody-content {
+				left: 36px;
+			}
+			@media (max-width: 960px) {
+				body[class*="_page_akismet-key-config"].auto-fold #wpbody-content {
+					left: 36px;
+				}
+			}
+			@media (min-width: 961px) {
+				body[class*="_page_akismet-key-config"].is-nav-unification:not(.folded) #wpbody-content {
+					left: 272px;
+				}
+			}
+			body[class*="_page_akismet-key-config"] #akismet-plugin-container {
+				flex: 1 1 auto;
+				min-height: 0;
+				min-width: 0;
+				display: flex;
+				flex-direction: column;
+				/* Drop Akismet's 1px container border: it insets the whole column by 1px,
+					pushing the header logo/title off the admin-ui alignment grid. */
+				border: 0;
+			}
+			body[class*="_page_akismet-key-config"] .jp-akismet-header {
+				flex-shrink: 0;
+			}
+			/* The scrollable middle. Target the generic child between header and
+				footer (not `.akismet-lower` specifically) so the config, start AND
+				stats (bare iframe) views all get a full-width scroll surface. The
+				`#wpbody-content` id keeps these rules ahead of Akismet's own
+				`.akismet-lower { width: 720px }`. */
+			body[class*="_page_akismet-key-config"] #wpbody-content > #akismet-plugin-container > :not(.jp-akismet-header):not(.jp-akismet-footer) {
+				flex: 1 1 auto;
+				min-height: 0;
+				min-width: 0;
+				width: auto;
+				max-width: none;
+				margin: 0;
+				overflow: auto;
+			}
+			/* Move the readable-width restriction onto the content blocks so the
+				scroll surface itself spans the full width (scrolling works wherever
+				the pointer is), while the cards stay a comfortable column, left-
+				aligned with the header. 45rem ≈ Akismet's original 720px column. */
+			body[class*="_page_akismet-key-config"] .akismet-lower > * {
+				box-sizing: border-box;
+				max-width: 45rem;
+				margin-left: auto;
+				margin-right: auto;
+			}
+			body[class*="_page_akismet-key-config"] .jp-akismet-footer {
+				flex-shrink: 0;
+			}
+			@media (max-width: 782px) {
+				body[class*="_page_akismet-key-config"] #wpbody-content,
+				body[class*="_page_akismet-key-config"].folded #wpbody-content,
+				body[class*="_page_akismet-key-config"].auto-fold #wpbody-content {
+					top: var(--wp-admin-bar-height, 46px);
+					left: 0;
+				}
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Render the Jetpack-branded admin-ui-style header that replaces Akismet's default masthead.
+	 */
+	public function render_header() {
+		$this->print_styles();
+		?>
+		<header class="jp-akismet-header">
+			<div class="jp-akismet-header__title">
+				<span class="jp-akismet-header__visual" aria-hidden="true"><?php echo $this->jetpack_logo( 20 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG. ?></span>
+				<h1><?php esc_html_e( 'Akismet Anti-spam', 'jetpack' ); ?></h1>
+			</div>
+		</header>
+		<?php
+	}
+
+	/**
+	 * Render the unified Jetpack footer (`.jetpack-footer` look) at the bottom of the page.
+	 */
+	public function render_footer() {
+		// Match wrap_ui(): link the byline to the local About page when Jetpack isn't connectable,
+		// otherwise to the external jetpack.com redirect.
+		$connectable = ! Jetpack::is_connection_ready() && ! ( new Status() )->is_offline_mode();
+		$a8c_url     = ! $connectable
+			? admin_url( 'admin.php?page=jetpack_about' )
+			: Redirect::get_url( 'jetpack' );
+		?>
+		<footer class="jp-akismet-footer jetpack-footer" aria-label="<?php esc_attr_e( 'Jetpack', 'jetpack' ); ?>" role="contentinfo">
+			<div class="jp-akismet-footer__logo">
+				<?php echo $this->jetpack_logo( 16 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG. ?>
+				<span><?php esc_html_e( 'Jetpack', 'jetpack' ); ?></span>
+			</div>
+			<?php if ( ! ( new Host() )->is_wpcom_platform() ) : ?>
+			<nav class="jp-akismet-footer__menu">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/products' ) ); ?>"><?php echo esc_html_x( 'Products', 'Navigation item', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/help' ) ); ?>"><?php echo esc_html_x( 'Help', 'Navigation item', 'jetpack' ); ?></a>
+			</nav>
+			<?php endif; ?>
+			<a class="jp-akismet-footer__a8c" href="<?php echo esc_url( $a8c_url ); ?>" aria-label="<?php esc_attr_e( 'An Automattic Airline', 'jetpack' ); ?>">
+				<svg role="img" x="0" y="0" viewBox="0 0 935 38.2" height="7" aria-hidden="true"><path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"></path><path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"></path><path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"></path></svg>
+			</a>
+		</footer>
+		<?php
+	}
+}

--- a/projects/plugins/jetpack/changelog/add-akismet-jetpack-admin-chrome
+++ b/projects/plugins/jetpack/changelog/add-akismet-jetpack-admin-chrome
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Render the unified Jetpack admin header and footer on Akismet's admin pages.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -100,6 +100,13 @@ class Jetpack_Admin {
 				// Add an Anti-spam menu item for Jetpack. This is handled automatically by the Admin_Menu as long as it has been initialized.
 				Admin_Menu::init();
 			}
+
+			// Render the unified Jetpack header/footer chrome on Akismet's admin pages by
+			// consuming Akismet's `akismet_header` / `akismet_footer` action hooks. This does
+			// not modify the Akismet plugin; it only registers callbacks on its own hooks.
+			require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class-akismet-admin-chrome.php';
+			$akismet_admin_chrome = new Akismet_Admin_Chrome();
+			$akismet_admin_chrome->init_hooks();
 		}
 
 		// Ensure an Additional CSS menu item is added to the Appearance menu whenever Jetpack is connected.


### PR DESCRIPTION
## What

Renders the unified Jetpack admin **header, footer and layout** on Akismet's admin pages, driven entirely from the Jetpack plugin by consuming Akismet's own `akismet_header` / `akismet_footer` action hooks (shipped in Akismet 5.7+). This is the last leg of the Jetpack header/footer unification: Akismet now matches My Jetpack / Protect / Social.

No changes are made to the Akismet plugin — this only registers callbacks on hooks Akismet already exposes.

## How

A single self-contained class, `Akismet_Admin_Chrome` (`projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php`), wired up from `Jetpack_Admin` inside the existing `class_exists( 'Akismet_Admin' )` block. It registers:

- `akismet_header` → an admin-ui-style page header (Jetpack logo + "Akismet Anti-spam") that replaces Akismet's default masthead.
- `akismet_footer` → the `JetpackFooter` look (logo, Products/Help, "An Automattic Airline" byline).

Styling is a small inline stylesheet that reproduces the measured computed styles of the real `@wordpress/admin-ui` page header and `JetpackFooter` components — **no JavaScript, no external CSS, no build step**. The contained layout (fixed header, internally-scrolling middle, pinned footer) mirrors the `jetpack-admin-page-layout` mixin, adapted to Akismet's markup and scoped to `body[class*="_page_akismet-key-config"]` so it applies under both the Jetpack menu and the Settings menu.

Content is centered and capped at 45rem; the full content area is the scroll surface (so scrolling works wherever the pointer is); responsive down to mobile.

## Testing instructions

1. With Jetpack + Akismet active, visit **Jetpack → Akismet Anti-spam**.
2. Confirm the Jetpack header (logo + "Akismet Anti-spam") replaces Akismet's logo masthead, with a hairline underneath.
3. Confirm the Jetpack footer is pinned to the bottom of the viewport; the content area scrolls between header and footer.
4. Confirm footer links are neutral grey (not green) and the "An Automattic Airline" byline sits at the right.
5. Resize to a narrow/mobile viewport: no horizontal scroll; the footer byline wraps to its own left-aligned row.
6. Confirm the chrome assets do not load on other admin pages.
7. Repeat on the start view (no API key) and the stats view (`&view=stats`).

## Screenshots

Before:
<img width="1263" height="293" alt="image" src="https://github.com/user-attachments/assets/d93a89f0-30c8-4cd5-9f6d-0b57e56e7c5a" />

After:
<img width="1264" height="241" alt="image" src="https://github.com/user-attachments/assets/50d1245d-8fac-4ae0-98d7-95ebbc64c924" />

