### PR TITLE
Premium Analytics: clean up proxy transients via the stats Transient_Cleanup cron

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1547-cleanup-proxy-transients
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1547-cleanup-proxy-transients
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+REST: Register the API proxy's transient cache prefix with the stats package's transient cleanup cron, so expired proxy response caches are garbage-collected on sites without a persistent object cache instead of accumulating in wp_options.

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -158,13 +158,18 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 * GC never reaches the rarely re-read, param-keyed entries). The coupling is loose: the filter
 	 * is just a hook name, so if the stats package isn't loaded it never fires and nothing breaks.
 	 *
+	 * Appends only when handed a valid array; a non-array (from a misbehaving upstream filter) is
+	 * returned untouched so the stats consumer's own fall-back-to-defaults normalization still runs
+	 * instead of being masked into dropping the default stats prefix.
+	 *
 	 * @param mixed $prefixes Transient prefixes the stats cleanup cron will sweep.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function register_transient_cleanup_prefix( $prefixes ): array {
-		$prefixes   = is_array( $prefixes ) ? $prefixes : array();
-		$prefixes[] = self::CACHE_PREFIX;
+	public function register_transient_cleanup_prefix( $prefixes ) {
+		if ( is_array( $prefixes ) ) {
+			$prefixes[] = self::CACHE_PREFIX;
+		}
 
 		return $prefixes;
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -141,13 +141,32 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Hook the controller's routes onto rest_api_init.
+	 * Hook the controller's routes onto rest_api_init, and register its cache prefix with the
+	 * stats package's transient cleanup cron.
 	 *
 	 * @return void
 	 */
 	public static function register(): void {
 		$controller = new self();
 		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+		add_filter( 'jetpack_stats_transient_cleanup_prefixes', array( $controller, 'register_transient_cleanup_prefix' ) );
+	}
+
+	/**
+	 * Register the proxy cache prefix with the stats package's transient cleanup cron, so expired
+	 * proxy transients are swept on sites without a persistent object cache (where WordPress's lazy
+	 * GC never reaches the rarely re-read, param-keyed entries). The coupling is loose: the filter
+	 * is just a hook name, so if the stats package isn't loaded it never fires and nothing breaks.
+	 *
+	 * @param mixed $prefixes Transient prefixes the stats cleanup cron will sweep.
+	 *
+	 * @return array
+	 */
+	public function register_transient_cleanup_prefix( $prefixes ): array {
+		$prefixes   = is_array( $prefixes ) ? $prefixes : array();
+		$prefixes[] = self::CACHE_PREFIX;
+
+		return $prefixes;
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -657,14 +657,16 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertStringStartsWith( 'jetpack-premium-analytics_proxy_', $real_key );
 	}
 
-	public function test_register_transient_cleanup_prefix_preserves_existing_and_tolerates_non_array() {
+	public function test_register_transient_cleanup_prefix_preserves_existing_and_passes_non_array_through() {
 		$this->assertSame(
 			array( 'other_prefix_', 'jetpack-premium-analytics_proxy_' ),
 			$this->controller->register_transient_cleanup_prefix( array( 'other_prefix_' ) )
 		);
 
+		// A non-array (from a misbehaving upstream filter) is returned untouched, so the stats
+		// consumer's own fall-back-to-defaults normalization runs instead of being masked.
 		$this->assertSame(
-			array( 'jetpack-premium-analytics_proxy_' ),
+			'not-an-array',
 			$this->controller->register_transient_cleanup_prefix( 'not-an-array' )
 		);
 	}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -646,6 +646,40 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		);
 	}
 
+	public function test_register_transient_cleanup_prefix_covers_the_stored_transients() {
+		$prefixes = $this->controller->register_transient_cleanup_prefix( array() );
+
+		$this->assertContains( 'jetpack-premium-analytics_proxy_', $prefixes );
+
+		// The registered prefix must genuinely prefix the keys the controller writes, so the stats
+		// cron's LIKE match reaches them — guards against it drifting from CACHE_PREFIX.
+		$real_key = $this->cache_key( $this->build_data_request( 'GET', 'analytics/reports/totals' ) );
+		$this->assertStringStartsWith( 'jetpack-premium-analytics_proxy_', $real_key );
+	}
+
+	public function test_register_transient_cleanup_prefix_preserves_existing_and_tolerates_non_array() {
+		$this->assertSame(
+			array( 'other_prefix_', 'jetpack-premium-analytics_proxy_' ),
+			$this->controller->register_transient_cleanup_prefix( array( 'other_prefix_' ) )
+		);
+
+		$this->assertSame(
+			array( 'jetpack-premium-analytics_proxy_' ),
+			$this->controller->register_transient_cleanup_prefix( 'not-an-array' )
+		);
+	}
+
+	public function test_register_hooks_the_proxy_prefix_onto_the_stats_cleanup_filter() {
+		remove_all_filters( 'jetpack_stats_transient_cleanup_prefixes' );
+
+		Api_Proxy_Controller::register();
+		$prefixes = apply_filters( 'jetpack_stats_transient_cleanup_prefixes', array() );
+
+		$this->assertContains( 'jetpack-premium-analytics_proxy_', $prefixes );
+
+		remove_all_filters( 'jetpack_stats_transient_cleanup_prefixes' );
+	}
+
 	public function test_successful_write_busts_matching_read_cache() {
 		// A no-param GET to this dashboard read caches under this key; a 200 POST to it clears it.
 		$endpoint = 'jetpack-stats-dashboard/modules';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1547/clean-up-premium-analytics-proxy-transients-via-the-stats-transient

## Why
On sites without a persistent object cache, the Premium Analytics dashboard's API proxy was quietly bloating `wp_options`. It caches every successful GET in a 5-minute transient keyed by path + version + params, and because those keys are almost never re-read after they expire, WordPress's lazy garbage collection never reaches them — so expired rows piled up indefinitely. This change hands those transients to the existing stats cleanup cron so they get swept automatically.

## Proposed changes
* Register the proxy cache prefix (`jetpack-premium-analytics_proxy_`) with the stats package's `Transient_Cleanup` cron via the `jetpack_stats_transient_cleanup_prefixes` filter, so the existing 8-hour sweep garbage-collects expired proxy transients.
* The coupling is loose — the filter is just a hook name. Premium Analytics ships alongside the always-loaded stats module; if stats were ever absent the filter simply never fires and nothing breaks. No new composer dependency is needed.
* Add unit tests covering the prefix registration, the defensive non-array handling, and that `register()` actually hooks the filter.

## Verification
Backend-only change — no user-visible surface. Exercised end-to-end in a local docker WP (Premium Analytics + Jetpack/stats active, no persistent object cache): the proxy prefix is registered on the stats filter, and `Transient_Cleanup::run_cleanup()` sweeps an expired proxy transient while leaving a fresh one untouched.

<details>
<summary>Output (<code>wp eval-file</code>)</summary>

```text
ext_object_cache: no (cleanup runs)
Transient_Cleanup class: available
filter prefixes: jetpack-premium-analytics_proxy_, STATS_REST_RESP_
proxy prefix registered: YES

-- options before cleanup --
_transient_jetpack-premium-analytics_proxy_EXPIRED
_transient_jetpack-premium-analytics_proxy_FRESH
_transient_timeout_jetpack-premium-analytics_proxy_EXPIRED
_transient_timeout_jetpack-premium-analytics_proxy_FRESH

run_cleanup() deleted option rows: 8

-- options after cleanup --
_transient_jetpack-premium-analytics_proxy_FRESH
_transient_timeout_jetpack-premium-analytics_proxy_FRESH

EXPIRED swept: YES
FRESH survived: YES
```

</details>

## Related product discussion/links
* https://linear.app/a8c/issue/WOOA7S-1547/clean-up-premium-analytics-proxy-transients-via-the-stats-transient

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Acceptance criteria from the issue:

* [ ] The premium-analytics proxy prefix `jetpack-premium-analytics_proxy_` is registered with the stats `Transient_Cleanup` cron via the `jetpack_stats_transient_cleanup_prefixes` filter.
* [ ] The dependency direction is acceptable — premium-analytics reuses the stats package's cleanup filter rather than scheduling its own cron (the lighter option; stats is always loaded alongside).
* [ ] The filter adds only the bare prefix; `Transient_Cleanup` handles the `_transient_*` / `_transient_timeout_*` option-name matching.
* [ ] Cleanup is correctly skipped when `wp_using_ext_object_cache()` is true (handled by `Transient_Cleanup`).

To verify locally with Premium Analytics + Jetpack active and no persistent object cache:

1. Plant an expired and a fresh proxy transient:
   ```php
   set_transient( 'jetpack-premium-analytics_proxy_EXPIRED', 'stale', 300 );
   update_option( '_transient_timeout_jetpack-premium-analytics_proxy_EXPIRED', time() - 100 );
   set_transient( 'jetpack-premium-analytics_proxy_FRESH', 'live', 300 );
   ```
2. Confirm the prefix is registered: `apply_filters( 'jetpack_stats_transient_cleanup_prefixes', array() )` includes `jetpack-premium-analytics_proxy_`.
3. Run `\Automattic\Jetpack\Stats\Transient_Cleanup::run_cleanup();`.
4. Confirm the `_EXPIRED` transient (and its timeout) is gone and the `_FRESH` one survives.
