### PR TITLE
Site launch: ship semi-gated flow as the default for all users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/ship-semi-gated-site-launch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/ship-semi-gated-site-launch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Site launch: ship the semi-gated launch flow as the default for all users.

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/index.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/index.ts
@@ -1,3 +1,5 @@
 export { default as useCanvasMode } from './use-canvas-mode';
 export { default as useLaunchSiteMutation } from './use-launch-site-mutation';
 export { default as useLocation } from './use-location';
+export { default as useSiteLaunchGatingVariant } from './use-site-launch-gating-variant';
+export type { SiteLaunchGatingVariant } from './use-site-launch-gating-variant';

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-site-launch-gating-variant.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-site-launch-gating-variant.ts
@@ -1,0 +1,36 @@
+/*
+ * The site launch gating variant.
+ *
+ * The ExPlat experiment `calypso_standardized_site_launch_gating_202603_v1`
+ * concluded with `semi_gated_site_launch` as the winning variant. It is now the
+ * shipped default for all users, so this hook returns it directly instead of
+ * calling ExPlat (a concluded experiment always returns the same assignment).
+ *
+ * The return value mirrors the tuple shape of `useExperimentWithAuth`,
+ * `[ isLoading, variant ]`, so call sites read like a live experiment.
+ *
+ * To wire up the next experiment:
+ *   1. Import `useExperimentWithAuth` from `@automattic/jetpack-explat`.
+ *   2. Add the new variant name(s) to the `SiteLaunchGatingVariant` type below.
+ *   3. Replace the hardcoded return with the live assignment, mapping it onto
+ *      this tuple shape:
+ *        const [ isLoading, assignment ] = useExperimentWithAuth( '<new_experiment_name>' );
+ *        return [ isLoading, ( assignment?.variationName ?? null ) as SiteLaunchGatingVariant ];
+ *   4. Add `case` branches for the new variant(s) to the `switch` statements at
+ *      each call site (search for references to this hook).
+ *
+ * This is intentionally a hook so the future swap to `useExperimentWithAuth`
+ * obeys the rules of hooks at every call site.
+ */
+
+export type SiteLaunchGatingVariant = 'semi_gated_site_launch' | null;
+
+/**
+ * Returns the shipped site launch gating variant, mirroring the
+ * `useExperimentWithAuth` return shape.
+ *
+ * @return {[ boolean, SiteLaunchGatingVariant ]} A `[ isLoading, variant ]` tuple.
+ */
+export default function useSiteLaunchGatingVariant(): [ boolean, SiteLaunchGatingVariant ] {
+	return [ false, 'semi_gated_site_launch' ];
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
@@ -1,11 +1,5 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 import { LaunchButton } from './launch-button';
-
-const queryClient = new QueryClient();
-
-const launchButtonDataAdmin =
-	typeof window === 'object' ? window.JETPACK_LAUNCH_BUTTON_DATA_ADMIN : false;
 
 /**
  * Renders the launch button.
@@ -18,22 +12,7 @@ async function renderLaunchButton() {
 	}
 
 	const root = createRoot( launchButton );
-	root.render(
-		<QueryClientProvider client={ queryClient }>
-			<LaunchButton
-				onCelebrationModalClose={ () => {
-					if ( launchButtonDataAdmin ) {
-						// If we're in wp-admin, reload the page so the new site status is reflected.
-						window.location.reload();
-						return;
-					}
-
-					root.unmount();
-					launchButton.remove();
-				} }
-			/>
-		</QueryClientProvider>
-	);
+	root.render( <LaunchButton /> );
 }
 
 document.addEventListener( 'DOMContentLoaded', renderLaunchButton, { once: true } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.js
@@ -1,9 +1,6 @@
-import { useExperimentWithAuth } from '@automattic/jetpack-explat';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
-import CelebrateLaunchModal from '../../common/celebrate-launch/celebrate-launch-modal';
-import { useLaunchSiteMutation } from '../../common/hooks';
+import { useSiteLaunchGatingVariant } from '../../common/hooks';
 import { wpcomTrackEvent } from '../../common/tracks';
 
 const icon = (
@@ -28,69 +25,33 @@ const launchButtonData = typeof window === 'object' ? window.JETPACK_LAUNCH_BUTT
 
 /**
  * The LaunchButton component.
- * @param {object}   props                         - Props
- * @param {Function} props.onCelebrationModalClose - Callback on celebration modal close.
  * @return {React.ReactNode} The LaunchButton component.
  */
-export function LaunchButton( { onCelebrationModalClose } ) {
-	const [ , data ] = useExperimentWithAuth( 'calypso_standardized_site_launch_gating_202603_v1' );
-	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( false );
+export function LaunchButton() {
+	const [ , variant ] = useSiteLaunchGatingVariant();
 
-	const {
-		mutate: launchSite,
-		isPending,
-		isSuccess,
-	} = useLaunchSiteMutation( launchButtonData.blogId, () => setShowCelebrateLaunchModal( true ) );
+	// Site launch gating: 'semi_gated_site_launch' is the shipped default. The other
+	// branches are scaffolding for future experiments; see useSiteLaunchGatingVariant.
+	switch ( variant ) {
+		case 'semi_gated_site_launch':
+		case null:
+		default: {
+			// Markup should match what's coming from the back-end.
+			const launchUrl = addQueryArgs( 'https://wordpress.com/start/launch-site', {
+				siteSlug: launchButtonData.siteDomain,
+				ref: 'wp-admin',
+			} );
 
-	// Default experience. Markup should match what's coming from the back-end.
-	if ( ! data || data.variationName !== 'ungated_site_launch' ) {
-		// Maybe this data can come from the server.
-		const launchUrl = addQueryArgs( 'https://wordpress.com/start/launch-site', {
-			siteSlug: launchButtonData.siteDomain,
-			ref: 'wp-admin',
-		} );
-
-		return (
-			<a
-				className="ab-item"
-				role="menuitem"
-				href={ launchUrl }
-				onClick={ () => wpcomTrackEvent( 'wpcom_adminbar_launch_site' ) }
-			>
-				<Content />
-			</a>
-		);
-	}
-
-	const handleLaunchClick = e => {
-		e.preventDefault();
-		if ( isPending ) return;
-		wpcomTrackEvent( 'wpcom_adminbar_launch_site' );
-		launchSite();
-	};
-
-	return (
-		<>
-			{ ! isSuccess && (
+			return (
 				<a
-					className={ `ab-item${ isPending ? ' is-busy' : '' }` }
+					className="ab-item"
 					role="menuitem"
-					href="#"
-					onClick={ handleLaunchClick }
-					aria-disabled={ isPending }
+					href={ launchUrl }
+					onClick={ () => wpcomTrackEvent( 'wpcom_adminbar_launch_site' ) }
 				>
 					<Content />
 				</a>
-			) }
-			{ showCelebrateLaunchModal && (
-				<CelebrateLaunchModal
-					{ ...launchButtonData }
-					onRequestClose={ () => {
-						setShowCelebrateLaunchModal( false );
-						onCelebrationModalClose();
-					} }
-				/>
-			) }
-		</>
-	);
+			);
+		}
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/launch-site/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/launch-site/index.tsx
@@ -1,9 +1,6 @@
-import { useExperimentWithAuth } from '@automattic/jetpack-explat';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
-import CelebrateLaunchModal from '../../../common/celebrate-launch/celebrate-launch-modal';
-import { useLaunchSiteMutation } from '../../../common/hooks';
+import { useSiteLaunchGatingVariant } from '../../../common/hooks';
 import { wpcomTrackEvent } from '../../../common/tracks';
 import SitePreviewLink from '../site-preview-link';
 import type { SitePreviewLinkObject } from '../site-preview-link';
@@ -25,7 +22,6 @@ interface Props {
 }
 
 const LaunchSite = ( {
-	blogId,
 	homeUrl,
 	siteTitle,
 	isUnlaunchedSite,
@@ -35,18 +31,8 @@ const LaunchSite = ( {
 	blogPublic,
 	wpcomComingSoon,
 	wpcomPublicComingSoon,
-	siteDomain,
-	sitePlan,
-	hasCustomDomain,
 }: Props ) => {
-	const [ , experimentData ] = useExperimentWithAuth(
-		'calypso_standardized_site_launch_gating_202603_v1'
-	);
-	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( false );
-
-	const { mutate: launchSite, isPending } = useLaunchSiteMutation( blogId, () =>
-		setShowCelebrateLaunchModal( true )
-	);
+	const [ , variant ] = useSiteLaunchGatingVariant();
 
 	// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 	const isPrivateAndUnlaunched = -1 === blogPublic && isUnlaunchedSite;
@@ -77,12 +63,14 @@ const LaunchSite = ( {
 	const handleLaunchClick = () => {
 		wpcomTrackEvent( 'wpcom_settings_reading_launch_site_button_click' );
 
-		if ( experimentData?.variationName === 'ungated_site_launch' ) {
-			launchSite();
-			return;
+		// Site launch gating: 'semi_gated_site_launch' is the shipped default. The other
+		// branches are scaffolding for future experiments; see useSiteLaunchGatingVariant.
+		switch ( variant ) {
+			case 'semi_gated_site_launch':
+			case null:
+			default:
+				window.location.href = launchUrl;
 		}
-
-		window.location.href = launchUrl;
 	};
 
 	return (
@@ -92,7 +80,6 @@ const LaunchSite = ( {
 				className="button is-secondary"
 				type="button"
 				style={ { marginTop: '0.5em' } }
-				disabled={ isPending }
 				onClick={ handleLaunchClick }
 			>
 				{ __( 'Launch site', 'jetpack-mu-wpcom' ) }
@@ -111,18 +98,6 @@ const LaunchSite = ( {
 							&nbsp;
 						</>
 					}
-				/>
-			) }
-			{ showCelebrateLaunchModal && (
-				<CelebrateLaunchModal
-					siteDomain={ siteDomain }
-					siteUrl={ homeUrl }
-					sitePlan={ sitePlan }
-					hasCustomDomain={ hasCustomDomain }
-					onRequestClose={ () => {
-						setShowCelebrateLaunchModal( false );
-						window.location.reload();
-					} }
 				/>
 			) }
 		</>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
@@ -1,17 +1,12 @@
-import { useExperimentWithAuth } from '@automattic/jetpack-explat';
 import { Launchpad } from '@automattic/launchpad';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRefEffect } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
-import CelebrateLaunchModal from '../../../common/celebrate-launch/celebrate-launch-modal';
-import { useLaunchSiteMutation } from '../../../common/hooks';
+import { useSiteLaunchGatingVariant } from '../../../common/hooks';
 
 import './style.scss';
 
 const queryClient = new QueryClient();
-
-const data = typeof window === 'object' ? window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS : {};
 
 /**
  * Set the href base of all relative links to the wordpress.com.
@@ -41,67 +36,38 @@ function useSetHrefBase() {
 }
 
 const LaunchpadWidget = ( { siteDomain, siteIntent } ) => {
-	const [ , experimentData ] = useExperimentWithAuth(
-		'calypso_standardized_site_launch_gating_202603_v1'
-	);
-	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( false );
-
-	const variationName = experimentData?.variationName;
-
-	const { mutate: launchSite } = useLaunchSiteMutation( data.blogId, () =>
-		setShowCelebrateLaunchModal( true )
-	);
+	const [ , variant ] = useSiteLaunchGatingVariant();
 
 	const onTaskClick = task => {
-		// If not a launch task or no variant (control), resort to default behavior.
-		if ( ! task.isLaunchTask || ! variationName ) {
+		if ( ! task.isLaunchTask ) {
 			return;
 		}
 
-		if ( variationName === 'ungated_site_launch' ) {
-			launchSite();
-			return false;
+		// Site launch gating: 'semi_gated_site_launch' is the shipped default. The other
+		// branches are scaffolding for future experiments; see useSiteLaunchGatingVariant.
+		switch ( variant ) {
+			case 'semi_gated_site_launch':
+			case null:
+			default:
+				window.location.assign(
+					addQueryArgs( 'https://wordpress.com/start/launch-site', {
+						siteSlug: siteDomain,
+						ref: 'wp-admin',
+					} )
+				);
+				return false;
 		}
-
-		if ( variationName === 'semi_gated_site_launch' ) {
-			window.location.assign(
-				addQueryArgs( 'https://wordpress.com/start/launch-site', {
-					siteSlug: siteDomain,
-					ref: 'wp-admin',
-				} )
-			);
-			return false;
-		}
-	};
-
-	// Control: launchpad handles the API call, redirect to celebrate on success.
-	const onSiteLaunched = () => {
-		const url = new URL( window.location.href );
-		url.searchParams.set( 'celebrate-launch', 'true' );
-		window.location.href = url.toString();
 	};
 
 	return (
-		<>
-			<div ref={ useSetHrefBase() }>
-				<Launchpad
-					siteSlug={ siteDomain }
-					checklistSlug={ siteIntent }
-					launchpadContext="wpadmin-dashboard-widget"
-					onSiteLaunched={ onSiteLaunched }
-					onTaskClick={ onTaskClick }
-				/>
-			</div>
-			{ showCelebrateLaunchModal && (
-				<CelebrateLaunchModal
-					{ ...data }
-					onRequestClose={ () => {
-						setShowCelebrateLaunchModal( false );
-						window.location.reload();
-					} }
-				/>
-			) }
-		</>
+		<div ref={ useSetHrefBase() }>
+			<Launchpad
+				siteSlug={ siteDomain }
+				checklistSlug={ siteIntent }
+				launchpadContext="wpadmin-dashboard-widget"
+				onTaskClick={ onTaskClick }
+			/>
+		</div>
 	);
 };
 


### PR DESCRIPTION
Related to: DATSCI-1475

## Proposed changes

The ExPlat experiment `calypso_standardized_site_launch_gating_202603_v1` (id 22525) has concluded, with **`semi_gated_site_launch`** as the winning variant. This PR ships that variant as the default for all users and removes the live experiment lookups, while leaving a clearly documented seam for the next experiment.

* Adds a shared `useSiteLaunchGatingVariant` hook (`src/common/hooks/use-site-launch-gating-variant.ts`) that returns the shipped variant hardcoded, mirroring the `[ isLoading, variant ]` tuple shape of `useExperimentWithAuth` so call sites read like a live experiment. The doc comment records the concluded experiment, the winner, and step-by-step instructions for wiring up the next experiment.
* Replaces the `useExperimentWithAuth( 'calypso_standardized_site_launch_gating_202603_v1' )` calls at the three launch entry points with the shared hook:
  * Admin-bar launch button (`features/launch-button`)
  * Reading Settings launch button (`features/replace-site-visibility/launch-site`)
  * Dashboard Launchpad widget (`features/wpcom-dashboard-widgets/wpcom-launchpad-widget`)
* Each call site uses a `switch` on the variant where the winner, `null`, and `default` all fall through to the shipped (semi-gated) behavior, leaving scaffolding so the next experiment can add branches by swapping only the hook body.
* Removes the now-dead `ungated_site_launch` inline-launch branches and their unused state/imports (inline `useLaunchSiteMutation` usage, the inline `CelebrateLaunchModal`, `onSiteLaunched`). `useLaunchSiteMutation` itself is kept for future reuse, and the separate post-redirect `?celebrate-launch` celebration flow is untouched.

Type type `SiteLaunchGatingVariant` is intentionally limited to the winning variant and `null` (control), per the shipping plan.

## Related product discussion/links

* ExPlat experiment: `calypso_standardized_site_launch_gating_202603_v1` (id 22525, status: completed)

## Does this pull request change what data or activity we track or use?

No new tracking. The existing `wpcomTrackEvent` calls (`wpcom_adminbar_launch_site`, `wpcom_settings_reading_launch_site_button_click`, Launchpad task clicks) are unchanged. The PR does stop recording ExPlat assignments/exposures for this experiment, which is expected since the experiment has concluded.

## Testing instructions

On a WordPress.com / WoA site running this branch of `jetpack-mu-wpcom`, with an **unlaunched** site:

* **Admin-bar button:** open any wp-admin screen and click the "Launch site" item in the admin bar. It should link to `https://wordpress.com/start/launch-site?siteSlug=...&ref=wp-admin` (the semi-gated flow), not launch inline.
* **Reading Settings:** go to Settings → Reading and click "Launch site". It should redirect to the same `wordpress.com/start/launch-site` flow.
* **Dashboard Launchpad widget:** on the wp-admin dashboard, click the site-launch task in the Launchpad widget. It should redirect to `wordpress.com/start/launch-site`.
* Complete the launch in the Calypso flow and confirm the existing post-launch `?celebrate-launch` celebration still appears on return.
* Confirm no console errors and that no ExPlat request is made for `calypso_standardized_site_launch_gating_202603_v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)