### PR TITLE
Newsletter: replace Add subscribers CSV file selector with a drag-and-drop area

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
@@ -1,0 +1,64 @@
+// CSV upload drop area for the Add Subscribers modal. Replaces the bare file
+// input with a clickable + drag-and-drop box, matching Calypso's importer and
+// borrowing VideoPress's drag-over highlight — recolored to the modal's WPDS
+// tokens so it fits the surrounding dialog.
+.jetpack-newsletter__csv-dropzone {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--wpds-dimension-gap-sm);
+	width: 100%;
+	min-height: 140px;
+	padding: var(--wpds-dimension-padding-2xl);
+	border: var(--wpds-border-width-xs, 1px) dashed var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	background: transparent;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	text-align: center;
+	cursor: pointer;
+	transition:
+		border-color 0.1s ease-in-out,
+		background-color 0.1s ease-in-out,
+		color 0.1s ease-in-out;
+
+	&:hover:not(:disabled) {
+		border-color: var(--wpds-color-stroke-interactive-neutral-strong);
+		background: var(--wpds-color-bg-surface-neutral-weak);
+	}
+
+	&:focus-visible {
+		outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus-brand);
+		outline-offset: 2px;
+	}
+
+	// Drag-over highlight, mirroring the VideoPress Library overlay in WPDS
+	// accent tokens.
+	&.is-dragging {
+		border-color: var(--wpds-color-stroke-interactive-brand);
+		background: var(--wpds-color-bg-surface-info-weak);
+		color: var(--wpds-color-fg-interactive-brand);
+	}
+
+	// Once a file is chosen the box keeps its shape but switches to a settled,
+	// solid border.
+	&.has-file {
+		border-style: solid;
+		color: var(--wpds-color-fg-content-neutral);
+	}
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.6;
+	}
+}
+
+.jetpack-newsletter__csv-dropzone-icon {
+	fill: currentColor;
+}
+
+// The real <input type="file"> lives next to the box and is driven via a ref;
+// keep it out of the layout entirely so it adds no gap inside the Stack.
+.jetpack-newsletter__csv-dropzone-input {
+	display: none;
+}

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
@@ -1,7 +1,18 @@
 // CSV upload drop area for the Add Subscribers modal. Replaces the bare file
-// input with a clickable + drag-and-drop box, matching Calypso's importer and
-// borrowing VideoPress's drag-over highlight — recolored to the modal's WPDS
-// tokens so it fits the surrounding dialog.
+// input with a clickable box (click to open the picker) and lets core's
+// `<DropZone>` own the drag-and-drop — the same primitive the modernized
+// VideoPress Library uses. The wrapper is the DropZone's positioning context.
+.jetpack-newsletter__csv-dropzone-wrap {
+	position: relative;
+
+	// Round the core DropZone overlay to match the box it covers. The
+	// `.components-drop-zone` class is a stable @wordpress/components class
+	// (not a hashed one), so it is safe to target.
+	.components-drop-zone {
+		border-radius: var(--wpds-border-radius-md);
+	}
+}
+
 .jetpack-newsletter__csv-dropzone {
 	display: flex;
 	flex-direction: column;
@@ -30,14 +41,6 @@
 	&:focus-visible {
 		outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus-brand);
 		outline-offset: 2px;
-	}
-
-	// Drag-over highlight, mirroring the VideoPress Library overlay in WPDS
-	// accent tokens.
-	&.is-dragging {
-		border-color: var(--wpds-color-stroke-interactive-brand);
-		background: var(--wpds-color-bg-surface-info-weak);
-		color: var(--wpds-color-fg-interactive-brand);
 	}
 
 	// Once a file is chosen the box keeps its shape but switches to a settled,

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -36,6 +36,31 @@ const PLATFORM_EXPORT_URLS = {
 		'https://support.patreon.com/hc/en-gb/articles/360004385971-How-do-I-manage-my-members#h_01EQGYDNF2J3XR12ABBMTZPSQM',
 };
 
+// Text formats the importer accepts. The picker's `accept` attribute and the drag-and-drop
+// validation both derive from this single list, so click-to-upload and drop enforce the same set.
+const ACCEPTED_CSV_EXTENSIONS = [ 'csv', 'txt', 'tsv' ];
+const ACCEPTED_CSV_ACCEPT_ATTR = [
+	...ACCEPTED_CSV_EXTENSIONS.map( extension => `.${ extension }` ),
+	'text/csv',
+	'text/plain',
+].join( ',' );
+
+/**
+ * Whether a file is one of the accepted text exports, by extension. Extension-based because CSV
+ * MIME types are unreliable (often empty or `application/vnd.ms-excel`), and this matches the
+ * `accept` attribute the file picker already advertises — so a dropped file is held to the same
+ * rule the picker enforces.
+ *
+ * @param file - Candidate file.
+ * @return True when the extension is one we parse.
+ */
+function isAcceptedCsvFile( file: File ): boolean {
+	const name = file.name.toLowerCase();
+	const dot = name.lastIndexOf( '.' );
+	const extension = dot === -1 ? '' : name.slice( dot + 1 );
+	return ACCEPTED_CSV_EXTENSIONS.includes( extension );
+}
+
 type TabValue = 'manual' | 'upload' | 'substack';
 
 /**
@@ -414,7 +439,7 @@ function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps
 			<input
 				ref={ inputRef }
 				type="file"
-				accept=".csv,.txt,.tsv,text/csv,text/plain"
+				accept={ ACCEPTED_CSV_ACCEPT_ATTR }
 				className="jetpack-newsletter__csv-dropzone-input"
 				onChange={ handleInputChange }
 				disabled={ disabled }
@@ -442,6 +467,19 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 	const [ readError, setReadError ] = useState< string | null >( null );
 
 	const handleFile = useCallback( ( file: File ) => {
+		// Drag-and-drop can deliver any file type, so enforce the same allow-list the picker
+		// advertises rather than reading an arbitrary file as text.
+		if ( ! isAcceptedCsvFile( file ) ) {
+			setFileName( null );
+			setEmails( [] );
+			setReadError(
+				__(
+					'That file type isn’t supported. Please upload a CSV file (.csv, .txt, or .tsv).',
+					'jetpack-newsletter'
+				)
+			);
+			return;
+		}
 		setFileName( file.name );
 		setReadError( null );
 		setEmails( [] );

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -7,12 +7,14 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { check, cloudUpload, Icon } from '@wordpress/icons';
 import { Button, Dialog, Notice, Stack, Tabs, Text } from '@wordpress/ui';
 import { useAddSubscribersMutation } from '../../data/use-add-subscribers-mutation';
 import { isJobInProgress, isJobStale, useImportJobs } from '../../data/use-import-jobs';
 import { useResetImportMutation } from '../../data/use-reset-import-mutation';
 import { extractEmailsFromCsv } from '../../lib/csv-parse';
 import { recordTracksEvent } from '../../lib/tracks';
+import './add-subscribers-modal.scss';
 import type { ImportJob } from '../../data/types';
 
 type Props = {
@@ -333,6 +335,122 @@ function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 	);
 }
 
+type CsvDropzoneProps = {
+	// Name of the currently selected file, or null before one is chosen.
+	fileName: string | null;
+	// Whether selection is blocked (an import is already in flight).
+	disabled: boolean;
+	// Called with the picked or dropped file.
+	onFile: ( file: File ) => void;
+	// Ref to the hidden <input>, shared with UploadTab so it can reset the value after a submit.
+	inputRef: React.RefObject< HTMLInputElement >;
+};
+
+/**
+ * Clickable + drag-and-drop CSV drop area. Visually replaces the bare file input: the real
+ * `<input>` stays in the DOM but hidden and is driven through `inputRef`, so a click anywhere in the
+ * box — or a keyboard activation — opens the native picker, while files dragged onto the box are
+ * handled the same way. The drag-over highlight borrows VideoPress's Library overlay, recolored to
+ * the modal's WPDS tokens.
+ *
+ * @param props          - Component props.
+ * @param props.fileName - Name of the selected file, or null.
+ * @param props.disabled - Whether selection is blocked.
+ * @param props.onFile   - Picked/dropped file handler.
+ * @param props.inputRef - Ref to the hidden file input.
+ * @return Drop area element.
+ */
+function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps ): JSX.Element {
+	const [ isDraggingOver, setIsDraggingOver ] = useState( false );
+
+	const openPicker = useCallback( () => {
+		if ( ! disabled ) {
+			inputRef.current?.click();
+		}
+	}, [ disabled, inputRef ] );
+
+	const handleInputChange = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const file = event.target.files?.[ 0 ];
+			if ( file ) {
+				onFile( file );
+			}
+		},
+		[ onFile ]
+	);
+
+	const handleDragOver = useCallback(
+		( event: React.DragEvent ) => {
+			// preventDefault keeps the browser from navigating to the dropped file.
+			event.preventDefault();
+			if ( ! disabled ) {
+				setIsDraggingOver( true );
+			}
+		},
+		[ disabled ]
+	);
+
+	const handleDragLeave = useCallback( ( event: React.DragEvent ) => {
+		event.preventDefault();
+		setIsDraggingOver( false );
+	}, [] );
+
+	const handleDrop = useCallback(
+		( event: React.DragEvent ) => {
+			event.preventDefault();
+			setIsDraggingOver( false );
+			if ( disabled ) {
+				return;
+			}
+			const file = event.dataTransfer.files?.[ 0 ];
+			if ( file ) {
+				onFile( file );
+			}
+		},
+		[ disabled, onFile ]
+	);
+
+	const className = [
+		'jetpack-newsletter__csv-dropzone',
+		isDraggingOver && 'is-dragging',
+		fileName && 'has-file',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
+	return (
+		<>
+			<button
+				type="button"
+				className={ className }
+				onClick={ openPicker }
+				onDragOver={ handleDragOver }
+				onDragEnter={ handleDragOver }
+				onDragLeave={ handleDragLeave }
+				onDrop={ handleDrop }
+				disabled={ disabled }
+			>
+				<Icon
+					className="jetpack-newsletter__csv-dropzone-icon"
+					icon={ fileName ? check : cloudUpload }
+					size={ 32 }
+				/>
+				<Text variant="body-md">
+					{ fileName ?? __( 'Drag a file here, or click to upload a file', 'jetpack-newsletter' ) }
+				</Text>
+			</button>
+			<input
+				ref={ inputRef }
+				type="file"
+				accept=".csv,.txt,.tsv,text/csv,text/plain"
+				className="jetpack-newsletter__csv-dropzone-input"
+				onChange={ handleInputChange }
+				disabled={ disabled }
+			/>
+		</>
+	);
+}
+
 /**
  * CSV upload tab. We don't have multipart pass-through against WPCOM yet, so the file is parsed
  * client-side and the resulting emails are POSTed to the existing `/subscribers/add` proxy. The
@@ -351,11 +469,7 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 	const [ emails, setEmails ] = useState< string[] >( [] );
 	const [ readError, setReadError ] = useState< string | null >( null );
 
-	const handleFileChange = useCallback( ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		const file = event.target.files?.[ 0 ];
-		if ( ! file ) {
-			return;
-		}
+	const handleFile = useCallback( ( file: File ) => {
 		setFileName( file.name );
 		setReadError( null );
 		setEmails( [] );
@@ -407,12 +521,11 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 					}
 				) }
 			</Text>
-			<input
-				ref={ fileInputRef }
-				type="file"
-				accept=".csv,.txt,.tsv,text/csv,text/plain"
-				onChange={ handleFileChange }
+			<CsvDropzone
+				fileName={ fileName }
 				disabled={ mutation.isPending }
+				onFile={ handleFile }
+				inputRef={ fileInputRef }
 			/>
 			<ImportConsentNotice />
 			{ readError ? (

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -1,4 +1,4 @@
-import { TextareaControl } from '@wordpress/components';
+import { DropZone, TextareaControl } from '@wordpress/components';
 import {
 	createInterpolateElement,
 	useCallback,
@@ -349,9 +349,10 @@ type CsvDropzoneProps = {
 /**
  * Clickable + drag-and-drop CSV drop area. Visually replaces the bare file input: the real
  * `<input>` stays in the DOM but hidden and is driven through `inputRef`, so a click anywhere in the
- * box — or a keyboard activation — opens the native picker, while files dragged onto the box are
- * handled the same way. The drag-over highlight borrows VideoPress's Library overlay, recolored to
- * the modal's WPDS tokens.
+ * box — or a keyboard activation — opens the native picker. Core's `<DropZone>` (the same primitive
+ * the modernized VideoPress Library uses) overlays the box and handles the drag-and-drop, showing
+ * its accent-colored "drop to upload" overlay while a file is dragged over. The inactive DropZone is
+ * `visibility: hidden`, so it never blocks the click target underneath.
  *
  * @param props          - Component props.
  * @param props.fileName - Name of the selected file, or null.
@@ -361,8 +362,6 @@ type CsvDropzoneProps = {
  * @return Drop area element.
  */
 function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps ): JSX.Element {
-	const [ isDraggingOver, setIsDraggingOver ] = useState( false );
-
 	const openPicker = useCallback( () => {
 		if ( ! disabled ) {
 			inputRef.current?.click();
@@ -379,57 +378,23 @@ function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps
 		[ onFile ]
 	);
 
-	const handleDragOver = useCallback(
-		( event: React.DragEvent ) => {
-			// preventDefault keeps the browser from navigating to the dropped file.
-			event.preventDefault();
-			if ( ! disabled ) {
-				setIsDraggingOver( true );
-			}
-		},
-		[ disabled ]
-	);
-
-	const handleDragLeave = useCallback( ( event: React.DragEvent ) => {
-		event.preventDefault();
-		setIsDraggingOver( false );
-	}, [] );
-
-	const handleDrop = useCallback(
-		( event: React.DragEvent ) => {
-			event.preventDefault();
-			setIsDraggingOver( false );
-			if ( disabled ) {
-				return;
-			}
-			const file = event.dataTransfer.files?.[ 0 ];
+	const handleFilesDrop = useCallback(
+		( files: File[] ) => {
+			const file = files?.[ 0 ];
 			if ( file ) {
 				onFile( file );
 			}
 		},
-		[ disabled, onFile ]
+		[ onFile ]
 	);
 
-	const className = [
-		'jetpack-newsletter__csv-dropzone',
-		isDraggingOver && 'is-dragging',
-		fileName && 'has-file',
-	]
+	const className = [ 'jetpack-newsletter__csv-dropzone', fileName && 'has-file' ]
 		.filter( Boolean )
 		.join( ' ' );
 
 	return (
-		<>
-			<button
-				type="button"
-				className={ className }
-				onClick={ openPicker }
-				onDragOver={ handleDragOver }
-				onDragEnter={ handleDragOver }
-				onDragLeave={ handleDragLeave }
-				onDrop={ handleDrop }
-				disabled={ disabled }
-			>
+		<div className="jetpack-newsletter__csv-dropzone-wrap">
+			<button type="button" className={ className } onClick={ openPicker } disabled={ disabled }>
 				<Icon
 					className="jetpack-newsletter__csv-dropzone-icon"
 					icon={ fileName ? check : cloudUpload }
@@ -439,6 +404,13 @@ function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps
 					{ fileName ?? __( 'Drag a file here, or click to upload a file', 'jetpack-newsletter' ) }
 				</Text>
 			</button>
+			{ ! disabled && (
+				<DropZone
+					icon={ cloudUpload }
+					label={ __( 'Drop your CSV file to upload', 'jetpack-newsletter' ) }
+					onFilesDrop={ handleFilesDrop }
+				/>
+			) }
 			<input
 				ref={ inputRef }
 				type="file"
@@ -447,7 +419,7 @@ function CsvDropzone( { fileName, disabled, onFile, inputRef }: CsvDropzoneProps
 				onChange={ handleInputChange }
 				disabled={ disabled }
 			/>
-		</>
+		</div>
 	);
 }
 

--- a/projects/packages/newsletter/changelog/update-newsletter-modernization-csv-drop
+++ b/projects/packages/newsletter/changelog/update-newsletter-modernization-csv-drop
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Subscribers dashboard (Newsletter modernization, behind a feature flag): replace the Add subscribers CSV file selector with a clickable drag-and-drop upload area.
+
+


### PR DESCRIPTION
Fixes #

## Proposed changes

* Replace the bare `<input type="file">` on the **Add subscribers → Upload CSV** tab with a clickable drag-and-drop area, matching Calypso's importer.
* The drop box shows a cloud-upload icon and "Drag a file here, or click to upload a file"; clicking anywhere in it opens the native file picker (the real input stays in the DOM, hidden, and is driven via a ref).
* Files dragged onto the box are parsed the same way as picked files — the read logic is now a single shared `handleFile()` helper.
* On drag-over the box highlights with a blue tint + brand dashed border and recolored icon/text, mirroring the VideoPress Library overlay but using the modal's WPDS design tokens.
* Once a file is chosen, the box switches to a check icon + filename with a settled solid border; the existing "Found N email addresses in …" line and submit button are unchanged.
* All copy/behavior lives behind the existing Newsletter modernization flag — legacy paths are untouched.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Jetpack-connected site, enable the modernized Newsletter dashboard, e.g. `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );`.
* Go to **Jetpack → Newsletter** and click **Add subscribers**, then open the **Upload CSV** tab.
* Confirm the drop area renders with the cloud icon and "Drag a file here, or click to upload a file".
* Drag a CSV file over the box and confirm it highlights blue (tint + dashed border + blue icon/text); confirm it clears when you drag away.
* Drop the file (or click the box and pick one) and confirm the box shows a check icon + the filename, the "Found N email addresses …" line appears, and the submit button enables.
* Confirm a successful import still works end-to-end, and that keyboard focus + Enter/Space on the box opens the picker.

## Real-screen — drop zone interaction states

Captured on a live site at `/wp-admin/admin.php?page=jetpack-newsletter` (Add subscribers → Upload CSV).

| Before dropping | While hovering (drag-over) | After dropping |
|---|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/newsletter-modernization-csv-drop/dropzone-1-before.png) | ![hover](https://github.com/Automattic/jetpack/raw/screenshots/update/newsletter-modernization-csv-drop/dropzone-2-hover.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/newsletter-modernization-csv-drop/dropzone-3-after.png) |
