### PR TITLE
Agents Manager: Release 0.5.0

### DIFF
--- a/projects/js-packages/ai-client/changelog/force-a-release
+++ b/projects/js-packages/ai-client/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## [1.1.4] - 2026-06-08
 ### Changed
 - Internal updates.
@@ -269,6 +273,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.1.5]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.1...v1.1.2

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"keywords": [
 		"babel",

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.48] - 2026-06-15
+### Changed
+- Update dependencies. [#48834]
+
 ## [1.0.47] - 2026-06-09
 ### Changed
 - Update package dependencies. [#49273]
@@ -477,6 +481,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[1.0.48]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.47...v1.0.48
 [1.0.47]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.46...v1.0.47
 [1.0.46]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.45...v1.0.46
 [1.0.45]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.44...v1.0.45

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "1.0.47",
+	"version": "1.0.48",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.12.8] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## [1.12.7] - 2026-06-15
 ### Changed
 - Internal updates.
@@ -1840,6 +1844,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[1.12.8]: https://github.com/Automattic/jetpack-components/compare/1.12.7...1.12.8
 [1.12.7]: https://github.com/Automattic/jetpack-components/compare/1.12.6...1.12.7
 [1.12.6]: https://github.com/Automattic/jetpack-components/compare/1.12.5...1.12.6
 [1.12.5]: https://github.com/Automattic/jetpack-components/compare/1.12.4...1.12.5

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "1.12.7",
+	"version": "1.12.8",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [1.4.61] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## [1.4.60] - 2026-06-15
 ### Changed
 - Internal updates.
@@ -1381,6 +1385,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[1.4.61]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.60...v1.4.61
 [1.4.60]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.59...v1.4.60
 [1.4.59]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.58...v1.4.59
 [1.4.58]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.57...v1.4.58

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "1.4.60",
+	"version": "1.4.61",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.41] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## [1.1.40] - 2026-06-08
 ### Changed
 - Internal updates.
@@ -338,6 +342,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.41]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.40...v1.1.41
 [1.1.40]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.39...v1.1.40
 [1.1.39]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.38...v1.1.39
 [1.1.38]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.37...v1.1.38

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.40",
+	"version": "1.1.41",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.76 - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## 1.0.75 - 2026-06-15
 ### Changed
 - Update dependencies. [#46035]

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.75",
+	"version": "1.0.76",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/number-formatters/CHANGELOG.md
+++ b/projects/js-packages/number-formatters/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.3] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## [1.2.2] - 2026-06-08
 ### Changed
 - Internal updates.
@@ -164,6 +168,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release
 - Basic number formatting functionality
 
+[1.2.3]: https://github.com/Automattic/number-formatters/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/Automattic/number-formatters/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/Automattic/number-formatters/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/Automattic/number-formatters/compare/1.1.10...1.2.0

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Number formatting utilities",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/number-formatters/#readme",
 	"bugs": {

--- a/projects/js-packages/react-data-sync-client/changelog/force-a-release
+++ b/projects/js-packages/react-data-sync-client/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/js-packages/scan/changelog/force-a-release
+++ b/projects/js-packages/scan/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.9.4 - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
 ## 3.9.3 - 2026-06-09
 ### Changed
 - Update package dependencies. [#49273]

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.9.3",
+	"version": "3.9.4",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-06-15
+### Changed
+- Update dependencies. [#48834]
+
 ## [0.9.2] - 2026-06-09
 ### Changed
 - Update package dependencies. [#49273]
@@ -287,6 +291,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.9.3]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.0...0.9.1
 [0.9.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.8.9...0.9.0

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.9.2';
+	const PACKAGE_VERSION = '0.9.3';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/agents-manager/CHANGELOG.md
+++ b/projects/packages/agents-manager/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-15
+### Changed
+- Update package dependencies. [#49631]
+
+### Fixed
+- Agents Manager: Bootstrap hooks exactly once even if multiple versions of the class are shipped. [#49636]
+- Agents Manager: drive the sidebar pre-render from the persisted open state (cached in a transient) instead of a path-scoped cookie, and only pre-render where the app is actually loaded, so closing the assistant on another domain no longer leaves a stale sidebar shell behind. [#49439]
+
 ## [0.4.0] - 2026-06-15
 ### Added
 - Add a standalone AI chat button to the admin bar. [#49455]
@@ -35,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agents Manager: Allow overriding variant and sectionName through filters [#49283]
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption. [#49202]
 
+[0.5.0]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.3.0...v0.3.1

--- a/projects/packages/agents-manager/changelog/agents-manager-initialize-just-once
+++ b/projects/packages/agents-manager/changelog/agents-manager-initialize-just-once
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Agents Manager: Bootstrap hooks exactly once even if multiple versions of the class are shipped.

--- a/projects/packages/agents-manager/changelog/fix-agents-manager-sidebar-open-stale-shell
+++ b/projects/packages/agents-manager/changelog/fix-agents-manager-sidebar-open-stale-shell
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Agents Manager: drive the sidebar pre-render from the persisted open state (cached in a transient) instead of a path-scoped cookie, and only pre-render where the app is actually loaded, so closing the assistant on another domain no longer leaves a stale sidebar shell behind.

--- a/projects/packages/agents-manager/changelog/fix-phan-various
+++ b/projects/packages/agents-manager/changelog/fix-phan-various
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Phan: Address various violations.
-

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -54,7 +54,7 @@
 		"autorelease": true,
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.4.x-dev"
+			"dev-trunk": "0.5.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"

--- a/projects/packages/agents-manager/package.json
+++ b/projects/packages/agents-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-agents-manager",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"private": true,
 	"description": "Shared AI infrastructure helpers for Automattic plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/agents-manager/#readme",

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -19,7 +19,7 @@ class Agents_Manager {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.4.0';
+	const PACKAGE_VERSION = '0.5.0';
 
 	/**
 	 * Help Center URL for disconnected variants.

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.44] - 2026-06-15
+### Changed
+- Update dependencies. [#42554]
+
 ## [4.3.43] - 2026-06-10
 ### Changed
 - Update package dependencies. [#49492]
@@ -861,6 +865,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.3.44]: https://github.com/Automattic/jetpack-assets/compare/v4.3.43...v4.3.44
 [4.3.43]: https://github.com/Automattic/jetpack-assets/compare/v4.3.42...v4.3.43
 [4.3.42]: https://github.com/Automattic/jetpack-assets/compare/v4.3.41...v4.3.42
 [4.3.41]: https://github.com/Automattic/jetpack-assets/compare/v4.3.40...v4.3.41

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.7.0] - 2026-06-15
+### Added
+- Connectors: Surface Jetpack Safe Mode (Identity Crisis) state and resolution options in the connector card. [#49486]
+
+### Changed
+- Update package dependencies. [#49631]
+
+### Fixed
+- Connectors: Add cache-busting version to the connector card script module so updated assets are served after changes. [#49486]
+- Identity Crisis: Fix confirming Safe Mode again after clearing it from the admin bar, which could silently fail when the safe_mode_confirmed option was stale in a persistent object cache. [#49486]
+- Identity Crisis: Prevent the migrate (Update address) action from failing with a false "Could not delete sync error option" error when the sync_error_idc option is stale in cache. [#49486]
+
 ## [8.6.1] - 2026-06-15
 ### Changed
 - Internal updates.
@@ -1896,6 +1908,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.7.0]: https://github.com/Automattic/jetpack-connection/compare/v8.6.1...v8.7.0
 [8.6.1]: https://github.com/Automattic/jetpack-connection/compare/v8.6.0...v8.6.1
 [8.6.0]: https://github.com/Automattic/jetpack-connection/compare/v8.5.6...v8.6.0
 [8.5.6]: https://github.com/Automattic/jetpack-connection/compare/v8.5.5...v8.5.6

--- a/projects/packages/connection/changelog/connector-card-script-version
+++ b/projects/packages/connection/changelog/connector-card-script-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connectors: Add cache-busting version to the connector card script module so updated assets are served after changes.

--- a/projects/packages/connection/changelog/fix-phan-various
+++ b/projects/packages/connection/changelog/fix-phan-various
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Phan: Address various violations.
-

--- a/projects/packages/connection/changelog/idc-confirm-safe-mode-cache
+++ b/projects/packages/connection/changelog/idc-confirm-safe-mode-cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Identity Crisis: Fix confirming Safe Mode again after clearing it from the admin bar, which could silently fail when the safe_mode_confirmed option was stale in a persistent object cache.

--- a/projects/packages/connection/changelog/idc-connector-card
+++ b/projects/packages/connection/changelog/idc-connector-card
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Connectors: Surface Jetpack Safe Mode (Identity Crisis) state and resolution options in the connector card.

--- a/projects/packages/connection/changelog/idc-migrate-stale-cache
+++ b/projects/packages/connection/changelog/idc-migrate-stale-cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Identity Crisis: Prevent the migrate (Update address) action from failing with a false "Could not delete sync error option" error when the sync_error_idc option is stale in cache.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "8.6.x-dev"
+			"dev-trunk": "8.7.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.6.1';
+	const PACKAGE_VERSION = '8.7.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -200,7 +200,7 @@ class Jetpack_Connector {
 	 * mode) in the expanded details. Mirrors the data assembled by
 	 * \Automattic\Jetpack\IdentityCrisis\UI::get_initial_state_data().
 	 *
-	 * @since $$next-version$$
+	 * @since 8.7.0
 	 *
 	 * @param array $data Script module data passed by reference.
 	 */

--- a/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
+++ b/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
@@ -151,7 +151,7 @@ class REST_Endpoints {
 	 * bust both the individual key and the autoloaded-options cache to keep
 	 * persistent object caches from returning a stale value across requests.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.7.0
 	 *
 	 * @param string $option The prefixed option name (e.g. `jetpack_safe_mode_confirmed`).
 	 */
@@ -164,7 +164,7 @@ class REST_Endpoints {
 	 * Flush any cached copy of the sync_error_idc option so a subsequent read
 	 * reflects the option's true state in the database.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.7.0
 	 */
 	private static function flush_sync_error_idc_cache() {
 		self::flush_jetpack_option_cache( 'jetpack_sync_error_idc' );

--- a/projects/packages/jitm/changelog/force-a-release
+++ b/projects/packages/jitm/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/plugin-deactivation/changelog/force-a-release
+++ b/projects/packages/plugin-deactivation/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/post-list/changelog/force-a-release
+++ b/projects/packages/post-list/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/plugins/agents-manager/changelog/prerelease#2
+++ b/projects/plugins/agents-manager/changelog/prerelease#2
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/agents-manager/composer.lock
+++ b/projects/plugins/agents-manager/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -418,7 +418,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -454,7 +454,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#12
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#12
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -450,7 +450,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#13
+++ b/projects/plugins/backup/changelog/prerelease#13
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -751,7 +751,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/prerelease#2
+++ b/projects/plugins/boost/changelog/prerelease#2
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -644,7 +644,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#36
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#36
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -599,7 +599,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -635,7 +635,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/prerelease#6
+++ b/projects/plugins/inspect/changelog/prerelease#6
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -450,7 +450,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -348,7 +348,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -370,7 +370,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -1188,7 +1188,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1224,7 +1224,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#13
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#13
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -205,7 +205,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -227,7 +227,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -644,7 +644,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -680,7 +680,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease#6
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease#6
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -435,7 +435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/premium-analytics/changelog/prerelease#3
+++ b/projects/plugins/premium-analytics/changelog/prerelease#3
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -343,7 +343,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -379,7 +379,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/prerelease#13
+++ b/projects/plugins/protect/changelog/prerelease#13
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -210,7 +210,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -232,7 +232,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -730,7 +730,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -766,7 +766,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/prerelease#2
+++ b/projects/plugins/search/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -644,7 +644,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/prerelease#7
+++ b/projects/plugins/social/changelog/prerelease#7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -205,7 +205,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -227,7 +227,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -671,7 +671,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -707,7 +707,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/starter-plugin/changelog/prerelease#13
+++ b/projects/plugins/starter-plugin/changelog/prerelease#13
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -644,7 +644,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/prerelease#9
+++ b/projects/plugins/videopress/changelog/prerelease#9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -142,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -164,7 +164,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -644,7 +644,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcloud-sso/changelog/prerelease#28
+++ b/projects/plugins/wpcloud-sso/changelog/prerelease#28
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -450,7 +450,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/prerelease#15
+++ b/projects/plugins/wpcomsh/changelog/prerelease#15
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -253,7 +253,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "6d7594f8cdecefc57a78d02efcb83565db903341"
+                "reference": "a95c9103c938904a50375cf96ddd919bad379053"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -275,7 +275,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
@@ -831,7 +831,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "eebe307b66ea009bea1ebd421a53ba8be8b4060c"
+                "reference": "74e1711653df3561aadf672c5228cb2a2479d0d4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -867,7 +867,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.6.x-dev"
+                    "dev-trunk": "8.7.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
## Proposed changes

Release a new version of Agents Manager following the merge of https://github.com/Automattic/jetpack/pull/49439.

## Related product discussion/links

See attached PR.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

No instructions, just watch everything become green.