### PR TITLE
Agents Manager: Bootstrap hooks exactly once even if multiple versions of the class are shipped

### DIFF
--- a/projects/packages/agents-manager/changelog/agents-manager-initialize-just-once
+++ b/projects/packages/agents-manager/changelog/agents-manager-initialize-just-once
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Agents Manager: Bootstrap hooks exactly once even if multiple versions of the class are shipped.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -29,13 +29,6 @@ class Agents_Manager {
 	private const HELP_CENTER_URL = 'https://wordpress.com/help?help-center=home';
 
 	/**
-	 * Class instance.
-	 *
-	 * @var Agents_Manager
-	 */
-	private static $instance = null;
-
-	/**
 	 * Agents_Manager constructor.
 	 */
 	public function __construct() {
@@ -576,9 +569,18 @@ class Agents_Manager {
 	 * @return void
 	 */
 	public static function init() {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
+		if ( did_action( 'jetpack_agents_manager_initialized' ) ) {
+			return;
 		}
+
+		new self();
+
+		/**
+		 * Fires once the Agents Manager class has been instantiated.
+		 *
+		 * @since 0.5.0
+		 */
+		do_action( 'jetpack_agents_manager_initialized' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -29,9 +29,16 @@ class Agents_Manager {
 	private const HELP_CENTER_URL = 'https://wordpress.com/help?help-center=home';
 
 	/**
+	 * Class instance.
+	 *
+	 * @var Agents_Manager
+	 */
+	private static $instance = null;
+
+	/**
 	 * Agents_Manager constructor.
 	 */
-	public function __construct() {
+	private function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );
 		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
 
@@ -566,14 +573,14 @@ class Agents_Manager {
 	/**
 	 * Creates instance.
 	 *
-	 * @return void
+	 * @return Agents_Manager
 	 */
 	public static function init() {
 		if ( did_action( 'jetpack_agents_manager_initialized' ) ) {
-			return;
+			return self::get_instance();
 		}
 
-		new self();
+		self::$instance = new self();
 
 		/**
 		 * Fires once the Agents Manager class has been instantiated.
@@ -581,6 +588,17 @@ class Agents_Manager {
 		 * @since 0.5.0
 		 */
 		do_action( 'jetpack_agents_manager_initialized' );
+
+		return self::$instance;
+	}
+
+	/**
+	 * Returns the instance of the Agents Manager class.
+	 *
+	 * @return Agents_Manager
+	 */
+	public static function get_instance() {
+		return self::$instance;
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -65,6 +65,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private $original_next_admin_init_count;
 
 	/**
+	 * Original jetpack_agents_manager_initialized action count to restore after tests.
+	 *
+	 * @var int
+	 */
+	private $original_agents_manager_initialized_count;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
@@ -100,6 +107,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Save original next_admin_init action count (CIAB detection).
 		global $wp_actions;
 		$this->original_next_admin_init_count = $wp_actions['next_admin_init'] ?? 0;
+
+		// Save original init guard action count; did_action() accumulates per-process.
+		$this->original_agents_manager_initialized_count = $wp_actions['jetpack_agents_manager_initialized'] ?? 0;
 	}
 
 	/**
@@ -152,6 +162,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			unset( $wp_actions['next_admin_init'] );
 		} else {
 			$wp_actions['next_admin_init'] = $this->original_next_admin_init_count;
+		}
+
+		// Restore init guard action count.
+		if ( $this->original_agents_manager_initialized_count === 0 ) {
+			unset( $wp_actions['jetpack_agents_manager_initialized'] );
+		} else {
+			$wp_actions['jetpack_agents_manager_initialized'] = $this->original_agents_manager_initialized_count;
 		}
 
 		// Clear the status cache and constants.
@@ -348,33 +365,37 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the init method creates a singleton instance.
+	 * Tests that init() bootstraps the Agents Manager exactly once, even when
+	 * called by multiple plugin copies.
+	 *
+	 * The guard is the 'jetpack_agents_manager_initialized' action rather than a
+	 * class static: did_action() reads the process-global $wp_actions table, so
+	 * the dedup holds across the separate copies of this package that different
+	 * plugins (e.g. jetpack-mu-wpcom and WooCommerce AI) each load and init.
 	 */
-	public function test_init_creates_singleton_instance() {
-		// Reset the static instance for testing
-		$reflection = new \ReflectionClass( Agents_Manager::class );
-		$property   = $reflection->getProperty( 'instance' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
+	public function test_init_bootstraps_only_once() {
+		// Start from a clean count regardless of test ordering; tear_down restores it.
+		global $wp_actions;
+		unset( $wp_actions['jetpack_agents_manager_initialized'] );
 
-		// Use an instance for Phan compatibility when accessing static property.
-		$dummy = $this->agents_manager;
+		$fired = 0;
+		add_action(
+			'jetpack_agents_manager_initialized',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
 
-		$property->setValue( $dummy, null );
-
+		// Simulate multiple bootstrappers each calling init() independently.
+		Agents_Manager::init();
+		Agents_Manager::init();
 		Agents_Manager::init();
 
-		$instance1 = $property->getValue( $dummy );
-		$this->assertInstanceOf( Agents_Manager::class, $instance1 );
+		// The action - and therefore the constructor - runs exactly once.
+		$this->assertSame( 1, $fired, 'Agents Manager must bootstrap exactly once across init() calls.' );
+		$this->assertSame( 1, did_action( 'jetpack_agents_manager_initialized' ) );
 
-		Agents_Manager::init();
-
-		$instance2 = $property->getValue( $dummy );
-		$this->assertSame( $instance1, $instance2 );
-
-		// Reset back to null for other tests
-		$property->setValue( $dummy, null );
+		remove_all_actions( 'jetpack_agents_manager_initialized' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -91,7 +91,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			}
 		);
 
-		$this->agents_manager = new Agents_Manager();
+		$this->agents_manager = Agents_Manager::init();
 
 		// Save original superglobal values that tests may modify.
 		$this->original_get_preview = $_GET['preview'] ?? null;
@@ -388,7 +388,9 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Simulate multiple bootstrappers each calling init() independently.
 		Agents_Manager::init();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally calling twice to ensure duplicates are not registered.
 		Agents_Manager::init();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally calling twice to ensure duplicates are not registered.
 		Agents_Manager::init();
 
 		// The action - and therefore the constructor - runs exactly once.


### PR DESCRIPTION
Fixes p1781554332994699-slack-C056QSJJQ91.

## Proposed changes

It's possible that multiple copies of the `Agents_Manager` class end up being called. In that case, our `init` function is called multiple times by different classes, each with its own `$instance` variable, so the singleton pattern fails, and we end up calling the hooks more than once.

Let's switch to a strategy that does not depend on a specific class variable. We're using the same strategy in several other packages, including [Activity Log](https://github.com/Automattic/jetpack/blob/wooai-567-sidebar-open-bug/projects/packages/activity-log/src/class-jetpack-activity-log.php#L65-L80) and [Backup](https://github.com/Automattic/jetpack/blob/agents-manager-initialize-just-once/projects/packages/backup/src/class-jetpack-backup.php#L117).

## Related product discussion/links

See p1781554332994699-slack-C056QSJJQ91.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

In an existing Atomic site, install the Woo AI plugin and enable the AI Assistant. Open the source code and verify you see `const agentsManagerData` being declared twice.

Install the Jetpack Beta Tester plugin. Enter it and enable this branch for both Jetpack and WordPress.com Site Helper.

Enter the Woo AI repo, run `rm -rf vendor composer.lock`, apply this patch:

```diff
diff --git a/composer.json b/composer.json
index dd338d6..cc70f64 100644
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,13 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"repositories": [
+		{
+			"type": "path",
+			"url": "../jetpack/projects/packages/agents-manager",
+			"options": {
+				"symlink": false
+			}
+		},
 		{
 			"type": "path",
 			"url": "packages/*",
@@ -20,7 +27,7 @@
 		"automattic/jetpack-sync": "^4.28",
 		"automattic/jetpack-config": "^3.1",
 		"woocommerce/ai-abilities": "@dev",
-		"automattic/jetpack-agents-manager": "^0.3.0"
+		"automattic/jetpack-agents-manager": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",

```

Make sure your local Jetpack copy has this branch checked out, of course. Run `composer install` and `pnpm build:zip`. Install the plugin from the zip (root of Woo AI repo) and enable the AI assistant.

Verify that you see `const agentsManagerData` being emitted just once in the source code. 