### PR TITLE
Premium Analytics: point data layer at the versioned agnostic proxy route

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1539-data-layer-versioned-proxy
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1539-data-layer-versioned-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Data layer: point report requests at the endpoint-agnostic proxy route (proxy/v2/analytics/reports) after the per-endpoint proxy route was removed.

--- a/projects/packages/premium-analytics/packages/data/src/api/constants.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Constants for API endpoints
  */
-export const reportsPath = '/jetpack-premium-analytics/v1/proxy/reports';
+export const reportsPath = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';

--- a/projects/packages/premium-analytics/packages/data/src/api/report-visitors-by-location-fetch/report-visitors-by-location-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/report-visitors-by-location-fetch/report-visitors-by-location-fetch.ts
@@ -36,7 +36,7 @@ export type RequestReportVisitorsByLocationParams = BaseReportParams & {
 /**
  * Fetch visitors grouped by location (country or region) for the selected period.
  *
- * This endpoint is proxied through `/jetpack-premium-analytics/v1/proxy/reports/...`
+ * This endpoint is proxied through `/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/...`
  * and ultimately served by wpcom analytics.
  */
 export async function fetchReportVisitorsByLocation( {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -48,7 +48,7 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
  * Base path that all report requests share. Matches `reportsPath` in the data
  * package (`@jetpack-premium-analytics/data`).
  */
-const API_BASE = '/jetpack-premium-analytics/v1/proxy/reports';
+const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
 
 /**
  * Days of mock data to generate (covering past requests).


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1539

## Why

PR #49571 replaced the Premium Analytics REST proxy's per-endpoint route with a single endpoint-agnostic, versioned route and **removed** the old `proxy/<subpath>` route. The dashboard data layer was still pointing at the removed route, so every report request resolved to a dead endpoint (`rest_no_route`). This points the data layer at the new route so report requests reach the live proxy again.

## Proposed changes

* Update `reportsPath` in `@automattic/jetpack-premium-analytics-data` from `/jetpack-premium-analytics/v1/proxy/reports` to `/jetpack-premium-analytics/v1/proxy/v2/analytics/reports`, matching the new `proxy/v<version>/<prefix>/<subpath>` shape (analytics is the `analytics` prefix on WPCOM API v2). All 14 `report-*-fetch` functions build off this single constant.
* Move the Storybook MSW mock base (`register-report-mocks.ts` `API_BASE`) in lockstep so widget stories keep intercepting.
* Fix the stale path reference in the `report-visitors-by-location-fetch` doc comment.

## Related product discussion/links

* WOOA7S-1539 — https://linear.app/a8c/issue/WOOA7S-1539
* WOOA7S-1534 / PR #49571 — the proxy rewrite this follows.

## Does this pull request change what data or activity we track or use?

No. This only changes the REST path the dashboard calls; the data fetched and the blog-token auth are unchanged.

## Verification

Dispatched the report path against a local env with the proxy controller active, comparing the route the data layer used **before** this change with the one it uses **after**. The old path is gone (`rest_no_route`); the new path routes through to the analytics orders handler (it only errors because this env has no live WPCOM analytics backend — `woocommerce_analytics_orders_error`, not a routing miss).

<details>
<summary>Output</summary>

```text
OLD (data layer before #49571):
  GET .../jetpack-premium-analytics/v1/proxy/reports/orders/by-date
  404 => {"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}

NEW (data layer after this PR):
  GET .../jetpack-premium-analytics/v1/proxy/v2/analytics/reports/orders/by-date
  500 => {"code":"woocommerce_analytics_orders_error","message":"Failed to retrieve orders data. Please try again later.","data":{"status":500}}
```

The registered route confirms the prefix/version shape the constant now targets:

```text
/jetpack-premium-analytics/v1/proxy/v(?P<version>[0-9]+(?:\.[0-9]+)?)/(?P<endpoint>(?:analytics|stats|wordads|subscribers|...)(?:/.*)?)
```

</details>

## Testing instructions

* [ ] `reportsPath` resolves to `/jetpack-premium-analytics/v1/proxy/v2/analytics/reports`.
* [ ] On a site with the premium-analytics plugin active, a report request (e.g. `GET /wp-json/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/orders/by-date`) reaches the proxy controller rather than returning `rest_no_route`.
* [ ] The old `…/proxy/reports/…` path returns `rest_no_route` (route removed in #49571).
* [ ] Storybook `API_BASE` matches `reportsPath` so widget stories keep intercepting.
* [ ] Build passes: `jp build packages/premium-analytics`.
