### PR TITLE
wpcomsh: let users deactivate the Google Fonts module on Atomic sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
+++ b/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Google Fonts: respect an explicit user deactivation instead of force-re-activating the module on every request, so the My Jetpack toggle sticks.
+Google Fonts: stop force-activating the module on every request so it is no longer auto-enabled by default and the My Jetpack toggle can be turned off.

--- a/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
+++ b/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Google Fonts: stop force-activating the module on every request so it is no longer auto-enabled by default and the My Jetpack toggle can be turned off.
+Google Fonts: stop force-activating the module on every request, and stop hiding it from the classic Jetpack modules screen, so it is no longer auto-enabled by default and can be toggled off and back on.

--- a/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
+++ b/projects/plugins/wpcomsh/changelog/fix-google-fonts-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Google Fonts: respect an explicit user deactivation instead of force-re-activating the module on every request, so the My Jetpack toggle sticks.

--- a/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
+++ b/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
@@ -15,12 +15,26 @@ if ( ! defined( 'FONT_LIBRARY_DISABLED' ) ) {
 }
 
 /**
+ * Option that records an explicit user opt-out of the Google Fonts module.
+ *
+ * When set, wpcomsh stops force-activating the module on every request so the
+ * user's deactivation (e.g. via My Jetpack) actually sticks.
+ */
+const WPCOMSH_GOOGLE_FONTS_OPTED_OUT = 'wpcomsh_google_fonts_opted_out';
+
+/**
  * Force-enable the Google fonts module
  * If you use a version of Jetpack that supports it,
- * and if it is not already enabled.
+ * if it is not already enabled,
+ * and if the user has not explicitly deactivated it.
  */
 function wpcomsh_activate_google_fonts_module() {
 	if ( ! defined( 'JETPACK__VERSION' ) ) {
+		return;
+	}
+
+	// Respect an explicit user deactivation instead of re-enabling on every request.
+	if ( get_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT ) ) {
 		return;
 	}
 
@@ -29,6 +43,24 @@ function wpcomsh_activate_google_fonts_module() {
 	}
 }
 add_action( 'setup_theme', 'wpcomsh_activate_google_fonts_module' );
+
+/**
+ * Record that the user has explicitly deactivated the Google Fonts module so
+ * wpcomsh stops force-activating it on subsequent requests.
+ */
+function wpcomsh_google_fonts_opt_out() {
+	update_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT, true );
+}
+add_action( 'jetpack_deactivate_module_google-fonts', 'wpcomsh_google_fonts_opt_out' );
+
+/**
+ * Clear the opt-out when the user re-activates the Google Fonts module so the
+ * default "always available on Atomic" behavior resumes.
+ */
+function wpcomsh_google_fonts_opt_in() {
+	delete_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT );
+}
+add_action( 'jetpack_activate_module_google-fonts', 'wpcomsh_google_fonts_opt_in' );
 
 /**
  * Remove Google Fonts from the old Module list.

--- a/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
+++ b/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
@@ -14,21 +14,6 @@ if ( ! defined( 'FONT_LIBRARY_DISABLED' ) ) {
 }
 
 /**
- * Remove Google Fonts from the old Module list.
- * Available at wp-admin/admin.php?page=jetpack_modules
- *
- * @param array $items Array of Jetpack modules.
- * @return array
- */
-function wpcomsh_rm_google_fonts_module_list( $items ) {
-	if ( isset( $items['google-fonts'] ) ) {
-		unset( $items['google-fonts'] );
-	}
-	return $items;
-}
-add_filter( 'jetpack_modules_list_table_items', 'wpcomsh_rm_google_fonts_module_list' );
-
-/**
  * Replaces Google Fonts API references in enqueued styles with our caching reverse proxy.
  *
  * @see pMz3w-g6E-p2#comment-103418

--- a/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
+++ b/projects/plugins/wpcomsh/feature-plugins/google-fonts.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Customizations to the Google Fonts module available in Jetpack.
- * We want that feature to always be available on Atomic sites.
  *
  * @package wpcomsh
  */
@@ -13,54 +12,6 @@
 if ( ! defined( 'FONT_LIBRARY_DISABLED' ) ) {
 	define( 'FONT_LIBRARY_DISABLED', true );
 }
-
-/**
- * Option that records an explicit user opt-out of the Google Fonts module.
- *
- * When set, wpcomsh stops force-activating the module on every request so the
- * user's deactivation (e.g. via My Jetpack) actually sticks.
- */
-const WPCOMSH_GOOGLE_FONTS_OPTED_OUT = 'wpcomsh_google_fonts_opted_out';
-
-/**
- * Force-enable the Google fonts module
- * If you use a version of Jetpack that supports it,
- * if it is not already enabled,
- * and if the user has not explicitly deactivated it.
- */
-function wpcomsh_activate_google_fonts_module() {
-	if ( ! defined( 'JETPACK__VERSION' ) ) {
-		return;
-	}
-
-	// Respect an explicit user deactivation instead of re-enabling on every request.
-	if ( get_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT ) ) {
-		return;
-	}
-
-	if ( ! Jetpack::is_module_active( 'google-fonts' ) ) {
-		Jetpack::activate_module( 'google-fonts', false, false );
-	}
-}
-add_action( 'setup_theme', 'wpcomsh_activate_google_fonts_module' );
-
-/**
- * Record that the user has explicitly deactivated the Google Fonts module so
- * wpcomsh stops force-activating it on subsequent requests.
- */
-function wpcomsh_google_fonts_opt_out() {
-	update_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT, true );
-}
-add_action( 'jetpack_deactivate_module_google-fonts', 'wpcomsh_google_fonts_opt_out' );
-
-/**
- * Clear the opt-out when the user re-activates the Google Fonts module so the
- * default "always available on Atomic" behavior resumes.
- */
-function wpcomsh_google_fonts_opt_in() {
-	delete_option( WPCOMSH_GOOGLE_FONTS_OPTED_OUT );
-}
-add_action( 'jetpack_activate_module_google-fonts', 'wpcomsh_google_fonts_opt_in' );
 
 /**
  * Remove Google Fonts from the old Module list.


### PR DESCRIPTION
## What

On Atomic sites, Google Fonts could not be turned off. Toggling it off in My Jetpack reported success, but it was re-enabled on the next request and the toggle flipped back on. There was also no working place to manage it, since the module was hidden from the classic Jetpack modules screen.

This makes two related changes in wpcomsh:

- Stop force-activating the module on every request. It is no longer auto-enabled by default, and a deactivation now sticks.
- Stop hiding the module from the classic Jetpack modules screen, so it has a working on/off toggle again.

## Why

The forced activation and the hidden toggle were two halves of an old "always on for Atomic" behavior that predated any user-facing control. That behavior is no longer wanted now that the feature is being wound down, and it left users with a toggle that could never be turned off. Removing both gives a module that defaults off on new sites, can be deactivated, and can be reactivated.

Existing sites that already have the module active are unaffected, and self-hosted sites are not touched.

## Testing instructions

On an Atomic site:
1. Go to My Jetpack and deactivate Google Fonts. Reload — it should stay off (previously it flipped back on).
2. Visit `wp-admin/admin.php?page=jetpack_modules`, confirm Google Fonts is listed, and toggle it on and off — the state should persist across reloads.
