### PR TITLE
Premium Analytics: port the Stats user-feedback POST to the API proxy

### DIFF
--- a/projects/packages/premium-analytics/changelog/port-stats-user-feedback
+++ b/projects/packages/premium-analytics/changelog/port-stats-user-feedback
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST: Port the Stats user-feedback POST to the premium-analytics proxy. Served at jetpack-premium-analytics/v1/jetpack-stats/user-feedback, it injects the current user's email into the request body and reuses the shared forward core to reach WordPress.com.
+REST: Port the Stats user-feedback POST to a dedicated premium-analytics controller. Served at jetpack-premium-analytics/v1/jetpack-stats/user-feedback, it injects the current user's email into the request body before forwarding to WordPress.com. It is kept separate from the transparent API proxy, which does not rewrite request bodies.

--- a/projects/packages/premium-analytics/changelog/port-stats-user-feedback
+++ b/projects/packages/premium-analytics/changelog/port-stats-user-feedback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Port the Stats user-feedback POST to the premium-analytics proxy. Served at jetpack-premium-analytics/v1/jetpack-stats/user-feedback, it injects the current user's email into the request body and reuses the shared forward core to reach WordPress.com.

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -206,55 +206,6 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				),
 			)
 		);
-
-		// Bespoke endpoint: not a transparent forward. It rewrites the request body (injects the
-		// current user's email) before reusing the shared forward() core, so it lives on its own
-		// route outside `proxy/` per this controller's pass-through-only policy.
-		register_rest_route(
-			$this->namespace,
-			'/jetpack-stats/user-feedback',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'handle_user_feedback' ),
-				'permission_callback' => array( $this, 'check_stats_permission' ),
-			)
-		);
-	}
-
-	/**
-	 * Permission for the Stats user-feedback endpoint: `view_stats`, with `manage_options` always
-	 * accepted. Mirrors the `jetpack-stats` prefix's capability and stats-admin's parity check.
-	 *
-	 * @return bool
-	 */
-	public function check_stats_permission(): bool {
-		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
-	}
-
-	/**
-	 * Proxy the Stats user-feedback POST to WPCOM, injecting the current user's email into the body
-	 * first. The augmentation is the only thing this endpoint does beyond a plain forward, so it
-	 * mutates the request body and then delegates to the shared forward() core (connection check,
-	 * error normalization, header forwarding) — keeping forward() a pure transparent transport.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function handle_user_feedback( WP_REST_Request $request ) {
-		$body               = json_decode( (string) $request->get_body(), true );
-		$body               = is_array( $body ) ? $body : array();
-		$body['user_email'] = wp_get_current_user()->user_email;
-		$request->set_body( wp_json_encode( $body, JSON_UNESCAPED_SLASHES ) );
-
-		return $this->forward(
-			$request,
-			sprintf( '/sites/%d/jetpack-stats/user-feedback', (int) Jetpack_Options::get_option( 'id' ) ),
-			array(
-				'version' => '2',
-				'base'    => 'wpcom',
-			)
-		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -206,6 +206,55 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				),
 			)
 		);
+
+		// Bespoke endpoint: not a transparent forward. It rewrites the request body (injects the
+		// current user's email) before reusing the shared forward() core, so it lives on its own
+		// route outside `proxy/` per this controller's pass-through-only policy.
+		register_rest_route(
+			$this->namespace,
+			'/jetpack-stats/user-feedback',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_user_feedback' ),
+				'permission_callback' => array( $this, 'check_stats_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Permission for the Stats user-feedback endpoint: `view_stats`, with `manage_options` always
+	 * accepted. Mirrors the `jetpack-stats` prefix's capability and stats-admin's parity check.
+	 *
+	 * @return bool
+	 */
+	public function check_stats_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Proxy the Stats user-feedback POST to WPCOM, injecting the current user's email into the body
+	 * first. The augmentation is the only thing this endpoint does beyond a plain forward, so it
+	 * mutates the request body and then delegates to the shared forward() core (connection check,
+	 * error normalization, header forwarding) — keeping forward() a pure transparent transport.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_user_feedback( WP_REST_Request $request ) {
+		$body               = json_decode( (string) $request->get_body(), true );
+		$body               = is_array( $body ) ? $body : array();
+		$body['user_email'] = wp_get_current_user()->user_email;
+		$request->set_body( wp_json_encode( $body, JSON_UNESCAPED_SLASHES ) );
+
+		return $this->forward(
+			$request,
+			sprintf( '/sites/%d/jetpack-stats/user-feedback', (int) Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'version' => '2',
+				'base'    => 'wpcom',
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-user-feedback-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-user-feedback-controller.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * REST controller for the Stats user-feedback submission.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Accepts the Stats dashboard's "send feedback" POST, stamps the current user's email onto the
+ * body, and forwards it to WordPress.com.
+ *
+ * This is deliberately separate from {@see Api_Proxy_Controller}: that controller is a transparent
+ * WordPress.com pass-through, whereas this endpoint rewrites the request body before forwarding, so
+ * it does not belong on the proxy. It is a single uncached POST, so it carries its own small forward
+ * rather than the proxy's cache-aware transport.
+ */
+class User_Feedback_Controller extends WP_REST_Controller {
+
+	/**
+	 * Package slug, used as the connection plugin slug and the namespace root.
+	 *
+	 * @var string
+	 */
+	private const SLUG = 'jetpack-premium-analytics';
+
+	/**
+	 * Timeout for the outbound WordPress.com request, in seconds.
+	 *
+	 * @var int
+	 */
+	private const API_TIMEOUT = 20;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = self::SLUG . '/v1';
+	}
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the user-feedback route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/jetpack-stats/user-feedback',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'submit_feedback' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Gate the endpoint to users who can view stats, with `manage_options` always accepted —
+	 * matching the originating `stats-admin` permission check.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Inject the current user's email into the body and forward the submission to WordPress.com.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function submit_feedback( WP_REST_Request $request ) {
+		if ( ! ( new Manager( self::SLUG ) )->is_connected() ) {
+			return new WP_Error(
+				'no_connection',
+				__( 'Please connect Jetpack to load your data.', 'jetpack-premium-analytics' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		try {
+			$response = Client::wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%d/jetpack-stats/user-feedback', (int) Jetpack_Options::get_option( 'id' ) ),
+				'2',
+				array(
+					'method'  => 'POST',
+					'timeout' => self::API_TIMEOUT,
+					'headers' => array( 'Content-Type' => 'application/json' ),
+				),
+				wp_json_encode( $this->augment_body( $request ), JSON_UNESCAPED_SLASHES ),
+				'wpcom'
+			);
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'api_error',
+				__( 'Error processing the request.', 'jetpack-premium-analytics' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'api_error',
+				__( 'Error communicating with the data service.', 'jetpack-premium-analytics' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return new WP_REST_Response(
+			json_decode( wp_remote_retrieve_body( $response ), false ),
+			(int) wp_remote_retrieve_response_code( $response )
+		);
+	}
+
+	/**
+	 * Merge the current user's email onto the submitted feedback body. The email is always set last,
+	 * so a client-supplied `user_email` can never spoof it.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function augment_body( WP_REST_Request $request ): array {
+		$body               = (array) json_decode( (string) $request->get_body(), true );
+		$body['user_email'] = wp_get_current_user()->user_email;
+
+		return $body;
+	}
+}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
 use Automattic\Jetpack\PremiumAnalytics\REST\Notices_Controller;
+use Automattic\Jetpack\PremiumAnalytics\REST\User_Feedback_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Configuration as Sync_Configuration;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
@@ -67,6 +68,7 @@ class Analytics {
 		Sync_Configuration::register();
 		Api_Proxy_Controller::register();
 		Notices_Controller::register();
+		User_Feedback_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -308,7 +308,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'no_connection', $response->get_error_code() );
 
-		$augmented = json_decode( $request->get_body(), true );
+		$augmented = (array) json_decode( $request->get_body(), true );
 		$this->assertSame( 'hello', $augmented['message'], 'the original body is preserved' );
 		$this->assertSame( 'feedback@example.com', $augmented['user_email'], 'the current user email is injected' );
 	}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -258,80 +258,6 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
 	}
 
-	public function test_user_feedback_route_is_registered_outside_the_proxy_path() {
-		// The body-rewriting feedback endpoint is bespoke, so it lives on its own route — not under
-		// the agnostic `proxy/` path that only carries transparent forwards.
-		$route   = '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback';
-		$routes  = rest_get_server()->get_routes();
-		$handler = $routes[ $route ][0] ?? null;
-
-		$this->assertNotNull( $handler, 'The user-feedback route should be registered.' );
-		$this->assertStringNotContainsString( 'proxy', $route );
-		$this->assertArrayHasKey( 'POST', $handler['methods'] );
-		$this->assertSame( array( $this->controller, 'handle_user_feedback' ), $handler['callback'] );
-		$this->assertSame( array( $this->controller, 'check_stats_permission' ), $handler['permission_callback'] );
-	}
-
-	public function test_stats_permission_matches_view_stats_tier() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jpa_feedback_viewer',
-				'user_pass'  => 'password',
-				'role'       => 'subscriber',
-			)
-		);
-		$user    = new \WP_User( $user_id );
-		$user->add_cap( 'view_stats' );
-		wp_set_current_user( $user_id );
-		$this->assertTrue( $this->controller->check_stats_permission() );
-
-		wp_set_current_user( 0 );
-		$this->assertFalse( $this->controller->check_stats_permission() );
-	}
-
-	public function test_user_feedback_injects_current_user_email_into_the_body() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jpa_feedback_author',
-				'user_pass'  => 'password',
-				'user_email' => 'feedback@example.com',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
-		$request->set_body( wp_json_encode( array( 'message' => 'hello' ), JSON_UNESCAPED_SLASHES ) );
-
-		// Not connected, so the forward bails after the body is augmented — which is all we assert.
-		$response = $this->controller->handle_user_feedback( $request );
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'no_connection', $response->get_error_code() );
-
-		$augmented = (array) json_decode( $request->get_body(), true );
-		$this->assertSame( 'hello', $augmented['message'], 'the original body is preserved' );
-		$this->assertSame( 'feedback@example.com', $augmented['user_email'], 'the current user email is injected' );
-	}
-
-	public function test_user_feedback_tolerates_an_empty_body() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jpa_feedback_empty',
-				'user_pass'  => 'password',
-				'user_email' => 'empty@example.com',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
-
-		$this->controller->handle_user_feedback( $request );
-
-		$augmented = json_decode( $request->get_body(), true );
-		$this->assertSame( array( 'user_email' => 'empty@example.com' ), $augmented );
-	}
-
 	/**
 	 * @dataProvider data_data_paths
 	 *
@@ -406,9 +332,10 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	public function test_user_feedback_cannot_be_written_through_the_agnostic_proxy_route() {
-		// The bespoke route is the only POST path that injects the user's email. A POST to the same
-		// endpoint via the agnostic proxy must be rejected (the `jetpack-stats` prefix has no write
-		// allowlist), so the augmentation can never be bypassed.
+		// User-feedback has its own controller (User_Feedback_Controller) that injects the user's
+		// email. A POST to the same endpoint via the agnostic proxy must be rejected (the
+		// `jetpack-stats` prefix has no write allowlist), so the proxy can't be used to submit
+		// feedback while sidestepping that injection.
 		$response = $this->controller->handle_data_request( $this->build_data_request( 'POST', 'jetpack-stats/user-feedback' ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $response );

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -258,6 +258,80 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertFalse( $this->controller->check_data_permission( $this->build_data_request( 'GET', 'wordads/earnings' ) ) );
 	}
 
+	public function test_user_feedback_route_is_registered_outside_the_proxy_path() {
+		// The body-rewriting feedback endpoint is bespoke, so it lives on its own route — not under
+		// the agnostic `proxy/` path that only carries transparent forwards.
+		$route   = '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback';
+		$routes  = rest_get_server()->get_routes();
+		$handler = $routes[ $route ][0] ?? null;
+
+		$this->assertNotNull( $handler, 'The user-feedback route should be registered.' );
+		$this->assertStringNotContainsString( 'proxy', $route );
+		$this->assertArrayHasKey( 'POST', $handler['methods'] );
+		$this->assertSame( array( $this->controller, 'handle_user_feedback' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_stats_permission' ), $handler['permission_callback'] );
+	}
+
+	public function test_stats_permission_matches_view_stats_tier() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( $this->controller->check_stats_permission() );
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_stats_permission() );
+	}
+
+	public function test_user_feedback_injects_current_user_email_into_the_body() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_author',
+				'user_pass'  => 'password',
+				'user_email' => 'feedback@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+		$request->set_body( wp_json_encode( array( 'message' => 'hello' ), JSON_UNESCAPED_SLASHES ) );
+
+		// Not connected, so the forward bails after the body is augmented — which is all we assert.
+		$response = $this->controller->handle_user_feedback( $request );
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'no_connection', $response->get_error_code() );
+
+		$augmented = json_decode( $request->get_body(), true );
+		$this->assertSame( 'hello', $augmented['message'], 'the original body is preserved' );
+		$this->assertSame( 'feedback@example.com', $augmented['user_email'], 'the current user email is injected' );
+	}
+
+	public function test_user_feedback_tolerates_an_empty_body() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_empty',
+				'user_pass'  => 'password',
+				'user_email' => 'empty@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+
+		$this->controller->handle_user_feedback( $request );
+
+		$augmented = json_decode( $request->get_body(), true );
+		$this->assertSame( array( 'user_email' => 'empty@example.com' ), $augmented );
+	}
+
 	/**
 	 * @dataProvider data_data_paths
 	 *

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -405,6 +405,17 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertSame( 405, $response->get_error_data()['status'] );
 	}
 
+	public function test_user_feedback_cannot_be_written_through_the_agnostic_proxy_route() {
+		// The bespoke route is the only POST path that injects the user's email. A POST to the same
+		// endpoint via the agnostic proxy must be rejected (the `jetpack-stats` prefix has no write
+		// allowlist), so the augmentation can never be bypassed.
+		$response = $this->controller->handle_data_request( $this->build_data_request( 'POST', 'jetpack-stats/user-feedback' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'rest_read_only', $response->get_error_code() );
+		$this->assertSame( 405, $response->get_error_data()['status'] );
+	}
+
 	public function test_put_to_write_endpoint_returns_405() {
 		// Only POST may mutate — PUT/PATCH on a write-allowed endpoint is still rejected locally.
 		$response = $this->controller->handle_data_request( $this->build_data_request( 'PUT', 'jetpack-stats-dashboard/modules' ) );

--- a/projects/packages/premium-analytics/tests/php/REST/User_Feedback_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/User_Feedback_Controller_Test.php
@@ -101,7 +101,7 @@ class User_Feedback_Controller_Test extends BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
 		$request->set_body( wp_json_encode( array( 'message' => 'hello' ), JSON_UNESCAPED_SLASHES ) );
 
-		$body = $this->augment_body( $request );
+		$body = $this->invoke_augment_body( $request );
 
 		$this->assertSame( 'hello', $body['message'], 'the original body is preserved' );
 		$this->assertSame( 'feedback@example.com', $body['user_email'], 'the current user email is injected' );
@@ -121,7 +121,7 @@ class User_Feedback_Controller_Test extends BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
 		$request->set_body( wp_json_encode( array( 'user_email' => 'spoofed@example.com' ), JSON_UNESCAPED_SLASHES ) );
 
-		$body = $this->augment_body( $request );
+		$body = $this->invoke_augment_body( $request );
 
 		$this->assertSame( 'real@example.com', $body['user_email'], 'a client-supplied email cannot win' );
 	}
@@ -139,7 +139,7 @@ class User_Feedback_Controller_Test extends BaseTestCase {
 
 		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
 
-		$this->assertSame( array( 'user_email' => 'empty@example.com' ), $this->augment_body( $request ) );
+		$this->assertSame( array( 'user_email' => 'empty@example.com' ), $this->invoke_augment_body( $request ) );
 	}
 
 	/**
@@ -149,7 +149,7 @@ class User_Feedback_Controller_Test extends BaseTestCase {
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function augment_body( WP_REST_Request $request ): array {
+	private function invoke_augment_body( WP_REST_Request $request ): array {
 		$accessor = function ( WP_REST_Request $req ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
 			return $this->augment_body( $req );

--- a/projects/packages/premium-analytics/tests/php/REST/User_Feedback_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/User_Feedback_Controller_Test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Tests for User_Feedback_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\User_Feedback_Controller
+ */
+#[CoversClass( User_Feedback_Controller::class )]
+class User_Feedback_Controller_Test extends BaseTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var User_Feedback_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Set up the controller and a fresh REST server.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new User_Feedback_Controller();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_registers_a_post_route_with_the_controller_callbacks() {
+		$route   = '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback';
+		$handler = rest_get_server()->get_routes()[ $route ][0] ?? null;
+
+		$this->assertNotNull( $handler, 'The user-feedback route should be registered.' );
+		$this->assertArrayHasKey( 'POST', $handler['methods'] );
+		$this->assertArrayNotHasKey( 'GET', $handler['methods'], 'Feedback is write-only.' );
+		$this->assertSame( array( $this->controller, 'submit_feedback' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $handler['permission_callback'] );
+	}
+
+	public function test_permission_granted_for_view_stats_and_denied_otherwise() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( $this->controller->check_permission() );
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+
+	public function test_permission_granted_for_administrator() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_returns_403_when_not_connected() {
+		$request  = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+		$response = $this->controller->submit_feedback( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'no_connection', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	public function test_augment_body_injects_current_user_email_and_preserves_the_payload() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_author',
+				'user_pass'  => 'password',
+				'user_email' => 'feedback@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+		$request->set_body( wp_json_encode( array( 'message' => 'hello' ), JSON_UNESCAPED_SLASHES ) );
+
+		$body = $this->augment_body( $request );
+
+		$this->assertSame( 'hello', $body['message'], 'the original body is preserved' );
+		$this->assertSame( 'feedback@example.com', $body['user_email'], 'the current user email is injected' );
+	}
+
+	public function test_augment_body_overrides_a_client_supplied_email() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_spoof',
+				'user_pass'  => 'password',
+				'user_email' => 'real@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+		$request->set_body( wp_json_encode( array( 'user_email' => 'spoofed@example.com' ), JSON_UNESCAPED_SLASHES ) );
+
+		$body = $this->augment_body( $request );
+
+		$this->assertSame( 'real@example.com', $body['user_email'], 'a client-supplied email cannot win' );
+	}
+
+	public function test_augment_body_tolerates_an_empty_body() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_feedback_empty',
+				'user_pass'  => 'password',
+				'user_email' => 'empty@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack-premium-analytics/v1/jetpack-stats/user-feedback' );
+
+		$this->assertSame( array( 'user_email' => 'empty@example.com' ), $this->augment_body( $request ) );
+	}
+
+	/**
+	 * Invoke the controller's private augment_body().
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function augment_body( WP_REST_Request $request ): array {
+		$accessor = function ( WP_REST_Request $req ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->augment_body( $req );
+		};
+
+		return $accessor->call( $this->controller, $request );
+	}
+}

--- a/projects/plugins/premium-analytics/changelog/port-stats-user-feedback
+++ b/projects/plugins/premium-analytics/changelog/port-stats-user-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update package dependencies to bundle the ported Stats user-feedback proxy endpoint.

--- a/projects/plugins/premium-analytics/changelog/port-stats-user-feedback
+++ b/projects/plugins/premium-analytics/changelog/port-stats-user-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update package dependencies to bundle the ported Stats user-feedback proxy endpoint.
+Update package dependencies to bundle the ported Stats user-feedback endpoint.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1538/port-jetpack-statsuser-feedback-post-to-the-premium-analytics-proxy

## Why
The Stats dashboard's "send feedback" submission used to be served only by the `stats-admin` REST controller. As the dashboard's data layer moves onto the `premium-analytics` package (the path toward deprecating `stats-admin`), the feedback POST needs a home under the new `jetpack-premium-analytics/v1` namespace so the ported frontend can submit feedback without going back to the old controller.

## Proposed changes
* Add a dedicated `User_Feedback_Controller` serving `POST jetpack-premium-analytics/v1/jetpack-stats/user-feedback`.
* Its handler injects the current user's email (`wp_get_current_user()->user_email`) into the request body — always last, so a client-supplied `user_email` can't spoof it — then forwards to the WordPress.com v2 endpoint `/sites/<id>/jetpack-stats/user-feedback`.
* Gate it with `view_stats ∨ manage_options`, matching the original `stats-admin` permission check.
* Register the controller alongside the proxy in `Analytics::init()`.
* Add unit coverage (route registration, permission tier, email injection, client-email override, empty-body tolerance) plus a guard in the proxy test that the agnostic route rejects a POST to this endpoint. Changelog entries for the package and the plugin.

### Why a dedicated controller and not the API proxy
The `Api_Proxy_Controller` (`proxy/v<version>/<prefix>/<subpath>`) is deliberately an endpoint-agnostic **transparent** WordPress.com forward — it does not rewrite request bodies. user-feedback's whole job is to rewrite the body (inject the email), so it does not fit the proxy's contract. Rather than hang a bespoke route off the proxy controller and borrow its private cache-aware `forward()` core, it gets its own controller with a small **uncached** POST forward of its own. This keeps the proxy purely the agnostic forwarder, and keeps the feedback endpoint independently understandable and trivially removable when `stats-admin` is eventually deprecated.

## API changes
Adds one write endpoint. The handler augments the body before forwarding to WordPress.com.

<details>
<summary>Request</summary>

```http
POST /wp-json/jetpack-premium-analytics/v1/jetpack-stats/user-feedback
Content-Type: application/json

{ "message": "Great dashboard!" }
```

</details>

<details>
<summary>Forwarded to WordPress.com (body augmented)</summary>

```json
{ "message": "Great dashboard!", "user_email": "current-user@example.com" }
```

</details>

## Verification
No user-visible UI change — this is a backend REST endpoint. A live forward requires a connected commercial Stats site on WordPress.com (not reproducible in a fresh local env), so the behavior is exercised by unit tests against a real `WP_REST_Server` and `WP_User`: route registration, the `view_stats ∨ manage_options` gate, the not-connected 403 path, the email injection (payload preserved; client-supplied email overridden; empty body tolerated), and a proxy-side guard that the agnostic route can't POST this endpoint. Full suite: `OK (125 tests, 268 assertions)`, phpcs clean.

<details>
<summary>Output</summary>

```text
$ composer phpunit -- --filter User_Feedback_Controller_Test --testdox
User Feedback Controller (Automattic\Jetpack\PremiumAnalytics\REST\User_Feedback_Controller)
 ✔ Registers a post route with the controller callbacks
 ✔ Permission granted for view stats and denied otherwise
 ✔ Permission granted for administrator
 ✔ Returns 403 when not connected
 ✔ Augment body injects current user email and preserves the payload
 ✔ Augment body overrides a client supplied email
 ✔ Augment body tolerates an empty body
OK (7 tests, 16 assertions)
```

</details>

## Related product discussion/links
* [WOOA7S-1538](https://linear.app/a8c/issue/WOOA7S-1538/port-jetpack-statsuser-feedback-post-to-the-premium-analytics-proxy) (deferred from [WOOA7S-1534](https://linear.app/a8c/issue/WOOA7S-1534))

## Does this pull request change what data or activity we track or use?
No. This ports an existing submission path (the user's email was already sent to WordPress.com by the `stats-admin` controller); it does not add new data collection.

## Testing instructions
Acceptance criteria from the issue:
- [ ] The user-feedback POST is reachable at `jetpack-premium-analytics/v1/jetpack-stats/user-feedback`.
- [ ] The handler injects the current user's email (`wp_get_current_user()->user_email`) into the request body before forwarding.
- [ ] It forwards to the WordPress.com v2 endpoint `/sites/<id>/jetpack-stats/user-feedback`, matching the original `stats-admin` behavior.
- [ ] Permission gate is `view_stats ∨ manage_options`.
- [ ] The agnostic proxy route behavior is unchanged (and can't be used to POST this endpoint).
- [ ] `stats-admin` remains registered (no deprecation in this change).

To verify locally:
* `cd projects/packages/premium-analytics && composer phpunit` → `OK (125 tests, 268 assertions)`.
* Confirm the route exists: the `wp rest` index includes `jetpack-premium-analytics/v1/jetpack-stats/user-feedback` with `POST` once the premium-analytics plugin is active.
