### PR TITLE
Memberships: add allow="payment *" to checkout iframe for wallet support

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-memberships-iframe-allow-payment
+++ b/projects/plugins/jetpack/changelog/fix-memberships-iframe-allow-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Memberships: delegate the Payment Request API to the checkout iframe so Apple Pay, Google Pay, and Stripe Link can load and complete payments.

--- a/projects/plugins/jetpack/extensions/shared/memberships.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships.js
@@ -50,6 +50,12 @@ export function showModal( url ) {
 		iframe.setAttribute( 'frameborder', '0' );
 		iframe.setAttribute( 'allowtransparency', 'true' );
 		iframe.setAttribute( 'allowfullscreen', 'true' );
+		// Delegate the Payment Request API (Apple Pay / Google Pay / Link) to the
+		// cross-origin checkout iframe. Use `payment *` rather than bare `payment`
+		// because the wallet call originates from Stripe's nested js.stripe.com frame
+		// inside our subscribe.wordpress.com frame, so the feature must be delegated
+		// to all nested origins, not just 'src'.
+		iframe.setAttribute( 'allow', 'payment *' );
 
 		iframe.addEventListener( 'load', function () {
 			// prevent double scroll bars. We use the entire viewport for the modal so we need to hide overflow on the body element.


### PR DESCRIPTION
Fixes SHILL-2145

## Proposed changes
* Adds `allow="payment *"` to the shared Memberships/Monetize checkout `<iframe>` so the browser Payment Request API (Apple Pay / Google Pay) and Stripe Link can load and complete payments inside the cross-origin checkout modal.

The Payment Request API is denied to cross-origin iframes by default and must be delegated via the `allow` Permissions-Policy attribute. The modal iframe previously set only `frameborder`, `allowtransparency`, and `allowfullscreen`, so Stripe's nested wallet frame could not run — clicking Google Pay threw an `Unsafe attempt to initiate navigation … sandboxed` / Payment Request denial error.

`payment *` (not bare `payment`) is required because the wallet call originates from Stripe's nested `js.stripe.com` frame inside our `subscribe.wordpress.com` frame, so the feature must be delegated to all nested origins, not just `'src'`.

The fix is applied once in the shared `showModal` helper (`extensions/shared/memberships.js`), which is the single iframe creator used by all four callers: **recurring-payments**, **subscriptions**, **premium-content**, and **donations**.

Pairs with wpcom PR Automattic/wpcom#223244 (migrates this checkout to the Stripe Payment Element + deferred confirmation).

## Related product discussion/links
* Linear: [SHILL-2145 — Investigation about GPay/Apple Pay in Monetize checkout](https://linear.app/a8c/issue/SHILL-2145/investigation-about-gpayapple-pay-in-monetize-checkout)
* Pairs with Automattic/wpcom#223244

## Does this pull request change what data or activity we track or use?
No. This only adds a Permissions-Policy delegation attribute to an existing iframe.

## Testing instructions
* Build the block: `pnpm jetpack build plugins/jetpack` (or the standard block build).
* Load a post with a paid Payments / Subscribe / Premium Content button and open the checkout modal.
* Confirm Apple Pay (Safari) and Google Pay (Chrome) now render and can complete a test payment.
  * Note: Apple Pay additionally requires the seller domain to be registered with Stripe (operational, handled separately).
* Verify normal card payment still works and the modal layout is unchanged.

## Out of scope
* Redirect-based APMs (Cash App Pay, iDEAL, etc.) require top-navigation that the embed restricts — not enabled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

