### PR TITLE
Premium Analytics: interim port of the woocommerce_analytics Jetpack Sync module 

### DIFF
--- a/projects/packages/premium-analytics/.phan/baseline.php
+++ b/projects/packages/premium-analytics/.phan/baseline.php
@@ -11,6 +11,7 @@ return [
     // # Issue statistics:
     // PhanUndeclaredMethod : 10+ occurrences
     // PhanUndeclaredClassReference : 3 occurrences
+    // UnusedPluginSuppression : 3 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanUndeclaredClassConstant : 1 occurrence
 
@@ -20,13 +21,15 @@ return [
     // (e.g. get_report_customer_id, is_returning_customer, get_item_shipping_amount, get_taxes),
     // and internal classes absent from the stubs (FulfillmentUtils, FeaturesController,
     // OrderInternalStatus). All are guarded behind a WooCommerce-active check at runtime.
-    // The older WooCommerce stubs used by the "previous WP version and old Woo" Phan job also
-    // lack the OrderAttributionMeta trait and the OrderStatsDataStore::has_fulfillment_status_column /
-    // OrderUtil::uses_new_full_refund_data static methods, which surface as PhanUndeclaredTrait and
-    // PhanUndeclaredStaticMethod; both are likewise guarded at runtime.
+    // The OrderAttributionMeta trait and the OrderStatsDataStore::has_fulfillment_status_column /
+    // OrderUtil::uses_new_full_refund_data static methods exist in current WooCommerce stubs but
+    // are absent from the older stubs used by the "previous WP version and old Woo" Phan job. They
+    // are suppressed inline in the source (@phan-suppress-next-line) rather than here, because that
+    // pass cannot baseline them; the resulting UnusedPluginSuppression under current stubs is what
+    // this baseline records instead.
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/Sync/class-woocommerce-analytics-module.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod', 'PhanUndeclaredTrait'],
+        'src/Sync/class-woocommerce-analytics-module.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredMethod', 'UnusedPluginSuppression'],
         'src/Sync/trait-utilities.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/premium-analytics/.phan/baseline.php
+++ b/projects/packages/premium-analytics/.phan/baseline.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
+ *
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
+ */
+return [
+    // # Issue statistics:
+    // PhanUndeclaredMethod : 10+ occurrences
+    // PhanUndeclaredClassReference : 3 occurrences
+    // PhanUndeclaredClassMethod : 2 occurrences
+    // PhanUndeclaredClassConstant : 1 occurrence
+
+    // These are WooCommerce runtime symbols that this TEMPORARY sync-module port (WOOA7S-1550)
+    // references but Phan cannot resolve from the bundled WooCommerce stubs: methods that
+    // WooCommerce Analytics mixes onto WC_Order/WC_Order_Item via runtime trait/subclass overrides
+    // (e.g. get_report_customer_id, is_returning_customer, get_item_shipping_amount, get_taxes),
+    // and internal classes absent from the stubs (FulfillmentUtils, FeaturesController,
+    // OrderInternalStatus). All are guarded behind a WooCommerce-active check at runtime.
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [
+        'src/Sync/class-woocommerce-analytics-module.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredMethod'],
+        'src/Sync/trait-utilities.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
+    ],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/premium-analytics/.phan/baseline.php
+++ b/projects/packages/premium-analytics/.phan/baseline.php
@@ -20,9 +20,13 @@ return [
     // (e.g. get_report_customer_id, is_returning_customer, get_item_shipping_amount, get_taxes),
     // and internal classes absent from the stubs (FulfillmentUtils, FeaturesController,
     // OrderInternalStatus). All are guarded behind a WooCommerce-active check at runtime.
+    // The older WooCommerce stubs used by the "previous WP version and old Woo" Phan job also
+    // lack the OrderAttributionMeta trait and the OrderStatsDataStore::has_fulfillment_status_column /
+    // OrderUtil::uses_new_full_refund_data static methods, which surface as PhanUndeclaredTrait and
+    // PhanUndeclaredStaticMethod; both are likewise guarded at runtime.
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/Sync/class-woocommerce-analytics-module.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredMethod'],
+        'src/Sync/class-woocommerce-analytics-module.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod', 'PhanUndeclaredTrait'],
         'src/Sync/trait-utilities.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/premium-analytics/.phan/config.php
+++ b/projects/packages/premium-analytics/.phan/config.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
-		// WooCommerce stubs for the TEMPORARY interim sync module port (WOOA7S-1550 Option B).
+		// WooCommerce stubs for the TEMPORARY interim sync module port (WOOA7S-1550).
 		// WooCommerce is a runtime, not composer, dependency; these let Phan resolve WC symbols.
 		'+stubs'             => array( 'woocommerce', 'woocommerce-internal' ),
 		'exclude_file_regex' => array(

--- a/projects/packages/premium-analytics/.phan/config.php
+++ b/projects/packages/premium-analytics/.phan/config.php
@@ -13,6 +13,9 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
+		// WooCommerce stubs for the TEMPORARY interim sync module port (WOOA7S-1550 Option B).
+		// WooCommerce is a runtime, not composer, dependency; these let Phan resolve WC symbols.
+		'+stubs'             => array( 'woocommerce', 'woocommerce-internal' ),
 		'exclude_file_regex' => array(
 			'build/',
 		),

--- a/projects/packages/premium-analytics/changelog/wooa7s-1550-sync-module-port
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1550-sync-module-port
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Interim port of the woocommerce_analytics Jetpack Sync module.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
+		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},

--- a/projects/packages/premium-analytics/src/Sync/class-configuration.php
+++ b/projects/packages/premium-analytics/src/Sync/class-configuration.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ *
+ * Plain replacement for woocommerce-analytics' src/Internal/Jetpack/Sync/Configuration.php.
+ * The upstream class is wired through a PHP-DI container and RegistrableInterface; the
+ * monorepo package has no DI container, so this is a plain class invoked from
+ * {@see \Automattic\Jetpack\PremiumAnalytics\Analytics::init()}.
+ *
+ * It registers the same Jetpack Sync filters upstream's Configuration does and ensures the
+ * Sync feature so the `woocommerce_analytics` full-sync module runs. Connection bootstrap and
+ * the admin-script enqueue from the upstream class are intentionally omitted — they are handled
+ * elsewhere in the monorepo and are out of scope for this sync port.
+ *
+ * WooCommerce is a runtime (not composer) dependency, so {@see register()} guards on WooCommerce
+ * being active before hooking anything; the ported module is only ever instantiated in that case.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\Sync;
+
+use Automattic\Jetpack\Config;
+use Automattic\Jetpack\Sync\Data_Settings;
+use Automattic\Jetpack\Sync\Modules as JetpackSyncModules;
+use Automattic\Jetpack\Sync\Modules\Meta as Meta_Module;
+use Automattic\Jetpack\Sync\Modules\Posts as Posts_Module;
+use Automattic\Jetpack\Sync\Modules\Term_Relationships as Term_Relationships_Module;
+use Automattic\Jetpack\Sync\Modules\Terms as Terms_Module;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the WooCommerce Analytics Jetpack Sync module and its supporting filters.
+ */
+class Configuration {
+
+	use Utilities;
+
+	/**
+	 * List of post meta to add to Sync's post meta whitelist.
+	 * Any changes to these meta will by synced to WordPress.com.
+	 *
+	 * @static
+	 * @var array
+	 */
+	private static $postmeta_to_sync = array(
+		// Products.
+		'_stock',
+		'_stock_quantity',
+		'_cogs_total_value',
+		'_global_unique_id',
+		// Bookings.
+		'_booking_parent_id',
+		'_booking_duplicate_of',
+		'_booking_product_id',
+		'_booking_resource_id',
+		'_booking_order_id',
+		'_booking_order_item_id',
+		'_booking_customer_id',
+		'_booking_start',
+		'_booking_end',
+		'_booking_all_day',
+		'_booking_persons',
+		'_booking_cost',
+		'_booking_date_cancelled',
+		'_booking_attendance_status',
+	);
+
+	/**
+	 * Entry point called from Analytics::init(). Schedules the Sync hookups on plugins_loaded;
+	 * the actual registration is a no-op unless WooCommerce is active (see {@see configure_sync()}).
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		$instance = new self();
+
+		// Defer the WooCommerce-active guard and all hookups to plugins_loaded so they run after
+		// every plugin (including WooCommerce) has loaded, regardless of plugin load order.
+		// Analytics::init() runs during plugin include, before plugins_loaded fires; the priority-1
+		// timing also lets the Jetpack Config constructed below run its own on_plugins_loaded
+		// (priority 2) handler in the same cycle.
+		if ( did_action( 'plugins_loaded' ) ) {
+			$instance->configure_sync();
+		} else {
+			add_action( 'plugins_loaded', array( $instance, 'configure_sync' ), 1 );
+		}
+	}
+
+	/**
+	 * Whether WooCommerce is active in the current request.
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_active(): bool {
+		return class_exists( 'WooCommerce' ) || function_exists( 'WC' );
+	}
+
+	/**
+	 * Register the Jetpack Sync filters and ensure the Sync feature, when WooCommerce is active.
+	 *
+	 * No-op unless WooCommerce is active, since the module relies on WooCommerce runtime symbols
+	 * (WC_Order, the wc_order_stats table, OrderUtil, etc.).
+	 *
+	 * @return void
+	 */
+	public function configure_sync(): void {
+		if ( ! self::is_woocommerce_active() ) {
+			return;
+		}
+
+		add_filter( 'jetpack_sync_modules', array( $this, 'add_woocommerce_analytics_module' ) );
+		add_filter( 'jetpack_full_sync_config', array( $this, 'expand_full_sync_config' ) );
+		add_filter( 'jetpack_sync_checksum_allowed_tables', array( $this, 'add_order_stats_to_checksum' ) );
+		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_meta_to_sync_post_meta_whitelist' ) );
+
+		( new Config() )->ensure( 'sync', $this->get_jetpack_sync_config() );
+	}
+
+	/**
+	 * Add the WooCommerce Analytics module to the list of Jetpack Sync modules.
+	 *
+	 * Additive: appends to whatever module list is already configured rather than replacing it.
+	 *
+	 * @param array $modules The current list of sync module class names.
+	 * @return array
+	 */
+	public function add_woocommerce_analytics_module( $modules ) {
+		if ( is_array( $modules ) && ! in_array( WooCommerce_Analytics_Module::class, $modules, true ) ) {
+			$modules[] = WooCommerce_Analytics_Module::class;
+		}
+
+		return $modules;
+	}
+
+	/**
+	 * Jetpack Sync module configuration.
+	 *
+	 * @return array Jetpack Sync config array.
+	 */
+	private function get_jetpack_sync_config(): array {
+		$jetpack_sync_modules = array_keys(
+			array_filter(
+				array(
+					WooCommerce_Analytics_Module::class => true, // WooCommerce Analytics module.
+					Meta_Module::class                  => true,
+					Posts_Module::class                 => true,
+					Terms_Module::class                 => true,
+					Term_Relationships_Module::class    => true,
+				)
+			)
+		);
+
+		return array_merge_recursive(
+			Data_Settings::MUST_SYNC_DATA_SETTINGS,
+			array(
+				'jetpack_sync_modules'             => $jetpack_sync_modules,
+				'jetpack_sync_options_whitelist'   => array(
+					'woocommerce_custom_orders_table_enabled', // Required for HPOS checksums.
+					'woocommerce_excluded_report_order_statuses', // Required for generating analytics reports.
+					'woocommerce_date_type', // Date used to determine the date range for analytics reports.
+				),
+				'jetpack_sync_constants_whitelist' => array(
+					'WC_ANALYTICS_VERSION',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Expand full sync config with module required by WooCommerce Analytics if not already present.
+	 *
+	 * @param array $config The current full sync configuration.
+	 * @return array The modified full sync configuration.
+	 */
+	public function expand_full_sync_config( array $config ): array {
+		if ( ! $this->can_site_sync_orders() ) {
+			return $config;
+		}
+
+		// Let's ensure Terms and Term_Relationships will always get synced before Posts during Full Sync.
+		if ( isset( $config['posts'] ) ) {
+			unset( $config['posts'] );
+			$config = $config + array( 'posts' => 1 );
+		}
+
+		if ( ! isset( $config['woocommerce_analytics'] ) ) {
+			$config = array( 'woocommerce_analytics' => 1 ) + $config;
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Adds the order stats table to the checksum allowed tables.
+	 *
+	 * @param array $tables The current checksum allowed tables.
+	 * @return array The modified checksum allowed tables.
+	 */
+	public function add_order_stats_to_checksum( array $tables ): array {
+		if ( ! $this->can_site_sync_orders() ) {
+			return $tables;
+		}
+
+		global $wpdb;
+		$order_stats_checksum_table = array(
+			'wc_order_stats'          => array(
+				'table'                     => "{$wpdb->prefix}wc_order_stats",
+				'range_field'               => 'order_id',
+				'key_fields'                => array( 'order_id' ),
+				'checksum_fields'           => array( 'date_paid', 'date_completed', 'total_sales' ),
+				'checksum_text_fields'      => array( 'status' ),
+				'is_table_enabled_callback' => function () {
+					return false !== JetpackSyncModules::get_module( 'woocommerce_analytics' );
+				},
+			),
+			'wc_order_product_lookup' => array(
+				'table'                     => "{$wpdb->prefix}wc_order_product_lookup",
+				'range_field'               => 'order_id',
+				'key_fields'                => array( 'order_id', 'order_item_id' ),
+				'checksum_fields'           => array( 'product_id', 'variation_id', 'product_qty', 'product_net_revenue', 'date_created' ),
+				'is_table_enabled_callback' => function () {
+					return false !== JetpackSyncModules::get_module( 'woocommerce_analytics' );
+				},
+			),
+			'wc_order_coupon_lookup'  => array(
+				'table'                     => "{$wpdb->prefix}wc_order_coupon_lookup",
+				'range_field'               => 'order_id',
+				'key_fields'                => array( 'order_id', 'coupon_id' ),
+				'checksum_fields'           => array( 'discount_amount', 'date_created' ),
+				'is_table_enabled_callback' => function () {
+					return false !== JetpackSyncModules::get_module( 'woocommerce_analytics' );
+				},
+			),
+			'wc_order_tax_lookup'     => array(
+				'table'                     => "{$wpdb->prefix}wc_order_tax_lookup",
+				'range_field'               => 'order_id',
+				'key_fields'                => array( 'order_id', 'tax_rate_id' ),
+				'checksum_fields'           => array( 'order_tax', 'total_tax', 'shipping_tax', 'date_created' ),
+				'is_table_enabled_callback' => function () {
+					return false !== JetpackSyncModules::get_module( 'woocommerce_analytics' );
+				},
+			),
+		);
+		return array_merge( $tables, $order_stats_checksum_table );
+	}
+
+	/**
+	 * Add WC Analytics post meta to Sync's post meta whitelist.
+	 * Any changes to these meta will by synced to WordPress.com.
+	 *
+	 * @param array $whitelist Existing post meta whitelist.
+	 * @return array Updated post meta whitelist.
+	 */
+	public function add_meta_to_sync_post_meta_whitelist( array $whitelist ): array {
+		return array_merge( self::$postmeta_to_sync, $whitelist );
+	}
+}

--- a/projects/packages/premium-analytics/src/Sync/class-configuration.php
+++ b/projects/packages/premium-analytics/src/Sync/class-configuration.php
@@ -182,7 +182,7 @@ class Configuration {
 		// Let's ensure Terms and Term_Relationships will always get synced before Posts during Full Sync.
 		if ( isset( $config['posts'] ) ) {
 			unset( $config['posts'] );
-			$config = $config + array( 'posts' => 1 );
+			$config += array( 'posts' => 1 );
 		}
 
 		if ( ! isset( $config['woocommerce_analytics'] ) ) {

--- a/projects/packages/premium-analytics/src/Sync/class-configuration.php
+++ b/projects/packages/premium-analytics/src/Sync/class-configuration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ * TEMPORARY: interim port for WOOA7S-1550 — remove when the shared sync-modules composer package lands.
  *
  * Plain replacement for woocommerce-analytics' src/Internal/Jetpack/Sync/Configuration.php.
  * The upstream class is wired through a PHP-DI container and RegistrableInterface; the

--- a/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
+++ b/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
@@ -40,6 +40,7 @@ defined( 'ABSPATH' ) || exit;
 class WooCommerce_Analytics_Module extends JetpackSyncModule {
 
 	use Utilities;
+	// @phan-suppress-next-line PhanUndeclaredTrait -- Provided by WooCommerce at runtime; absent from the older WooCommerce stubs used by the "old Woo" Phan job.
 	use OrderAttributionMeta;
 
 	/**
@@ -585,6 +586,7 @@ class WooCommerce_Analytics_Module extends JetpackSyncModule {
 		}
 
 		$order_fulfillment_status = null;
+		// @phan-suppress-next-line PhanUndeclaredStaticMethod -- Guarded by is_callable(); absent from the older WooCommerce stubs used by the "old Woo" Phan job.
 		if ( is_callable( array( OrderStatsDataStore::class, 'has_fulfillment_status_column' ) ) && OrderStatsDataStore::has_fulfillment_status_column() ) {
 			$order_stats_item         = $this->get_order_stats_item( $order->get_id() );
 			$order_fulfillment_status = $order_stats_item['fulfillment_status'] ?? null;
@@ -621,6 +623,7 @@ class WooCommerce_Analytics_Module extends JetpackSyncModule {
 				$order_stats_data['parent_id'] = $parent_order->get_id();
 
 				$refund_type = $order->get_meta( '_refund_type' );
+				// @phan-suppress-next-line PhanUndeclaredStaticMethod -- Absent from the older WooCommerce stubs used by the "old Woo" Phan job.
 				if ( 'full' === $refund_type && OrderUtil::uses_new_full_refund_data() ) {
 					$order_stats_data['tax_total']      = -1 * $parent_order->get_total_tax();
 					$order_stats_data['num_items_sold'] = -1 * self::get_num_items_sold( $parent_order );

--- a/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
+++ b/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
@@ -1,0 +1,1131 @@
+<?php
+/**
+ * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ *
+ * Ported (near-verbatim) from woocommerce-analytics'
+ * src/Internal/Jetpack/Sync/Modules/Analytics.php so the monorepo package can register the
+ * `woocommerce_analytics` full-sync module and unblock end-to-end sync testing for the
+ * connection flow (WOOA7S-1549). name() intentionally stays 'woocommerce_analytics' — the JS
+ * site-sync and {@see Sync_Status_Tracker} both target the module by that exact key.
+ *
+ * WooCommerce is a runtime (not composer) dependency. The WC classes/traits referenced here
+ * resolve via WooCommerce's autoloader at runtime; registration is guarded so this class is only
+ * instantiated when WooCommerce is active (see {@see Configuration::register()}).
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\Sync;
+
+use Automattic\Jetpack\Sync\Modules\Module as JetpackSyncModule;
+use Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders;
+use Automattic\WooCommerce\Admin\API\Reports\Coupons\DataStore as CouponsDataStore;
+use Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrderStatsDataStore;
+use Automattic\WooCommerce\Enums\OrderInternalStatus;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
+use Automattic\WooCommerce\Internal\Traits\OrderAttributionMeta;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use WC_Abstract_Order;
+use WC_Coupon;
+use WC_Order;
+use WC_Order_Factory;
+use WC_Tax;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Analytics Module class.
+ *
+ * @phan-suppress-next-line PhanUndeclaredTrait -- OrderAttributionMeta is a WooCommerce runtime trait; WC is a runtime, not composer, dependency.
+ */
+class WooCommerce_Analytics_Module extends JetpackSyncModule {
+
+	use Utilities;
+	use OrderAttributionMeta;
+
+	/**
+	 * Get the module name.
+	 *
+	 * @return string
+	 */
+	public function name() {
+		return 'woocommerce_analytics';
+	}
+
+	/**
+	 * Get the ID field for the module.
+	 *
+	 * @return string
+	 */
+	public function id_field() {
+		return 'order_id';
+	}
+
+	/**
+	 * Get the table in the database.
+	 *
+	 * @return string
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->prefix . 'wc_order_stats';
+	}
+
+	/**
+	 * Init listeners.
+	 *
+	 * @param callable $handler Action handler callable.
+	 *
+	 * @return void
+	 */
+	public function init_listeners( $handler ) {
+		// Actions to update order stats.
+		add_action( 'woocommerce_analytics_delete_order_stats', array( $this, 'sync_deleted_analytics_data' ) );
+
+		// In WooCommerce 10.3+ the new action is available.
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '10.3', '>=' ) ) {
+			add_action( 'woocommerce_order_scheduler_after_import_order', array( $this, 'sync_analytics_reports_data' ) );
+		} else {
+			add_action( 'woocommerce_analytics_update_order_stats', array( $this, 'sync_analytics_reports_data' ) );
+		}
+
+		// Sync actions.
+		add_action( 'woocommerce_analytics_sync_reports_data', $handler );
+		add_action( 'woocommerce_analytics_delete_reports_data', $handler );
+
+		// Expand data.
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_analytics_sync_reports_data', array( $this, 'expand_data' ) );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_analytics_delete_reports_data', array( $this, 'expand_data' ) );
+	}
+
+	/**
+	 * Expand order stats data and attribution data.
+	 *
+	 * @param array $args List of arguments.
+	 *
+	 * @return array
+	 */
+	public function expand_data( $args ) {
+		if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
+			return false;
+		}
+
+		$data = $args[0];
+
+		return $data;
+	}
+
+	/**
+	 * Init full sync listeners.
+	 *
+	 * @param callable $handler Action handler callable.
+	 *
+	 * @return void
+	 */
+	public function init_full_sync_listeners( $handler ) {
+		add_action( 'jetpack_full_sync_woocommerce_analytics', $handler );
+	}
+
+	/**
+	 * Get full sync actions.
+	 *
+	 * @return string[] The full sync actions.
+	 */
+	public function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_woocommerce_analytics' );
+	}
+
+	/**
+	 * Get the supported object types.
+	 *
+	 * @return array The supported object types.
+	 */
+	private function get_supported_object_types() {
+		return array( 'order', 'order_tax_lookup', 'order_product_lookup', 'order_coupon_lookup' );
+	}
+
+	/**
+	 * Retrieves multiple orders data by their ID.
+	 *
+	 * @param string $object_type Type of object to retrieve. Should be `order`.
+	 * @param array  $ids         List of order IDs.
+	 *
+	 * @return array
+	 */
+	public function get_objects_by_id( $object_type, $ids ) {
+		if ( empty( $ids ) || ! is_array( $ids ) || empty( $object_type ) ) {
+			return array();
+		}
+
+		if ( ! in_array( $object_type, $this->get_supported_object_types(), true ) ) {
+			return array();
+		}
+
+		$orders = wc_get_orders(
+			array(
+				'post__in'    => $ids,
+				'post_status' => WooCommerce_HPOS_Orders::get_all_possible_order_status_keys(),
+				'limit'       => -1,
+				'orderby'     => 'id',
+				'order'       => 'DESC',
+			)
+		);
+
+		// Get the order stats data for the orders.
+		$order_stats_items = $this->get_order_stats_items( $ids );
+		$order_stats_data  = array();
+		if ( ! empty( $order_stats_items ) ) {
+			$order_stats_data = array_column( $order_stats_items, null, 'order_id' );
+		}
+
+		$orders_data     = array();
+		$found_order_ids = array();
+		foreach ( $orders as $order ) {
+			$order_id                 = $order->get_id();
+			$found_order_ids[]        = $order_id;
+			$orders_data[ $order_id ] = $this->build_woocommerce_analytics_reports_data( $order );
+			if ( 'order' === $object_type ) {
+				// Sync everything if the object type is order.
+				$orders_data[ $order_id ] = $this->build_woocommerce_analytics_reports_data( $order );
+			} else {
+				$orders_data[ $order_id ] = $this->build_woocommerce_analytics_reports_lookup_data( $order, $object_type );
+			}
+			if ( isset( $order_stats_data[ $order_id ] ) ) {
+				$this->do_order_status_discrepancy_check( $order, $order_stats_data[ $order_id ] );
+			}
+		}
+
+		// Check for missing order_ids in wc_order_stats table for orders that were not found.
+		$missing_order_ids = array_diff( $ids, $found_order_ids );
+
+		/**
+		 * Trigger missing orders detected action.
+		 *
+		 * @param array $missing_order_ids The missing order IDs.
+		 */
+		do_action( 'woocommerce_analytics_missing_orders_detected', $missing_order_ids );
+
+		foreach ( $missing_order_ids as $missing_order_id ) {
+			if ( 'order' === $object_type ) {
+				$orders_data[ $missing_order_id ] = $this->build_woocommerce_analytics_reports_data( $missing_order_id );
+			} else {
+				$orders_data[ $missing_order_id ] = $this->build_woocommerce_analytics_reports_lookup_data( $missing_order_id, $object_type );
+			}
+		}
+		// Let's sort the orders by ID in descending order. This is useful for the full sync to ensure that the latest orders are processed first.
+		krsort( $orders_data, SORT_NUMERIC );
+		return $orders_data;
+	}
+
+	/**
+	 * Retrieve the analytics order data by its ID.
+	 *
+	 * @param string $object_type Type of the sync object.
+	 * @param int    $id          ID of the sync object.
+	 * @return mixed Object, or false if the object is invalid.
+	 */
+	public function get_object_by_id( $object_type, $id ) {
+		if ( ! in_array( $object_type, $this->get_supported_object_types(), true ) ) {
+			return false;
+		}
+
+		$order = wc_get_order( $id );
+
+		if ( ! $order instanceof WC_Abstract_Order ) {
+			$order = $id; // If the order does not exists. We'll check if the order_id exists in wc_order_stats table.
+		}
+
+		if ( 'order' === $object_type ) {
+			return $this->build_woocommerce_analytics_reports_data( $order );
+		}
+
+		return $this->build_woocommerce_analytics_reports_lookup_data( $order, $object_type );
+	}
+
+	/**
+	 * Enqueue full sync actions.
+	 *
+	 * @param array   $config               Full sync configuration.
+	 * @param int     $max_items_to_enqueue Maximum number of items to enqueue.
+	 * @param boolean $state                True if full sync has finished enqueueing this module.
+	 * @return array Number of actions enqueued, and next module state.
+	 */
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+		return $this->enqueue_all_ids_as_action(
+			'jetpack_full_sync_woocommerce_analytics',
+			$this->table(),
+			$this->id_field(),
+			$this->get_where_sql( $config ),
+			$max_items_to_enqueue,
+			$state
+		);
+	}
+
+	/**
+	 * Estimate full sync actions.
+	 *
+	 * @param array $config Full sync configuration.
+	 * @return int Number of items yet to be enqueued.
+	 */
+	public function estimate_full_sync_actions( $config ) {
+		global $wpdb;
+
+		$query = "SELECT COUNT(*) FROM {$this->table()}";
+
+		$where_sql = $this->get_where_sql( $config );
+		if ( $where_sql ) {
+			$query .= ' WHERE ' . $where_sql;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$count = (int) $wpdb->get_var( $query );
+
+		return (int) ceil( $count / self::ARRAY_CHUNK_SIZE );
+	}
+
+	/**
+	 * Get where SQL clause for the module.
+	 *
+	 * @param array $config Full sync configuration.
+	 * @return string
+	 */
+	public function get_where_sql( $config ) {
+		global $wpdb;
+
+		$where = '1=1';
+
+		if ( ! empty( $config['start_date'] ) ) {
+			$where .= $wpdb->prepare( ' AND date_created >= %s', $config['start_date'] );
+		}
+		if ( ! empty( $config['end_date'] ) ) {
+			$where .= $wpdb->prepare( ' AND date_created <= %s', $config['end_date'] );
+		}
+
+		/**
+		 * Filter the WHERE SQL for analytics full sync
+		 *
+		 * @param string $where The WHERE SQL clause
+		 * @param array  $config The sync configuration
+		 */
+		return apply_filters( 'woocommerce_analytics_full_sync_where_sql', $where, $config );
+	}
+
+	/**
+	 * Initialize module in the sender.
+	 */
+	public function init_before_send() {
+		// Full sync.
+		add_filter(
+			'jetpack_sync_before_send_jetpack_full_sync_woocommerce_analytics',
+			array( $this, 'build_full_sync_action_array' )
+		);
+	}
+
+	/**
+	 * Build the full sync action object.
+	 *
+	 * @param array $args An array with filtered objects and previous end.
+	 *
+	 * @return array An array with orders and previous end.
+	 */
+	public function build_full_sync_action_array( $args ) {
+		list( $filtered_orders, $previous_end ) = $args;
+		return array(
+			'orders'       => $filtered_orders['objects'],
+			'previous_end' => $previous_end,
+		);
+	}
+
+	/**
+	 * Given the Module Configuration and Status return the next chunk of items to send.
+	 * This function also expands the posts and metadata and filters them based on the maximum size constraints.
+	 *
+	 * @param array $config This module Full Sync configuration.
+	 * @param array $status This module Full Sync status.
+	 * @param int   $chunk_size Chunk size.
+	 *
+	 * @return array
+	 */
+	public function get_next_chunk( $config, $status, $chunk_size ) {
+
+		$order_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+
+		if ( empty( $order_ids ) ) {
+			return array();
+		}
+
+		$orders = $this->get_objects_by_id( 'order', $order_ids );
+
+		// If no orders were fetched, make sure to return the expected structure so that status is updated correctly.
+		if ( empty( $orders ) ) {
+			return array(
+				'object_ids' => $order_ids,
+				'objects'    => array(),
+			);
+		}
+
+		// Filter the orders based on the maximum size constraints.
+		list( $filtered_order_ids, $filtered_orders, ) = $this->filter_analytics_objects_by_size( $orders );
+
+		return array(
+			'object_ids' => $filtered_order_ids,
+			'objects'    => $filtered_orders,
+		);
+	}
+
+	/**
+	 * Filters objects and metadata based on maximum size constraints.
+	 * It always allows the first object with its metadata, even if they exceed the limit.
+	 *
+	 * @param array $objects The array of objects to filter.
+	 *
+	 * @return array An array containing the filtered object IDsand  filtered objects
+	 */
+	public function filter_analytics_objects_by_size( $objects ) {
+		$filtered_objects    = array();
+		$filtered_object_ids = array();
+		$current_size        = 0;
+
+		foreach ( $objects as $key => $value ) {
+			$object_size = strlen( maybe_serialize( $value ) );
+
+			// Always allow the first object.
+			if ( empty( $filtered_object_ids ) || ( $current_size + $object_size ) <= self::MAX_SIZE_FULL_SYNC ) {
+				$filtered_object_ids[]    = $key;
+				$filtered_objects[ $key ] = $value;
+				$current_size            += $object_size;
+			} else {
+				break;
+			}
+		}
+
+		return array(
+			$filtered_object_ids,
+			$filtered_objects,
+		);
+	}
+
+	/**
+	 * Handle Sync analytics reports data.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return void
+	 */
+	public function sync_analytics_reports_data( $order_id ) {
+
+		$data = $this->get_object_by_id( 'order', $order_id );
+
+		if ( ! $data ) {
+			return;
+		}
+
+		/**
+		 * Trigger the action to sync the reports data.
+		 *
+		 * @param array $data Analytics reports sync data.
+		 */
+		do_action( 'woocommerce_analytics_sync_reports_data', $data );
+	}
+
+	/**
+	 * Handle syncing of analytics deletion data.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return void
+	 */
+	public function sync_deleted_analytics_data( $order_id ) {
+		if ( empty( $order_id ) ) {
+			return;
+		}
+
+		$data = array(
+			'id' => $order_id,
+		);
+
+		/**
+		 * Filter the deletion data before syncing.
+		 *
+		 * @param array    $data The deletion data.
+		 * @param WC_Order $order The order object.
+		 */
+		$data = apply_filters( 'woocommerce_analytics_deletion_data', $data );
+
+		/**
+		 * Trigger the action to sync the deletion.
+		 *
+		 * @param array $data The deletion sync data.
+		 */
+		do_action( 'woocommerce_analytics_delete_reports_data', $data );
+	}
+
+	/**
+	 * Build the WooCommerce analytics reports data.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array The reports data.
+	 */
+	protected function build_woocommerce_analytics_reports_data( $order ) {
+		$data_types = array(
+			'order_stats'            => $this->get_order_stats_data( $order ),
+			'order_attribution_data' => $this->get_order_attribution_data( $order ),
+			'order_product_data'     => $this->get_order_product_data( $order ),
+			'order_coupon_data'      => $this->get_order_coupon_data( $order ),
+			'order_tax_data'         => $this->get_order_tax_data( $order ),
+		);
+
+		$reports_data = array_filter( $data_types );
+
+		/**
+		 * Filter the reports data before syncing.
+		 *
+		 * @param array $data The reports data.
+		 * @param WC_Order $order The order object.
+		 */
+		return apply_filters( 'woocommerce_analytics_reports_data', $reports_data, $order );
+	}
+
+	/**
+	 * Build the WooCommerce analytics reports data for lookup tables.
+	 *
+	 * @param mixed  $order The order ID or the WC_Order object.
+	 * @param string $object_type The object type.
+	 * @return array The reports data.
+	 */
+	protected function build_woocommerce_analytics_reports_lookup_data( $order, $object_type ) {
+		$report_data = array();
+		switch ( $object_type ) {
+			case 'order_product_lookup':
+				$report_data['order_product_data'] = $this->get_order_product_data( $order );
+				break;
+			case 'order_coupon_lookup':
+				$report_data['order_coupon_data'] = $this->get_order_coupon_data( $order );
+				break;
+			case 'order_tax_lookup':
+				$report_data['order_tax_data'] = $this->get_order_tax_data( $order );
+				break;
+		}
+
+		/**
+		 * Filter the reports lookup data before syncing.
+		 *
+		 * @param array $data The reports lookup data.
+		 * @param WC_Order $order The order object.
+		 * @param string $object_type The object type.
+		 */
+		return apply_filters( 'woocommerce_analytics_reports_lookup_data', $report_data, $order, $object_type );
+	}
+
+	/**
+	 * Get order attribution data.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array|bool The order attribution data or false if the order is invalid.
+	 */
+	protected function get_order_attribution_data( $order ) {
+		if ( is_numeric( $order ) ) {
+			$order = wc_get_order( $order );
+		}
+
+		if ( ! $order ) {
+			return false;
+		}
+
+		$this->set_fields_and_prefix();
+		$order_id     = $order->get_id();
+		$type         = $order->get_type();
+		$allowed_keys = array(
+			'utm_campaign',
+			'utm_source',
+			'utm_medium',
+			'utm_content',
+			'utm_term',
+			'utm_source_platform',
+			'origin',
+			'device_type',
+			'source_type',
+		);
+
+		if ( 'shop_order_refund' === $type && ! empty( $order->get_parent_id() ) ) {
+			$order_object_to_use = wc_get_order( $order->get_parent_id() );
+		} else {
+			$order_object_to_use = $order;
+		}
+
+		$attribution_data = array(
+			'order_id' => $order_id,
+		);
+
+		foreach ( $allowed_keys as $key ) {
+			$meta_key                 = $this->get_meta_prefixed_field_name( $key );
+			$attribution_data[ $key ] = $order_object_to_use->get_meta( $meta_key, true );
+		}
+
+		return $attribution_data;
+	}
+
+	/**
+	 * Handler order stats update.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array|bool The order attribution data or false if the order stats item does not exist.
+	 */
+	protected function get_order_stats_data( $order ) {
+		if ( is_numeric( $order ) ) {
+			$order_id = $order;
+			$order    = wc_get_order( $order );
+		} elseif ( $order instanceof WC_Abstract_Order ) {
+			$order_id = $order->get_id();
+		} else {
+			return false;
+		}
+
+		// If the order does not exit, check if the stats item is present in the wc_order_stats table.
+		if ( ! $order ) {
+			$order_stats_data_from_db = $this->get_order_stats_data_from_db( $order_id );
+			return $order_stats_data_from_db;
+		}
+
+		$order_fulfillment_status = null;
+		if ( is_callable( array( OrderStatsDataStore::class, 'has_fulfillment_status_column' ) ) && OrderStatsDataStore::has_fulfillment_status_column() ) {
+			$order_stats_item         = $this->get_order_stats_item( $order->get_id() );
+			$order_fulfillment_status = $order_stats_item['fulfillment_status'] ?? null;
+		} elseif ( is_callable( array( FulfillmentUtils::class, 'get_order_fulfillment_status' ) ) && $order instanceof WC_Order ) {
+			$fulfillment_status       = FulfillmentUtils::get_order_fulfillment_status( $order );
+			$order_fulfillment_status = 'no_fulfillments' !== $fulfillment_status ? $fulfillment_status : null;
+		}
+
+		$order_stats_data = array(
+			'order_id'           => $order->get_id(),
+			'parent_id'          => $order->get_parent_id(),
+			'date_created'       => self::datetime_to_object( $order->get_date_created() ),
+			'date_paid'          => self::datetime_to_object( $order->get_date_paid() ),
+			'date_completed'     => self::datetime_to_object( $order->get_date_completed() ),
+			'num_items_sold'     => self::get_num_items_sold( $order ),
+			'total_sales'        => $order->get_total(),
+			'tax_total'          => $order->get_total_tax(),
+			'total_fees'         => $order->get_total_fees(),
+			'total_fees_tax'     => self::get_total_fees_tax( $order ),
+			'shipping_total'     => $order->get_shipping_total(),
+			'shipping_tax'       => $order->get_shipping_tax(),
+			'discount_total'     => $order->get_discount_total(),
+			'discount_tax'       => $order->get_discount_tax(),
+			'net_total'          => self::get_net_total( $order ),
+			'returning_customer' => $order->is_returning_customer(),
+			'status'             => self::normalize_order_status( $order->get_status() ),
+			'customer_id'        => $order->get_report_customer_id(),
+			'fulfillment_status' => $order_fulfillment_status,
+		);
+
+		if ( 'shop_order_refund' === $order->get_type() ) {
+			$parent_order = wc_get_order( $order->get_parent_id() );
+			if ( $parent_order ) {
+				$order_stats_data['parent_id'] = $parent_order->get_id();
+
+				$refund_type = $order->get_meta( '_refund_type' );
+				if ( 'full' === $refund_type && OrderUtil::uses_new_full_refund_data() ) {
+					$order_stats_data['tax_total']      = -1 * $parent_order->get_total_tax();
+					$order_stats_data['num_items_sold'] = -1 * self::get_num_items_sold( $parent_order );
+					$order_stats_data['net_total']      = -1 * self::get_net_total( $parent_order );
+					$order_stats_data['shipping_total'] = -1 * $parent_order->get_shipping_total();
+				}
+			}
+			/**
+			 * Set date_completed and date_paid the same as date_created to avoid problems
+			 * when they are being used to sort the data, as refunds don't have them filled
+			 */
+			$date_created_gmt                   = self::datetime_to_object( $order->get_date_created() );
+			$order_stats_data['date_completed'] = $date_created_gmt;
+			$order_stats_data['date_paid']      = $date_created_gmt;
+		}
+
+		return $order_stats_data;
+	}
+
+	/**
+	 * Calculation methods.
+	 */
+
+	/**
+	 * Get number of items sold among all orders.
+	 *
+	 * @param WC_Order $order WC_Order object.
+	 * @return int
+	 */
+	protected static function get_num_items_sold( $order ) {
+		$num_items = 0;
+
+		$line_items = $order->get_items( 'line_item' );
+		foreach ( $line_items as $line_item ) {
+			$num_items += $line_item->get_quantity();
+		}
+
+		return $num_items;
+	}
+
+	/**
+	 * Get the net amount from an order without shipping, tax, or refunds.
+	 *
+	 * @param WC_Order $order WC_Order object.
+	 * @return float
+	 */
+	protected static function get_net_total( $order ) {
+		$net_total = floatval( $order->get_total() ) - floatval( $order->get_total_tax() ) - floatval( $order->get_shipping_total() );
+		return (float) $net_total;
+	}
+
+	/**
+	 * Get the total fees tax from an order.
+	 *
+	 * @param WC_Order $order WC_Order object.
+	 * @return float
+	 */
+	protected static function get_total_fees_tax( $order ) {
+		$total_fees_tax = array_sum(
+			array_map(
+				function ( $item ) {
+					return $item->get_total_tax();
+				},
+				array_values( $order->get_items( 'fee' ) )
+			)
+		);
+
+		return $total_fees_tax;
+	}
+
+	/**
+	 * Get the order stats row for a given order ID.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return array|null|void Database query result in format specified by $output or null on failure.
+	 */
+	private function get_order_stats_item( $order_id ) {
+		global $wpdb;
+
+		$query = $wpdb->prepare(
+			"SELECT * FROM {$this->table()} WHERE order_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$order_id
+		);
+
+		return $wpdb->get_row( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Get the order stats rows for a given order IDs.
+	 *
+	 * @param array $order_ids The order IDs.
+	 * @return array|null Database query result in format specified by $output or null on failure.
+	 */
+	private function get_order_stats_items( $order_ids ) {
+		global $wpdb;
+
+		$placeholders = implode( ',', array_fill( 0, count( $order_ids ), '%d' ) );
+		$query        = $wpdb->prepare(
+			"SELECT * FROM {$this->table()} WHERE order_id IN ( $placeholders )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			$order_ids
+		);
+
+		return $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Check if the COGS feature is enabled.
+	 *
+	 * @return bool True if the COGS feature is enabled, false otherwise.
+	 */
+	private function is_cogs_enabled() {
+		return FeaturesUtil::feature_is_enabled( 'cost_of_goods_sold' );
+	}
+
+	/**
+	 * Get order product lookup data.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array|bool The order product data or false if no data exists.
+	 */
+	protected function get_order_product_data( $order ) {
+		if ( is_numeric( $order ) ) {
+			$order_id = $order;
+			$order    = wc_get_order( $order );
+		} elseif ( $order instanceof WC_Abstract_Order ) {
+			$order_id = $order->get_id();
+		} else {
+			return false;
+		}
+
+		// If the order does not exist, check if product lookup data exists in the database.
+		if ( ! $order ) {
+			return $this->get_order_product_data_from_db( $order_id );
+		}
+
+		// Get the order product data from the order object.
+		$order_products = $order->get_items( 'line_item' );
+
+		if ( empty( $order_products ) ) {
+			// Not a common use case, but there could be a case where this returns empty.
+			return $this->get_order_product_data_from_db( $order_id );
+		}
+
+		$is_refund_order = $this->is_refund_order( $order_id );
+		$round_tax       = 'no' === get_option( 'woocommerce_tax_round_at_subtotal' );
+		$decimals        = wc_get_price_decimals();
+
+		$results = array();
+		foreach ( $order_products as $order_product ) {
+			$shipping_amount     = $order->get_item_shipping_amount( $order_product );
+			$shipping_tax_amount = $order->get_item_shipping_tax_amount( $order_product );
+			$coupon_amount       = $order->get_item_coupon_amount( $order_product );
+			// Tax amount.
+			$tax_amount  = 0;
+			$order_taxes = $order->get_taxes();
+			$tax_data    = $order_product->get_taxes();
+			foreach ( $order_taxes as $tax_item ) {
+				$tax_item_id = $tax_item->get_rate_id();
+				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? (float) $tax_data['total'][ $tax_item_id ] : 0;
+			}
+
+			$net_revenue = round( $order_product->get_total( 'edit' ), $decimals );
+			if ( $round_tax ) {
+				$tax_amount = round( $tax_amount, $decimals );
+			}
+
+			$product_id  = $order_product->get_product_id();
+			$cogs_amount = $this->get_order_product_cogs_value( $order_product );
+
+			$product_data = array(
+				'order_id'              => $order_id,
+				'order_item_id'         => $order_product->get_id(),
+				'product_id'            => $product_id,
+				'variation_id'          => $order_product->get_variation_id(),
+				'product_qty'           => $order_product->get_quantity(),
+				'product_net_revenue'   => $net_revenue,
+				'product_gross_revenue' => $net_revenue + $tax_amount + $shipping_amount + $shipping_tax_amount,
+				'shipping_amount'       => $shipping_amount,
+				'shipping_tax_amount'   => $shipping_tax_amount,
+				'coupon_amount'         => $coupon_amount,
+				'tax_amount'            => $tax_amount,
+				'customer_id'           => $order->get_report_customer_id(),
+				'date_created'          => self::datetime_to_object( $order->get_date_created() ),
+				'cogs_amount'           => $is_refund_order ? -abs( $cogs_amount ) : $cogs_amount,
+			);
+
+			$results[] = $product_data;
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get COGS value for an order product.
+	 *
+	 * @param object $order_product The order product object.
+	 * @return float|null The COGS amount or null if not available.
+	 */
+	private function get_order_product_cogs_value( $order_product ) {
+		if ( ! method_exists( $order_product, 'get_cogs_value' ) || ! $this->is_cogs_enabled() ) {
+			return null;
+		}
+
+		$cogs_amount = $order_product->get_cogs_value();
+
+		// Only fallback to product's COGS value if order product's COGS is null (not set).
+		if ( null === $cogs_amount ) {
+			$product_id = $order_product->get_product_id();
+			$product    = wc_get_product( $product_id );
+
+			if ( $product && method_exists( $product, 'get_cogs_value' ) ) {
+				$product_cogs_value = $product->get_cogs_value();
+				if ( null !== $product_cogs_value ) {
+					$cogs_amount = $product_cogs_value;
+				}
+			}
+		}
+
+		return $cogs_amount;
+	}
+
+	/**
+	 * Get order product lookup data from database.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return array|bool The order product data or false if no data exists.
+	 */
+	protected function get_order_product_data_from_db( $order_id ) {
+		$results = $this->get_order_lookup_data_from_db( 'wc_order_product_lookup', $order_id );
+
+		if ( empty( $results ) ) {
+			return false;
+		}
+
+		$is_refund_order = $this->is_refund_order( $order_id );
+
+		$parsed_results = array();
+		foreach ( $results as $result ) {
+			$order_item  = WC_Order_Factory::get_order_item( absint( $result['order_item_id'] ) );
+			$cogs_amount = $this->get_order_product_cogs_value( $order_item );
+
+			$product_data = array(
+				'date_created'          => self::datetime_to_object( $result['date_created'] ),
+				'product_net_revenue'   => floatval( $result['product_net_revenue'] ),
+				'product_gross_revenue' => floatval( $result['product_gross_revenue'] ),
+				'shipping_amount'       => floatval( $result['shipping_amount'] ),
+				'shipping_tax_amount'   => floatval( $result['shipping_tax_amount'] ),
+				'product_qty'           => intval( $result['product_qty'] ),
+				'variation_id'          => intval( $result['variation_id'] ),
+				'product_id'            => intval( $result['product_id'] ),
+				'customer_id'           => intval( $result['customer_id'] ),
+				'coupon_amount'         => floatval( $result['coupon_amount'] ),
+				'tax_amount'            => floatval( $result['tax_amount'] ),
+				'order_item_id'         => intval( $result['order_item_id'] ),
+				'order_id'              => intval( $result['order_id'] ),
+				'cogs_amount'           => $is_refund_order ? -abs( $cogs_amount ) : $cogs_amount,
+			);
+
+			$parsed_results[] = $product_data;
+		}
+
+		return $parsed_results;
+	}
+
+	/**
+	 * Check if the order is a refund order.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return bool True if the order is a refund order, false otherwise.
+	 */
+	private function is_refund_order( $order_id ) {
+		$order_stats_data = $this->get_order_stats_item( $order_id );
+
+		if ( ! $order_stats_data || empty( $order_stats_data['parent_id'] ) ) {
+			return false;
+		}
+
+		$parent_id               = $order_stats_data['parent_id'];
+		$parent_order_stats_data = $this->get_order_stats_item( $parent_id );
+
+		if ( ! $parent_order_stats_data || empty( $parent_order_stats_data['status'] ) ) {
+			return false;
+		}
+
+		return OrderInternalStatus::REFUNDED === $parent_order_stats_data['status'];
+	}
+
+	/**
+	 * Get order coupon lookup data.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array|bool The order coupon data or false if no data exists.
+	 */
+	protected function get_order_coupon_data( $order ) {
+		if ( is_numeric( $order ) ) {
+			$order_id = $order;
+			$order    = wc_get_order( $order );
+		} elseif ( $order instanceof WC_Abstract_Order ) {
+			$order_id = $order->get_id();
+		} else {
+			return false;
+		}
+
+		// If the order does not exist, check if coupon lookup data exists in the database.
+		if ( ! $order ) {
+			return $this->get_order_coupon_data_from_db( $order_id );
+		}
+
+		// Get the order coupon data from the order object.
+		$order_coupons = $order->get_coupons();
+
+		$results = array();
+		foreach ( $order_coupons as $coupon ) {
+			$results[] = array(
+				'order_id'        => $order_id,
+				'coupon_id'       => CouponsDataStore::get_coupon_id( $coupon ),
+				'discount_amount' => $coupon->get_discount(),
+				'date_created'    => self::datetime_to_object( $order->get_date_created() ),
+				'coupon_code'     => $coupon->get_code(),
+			);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get order coupon lookup data from database.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return array|bool The order coupon data or false if no data exists.
+	 */
+	protected function get_order_coupon_data_from_db( $order_id ) {
+		$results = $this->get_order_lookup_data_from_db( 'wc_order_coupon_lookup', $order_id );
+
+		if ( empty( $results ) ) {
+			return false;
+		}
+
+		$parsed_results = array();
+		foreach ( $results as $result ) {
+			$result_data                = array(
+				'date_created'    => self::datetime_to_object( $result['date_created'] ),
+				'discount_amount' => floatval( $result['discount_amount'] ),
+				'order_id'        => intval( $result['order_id'] ),
+				'coupon_id'       => intval( $result['coupon_id'] ),
+			);
+			$coupon                     = new WC_Coupon( absint( $result['coupon_id'] ) );
+			$result_data['coupon_code'] = $coupon->get_code();
+			$parsed_results[]           = $result_data;
+		}
+
+		return $parsed_results;
+	}
+
+	/**
+	 * Get order tax lookup data.
+	 *
+	 * @param mixed $order The order ID or the WC_Order object.
+	 * @return array|bool The order tax data or false if no data exists.
+	 */
+	protected function get_order_tax_data( $order ) {
+		if ( is_numeric( $order ) ) {
+			$order_id = $order;
+			$order    = wc_get_order( $order );
+		} elseif ( $order instanceof WC_Abstract_Order ) {
+			$order_id = $order->get_id();
+		} else {
+			return false;
+		}
+
+		// If the order does not exist, check if tax lookup data exists in the database.
+		if ( ! $order ) {
+			return $this->get_order_tax_data_from_db( $order_id );
+		}
+
+		// Get the order tax data from the order object.
+		$order_taxes = $order->get_taxes();
+
+		$results = array();
+		foreach ( $order_taxes as $tax ) {
+			$order_tax    = (float) $tax->get_tax_total();
+			$shipping_tax = (float) $tax->get_shipping_tax_total();
+			$results[]    = array(
+				'order_id'      => $order_id,
+				'tax_rate_id'   => $tax->get_rate_id(),
+				'order_tax'     => $order_tax,
+				'shipping_tax'  => $shipping_tax,
+				'total_tax'     => $order_tax + $shipping_tax,
+				'date_created'  => self::datetime_to_object( $order->get_date_created() ),
+				'tax_rate_code' => $tax->get_rate_code(),
+			);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get order tax lookup data from database.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return array|bool The order tax data or false if no data exists.
+	 */
+	protected function get_order_tax_data_from_db( $order_id ) {
+		$results = $this->get_order_lookup_data_from_db( 'wc_order_tax_lookup', $order_id );
+
+		if ( empty( $results ) ) {
+			return false;
+		}
+
+		$parsed_results = array();
+		foreach ( $results as $result ) {
+			$result_data      = array(
+				'date_created'  => self::datetime_to_object( $result['date_created'] ),
+				'order_tax'     => floatval( $result['order_tax'] ),
+				'total_tax'     => floatval( $result['total_tax'] ),
+				'shipping_tax'  => floatval( $result['shipping_tax'] ),
+				'order_id'      => intval( $result['order_id'] ),
+				'tax_rate_id'   => intval( $result['tax_rate_id'] ),
+				'tax_rate_code' => WC_Tax::get_rate_code( $result['tax_rate_id'] ) ?? '',
+			);
+			$parsed_results[] = $result_data;
+		}
+
+		return $parsed_results;
+	}
+
+	/**
+	 * Get order lookup data from database.
+	 *
+	 * @param string $table_name The name of the table.
+	 * @param int    $order_id The order ID.
+	 * @return array|bool The order lookup data or false if no data exists.
+	 */
+	protected function get_order_lookup_data_from_db( $table_name, $order_id ) {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$query = $wpdb->prepare(
+			"SELECT * FROM {$wpdb->prefix}{$table_name} WHERE order_id = %d",
+			$order_id
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results( $query, ARRAY_A );
+
+		if ( empty( $results ) ) {
+			return false;
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get the order stats data from the database.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return array|bool The order stats data or false if the order stats item does not exist.
+	 */
+	private function get_order_stats_data_from_db( $order_id ) {
+		$order_stats_data = $this->get_order_stats_item( $order_id );
+
+		if ( ! $order_stats_data ) {
+			return false;
+		}
+
+		// Convert date strings to datetime objects.
+		$order_stats_data['date_created']   = self::datetime_to_object( $order_stats_data['date_created'] );
+		$order_stats_data['date_completed'] = self::datetime_to_object( $order_stats_data['date_completed'] );
+		$order_stats_data['date_paid']      = self::datetime_to_object( $order_stats_data['date_paid'] );
+
+		return $order_stats_data;
+	}
+
+	/**
+	 * Perform an order status discrepancy check between the order object and the item in the wc_order_stats table.
+	 *
+	 * @param WC_Order $order WC_Order object.
+	 * @param array    $order_stats_item The order stats item.
+	 *
+	 * @return void
+	 */
+	private function do_order_status_discrepancy_check( $order, $order_stats_item = array() ) {
+		if ( ! $order instanceof WC_Abstract_Order ) {
+			return;
+		}
+
+		$order_id = $order->get_id();
+
+		// If the order_stats_item is empty, then fetch it from the wc_order_stats table.
+		if ( empty( $order_stats_item ) ) {
+			$order_stats_item = $this->get_order_stats_data_from_db( $order_id );
+		}
+
+		// Check for discrepancy in the order status. Happens in old orders that were not updated and hence the OrderStatsFixer did not run.
+		$normalized_order_status = self::normalize_order_status( $order->get_status() );
+		if ( $order_stats_item && $normalized_order_status !== $order_stats_item['status'] ) {
+			/**
+			 * Trigger the action to fix the order stats. The OrderStatusFixer should be hooked to this action.
+			 *
+			 * @param int $order_id The order ID.
+			 */
+			do_action( 'woocommerce_analytics_incorrect_order_status_detected', $order_id );
+		}
+	}
+}

--- a/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
+++ b/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ * TEMPORARY: interim port for WOOA7S-1550 — remove when the shared sync-modules composer package lands.
  *
  * Ported (near-verbatim) from woocommerce-analytics'
  * src/Internal/Jetpack/Sync/Modules/Analytics.php so the monorepo package can register the

--- a/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
+++ b/projects/packages/premium-analytics/src/Sync/class-woocommerce-analytics-module.php
@@ -36,8 +36,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * WooCommerce Analytics Module class.
- *
- * @phan-suppress-next-line PhanUndeclaredTrait -- OrderAttributionMeta is a WooCommerce runtime trait; WC is a runtime, not composer, dependency.
  */
 class WooCommerce_Analytics_Module extends JetpackSyncModule {
 
@@ -104,7 +102,7 @@ class WooCommerce_Analytics_Module extends JetpackSyncModule {
 	 *
 	 * @param array $args List of arguments.
 	 *
-	 * @return array
+	 * @return array|false
 	 */
 	public function expand_data( $args ) {
 		if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
@@ -627,7 +625,7 @@ class WooCommerce_Analytics_Module extends JetpackSyncModule {
 					$order_stats_data['tax_total']      = -1 * $parent_order->get_total_tax();
 					$order_stats_data['num_items_sold'] = -1 * self::get_num_items_sold( $parent_order );
 					$order_stats_data['net_total']      = -1 * self::get_net_total( $parent_order );
-					$order_stats_data['shipping_total'] = -1 * $parent_order->get_shipping_total();
+					$order_stats_data['shipping_total'] = -1 * (float) $parent_order->get_shipping_total();
 				}
 			}
 			/**
@@ -671,7 +669,7 @@ class WooCommerce_Analytics_Module extends JetpackSyncModule {
 	 */
 	protected static function get_net_total( $order ) {
 		$net_total = floatval( $order->get_total() ) - floatval( $order->get_total_tax() ) - floatval( $order->get_shipping_total() );
-		return (float) $net_total;
+		return $net_total;
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/Sync/trait-utilities.php
+++ b/projects/packages/premium-analytics/src/Sync/trait-utilities.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ * TEMPORARY: interim port for WOOA7S-1550 — remove when the shared sync-modules composer package lands.
  *
  * Minimal slice of woocommerce-analytics' HelperTraits\Utilities trait: only the
  * helpers actually referenced by the ported sync module and its registration.

--- a/projects/packages/premium-analytics/src/Sync/trait-utilities.php
+++ b/projects/packages/premium-analytics/src/Sync/trait-utilities.php
@@ -114,7 +114,7 @@ trait Utilities {
 	/**
 	 * Convert offset in seconds to ISO 8601 timezone offset format.
 	 *
-	 * @param int $offset_seconds The timezone offset in seconds.
+	 * @param int|float $offset_seconds The timezone offset in seconds.
 	 * @return string The ISO 8601 timezone offset string (e.g., '+08:00', '-08:30', '+00:00').
 	 */
 	protected static function format_utc_offset( $offset_seconds ) {

--- a/projects/packages/premium-analytics/src/Sync/trait-utilities.php
+++ b/projects/packages/premium-analytics/src/Sync/trait-utilities.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * TEMPORARY: interim port for WOOA7S-1550 Option B — remove when the shared sync-modules composer package lands.
+ *
+ * Minimal slice of woocommerce-analytics' HelperTraits\Utilities trait: only the
+ * helpers actually referenced by the ported sync module and its registration.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\Sync;
+
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use DateTimeZone;
+use WC_DateTime;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait Utilities.
+ *
+ * WooCommerce is a runtime (not composer) dependency, so the WC symbols below are
+ * only ever reached when WooCommerce is active. Callers guard with class/function
+ * existence checks; see {@see Configuration::register()}.
+ */
+trait Utilities {
+
+	/**
+	 * Can site sync orders to WPCOM infrastructure.
+	 *
+	 * @return boolean
+	 */
+	protected function can_site_sync_orders(): bool {
+		return $this->is_order_attribution_enabled();
+	}
+
+	/**
+	 * Check if the order attribution feature is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_order_attribution_enabled(): bool {
+
+		if ( ! class_exists( FeaturesController::class ) || ! function_exists( 'wc_get_container' ) ) {
+			return false;
+		}
+
+		try {
+			$feature_controller = wc_get_container()->get( FeaturesController::class );
+			'@phan-var FeaturesController $feature_controller';
+			$is_enabled = $feature_controller->feature_is_enabled( 'order_attribution' );
+
+			/*
+			 * When the feature settings form is submitted, feature_is_enabled won't return false right away
+			 * We need to check what value was actually posted. Only checked options are posted.
+			 * So if it's a POST request and $_POST[ 'woocommerce_custom_orders_table_enabled' ] does not exist
+			 * we optimistically assume this is now false.
+			 */
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['section'] ) && 'features' === $_GET['section'] ) {
+				// phpcs:disable WordPress.Security.NonceVerification.Missing
+				if ( isset( $_POST['woocommerce_feature_order_attribution_enabled'] ) ) {
+					$posted_order_attribution = wc_clean( sanitize_text_field( wp_unslash( $_POST['woocommerce_feature_order_attribution_enabled'] ) ) );
+					$is_enabled               = wc_string_to_bool( $posted_order_attribution );
+				} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
+					$is_enabled = false;
+				}
+				// phpcs:enable WordPress.Security.NonceVerification.Missing
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+			return $is_enabled;
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Maps order status provided by the user to the one used in the database.
+	 *
+	 * @param string $status Order status.
+	 * @return string
+	 */
+	protected static function normalize_order_status( $status ) {
+		$status                 = str_replace( 'wc-', '', $status );
+		$wc_order_status_keys   = array_keys( wc_get_order_statuses() );
+		$wc_order_status_keys[] = 'wc-checkout-draft'; // Related to Woo bug as `wc-checkout-draft` is missing from `wc_get_order_statuses`.
+
+		return in_array( 'wc-' . $status, $wc_order_status_keys, true ) ? 'wc-' . $status : $status;
+	}
+
+	/**
+	 * Convert the WC_DateTime objects to stdClass objects to ensure they are properly encoded.
+	 *
+	 * @param WC_DateTime|mixed $wc_datetime The datetime object.
+	 * @param bool              $utc         Whether to convert to UTC.
+	 * @return object|null
+	 */
+	protected static function datetime_to_object( $wc_datetime, $utc = false ) {
+		if ( is_string( $wc_datetime ) ) {
+			$wc_datetime = new WC_DateTime( $wc_datetime, self::get_site_datetimezone() );
+		}
+
+		if ( is_a( $wc_datetime, 'WC_DateTime' ) ) {
+			if ( $utc ) {
+				$wc_datetime->setTimezone( new DateTimeZone( 'UTC' ) );
+			} else {
+				$wc_datetime->setTimezone( self::get_site_datetimezone() );
+			}
+			return (object) (array) $wc_datetime;
+		}
+	}
+
+	/**
+	 * Convert offset in seconds to ISO 8601 timezone offset format.
+	 *
+	 * @param int $offset_seconds The timezone offset in seconds.
+	 * @return string The ISO 8601 timezone offset string (e.g., '+08:00', '-08:30', '+00:00').
+	 */
+	protected static function format_utc_offset( $offset_seconds ) {
+		$hours   = intval( abs( $offset_seconds ) / HOUR_IN_SECONDS );
+		$minutes = intval( ( abs( $offset_seconds ) % HOUR_IN_SECONDS ) / MINUTE_IN_SECONDS );
+		$sign    = $offset_seconds >= 0 ? '+' : '-';
+
+		return sprintf( '%s%02d:%02d', $sign, $hours, $minutes );
+	}
+
+	/**
+	 * Get DateTimeZone object for WooCommerce timezone.
+	 *
+	 * @return DateTimeZone The DateTimeZone object for the site timezone.
+	 */
+	protected static function get_site_datetimezone() {
+		return new DateTimeZone( self::format_utc_offset( wc_timezone_offset() ) );
+	}
+}

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
+use Automattic\Jetpack\PremiumAnalytics\Sync\Configuration as Sync_Configuration;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
 
 /**
@@ -60,6 +61,9 @@ class Analytics {
 		}
 
 		Sync_Status_Tracker::configure();
+		// TEMPORARY (WOOA7S-1550 Option B): register the interim woocommerce_analytics sync module so
+		// Sync_Status_Tracker has a full sync to observe. Remove when the shared sync-modules package lands.
+		Sync_Configuration::register();
 		Api_Proxy_Controller::register();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -61,7 +61,7 @@ class Analytics {
 		}
 
 		Sync_Status_Tracker::configure();
-		// TEMPORARY (WOOA7S-1550 Option B): register the interim woocommerce_analytics sync module so
+		// TEMPORARY (WOOA7S-1550): register the interim woocommerce_analytics sync module so
 		// Sync_Status_Tracker has a full sync to observe. Remove when the shared sync-modules package lands.
 		Sync_Configuration::register();
 		Api_Proxy_Controller::register();

--- a/projects/plugins/premium-analytics/changelog/fix-sync-module-port-lock-file
+++ b/projects/plugins/premium-analytics/changelog/fix-sync-module-port-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update lock file to declare the jetpack-config dependency added for the sync module port.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -338,6 +338,77 @@
             }
         },
         {
+            "name": "automattic/jetpack-config",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/config",
+                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-account-protection": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-import": "@dev",
+                "automattic/jetpack-jitm": "@dev",
+                "automattic/jetpack-post-list": "@dev",
+                "automattic/jetpack-publicize": "@dev",
+                "automattic/jetpack-search": "@dev",
+                "automattic/jetpack-stats": "@dev",
+                "automattic/jetpack-stats-admin": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-videopress": "@dev",
+                "automattic/jetpack-waf": "@dev",
+                "automattic/jetpack-yoast-promo": "@dev"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-config",
+                "textdomain": "jetpack-config",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.1.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/account-protection",
+                        "packages/connection",
+                        "packages/import",
+                        "packages/jitm",
+                        "packages/post-list",
+                        "packages/publicize",
+                        "packages/search",
+                        "packages/stats-admin",
+                        "packages/stats",
+                        "packages/sync",
+                        "packages/videopress",
+                        "packages/waf",
+                        "packages/yoast-promo"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-connection",
             "version": "dev-trunk",
             "dist": {
@@ -597,9 +668,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "dd17cf5694478ecd58ce9249b8dc70081a75531a"
+                "reference": "e5b24ea8f6e96b4c91a71795ae6e3efa81104a8e"
             },
             "require": {
+                "automattic/jetpack-config": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "php": ">=7.2"


### PR DESCRIPTION
## Proposed changes

Temporary port of the `woocommerce_analytics` Jetpack Sync module into the `premium-analytics` package, to unblock end-to-end sync testing for the connection flow (WOOA7S-1549). This is Option B of WOOA7S-1550; it's deleted once the shared sync-modules composer package (Option A) lands.

**Why:** The dashboard route guard only unlocks once `Sync_Status_Tracker` sees a completed `woocommerce_analytics` full sync, but nothing in the monorepo currently provides that module. This adds it so the tracker fires `initial_full_sync_finished`.

Everything is isolated under `src/Sync/`, and every new file carries a `TEMPORARY: … remove when the shared sync-modules composer package lands` header so it's easy to delete later:

- `class-woocommerce-analytics-module.php` — port of upstream `Analytics.php`; `name()` stays `'woocommerce_analytics'`.
- `trait-utilities.php` — minimal slice of upstream's `Utilities` trait (only the 6 methods the module + registration use).
- `class-configuration.php` — plain registration (no php-di): on `plugins_loaded`, guarded on WooCommerce being active, adds the `jetpack_sync_modules` / `jetpack_full_sync_config` / `jetpack_sync_post_meta_whitelist` / `jetpack_sync_checksum_allowed_tables` filters and `Config::ensure('sync', …)`.
- `class-analytics.php` calls `Sync_Configuration::register()` in `init()`; `.phan/config.php` adds the WooCommerce stubs.

WooCommerce stays a runtime dependency (not added to composer) — registration is guarded by `class_exists('WooCommerce')`, so the module only loads when WooCommerce is active.

## Related product discussion/links

* Linear: WOOA7S-1550 (unblocks WOOA7S-1549)

## Does this pull request change what data or activity we track or use?

No new data. It re-enables the existing `woocommerce_analytics` module's sync (order stats / lookups) so a connected site can full-sync to WordPress.com.

## Testing instructions

On a WooCommerce-active site connected to WP.com (e.g. Jurassic Ninja):

1. Confirm the module is registered:
   `wp eval 'var_dump( (bool) Automattic\Jetpack\Sync\Modules::get_module( "woocommerce_analytics" ) );'` → `true`.
2. Trigger a full sync: `wp jetpack sync start` (or `POST /jetpack/v4/sync/full-sync`).
3. `woocommerce_analytics` now appears in `wp jetpack sync status` under `config` and `progress`. (Note: sync status reflects the *last* full sync, so the module only shows up after step 2 — the initial connection-time sync predates this plugin's config and won't list it.)
4. Confirm the milestone fired: `wp option get jetpack_premium_analytics_initial_full_sync_finished` returns a timestamp — this is what unlocks the dashboard route guard at `/` (also surfaced on `GET /jetpack/v4/sync/status` and in `JetpackScriptData.premium_analytics`).
5. Optional, with real data: create a completed WooCommerce order, then re-run `wp jetpack sync start`; `woocommerce_analytics` should report `total` ≥ 1 in sync progress.

Verified on Jurassic Ninja: module registers, a fresh full sync includes `woocommerce_analytics`, the milestone fires, and a completed test order syncs (`total:1, sent:1`) with no PHP errors.
