### PR TITLE
Premium Analytics: sweep residual proxy/reports references in mock docs and a test literal

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1539-sweep-stale-proxy-comments
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1539-sweep-stale-proxy-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comments/tests: update residual proxy/reports path references in Storybook mock docs and a REST test literal to the versioned agnostic proxy route. No functional change.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/bookings.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/bookings.ts
@@ -1,7 +1,7 @@
 /**
  * Mock data generator for bookings endpoint
  *
- * API endpoint: /wc/v3/woocommerce-analytics/proxy/reports/bookings/by-date
+ * API endpoint: /jetpack-premium-analytics/v1/proxy/v2/analytics/reports/bookings/by-date
  *
  * This module provides dynamic fixture generation based on request parameters.
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/order-attribution.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/order-attribution.ts
@@ -2,7 +2,7 @@
  * Mock data for order attribution endpoint
  * Used by: SalesByDeviceWidget
  *
- * API format: /wc/v3/woocommerce-analytics/proxy/reports/order-attribution/:view/summary
+ * API format: /jetpack-premium-analytics/v1/proxy/v2/analytics/reports/order-attribution/:view/summary
  * Values are strings (the sanitizer converts them to numbers)
  */
 import type { fetchReportOrderAttributionSummary } from '../../../../../data/src/api/report-order-attribution-summary-fetch/report-order-attribution-summary-fetch';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/orders-by-product-type.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/orders-by-product-type.ts
@@ -2,7 +2,7 @@
  * Mock data generator for orders-by-product-type endpoint
  * Used by: BookingOrderMetricWidget, future product-filtered widgets
  *
- * API endpoint: /wc/v3/woocommerce-analytics/proxy/reports/orders-by-product-type/by-date
+ * API endpoint: /jetpack-premium-analytics/v1/proxy/v2/analytics/reports/orders-by-product-type/by-date
  * Called when: Product type filters are present (bookings, simple products, etc.)
  *
  * This module provides dynamic fixture generation based on request parameters.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -3,10 +3,10 @@
  *
  * The shared Jetpack Storybook config cannot be modified, and there is no
  * analytics backend in Storybook. Upstream (woocommerce-analytics) solves this
- * with MSW handlers that intercept `/wc/v3/woocommerce-analytics/proxy/reports/*`.
+ * with MSW handlers that intercept its report REST paths.
  *
  * Here we achieve the same effect by registering an `apiFetch` middleware that
- * intercepts the same report paths and returns generated mock data. The data
+ * intercepts the proxy report paths and returns generated mock data. The data
  * package fetches every report through `apiFetch( { path } )` using the same
  * base path (`reportsPath`), so a single middleware covers all widget stories.
  *

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -135,7 +135,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 			'reports/totals',
 			array(
 				'period'     => 'week',
-				'rest_route' => '/jetpack-premium-analytics/v1/proxy/reports/totals',
+				'rest_route' => '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/totals',
 				'_locale'    => 'user',
 			)
 		);


### PR DESCRIPTION
Follow-up to #49646 (WOOA7S-1539).

## Why

While reviewing #49646, the AI reviewers flagged a few `proxy/reports` path references that survived the main fix — doc comments and one test literal that still describe the pre-#49571 route shape. They're cosmetic (no behavior depends on them), but they're confusing next to the now-versioned route, so this sweeps them for consistency.

## Proposed changes

* Update the three Storybook mock-data doc comments (`order-attribution.ts`, `orders-by-product-type.ts`, `bookings.ts`) to the current `/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/...` route shape.
* Reword the `register-report-mocks.ts` header so the upstream-context sentence no longer asserts the stale `/wc/v3/woocommerce-analytics/proxy/reports/*` literal that could be misread as the local path.
* Update an inert `rest_route` literal in `Api_Proxy_Controller_Test.php` (`test_cache_key_ignores_wordpress_routing_params`) to the new route shape — it's an arbitrary routing-param value used to prove the cache key strips routing params, so the assertion is unaffected.

## Related product discussion/links

* WOOA7S-1539 — https://linear.app/a8c/issue/WOOA7S-1539
* Parent PR — #49646

## Does this pull request change what data or activity we track or use?

No. Comment- and test-only changes; no runtime behavior changes.

## Testing instructions

* [ ] No `proxy/reports` (pre-#49571 shape) references remain in `projects/packages/premium-analytics` outside changelog: `grep -rn "proxy/reports" projects/packages/premium-analytics | grep -v "proxy/v2/analytics/reports"` returns nothing.
* [ ] `Api_Proxy_Controller_Test.php` PHP tests still pass (the `rest_route` literal change is inert — the cache key strips routing params regardless of value).
* [ ] Storybook still builds and widget stories render with mock data (the mock middleware base is unchanged; only doc comments moved).
