### PR TITLE
Premium Analytics: add post-list and post-likes public-api endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1536-public-api-posts-endpoints
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1536-public-api-posts-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Add dedicated post-list (`jetpack-premium-analytics/v1/posts`, WPCOM API v1.1, `force=wpcom`) and post-likes (`jetpack-premium-analytics/v1/posts/<id>/likes`, v1.2) endpoints that read from the WordPress.com public API, ported from the stats-admin controller as part of deprecating that package.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {

--- a/projects/packages/premium-analytics/src/REST/class-post-likes-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-post-likes-controller.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * REST controller exposing a single post's likes for the analytics dashboard.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Jetpack_Options;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Returns a single post's likes via the WordPress.com public API at v1.2.
+ */
+class Post_Likes_Controller extends Public_Api_Controller {
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the post-likes route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/posts/(?P<resource_id>[\d]+)/likes',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Return the post's likes.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return mixed|\WP_Error
+	 */
+	public function get_items( $request ) {
+		$site_id = (int) Jetpack_Options::get_option( 'id' );
+		$post_id = (int) $request->get_param( 'resource_id' );
+
+		// resource_id lives in the path, so it's dropped from the forwarded query string.
+		return $this->request_public_api(
+			sprintf( 'sites/%d/posts/%d/likes', $site_id, $post_id ),
+			'1.2',
+			$request->get_params(),
+			array( 'resource_id' )
+		);
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/class-posts-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-posts-controller.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * REST controller exposing the site's post list for the analytics dashboard.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Jetpack_Options;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Lists the site's posts via the WordPress.com public API at v1.1, forcing the WPCOM-backed
+ * response (`force=wpcom`) so the dashboard sees the same data regardless of the local site's
+ * Jetpack sync state.
+ */
+class Posts_Controller extends Public_Api_Controller {
+
+	/**
+	 * Hook the controller's routes onto rest_api_init.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$controller = new self();
+		add_action( 'rest_api_init', array( $controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the post-list route.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/posts',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * List the site's posts.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return mixed|\WP_Error
+	 */
+	public function get_items( $request ) {
+		$params = array_merge( array( 'force' => 'wpcom' ), $request->get_params() );
+
+		return $this->request_public_api(
+			sprintf( 'sites/%d/posts', (int) Jetpack_Options::get_option( 'id' ) ),
+			'1.1',
+			$params
+		);
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/class-public-api-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-public-api-controller.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Base REST controller for endpoints that read directly from the WordPress.com public API.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\Constants;
+use WP_Error;
+use WP_REST_Controller;
+
+/**
+ * Shared plumbing for dashboard endpoints that fetch from `public-api.wordpress.com` over an
+ * unauthenticated `wp_remote_get`, rather than the blog-token proxy ({@see Api_Proxy_Controller}).
+ *
+ * These endpoints exist because their WPCOM counterparts behave differently per API version
+ * (e.g. `force=wpcom`) and don't fit the agnostic proxy's `/sites/<id>/<path>` shape. Subclasses
+ * register their own route and call {@see request_public_api()} with the target path, version, and
+ * request params.
+ */
+abstract class Public_Api_Controller extends WP_REST_Controller {
+
+	/**
+	 * Timeout for the outbound public-api request, in seconds.
+	 *
+	 * @var int
+	 */
+	private const API_TIMEOUT = 5;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'jetpack-premium-analytics/v1';
+	}
+
+	/**
+	 * Stats access: an administrator or any user who can view stats.
+	 *
+	 * @return bool
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Fetch a path from the WordPress.com public API and normalize the result.
+	 *
+	 * Mirrors `stats-admin`: transport errors pass through as-is, a non-200 becomes a `WP_Error`
+	 * carrying the remote status and message, and a 200 returns the decoded body.
+	 *
+	 * @param string               $path          WPCOM path under the version base (e.g. `sites/123/posts`).
+	 * @param string               $version       WPCOM API version (e.g. `1.1`, `1.2`).
+	 * @param array<string, mixed> $params        Request params to forward as the query string.
+	 * @param string[]             $keys_to_unset Param keys to drop before building the query.
+	 *
+	 * @return mixed|WP_Error Decoded response body, or a WP_Error on transport/remote failure.
+	 */
+	protected function request_public_api( string $path, string $version, array $params, array $keys_to_unset = array() ) {
+		$url = sprintf(
+			'%s/rest/v%s/%s?%s',
+			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
+			$version,
+			$path,
+			$this->build_query( $params, $keys_to_unset )
+		);
+
+		$response = wp_remote_get( $url, array( 'timeout' => self::API_TIMEOUT ) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $code ) {
+			return new WP_Error(
+				isset( $body['error'] ) ? 'remote-error-' . $body['error'] : 'remote-error',
+				$body['message'] ?? 'unknown remote error',
+				array( 'status' => $code )
+			);
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Build a query string from request params, dropping WordPress routing noise and the given keys.
+	 *
+	 * @param array<string, mixed> $params        Request params.
+	 * @param string[]             $keys_to_unset Param keys to drop (e.g. route-only params).
+	 *
+	 * @return string
+	 */
+	private function build_query( array $params, array $keys_to_unset = array() ): string {
+		unset( $params['rest_route'] );
+		foreach ( $keys_to_unset as $key ) {
+			unset( $params[ $key ] );
+		}
+
+		return http_build_query( $params );
+	}
+}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
+use Automattic\Jetpack\PremiumAnalytics\REST\Post_Likes_Controller;
+use Automattic\Jetpack\PremiumAnalytics\REST\Posts_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
 /**
@@ -61,6 +63,8 @@ class Analytics {
 
 		Sync_Status_Tracker::configure();
 		Api_Proxy_Controller::register();
+		Posts_Controller::register();
+		Post_Likes_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/tests/php/REST/Post_Likes_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Post_Likes_Controller_Test.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for Post_Likes_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Post_Likes_Controller
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Public_Api_Controller
+ */
+#[CoversClass( Post_Likes_Controller::class )]
+#[CoversClass( Public_Api_Controller::class )]
+class Post_Likes_Controller_Test extends BaseTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Post_Likes_Controller
+	 */
+	private $controller;
+
+	/**
+	 * The URL the stubbed transport last saw.
+	 *
+	 * @var string
+	 */
+	private $requested_url = '';
+
+	/**
+	 * Set up the controller, a fresh REST server, and a known blog id.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new Post_Likes_Controller();
+		Jetpack_Options::update_option( 'id', 1234 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down() {
+		$this->requested_url = '';
+		remove_all_filters( 'pre_http_request' );
+		Constants::clear_constants();
+		parent::tear_down();
+	}
+
+	public function test_registers_the_post_likes_route() {
+		$this->assertArrayHasKey( '/jetpack-premium-analytics/v1/posts/(?P<resource_id>[\d]+)/likes', rest_get_server()->get_routes() );
+	}
+
+	public function test_route_is_read_only_and_uses_the_controller_callbacks() {
+		$handler = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/posts/(?P<resource_id>[\d]+)/likes'][0];
+
+		$this->assertArrayHasKey( 'GET', $handler['methods'] );
+		$this->assertArrayNotHasKey( 'POST', $handler['methods'] );
+		$this->assertSame( array( $this->controller, 'get_items' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $handler['permission_callback'] );
+	}
+
+	public function test_permission_denied_for_anonymous_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+
+	public function test_get_items_requests_v1_2_likes_and_drops_resource_id_from_query() {
+		$this->stub_http( 200, array( 'found' => 7 ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts/55/likes' );
+		$request->set_param( 'resource_id', '55' );
+		$this->controller->get_items( $request );
+
+		$this->assertStringContainsString( 'https://public-api.wordpress.com/rest/v1.2/sites/1234/posts/55/likes?', $this->requested_url );
+		$this->assertStringNotContainsString( 'resource_id', $this->requested_url );
+	}
+
+	public function test_get_items_returns_decoded_body_on_success() {
+		$this->stub_http( 200, array( 'found' => 7 ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts/55/likes' );
+		$request->set_param( 'resource_id', '55' );
+
+		$this->assertSame( 7, $this->controller->get_items( $request )['found'] );
+	}
+
+	public function test_get_items_maps_remote_error_to_wp_error() {
+		$this->stub_http( 404, array( 'message' => 'not found' ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts/55/likes' );
+		$request->set_param( 'resource_id', '55' );
+		$result = $this->controller->get_items( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'remote-error', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Stub the outbound HTTP request, capturing the URL and returning a canned response.
+	 *
+	 * @param int   $status Response status code.
+	 * @param array $body   Response body (JSON-encoded into the response).
+	 */
+	private function stub_http( int $status, array $body ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $status, $body ) {
+				$this->requested_url = $url;
+				return array(
+					'response' => array( 'code' => $status ),
+					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/REST/Posts_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Posts_Controller_Test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for Posts_Controller.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST;
+
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Posts_Controller
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Public_Api_Controller
+ */
+#[CoversClass( Posts_Controller::class )]
+#[CoversClass( Public_Api_Controller::class )]
+class Posts_Controller_Test extends BaseTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Posts_Controller
+	 */
+	private $controller;
+
+	/**
+	 * The URL the stubbed transport last saw.
+	 *
+	 * @var string
+	 */
+	private $requested_url = '';
+
+	/**
+	 * Set up the controller, a fresh REST server, and a known blog id.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new Posts_Controller();
+		Jetpack_Options::update_option( 'id', 1234 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down() {
+		$this->requested_url = '';
+		remove_all_filters( 'pre_http_request' );
+		Constants::clear_constants();
+		parent::tear_down();
+	}
+
+	public function test_registers_the_posts_route() {
+		$this->assertArrayHasKey( '/jetpack-premium-analytics/v1/posts', rest_get_server()->get_routes() );
+	}
+
+	public function test_route_is_read_only_and_uses_the_controller_callbacks() {
+		$handler = rest_get_server()->get_routes()['/jetpack-premium-analytics/v1/posts'][0];
+
+		$this->assertArrayHasKey( 'GET', $handler['methods'] );
+		$this->assertArrayNotHasKey( 'POST', $handler['methods'] );
+		$this->assertSame( array( $this->controller, 'get_items' ), $handler['callback'] );
+		$this->assertSame( array( $this->controller, 'check_permission' ), $handler['permission_callback'] );
+	}
+
+	public function test_permission_granted_for_view_stats_capability() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jpa_posts_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		$user    = new \WP_User( $user_id );
+		$user->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( $this->controller->check_permission() );
+	}
+
+	public function test_permission_denied_for_anonymous_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->controller->check_permission() );
+	}
+
+	public function test_get_items_requests_v1_1_posts_with_force_wpcom() {
+		$this->stub_http( 200, array( 'posts' => array() ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts' );
+		$request->set_query_params( array( 'number' => '5' ) );
+		$this->controller->get_items( $request );
+
+		$this->assertStringContainsString( 'https://public-api.wordpress.com/rest/v1.1/sites/1234/posts?', $this->requested_url );
+		$this->assertStringContainsString( 'force=wpcom', $this->requested_url );
+		$this->assertStringContainsString( 'number=5', $this->requested_url );
+	}
+
+	public function test_get_items_returns_decoded_body_on_success() {
+		$this->stub_http( 200, array( 'found' => 2 ) );
+
+		$result = $this->controller->get_items( new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts' ) );
+
+		$this->assertSame( 2, $result['found'] );
+	}
+
+	public function test_get_items_maps_remote_error_to_wp_error() {
+		$this->stub_http(
+			403,
+			array(
+				'error'   => 'unauthorized',
+				'message' => 'nope',
+			)
+		);
+
+		$result = $this->controller->get_items( new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/posts' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'remote-error-unauthorized', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Stub the outbound HTTP request, capturing the URL and returning a canned response.
+	 *
+	 * @param int   $status Response status code.
+	 * @param array $body   Response body (JSON-encoded into the response).
+	 */
+	private function stub_http( int $status, array $body ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $status, $body ) {
+				$this->requested_url = $url;
+				return array(
+					'response' => array( 'code' => $status ),
+					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1536/port-local-post-endpoints-to-the-premium-analytics-proxy

## Why

The Premium Analytics dashboard needs the site's post list and a post's likes. In `stats-admin` these were fetched directly from `public-api.wordpress.com` (not the blog-token-signed JSON API) — the post list at v1.1 with `force=wpcom`, the likes at v1.2 — because their behaviour is version-specific and doesn't fit the agnostic proxy's `/sites/<id>/<path>` shape. As `stats-admin` is deprecated, these move into `premium-analytics` as dedicated controllers, deliberately kept **outside** `Api_Proxy_Controller` (which is reserved for transparent blog-token WPCOM forwards).

This is the second of two PRs splitting WOOA7S-1536 by mechanism; the companion ([#49643](https://github.com/Automattic/jetpack/pull/49643)) ports the local-DB single-post endpoint.

## Proposed changes

* Add `Public_Api_Controller` (`src/REST/class-public-api-controller.php`), an abstract base sharing the unauthenticated `public-api.wordpress.com` `wp_remote_get`, the `manage_options ∨ view_stats` permission check, and the `stats-admin` error normalization (transport error passthrough; non-200 → `WP_Error('remote-error[-<error>]', <message>, status)`).
* Add `Posts_Controller` → `GET jetpack-premium-analytics/v1/posts` (v1.1, injects `force=wpcom`).
* Add `Post_Likes_Controller` → `GET jetpack-premium-analytics/v1/posts/<id>/likes` (v1.2, `resource_id` dropped from the forwarded query since it's in the path).
* **Bug fix vs source:** `get_site_posts`' `sprintf` had 3 format specifiers but 4 args, so `resource_id` (empty) filled the query-string slot and the real params — including `force=wpcom` — were silently dropped. The ported version forwards the intended query (verified below: `"wpcom":true` and `number`/`fields` are honored).
* Declare the now-direct `automattic/jetpack-constants` dependency; wire both controllers into `Analytics::init()`; add unit tests and a changelog entry.

## API changes

Adds two local REST endpoints that read from the WordPress.com public API.

<details>
<summary>Request — post list</summary>

```http
GET /wp-json/jetpack-premium-analytics/v1/posts?number=1&fields=ID,title,URL
```

</details>

<details>
<summary>Response — 200 (force=wpcom honored, query forwarded)</summary>

```json
{
    "found": 59,
    "posts": [
        { "ID": 2083, "title": "stats", "URL": "https://jp-atlas.jurassic.tube/2025/12/09/stats/" }
    ],
    "meta": { "links": { "counts": "https://public-api.wordpress.com/rest/v1.1/sites/254381802/post-counts/post" }, "wpcom": true }
}
```

</details>

<details>
<summary>Request / Response — post likes (v1.2)</summary>

```http
GET /wp-json/jetpack-premium-analytics/v1/posts/2083/likes
```

```json
{
    "found": 0,
    "i_like": false,
    "likes": [],
    "meta": { "links": {
        "help": "https://public-api.wordpress.com/rest/v1.2/sites/254381802/posts/2083/likes/help",
        "post": "https://public-api.wordpress.com/rest/v1.1/sites/254381802/posts/2083",
        "site": "https://public-api.wordpress.com/rest/v1.2/sites/254381802"
    } }
}
```

</details>

<details>
<summary>Edge cases — remote error normalization, anonymous user</summary>

```text
GET /jetpack-premium-analytics/v1/posts/999999999/likes   (admin)
STATUS: 404  {"code":"remote-error-unknown_post","message":"Unknown post","data":{"status":404}}

GET /jetpack-premium-analytics/v1/posts                     (anonymous)
STATUS: 401
```

</details>

Exercised on a WPCOM-connected local docker env via `rest_do_request`; 130 package PHPUnit tests pass; phpcs clean. No user-visible UI, so no screenshots.

## Related product discussion/links

* [WOOA7S-1536](https://linear.app/a8c/issue/WOOA7S-1536/port-local-post-endpoints-to-the-premium-analytics-proxy) (follow-up to WOOA7S-1534)
* Companion PR: #49643 (single-post local-DB endpoint)

## Does this pull request change what data or activity we track or use?

No. It re-exposes existing post data that `stats-admin` already served via the same public API; no new data is collected or shared.

## Testing instructions

* Build the env: `jp build packages/premium-analytics && jp build plugins/premium-analytics` (plus the foundational `my-jetpack` / `plugins/jetpack` layers), bring up a docker WP env connected to WordPress.com with the Premium Analytics plugin active.
* `GET /wp-json/jetpack-premium-analytics/v1/posts` as an admin → `200`; the WPCOM-backed payload includes `"wpcom": true`, and passing `number` / `fields` narrows the response (proving the query reaches WPCOM).
* `GET /wp-json/jetpack-premium-analytics/v1/posts/<id>/likes` as an admin → `200` with `found` / `i_like` / `likes` / `meta`.
* `GET .../posts/<bad-id>/likes` → `404` `remote-error-unknown_post` (remote error normalized to a `WP_Error`).
* `GET .../posts` as a logged-out user → `401`/`403`. A `view_stats`-only user is permitted; a plain subscriber is denied.
* `cd projects/packages/premium-analytics && composer phpunit` passes (130 tests).
