### PR TITLE
PCG: increase rollout to 20%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-pcg-rollout-20-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-pcg-rollout-20-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: increase rollout to 20%.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -10,7 +10,7 @@
  */
 class PCG_Rollout {
 
-	const DEFAULT_PERCENTAGE = 10;
+	const DEFAULT_PERCENTAGE = 20;
 
 	/**
 	 * Priority 100 leaves room for emergency overrides at higher priorities.


### PR DESCRIPTION
## Changes proposed in this Pull Request

Bump the Plugin Conflicts Guardian default rollout percentage from 10% to 20%.

`PCG_Rollout::DEFAULT_PERCENTAGE` controls the share of sites where the Plugin Conflicts Guardian gates plugin activations/updates. This continues the staged rollout (5% → 10% → 20%).

Note: this branch builds on `update/pcg-rollout-10-percent` (not yet merged), so the diff against trunk reads 5% → 20%.

## Other information

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you added a changelog entry?

## Jetpack product discussion

N/A — internal rollout tuning.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- The default percentage is now `20`. The `pcg_rollout_percentage` filter still overrides it.