### PR TITLE
Blaze: warn before disabling active campaigns

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1159-blaze-disable-warning
+++ b/projects/packages/blaze/changelog/add-ads-1159-blaze-disable-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: add active campaign status checks.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -44,6 +44,13 @@ class Blaze {
 	const ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_TTL = HOUR_IN_SECONDS;
 
 	/**
+	 * Transient TTL for active campaign status checks that cannot determine campaign status.
+	 *
+	 * @var int
+	 */
+	const UNKNOWN_ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Minimum campaign statuses that should trigger a warning.
 	 *
 	 * @var string[]
@@ -271,13 +278,13 @@ class Blaze {
 		);
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return self::get_unknown_active_campaigns_status();
+			return self::get_unknown_active_campaigns_status( $transient_name );
 		}
 
 		$result = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( ! is_array( $result ) || ! isset( $result['campaigns'] ) || ! is_array( $result['campaigns'] ) ) {
-			return self::get_unknown_active_campaigns_status();
+			return self::get_unknown_active_campaigns_status( $transient_name );
 		}
 
 		$has_active_campaigns = ! empty( $result['campaigns'] );
@@ -296,13 +303,20 @@ class Blaze {
 	/**
 	 * Get the unknown active campaign status response.
 	 *
+	 * @param string|null $transient_name Optional transient name used to cache the unknown status.
 	 * @return array Unknown active campaign status.
 	 */
-	private static function get_unknown_active_campaigns_status() {
-		return array(
+	private static function get_unknown_active_campaigns_status( $transient_name = null ) {
+		$status = array(
 			'has_active_campaigns' => false,
 			'status'               => 'unknown',
 		);
+
+		if ( $transient_name ) {
+			set_transient( $transient_name, $status, self::UNKNOWN_ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_TTL );
+		}
+
+		return $status;
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -30,6 +30,27 @@ class Blaze {
 	const SCRIPT_HANDLE = 'jetpack-promote-editor';
 
 	/**
+	 * Transient prefix for active campaign status checks.
+	 *
+	 * @var string
+	 */
+	const ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_PREFIX = 'jetpack_blaze_active_campaigns_status_';
+
+	/**
+	 * Transient TTL for active campaign status checks that find campaigns.
+	 *
+	 * @var int
+	 */
+	const ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_TTL = HOUR_IN_SECONDS;
+
+	/**
+	 * Minimum campaign statuses that should trigger a warning.
+	 *
+	 * @var string[]
+	 */
+	const ACTIVE_CAMPAIGN_STATUSES = array( 'active' );
+
+	/**
 	 * Path of the JS file we enqueue in the post editor.
 	 *
 	 * @var string
@@ -195,6 +216,93 @@ class Blaze {
 		set_transient( $transient_name, array( 'approved' => (bool) $result['approved'] ), DAY_IN_SECONDS );
 
 		return (bool) $result['approved'];
+	}
+
+	/**
+	 * Get the active campaign status for a site.
+	 *
+	 * @param int $blog_id The blog ID to check.
+	 *
+	 * @return array Active campaign status.
+	 */
+	public static function get_active_campaigns_status( $blog_id ) {
+		$blog_id = absint( $blog_id );
+
+		if ( empty( $blog_id ) ) {
+			return self::get_unknown_active_campaigns_status();
+		}
+
+		$transient_name = self::ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_PREFIX . $blog_id;
+		$cached_result  = get_transient( $transient_name );
+
+		if ( false !== $cached_result ) {
+			return $cached_result;
+		}
+
+		/**
+		 * Filter the campaign statuses that should trigger the active campaign warning.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string[] $statuses Campaign statuses to check.
+		 * @param int      $blog_id  The blog ID being checked.
+		 */
+		$statuses = apply_filters( 'jetpack_blaze_active_campaign_statuses', self::ACTIVE_CAMPAIGN_STATUSES, $blog_id );
+		$statuses = array_filter( array_map( 'sanitize_key', (array) $statuses ) );
+
+		if ( empty( $statuses ) ) {
+			$statuses = self::ACTIVE_CAMPAIGN_STATUSES;
+		}
+
+		$url = add_query_arg(
+			array(
+				'status' => implode( ',', $statuses ),
+				'limit'  => 1,
+			),
+			sprintf( '/sites/%d/wordads/dsp/api/v1/search/campaigns/site/%d', $blog_id, $blog_id )
+		);
+
+		$response = Client::wpcom_json_api_request_as_user(
+			$url,
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return self::get_unknown_active_campaigns_status();
+		}
+
+		$result = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $result ) || ! isset( $result['campaigns'] ) || ! is_array( $result['campaigns'] ) ) {
+			return self::get_unknown_active_campaigns_status();
+		}
+
+		$has_active_campaigns = ! empty( $result['campaigns'] );
+		$status               = array(
+			'has_active_campaigns' => $has_active_campaigns,
+			'status'               => $has_active_campaigns ? 'active' : 'none',
+		);
+
+		if ( $has_active_campaigns ) {
+			set_transient( $transient_name, $status, self::ACTIVE_CAMPAIGNS_STATUS_TRANSIENT_TTL );
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Get the unknown active campaign status response.
+	 *
+	 * @return array Unknown active campaign status.
+	 */
+	private static function get_unknown_active_campaigns_status() {
+		return array(
+			'has_active_campaigns' => false,
+			'status'               => 'unknown',
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -26,6 +26,22 @@ class REST_Controller {
 	public static $namespace = 'jetpack/v4/blaze';
 
 	/**
+	 * Connection manager object.
+	 *
+	 * @var \Automattic\Jetpack\Connection\Manager
+	 */
+	private $connection;
+
+	/**
+	 * Creates the REST_Controller object.
+	 *
+	 * @param \Automattic\Jetpack\Connection\Manager $connection The connection manager object.
+	 */
+	public function __construct( $connection = null ) {
+		$this->connection = $connection ?? new Connection_Manager();
+	}
+
+	/**
 	 * Registers the REST routes.
 	 *
 	 * @access public
@@ -33,26 +49,35 @@ class REST_Controller {
 	 */
 	public function register_rest_routes() {
 		$site_id = $this->get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return;
+
+		if ( ! is_wp_error( $site_id ) ) {
+			register_rest_route(
+				static::$namespace,
+				'eligibility',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'blaze_eligibility' ),
+					'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
+				)
+			);
+
+			register_rest_route(
+				static::$namespace,
+				'dashboard',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'is_dashboard_enabled' ),
+					'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
+				)
+			);
 		}
 
 		register_rest_route(
 			static::$namespace,
-			'eligibility',
+			'active-campaigns',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'blaze_eligibility' ),
-				'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
-			)
-		);
-
-		register_rest_route(
-			static::$namespace,
-			'dashboard',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'is_dashboard_enabled' ),
+				'callback'            => array( $this, 'get_active_campaigns' ),
 				'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
 			)
 		);
@@ -98,6 +123,20 @@ class REST_Controller {
 	}
 
 	/**
+	 * Get active Blaze campaign status for the site.
+	 *
+	 * @return array
+	 */
+	public function get_active_campaigns() {
+		$site_id = $this->get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return Blaze::get_active_campaigns_status( 0 );
+		}
+
+		return Blaze::get_active_campaigns_status( $site_id );
+	}
+
+	/**
 	 * Check if the current user is connected.
 	 * On WordPress.com Simple, it is always connected.
 	 *
@@ -108,8 +147,7 @@ class REST_Controller {
 			return true;
 		}
 
-		$connection = new Connection_Manager();
-		return $connection->is_connected() && $connection->is_user_connected();
+		return $this->connection->is_connected() && $this->connection->is_user_connected();
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -45,7 +45,6 @@ class REST_Controller {
 	 * Registers the REST routes.
 	 *
 	 * @access public
-	 * @static
 	 */
 	public function register_rest_routes() {
 		$site_id = $this->get_site_id();

--- a/projects/packages/blaze/tests/php/Blaze_Test.php
+++ b/projects/packages/blaze/tests/php/Blaze_Test.php
@@ -324,6 +324,110 @@ class Blaze_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that unknown status responses use a transient cache.
+	 */
+	public function test_get_active_campaigns_status_uses_unknown_cache() {
+		$request_count = 0;
+		$expected      = array(
+			'has_active_campaigns' => false,
+			'status'               => 'unknown',
+		);
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$request_count ) {
+				if ( false !== strpos( $url, '/sites/123/wordads/dsp/api/v1/search/campaigns/site/123' ) ) {
+					++$request_count;
+
+					return array(
+						'response' => array( 'code' => 500 ),
+						'body'     => wp_json_encode( array( 'error' => 'server_error' ), JSON_UNESCAPED_SLASHES ),
+					);
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$this->assertSame( $expected, Blaze::get_active_campaigns_status( 123 ) );
+		$this->assertSame( $expected, Blaze::get_active_campaigns_status( 123 ) );
+		$this->assertSame( 1, $request_count );
+
+		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
+	}
+
+	/**
+	 * Test that statuses without active campaigns are not cached.
+	 */
+	public function test_get_active_campaigns_status_does_not_cache_none_status() {
+		$request_count = 0;
+		$responses     = array(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'campaigns' => array() ), JSON_UNESCAPED_SLASHES ),
+			),
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'campaigns' => array(
+							array(
+								'campaign_id' => 1,
+								'status'      => 'active',
+							),
+						),
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+			),
+		);
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$request_count, $responses ) {
+				if ( false !== strpos( $url, '/sites/123/wordads/dsp/api/v1/search/campaigns/site/123' ) ) {
+					$response = $responses[ $request_count ] ?? end( $responses );
+					++$request_count;
+
+					return $response;
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => false,
+				'status'               => 'none',
+			),
+			Blaze::get_active_campaigns_status( 123 )
+		);
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => true,
+				'status'               => 'active',
+			),
+			Blaze::get_active_campaigns_status( 123 )
+		);
+		$this->assertSame( 2, $request_count );
+
+		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
+	}
+
+	/**
 	 * Test that empty blog IDs return an unknown status.
 	 */
 	public function test_get_active_campaigns_status_returns_unknown_without_blog_id() {

--- a/projects/packages/blaze/tests/php/Blaze_Test.php
+++ b/projects/packages/blaze/tests/php/Blaze_Test.php
@@ -355,8 +355,11 @@ class Blaze_Test extends BaseTestCase {
 			3
 		);
 
-		$this->assertSame( $expected, Blaze::get_active_campaigns_status( 123 ) );
-		$this->assertSame( $expected, Blaze::get_active_campaigns_status( 123 ) );
+		$first_status  = Blaze::get_active_campaigns_status( 123 );
+		$second_status = Blaze::get_active_campaigns_status( 123 );
+
+		$this->assertSame( $expected, $first_status );
+		$this->assertSame( $expected, $second_status );
 		$this->assertSame( 1, $request_count );
 
 		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
@@ -396,7 +399,8 @@ class Blaze_Test extends BaseTestCase {
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( &$request_count, $responses ) {
 				if ( false !== strpos( $url, '/sites/123/wordads/dsp/api/v1/search/campaigns/site/123' ) ) {
-					$response = $responses[ $request_count ] ?? end( $responses );
+					$response_index = min( $request_count, count( $responses ) - 1 );
+					$response       = $responses[ $response_index ];
 					++$request_count;
 
 					return $response;

--- a/projects/packages/blaze/tests/php/Blaze_Test.php
+++ b/projects/packages/blaze/tests/php/Blaze_Test.php
@@ -64,6 +64,8 @@ class Blaze_Test extends BaseTestCase {
 		wp_dequeue_script( Blaze::SCRIPT_HANDLE );
 		wp_deregister_script( Blaze::SCRIPT_HANDLE );
 		wp_set_current_user( 0 );
+		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
 	}
 
 	/**
@@ -240,6 +242,126 @@ class Blaze_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test the active campaign status check.
+	 *
+	 * @dataProvider get_active_campaign_status_responses
+	 *
+	 * @param array $response_details The mocked remote response.
+	 * @param array $expected_status  The expected status response.
+	 */
+	#[DataProvider( 'get_active_campaign_status_responses' )]
+	public function test_get_active_campaigns_status( $response_details, $expected_status ) {
+		$request_url   = '';
+		$request_count = 0;
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		if ( isset( $response_details['body'] ) ) {
+			$response_details['body'] = wp_json_encode( $response_details['body'], JSON_UNESCAPED_SLASHES );
+		}
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $response_details, &$request_url, &$request_count ) {
+				if ( false !== strpos( $url, '/sites/123/wordads/dsp/api/v1/search/campaigns/site/123' ) ) {
+					$request_url = $url;
+					++$request_count;
+
+					return $response_details;
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$status = Blaze::get_active_campaigns_status( 123 );
+
+		$this->assertSame( $expected_status, $status );
+		$this->assertSame( 1, $request_count );
+		$this->assertStringContainsString( 'status=active', $request_url );
+		$this->assertStringContainsString( 'limit=1', $request_url );
+
+		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
+	}
+
+	/**
+	 * Test that active status responses use the transient cache.
+	 */
+	public function test_get_active_campaigns_status_uses_active_cache() {
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		set_transient(
+			'jetpack_blaze_active_campaigns_status_123',
+			array(
+				'has_active_campaigns' => true,
+				'status'               => 'active',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				$this->fail( 'The remote active campaigns request should not run when active status is cached.' );
+			}
+		);
+
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => true,
+				'status'               => 'active',
+			),
+			Blaze::get_active_campaigns_status( 123 )
+		);
+
+		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
+	}
+
+	/**
+	 * Test that empty blog IDs return an unknown status.
+	 */
+	public function test_get_active_campaigns_status_returns_unknown_without_blog_id() {
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => false,
+				'status'               => 'unknown',
+			),
+			Blaze::get_active_campaigns_status( 0 )
+		);
+	}
+
+	/**
+	 * Mock Jetpack site ID and tokens for API requests.
+	 *
+	 * @param mixed  $value The option value.
+	 * @param string $name  The option name.
+	 * @return mixed
+	 */
+	public function mock_jetpack_site_connection_options( $value, $name ) {
+		switch ( $name ) {
+			case 'blog_token':
+				return 'blog.token.123';
+			case 'id':
+				return 123;
+			case 'user_tokens':
+				$current_user_id = get_current_user_id();
+				if ( $current_user_id ) {
+					return array(
+						$current_user_id => sprintf( 'token%d.secret%d.%d', $current_user_id, $current_user_id, $current_user_id ),
+					);
+				}
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Different scenarios (pages, Blaze eligibility) to test if Blaze js is enqueued in the editor.
 	 *
 	 * @return array
@@ -332,6 +454,65 @@ class Blaze_Test extends BaseTestCase {
 					'transient' => array( 'approved' => false ),
 				),
 				false,
+			),
+		);
+	}
+
+	/**
+	 * Different potential responses from the active campaign status check.
+	 *
+	 * @return array[]
+	 */
+	public static function get_active_campaign_status_responses() {
+		return array(
+			'active campaign exists'    => array(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => array(
+						'campaigns' => array(
+							array(
+								'campaign_id' => 1,
+								'status'      => 'active',
+							),
+						),
+					),
+				),
+				array(
+					'has_active_campaigns' => true,
+					'status'               => 'active',
+				),
+			),
+			'no active campaigns exist' => array(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => array(
+						'campaigns' => array(),
+					),
+				),
+				array(
+					'has_active_campaigns' => false,
+					'status'               => 'none',
+				),
+			),
+			'remote request fails'      => array(
+				array(
+					'response' => array( 'code' => 500 ),
+					'body'     => array( 'error' => 'server_error' ),
+				),
+				array(
+					'has_active_campaigns' => false,
+					'status'               => 'unknown',
+				),
+			),
+			'malformed response'        => array(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => array( 'unexpected' => 'shape' ),
+				),
+				array(
+					'has_active_campaigns' => false,
+					'status'               => 'unknown',
+				),
 			),
 		);
 	}

--- a/projects/packages/blaze/tests/php/REST_Controller_Test.php
+++ b/projects/packages/blaze/tests/php/REST_Controller_Test.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * This file contains PHPUnit tests for the REST_Controller class.
+ * To run the package unit tests, run jetpack test php packages/blaze
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * PHPUnit tests for the REST_Controller class.
+ *
+ * @covers \Automattic\Jetpack\Blaze\REST_Controller
+ */
+#[CoversClass( REST_Controller::class )]
+class REST_Controller_Test extends BaseTestCase {
+	/**
+	 * Admin user id.
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
+	 * Editor user id.
+	 *
+	 * @var int
+	 */
+	protected $editor_id;
+
+	/**
+	 * REST server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Whether the site is connected.
+	 *
+	 * @var bool
+	 */
+	private $is_connected = true;
+
+	/**
+	 * Whether the user is connected.
+	 *
+	 * @var bool
+	 */
+	private $is_user_connected = true;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function set_up() {
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user_2',
+				'user_pass'  => 'dummy_pass_2',
+				'role'       => 'editor',
+			)
+		);
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		$this->is_connected                                       = true;
+		$this->is_user_connected                                  = true;
+
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+		( new REST_Controller( $this->get_mocked_connection_manager() ) )->register_rest_routes();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
+	}
+
+	/**
+	 * Test that the active campaigns endpoint requires admin permission.
+	 */
+	public function test_active_campaigns_requires_admin_permission() {
+		wp_set_current_user( $this->editor_id );
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/blaze/active-campaigns' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test that the active campaigns endpoint returns active campaign status.
+	 */
+	public function test_active_campaigns_returns_campaign_status() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				if ( false !== strpos( $url, '/sites/123/wordads/dsp/api/v1/search/campaigns/site/123' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode(
+							array(
+								'campaigns' => array(
+									array( 'campaign_id' => 1 ),
+								),
+							),
+							JSON_UNESCAPED_SLASHES
+						),
+					);
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/blaze/active-campaigns' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => true,
+				'status'               => 'active',
+			),
+			$response->get_data()
+		);
+
+		delete_transient( 'jetpack_blaze_active_campaigns_status_123' );
+	}
+
+	/**
+	 * Test that the active campaigns endpoint returns an unknown status when the site ID is missing.
+	 */
+	public function test_active_campaigns_returns_unknown_without_site_id() {
+		global $wp_rest_server;
+
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		wp_set_current_user( $this->admin_id );
+		( new REST_Controller( $this->get_mocked_connection_manager() ) )->register_rest_routes();
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/blaze/active-campaigns' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'has_active_campaigns' => false,
+				'status'               => 'unknown',
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Mock Jetpack site ID and tokens for route registration and API requests.
+	 *
+	 * @param mixed  $value The option value.
+	 * @param string $name  The option name.
+	 * @return mixed
+	 */
+	public function mock_jetpack_site_connection_options( $value, $name ) {
+		switch ( $name ) {
+			case 'blog_token':
+				return 'blog.token.123';
+			case 'id':
+				return 123;
+			case 'user_tokens':
+				$current_user_id = get_current_user_id();
+				if ( $current_user_id ) {
+					return array(
+						$current_user_id => sprintf( 'token%d.secret%d.%d', $current_user_id, $current_user_id, $current_user_id ),
+					);
+				}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Create a stubbed Connection_Manager instance.
+	 *
+	 * @return Connection_Manager PHPUnit stub object.
+	 */
+	private function get_mocked_connection_manager() {
+		$connection_manager = $this->createStub( Connection_Manager::class );
+		$connection_manager->method( 'is_connected' )->willReturnCallback(
+			function () {
+				return $this->is_connected;
+			}
+		);
+		$connection_manager->method( 'is_user_connected' )->willReturnCallback(
+			function () {
+				return $this->is_user_connected;
+			}
+		);
+
+		return $connection_manager;
+	}
+}

--- a/projects/packages/blaze/tests/php/REST_Controller_Test.php
+++ b/projects/packages/blaze/tests/php/REST_Controller_Test.php
@@ -61,6 +61,8 @@ class REST_Controller_Test extends BaseTestCase {
 	 * Setting up the test.
 	 */
 	public function set_up() {
+		parent::set_up();
+
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -97,6 +99,8 @@ class REST_Controller_Test extends BaseTestCase {
 		wp_set_current_user( 0 );
 		remove_all_filters( 'pre_http_request' );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/components/module-toggle/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/module-toggle/README.md
@@ -28,3 +28,4 @@ render: function() {
 * `toggling`: (bool) - If true, the toggle is rendered in a transition state style.
 * `className`: (string) - A CSS class to append
 * `overrideCondition`: (string) - By default, the toggle will be disabled if the module is overridden. When this prop is `active`, the toggle will only be disabled when the module is forced on and when this prop is `inactive` the toggle will be disabled when the module is forced off.
+* `trackToggle`: (bool) - If false, the toggle does not record the default module toggle event.

--- a/projects/plugins/jetpack/_inc/client/components/module-toggle/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-toggle/index.jsx
@@ -19,16 +19,20 @@ class ModuleToggleComponent extends Component {
 		compact: PropTypes.bool,
 		id: PropTypes.string,
 		overrideCondition: PropTypes.string,
+		trackToggle: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		activated: false,
 		disabled: false,
 		overrideCondition: '',
+		trackToggle: true,
 	};
 
 	toggleModule = () => {
-		this.trackModuleToggle( this.props.slug, this.props.activated );
+		if ( this.props.trackToggle ) {
+			this.trackModuleToggle( this.props.slug, this.props.activated );
+		}
 		return this.props.toggleModule( this.props.slug, this.props.activated );
 	};
 

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -26,10 +26,10 @@ const trackDashboardClick = () => {
 	analytics.tracks.recordJetpackClick( 'blaze-dashboard' );
 };
 
-const trackModuleToggle = ( module, activated ) => {
+const trackModuleToggle = ( module, currentlyActivated ) => {
 	analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
 		module,
-		toggled: activated ? 'off' : 'on',
+		toggled: currentlyActivated ? 'off' : 'on',
 	} );
 };
 

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,7 +1,16 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
-import { ToggleControl } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Modal,
+	ToggleControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -17,13 +26,30 @@ const trackDashboardClick = () => {
 	analytics.tracks.recordJetpackClick( 'blaze-dashboard' );
 };
 
+const trackModuleToggle = ( module, activated ) => {
+	analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
+		module,
+		toggled: activated ? 'off' : 'on',
+	} );
+};
+
+const disableWarningModalStyle = {
+	alignSelf: 'center',
+	borderRadius: '8px',
+	height: 'auto',
+	margin: 'auto',
+	maxHeight: 'calc(100% - 32px)',
+	maxWidth: '512px',
+	width: 'calc(100% - 32px)',
+};
+
 /**
  * Blaze settings component.
  *
  * @param {object} props - Component props.
  * @return {import('react').Component} Blaze settings component.
  */
-function Blaze( props ) {
+export function Blaze( props ) {
 	const {
 		blazeActive,
 		blazeAvailable,
@@ -36,8 +62,75 @@ function Blaze( props ) {
 		siteAdminUrl,
 		toggleModuleNow,
 	} = props;
+	const [ showDisableWarning, setShowDisableWarning ] = useState( false );
+	const [ checkingActiveCampaigns, setCheckingActiveCampaigns ] = useState( false );
 
 	const { can_init: canInit, reason } = blazeAvailable;
+
+	const getBlazeDashboardUrl = () => {
+		return blazeDashboardEnabled
+			? siteAdminUrl + 'tools.php?page=advertising'
+			: getRedirectUrl( 'jetpack-blaze' );
+	};
+
+	const getBlazeDashboardLinkProps = () => {
+		return ! blazeDashboardEnabled ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+	};
+
+	const closeDisableWarning = useCallback( () => {
+		setShowDisableWarning( false );
+	}, [] );
+
+	const manageCampaigns = useCallback( () => {
+		setShowDisableWarning( false );
+		trackDashboardClick();
+	}, [] );
+
+	const toggleBlazeModule = useCallback(
+		( module, currentlyActivated ) => {
+			trackModuleToggle( module, currentlyActivated );
+			toggleModuleNow( module );
+		},
+		[ toggleModuleNow ]
+	);
+
+	const disableBlaze = useCallback( () => {
+		setShowDisableWarning( false );
+		toggleBlazeModule( 'blaze', true );
+	}, [ toggleBlazeModule ] );
+
+	const handleToggleModule = useCallback(
+		async ( module, currentlyActivated ) => {
+			if ( checkingActiveCampaigns ) {
+				return;
+			}
+
+			if ( ! currentlyActivated ) {
+				toggleBlazeModule( module, currentlyActivated );
+				return;
+			}
+
+			setCheckingActiveCampaigns( true );
+
+			try {
+				const activeCampaignsStatus = await apiFetch( {
+					path: '/jetpack/v4/blaze/active-campaigns',
+				} );
+
+				if ( activeCampaignsStatus?.status === 'none' ) {
+					toggleBlazeModule( module, currentlyActivated );
+					return;
+				}
+			} catch {
+				// Warn conservatively when the status check is unavailable.
+			} finally {
+				setCheckingActiveCampaigns( false );
+			}
+
+			setShowDisableWarning( true );
+		},
+		[ checkingActiveCampaigns, toggleBlazeModule ]
+	);
 
 	if ( isWoASite() ) {
 		return null;
@@ -50,13 +143,9 @@ function Blaze( props ) {
 			<Card
 				compact
 				className="jp-settings-card__configure-link"
-				href={
-					blazeDashboardEnabled
-						? siteAdminUrl + 'tools.php?page=advertising'
-						: getRedirectUrl( 'jetpack-blaze' )
-				}
+				href={ getBlazeDashboardUrl() }
 				onClick={ trackDashboardClick }
-				{ ...( ! blazeDashboardEnabled ? { target: '_blank', rel: 'noopener noreferrer' } : {} ) }
+				{ ...getBlazeDashboardLinkProps() }
 			>
 				{ __( 'Manage your campaigns and view your earnings in the Blaze dashboard', 'jetpack' ) }
 			</Card>
@@ -88,8 +177,14 @@ function Blaze( props ) {
 			<ModuleToggle
 				slug="blaze"
 				activated={ blazeActive }
-				disabled={ unavailableInOfflineMode || ! hasConnectedOwner || isSavingAnyOption( 'blaze' ) }
-				toggleModule={ toggleModuleNow }
+				disabled={
+					unavailableInOfflineMode ||
+					! hasConnectedOwner ||
+					isSavingAnyOption( 'blaze' ) ||
+					checkingActiveCampaigns
+				}
+				trackToggle={ false }
+				toggleModule={ handleToggleModule }
 			>
 				<span className="jp-form-toggle-explanation">
 					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
@@ -118,6 +213,40 @@ function Blaze( props ) {
 				{ blazeToggle() }
 			</SettingsGroup>
 			{ canInit && blazeActive && ! isOfflineMode && blazeDashboardLink() }
+			{ showDisableWarning && (
+				<Modal
+					title={ __( 'Active Blaze campaigns are still running', 'jetpack' ) }
+					onRequestClose={ closeDisableWarning }
+					className="jp-blaze-disable-warning-modal"
+					size="medium"
+					style={ disableWarningModalStyle }
+				>
+					<VStack spacing="4">
+						<Text as="p">
+							{ __(
+								'Disabling this setting only hides the Blaze interface. Your campaigns will continue to serve ads, and you will continue to be charged. To stop your campaigns, open campaign management.',
+								'jetpack'
+							) }
+						</Text>
+						<HStack justify="start" spacing="3" wrap>
+							<Button variant="primary" onClick={ closeDisableWarning }>
+								{ __( 'Keep Blaze enabled', 'jetpack' ) }
+							</Button>
+							<Button
+								variant="secondary"
+								href={ getBlazeDashboardUrl() }
+								onClick={ manageCampaigns }
+								{ ...getBlazeDashboardLinkProps() }
+							>
+								{ __( 'Manage campaigns', 'jetpack' ) }
+							</Button>
+							<Button variant="tertiary" isDestructive onClick={ disableBlaze }>
+								{ __( 'Disable anyway', 'jetpack' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
+			) }
 		</SettingsCard>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze/test/component.js
@@ -1,0 +1,289 @@
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+import analytics from 'lib/analytics';
+import { render, screen } from 'test/test-utils';
+import { Blaze } from '../../blaze';
+
+jest.mock( '@wordpress/api-fetch' );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn().mockReturnValue( {
+		site: {
+			suffix: 'example.com',
+		},
+	} ),
+	isWoASite: jest.fn().mockReturnValue( false ),
+} ) );
+
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+		recordJetpackClick: jest.fn(),
+	},
+} ) );
+
+describe( 'Blaze settings', () => {
+	const defaultProps = {
+		blazeActive: true,
+		blazeAvailable: {
+			can_init: true,
+			reason: null,
+		},
+		blazeDashboardEnabled: true,
+		blazeModule: {
+			description: 'Blaze module description.',
+		},
+		hasConnectedOwner: true,
+		isOfflineMode: false,
+		isSavingAnyOption: jest.fn().mockReturnValue( false ),
+		isUnavailableInOfflineMode: jest.fn().mockReturnValue( false ),
+		siteAdminUrl: 'https://example.com/wp-admin/',
+		toggleModuleNow: jest.fn(),
+	};
+
+	const initialState = {
+		jetpack: {
+			initialState: {
+				adminUrl: 'https://example.com/wp-admin/',
+				isBlazeDashboardEnabled: true,
+				shouldInitializeBlaze: {
+					can_init: true,
+					reason: null,
+				},
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true,
+						},
+					},
+				},
+			},
+			connection: {
+				status: {
+					siteConnected: {
+						hasConnectedOwner: true,
+						offlineMode: {
+							isActive: false,
+						},
+						status: 'connected',
+					},
+				},
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+			},
+			modules: {
+				items: {
+					blaze: {},
+				},
+			},
+			settings: {
+				items: {},
+				requests: {
+					fetchingSettingsList: false,
+					settingsSent: {},
+					updatedSettings: {},
+				},
+			},
+			dashboard: {
+				requests: {
+					fetchingVaultPressData: false,
+					checkingAkismetKey: false,
+				},
+			},
+			siteData: {
+				data: {
+					site: {
+						features: {
+							active: [],
+						},
+					},
+				},
+				requests: {},
+			},
+		},
+	};
+
+	const renderCard = ( props = {} ) => {
+		const mergedProps = {
+			...defaultProps,
+			...props,
+		};
+
+		render( <Blaze { ...mergedProps } />, {
+			initialState,
+		} );
+
+		return {
+			toggle: screen.getByRole( 'checkbox', {
+				name: /Attract high-quality traffic to your site using Blaze./,
+			} ),
+			props: mergedProps,
+		};
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'disables without warning when no active campaigns exist', async () => {
+		apiFetch.mockResolvedValue( {
+			has_active_campaigns: false,
+			status: 'none',
+		} );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack/v4/blaze/active-campaigns',
+		} );
+		expect( props.toggleModuleNow ).toHaveBeenCalledWith( 'blaze' );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_wpa_module_toggle', {
+			module: 'blaze',
+			toggled: 'off',
+		} );
+		expect(
+			screen.queryByRole( 'dialog', { name: /Active Blaze campaigns/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'warns before disabling when active campaigns exist', async () => {
+		apiFetch.mockResolvedValue( {
+			has_active_campaigns: true,
+			status: 'active',
+		} );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack/v4/blaze/active-campaigns',
+		} );
+		expect( props.toggleModuleNow ).not.toHaveBeenCalled();
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		await expect(
+			screen.findByRole( 'dialog', { name: /Active Blaze campaigns are still running/ } )
+		).resolves.toBeInTheDocument();
+		expect(
+			screen.getByRole( 'dialog', { name: /Active Blaze campaigns are still running/ } )
+		).toHaveClass( 'jp-blaze-disable-warning-modal' );
+		expect( screen.getByRole( 'button', { name: /^Close$/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /Manage campaigns/ } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-admin/tools.php?page=advertising'
+		);
+	} );
+
+	it( 'disables after explicit confirmation from the warning', async () => {
+		apiFetch.mockResolvedValue( {
+			has_active_campaigns: true,
+			status: 'active',
+		} );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+		await user.click(
+			await screen.findByRole( 'button', {
+				name: /Disable anyway/,
+			} )
+		);
+
+		expect( props.toggleModuleNow ).toHaveBeenCalledWith( 'blaze' );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_wpa_module_toggle', {
+			module: 'blaze',
+			toggled: 'off',
+		} );
+	} );
+
+	it( 'keeps Blaze enabled from the warning', async () => {
+		apiFetch.mockResolvedValue( {
+			has_active_campaigns: true,
+			status: 'active',
+		} );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+		await user.click(
+			await screen.findByRole( 'button', {
+				name: /Keep Blaze enabled/,
+			} )
+		);
+
+		expect( props.toggleModuleNow ).not.toHaveBeenCalled();
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByRole( 'dialog', { name: /Active Blaze campaigns are still running/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps Blaze enabled after opening campaign management from the warning', async () => {
+		apiFetch.mockResolvedValue( {
+			has_active_campaigns: true,
+			status: 'active',
+		} );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+
+		const manageCampaignsLink = await screen.findByRole( 'link', { name: /Manage campaigns/ } );
+		manageCampaignsLink.addEventListener( 'click', event => event.preventDefault() );
+		await user.click( manageCampaignsLink );
+
+		expect( props.toggleModuleNow ).not.toHaveBeenCalled();
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByRole( 'dialog', { name: /Active Blaze campaigns are still running/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'warns conservatively when the active campaign lookup fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'network unavailable' ) );
+
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard();
+
+		await user.click( toggle );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack/v4/blaze/active-campaigns',
+		} );
+		expect( props.toggleModuleNow ).not.toHaveBeenCalled();
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		await expect(
+			screen.findByRole( 'dialog', { name: /Active Blaze campaigns are still running/ } )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'activates without checking for active campaigns', async () => {
+		const user = userEvent.setup();
+		const { toggle, props } = renderCard( { blazeActive: false } );
+
+		await user.click( toggle );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( props.toggleModuleNow ).toHaveBeenCalledWith( 'blaze' );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_wpa_module_toggle', {
+			module: 'blaze',
+			toggled: 'on',
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/add-ads-1159-blaze-disable-warning
+++ b/projects/plugins/jetpack/changelog/add-ads-1159-blaze-disable-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blaze: warn users with active campaigns before disabling the Blaze module.


### PR DESCRIPTION
Fixes ADS-1159

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add a Blaze package active-campaign status check and expose it through `GET /jetpack/v4/blaze/active-campaigns`.
* Show a Jetpack Traffic settings warning before disabling Blaze when active campaign status is active or unknown.
* Keep the client-side check local to Jetpack via `@wordpress/api-fetch`, instead of adding a shared `@automattic/jetpack-api` helper. This recreates the reverted behavior without the broad shared API package bundle churn.
* Add PHP coverage for the status check and REST route, plus JS coverage for the warning modal flow.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: https://linear.app/a8c/issue/ADS-1159/show-warning-when-user-disables-blaze-module-while-active-campaigns
* Follow-up to the previous PR: https://github.com/Automattic/jetpack/pull/49522
* The previous PR was reverted in https://github.com/Automattic/jetpack/pull/49609 to unblock sun/moon deployment after the shared `projects/js-packages/api` changes caused broad production bundle churn. This PR recreates the user-facing fix while keeping the active-campaign lookup local to Jetpack.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No new Tracks events or properties are added. The existing `jetpack_wpa_module_toggle` event is still recorded for confirmed Blaze toggles. This PR delays recording for the Blaze toggle until the user either toggles directly with no active campaigns or confirms `Disable anyway` from the warning.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Original PR for context and previous manual testing notes: https://github.com/Automattic/jetpack/pull/49522
* Build or sync this branch to a connected Jetpack test site, such as a temporary test site (JN) or sandbox, where Blaze can initialize.
* Open `Jetpack > Settings > Traffic` and confirm Blaze is enabled.
* To exercise the active-campaign warning, use either a site with a real active Blaze campaign, or temporarily mock the WPCOM campaign lookup on the test site with a `pre_http_request` filter that returns:

```php
array(
	'response' => array( 'code' => 200 ),
	'body'     => wp_json_encode(
		array(
			'campaigns' => array(
				array( 'campaign_id' => 123 ),
			),
		)
	),
)
```

for URLs containing `/wordads/dsp/api/v1/search/campaigns/site/`.
* Disable the Blaze toggle. Confirm the modal appears with the title `Active Blaze campaigns are still running`.
* Confirm `Keep Blaze enabled` closes the modal and leaves Blaze enabled.
* Open the modal again and confirm `Manage campaigns` opens campaign management and leaves Blaze enabled.
* Open the modal again and confirm `Disable anyway` closes the modal and disables Blaze.
* In a mobile-width viewport, repeat the disable step and confirm the modal stays centered with visible padding, rather than filling the whole page.
* Remove the mock or return an empty `campaigns` array. Re-enable Blaze, then disable it again. Confirm no warning appears and Blaze disables directly.
* Optional REST checks: as an administrator, request `/wp-json/jetpack/v4/blaze/active-campaigns` and confirm it returns one of `active`, `none`, or `unknown`; as a non-admin, confirm the endpoint is forbidden.
