### PR TITLE
RTC: add jetpack_rtc_connection_error Tracks event

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17555-jetpack-rtc-connection-error
+++ b/projects/packages/rtc/changelog/dotcom-17555-jetpack-rtc-connection-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+RTC: add a jetpack_rtc_connection_error Tracks event recorded on a genuine (non-limit) sync connection error; the per-room-limit case is skipped to avoid double-counting with jetpack_rtc_blocked.

--- a/projects/packages/rtc/src/js/notices/index.tsx
+++ b/projects/packages/rtc/src/js/notices/index.tsx
@@ -13,6 +13,7 @@ import './public-path';
 
 import { addFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
+import { registerConnectionErrorTracking } from '../tracking/track-connection-error';
 import { registerJoinTracking } from '../tracking/track-join';
 import RtcAdminSomeoneWaitingNotice from './notices/rtc-admin-someone-waiting-notice';
 import { registerConnectionErrorModalFilter } from './notices/rtc-connection-error-modal-filter';
@@ -50,6 +51,10 @@ function registerRoomLimitFilter(): void {
 
 // Join tracking runs on every site with RTC, regardless of the room limit.
 registerJoinTracking();
+
+// Connection-error tracking also runs everywhere; it skips the room-limit case
+// (recorded separately as jetpack_rtc_blocked) to avoid double-counting.
+registerConnectionErrorTracking();
 
 // Room-limit enforcement always runs (it stops polling, sends join requests).
 // The branded modals are gated behind enableLimitNotices.

--- a/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
@@ -1,0 +1,169 @@
+import { jest } from '@jest/globals';
+
+const recordRtcEventMock = jest.fn();
+const addFilterMock = jest.fn();
+const isRoomLimitBreachedMock = jest.fn( () => false );
+
+jest.unstable_mockModule( '../tracks', () => ( {
+	recordRtcEvent: recordRtcEventMock,
+} ) );
+
+jest.unstable_mockModule( '@wordpress/hooks', () => ( {
+	addFilter: addFilterMock,
+} ) );
+
+jest.unstable_mockModule( '../../notices/room-limit', () => ( {
+	isRoomLimitBreached: isRoomLimitBreachedMock,
+} ) );
+
+const { withConnectionErrorTracking, registerConnectionErrorTracking } = await import(
+	'../track-connection-error'
+);
+
+type StatusListener = ( status: unknown ) => void;
+
+/**
+ * Build a fake provider whose `on('status')` listeners can be fired by the test
+ * via the returned `emitStatus()` helper.
+ *
+ * @return A fake provider result plus an `emitStatus` trigger.
+ */
+function makeProvider() {
+	const listeners: StatusListener[] = [];
+	return {
+		destroy: jest.fn(),
+		on: ( event: string, cb: StatusListener ) => {
+			if ( event === 'status' ) {
+				listeners.push( cb );
+			}
+		},
+		emitStatus: ( status: unknown ) => listeners.forEach( cb => cb( status ) ),
+	};
+}
+
+const entityRoom = {
+	objectType: 'postType',
+	objectId: 'post-42',
+	ydoc: {} as never,
+};
+
+describe( 'withConnectionErrorTracking', () => {
+	beforeEach( () => {
+		recordRtcEventMock.mockClear();
+		isRoomLimitBreachedMock.mockReturnValue( false );
+	} );
+
+	it( 'records jetpack_rtc_connection_error on a genuine disconnect with an error', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
+			error_code: 'unknown-error',
+		} );
+	} );
+
+	it( 'does not record a clean disconnect with no error', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected' } );
+		provider.emitStatus( { status: 'connected' } );
+		provider.emitStatus( { status: 'connecting' } );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips the per-room-limit case (connection-limit-exceeded code)', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( {
+			status: 'disconnected',
+			error: { code: 'connection-limit-exceeded' },
+		} );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips when the room limit has been breached, whatever the error code', async () => {
+		isRoomLimitBreachedMock.mockReturnValue( true );
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records only once even if the connection keeps flapping', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'connection-expired' } } );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not subscribe for a collection room (objectId === null)', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( { ...entityRoom, objectId: null } as never );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns the inner provider result', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		const result = await wrapped( entityRoom as never );
+
+		expect( result ).toBe( provider );
+	} );
+} );
+
+describe( 'registerConnectionErrorTracking', () => {
+	beforeEach( () => addFilterMock.mockClear() );
+
+	it( 'registers a sync.providers filter at priority 30', () => {
+		registerConnectionErrorTracking();
+
+		expect( addFilterMock ).toHaveBeenCalledWith(
+			'sync.providers',
+			'jetpack/rtc-connection-error-tracking',
+			expect.any( Function ),
+			30
+		);
+	} );
+
+	it( 'wraps each provider creator with connection-error tracking', () => {
+		registerConnectionErrorTracking();
+
+		const mapper = addFilterMock.mock.calls[ 0 ][ 2 ] as ( p: unknown[] ) => unknown[];
+		const creatorA = jest.fn();
+		const creatorB = jest.fn();
+		const wrapped = mapper( [ creatorA, creatorB ] );
+
+		expect( wrapped ).toHaveLength( 2 );
+		expect( wrapped[ 0 ] ).not.toBe( creatorA );
+		expect( wrapped[ 1 ] ).not.toBe( creatorB );
+	} );
+} );

--- a/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
@@ -24,7 +24,7 @@ type StatusListener = ( status: unknown ) => void;
 
 /**
  * Build a fake provider whose `on('status')` listeners can be fired by the test
- * via the returned `emitStatus()` helper.
+ * via the returned `emitStatus()` helper, and whose `destroy` is observable.
  *
  * @return A fake provider result plus an `emitStatus` trigger.
  */
@@ -53,31 +53,58 @@ describe( 'withConnectionErrorTracking', () => {
 		isRoomLimitBreachedMock.mockReturnValue( false );
 	} );
 
-	it( 'records jetpack_rtc_connection_error on a genuine disconnect with an error', async () => {
-		const provider = makeProvider();
-		const creator = jest.fn().mockResolvedValue( provider );
-		const wrapped = withConnectionErrorTracking( creator as never );
-
-		await wrapped( entityRoom as never );
-		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
-
-		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
-		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
-			error_code: 'unknown-error',
-		} );
-	} );
-
-	it( 'does not record a clean disconnect with no error', async () => {
+	it( 'records jetpack_rtc_connection_error on a bare disconnect (no error, e.g. PingHub)', async () => {
 		const provider = makeProvider();
 		const creator = jest.fn().mockResolvedValue( provider );
 		const wrapped = withConnectionErrorTracking( creator as never );
 
 		await wrapped( entityRoom as never );
 		provider.emitStatus( { status: 'disconnected' } );
-		provider.emitStatus( { status: 'connected' } );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
+			error_code: undefined,
+		} );
+	} );
+
+	it( 'includes the error code when the transport supplies one', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected', error: { code: 'authentication-failed' } } );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
+			error_code: 'authentication-failed',
+		} );
+	} );
+
+	it( 'does not record connected or connecting statuses', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		await wrapped( entityRoom as never );
 		provider.emitStatus( { status: 'connecting' } );
+		provider.emitStatus( { status: 'connected' } );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not record a disconnect emitted during teardown', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		const result = await wrapped( entityRoom as never );
+		// Navigating away / switching posts tears the provider down, which emits
+		// 'disconnected' synchronously — that must not count as a connection error.
+		( result as { destroy: () => void } ).destroy();
+		provider.emitStatus( { status: 'disconnected' } );
+
+		expect( recordRtcEventMock ).not.toHaveBeenCalled();
+		expect( provider.destroy ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'skips the per-room-limit case (connection-limit-exceeded code)', async () => {
@@ -101,19 +128,20 @@ describe( 'withConnectionErrorTracking', () => {
 		const wrapped = withConnectionErrorTracking( creator as never );
 
 		await wrapped( entityRoom as never );
-		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+		provider.emitStatus( { status: 'disconnected' } );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 	} );
 
-	it( 'records only once even if the connection keeps flapping', async () => {
+	it( 'records only once even if the connection keeps dropping', async () => {
 		const provider = makeProvider();
 		const creator = jest.fn().mockResolvedValue( provider );
 		const wrapped = withConnectionErrorTracking( creator as never );
 
 		await wrapped( entityRoom as never );
+		provider.emitStatus( { status: 'disconnected' } );
+		provider.emitStatus( { status: 'connecting' } );
 		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
-		provider.emitStatus( { status: 'disconnected', error: { code: 'connection-expired' } } );
 
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -124,19 +152,20 @@ describe( 'withConnectionErrorTracking', () => {
 		const wrapped = withConnectionErrorTracking( creator as never );
 
 		await wrapped( { ...entityRoom, objectId: null } as never );
-		provider.emitStatus( { status: 'disconnected', error: { code: 'unknown-error' } } );
+		provider.emitStatus( { status: 'disconnected' } );
 
 		expect( recordRtcEventMock ).not.toHaveBeenCalled();
 	} );
 
-	it( 'returns the inner provider result', async () => {
+	it( 'forwards destroy to the inner provider', async () => {
 		const provider = makeProvider();
 		const creator = jest.fn().mockResolvedValue( provider );
 		const wrapped = withConnectionErrorTracking( creator as never );
 
 		const result = await wrapped( entityRoom as never );
+		( result as { destroy: () => void } ).destroy();
 
-		expect( result ).toBe( provider );
+		expect( provider.destroy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/projects/packages/rtc/src/js/tracking/track-connection-error.ts
+++ b/projects/packages/rtc/src/js/tracking/track-connection-error.ts
@@ -1,0 +1,80 @@
+import { addFilter } from '@wordpress/hooks';
+import { isRoomLimitBreached } from '../notices/room-limit';
+import { recordRtcEvent } from './tracks';
+import type { ConnectionStatus, ProviderCreator } from '@wordpress/sync';
+
+const CONNECTION_ERROR_EVENT = 'jetpack_rtc_connection_error';
+
+/**
+ * Whether a status event represents a genuine, non-limit connection error.
+ *
+ * A clean disconnect (no `error`, e.g. page teardown or a normal close) is not
+ * an error. The per-room-limit case is deliberately skipped: it is already
+ * reported as `jetpack_rtc_blocked`, so counting it here too would double-count.
+ * The limit case is recognised exactly as the connection-error modal recognises
+ * it — the `connection-limit-exceeded` code (emitted by the room-limit wrapper)
+ * or the `isRoomLimitBreached()` flag that wrapper sets.
+ *
+ * @param status - The connection status emitted by the provider.
+ * @return True for a genuine, non-limit connection error.
+ */
+function isGenuineConnectionError( status: ConnectionStatus ): boolean {
+	if ( status.status !== 'disconnected' || ! status.error ) {
+		return false;
+	}
+	return status.error.code !== 'connection-limit-exceeded' && ! isRoomLimitBreached();
+}
+
+/**
+ * Wrap a provider creator so the first genuine (non-limit) connection error on
+ * an entity room records a `jetpack_rtc_connection_error` Tracks event.
+ *
+ * Records at most once per provider: a flapping connection emits repeated
+ * `disconnected` events, but the metric only needs the first occurrence per
+ * room. `transport`, `post_id`, `post_type`, and `wp_user_id` are added by
+ * `recordRtcEvent`; this only supplies the error code.
+ *
+ * Collection rooms (objectId === null) are ignored — they disconnect in lockstep
+ * with the entity room on a network drop, so tracking both would double-count.
+ * This matches the room-limit and join-tracking wrappers.
+ *
+ * @param creator - The provider creator to wrap.
+ * @return The wrapped provider creator.
+ */
+export function withConnectionErrorTracking( creator: ProviderCreator ): ProviderCreator {
+	return async options => {
+		const result = await creator( options );
+		if ( options.objectId === null ) {
+			return result;
+		}
+
+		let recorded = false;
+		result.on( 'status', ( status: ConnectionStatus ) => {
+			if ( recorded || ! isGenuineConnectionError( status ) ) {
+				return;
+			}
+			recorded = true;
+			recordRtcEvent( CONNECTION_ERROR_EVENT, {
+				error_code: status.status === 'disconnected' ? status.error?.code : undefined,
+			} );
+		} );
+
+		return result;
+	};
+}
+
+/**
+ * Register the connection-error-tracking wrapper on the sync.providers filter.
+ *
+ * Runs at priority 30 — outside the room-limit wrapper (priority 20) — so it
+ * observes the synthetic `connection-limit-exceeded` status that wrapper emits
+ * and skips it, alongside the join-tracking wrapper.
+ */
+export function registerConnectionErrorTracking(): void {
+	addFilter(
+		'sync.providers',
+		'jetpack/rtc-connection-error-tracking',
+		( providers: ProviderCreator[] ) => providers.map( withConnectionErrorTracking ),
+		30
+	);
+}

--- a/projects/packages/rtc/src/js/tracking/track-connection-error.ts
+++ b/projects/packages/rtc/src/js/tracking/track-connection-error.ts
@@ -6,37 +6,42 @@ import type { ConnectionStatus, ProviderCreator } from '@wordpress/sync';
 const CONNECTION_ERROR_EVENT = 'jetpack_rtc_connection_error';
 
 /**
- * Whether a status event represents a genuine, non-limit connection error.
+ * Whether a disconnect is the per-room-limit case, which is reported separately
+ * as `jetpack_rtc_blocked` and so must be skipped here to avoid double-counting.
  *
- * A clean disconnect (no `error`, e.g. page teardown or a normal close) is not
- * an error. The per-room-limit case is deliberately skipped: it is already
- * reported as `jetpack_rtc_blocked`, so counting it here too would double-count.
- * The limit case is recognised exactly as the connection-error modal recognises
- * it — the `connection-limit-exceeded` code (emitted by the room-limit wrapper)
- * or the `isRoomLimitBreached()` flag that wrapper sets.
+ * Recognised by the `connection-limit-exceeded` code the room-limit wrapper
+ * emits, or the `isRoomLimitBreached()` flag it sets — the same distinction the
+ * connection-error modal uses.
  *
- * @param status - The connection status emitted by the provider.
- * @return True for a genuine, non-limit connection error.
+ * @param status - The disconnected status emitted by the provider.
+ * @return True for the room-limit disconnect.
  */
-function isGenuineConnectionError( status: ConnectionStatus ): boolean {
-	if ( status.status !== 'disconnected' || ! status.error ) {
-		return false;
-	}
-	return status.error.code !== 'connection-limit-exceeded' && ! isRoomLimitBreached();
+function isRoomLimitDisconnect( status: ConnectionStatus ): boolean {
+	const code = status.status === 'disconnected' ? status.error?.code : undefined;
+	return code === 'connection-limit-exceeded' || isRoomLimitBreached();
 }
 
 /**
- * Wrap a provider creator so the first genuine (non-limit) connection error on
- * an entity room records a `jetpack_rtc_connection_error` Tracks event.
+ * Wrap a provider creator so the first genuine (non-limit) connection loss on an
+ * entity room records a `jetpack_rtc_connection_error` Tracks event.
  *
- * Records at most once per provider: a flapping connection emits repeated
- * `disconnected` events, but the metric only needs the first occurrence per
- * room. `transport`, `post_id`, `post_type`, and `wp_user_id` are added by
+ * The signal is the provider's own `disconnected` status, not Gutenberg's error
+ * modal: the modal is shown via a filter whose API has changed across Gutenberg
+ * versions (and the component variant is gated behind `IS_GUTENBERG_PLUGIN`),
+ * whereas the provider status is the transport-agnostic source of truth that
+ * drives it. The PingHub transport emits a bare `disconnected` with no `error`,
+ * so an `error` is not required; `error_code` is reported when the transport
+ * supplies one (e.g. `authentication-failed`, `protocol-mismatch`).
+ *
+ * Records at most once per provider — a connection that keeps dropping and
+ * retrying emits repeated `disconnected` events, but the metric only needs the
+ * first occurrence per room. A clean teardown (navigating away, switching posts)
+ * also emits `disconnected`, so the `tearingDown` guard keeps it from counting
+ * as an error. Collection rooms (objectId === null) are ignored, matching the
+ * room-limit and join-tracking wrappers.
+ *
+ * `transport`, `post_id`, `post_type`, and `wp_user_id` are added by
  * `recordRtcEvent`; this only supplies the error code.
- *
- * Collection rooms (objectId === null) are ignored — they disconnect in lockstep
- * with the entity room on a network drop, so tracking both would double-count.
- * This matches the room-limit and join-tracking wrappers.
  *
  * @param creator - The provider creator to wrap.
  * @return The wrapped provider creator.
@@ -49,17 +54,28 @@ export function withConnectionErrorTracking( creator: ProviderCreator ): Provide
 		}
 
 		let recorded = false;
+		let tearingDown = false;
+
 		result.on( 'status', ( status: ConnectionStatus ) => {
-			if ( recorded || ! isGenuineConnectionError( status ) ) {
+			if ( recorded || tearingDown || status.status !== 'disconnected' ) {
+				return;
+			}
+			if ( isRoomLimitDisconnect( status ) ) {
 				return;
 			}
 			recorded = true;
 			recordRtcEvent( CONNECTION_ERROR_EVENT, {
-				error_code: status.status === 'disconnected' ? status.error?.code : undefined,
+				error_code: status.error?.code,
 			} );
 		} );
 
-		return result;
+		return {
+			...result,
+			destroy: () => {
+				tearingDown = true;
+				result.destroy();
+			},
+		};
 	};
 }
 
@@ -68,7 +84,7 @@ export function withConnectionErrorTracking( creator: ProviderCreator ): Provide
  *
  * Runs at priority 30 — outside the room-limit wrapper (priority 20) — so it
  * observes the synthetic `connection-limit-exceeded` status that wrapper emits
- * and skips it, alongside the join-tracking wrapper.
+ * (and skips it), alongside the join-tracking wrapper.
  */
 export function registerConnectionErrorTracking(): void {
 	addFilter(


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Add a `jetpack_rtc_connection_error` Tracks event, recorded the first time a client loses its real-time-collaboration sync connection (genuine, non-limit) in the WordPress.com block editor.
* Skip the per-room-limit case (`connection-limit-exceeded` code / `isRoomLimitBreached()`) — it is already reported as `jetpack_rtc_blocked`, so recording it here too would double-count.
* Hook the `sync.providers` filter at **priority 30** (outside the room-limit wrapper at priority 20) and subscribe to the provider's `status` events, mirroring the existing `withJoinTracking` wrapper.

### Why the provider status, not the error modal
The connection-error modal is shown via a Gutenberg filter whose API has changed across versions — the original `editor.SyncConnectionErrorModal` **component** filter ([#76554](https://github.com/WordPress/gutenberg/pull/76554)) was replaced by the `editor.isSyncConnectionErrorHandled` **value** filter ([#76853](https://github.com/WordPress/gutenberg/pull/76853)), and the component variant is additionally gated behind `IS_GUTENBERG_PLUGIN` (a no-op in production builds). The provider `status` is the transport-agnostic source of truth that *drives* that modal, so hooking it works regardless of which Gutenberg the site runs.

Notes on the implementation:
* The **PingHub** transport emits a bare `{ status: 'disconnected' }` with no `error` object, so an `error` is **not** required to record. `error_code` is included only when the transport supplies one (e.g. `authentication-failed`, `protocol-mismatch`); `recordRtcEvent` drops it when absent.
* A clean teardown (navigating away, switching posts) also emits `disconnected`; a `tearingDown` guard set in the wrapper's `destroy()` keeps that from counting as an error.
* Records at most once per provider (a flapping connection emits repeated `disconnected` events), ignores collection rooms (`objectId === null`), and runs on every RTC site regardless of the limit-notices feature flag — matching the room-limit and join-tracking wrappers.
* Reuses the shared `recordRtcEvent`, so `transport`, `post_id`, `post_type`, and `wp_user_id` come from the server-injected `window.jetpackRtcNotices` config wired up in #49579 — no PHP changes needed.
* Adds unit tests for the new module (suite goes 28 → 39).

Third of the RTC Tracks PRs. PR 1 (#49559) added `jetpack_rtc_join`; PR 2 (#49579) added `jetpack_rtc_blocked`. A final PR will remove the inaccurate PingHub-only `room_peers` `pixel()` telemetry these events replace (the existing `logConnectionEvent()` connection logging stays).

## Related product discussion/links
* DOTCOM-17555

## Does this pull request change what data or activity we track or use?
Yes — this PR adds a new Tracks event. Adding the "[Status] Needs Privacy Updates" label.

The `jetpack_rtc_connection_error` event is recorded in the WordPress.com block editor when a logged-in user editing a post loses the real-time-collaboration sync connection for a genuine (non-limit) reason. The per-room contributor-limit disconnection is deliberately excluded (reported separately as `jetpack_rtc_blocked`). Properties:
- `transport` — `pinghub` or `http-polling`
- `post_id`, `post_type` — the post being edited
- `wp_user_id` — the WordPress user id of the affected user (site-local id; equals the WordPress.com id on Simple sites)
- `error_code` — the sync `ConnectionErrorCode` when the transport supplies one (e.g. `authentication-failed`, `connection-expired`, `protocol-mismatch`, `unknown-error`); omitted for a bare disconnect (e.g. PingHub); `connection-limit-exceeded` is never recorded here

`blog_id` is attached automatically by the analytics library. No new persistent storage is introduced; the event is sent to Tracks. Purpose: measure how often RTC connections fail for genuine (non-limit) reasons.

## Testing instructions

Unit tests:
* `cd projects/packages/rtc && pnpm test` — all suites should pass (39 tests).

Functional (requires a WordPress.com environment with RTC enabled; depends on wpcom Tracks + RTC infrastructure):
* Open a post in the block editor on an RTC-enabled site and confirm collaboration connects.
* Force a genuine connection failure — e.g. block the `POST /wpcom/v2/rtc/pinghub-token` request (PingHub) or the polling endpoint — so the editor surfaces the "Connection lost" modal.
* Confirm a single `jetpack_rtc_connection_error` Tracks beacon fires (filter the Network tab for `pixel.wp.com`) with `transport`, `post_id`, `post_type`, `wp_user_id`, and — when the transport provides one — an `error_code` that is **not** `connection-limit-exceeded`.
* Confirm a clean exit (navigating away / "Back to Posts" / switching posts) does **not** fire the event.
* Confirm the per-room-limit block still fires only `jetpack_rtc_blocked` and **not** `jetpack_rtc_connection_error`.
* Verify on both a PingHub (Simple) and an HTTP-polling (non-edge Atomic) site.
