### PR TITLE
RTC: disable real-time collaboration by default

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17579-disable-rtc-by-default-on-wpcom-atomic-sites
+++ b/projects/packages/rtc/changelog/dotcom-17579-disable-rtc-by-default-on-wpcom-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Disable real-time collaboration by default while keeping the existing opt-in setting.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -226,13 +226,16 @@ class RTC {
 	}
 
 	/**
-	 * When RTC is allowed and the option is NOT stored yet,
-	 * default the option to enabled (1), unless the old option
-	 * has a stored value to migrate from.
+	 * When the option is NOT stored yet, default it to disabled (0).
 	 *
-	 * This handles the Gutenberg upgrade path: e.g. a site on 22.7 stored
-	 * wp_enable_real_time_collaboration, then upgraded to 22.8 which reads
-	 * wp_collaboration_enabled — the new option inherits the old value.
+	 * RTC is no longer enabled by default on WP.com sites while it remains
+	 * in development; sites can still opt in through the existing setting.
+	 *
+	 * The old option is still migrated to the new one to preserve the choice
+	 * of sites that had explicitly opted in before the Gutenberg rename: e.g.
+	 * a site on 22.7 stored wp_enable_real_time_collaboration, then upgraded to
+	 * 22.8 which reads wp_collaboration_enabled — the new option inherits the
+	 * old stored value.
 	 *
 	 * @param mixed  $default The default value.
 	 * @param string $option  The option name.
@@ -243,13 +246,13 @@ class RTC {
 		if ( ! self::is_allowed() ) {
 			return '0';
 		}
-		// RTC allowed and option is not stored yet
+		// When the new option is not stored yet, migrate from the old option's
+		// stored value so sites that previously opted in keep their setting.
 		if ( $option === self::OPTION_NEW ) {
-			// If the old option is set, use that.
 			return get_option( self::OPTION_OLD );
 		}
-		// Default to enabled.
-		return '1';
+		// Default to disabled.
+		return '0';
 	}
 
 	/**
@@ -271,7 +274,7 @@ class RTC {
 	}
 
 	/**
-	 * Override the default for the Gutenberg RTC setting so it defaults to enabled in the UI.
+	 * Override the default for the Gutenberg RTC setting so it defaults to disabled in the UI.
 	 *
 	 * @return void
 	 */
@@ -299,7 +302,7 @@ class RTC {
 					'type'              => 'boolean',
 					'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-rtc' ),
 					'sanitize_callback' => 'rest_sanitize_boolean',
-					'default'           => true,
+					'default'           => false,
 					'show_in_rest'      => true,
 				)
 			);

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -185,7 +185,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		update_option( RTC::OPTION_NEW, '1' );
-		RTC::init();
 		$this->assertTrue( RTC::is_enabled() );
 	}
 

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -184,6 +184,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		$this->assertTrue( RTC::is_enabled() );
 	}
@@ -240,6 +241,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_returns_providers_when_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -256,6 +258,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_filters_unknown_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -288,6 +291,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_reindexes_after_filtering() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -323,6 +327,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_default_passes_allowlist() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 
 		$this->assertSame( array( 'pinghub' ), RTC::get_providers() );
@@ -355,6 +360,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_enqueues_when_pinghub() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -373,6 +379,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_enqueues_with_multiple_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -391,6 +398,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_does_not_include_jwt_token() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -504,12 +504,14 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that default_rtc_option returns '1' when RTC is allowed and no option is stored.
+	 * Tests that default_rtc_option returns '0' when RTC is allowed but no option is stored.
+	 *
+	 * RTC is disabled by default; sites must explicitly opt in via the setting.
 	 */
-	public function test_default_rtc_option_returns_1_when_allowed() {
+	public function test_default_rtc_option_returns_0_when_allowed_and_not_stored() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 
-		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
 	}
 
 	/**
@@ -517,9 +519,9 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_default_rtc_option_migrates_old_to_new() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_OLD, '0' );
+		update_option( RTC::OPTION_OLD, '1' );
 
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
 	}
 
 	// -------------------------------------------------------------------------

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -184,7 +184,9 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
+		// Short-circuit get_option so the stored value is independent of how the
+		// test harness persists this option across WP versions.
+		add_filter( 'pre_option_' . RTC::OPTION_NEW, '__return_true' );
 		$this->assertTrue( RTC::is_enabled() );
 	}
 


### PR DESCRIPTION
Fixes DOTCOM-17579

## Proposed changes
* Disable the RTC setting by default.
* Sites can still enable it through Settings > Writing.

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply these changes to a WP.com site (either Simple or Atomic)
* Make sure the `wp_collaboration_enabled` option is not stored on your site: `delete_option( 'wp_collaboration_enabled' )`
* Go to Settings > Writing
* Make sure the RTC setting is disabled by default
* Make sure you can enable it
