### PR TITLE
Tooling: remove obsolete ESLint v10_config_lookup_from_file flag

### DIFF
--- a/.vscode/settings.dist.jsonc
+++ b/.vscode/settings.dist.jsonc
@@ -57,14 +57,6 @@
 	"prettier.prettierPath": "tools/js-tools/node_modules/prettier/index.cjs",
 	// Use ESLint from this path.
 	"eslint.nodePath": "tools/js-tools/node_modules",
-	// Look up the nearest eslint.config.mjs from each file (matches the repo's
-	// lint scripts, which pass this same flag). Without it the extension only
-	// loads the root config, which skips packages that have their own
-	// eslint.config.mjs — so their text domain isn't applied and every
-	// translated string is wrongly flagged as an invalid text domain.
-	"eslint.options": {
-		"flags": [ "v10_config_lookup_from_file" ]
-	},
 
 	// Set to the target minimum PHP version for the codebase. Unrelated to the monorepo tooling.
 	"intelephense.environment.phpVersion": "7.2.24",


### PR DESCRIPTION
Fixes #

## Proposed changes
* Remove the `eslint.options.flags` setting (`v10_config_lookup_from_file`) from the recommended VS Code settings.
* Following the upgrade to ESLint v10 (#49352), config lookup from the nearest `eslint.config.mjs` is the default behavior, so the flag is no longer needed.
* The flag is now unknown to ESLint v10, so the VS Code ESLint extension reports `Unknown flag v10_config_lookup_from_file` and fails to lint. Removing it restores linting in the editor.
* The flag was originally added in #49368.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Copy `.vscode/settings.dist.jsonc` to `.vscode/settings.json` (or apply the same change to your existing `.vscode/settings.json`).
* Reload VS Code and open the ESLint output panel.
* Confirm there is no `Unknown flag v10_config_lookup_from_file` error.
* Open a translated string in a package that has its own `eslint.config.mjs` and confirm it is linted with the correct text domain (no spurious invalid-text-domain errors).
