### PR TITLE
VideoPress: Prevent PHP warnings from incomplete video metadata

### DIFF
--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -42,7 +42,7 @@ return [
         'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/tus/class-tus-client.php' => ['PhanNonClassMethodCall', 'PhanTypeMismatchArgument'],
         'src/tus/class-tus-file.php' => ['PhanTypeArraySuspiciousNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeThrowsType'],
-        'src/utility-functions.php' => ['PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/utility-functions.php' => ['PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable'],
         'src/videopress-divi/class-videopress-divi-extension.php' => ['PhanCommentOverrideOnNonOverrideMethod', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
         'src/videopress-divi/class-videopress-divi-module.php' => ['PhanUndeclaredExtendedClass'],
         'tests/php/VideoPress_Uploader_Test.php' => ['PhanTypeMismatchArgument'],

--- a/projects/packages/videopress/changelog/fix-videopress-php-warnings
+++ b/projects/packages/videopress/changelog/fix-videopress-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warnings when building the VideoPress dashboard state and resolving video metadata for videos with incomplete data

--- a/projects/packages/videopress/changelog/fix-videopress-php-warnings
+++ b/projects/packages/videopress/changelog/fix-videopress-php-warnings
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Prevent PHP warnings when building the VideoPress dashboard state and resolving video metadata for videos with incomplete data
+Prevent PHP warnings when building the VideoPress dashboard state and resolving video metadata for videos with incomplete data.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -290,7 +290,7 @@ class Attachment_Handler {
 		}
 
 		// Only apply this filter to VideoPress attachments
-		if ( ! is_videopress_attachment( $args[2] ) ) {
+		if ( ! isset( $args[2] ) || ! is_videopress_attachment( $args[2] ) ) {
 			return $allcaps;
 		}
 

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -285,7 +285,7 @@ class Attachment_Handler {
 	public static function disable_delete_if_disconnected( $allcaps, $cap, $args ) {
 
 		// Only apply this filter to `delete_post` checks
-		if ( 'delete_post' !== $args[0] ) {
+		if ( ! isset( $args[0] ) || 'delete_post' !== $args[0] ) {
 			return $allcaps;
 		}
 

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -408,8 +408,8 @@ class Data {
 		$files         = $videopress_media_details['files'] ?? null;
 		$filename      = $original !== null ? basename( $original ) : null;
 
-		if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 1 ) {
-			$thumbnail = ( $file_url_base['https'] ?? '' ) . $files['dvd']['original_img'];
+		if ( isset( $files['dvd']['original_img'] ) && isset( $file_url_base['https'] ) && $privacy_setting !== 1 ) {
+			$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
 		} else {
 			$thumbnail = null;
 		}

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -315,68 +315,7 @@ class Data {
 
 		// Tweak VideoPress videos data.
 		$videos = array_map(
-			function ( $video ) {
-				$video              = (array) $video;
-				$id                 = $video['id'];
-				$guid               = $video['jetpack_videopress_guid'];
-				$media_details      = (array) $video['media_details'];
-				$jetpack_videopress = (array) $video['jetpack_videopress'];
-
-				$videopress_media_details = $media_details['videopress'];
-				$width                    = $media_details['width'];
-				$height                   = $media_details['height'];
-
-				$title                = $jetpack_videopress['title'];
-				$description          = $jetpack_videopress['description'];
-				$caption              = $jetpack_videopress['caption'];
-				$rating               = $jetpack_videopress['rating'];
-				$allow_download       = $jetpack_videopress['allow_download'];
-				$display_embed        = $jetpack_videopress['display_embed'];
-				$privacy_setting      = $jetpack_videopress['privacy_setting'];
-				$needs_playback_token = $jetpack_videopress['needs_playback_token'];
-				$is_private           = $jetpack_videopress['is_private'];
-
-				$original      = $videopress_media_details['original'];
-				$poster        = ( ! $needs_playback_token ) ? $videopress_media_details['poster'] : null;
-				$upload_date   = $videopress_media_details['upload_date'];
-				$duration      = $videopress_media_details['duration'];
-				$file_url_base = $videopress_media_details['file_url_base'];
-				$finished      = $videopress_media_details['finished'];
-				$files         = $videopress_media_details['files'];
-				$filename      = basename( $original );
-
-				if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 1 ) {
-					$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
-				} else {
-					$thumbnail = null;
-				}
-
-				return array(
-					'id'                 => $id,
-					'guid'               => $guid,
-					'title'              => $title,
-					'description'        => $description,
-					'caption'            => $caption,
-					'url'                => $original,
-					'uploadDate'         => $upload_date,
-					'duration'           => $duration,
-					'isPrivate'          => $is_private,
-					'posterImage'        => $poster,
-					'allowDownload'      => $allow_download,
-					'displayEmbed'       => $display_embed,
-					'rating'             => $rating,
-					'privacySetting'     => $privacy_setting,
-					'needsPlaybackToken' => $needs_playback_token,
-					'width'              => $width,
-					'height'             => $height,
-					'poster'             => array(
-						'src' => $poster,
-					),
-					'thumbnail'          => $thumbnail,
-					'finished'           => $finished,
-					'filename'           => $filename,
-				);
-			},
+			array( __CLASS__, 'prepare_videopress_video_data' ),
 			$videopress_data['videos']
 		);
 
@@ -425,5 +364,80 @@ class Data {
 		}
 
 		return $initial_state;
+	}
+
+	/**
+	 * Maps a single VideoPress video, as returned by the media REST endpoint, to
+	 * the shape consumed by the VideoPress dashboard app.
+	 *
+	 * Videos that are still processing (or otherwise have partial metadata) come
+	 * back without `videopress`, `width` or `height` in their media_details, so
+	 * every nested access is coalesced to avoid undefined-key and offset-on-null
+	 * warnings.
+	 *
+	 * @param array|object $video A single video entry from the media REST endpoint.
+	 * @return array The video data formatted for the dashboard app.
+	 */
+	private static function prepare_videopress_video_data( $video ) {
+		$video              = (array) $video;
+		$id                 = $video['id'];
+		$guid               = $video['jetpack_videopress_guid'];
+		$media_details      = (array) $video['media_details'];
+		$jetpack_videopress = (array) $video['jetpack_videopress'];
+
+		$videopress_media_details = $media_details['videopress'] ?? array();
+		$width                    = $media_details['width'] ?? null;
+		$height                   = $media_details['height'] ?? null;
+
+		$title                = $jetpack_videopress['title'];
+		$description          = $jetpack_videopress['description'];
+		$caption              = $jetpack_videopress['caption'];
+		$rating               = $jetpack_videopress['rating'];
+		$allow_download       = $jetpack_videopress['allow_download'];
+		$display_embed        = $jetpack_videopress['display_embed'];
+		$privacy_setting      = $jetpack_videopress['privacy_setting'];
+		$needs_playback_token = $jetpack_videopress['needs_playback_token'];
+		$is_private           = $jetpack_videopress['is_private'];
+
+		$original      = $videopress_media_details['original'] ?? null;
+		$poster        = ( ! $needs_playback_token ) ? ( $videopress_media_details['poster'] ?? null ) : null;
+		$upload_date   = $videopress_media_details['upload_date'] ?? null;
+		$duration      = $videopress_media_details['duration'] ?? null;
+		$file_url_base = $videopress_media_details['file_url_base'] ?? null;
+		$finished      = $videopress_media_details['finished'] ?? null;
+		$files         = $videopress_media_details['files'] ?? null;
+		$filename      = $original !== null ? basename( $original ) : null;
+
+		if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 1 ) {
+			$thumbnail = ( $file_url_base['https'] ?? '' ) . $files['dvd']['original_img'];
+		} else {
+			$thumbnail = null;
+		}
+
+		return array(
+			'id'                 => $id,
+			'guid'               => $guid,
+			'title'              => $title,
+			'description'        => $description,
+			'caption'            => $caption,
+			'url'                => $original,
+			'uploadDate'         => $upload_date,
+			'duration'           => $duration,
+			'isPrivate'          => $is_private,
+			'posterImage'        => $poster,
+			'allowDownload'      => $allow_download,
+			'displayEmbed'       => $display_embed,
+			'rating'             => $rating,
+			'privacySetting'     => $privacy_setting,
+			'needsPlaybackToken' => $needs_playback_token,
+			'width'              => $width,
+			'height'             => $height,
+			'poster'             => array(
+				'src' => $poster,
+			),
+			'thumbnail'          => $thumbnail,
+			'finished'           => $finished,
+			'filename'           => $filename,
+		);
 	}
 }

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -607,7 +607,7 @@ function video_format_done( $info, $format ) {
  *
  * @param string $guid VideoPress GUID.
  * @param string $format Video format.
- * @return string
+ * @return string|null The poster image URL, or null if it cannot be resolved.
  */
 function video_image_url_by_guid( $guid, $format ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -377,6 +377,11 @@ function videopress_update_meta_data( $post_id ) {
 
 	$info = (object) $meta['videopress'];
 
+	// Without a guid there is no video to query for.
+	if ( ! isset( $info->guid ) ) {
+		return false;
+	}
+
 	$result = Client::wpcom_json_api_request_as_blog( 'videos/' . $info->guid );
 
 	if ( is_wp_error( $result ) ) {
@@ -608,11 +613,15 @@ function video_image_url_by_guid( $guid, $format ) { // phpcs:ignore VariableAna
 
 	$post = videopress_get_post_by_guid( $guid );
 
-	if ( is_wp_error( $post ) ) {
+	if ( is_wp_error( $post ) || ! $post ) {
 		return null;
 	}
 
 	$meta = wp_get_attachment_metadata( $post->ID );
+
+	if ( ! is_array( $meta ) || ! isset( $meta['videopress']['poster'] ) ) {
+		return null;
+	}
 
 	$poster = apply_filters( 'jetpack_photon_url', $meta['videopress']['poster'] );
 

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -219,4 +219,21 @@ class Attachment_Handler_Test extends BaseTestCase {
 
 		$this->assertSame( $allcaps, $result );
 	}
+
+	/**
+	 * Test that disable_delete_if_disconnected handles a delete_post check made
+	 * without an object ID.
+	 *
+	 * `current_user_can( 'delete_post' )` can be called without a post ID, so
+	 * $args[2] (the object ID) may be unset. Reading it unconditionally would
+	 * raise an "Undefined array key 2" warning. The capabilities should be
+	 * returned unchanged.
+	 */
+	public function test_disable_delete_if_disconnected_ignores_missing_object_id() {
+		$allcaps = array( 'delete_posts' => true );
+
+		$result = Attachment_Handler::disable_delete_if_disconnected( $allcaps, array( 'delete_post' ), array( 'delete_post' ) );
+
+		$this->assertSame( $allcaps, $result );
+	}
 }

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -203,4 +203,20 @@ class Attachment_Handler_Test extends BaseTestCase {
 
 		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
 	}
+
+	/**
+	 * Test that disable_delete_if_disconnected handles an empty $args array.
+	 *
+	 * The `user_has_cap` filter can invoke the callback with an empty $args
+	 * array (e.g. for capability checks made without an object). Reading
+	 * $args[0] unconditionally previously raised an "Undefined array key 0"
+	 * warning. The capabilities should be returned unchanged.
+	 */
+	public function test_disable_delete_if_disconnected_ignores_empty_args() {
+		$allcaps = array( 'delete_posts' => true );
+
+		$result = Attachment_Handler::disable_delete_if_disconnected( $allcaps, array( 'delete_posts' ), array() );
+
+		$this->assertSame( $allcaps, $result );
+	}
 }

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -165,4 +165,96 @@ class Data_Test extends BaseTestCase {
 		$this->assertEquals( 'video/videopress', $captured_params['mime_type'], 'mime_type should be video/videopress' );
 		$this->assertArrayNotHasKey( 'media_type', $captured_params, 'Request should NOT include media_type parameter (this causes the bug)' );
 	}
+
+	/**
+	 * Invokes the private Data::prepare_videopress_video_data() method.
+	 *
+	 * @param array|object $video A single video entry from the media REST endpoint.
+	 * @return array The formatted video data.
+	 */
+	private function prepare_videopress_video_data( $video ) {
+		$method = new \ReflectionMethod( Data::class, 'prepare_videopress_video_data' );
+
+		return $method->invoke( null, $video );
+	}
+
+	/**
+	 * Returns a video entry as the media REST endpoint shapes it, with the
+	 * jetpack_videopress field fully populated.
+	 *
+	 * @param array $media_details The media_details value to use.
+	 * @return array
+	 */
+	private function videopress_rest_video( $media_details ) {
+		return array(
+			'id'                      => 123,
+			'jetpack_videopress_guid' => 'abcd1234',
+			'media_details'           => $media_details,
+			'jetpack_videopress'      => array(
+				'title'                => 'Test video',
+				'description'          => '',
+				'caption'              => '',
+				'rating'               => 'G',
+				'allow_download'       => 0,
+				'display_embed'        => 0,
+				'privacy_setting'      => 2,
+				'needs_playback_token' => false,
+				'is_private'           => false,
+			),
+		);
+	}
+
+	/**
+	 * Test that prepare_videopress_video_data does not emit warnings when the
+	 * media_details is missing the `videopress`, `width` and `height` keys.
+	 *
+	 * Videos that are still processing (or otherwise have partial metadata) come
+	 * back from the media REST endpoint without those keys. The data-shaping map
+	 * previously accessed them directly, raising "Undefined array key" and
+	 * "Trying to access array offset on null" warnings for every such video.
+	 */
+	public function test_prepare_videopress_video_data_handles_missing_media_details() {
+		// media_details intentionally lacks `videopress`, `width` and `height`.
+		$result = $this->prepare_videopress_video_data( $this->videopress_rest_video( array( 'length' => 5 ) ) );
+
+		$this->assertSame( 123, $result['id'] );
+		$this->assertNull( $result['url'] );
+		$this->assertNull( $result['posterImage'] );
+		$this->assertNull( $result['width'] );
+		$this->assertNull( $result['height'] );
+		$this->assertNull( $result['thumbnail'] );
+		$this->assertNull( $result['filename'] );
+		$this->assertSame( array( 'src' => null ), $result['poster'] );
+	}
+
+	/**
+	 * Test that prepare_videopress_video_data maps a fully-populated video.
+	 */
+	public function test_prepare_videopress_video_data_maps_complete_media_details() {
+		$video = $this->videopress_rest_video(
+			array(
+				'width'      => 1920,
+				'height'     => 1080,
+				'videopress' => array(
+					'original'      => 'https://videos.example.com/original.mp4',
+					'poster'        => 'https://videos.example.com/poster.jpg',
+					'upload_date'   => '2026-01-01',
+					'duration'      => 12345,
+					'file_url_base' => array( 'https' => 'https://videos.example.com/' ),
+					'finished'      => true,
+					'files'         => array( 'dvd' => array( 'original_img' => 'thumb.jpg' ) ),
+				),
+			)
+		);
+		$video['jetpack_videopress']['privacy_setting'] = 0;
+
+		$result = $this->prepare_videopress_video_data( $video );
+
+		$this->assertSame( 'https://videos.example.com/original.mp4', $result['url'] );
+		$this->assertSame( 'https://videos.example.com/poster.jpg', $result['posterImage'] );
+		$this->assertSame( 1920, $result['width'] );
+		$this->assertSame( 1080, $result['height'] );
+		$this->assertSame( 'original.mp4', $result['filename'] );
+		$this->assertSame( 'https://videos.example.com/thumb.jpg', $result['thumbnail'] );
+	}
 }

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -175,6 +175,12 @@ class Data_Test extends BaseTestCase {
 	private function prepare_videopress_video_data( $video ) {
 		$method = new \ReflectionMethod( Data::class, 'prepare_videopress_video_data' );
 
+		// setAccessible() is required to invoke private methods on PHP < 8.1, but
+		// is a no-op (and deprecated as of 8.5) on newer versions.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
 		return $method->invoke( null, $video );
 	}
 

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -263,4 +263,24 @@ class Data_Test extends BaseTestCase {
 		$this->assertSame( 'original.mp4', $result['filename'] );
 		$this->assertSame( 'https://videos.example.com/thumb.jpg', $result['thumbnail'] );
 	}
+
+	/**
+	 * Test that the thumbnail is null when the DVD image is present but its base
+	 * URL is missing, rather than a bare, relative filename.
+	 */
+	public function test_prepare_videopress_video_data_thumbnail_null_without_base_url() {
+		$video = $this->videopress_rest_video(
+			array(
+				'videopress' => array(
+					// original_img is present, but file_url_base is missing.
+					'files' => array( 'dvd' => array( 'original_img' => 'thumb.jpg' ) ),
+				),
+			)
+		);
+		$video['jetpack_videopress']['privacy_setting'] = 0;
+
+		$result = $this->prepare_videopress_video_data( $video );
+
+		$this->assertNull( $result['thumbnail'] );
+	}
 }

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -183,6 +183,47 @@ class Utility_Functions_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that video_image_url_by_guid returns null without warnings when the
+	 * attachment is found but has no usable poster metadata.
+	 *
+	 * When wp_get_attachment_metadata() returns false (no metadata stored), or
+	 * the metadata lacks videopress['poster'], reading
+	 * $meta['videopress']['poster'] previously raised "Trying to access array
+	 * offset on false" / "Undefined array key" warnings.
+	 */
+	public function test_video_image_url_by_guid_returns_null_for_missing_poster_metadata() {
+		// Attachment with a guid but no stored metadata: wp_get_attachment_metadata() returns false.
+		$no_meta_guid = 'guid-without-metadata';
+		$no_meta_id   = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_status'    => 'inherit',
+				'post_title'     => 'VideoPress video without metadata',
+			)
+		);
+		// Prime the guid->ID lookup cache directly, since the meta_query lookup is not supported by the test DB.
+		set_transient( 'videopress_get_post_id_by_guid_' . $no_meta_guid, $no_meta_id, HOUR_IN_SECONDS );
+
+		$this->assertNull( video_image_url_by_guid( $no_meta_guid, 'jpg' ) );
+
+		// Attachment whose metadata exists but lacks a videopress poster.
+		$partial_guid = 'guid-with-partial-metadata';
+		$partial_id   = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_status'    => 'inherit',
+				'post_title'     => 'VideoPress video with partial metadata',
+			)
+		);
+		wp_update_attachment_metadata( $partial_id, array( 'videopress' => array( 'finished' => false ) ) );
+		set_transient( 'videopress_get_post_id_by_guid_' . $partial_guid, $partial_id, HOUR_IN_SECONDS );
+
+		$this->assertNull( video_image_url_by_guid( $partial_guid, 'jpg' ) );
+	}
+
+	/**
 	 * Test that videopress_update_meta_data returns false without warnings when
 	 * the stored videopress metadata has no guid.
 	 *

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -168,4 +168,46 @@ class Utility_Functions_Test extends BaseTestCase {
 
 		$this->assertSame( $finish_time, videopress_is_finished_processing( $post_id ) );
 	}
+
+	/**
+	 * Test that video_image_url_by_guid returns null without warnings when no
+	 * post matches the guid.
+	 *
+	 * The videopress_get_post_by_guid() helper returns false (not a WP_Error)
+	 * when no post is found. The function previously only guarded against
+	 * WP_Error and then dereferenced false ($post->ID), raising "Attempt to read
+	 * property on false" and "array offset on false" warnings.
+	 */
+	public function test_video_image_url_by_guid_returns_null_for_unknown_guid() {
+		$this->assertNull( video_image_url_by_guid( 'nonexistent-guid', 'jpg' ) );
+	}
+
+	/**
+	 * Test that videopress_update_meta_data returns false without warnings when
+	 * the stored videopress metadata has no guid.
+	 *
+	 * Attachment metadata can contain a `videopress` key without a `guid` (e.g.
+	 * a video still being processed). Building the request URL from $info->guid
+	 * previously raised an "Undefined property: stdClass::$guid" warning.
+	 */
+	public function test_videopress_update_meta_data_without_guid_returns_false() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Processing video',
+			)
+		);
+
+		wp_update_attachment_metadata(
+			$post_id,
+			array(
+				'videopress' => array(
+					'finished' => false,
+				),
+			)
+		);
+
+		$this->assertFalse( videopress_update_meta_data( $post_id ) );
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes

Production `at-php-errors` logs surfaced a cluster of PHP warnings from the VideoPress package (the bulk of all jetpack-videopress errors), all rooted in code that assumed video metadata is always fully populated. This fixes the root causes:

* **`Data::get_initial_state()` (highest volume)** — the VideoPress videos map read `media_details['videopress'|'width'|'height']` directly and then dereferenced the (possibly `null`) `videopress` sub-array. Videos still processing — or with partial metadata — lack those keys, producing `Undefined array key "videopress"/"width"/"height"` and `Trying to access array offset on null` warnings (lines 325–345). The sibling local-videos map already coalesced these; this mirrors that defensiveness. The map closure is extracted into a private `Data::prepare_videopress_video_data()` method so the transform can be unit-tested directly.
* **`videopress_update_meta_data()`** — built a request URL from `$info->guid` without checking the stored `videopress` metadata actually contains a `guid` (`Undefined property: stdClass::$guid`).
* **`video_image_url_by_guid()`** — only guarded `is_wp_error()`, but `videopress_get_post_by_guid()` returns `false` (not a `WP_Error`) and `wp_get_attachment_metadata()` can return `false` too, causing `Attempt to read property "ID" on false` and `Trying to access array offset on false`.
* **`Attachment_Handler::disable_delete_if_disconnected()`** — read `$args[0]` unconditionally; the `user_has_cap` filter can invoke the callback with an empty `$args` array (`Undefined array key 0`).

Adds regression tests for each case. The package's PHPUnit config sets `failOnWarning="true"`, so these tests fail if any of the warnings return.

## Related product discussion/links

* Source: `at-php-errors-*` logstash/Grafana, filtered to `file:*jetpack-videopress*`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/videopress && composer phpunit` — all tests pass (119 tests).
* To see a regression test catch the bug: temporarily revert one of the guards (e.g. change `$media_details['videopress'] ?? array()` back to `$media_details['videopress']` in `Data::prepare_videopress_video_data()`) and re-run; `failOnWarning` makes the relevant test fail.
* Functionally: with a VideoPress library containing a video that is still processing (incomplete `media_details`), load the VideoPress admin dashboard. Previously this emitted PHP warnings to the error log on every load; the page should now render with no warnings and the processing video appears with empty/`null` url, poster, width and height instead of a fatal/warning.
