### PR TITLE
Newsletter: close inspector when its subscriber is removed

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { installDataViewsFooterI18n } from '../lib/dataviews-i18n';
 import { getBlogId } from '../lib/site';
+import { isOpenSubscriberRemoved, toFiniteNumber } from '../lib/subscriber-helpers';
 import HeaderActions from './header-actions';
 import AddSubscribersModal from './modals/add-subscribers-modal';
 import SubscribersDataViews from './subscribers-data-views';
@@ -77,11 +78,35 @@ export default function SubscribersBody( {
 		[ navigate, search ]
 	);
 
+	// Close the inspector when the subscriber it's showing gets removed — otherwise it lingers
+	// with stale data (and on reload reopens from the URL but never loads the deleted row). The
+	// inspector is keyed entirely by the `subscriber`/`u` URL params, so clearing them closes it.
+	const handleSubscribersRemoved = useCallback(
+		( removed: Subscriber[] ) => {
+			const open = {
+				subscriptionId: toFiniteNumber( search.subscriber ),
+				userId: toFiniteNumber( search.u ),
+			};
+			if ( ! isOpenSubscriberRemoved( open, removed ) ) {
+				return;
+			}
+			navigate( {
+				search: {
+					...search,
+					subscriber: undefined,
+					u: undefined,
+				},
+			} as unknown as Parameters< typeof navigate >[ 0 ] );
+		},
+		[ navigate, search ]
+	);
+
 	const body = (
 		<>
 			<SubscribersDataViews
 				onAddSubscribers={ openAdd }
 				onViewSubscriber={ handleViewSubscriber }
+				onSubscribersRemoved={ handleSubscribersRemoved }
 			/>
 			<AddSubscribersModal isOpen={ isAddOpen } onClose={ closeAdd } />
 		</>

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -47,20 +47,23 @@ const defaultLayouts = {
 type Props = {
 	onAddSubscribers: () => void;
 	onViewSubscriber: ( subscriber: Subscriber ) => void;
+	onSubscribersRemoved: ( removed: Subscriber[] ) => void;
 };
 
 /**
  * Subscribers DataViews table — server-driven pagination, sort, search, filters with URL
  * persistence, and per-row + bulk subscriber removal.
  *
- * @param props                  - Component props.
- * @param props.onAddSubscribers - Open the Add Subscribers modal (used by the empty-state CTA).
- * @param props.onViewSubscriber - Callback fired when the View row action is invoked.
+ * @param props                      - Component props.
+ * @param props.onAddSubscribers     - Open the Add Subscribers modal (used by the empty-state CTA).
+ * @param props.onViewSubscriber     - Callback fired when the View row action is invoked.
+ * @param props.onSubscribersRemoved - Callback fired with the rows that were actually removed.
  * @return The DataViews component bound to the subscribers query.
  */
 export default function SubscribersDataViews( {
 	onAddSubscribers,
 	onViewSubscriber,
+	onSubscribersRemoved,
 }: Props ): JSX.Element {
 	const [ view, setView ] = useViewState( defaultView );
 	const [ pendingRemoval, setPendingRemoval ] = useState< Subscriber[] >( [] );
@@ -287,11 +290,14 @@ export default function SubscribersDataViews( {
 			return;
 		}
 		try {
-			await removeMutation.mutateAsync( targets );
+			const result = await removeMutation.mutateAsync( targets );
+			if ( result.removed.length > 0 ) {
+				onSubscribersRemoved( result.removed );
+			}
 		} finally {
 			setPendingRemoval( [] );
 		}
-	}, [ pendingRemoval, removeMutation ] );
+	}, [ pendingRemoval, removeMutation, onSubscribersRemoved ] );
 
 	const handleCancelRemoval = useCallback( () => {
 		setPendingRemoval( [] );

--- a/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
+++ b/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
@@ -1,6 +1,20 @@
 import type { RemoveSubscriberPayload, Subscriber } from '../data/types';
 
 /**
+ * Coerce a URL search-param value into a positive finite number.
+ *
+ * @param value - Raw search-param value (string, number, undefined).
+ * @return Positive finite number, or undefined when the input is empty/invalid.
+ */
+export function toFiniteNumber( value: unknown ): number | undefined {
+	if ( value === undefined || value === null || value === '' ) {
+		return undefined;
+	}
+	const num = Number( value );
+	return Number.isFinite( num ) && num > 0 ? num : undefined;
+}
+
+/**
  * Best-effort subscription date — Calypso prefers `wpcom_date_subscribed`, falling back to the
  * email subscription date for email-only subscribers. Returns the value with a `+00:00` suffix
  * appended (matching Calypso's `getFormattedSubscriptionDate` helper) so the date renders in the
@@ -56,6 +70,38 @@ export function getRemovePayload( subscriber: Subscriber ): RemoveSubscriberPayl
  */
 export function getSubscriberLabel( subscriber: Subscriber ): string {
 	return subscriber.display_name || subscriber.email_address;
+}
+
+/**
+ * Whether the subscriber currently shown in the inspector — identified by the `subscriber`/`u`
+ * URL params — is among a list of just-removed subscribers. Used to close the inspector when its
+ * subscriber gets deleted from the table, so it doesn't linger with stale data. The open identity
+ * mirrors `handleViewSubscriber`: `subscriptionId` is the email-or-wpcom subscription id, `userId`
+ * is the wpcom user id. A removed row matches when either set identifier is the same.
+ *
+ * @param open                - Inspector's open identity from the URL.
+ * @param open.subscriptionId - Email or wpcom subscription id the inspector is keyed by, if any.
+ * @param open.userId         - WPCOM user id the inspector is keyed by, if any.
+ * @param removed             - Subscribers that were just removed.
+ * @return True when the open subscriber is among the removed rows.
+ */
+export function isOpenSubscriberRemoved(
+	open: { subscriptionId?: number; userId?: number },
+	removed: Subscriber[]
+): boolean {
+	const { subscriptionId, userId } = open;
+	if ( ! subscriptionId && ! userId ) {
+		return false;
+	}
+	return removed.some( subscriber => {
+		const removedSubscriptionId =
+			subscriber.email_subscription_id || subscriber.wpcom_subscription_id || undefined;
+		const removedUserId = subscriber.user_id || undefined;
+		return (
+			( !! subscriptionId && removedSubscriptionId === subscriptionId ) ||
+			( !! userId && removedUserId === userId )
+		);
+	} );
 }
 
 /**

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-inspector-close-on-delete
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-inspector-close-on-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: close the subscriber detail panel when its subscriber is removed instead of leaving it open with stale data

--- a/projects/packages/newsletter/routes/dashboard/inspector.tsx
+++ b/projects/packages/newsletter/routes/dashboard/inspector.tsx
@@ -7,25 +7,12 @@ import { useNavigate, useSearch } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import SubscriberDetailContent from '../../_inc/subscribers/components/detail/subscriber-detail-content';
 import { queryClient } from '../../_inc/subscribers/lib/query-client';
+import { toFiniteNumber } from '../../_inc/subscribers/lib/subscriber-helpers';
 
 type SubscribersSearch = Record< string, unknown > & {
 	subscriber?: string | number;
 	u?: string | number;
 };
-
-/**
- * Coerce a URL search-param value into a positive finite number.
- *
- * @param value - Raw search-param value (string, number, undefined).
- * @return Positive finite number, or undefined when the input is empty/invalid.
- */
-function toFiniteNumber( value: unknown ): number | undefined {
-	if ( value === undefined || value === null || value === '' ) {
-		return undefined;
-	}
-	const num = Number( value );
-	return Number.isFinite( num ) && num > 0 ? num : undefined;
-}
 
 /**
  * Inspector body — reads the selected subscriber from URL search params and

--- a/projects/packages/newsletter/tests/subscriber-helpers.test.ts
+++ b/projects/packages/newsletter/tests/subscriber-helpers.test.ts
@@ -1,4 +1,70 @@
-import { hasNoSubscribersOtherThanOwner } from '../_inc/subscribers/lib/subscriber-helpers';
+import {
+	hasNoSubscribersOtherThanOwner,
+	isOpenSubscriberRemoved,
+} from '../_inc/subscribers/lib/subscriber-helpers';
+import type { Subscriber } from '../_inc/subscribers/data/types';
+
+/**
+ * Build a minimal subscriber row for the matcher tests.
+ *
+ * @param overrides - Fields to set on the row.
+ * @return Subscriber.
+ */
+function makeSubscriber( overrides: Partial< Subscriber > ): Subscriber {
+	return {
+		user_id: 0,
+		display_name: '',
+		email_address: '',
+		subscription_status: 'Subscribed',
+		...overrides,
+	};
+}
+
+describe( 'isOpenSubscriberRemoved', () => {
+	it( 'is false when the inspector is closed (no open identity)', () => {
+		const removed = [ makeSubscriber( { email_subscription_id: 123, user_id: 45 } ) ];
+		expect( isOpenSubscriberRemoved( {}, removed ) ).toBe( false );
+	} );
+
+	it( 'is false when nothing was removed', () => {
+		expect( isOpenSubscriberRemoved( { subscriptionId: 123, userId: 45 }, [] ) ).toBe( false );
+	} );
+
+	it( 'matches on the email subscription id', () => {
+		const removed = [ makeSubscriber( { email_subscription_id: 123 } ) ];
+		expect( isOpenSubscriberRemoved( { subscriptionId: 123 }, removed ) ).toBe( true );
+	} );
+
+	it( 'matches on the wpcom subscription id when there is no email subscription id', () => {
+		const removed = [ makeSubscriber( { wpcom_subscription_id: 999 } ) ];
+		expect( isOpenSubscriberRemoved( { subscriptionId: 999 }, removed ) ).toBe( true );
+	} );
+
+	it( 'matches on the user id', () => {
+		const removed = [ makeSubscriber( { user_id: 45 } ) ];
+		expect( isOpenSubscriberRemoved( { userId: 45 }, removed ) ).toBe( true );
+	} );
+
+	it( 'does not match an unrelated removed subscriber', () => {
+		const removed = [ makeSubscriber( { email_subscription_id: 1, user_id: 2 } ) ];
+		expect( isOpenSubscriberRemoved( { subscriptionId: 123, userId: 45 }, removed ) ).toBe( false );
+	} );
+
+	it( 'finds the open subscriber among a bulk removal', () => {
+		const removed = [
+			makeSubscriber( { email_subscription_id: 1, user_id: 2 } ),
+			makeSubscriber( { email_subscription_id: 123, user_id: 45 } ),
+		];
+		expect( isOpenSubscriberRemoved( { subscriptionId: 123, userId: 45 }, removed ) ).toBe( true );
+	} );
+
+	it( 'does not match a zero user id against an email-only open identity', () => {
+		// Email-only rows carry `user_id: 0`; an inspector opened by user id must not be
+		// closed by removing an unrelated email-only subscriber.
+		const removed = [ makeSubscriber( { user_id: 0, email_subscription_id: 1 } ) ];
+		expect( isOpenSubscriberRemoved( { userId: 0 }, removed ) ).toBe( false );
+	} );
+} );
 
 describe( 'hasNoSubscribersOtherThanOwner', () => {
 	it( 'is true when there are no subscribers at all', () => {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Close the modernized Newsletter subscriber detail panel (inspector) when the subscriber it is showing gets removed. Previously the inspector stayed open with stale data, and on reload it re-opened from the `?subscriber`/`?u` URL params but never loaded the deleted row.
* `SubscribersDataViews` now reports the rows the server actually removed via a new `onSubscribersRemoved` callback (uses `result.removed`, so a failed removal doesn't close the panel).
* `SubscribersBody` — which already owns `navigate`/`search` and opens the inspector — clears the `subscriber`/`u` params when the open subscriber is among the removed rows, which is the single source of truth for the inspector being open.
* Matching is handled by a new pure, unit-tested `isOpenSubscriberRemoved` helper; the shared `toFiniteNumber` URL-coercion helper moved into `subscriber-helpers.ts` so the inspector and body coerce params identically.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the Newsletter package (`pnpm build` in `projects/packages/newsletter`, or `jetpack watch packages/newsletter`) and open **Jetpack → Newsletter → Subscribers** on a connected site.
* Click a subscriber row (or its **View** action) to open the detail panel on the right.
* With the panel open on that subscriber, open the row's actions menu (⋮) and choose **Remove subscriber**, then confirm in the dialog.
* Expected: the detail panel closes and the `subscriber`/`u` query params are cleared from the URL. Reloading the page no longer re-opens an empty panel.
* Also verify a non-matching removal: open the panel on subscriber A, remove subscriber B — the panel should stay open on A.
* Unit tests: `pnpm test tests/subscriber-helpers.test.ts` (covers the `isOpenSubscriberRemoved` matcher, including bulk removal and the `user_id: 0` edge case).
