### PR TITLE
PCG: increase rollout to 10%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-pcg-rollout-10-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-pcg-rollout-10-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: increase rollout to 10%.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -10,7 +10,7 @@
  */
 class PCG_Rollout {
 
-	const DEFAULT_PERCENTAGE = 5;
+	const DEFAULT_PERCENTAGE = 10;
 
 	/**
 	 * Priority 100 leaves room for emergency overrides at higher priorities.


### PR DESCRIPTION
## Summary

Bumps the Plugin Conflicts Guardian percentage rollout gate from 5% to 10% by raising `PCG_Rollout::DEFAULT_PERCENTAGE`.

The gate is hash-based and stable per blog (`blog_bucket()` = `crc32(blog_id) % 100`), so the sites enrolled at 5% remain enrolled at 10% — this only widens the cohort.

## Testing instructions

- Confirm `PCG_Rollout::is_enabled_for_blog()` returns `true` for blog IDs whose bucket is `< 10` and `false` otherwise.
- Existing `Plugin_Conflicts_Guardian_Test` suite passes.

## Does this pull request change what data or activity we track or use?

No. This only widens an existing percentage rollout gate; it does not add, remove, or change any tracked data or activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)