### PR TITLE
Charts: keep HTML tooltip within the viewport

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-tooltip-viewport-clamp
+++ b/projects/js-packages/charts/changelog/fix-charts-tooltip-viewport-clamp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tooltip: keep the HTML tooltip inside the viewport so it is no longer clipped at the screen edge when the content width varies between data points.

--- a/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, TooltipContext } from '@visx/xychart';
 import { useContext, useEffect, useCallback, useMemo } from 'react';
+import { useViewportClamp } from './use-viewport-clamp';
 import type { SeriesData, DataPointDate } from '../../types';
 import type {
 	TooltipProps as BaseTooltipProps,
@@ -38,6 +39,25 @@ interface AccessibleTooltipProps
 	 */
 	mode?: 'individual' | 'group';
 }
+
+// Wraps tooltip content in the `role="tooltip"` element while keeping it inside
+// the viewport (see `useViewportClamp`). Used for both the live (pointer)
+// tooltip and the keyboard-focused tooltip so the edge handling is consistent.
+const TooltipContentWrapper = ( {
+	children,
+	tooltipRef,
+	...divProps
+}: {
+	children: ReactNode;
+	tooltipRef?: ( element: HTMLDivElement | null ) => void;
+} & React.HTMLAttributes< HTMLDivElement > ) => {
+	const { ref, style } = useViewportClamp< HTMLDivElement >( tooltipRef );
+	return (
+		<div ref={ ref } role="tooltip" style={ style } { ...divProps }>
+			{ children }
+		</div>
+	);
+};
 
 export const AccessibleTooltip: React.FC< AccessibleTooltipProps > = ( {
 	renderTooltip,
@@ -126,25 +146,20 @@ export const AccessibleTooltip: React.FC< AccessibleTooltipProps > = ( {
 
 			if ( selectedIndex !== undefined ) {
 				return (
-					<div
-						ref={ tooltipRef }
+					<TooltipContentWrapper
+						tooltipRef={ tooltipRef }
 						tabIndex={ -1 }
-						role="tooltip"
 						aria-atomic="true"
 						className={ keyboardFocusedClassName }
 						data-testid={ `chart-tooltip-${ selectedIndex }` }
 						key={ `chart-tooltip-${ selectedIndex }` }
 					>
 						{ tooltipContent }
-					</div>
+					</TooltipContentWrapper>
 				);
 			}
 
-			return (
-				<div role="tooltip" aria-live="polite">
-					{ tooltipContent }
-				</div>
-			);
+			return <TooltipContentWrapper aria-live="polite">{ tooltipContent }</TooltipContentWrapper>;
 		};
 	}, [ renderTooltip, selectedIndex, tooltipRef, keyboardFocusedClassName ] );
 

--- a/projects/js-packages/charts/src/components/tooltip/test/use-viewport-clamp.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/use-viewport-clamp.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { useViewportClamp } from '../use-viewport-clamp';
+
+/**
+ * Minimal consumer of the hook used to assert the applied style.
+ *
+ * @return A div wired to the hook's ref and style.
+ */
+function Harness() {
+	const { ref, style } = useViewportClamp< HTMLDivElement >();
+	return (
+		<div data-testid="tip" ref={ ref } style={ style }>
+			content
+		</div>
+	);
+}
+
+/**
+ * Forces `getBoundingClientRect` to report a fixed rect so JSDOM (which has no
+ * layout) can exercise the clamping math.
+ *
+ * @param rect - Partial rect overriding the zeroed JSDOM default.
+ * @return The jest spy, so the caller can restore it.
+ */
+function mockRect( rect: Partial< DOMRect > ) {
+	return jest.spyOn( Element.prototype, 'getBoundingClientRect' ).mockReturnValue( {
+		width: 0,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ( {} ),
+		...rect,
+	} as DOMRect );
+}
+
+describe( 'useViewportClamp', () => {
+	const originalInnerWidth = window.innerWidth;
+	let rectSpy: jest.SpyInstance | undefined;
+
+	const setInnerWidth = ( width: number ) =>
+		Object.defineProperty( window, 'innerWidth', {
+			configurable: true,
+			value: width,
+		} );
+
+	afterEach( () => {
+		rectSpy?.mockRestore();
+		rectSpy = undefined;
+		setInnerWidth( originalInnerWidth );
+	} );
+
+	test( 'applies no transform when the tooltip fits within the viewport', () => {
+		setInnerWidth( 500 );
+		rectSpy = mockRect( { left: 50, width: 200, right: 250 } );
+
+		render( <Harness /> );
+
+		expect( screen.getByTestId( 'tip' ) ).not.toHaveAttribute( 'style' );
+	} );
+
+	test( 'shifts left when the tooltip overflows the right viewport edge', () => {
+		setInnerWidth( 500 );
+		// Right edge at 600, viewport edge (with 16px padding) at 484 → overflow 116.
+		rectSpy = mockRect( { left: 400, width: 200, right: 600 } );
+
+		render( <Harness /> );
+
+		expect( screen.getByTestId( 'tip' ) ).toHaveStyle( { transform: 'translateX(-116px)' } );
+	} );
+
+	test( 'never pulls the left edge past the opposite padding for an over-wide tooltip', () => {
+		setInnerWidth( 300 );
+		// Tooltip wider than the available space; left edge should land on the padding (16px).
+		rectSpy = mockRect( { left: 120, width: 400, right: 520 } );
+
+		render( <Harness /> );
+
+		// naturalLeft 120 → shift to 16px padding = -(120 - 16) = -104.
+		expect( screen.getByTestId( 'tip' ) ).toHaveStyle( { transform: 'translateX(-104px)' } );
+	} );
+} );

--- a/projects/js-packages/charts/src/components/tooltip/use-viewport-clamp.ts
+++ b/projects/js-packages/charts/src/components/tooltip/use-viewport-clamp.ts
@@ -1,0 +1,119 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+
+/**
+ * Gap kept between the tooltip and the viewport edge, in pixels.
+ */
+const VIEWPORT_EDGE_PADDING = 16;
+
+type ClampResult< T > = {
+	/** Callback ref to attach to the tooltip element. */
+	ref: ( element: T | null ) => void;
+	/** Style to spread onto the tooltip element (a corrective transform, or undefined). */
+	style: CSSProperties | undefined;
+};
+
+/**
+ * Keeps an HTML tooltip inside the horizontal bounds of the viewport.
+ *
+ * visx positions the tooltip with an inline `transform` on its `.visx-tooltip`
+ * portal node and, with `detectBounds` enabled, tries to flip it so it does not
+ * overflow. That flip is powered by `@visx/tooltip`'s `withBoundingRects`, which
+ * measures the tooltip's width only once — on mount — and never again. When the
+ * content width changes between data points during a single continuous hover
+ * (longer labels, different value widths, late font loads), the flip decision is
+ * made against a stale width, so a wide tooltip near the right edge gets clipped.
+ *
+ * This hook compensates at the layer that owns tooltip rendering: it measures the
+ * element after each content change / resize and applies a corrective horizontal
+ * shift so the box stays within the viewport. It reads the element's own rect —
+ * which already reflects visx's transform — so it needs no knowledge of the chart
+ * container, the portal, or the hovered datum's anchor position.
+ *
+ * @param externalRef - Optional ref the caller also needs on the element (e.g. for focus management).
+ * @return A `ref` to attach and a `style` to spread onto the tooltip element.
+ */
+export function useViewportClamp< T extends HTMLElement = HTMLDivElement >(
+	externalRef?: ( element: T | null ) => void
+): ClampResult< T > {
+	const nodeRef = useRef< T | null >( null );
+	// Mirrors `shiftPx` so the measurement callback can read the currently
+	// applied shift synchronously without re-subscribing observers on change.
+	const shiftRef = useRef( 0 );
+	const [ shiftPx, setShiftPx ] = useState( 0 );
+
+	const ref = useCallback(
+		( element: T | null ) => {
+			nodeRef.current = element;
+			externalRef?.( element );
+		},
+		[ externalRef ]
+	);
+
+	useLayoutEffect( () => {
+		const node = nodeRef.current;
+		if ( ! node || typeof window === 'undefined' ) {
+			return;
+		}
+
+		const update = () => {
+			const rect = node.getBoundingClientRect();
+			// Nothing rendered yet (hidden, not measured) — leave the shift be.
+			if ( rect.width === 0 ) {
+				return;
+			}
+
+			// Strip our own shift to recover visx's natural placement. `translateX`
+			// does not affect width, so the measured width can be used as-is.
+			const naturalLeft = rect.left - shiftRef.current;
+			const maxRight = window.innerWidth - VIEWPORT_EDGE_PADDING;
+
+			let nextShift = 0;
+			const rightOverflow = naturalLeft + rect.width - maxRight;
+			if ( rightOverflow > 0 ) {
+				nextShift = -rightOverflow;
+			}
+			// Don't pull the left edge past the padding on the opposite side. When
+			// the tooltip is wider than the available space an unavoidable right
+			// overflow is preferable to hiding the left edge.
+			if ( naturalLeft + nextShift < VIEWPORT_EDGE_PADDING ) {
+				nextShift = VIEWPORT_EDGE_PADDING - naturalLeft;
+			}
+
+			nextShift = Math.round( nextShift );
+			if ( nextShift !== shiftRef.current ) {
+				shiftRef.current = nextShift;
+				setShiftPx( nextShift );
+			}
+		};
+
+		update();
+
+		// visx writes the placement transform asynchronously (a post-mount bounds
+		// refresh) and again on every reposition. The transformed node is our
+		// parent (the `.visx-tooltip` portal element), so watch its inline style.
+		const anchor = node.parentElement;
+		const styleObserver = anchor ? new MutationObserver( update ) : null;
+		styleObserver?.observe( anchor as HTMLElement, {
+			attributes: true,
+			attributeFilter: [ 'style' ],
+		} );
+
+		// Content width can change between data points without a remount.
+		const sizeObserver =
+			typeof ResizeObserver !== 'undefined' ? new ResizeObserver( update ) : null;
+		sizeObserver?.observe( node );
+
+		window.addEventListener( 'resize', update );
+		return () => {
+			styleObserver?.disconnect();
+			sizeObserver?.disconnect();
+			window.removeEventListener( 'resize', update );
+		};
+	}, [] );
+
+	return {
+		ref,
+		style: shiftPx ? { transform: `translateX(${ shiftPx }px)` } : undefined,
+	};
+}


### PR DESCRIPTION
Fixes #

## Proposed changes

The chart HTML tooltip is clipped at the screen edge for the rightmost data points.

**Root cause:** visx's `detectBounds` flip is powered by `@visx/tooltip`'s `withBoundingRects`, which measures the tooltip width **once, on mount**, and never re-measures. When the content width changes between data points during a single continuous hover (longer labels, different value widths, late font loads), the flip is decided against a stale width — so a wide tooltip near the right edge overflows the viewport instead of flipping.

This adds a `useViewportClamp` hook, applied in `AccessibleTooltip`'s content wrapper:

* It measures the rendered tooltip on every content change / resize (`ResizeObserver`), on visx repositioning (`MutationObserver` on the transformed parent's inline `style`), and on window resize, then applies a corrective horizontal `translateX` to keep the box inside the viewport.
* It reads the element's **own** rect — which already reflects visx's transform — so it needs no knowledge of the chart container, the portal, or the hovered datum's anchor position.
* It's applied to both the pointer and keyboard-focused tooltips, so it benefits every chart that uses `AccessibleTooltip` (line, area, …), and downstream consumers no longer need to observe-and-correct visx's output themselves.

## Related product discussion/links

* DOTCOM-17112

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Render a `LineChart` (or `AreaChart`) wide enough that the rightmost data point sits near the right edge of the viewport, with a custom `renderTooltip` whose content varies in width between points (e.g. longer date labels / post titles).
* Hover from a left-hand point across to the rightmost point in one continuous motion.
* **Before:** the tooltip for the rightmost point is clipped at the screen edge.
* **After:** the tooltip stays fully within the viewport (shifted left as needed), with ~16px padding from the edge.
* Confirm tooltips that comfortably fit are unaffected (no transform applied), and keyboard navigation (arrow keys) still focuses tooltips correctly.

Unit tests: `cd projects/js-packages/charts && pnpm test use-viewport-clamp`