### PR TITLE
Phan: Fix various violations

### DIFF
--- a/projects/packages/agents-manager/.phan/baseline.php
+++ b/projects/packages/agents-manager/.phan/baseline.php
@@ -8,12 +8,9 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanPluginDuplicateAdjacentStatement : 1 occurrence
-
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'tests/php/WP_REST_Jetpack_AI_JWT_Test.php' => ['PhanPluginDuplicateAdjacentStatement'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/agents-manager/changelog/fix-phan-various
+++ b/projects/packages/agents-manager/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/agents-manager/changelog/fix-phan-various
+++ b/projects/packages/agents-manager/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
+++ b/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
@@ -152,7 +152,7 @@ class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_rest_route_does_not_register_duplicate_route() {
 		$this->controller->register_rest_route();
-		// phan-suppress-next-line PhanPluginDuplicateAdjacentStatement reason: Intentionally calling twice to ensure duplicates are not registered.
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally calling twice to ensure duplicates are not registered.
 		$this->controller->register_rest_route();
 
 		$routes     = rest_get_server()->get_routes();

--- a/projects/packages/analyzer/.phan/baseline.php
+++ b/projects/packages/analyzer/.phan/baseline.php
@@ -17,7 +17,6 @@ return [
     // PhanUndeclaredMethod : 6 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanUndeclaredTypeParameter : 4 occurrences
-    // PhanPluginDuplicateCatchStatementBody : 2 occurrences
     // PhanTypeMismatchDeclaredParam : 2 occurrences
     // PhanUndeclaredClassStaticProperty : 2 occurrences
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
@@ -42,8 +41,6 @@ return [
         'src/api/class-analyze-controller.php' => ['PhanPluginUseReturnValueInternalKnown'],
         'src/api/class-controller.php' => ['PhanUndeclaredMethod'],
         'src/api/class-model.php' => ['PhanTypeArraySuspiciousNullable'],
-        'src/class-declarations.php' => ['PhanPluginDuplicateCatchStatementBody'],
-        'src/class-invocations.php' => ['PhanPluginDuplicateCatchStatementBody'],
         'src/class-utils.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'src/class-warnings.php' => ['PhanUndeclaredMethod'],
     ],

--- a/projects/packages/analyzer/changelog/fix-phan-various
+++ b/projects/packages/analyzer/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/analyzer/changelog/fix-phan-various
+++ b/projects/packages/analyzer/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/packages/analyzer/src/class-declarations.php
+++ b/projects/packages/analyzer/src/class-declarations.php
@@ -70,10 +70,7 @@ class Declarations extends PersistentList {
 		$source = file_get_contents( $file_path );
 		try {
 			$ast = $this->parser->parse( $source );
-		} catch ( \Error $error ) {
-			echo "Parse error: {$error->getMessage()}\n";
-			return;
-		} catch ( \RuntimeException $error ) {
+		} catch ( \Error | \RuntimeException $error ) {
 			echo "Parse error: {$error->getMessage()}\n";
 			return;
 		}

--- a/projects/packages/analyzer/src/class-invocations.php
+++ b/projects/packages/analyzer/src/class-invocations.php
@@ -69,10 +69,7 @@ class Invocations extends PersistentList {
 		$source = file_get_contents( $file_path );
 		try {
 			$ast = $this->parser->parse( $source );
-		} catch ( \Error $error ) {
-			echo "Parse error: {$error->getMessage()}\n";
-			return;
-		} catch ( \RuntimeException $error ) {
+		} catch ( \Error | \RuntimeException $error ) {
 			echo "Parse error: {$error->getMessage()}\n";
 			return;
 		}

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -22,7 +22,6 @@ return [
     // PhanTypeMismatchPropertyDefault : 2 occurrences
     // PhanTypeObjectUnsetDeclaredProperty : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
-    // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
@@ -49,7 +48,7 @@ return [
         'tests/php/Error_Handler_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/Jetpack_XMLRPC_Server_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/ManagerTest.php' => ['PhanDeprecatedFunction', 'PhanTypeArraySuspiciousNullable', 'PhanTypeObjectUnsetDeclaredProperty'],
-        'tests/php/Nonce_Handler_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument'],
+        'tests/php/Nonce_Handler_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/REST_Authentication_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/REST_Endpoints_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/Server_Sandbox_Test.php' => ['PhanTypeArraySuspiciousNullable'],

--- a/projects/packages/connection/changelog/fix-phan-various
+++ b/projects/packages/connection/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/connection/changelog/fix-phan-various
+++ b/projects/packages/connection/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/packages/connection/tests/php/Nonce_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Nonce_Handler_Test.php
@@ -39,7 +39,7 @@ class Nonce_Handler_Test extends TestCase {
 		// Confirm that the nonce gets added.
 		self::assertTrue( ( new Nonce_Handler() )->add( static::TIMESTAMP, static::NONCE ) );
 
-		// Confirm that the nonce is loaded from cache and still valid during the request.
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Confirm that the nonce is loaded from cache and still valid during the request.
 		self::assertTrue( ( new Nonce_Handler() )->add( static::TIMESTAMP, static::NONCE ) );
 	}
 

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanTypeMismatchArgument : 50+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
     // PhanDeprecatedFunction : 3 occurrences
-    // PhanPluginDuplicateAdjacentStatement : 3 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanDeprecatedClass : 1 occurrence
@@ -23,7 +22,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/contact-form/class-contact-form-field.php' => ['PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/contact-form/class-contact-form-plugin.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/service/class-google-drive.php' => ['PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/forms/changelog/fix-phan-various
+++ b/projects/packages/forms/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/forms/changelog/fix-phan-various
+++ b/projects/packages/forms/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -621,10 +621,6 @@ class Contact_Form_Plugin {
 						unset( $atts['default'] );
 					}
 
-					if ( ! isset( $atts['showCountrySelector'] ) || ! $atts['showCountrySelector'] ) {
-						unset( $atts['default'] );
-					}
-
 					$input_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
 					$atts['inputclasses']  = 'wp-block-jetpack-input';
 					$atts['inputclasses'] .= isset( $input_attrs['class'] ) ? ' ' . $input_attrs['class'] : '';
@@ -952,6 +948,7 @@ class Contact_Form_Plugin {
 		$processor = new \WP_HTML_Tag_Processor( $button_blocks_html );
 
 		$processor->next_tag();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally bumping cursor to next tag.
 		$processor->next_tag();
 
 		$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
@@ -3746,9 +3743,8 @@ class Contact_Form_Plugin {
 				}
 			}
 
-			array_shift( $lines ); // Array
-			array_shift( $lines ); // (
-			array_pop( $lines ); // )
+			array_splice( $lines, 0, 2 ); // Remove first two items: 'Array' and '('.
+			array_pop( $lines ); // Remove last item: ')'.
 			$print_r_output = implode( "\n", $lines );
 
 			// make sure we only match stuff with 4 preceding spaces (stuff for this array and not a nested one

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanPluginMixedKeyNoKey : 7 occurrences
     // PhanPluginUnreachableCode : 4 occurrences
     // PhanTypeMismatchArgument : 3 occurrences
-    // PhanTypeMismatchDimFetch : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
@@ -23,6 +22,7 @@ return [
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
+    // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
 

--- a/projects/packages/publicize/.phan/config.php
+++ b/projects/packages/publicize/.phan/config.php
@@ -13,8 +13,11 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
-		'+stubs'          => array( 'wpcom' ),
-		'parse_file_list' => array(
+		'+stubs'             => array( 'wpcom' ),
+		'exclude_file_regex' => array(
+			'build/',
+		),
+		'parse_file_list'    => array(
 			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
 			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
 			//

--- a/projects/packages/publicize/changelog/fix-phan-various
+++ b/projects/packages/publicize/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/publicize/changelog/fix-phan-various
+++ b/projects/packages/publicize/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/packages/seo/.phan/config.php
+++ b/projects/packages/seo/.phan/config.php
@@ -10,4 +10,11 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'exclude_file_regex' => array(
+			'build/',
+		),
+	)
+);

--- a/projects/packages/seo/changelog/fix-phan-various
+++ b/projects/packages/seo/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/packages/seo/changelog/fix-phan-various
+++ b/projects/packages/seo/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -10,38 +10,37 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 420+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 200+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 220+ occurrences
     // PhanTypeMismatchReturn : 140+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 120+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 90+ occurrences
     // PhanTypeArraySuspiciousNullable : 70+ occurrences
     // PhanDeprecatedFunction : 60+ occurrences
     // PhanRedefineFunction : 45+ occurrences
-    // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanTypeExpectedObjectPropAccess : 30+ occurrences
+    // PhanDeprecatedProperty : 25+ occurrences
     // PhanTypeMismatchDefault : 25+ occurrences
     // PhanTypeMismatchPropertyProbablyReal : 25+ occurrences
-    // PhanDeprecatedProperty : 20+ occurrences
     // PhanParamSignatureMismatch : 20+ occurrences
-    // PhanTypeArraySuspicious : 20+ occurrences
     // PhanTypeMismatchDimFetch : 20+ occurrences
+    // PhanUndeclaredMethod : 20+ occurrences
     // PhanSuspiciousMagicConstant : 15+ occurrences
+    // PhanTypeArraySuspicious : 15+ occurrences
     // PhanTypeMismatchArgumentNullable : 15+ occurrences
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 15+ occurrences
     // PhanPluginMixedKeyNoKey : 10+ occurrences
     // PhanPluginUnreachableCode : 10+ occurrences
     // PhanRedefineClass : 10+ occurrences
-    // PhanTypeMismatchArgumentInternal : 10+ occurrences
     // PhanTypeMismatchArgumentNullableInternal : 10+ occurrences
     // PhanTypeMismatchProperty : 10+ occurrences
     // PhanTypeMismatchReturnNullable : 10+ occurrences
     // PhanUndeclaredFunction : 10+ occurrences
-    // PhanUndeclaredMethod : 10+ occurrences
     // PhanRedefinedClassReference : 8 occurrences
     // PhanTypeMissingReturn : 8 occurrences
     // PhanTypeComparisonToArray : 7 occurrences
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
+    // PhanTypeMismatchArgumentInternal : 6 occurrences
     // PhanDeprecatedClass : 5 occurrences
     // PhanPossiblyUndeclaredVariable : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
@@ -58,7 +57,6 @@ return [
     // PhanDeprecatedFunctionInternal : 2 occurrences
     // PhanImpossibleConditionInLoop : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
-    // PhanParamTooMany : 2 occurrences
     // PhanParamTooManyCallable : 2 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 2 occurrences
     // PhanUndeclaredClassInCallable : 2 occurrences
@@ -66,7 +64,6 @@ return [
     // PhanUndeclaredFunctionInCallable : 2 occurrences
     // PhanCoalescingAlwaysNull : 1 occurrence
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
-    // PhanPluginDuplicateSwitchCase : 1 occurrence
     // PhanPluginInvalidPregRegex : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
     // PhanStaticCallToNonStatic : 1 occurrence
@@ -87,7 +84,6 @@ return [
         '3rd-party/debug-bar/class-jetpack-search-debug-bar.php' => ['PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod'],
         '3rd-party/qtranslate-x.php' => ['PhanTypeMismatchReturn'],
         '3rd-party/wpml.php' => ['PhanUndeclaredFunction'],
-        '_inc/blogging-prompts.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal'],
         '_inc/class.jetpack-provision.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable'],
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument'],
@@ -160,7 +156,7 @@ return [
         'extensions/blocks/rating-star/rating-meta.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/rating-star/rating-star.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/slideshow/slideshow.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
+        'extensions/blocks/slideshow/slideshow.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanTypeMismatchArgument'],
         'functions.compat.php' => ['PhanRedefineFunction'],
@@ -189,7 +185,7 @@ return [
         'json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable'],
         'json-endpoints/class.wpcom-json-api-get-term-endpoint.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable'],
-        'json-endpoints/class.wpcom-json-api-list-comments-endpoint.php' => ['PhanCommentAbstractOnInheritedMethod', 'PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn'],
+        'json-endpoints/class.wpcom-json-api-list-comments-endpoint.php' => ['PhanCommentAbstractOnInheritedMethod', 'PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousNonTraversableForeach'],
         'json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php' => ['PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-list-media-endpoint.php' => ['PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
@@ -258,7 +254,7 @@ return [
         'modules/comments/comments.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
         'modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php' => ['PhanTypeMismatchReturnNullable'],
         'modules/custom-content-types.php' => ['PhanRedefineFunction'],
-        'modules/google-fonts/current/load-google-fonts.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
+        'modules/google-fonts/current/load-google-fonts.php' => ['PhanTypeArraySuspicious'],
         'modules/gravatar-hovercards.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/infinite-scroll.php' => ['PhanUndeclaredClassMethod'],
         'modules/infinite-scroll/infinity.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
@@ -290,7 +286,7 @@ return [
         'modules/shortcodes/pinterest.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/presentations.php' => ['PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/shortcodes/quiz.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal'],
-        'modules/shortcodes/recipe.php' => ['PhanPluginDuplicateSwitchCase', 'PhanTypeMismatchArgument'],
+        'modules/shortcodes/recipe.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/soundcloud.php' => ['PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/shortcodes/spotify.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/tweet.php' => ['PhanTypeMismatchArgument'],
@@ -389,8 +385,7 @@ return [
         'tests/php/core-api/wpcom-fields/WPCOM_REST_API_V2_Attachment_VideoPress_Field_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredMethod'],
         'tests/php/general/Jetpack_Client_Server_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/general/Jetpack_Gutenberg_Test.php' => ['PhanPluginDuplicateAdjacentStatement'],
-        'tests/php/general/Jetpack_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchPropertyDefault'],
+        'tests/php/general/Jetpack_Test.php' => ['PhanTypeMismatchPropertyDefault'],
         'tests/php/general/Jetpack_User_Agent_Test.php' => ['PhanDeprecatedFunction'],
         'tests/php/general/Jetpack_XMLRPC_Server_Test.php' => ['PhanDeprecatedFunction'],
         'tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
@@ -402,7 +397,6 @@ return [
         'tests/php/modules/photon/Jetpack_Photon_Static_Assets_CDN_Test.php' => ['PhanTypeMismatchProperty'],
         'tests/php/modules/publicize/Publicize_Test.php' => ['PhanPluginUnreachableCode'],
         'tests/php/modules/sharedaddy/Jetpack_ReCaptcha_Test.php' => ['PhanDeprecatedClass'],
-        'tests/php/modules/shortcodes/Jetpack_Shortcodes_Archives_Test.php' => ['PhanPluginDuplicateAdjacentStatement'],
         'tests/php/modules/shortcodes/Jetpack_Shortcodes_Getty_Test.php' => ['PhanPluginInvalidPregRegex'],
         'tests/php/modules/shortcodes/Jetpack_Shortcodes_Instagram_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/modules/shortcodes/Jetpack_Shortcodes_PocketCasts_Test.php' => ['PhanTypeMismatchArgument'],
@@ -418,22 +412,21 @@ return [
         'tests/php/sync/Jetpack_Sync_Checksum_Smoke_Test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'tests/php/sync/Jetpack_Sync_Checksum_Test.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn'],
         'tests/php/sync/Jetpack_Sync_Comments_Test.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/Jetpack_Sync_Full_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal'],
+        'tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal'],
+        'tests/php/sync/Jetpack_Sync_Full_Test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal'],
         'tests/php/sync/Jetpack_Sync_Functions_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypeMissingReturn'],
         'tests/php/sync/Jetpack_Sync_Import_Test.php' => ['PhanRedefineClass'],
         'tests/php/sync/Jetpack_Sync_Integration_Test.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Menus_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/Jetpack_Sync_Meta_Test.php' => ['PhanParamTooMany', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
+        'tests/php/sync/Jetpack_Sync_Meta_Test.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
         'tests/php/sync/Jetpack_Sync_Post_Test.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Queue_Dedicated_Table_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Queue_Options_Table_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Queue_Test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Queue_TestBase.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/Jetpack_Sync_Sender_Test.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgumentProbablyReal'],
+        'tests/php/sync/Jetpack_Sync_Sender_Test.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/Jetpack_Sync_Term_Relationships_Test.php' => ['PhanPluginUnreachableCode'],
         'tests/php/sync/Jetpack_Sync_TestBase.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
-        'tests/php/sync/Jetpack_Sync_Themes_Test.php' => ['PhanPluginDuplicateAdjacentStatement'],
         'tests/php/sync/Jetpack_Sync_Users_Test.php' => ['PhanTypeMismatchArgument'],
         'tests/php/sync/Jetpack_Sync_WP_Super_Cache_Test.php' => ['PhanTypeArraySuspiciousNullable'],
         'tests/php/sync/Jetpack_Sync_WooCommerce_Test.php' => ['PhanTypeMismatchArgument'],
@@ -441,7 +434,6 @@ return [
         'tests/php/sync/server/class.jetpack-sync-test-object-factory.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/server/class.jetpack-sync-test-replicastore.php' => ['PhanTypeInvalidLeftOperandOfAdd'],
         'tools/build-asset-cdn-json.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
-        'uninstall.php' => ['PhanTypeMismatchArgumentInternal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -12,7 +12,7 @@ return [
     // PhanTypeMismatchArgument : 420+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 220+ occurrences
     // PhanTypeMismatchReturn : 140+ occurrences
-    // PhanTypeMismatchReturnProbablyReal : 120+ occurrences
+    // PhanTypeMismatchReturnProbablyReal : 110+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 90+ occurrences
     // PhanTypeArraySuspiciousNullable : 70+ occurrences
     // PhanDeprecatedFunction : 60+ occurrences
@@ -156,7 +156,7 @@ return [
         'extensions/blocks/rating-star/rating-meta.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/rating-star/rating-star.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/slideshow/slideshow.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
+        'extensions/blocks/slideshow/slideshow.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanTypeMismatchArgument'],
         'functions.compat.php' => ['PhanRedefineFunction'],

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -140,7 +140,7 @@ add_action( 'wp_after_insert_post', 'jetpack_mark_if_post_answers_blogging_promp
  * Retrieve a blogging prompt by prompt ID.
  *
  * @param int $prompt_id ID of the prompt fetch.
- * @return stdClass|null Prompt object or null.
+ * @return array|null Prompt object or null.
  */
 function jetpack_get_blogging_prompt_by_id( $prompt_id ) {
 	// Ensure the REST API endpoint we need is loaded.

--- a/projects/plugins/jetpack/changelog/fix-phan-various
+++ b/projects/plugins/jetpack/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Phan: Address various violations.

--- a/projects/plugins/jetpack/changelog/fix-phan-various
+++ b/projects/plugins/jetpack/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -255,7 +255,7 @@ function slides( $ids = array(), $width = 400, $height = 300 ) {
  * @param array $ids Array of image ids.
  * @param int   $block_ordinal The ordinal number of the block, used in unique ID.
  *
- * @return array Array of bullets markup.
+ * @return array|string Array of bullets markup when less than 6 items, or a string if more.
  */
 function render_paginator( $ids = array(), $block_ordinal = 0 ) {
 	$total = count( $ids );

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -255,7 +255,7 @@ function slides( $ids = array(), $width = 400, $height = 300 ) {
  * @param array $ids Array of image ids.
  * @param int   $block_ordinal The ordinal number of the block, used in unique ID.
  *
- * @return array|string Array of bullets markup when less than 6 items, or a string if more.
+ * @return string Bullets or count markup.
  */
 function render_paginator( $ids = array(), $block_ordinal = 0 ) {
 	$total = count( $ids );
@@ -277,7 +277,7 @@ function render_paginator( $ids = array(), $block_ordinal = 0 ) {
  * @param array $ids Array of image ids.
  * @param int   $block_ordinal The ordinal number of the block, used in unique ID.
  *
- * @return array Array of bullets markup.
+ * @return string Bullets markup.
  */
 function bullets( $ids = array(), $block_ordinal = 0 ) {
 	$buttons = array_map(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -345,6 +345,7 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 		if ( $args['hierarchical'] ) {
 			$walker      = new WPCOM_JSON_API_List_Comments_Walker();
 			$comment_ids = $walker->paged_walk( $comments, get_option( 'thread_comments_depth', -1 ), $args['page'] ?? 1, $args['number'] );
+			'@phan-var int[] $comment_ids';
 			if ( ! empty( $comment_ids ) ) {
 				$comments = array_map( 'get_comment', $comment_ids );
 			}

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Jetpack_Google_Font_Face' ) ) {
 /**
  * Gets the Google Fonts data
  *
- * @return object[] The collection data of the Google Fonts.
+ * @return array|null The collection data of the Google Fonts.
  */
 function jetpack_get_google_fonts_data() {
 	/**
@@ -91,8 +91,8 @@ function jetpack_get_google_fonts_data() {
 /**
  * Gets the map of the available Google Fonts
  *
- * @param object[] $google_fonts_data The collection data of the Google Fonts.
- * @return object[] The map of the the available Google Fonts.
+ * @param array $google_fonts_data The collection data of the Google Fonts.
+ * @return array The map of the the available Google Fonts.
  */
 function jetpack_get_available_google_fonts_map( $google_fonts_data ) {
 	$jetpack_google_fonts_list = array_map(

--- a/projects/plugins/jetpack/modules/shortcodes/recipe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/recipe.php
@@ -484,11 +484,6 @@ class Jetpack_Recipes {
 				$itemprop              = ' itemprop="nutrition"';
 				$listtype              = 'ul';
 				break;
-			case 'nutrition':
-				$list_item_replacement = '<li class="jetpack-recipe-nutrition nutrition">${1}</li>';
-				$itemprop              = ' itemprop="nutrition"';
-				$listtype              = 'ul';
-				break;
 			default:
 				$list_item_replacement = '<li class="jetpack-recipe-notes">${1}</li>';
 				$itemprop              = '';

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -95,6 +95,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_does_calling_get_availability_twice_result_in_notice() {
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block' ) );
 		Jetpack_Gutenberg::get_availability();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Calling this twice is precisely the purpose of the test.
 		Jetpack_Gutenberg::get_availability();
 		$result = remove_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_block' ) );
 		$this->assertTrue( $result );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
@@ -212,8 +212,10 @@ EXPECTED;
 		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
 
 		Jetpack::update_active_modules( array( 'stats' ) );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Later it makes sure the module only shows once.
 		Jetpack::update_active_modules( array( 'stats' ) );
 		Jetpack::update_active_modules( array( 'json-api' ) );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Later it makes sure the module only shows once.
 		Jetpack::update_active_modules( array( 'json-api' ) );
 
 		$this->assertEquals( self::$activated_modules, array( 'stats', 'json-api' ) );
@@ -229,8 +231,10 @@ EXPECTED;
 		add_action( 'jetpack_deactivate_module_stats', array( __CLASS__, 'track_deactivated_modules' ) );
 
 		Jetpack::update_active_modules( array( 'stats' ) );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Later it makes sure the module only shows once.
 		Jetpack::update_active_modules( array( 'stats' ) );
 		Jetpack::update_active_modules( array( 'json-api' ) );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Later it makes sure the module only shows once.
 		Jetpack::update_active_modules( array( 'json-api' ) );
 
 		$this->assertEquals( self::$activated_modules, array( 'stats' ) );
@@ -252,6 +256,7 @@ EXPECTED;
 		add_filter( 'pre_update_option_jetpack_active_modules', array( __CLASS__, 'filter_pre_update_option_jetpack_active_modules' ), 10, 2 );
 
 		Jetpack::update_active_modules( array( 'json-api' ) );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Later it makes sure the module only shows once.
 		Jetpack::update_active_modules( array( 'json-api' ) );
 
 		$this->assertEquals( self::$activated_modules, array( 'json-api', 'stats' ) );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Archives_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Archives_Test.php
@@ -194,8 +194,7 @@ class Jetpack_Shortcodes_Archives_Test extends WP_UnitTestCase {
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_limit_one() {
-		self::factory()->post->create( array() );
-		self::factory()->post->create( array() );
+		self::factory()->post->create_many( 2 );
 		$attr = array(
 			'format' => 'html',
 			'limit'  => '1',
@@ -211,8 +210,7 @@ class Jetpack_Shortcodes_Archives_Test extends WP_UnitTestCase {
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_limit_zero_is_all() {
-		self::factory()->post->create( array() );
-		self::factory()->post->create( array() );
+		self::factory()->post->create_many( 2 );
 		$attr = array(
 			'format' => 'html',
 			'limit'  => '0',
@@ -235,7 +233,7 @@ class Jetpack_Shortcodes_Archives_Test extends WP_UnitTestCase {
 		);
 		self::factory()->post->create(
 			array(
-				'post_date' => '2014-01-01 01:00:00',
+				'post_date' => '2014-01-02 01:00:00',
 			)
 		);
 		$attr = array(

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Immediately_Test.php
@@ -870,7 +870,9 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_checksum ) );
@@ -884,7 +886,9 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_range ) );
@@ -1153,7 +1157,9 @@ class Jetpack_Sync_Full_Immediately_Test extends Jetpack_Sync_TestBase {
 		$this->full_sync->start( array( 'users' => true ) );
 
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$full_sync_status = $this->full_sync->get_status();

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Full_Test.php
@@ -89,7 +89,6 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 		self::factory()->comment->create_post_comments( $post, 1 );
 
 		$this->full_sync->start();
-		$this->full_sync->start();
 		$this->sender->do_full_sync();
 		$start_event                    = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 		list( $config, $range, $empty ) = $start_event->args; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
@@ -365,6 +364,7 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 		$this->assertNotTrue( $finished );
 
 		$this->full_sync->continue_enqueuing(); // try to enqueue $max_enqueue_full_sync items
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->full_sync->continue_enqueuing(); // try to enqueue $max_enqueue_full_sync items
 
 		// hit $max_queue_size_full_sync limit
@@ -1110,7 +1110,9 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_checksum ) );
@@ -1124,7 +1126,9 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_range ) );
@@ -1465,7 +1469,9 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 		$this->full_sync->start( array( 'users' => true ) );
 
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
@@ -1494,7 +1500,9 @@ class Jetpack_Sync_Full_Test extends Jetpack_Sync_TestBase {
 		$this->assertSame( null, $full_sync_status['finished'] );
 
 		$this->sender->do_full_sync();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync(); // juuuust in case
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional to ensure we get everything.
 		$this->sender->do_full_sync(); // juuuust in case - otherwise we use too many bytes for multisite
 
 		$full_sync_status = $this->full_sync->get_status();

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Meta_Test.php
@@ -372,6 +372,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 	 */
 	public function test_get_object_by_id_will_return_null_for_non_existing_meta() {
 		$module = Modules::get_module( 'meta' );
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Meta $module';
 		$this->assertNull( $module->get_object_by_id( 'post', $this->post_id, 'does_not_exist' ) );
 	}
 
@@ -382,6 +383,7 @@ class Jetpack_Sync_Meta_Test extends Jetpack_Sync_TestBase {
 		$meta_id = add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar' );
 		$module  = Modules::get_module( 'meta' );
 
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Meta $module';
 		$metas    = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
 		$expected = array(
 			array(

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -98,8 +98,8 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		// now let's trigger our action a few times
 		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
+		do_action( 'my_expanding_action', 'y' );
+		do_action( 'my_expanding_action', 'z' );
 
 		// trigger the sync
 		$this->sender->do_sync();
@@ -126,7 +126,9 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		// now let's trigger our action a few times
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
 
 		// trigger the sync
@@ -168,7 +170,9 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		// now let's trigger our action a few times
 		do_action( 'my_expanding_action', 'x' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_expanding_action', 'x' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_expanding_action', 'x' );
 
 		// trigger the sync
@@ -212,10 +216,15 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		// now let's trigger our action a few times
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional.
 		do_action( 'my_action' );
 
 		// now let's try to sync and observe the rate limit
@@ -429,7 +438,9 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		// it should only dequeue 2 of these, because each takes 3 seconds to process, and 3*2 = 6, which is > 4
 		do_action( 'super_slow_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally testing limits.
 		do_action( 'super_slow_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally testing limits.
 		do_action( 'super_slow_action' );
 
 		$this->assertEquals( 3, $this->sender->get_sync_queue()->size() );
@@ -690,8 +701,11 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		add_action( 'demo_action', array( $this->listener, 'action_handler' ) );
 
 		do_action( 'demo_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally testing that throttling does not happen.
 		do_action( 'demo_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally testing that throttling does not happen.
 		do_action( 'demo_action' );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally testing that throttling does not happen.
 		do_action( 'demo_action' );
 
 		// First sync should work and send 2 items.
@@ -899,8 +913,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		// Process one action at each run.
 		$this->sender->set_upload_max_rows( 1 );
 		// Trigger two new actions.
-		self::factory()->post->create();
-		self::factory()->post->create();
+		self::factory()->post->create_many( 2 );
 		// Current "request" is dedicated Sync request.
 		$_SERVER['REQUEST_URI'] = rest_url( 'jetpack/v4/sync/spawn-sync' );
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Themes_Test.php
@@ -151,6 +151,7 @@ class Jetpack_Sync_Themes_Test extends Jetpack_Sync_TestBase {
 		set_theme_mod( 'foo', 'bar' );
 		$this->sender->do_sync();
 
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- See above todo.
 		$this->sender->do_sync();
 		$theme_supports = $this->server_replica_storage->get_callable( 'theme_support' );
 

--- a/projects/plugins/jetpack/uninstall.php
+++ b/projects/plugins/jetpack/uninstall.php
@@ -20,6 +20,7 @@ function jetpack_uninstall() {
 	if (
 		! defined( 'WP_UNINSTALL_PLUGIN' ) ||
 		! WP_UNINSTALL_PLUGIN ||
+		// @phan-suppress-next-line PhanTypeMismatchArgumentInternal -- If it's defined, it's a string: https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/#method-2-uninstall-php
 		dirname( WP_UNINSTALL_PLUGIN ) !== dirname( plugin_basename( __FILE__ ) )
 	) {
 		status_header( 404 );

--- a/projects/plugins/vaultpress/.phan/baseline.php
+++ b/projects/plugins/vaultpress/.phan/baseline.php
@@ -17,7 +17,6 @@ return [
     // PhanPluginUnreachableCode : 5 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
-    // PhanCommentParamWithoutRealParam : 3 occurrences
     // PhanTypeMismatchDimFetch : 3 occurrences
     // PhanUndeclaredFunction : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
@@ -42,7 +41,7 @@ return [
         'class.vaultpress-hotfixes.php' => ['PhanDeprecatedFunction', 'PhanRedefineFunction', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset'],
         'cron-tasks.php' => ['PhanRedefineFunction'],
         'vaultpress.php' => ['PhanAccessMethodProtected', 'PhanDeprecatedFunction', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnMethod', 'PhanPluginUnreachableCode', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredVariable'],
-        'vp-scanner.php' => ['PhanCommentParamWithoutRealParam', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunction'],
+        'vp-scanner.php' => ['PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunction'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/vaultpress/changelog/fix-phan-various
+++ b/projects/plugins/vaultpress/changelog/fix-phan-various
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Phan: Address various violations.
 
-Phan: Address various violations.

--- a/projects/plugins/vaultpress/changelog/fix-phan-various
+++ b/projects/plugins/vaultpress/changelog/fix-phan-various
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phan: Address various violations.

--- a/projects/plugins/vaultpress/vp-scanner.php
+++ b/projects/plugins/vaultpress/vp-scanner.php
@@ -111,7 +111,7 @@ function split_file_to_php_html( $file ) {
  * Uses the PHP tokenizer to split a string into 3 arrays: PHP code with no comments,
  * PHP code with comments, and HTML/JS code.
  *
- * @param string $file The file path to read and parse
+ * @param string $source The file path to read and parse.
  * @return array An array with 3 arrays of lines
  */
 function split_to_php_html( $source ) {
@@ -179,10 +179,11 @@ function split_to_php_html( $source ) {
 
 /**
  * Helper function for split_file_to_php_html; adds a chunk of text to the arrays we'll return.
- * @param array $parsed The array containing all the languages we'll return
- * @param string $prefix The prefix for the languages we want to add this text to
- * @param int $line_number The line number that this text goes on
- * @param string $text The text to add
+ *
+ * @param array  $parsed The array containing all the languages we'll return.
+ * @param string $prefix The prefix for the languages we want to add this text to.
+ * @param int    $start_line_number The line number that this text goes on.
+ * @param string $all_text The text to add.
  */
 function add_text_to_parsed( &$parsed, $prefix, $start_line_number, $all_text ) {
 	$line_number = $start_line_number;


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In this PR, I addressed several rules:
* `PhanPluginDuplicateCatchStatementBody`: combine two catch types into one
* `PhanPluginDuplicateSwitchCase`: remove second case as dead code, as first one always wins
* `PhanPluginDuplicateAdjacentStatement`: in some cases removed the duplicate, but in many cases (e.g. tests) it was intentional, so suppressed those
* `PhanParamTooMany`: Helped Phan out with a `@phan-var` annotation
* `PhanCommentParamWithoutRealParam`: PHPDoc fixes
* `PhanTypeMismatchArgumentInternal`: One `@phan-var`, one suppression, and a few PHPDoc fixes

I also updated Phan configs for `packages/publicize` and `projects/packages/seo` to exclude build files.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI should be happy.