### PR TITLE
Premium Analytics: port the notices endpoints to the package

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1537-port-notices-endpoints
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1537-port-notices-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Expose the dashboard notices under `jetpack-premium-analytics/v1/notices` (GET + POST), backed by a Notices class ported from stats-admin that merges the WordPress.com dismissal state with locally-derived opt-in/opt-out/feedback/GDPR flags.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-stats": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {

--- a/projects/packages/premium-analytics/src/REST/class-notices-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-notices-controller.php
@@ -83,7 +83,7 @@ class Notices_Controller {
 						),
 						'postponed_for' => array(
 							'type'        => 'number',
-							'default'     => null,
+							'default'     => 0,
 							'description' => __( 'Postponed for (in seconds).', 'jetpack-premium-analytics' ),
 							'minimum'     => 0,
 						),
@@ -105,10 +105,12 @@ class Notices_Controller {
 	/**
 	 * Get the notices to show, with locally-derived flags merged in.
 	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @return array
 	 */
-	public function get_notices(): array {
-		return ( new Notices() )->get_notices_to_show();
+	public function get_notices( WP_REST_Request $request ): array {
+		return ( new Notices() )->get_notices_to_show( null !== $request->get_param( 'force_refresh' ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/REST/class-notices-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-notices-controller.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * REST controller for the dashboard notices, which need local processing the data proxy can't do.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\PremiumAnalytics\Notices;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Exposes `jetpack-premium-analytics/v1/notices` (GET + POST).
+ *
+ * Unlike the transparent endpoints served by {@see Api_Proxy_Controller}, the notices GET augments
+ * the WPCOM dismissal state with locally-derived flags (opt-in/opt-out/feedback/GDPR), so it lives
+ * on its own route outside `proxy/` and delegates to the {@see Notices} class.
+ */
+class Notices_Controller {
+
+	/**
+	 * Package slug, used as the REST namespace root.
+	 *
+	 * @var string
+	 */
+	private const SLUG = 'jetpack-premium-analytics';
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	private $namespace;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = self::SLUG . '/v1';
+	}
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the notices route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/notices',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_notices' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_notice' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => array(
+						'id'            => array(
+							'required'    => true,
+							'type'        => 'string',
+							'description' => __( 'ID of the notice.', 'jetpack-premium-analytics' ),
+						),
+						'status'        => array(
+							'required'    => true,
+							'type'        => 'string',
+							'description' => __( 'Status of the notice.', 'jetpack-premium-analytics' ),
+						),
+						'postponed_for' => array(
+							'type'        => 'number',
+							'default'     => null,
+							'description' => __( 'Postponed for (in seconds).', 'jetpack-premium-analytics' ),
+							'minimum'     => 0,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Whether the current user may read or change the dashboard notices.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Get the notices to show, with locally-derived flags merged in.
+	 *
+	 * @return array
+	 */
+	public function get_notices(): array {
+		return ( new Notices() )->get_notices_to_show();
+	}
+
+	/**
+	 * Dismiss or delay a notice.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function update_notice( WP_REST_Request $request ) {
+		return ( new Notices() )->update_notice(
+			$request->get_param( 'id' ),
+			$request->get_param( 'status' ),
+			$request->get_param( 'postponed_for' )
+		);
+	}
+}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
+use Automattic\Jetpack\PremiumAnalytics\REST\Notices_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
 /**
@@ -61,6 +62,7 @@ class Analytics {
 
 		Sync_Status_Tracker::configure();
 		Api_Proxy_Controller::register();
+		Notices_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/src/class-notices.php
+++ b/projects/packages/premium-analytics/src/class-notices.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Computes the dashboard notices, merging WPCOM-stored dismissals with locally-derived flags.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Jetpack_Options;
+use WP_Error;
+
+/**
+ * Ported from `Automattic\Jetpack\Stats_Admin\Notices` so premium-analytics owns the notices
+ * surface without depending on the (to-be-deprecated) stats-admin package. The WPCOM dismissal
+ * state is fetched/updated through the blog token; the opt-in/opt-out/feedback/GDPR flags are
+ * derived locally from `Stats\Options` and the environment.
+ */
+class Notices {
+	const NOTICES_CACHE_KEY             = 'jetpack_premium_analytics_notices_cache_key';
+	const OPT_OUT_NEW_STATS_NOTICE_ID   = 'opt_out_new_stats';
+	const NEW_STATS_FEEDBACK_NOTICE_ID  = 'new_stats_feedback';
+	const OPT_IN_NEW_STATS_NOTICE_ID    = 'opt_in_new_stats';
+	const GDPR_COOKIE_CONSENT_NOTICE_ID = 'gdpr_cookie_consent';
+
+	const VIEWS_TO_SHOW_FEEDBACK      = 3;
+	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
+
+	/**
+	 * How long the WPCOM dismissal state stays cached.
+	 *
+	 * @var int
+	 */
+	const CACHE_TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Update notice status.
+	 *
+	 * @param mixed $id ID of the notice.
+	 * @param mixed $status Status of the notice.
+	 * @param int   $postponed_for Postponed for how many seconds.
+	 * @return array|WP_Error
+	 */
+	public function update_notice( $id, $status, $postponed_for = 0 ) {
+		delete_transient( self::NOTICES_CACHE_KEY );
+
+		return $this->request_as_blog(
+			array(
+				'timeout' => 5,
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json' ),
+			),
+			wp_json_encode(
+				array(
+					'id'            => $id,
+					'status'        => $status,
+					'postponed_for' => $postponed_for,
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	/**
+	 * Return an array of notice IDs as keys and a boolean flagging whether to show them.
+	 *
+	 * @return array
+	 */
+	public function get_notices_to_show() {
+		$notices_wpcom = $this->get_notices_from_wpcom();
+
+		$new_stats_enabled        = Stats_Options::get_option( 'enable_odyssey_stats' );
+		$stats_views              = intval( Stats_Options::get_option( 'views' ) );
+		$odyssey_stats_changed_at = intval( Stats_Options::get_option( 'odyssey_stats_changed_at' ) );
+
+		// Check if Jetpack is integrated with the Complianz plugin, which blocks the Stats.
+		$complianz_options_integrations  = get_option( 'complianz_options_integrations' );
+		$is_jetpack_blocked_by_complianz = ! isset( $complianz_options_integrations['jetpack'] ) || $complianz_options_integrations['jetpack'];
+
+		return array_merge(
+			$notices_wpcom,
+			array(
+				// Show Opt-in notice 30 days after the new stats being disabled.
+				self::OPT_IN_NEW_STATS_NOTICE_ID    => ! $new_stats_enabled
+					&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+					&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+
+				// Show feedback notice after 3 views of the new stats.
+				self::NEW_STATS_FEEDBACK_NOTICE_ID  => $new_stats_enabled
+					&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
+					&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+
+				// Show opt-out notice before 3 views of the new stats, where 3 is included.
+				self::OPT_OUT_NEW_STATS_NOTICE_ID   => $new_stats_enabled
+					&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
+					&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+
+				// GDPR cookie consent notice for Complianz users.
+				self::GDPR_COOKIE_CONSENT_NOTICE_ID => class_exists( 'COMPLIANZ' ) && $is_jetpack_blocked_by_complianz
+					&& ! $this->is_notice_hidden( self::GDPR_COOKIE_CONSENT_NOTICE_ID ),
+			)
+		);
+	}
+
+	/**
+	 * Get the array of notice dismissal flags stored on WPCOM, cached for {@see CACHE_TTL}.
+	 *
+	 * @return array
+	 */
+	public function get_notices_from_wpcom() {
+		if ( ! $this->should_bypass_cache() ) {
+			$cached = get_transient( self::NOTICES_CACHE_KEY );
+			if ( false !== $cached ) {
+				return json_decode( $cached, true );
+			}
+		}
+
+		$notices_wpcom = $this->request_as_blog( array( 'timeout' => 5 ) );
+		if ( is_wp_error( $notices_wpcom ) ) {
+			return array();
+		}
+
+		set_transient( self::NOTICES_CACHE_KEY, wp_json_encode( $notices_wpcom, JSON_UNESCAPED_SLASHES ), self::CACHE_TTL );
+
+		return $notices_wpcom;
+	}
+
+	/**
+	 * Checks if a notice is hidden.
+	 *
+	 * @param mixed $id ID of the notice.
+	 * @return bool
+	 */
+	public function is_notice_hidden( $id ) {
+		$notices_wpcom = $this->get_notices_from_wpcom();
+		return array_key_exists( $id, $notices_wpcom ) && $notices_wpcom[ $id ] === false;
+	}
+
+	/**
+	 * Send a blog-token request to the WPCOM notices endpoint and return its decoded body.
+	 *
+	 * @param array       $args Request arguments passed to the connection client.
+	 * @param string|null $body Request body, for writes.
+	 * @return array|WP_Error Decoded response body, or a WP_Error on transport or API error.
+	 */
+	private function request_as_blog( array $args, $body = null ) {
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/jetpack-stats-dashboard/notices', Jetpack_Options::get_option( 'id' ) ),
+			'v2',
+			$args,
+			$body,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		$decoded       = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		$error_code = null;
+		foreach ( array( 'code', 'error' ) as $key ) {
+			if ( isset( $decoded[ $key ] ) ) {
+				$error_code = $decoded[ $key ];
+				break;
+			}
+		}
+
+		if ( null !== $error_code || 200 !== $response_code ) {
+			return new WP_Error(
+				$error_code,
+				$decoded['message'] ?? 'unknown remote error',
+				array( 'status' => $response_code )
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Whether the caller asked to skip the cached WPCOM dismissal state.
+	 *
+	 * @return bool
+	 */
+	private function should_bypass_cache() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['force_refresh'] );
+	}
+}

--- a/projects/packages/premium-analytics/src/class-notices.php
+++ b/projects/packages/premium-analytics/src/class-notices.php
@@ -188,11 +188,12 @@ class Notices {
 		if ( null !== $error_code || 200 !== $response_code ) {
 			return new WP_Error(
 				$error_code,
-				$decoded['message'] ?? 'unknown remote error',
+				is_array( $decoded ) ? ( $decoded['message'] ?? 'unknown remote error' ) : 'unknown remote error',
 				array( 'status' => $response_code )
 			);
 		}
 
-		return $decoded;
+		// The notices endpoint always returns a JSON object; coerce anything else to an empty map.
+		return is_array( $decoded ) ? $decoded : array();
 	}
 }

--- a/projects/packages/premium-analytics/src/class-notices.php
+++ b/projects/packages/premium-analytics/src/class-notices.php
@@ -119,7 +119,8 @@ class Notices {
 		if ( ! $bypass_cache ) {
 			$cached = get_transient( self::NOTICES_CACHE_KEY );
 			if ( false !== $cached ) {
-				return json_decode( $cached, true );
+				$decoded = json_decode( $cached, true );
+				return is_array( $decoded ) ? $decoded : array();
 			}
 		}
 
@@ -186,8 +187,10 @@ class Notices {
 		}
 
 		if ( null !== $error_code || 200 !== $response_code ) {
+			// Fall back to a non-empty code so WP_Error keeps the status/message instead of
+			// constructing an empty error (WP_Error::__construct bails on an empty code).
 			return new WP_Error(
-				$error_code,
+				$error_code ?? 'notices_request_failed',
 				is_array( $decoded ) ? ( $decoded['message'] ?? 'unknown remote error' ) : 'unknown remote error',
 				array( 'status' => $response_code )
 			);

--- a/projects/packages/premium-analytics/src/class-notices.php
+++ b/projects/packages/premium-analytics/src/class-notices.php
@@ -29,7 +29,9 @@ class Notices {
 	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
 
 	/**
-	 * How long the WPCOM dismissal state stays cached.
+	 * How long the WPCOM dismissal state stays cached. While stats-admin runs in parallel, both
+	 * surfaces read the same WPCOM resource under separate cache keys, so a dismissal through one
+	 * can leave the other stale for up to this window — acceptable during the migration.
 	 *
 	 * @var int
 	 */
@@ -66,10 +68,13 @@ class Notices {
 	/**
 	 * Return an array of notice IDs as keys and a boolean flagging whether to show them.
 	 *
+	 * @param bool $bypass_cache Refetch the WPCOM dismissal state instead of using the cached copy.
 	 * @return array
 	 */
-	public function get_notices_to_show() {
-		$notices_wpcom = $this->get_notices_from_wpcom();
+	public function get_notices_to_show( bool $bypass_cache = false ) {
+		// Fetch the WPCOM map once and reuse it for every flag, so a force-refresh costs a single
+		// round-trip rather than one per shared-key lookup.
+		$notices_wpcom = $this->get_notices_from_wpcom( $bypass_cache );
 
 		$new_stats_enabled        = Stats_Options::get_option( 'enable_odyssey_stats' );
 		$stats_views              = intval( Stats_Options::get_option( 'views' ) );
@@ -85,21 +90,21 @@ class Notices {
 				// Show Opt-in notice 30 days after the new stats being disabled.
 				self::OPT_IN_NEW_STATS_NOTICE_ID    => ! $new_stats_enabled
 					&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
-					&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+					&& ! $this->is_hidden( $notices_wpcom, self::OPT_IN_NEW_STATS_NOTICE_ID ),
 
 				// Show feedback notice after 3 views of the new stats.
 				self::NEW_STATS_FEEDBACK_NOTICE_ID  => $new_stats_enabled
 					&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
-					&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+					&& ! $this->is_hidden( $notices_wpcom, self::NEW_STATS_FEEDBACK_NOTICE_ID ),
 
 				// Show opt-out notice before 3 views of the new stats, where 3 is included.
 				self::OPT_OUT_NEW_STATS_NOTICE_ID   => $new_stats_enabled
 					&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
-					&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+					&& ! $this->is_hidden( $notices_wpcom, self::OPT_OUT_NEW_STATS_NOTICE_ID ),
 
 				// GDPR cookie consent notice for Complianz users.
 				self::GDPR_COOKIE_CONSENT_NOTICE_ID => class_exists( 'COMPLIANZ' ) && $is_jetpack_blocked_by_complianz
-					&& ! $this->is_notice_hidden( self::GDPR_COOKIE_CONSENT_NOTICE_ID ),
+					&& ! $this->is_hidden( $notices_wpcom, self::GDPR_COOKIE_CONSENT_NOTICE_ID ),
 			)
 		);
 	}
@@ -107,10 +112,11 @@ class Notices {
 	/**
 	 * Get the array of notice dismissal flags stored on WPCOM, cached for {@see CACHE_TTL}.
 	 *
+	 * @param bool $bypass_cache Refetch instead of returning the cached copy.
 	 * @return array
 	 */
-	public function get_notices_from_wpcom() {
-		if ( ! $this->should_bypass_cache() ) {
+	public function get_notices_from_wpcom( bool $bypass_cache = false ) {
+		if ( ! $bypass_cache ) {
 			$cached = get_transient( self::NOTICES_CACHE_KEY );
 			if ( false !== $cached ) {
 				return json_decode( $cached, true );
@@ -128,13 +134,23 @@ class Notices {
 	}
 
 	/**
-	 * Checks if a notice is hidden.
+	 * Checks if a notice is hidden, fetching the WPCOM dismissal state.
 	 *
 	 * @param mixed $id ID of the notice.
 	 * @return bool
 	 */
 	public function is_notice_hidden( $id ) {
-		$notices_wpcom = $this->get_notices_from_wpcom();
+		return $this->is_hidden( $this->get_notices_from_wpcom(), $id );
+	}
+
+	/**
+	 * Whether a notice is hidden in an already-fetched WPCOM dismissal map.
+	 *
+	 * @param array $notices_wpcom The WPCOM dismissal map.
+	 * @param mixed $id            ID of the notice.
+	 * @return bool
+	 */
+	private function is_hidden( array $notices_wpcom, $id ) {
 		return array_key_exists( $id, $notices_wpcom ) && $notices_wpcom[ $id ] === false;
 	}
 
@@ -178,15 +194,5 @@ class Notices {
 		}
 
 		return $decoded;
-	}
-
-	/**
-	 * Whether the caller asked to skip the cached WPCOM dismissal state.
-	 *
-	 * @return bool
-	 */
-	private function should_bypass_cache() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return isset( $_GET['force_refresh'] );
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Notices_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Notices_Test.php
@@ -71,6 +71,14 @@ class Notices_Test extends BaseTestCase {
 		$this->assertSame( array(), $this->notices->get_notices_from_wpcom() );
 	}
 
+	public function test_bypass_cache_still_resolves_the_flags() {
+		set_transient( Notices::NOTICES_CACHE_KEY, wp_json_encode( array( Notices::OPT_OUT_NEW_STATS_NOTICE_ID => false ), JSON_UNESCAPED_SLASHES ), Notices::CACHE_TTL );
+
+		// With the cache bypassed the stored map is ignored; the live fetch fails closed to [] here,
+		// so the opt-out flag is no longer suppressed by the cached dismissal.
+		$this->assertTrue( $this->notices->get_notices_to_show( true )[ Notices::OPT_OUT_NEW_STATS_NOTICE_ID ] );
+	}
+
 	public function test_is_notice_hidden_false_when_no_wpcom_state() {
 		$this->assertFalse( $this->notices->is_notice_hidden( Notices::OPT_OUT_NEW_STATS_NOTICE_ID ) );
 	}

--- a/projects/packages/premium-analytics/tests/php/Notices_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Notices_Test.php
@@ -9,8 +9,6 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -65,25 +63,17 @@ class Notices_Test extends BaseTestCase {
 		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::OPT_IN_NEW_STATS_NOTICE_ID ] );
 	}
 
-	public function test_gdpr_notice_hidden_without_complianz() {
+	public function test_gdpr_notice_reflects_complianz_presence() {
+		// Negative case first — a class can't be undefined, so the positive case below would leak
+		// the `COMPLIANZ` alias into a separate negative test.
 		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::GDPR_COOKIE_CONSENT_NOTICE_ID ] );
-	}
 
-	/**
-	 * Runs in a separate process: aliasing a stub onto the global `COMPLIANZ` name to satisfy the
-	 * notice's `class_exists()` gate would otherwise leak into the negative test above.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_gdpr_notice_shows_when_complianz_blocks_jetpack() {
 		require_once __DIR__ . '/fixtures/class-complianz-stub.php';
 		class_alias( Complianz_Stub::class, 'COMPLIANZ' );
 
 		// No `jetpack` key in the integrations option means Jetpack is treated as blocked.
 		delete_option( 'complianz_options_integrations' );
+		delete_transient( Notices::NOTICES_CACHE_KEY );
 
 		$this->assertTrue( ( new Notices() )->get_notices_to_show()[ Notices::GDPR_COOKIE_CONSENT_NOTICE_ID ] );
 	}

--- a/projects/packages/premium-analytics/tests/php/Notices_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Notices_Test.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for the ported Notices class.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * The WPCOM dismissal fetch fails closed to an empty array in the test environment (no connection),
+ * so these exercise the locally-derived flags layered on top of it.
+ *
+ * @covers \Automattic\Jetpack\PremiumAnalytics\Notices
+ */
+#[CoversClass( Notices::class )]
+class Notices_Test extends BaseTestCase {
+
+	/**
+	 * Notices instance under test.
+	 *
+	 * @var Notices
+	 */
+	private $notices;
+
+	/**
+	 * Set up a known stats-options baseline.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Stats_Options::set_option( 'enable_odyssey_stats', true );
+		Stats_Options::set_option( 'views', 0 );
+		Stats_Options::set_option( 'odyssey_stats_changed_at', 0 );
+		delete_transient( Notices::NOTICES_CACHE_KEY );
+		$this->notices = new Notices();
+	}
+
+	public function test_opt_out_notice_shows_below_the_feedback_view_threshold() {
+		$this->assertTrue( $this->notices->get_notices_to_show()[ Notices::OPT_OUT_NEW_STATS_NOTICE_ID ] );
+
+		Stats_Options::set_option( 'views', Notices::VIEWS_TO_SHOW_FEEDBACK );
+		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::OPT_OUT_NEW_STATS_NOTICE_ID ] );
+	}
+
+	public function test_feedback_notice_shows_at_the_view_threshold() {
+		Stats_Options::set_option( 'views', Notices::VIEWS_TO_SHOW_FEEDBACK );
+		$this->assertTrue( $this->notices->get_notices_to_show()[ Notices::NEW_STATS_FEEDBACK_NOTICE_ID ] );
+	}
+
+	public function test_opt_in_notice_shows_after_postpone_window_when_disabled() {
+		Stats_Options::set_option( 'enable_odyssey_stats', false );
+		Stats_Options::set_option( 'odyssey_stats_changed_at', time() - ( Notices::POSTPONE_OPT_IN_NOTICE_DAYS + 1 ) * DAY_IN_SECONDS );
+		$this->assertTrue( $this->notices->get_notices_to_show()[ Notices::OPT_IN_NEW_STATS_NOTICE_ID ] );
+	}
+
+	public function test_opt_in_notice_hidden_within_postpone_window() {
+		Stats_Options::set_option( 'enable_odyssey_stats', false );
+		Stats_Options::set_option( 'odyssey_stats_changed_at', time() );
+		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::OPT_IN_NEW_STATS_NOTICE_ID ] );
+	}
+
+	public function test_gdpr_notice_hidden_without_complianz() {
+		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::GDPR_COOKIE_CONSENT_NOTICE_ID ] );
+	}
+
+	public function test_wpcom_dismissal_fetch_fails_closed_to_empty_array() {
+		$this->assertSame( array(), $this->notices->get_notices_from_wpcom() );
+	}
+
+	public function test_is_notice_hidden_false_when_no_wpcom_state() {
+		$this->assertFalse( $this->notices->is_notice_hidden( Notices::OPT_OUT_NEW_STATS_NOTICE_ID ) );
+	}
+
+	public function test_update_notice_returns_error_without_a_connection() {
+		$this->assertInstanceOf( \WP_Error::class, $this->notices->update_notice( 'opt_out_new_stats', 'dismissed' ) );
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/Notices_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Notices_Test.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -65,6 +67,25 @@ class Notices_Test extends BaseTestCase {
 
 	public function test_gdpr_notice_hidden_without_complianz() {
 		$this->assertFalse( $this->notices->get_notices_to_show()[ Notices::GDPR_COOKIE_CONSENT_NOTICE_ID ] );
+	}
+
+	/**
+	 * Runs in a separate process: aliasing a stub onto the global `COMPLIANZ` name to satisfy the
+	 * notice's `class_exists()` gate would otherwise leak into the negative test above.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_gdpr_notice_shows_when_complianz_blocks_jetpack() {
+		require_once __DIR__ . '/fixtures/class-complianz-stub.php';
+		class_alias( Complianz_Stub::class, 'COMPLIANZ' );
+
+		// No `jetpack` key in the integrations option means Jetpack is treated as blocked.
+		delete_option( 'complianz_options_integrations' );
+
+		$this->assertTrue( ( new Notices() )->get_notices_to_show()[ Notices::GDPR_COOKIE_CONSENT_NOTICE_ID ] );
 	}
 
 	public function test_wpcom_dismissal_fetch_fails_closed_to_empty_array() {

--- a/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
@@ -78,6 +78,8 @@ class Notices_Controller_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'id', $args );
 		$this->assertArrayHasKey( 'status', $args );
 		$this->assertArrayHasKey( 'postponed_for', $args );
+		$this->assertNotEmpty( $args['id']['required'] );
+		$this->assertNotEmpty( $args['status']['required'] );
 	}
 
 	public function test_permission_granted_for_view_stats_capability() {

--- a/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
@@ -68,7 +68,7 @@ class Notices_Controller_Test extends BaseTestCase {
 	}
 
 	public function test_write_route_requires_id_and_status() {
-		$args = null;
+		$args = array();
 		foreach ( rest_get_server()->get_routes()[ self::ROUTE ] as $handler ) {
 			if ( isset( $handler['methods']['POST'] ) ) {
 				$args = $handler['args'];

--- a/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for Notices_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Notices_Controller
+ */
+#[CoversClass( Notices_Controller::class )]
+class Notices_Controller_Test extends BaseTestCase {
+
+	const ROUTE = '/jetpack-premium-analytics/v1/notices';
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Notices_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Set up the controller and a fresh REST server.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new Notices_Controller();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_registers_notices_route_with_read_and_write_methods() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+
+		$methods = array();
+		foreach ( $routes[ self::ROUTE ] as $handler ) {
+			$methods += $handler['methods'];
+		}
+		$this->assertArrayHasKey( 'GET', $methods );
+		$this->assertArrayHasKey( 'POST', $methods );
+	}
+
+	public function test_route_uses_expected_callbacks() {
+		$handlers = rest_get_server()->get_routes()[ self::ROUTE ];
+
+		$by_method = array();
+		foreach ( $handlers as $handler ) {
+			foreach ( $handler['methods'] as $method => $enabled ) {
+				$by_method[ $method ] = $handler;
+			}
+		}
+
+		$this->assertSame( array( $this->controller, 'get_notices' ), $by_method['GET']['callback'] );
+		$this->assertSame( array( $this->controller, 'update_notice' ), $by_method['POST']['callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $by_method['GET']['permission_callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $by_method['POST']['permission_callback'] );
+	}
+
+	public function test_write_route_requires_id_and_status() {
+		$args = null;
+		foreach ( rest_get_server()->get_routes()[ self::ROUTE ] as $handler ) {
+			if ( isset( $handler['methods']['POST'] ) ) {
+				$args = $handler['args'];
+			}
+		}
+
+		$this->assertTrue( $args['id']['required'] );
+		$this->assertTrue( $args['status']['required'] );
+		$this->assertArrayHasKey( 'postponed_for', $args );
+	}
+
+	public function test_permission_granted_for_view_stats_capability() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_notices_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_permission_granted_for_administrator() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_notices_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_permission_denied_for_anonymous_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Notices_Controller_Test.php
@@ -67,16 +67,16 @@ class Notices_Controller_Test extends BaseTestCase {
 		$this->assertSame( array( $this->controller, 'check_permission' ), $by_method['POST']['permission_callback'] );
 	}
 
-	public function test_write_route_requires_id_and_status() {
+	public function test_write_route_declares_notice_args() {
 		$args = array();
 		foreach ( rest_get_server()->get_routes()[ self::ROUTE ] as $handler ) {
-			if ( isset( $handler['methods']['POST'] ) ) {
-				$args = $handler['args'];
+			if ( isset( $handler['methods']['POST'] ) && isset( $handler['args'] ) ) {
+				$args = (array) $handler['args'];
 			}
 		}
 
-		$this->assertTrue( $args['id']['required'] );
-		$this->assertTrue( $args['status']['required'] );
+		$this->assertArrayHasKey( 'id', $args );
+		$this->assertArrayHasKey( 'status', $args );
 		$this->assertArrayHasKey( 'postponed_for', $args );
 	}
 

--- a/projects/packages/premium-analytics/tests/php/fixtures/class-complianz-stub.php
+++ b/projects/packages/premium-analytics/tests/php/fixtures/class-complianz-stub.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+/**
+ * Stand-in for the Complianz plugin's `COMPLIANZ` class, aliased onto that global name inside the
+ * process-isolated GDPR notice test.
+ */
+class Complianz_Stub {}

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1537-port-notices-endpoints
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1537-port-notices-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Pull in the jetpack-stats dependency for the ported notices endpoints.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -597,10 +597,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "dd17cf5694478ecd58ce9249b8dc70081a75531a"
+                "reference": "bc35ef49714df7ccf555ed326238ebe79158b25c"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-stats": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "php": ">=7.2"
             },
@@ -768,6 +769,73 @@
             }
         },
         {
+            "name": "automattic/jetpack-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/stats",
+                "reference": "353dcc22a8de746e21bd2c6334d1ca7206fea704"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-stats",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.19.x-dev"
+                },
+                "textdomain": "jetpack-stats"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Stats\\": "tests/php"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Collect valuable traffic stats and insights.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-status",
             "version": "dev-trunk",
             "dist": {
@@ -899,6 +967,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "97a1a9548ae11e0cd0f0514d81c0701474968828"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
             "transport-options": {
                 "relative": true
             }
@@ -1549,16 +1675,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.29",
+            "version": "12.5.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/900400a5b616d6fb306f9549f6da33ba615d3fbb",
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb",
                 "shasum": ""
             },
             "require": {
@@ -1627,7 +1753,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.30"
             },
             "funding": [
                 {
@@ -1635,7 +1761,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-04T06:14:42+00:00"
+            "time": "2026-06-15T13:12:30+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Fixes [WOOA7S-1537](https://linear.app/a8c/issue/WOOA7S-1537/port-notices-endpoints-local-notices-class-to-the-premium-analytics)

## Why

The Premium Analytics dashboard needs its stats notices (opt-in/opt-out/feedback/GDPR prompts) without depending on the `stats-admin` package we intend to deprecate. This ports the notices surface into `premium-analytics` so the dashboard can read and dismiss notices through its own namespace.

## Proposed changes

* Add a `Notices` class to `premium-analytics`, ported from `Stats_Admin\Notices`: it fetches the WordPress.com dismissal state and merges in the locally-derived `opt_in_new_stats` / `new_stats_feedback` / `opt_out_new_stats` / `gdpr_cookie_consent` flags.
* The port reads stats options via `Stats\Options` (the **backend** `jetpack-stats` package — not the deprecated `stats-admin`) and talks to WordPress.com through `Connection\Client` directly, dropping the `stats-admin` `WPCOM_Client` dependency.
* Add `Notices_Controller` exposing `GET`/`POST jetpack-premium-analytics/v1/notices`, gated by `view_stats` ∨ `manage_options`. The notices GET needs local processing, so it lives on its own route outside the transparent `proxy/` surface (per the proxy controller's own contract).
* Add `automattic/jetpack-stats` as a package dependency; add a `minor` changelog entry.
* Unit tests cover route registration, the permission callback, and every locally-derived notice flag.

This is a backend/API-only change — **no user-visible UI** in this PR. Wiring the frontend to the new route is tracked separately in WOOA7S-1539.

## API changes

Adds `GET`/`POST /wp-json/jetpack-premium-analytics/v1/notices`. The GET returns the WordPress.com dismissal map merged with the four local flags; the POST dismisses/postpones a notice and busts the local cache.

<details>
<summary>GET request + response (admin, live WPCOM)</summary>

```http
GET /wp-json/jetpack-premium-analytics/v1/notices
```

```json
{
  "opt_out_new_stats": false,
  "new_stats_feedback": true,
  "opt_in_new_stats": false,
  "do_you_love_jetpack_stats": true,
  "commercial_site_upgrade": true,
  "tier_upgrade": true,
  "focus_jetpack_purchase": true,
  "traffic_page_settings": true,
  "traffic_page_highlights_module_settings": true,
  "gdpr_cookie_consent": false,
  "able_to_submit_user_feedback": true,
  "show_floating_user_feedback_panel": true
}
```

</details>

<details>
<summary>POST request + response (admin, live WPCOM)</summary>

```http
POST /wp-json/jetpack-premium-analytics/v1/notices
Content-Type: application/json

{ "id": "opt_out_new_stats", "status": "dismissed", "postponed_for": 0 }
```

```json
{ "updated": true }
```

</details>

<details>
<summary>Permission gate</summary>

```text
admin (manage_options) GET     → 200
subscriber             GET     → 403
anonymous              GET     → 401
```

</details>

## Related product discussion/links

* [WOOA7S-1537](https://linear.app/a8c/issue/WOOA7S-1537/port-notices-endpoints-local-notices-class-to-the-premium-analytics)
* Parent: [WOOA7S-1534](https://linear.app/a8c/issue/WOOA7S-1534) — extend the API proxy to cover Stats-Admin endpoints

## Does this pull request change what data or activity we track or use?

No. It re-exposes the existing stats-notices behaviour under a new namespace; the data fetched and stored is unchanged.

## Testing instructions

The `stats-admin` notices routes remain registered and unchanged — this adds a parallel surface.

* Build the matrix and bring up a connected env: `jp build packages/premium-analytics && jp build plugins/premium-analytics`.
* As an admin, `GET /wp-json/jetpack-premium-analytics/v1/notices` returns 200 with the WordPress.com notices plus the four local flags (`opt_in_new_stats`, `new_stats_feedback`, `opt_out_new_stats`, `gdpr_cookie_consent`).
* `POST` the same route with `{ "id": "opt_out_new_stats", "status": "dismissed" }` and confirm it returns `{ "updated": true }` and that the next GET reflects the dismissal (cache is busted on write).
* Confirm the permission gate: a `view_stats`/admin user is allowed; a subscriber gets 403 and an anonymous request 401.
* `cd projects/packages/premium-analytics && composer phpunit` is green (131 tests); `composer phpcs:lint` is clean.
