### PR TITLE
Premium Analytics: add a dedicated single-post REST endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1536-single-post-endpoint
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1536-single-post-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Add a dedicated single-post endpoint (`jetpack-premium-analytics/v1/posts/<id>`) that serves a post's display metadata from the local database, ported from the stats-admin controller as part of deprecating that package.

--- a/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
@@ -18,8 +18,13 @@ use WP_REST_Server;
  *
  * Unlike the WPCOM pass-through endpoints ({@see Api_Proxy_Controller}), this reads the post
  * locally via `get_post()` rather than forwarding to WPCOM: `/sites/<id>/posts/<id>` can require a
- * user token for private posts/sites, which users without a WordPress.com account don't have. The
- * response shape mirrors `/sites/<id>/posts/<id>` so the dashboard can consume either source.
+ * user token for private posts/sites, which users without a WordPress.com account don't have.
+ *
+ * The response shape deliberately mirrors WordPress.com's `/sites/<id>/posts/<id>` (not WP core's
+ * `/wp/v2/posts/<id>`): the dashboard's data layer is shared between the public-api source and this
+ * local endpoint, so keeping one shape lets the same frontend code consume both. We may later
+ * migrate to the Core single-post endpoint and drop this controller, which would mean reworking
+ * that shared frontend data layer to handle Core's shape.
  */
 class Single_Post_Controller extends WP_REST_Controller {
 

--- a/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
@@ -51,7 +51,7 @@ class Single_Post_Controller extends WP_REST_Controller {
 			'/posts/(?P<resource_id>[\d]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_item' ),
+				'callback'            => array( $this, 'get_single_post' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
@@ -73,7 +73,10 @@ class Single_Post_Controller extends WP_REST_Controller {
 	 *
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public function get_item( $request ) {
+	public function get_single_post( WP_REST_Request $request ) {
+		// No per-post `read` capability check, matching the stats-admin source: the analytics
+		// dashboard reports on every post, so any stats viewer may read a post's metadata by ID
+		// (including drafts/private). Only the limited display fields below are exposed.
 		$post = get_post( (int) $request->get_param( 'resource_id' ), OBJECT, 'display' );
 
 		if ( empty( $post ) ) {
@@ -84,7 +87,8 @@ class Single_Post_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// `like_count` is intentionally omitted — it's served by the post-likes endpoint.
+		// `like_count` is intentionally omitted — likes are fetched separately from the
+		// WordPress.com public API.
 		return array(
 			'ID'             => $post->ID,
 			'site_ID'        => (int) Jetpack_Options::get_option( 'id' ),

--- a/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-single-post-controller.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * REST controller exposing single-post metadata for the analytics dashboard.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Serves a single post's display metadata from the local database.
+ *
+ * Unlike the WPCOM pass-through endpoints ({@see Api_Proxy_Controller}), this reads the post
+ * locally via `get_post()` rather than forwarding to WPCOM: `/sites/<id>/posts/<id>` can require a
+ * user token for private posts/sites, which users without a WordPress.com account don't have. The
+ * response shape mirrors `/sites/<id>/posts/<id>` so the dashboard can consume either source.
+ */
+class Single_Post_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'jetpack-premium-analytics/v1';
+	}
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the single-post route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/posts/(?P<resource_id>[\d]+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Stats access: an administrator or any user who can view stats.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Return a single post's display metadata.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function get_item( $request ) {
+		$post = get_post( (int) $request->get_param( 'resource_id' ), OBJECT, 'display' );
+
+		if ( empty( $post ) ) {
+			return new WP_Error(
+				'post_not_found',
+				__( 'Post not found.', 'jetpack-premium-analytics' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// `like_count` is intentionally omitted — it's served by the post-likes endpoint.
+		return array(
+			'ID'             => $post->ID,
+			'site_ID'        => (int) Jetpack_Options::get_option( 'id' ),
+			'title'          => $post->post_title,
+			'URL'            => get_permalink( $post->ID ),
+			'type'           => $post->post_type,
+			'status'         => $post->post_status,
+			'discussion'     => array( 'comment_count' => (int) $post->comment_count ),
+			'date'           => $post->post_date,
+			'post_thumbnail' => array( 'URL' => get_the_post_thumbnail_url( $post->ID ) ),
+		);
+	}
+}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
+use Automattic\Jetpack\PremiumAnalytics\REST\Single_Post_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
 /**
@@ -61,6 +62,7 @@ class Analytics {
 
 		Sync_Status_Tracker::configure();
 		Api_Proxy_Controller::register();
+		Single_Post_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/tests/php/REST/Single_Post_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Single_Post_Controller_Test.php
@@ -47,7 +47,7 @@ class Single_Post_Controller_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'GET', $handler['methods'] );
 		$this->assertArrayNotHasKey( 'POST', $handler['methods'] );
-		$this->assertSame( array( $this->controller, 'get_item' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'get_single_post' ), $handler['callback'] );
 		$this->assertSame( array( $this->controller, 'check_permission' ), $handler['permission_callback'] );
 	}
 
@@ -85,7 +85,7 @@ class Single_Post_Controller_Test extends BaseTestCase {
 		$this->assertFalse( $this->controller->check_permission() );
 	}
 
-	public function test_get_item_returns_the_mapped_post_shape() {
+	public function test_get_single_post_returns_the_mapped_post_shape() {
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => 'Hello Analytics',
@@ -95,7 +95,7 @@ class Single_Post_Controller_Test extends BaseTestCase {
 			)
 		);
 
-		$response = $this->controller->get_item( $this->build_request( $post_id ) );
+		$response = $this->controller->get_single_post( $this->build_request( $post_id ) );
 
 		$this->assertSame( $post_id, $response['ID'] );
 		$this->assertSame( (int) \Jetpack_Options::get_option( 'id' ), $response['site_ID'] );
@@ -108,8 +108,34 @@ class Single_Post_Controller_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'like_count', $response );
 	}
 
-	public function test_get_item_returns_404_for_a_missing_post() {
-		$response = $this->controller->get_item( $this->build_request( 999999 ) );
+	public function test_get_single_post_serves_payload_to_view_stats_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_post_stats_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Viewer Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertTrue( $this->controller->check_permission() );
+
+		$response = $this->controller->get_single_post( $this->build_request( $post_id ) );
+		$this->assertSame( $post_id, $response['ID'] );
+		$this->assertSame( 'Viewer Post', $response['title'] );
+	}
+
+	public function test_get_single_post_returns_404_for_a_missing_post() {
+		$response = $this->controller->get_single_post( $this->build_request( 999999 ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'post_not_found', $response->get_error_code() );

--- a/projects/packages/premium-analytics/tests/php/REST/Single_Post_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Single_Post_Controller_Test.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for Single_Post_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Single_Post_Controller
+ */
+#[CoversClass( Single_Post_Controller::class )]
+class Single_Post_Controller_Test extends BaseTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Single_Post_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Set up the controller and a fresh REST server.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new Single_Post_Controller();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_registers_the_single_post_route() {
+		$this->assertArrayHasKey( '/jetpack-premium-analytics/v1/posts/(?P<resource_id>[\d]+)', rest_get_server()->get_routes() );
+	}
+
+	public function test_route_is_read_only_and_uses_the_controller_callbacks() {
+		$handler = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/posts/(?P<resource_id>[\d]+)'][0];
+
+		$this->assertArrayHasKey( 'GET', $handler['methods'] );
+		$this->assertArrayNotHasKey( 'POST', $handler['methods'] );
+		$this->assertSame( array( $this->controller, 'get_item' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $handler['permission_callback'] );
+	}
+
+	public function test_permission_granted_for_administrator() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_post_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_permission_granted_for_view_stats_capability() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_post_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_permission_denied_for_anonymous_user() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+
+	public function test_get_item_returns_the_mapped_post_shape() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Hello Analytics',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_content' => 'Body',
+			)
+		);
+
+		$response = $this->controller->get_item( $this->build_request( $post_id ) );
+
+		$this->assertSame( $post_id, $response['ID'] );
+		$this->assertSame( (int) \Jetpack_Options::get_option( 'id' ), $response['site_ID'] );
+		$this->assertSame( 'Hello Analytics', $response['title'] );
+		$this->assertSame( 'post', $response['type'] );
+		$this->assertSame( 'publish', $response['status'] );
+		$this->assertSame( get_permalink( $post_id ), $response['URL'] );
+		$this->assertArrayHasKey( 'comment_count', $response['discussion'] );
+		$this->assertArrayHasKey( 'URL', $response['post_thumbnail'] );
+		$this->assertArrayNotHasKey( 'like_count', $response );
+	}
+
+	public function test_get_item_returns_404_for_a_missing_post() {
+		$response = $this->controller->get_item( $this->build_request( 999999 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'post_not_found', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Build a request carrying a resource_id route param.
+	 *
+	 * @param int $resource_id Post id.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function build_request( int $resource_id ): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts/' . $resource_id );
+		$request->set_param( 'resource_id', $resource_id );
+
+		return $request;
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1536/port-local-post-endpoints-to-the-premium-analytics-proxy

## Why

The Premium Analytics dashboard needs a post's display metadata (title, URL, type, status, comment count, thumbnail) to render its content views. The `stats-admin` package served this from a local `get_post()` read rather than a WPCOM forward, because `/sites/<id>/posts/<id>` can require a user token for private posts/sites — which users without a WordPress.com account don't have. As `stats-admin` is deprecated, that endpoint moves into `premium-analytics`. It can't ride the agnostic blog-token proxy, so it gets its own controller.

## Proposed changes

* Add `Single_Post_Controller` (`src/REST/class-single-post-controller.php`) registering `GET jetpack-premium-analytics/v1/posts/<id>`, which reads the post locally via `get_post()` and returns the same shape as WPCOM's `/sites/<id>/posts/<id>` (minus `like_count`, served by a separate endpoint).
* Gate access by `manage_options ∨ view_stats`, matching `stats-admin`'s general-stats permission.
* A missing post returns a proper `404` (`post_not_found`) instead of the source's bare `null`; the source's dead `is_wp_error()` branch (`get_post()` never returns `WP_Error`) is dropped.
* Wire the controller into `Analytics::init()`; add unit tests and a changelog entry.

This is the first of two PRs splitting WOOA7S-1536 by mechanism. The companion PR ports the two `public-api.wordpress.com` post endpoints (`posts`, `posts/<id>/likes`). These local endpoints deliberately live **outside** `Api_Proxy_Controller`, which is reserved for transparent blog-token WPCOM forwards.

## API changes

Adds a local REST endpoint: `GET jetpack-premium-analytics/v1/posts/<id>`.

<details>
<summary>Request — single post (admin)</summary>

```http
GET /wp-json/jetpack-premium-analytics/v1/posts/2263
```

</details>

<details>
<summary>Response — 200</summary>

```json
{
    "ID": 2263,
    "site_ID": 254381802,
    "title": "Hello Analytics",
    "URL": "http://localhost/2026/06/15/hello-analytics/",
    "type": "post",
    "status": "publish",
    "discussion": { "comment_count": 0 },
    "date": "2026-06-15 18:51:20",
    "post_thumbnail": { "URL": false }
}
```

</details>

<details>
<summary>Edge cases — missing post, anonymous user</summary>

```text
GET /jetpack-premium-analytics/v1/posts/999999   (admin)
STATUS: 404  {"code":"post_not_found","message":"Post not found.","data":{"status":404}}

GET /jetpack-premium-analytics/v1/posts/2263      (anonymous)
STATUS: 401  {"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}
```

</details>

Exercised on a local docker WP env via `rest_do_request`; 124 package PHPUnit tests pass; phpcs clean. No user-visible UI, so no screenshots.

## Related product discussion/links

* [WOOA7S-1536](https://linear.app/a8c/issue/WOOA7S-1536/port-local-post-endpoints-to-the-premium-analytics-proxy) (follow-up to WOOA7S-1534)

## Does this pull request change what data or activity we track or use?

No. It re-exposes existing post metadata that `stats-admin` already served; no new data is collected or shared.

## Testing instructions

* Build the env: `jp build packages/premium-analytics && jp build plugins/premium-analytics` (plus the foundational `my-jetpack` / `plugins/jetpack` layers), then bring up a docker WP env with the Premium Analytics plugin active.
* Create a published post.
* `GET /wp-json/jetpack-premium-analytics/v1/posts/<id>` as an admin → `200` with `ID`, `site_ID`, `title`, `URL`, `type`, `status`, `discussion.comment_count`, `date`, `post_thumbnail.URL`; `like_count` absent.
* `GET .../posts/<non-existent-id>` → `404` `post_not_found`.
* `GET .../posts/<id>` as a logged-out user → `401`/`403`.
* A `view_stats`-only (non-admin) user is permitted; a subscriber without `view_stats` is denied.
* `cd projects/packages/premium-analytics && composer phpunit` passes.
