### PR TITLE
Custom Colors: stop injecting Customizer colors into the block editor

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-custom-colors-editor-leak
+++ b/projects/plugins/wpcomsh/changelog/fix-custom-colors-editor-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: stop injecting Customizer colors into the block editor so they no longer leak into the editor UI

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -61,13 +61,6 @@ class Colors_Manager_Common {
 	protected static $color_palettes = array();
 
 	/**
-	 * If we're using Gutenberg or not.
-	 *
-	 * @var boolean
-	 */
-	protected static $is_gutenberg = false;
-
-	/**
 	 * Themes that will never support Custom Colors.
 	 *
 	 * Criteria for not supporting:
@@ -152,65 +145,54 @@ class Colors_Manager_Common {
 			return;
 		}
 
-		if ( ! self::is_gutenberg() ) {
-			// Classic Background stats
-			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_classic_stats' ) );
-			// always load ajax actions
-			add_action( 'wp_ajax_color_palettes', array( __CLASS__, 'ajax_color_palettes' ) );
-			add_action( 'wp_ajax_generate_palette', array( __CLASS__, 'ajax_generate_palette' ) );
-			add_action( 'wp_ajax_color_recommendations', array( __CLASS__, 'ajax_color_recommendations' ) );
-			add_action( 'wp_ajax_pattern_recommendations', array( __CLASS__, 'ajax_pattern_recommendations' ) );
+		// Customizer colors apply on the frontend, in the Customizer preview, and
+		// via the AJAX palette/pattern tools. We deliberately don't inject them
+		// into the block editor: Core doesn't either, and the site background is
+		// often not the post background, so injecting them leaks into the editor
+		// UI. The editor renders with default colors, matching Core.
 
-			// Notice in the core bg admin screen
-			add_action( 'admin_print_styles-appearance_page_custom-background', array( __CLASS__, 'core_bg_enqueue_styles' ) );
-			add_action( 'admin_notices', array( __CLASS__, 'core_bg_admin_notice' ) );
+		// Classic Background stats
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_classic_stats' ) );
+		// always load ajax actions
+		add_action( 'wp_ajax_color_palettes', array( __CLASS__, 'ajax_color_palettes' ) );
+		add_action( 'wp_ajax_generate_palette', array( __CLASS__, 'ajax_generate_palette' ) );
+		add_action( 'wp_ajax_color_recommendations', array( __CLASS__, 'ajax_color_recommendations' ) );
+		add_action( 'wp_ajax_pattern_recommendations', array( __CLASS__, 'ajax_pattern_recommendations' ) );
 
-			// Replace the Backgrounds link with a link to this plugin's section
-			add_action( 'admin_menu', array( __CLASS__, 'modify_admin_menu_links' ) );
+		// Notice in the core bg admin screen
+		add_action( 'admin_print_styles-appearance_page_custom-background', array( __CLASS__, 'core_bg_enqueue_styles' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'core_bg_admin_notice' ) );
 
-			// Load the Colors API class for fetching palettes and patterns from WordPress.com.
-			require_once __DIR__ . '/colors-api.php';
+		// Replace the Backgrounds link with a link to this plugin's section
+		add_action( 'admin_menu', array( __CLASS__, 'modify_admin_menu_links' ) );
 
-			$current_theme = get_option( 'stylesheet' );
+		// Load the Colors API class for fetching palettes and patterns from WordPress.com.
+		require_once __DIR__ . '/colors-api.php';
 
-			// High priority so that no other code manages to modify our URL before we do.  The default URL
-			// saved for background_image isn't meant to ever be used as is.
-			add_filter( 'pre_update_option_theme_mods_' . $current_theme, array( __CLASS__, 'format_colourlovers_urls' ), 1, 2 );
-			add_action( 'update_option_theme_mods_' . $current_theme, array( __CLASS__, 'save_colourlovers_metadata' ), 10, 2 );
+		$current_theme = get_option( 'stylesheet' );
 
-			add_action( 'init', array( __CLASS__, 'register_scripts_and_styles' ), 20 );
+		// High priority so that no other code manages to modify our URL before we do.  The default URL
+		// saved for background_image isn't meant to ever be used as is.
+		add_filter( 'pre_update_option_theme_mods_' . $current_theme, array( __CLASS__, 'format_colourlovers_urls' ), 1, 2 );
+		add_action( 'update_option_theme_mods_' . $current_theme, array( __CLASS__, 'save_colourlovers_metadata' ), 10, 2 );
 
-			// stuff for the customizer - only load if there are annotations.
-			if ( self::has_annotations() ) {
-				add_action( 'customize_register', array( __CLASS__, 'in_customizer' ), 10 );
-				add_action( 'customize_register', array( __CLASS__, 'theme_colors_js' ) );
-				add_action( 'customize_controls_init', array( __CLASS__, 'spinner_scripts' ) );
-			}
+		add_action( 'init', array( __CLASS__, 'register_scripts_and_styles' ), 20 );
 
-			// CSS only to be printed if colors are set.
-			if ( self::theme_has_set_colors() ) {
-				self::override_themecolors();
-				add_filter( 'body_class', array( __CLASS__, 'body_class' ) );
-				add_action( 'wp_head', array( __CLASS__, 'print_theme_css' ), 20 );
-			}
-
-			add_filter( 'tonesque_image_url', array( __CLASS__, 'gravatar_image_url' ) );
+		// stuff for the customizer - only load if there are annotations.
+		if ( self::has_annotations() ) {
+			add_action( 'customize_register', array( __CLASS__, 'in_customizer' ), 10 );
+			add_action( 'customize_register', array( __CLASS__, 'theme_colors_js' ) );
+			add_action( 'customize_controls_init', array( __CLASS__, 'spinner_scripts' ) );
 		}
 
-		// Customizer colors apply on the frontend only (see the `wp_head` hook
-		// above). We deliberately don't inject them into the block editor: Core
-		// doesn't either, and the site background is often not the post background,
-		// so injecting them leaks into the editor UI. The editor renders with
-		// default colors, matching Core.
-	}
+		// CSS only to be printed if colors are set.
+		if ( self::theme_has_set_colors() ) {
+			self::override_themecolors();
+			add_filter( 'body_class', array( __CLASS__, 'body_class' ) );
+			add_action( 'wp_head', array( __CLASS__, 'print_theme_css' ), 20 );
+		}
 
-	/**
-	 * Checks if we're in Gutenberg (Editor) mode.
-	 *
-	 * @see https://stackoverflow.com/a/14919877
-	 */
-	private static function is_gutenberg() {
-		return static::$is_gutenberg;
+		add_filter( 'tonesque_image_url', array( __CLASS__, 'gravatar_image_url' ) );
 	}
 
 	/**
@@ -1899,44 +1881,21 @@ function add_color_palette( $palette, $title = false ) {
 }
 
 /**
- * Gutenberg color manager.
- */
-class Colors_Manager_Gutenberg extends Colors_Manager_Common {
-
-	/**
-	 * Whether we're in Gutenberg.
-	 *
-	 * @var boolean
-	 */
-	protected static $is_gutenberg = true;
-
-	/**
-	 * Annotations file path.
-	 *
-	 * @var string
-	 */
-	protected static $annotations_file = 'wpcom-editor-colors.php';
-}
-
-/**
- * Load Gutenberg's color manager.
- */
-function colors_manager_gutenberg_load() {
-	if ( get_current_screen()->is_block_editor() ) {
-		Colors_Manager_Gutenberg::init(); // Gutenberg
-	}
-}
-
-/**
- * Load corresponding color manager.
+ * Load the color manager.
+ *
+ * Customizer colors apply on the frontend, in the Customizer preview, and via
+ * the AJAX palette/pattern tools. The block editor intentionally has no color
+ * manager: injecting Customizer colors leaked into the editor UI, so we leave
+ * those admin screens untouched and let the editor render with default colors,
+ * matching Core.
  */
 function load_corresponding_color_manager() {
 	global $pagenow;
 	if ( is_admin() && 'customize.php' !== $pagenow && ! defined( 'DOING_AJAX' ) ) {
-		add_action( 'current_screen', 'colors_manager_gutenberg_load' );
-	} else {
-		Colors_Manager::init();
+		return;
 	}
+
+	Colors_Manager::init();
 }
 
 add_action( 'init', 'load_corresponding_color_manager' );

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -197,13 +197,11 @@ class Colors_Manager_Common {
 			add_filter( 'tonesque_image_url', array( __CLASS__, 'gravatar_image_url' ) );
 		}
 
-		if ( self::is_gutenberg() ) {
-			// If colors are set, print them in the Block Editor as well.
-			if ( self::theme_has_set_colors() ) {
-				self::override_themecolors();
-				add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'print_block_editor_css' ), 20 );
-			}
-		}
+		// Customizer colors apply on the frontend only (see the `wp_head` hook
+		// above). We deliberately don't inject them into the block editor: Core
+		// doesn't either, and the site background is often not the post background,
+		// so injecting them leaks into the editor UI. The editor renders with
+		// default colors, matching Core.
 	}
 
 	/**
@@ -1421,28 +1419,6 @@ class Colors_Manager_Common {
 			wp_strip_all_tags( $css ), // phpcs:ignore -- CSS can't be properly escaped with esc_html
 			"\n"
 		);
-	}
-
-	/**
-	 * Enqueue the Customizer's custom colors for the block editor, scoped to the
-	 * editor content so they can't leak into the editor UI.
-	 *
-	 * @since 9.0.0
-	 */
-	public static function print_block_editor_css() {
-		if ( ! self::should_enable_colors() ) {
-			return;
-		}
-
-		// `@scope` already scopes to the wrapper, so map any legacy explicit
-		// "#editor .editor-styles-wrapper" prefix to `:scope` (the scope root)
-		// rather than leaving a redundant — and no-longer-matching — prefix.
-		$css = str_replace( '#editor .editor-styles-wrapper', ':scope', self::get_theme_css() );
-		$css = '@scope (.editor-styles-wrapper) {' . $css . '}';
-
-		wp_register_style( 'custom-colors-editor-css', false, array(), '20210311' ); // Register an empty stylesheet to append custom CSS to.
-		wp_enqueue_style( 'custom-colors-editor-css' );
-		wp_add_inline_style( 'custom-colors-editor-css', $css ); // Append inline style to our new stylesheet
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Customizer custom colors are meant for the frontend. We were also injecting them into the block editor, where they leaked into the editor UI — black input boxes and full-height white-space in the sidebar — because the site background is frequently not the post background, especially on older themes. Every prior attempt to scope the injection traded one regression for another.
* This stops injecting Customizer colors into the block editor entirely, matching Core. Frontend color output is unchanged.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On an Atomic site with a classic theme (e.g. a retired theme such as Olsen/Colinear/Canard), set custom colors in the Customizer.
* Open a post in the block editor and open the Settings sidebar.
* **Before:** the Categories panel (and text inputs) show excess white-space / black boxes from the injected colors.
* **After:** the editor renders with default colors; no leaked styling in the sidebar or inputs.
* Confirm the frontend still reflects the Customizer color choices.
