### PR TITLE
Social: fix blank Social admin page on WordPress 6.9.x

### DIFF
--- a/projects/packages/publicize/changelog/fix-jetpack-1716-social-blank-wp69
+++ b/projects/packages/publicize/changelog/fix-jetpack-1716-social-blank-wp69
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the Jetpack Social admin page rendering blank on WordPress 6.9.x by bundling @wordpress/theme and @wordpress/private-apis inline for the standalone admin page.
+Fix Jetpack Social admin page rendering blank on WordPress 6.9.x.

--- a/projects/packages/publicize/changelog/fix-jetpack-1716-social-blank-wp69
+++ b/projects/packages/publicize/changelog/fix-jetpack-1716-social-blank-wp69
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Jetpack Social admin page rendering blank on WordPress 6.9.x by bundling @wordpress/theme and @wordpress/private-apis inline for the standalone admin page.

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -2,6 +2,26 @@ const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 
+// Service-walkthrough illustrations referenced by
+// `_inc/components/services/utils.tsx` via runtime URLs (so the chassis esbuild
+// pipeline, which doesn't configure a binary loader, can consume them too). Copy
+// them verbatim into the shared `build/assets/` directory; both bundlers resolve
+// via `JetpackScriptData.social.assets_url + 'assets/<file>'`.
+const copyAssetsPlugin = new CopyWebpackPlugin( {
+	patterns: [
+		{
+			from: path.resolve( __dirname, '_inc/assets' ),
+			to: 'assets',
+		},
+	],
+} );
+
+// Standard plugin set, optionally overriding dependency extraction.
+const standardPlugins = ( extractionOptions = {} ) => [
+	...jetpackWebpackConfig.StandardPlugins( extractionOptions ),
+	copyAssetsPlugin,
+];
+
 const socialWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
@@ -16,23 +36,6 @@ const socialWebpackConfig = {
 		...jetpackWebpackConfig.resolve,
 	},
 	node: false,
-	plugins: [
-		...jetpackWebpackConfig.StandardPlugins(),
-		// Service-walkthrough illustrations referenced by
-		// `_inc/components/services/utils.tsx` via runtime URLs (so the
-		// chassis esbuild pipeline, which doesn't configure a binary
-		// loader, can consume them too). Copy them verbatim into the
-		// shared `build/assets/` directory; both bundlers resolve via
-		// `JetpackScriptData.social.assets_url + 'assets/<file>'`.
-		new CopyWebpackPlugin( {
-			patterns: [
-				{
-					from: path.resolve( __dirname, '_inc/assets' ),
-					to: 'assets',
-				},
-			],
-		} ),
-	],
 	module: {
 		strictExportPresence: true,
 		rules: [
@@ -78,16 +81,41 @@ const socialWebpackConfig = {
 module.exports = [
 	{
 		...socialWebpackConfig,
+		// Editor and classic-editor bundles: keep @wordpress/theme and
+		// @wordpress/private-apis EXTERNAL. These load inside the block editor and must
+		// share WordPress's canonical private-apis instance; bundling a copy inline
+		// breaks lock()/unlock() across bundles ("Cannot unlock an object that was not
+		// locked before"). On WP 6.9.x the wp-theme handle is absent, so these stay
+		// unenqueued there (unchanged from before); on newer WP they enqueue normally.
+		plugins: standardPlugins(),
 		entry: {
 			'classic-editor': './_inc/entry-points/classic-editor.js',
+			'block-editor-jetpack': './_inc/entry-points/block-editor-jetpack.tsx',
+			'block-editor-social': './_inc/entry-points/block-editor-social.tsx',
 		},
+		devServer: jetpackWebpackConfig.DevServer( {
+			static: { directory: path.resolve( './build' ) },
+		} ),
 	},
 	{
 		...socialWebpackConfig,
+		// Standalone Social admin page: bundle @wordpress/theme and
+		// @wordpress/private-apis inline so the page renders on WP 6.9.x, whose wp-theme
+		// script handle is missing (externalizing it makes the bundle silently fail to
+		// enqueue). Safe here because this is a standalone admin page, not the block
+		// editor, so there is no shared canonical private-apis instance to conflict with.
+		// Both are bundled jointly so @wordpress/theme's module-init lock() lands on the
+		// same private-apis consent map. See PR #48173.
+		plugins: standardPlugins( {
+			DependencyExtractionPlugin: {
+				requestMap: {
+					'@wordpress/theme': { external: false },
+					'@wordpress/private-apis': { external: false },
+				},
+			},
+		} ),
 		entry: {
 			'social-admin-page': './_inc/entry-points/social-admin-page.tsx',
-			'block-editor-jetpack': './_inc/entry-points/block-editor-jetpack.tsx',
-			'block-editor-social': './_inc/entry-points/block-editor-social.tsx',
 		},
 		devServer: jetpackWebpackConfig.DevServer( {
 			static: { directory: path.resolve( './build' ) },


### PR DESCRIPTION
## Summary

Fixes: [JETPACK-1716](https://linear.app/a8c/issue/JETPACK-1716) — the Jetpack Social admin page (Jetpack → Social) renders blank on WordPress 6.9.x.

## Bug

Linear: [JETPACK-1716](https://linear.app/a8c/issue/JETPACK-1716)

Since Jetpack 15.9, on sites running WordPress 6.9.x, **Jetpack → Social renders blank**. Connections stay healthy and posts still auto-share (that path is server-side), so it presents as an admin-UI-only failure. Reported across three Zendesk tickets and several WordPress.org forum threads; the only workaround so far has been upgrading to WordPress 7.0.

## Root cause

`@wordpress/theme` arrives transitively via `@wordpress/ui`. With the default build config it is externalized into the script handle `wp-theme`, which is registered in WordPress 7.0 but **not** in 6.9.x. WordPress silently refuses to enqueue a script whose declared dependency handle is unregistered, so the Social bundle never loads. No console error is thrown (the script simply is not enqueued), which matches the "blank page, nothing red in console" reports.

## What changed

`projects/packages/publicize/webpack.config.js`: split the entry points so dependency extraction differs by surface.

- **`social-admin-page`** (standalone admin page): bundle `@wordpress/theme` and `@wordpress/private-apis` inline, so the page renders on WP 6.9.x. They are bundled jointly so `@wordpress/theme`'s module-init `lock()` lands on the same `private-apis` consent map (same pattern as Boost / Jetpack AI admin / Search dashboard, PR #48173). This is safe here because the admin page is standalone, with no other script sharing a canonical `private-apis` instance.
- **`block-editor-jetpack`, `block-editor-social`, `classic-editor`**: keep externalizing both (unchanged). These load inside the block editor and must share WordPress's canonical `private-apis` instance; bundling a second copy inline breaks `lock()`/`unlock()` across bundles (`Cannot unlock an object that was not locked before`).

## Scope / known limitation (follow-up for the Social team)

This PR fixes the **blank Social admin page** on WP 6.9.x, the primary symptom in every ticket.

It does **not** restore the editor's per-post "Share to social media" controls on WP 6.9.x. Those controls live in the block-editor bundles, which still need the `wp-theme` handle that WP 6.9.x lacks, and that bundle cannot inline `@wordpress/theme` without breaking the shared `private-apis` instance (see above). Restoring them on old WP needs deeper work, e.g. registering a `wp-theme` shim for older WP or decoupling the editor bundle from `@wordpress/theme`. This is the same behaviour as the current release on 6.9.x (no regression), and is worth a follow-up owned by the Social team.

## Testing instructions

Tested on a JN sandbox rolled back to **WordPress 6.9.4** (standalone Jetpack Social plugin):

- Confirmed `wp-theme` is not registered on WP 6.9.4 (`wp_script_is( 'wp-theme', 'registered' )` returns false).
- **Before:** Jetpack → Social is blank (content area empty, no console error).
- **After:** Jetpack → Social renders the full dashboard.
- Verified the built `social-admin-page.asset.php` no longer lists `wp-theme` (inlined), while `block-editor-*.asset.php` still list it (externalized, unchanged).
- Verified the editor no longer throws `Cannot unlock ...` (an issue an earlier iteration of this PR introduced and this version resolves). On WP 6.9.x the editor Social panel remains absent, as in the current release.

**Not tested:** single-plugin layouts (the sandbox had both the main Jetpack plugin and the standalone Social plugin active), and WordPress versions other than 6.9.4.

## Screenshots

**Before (WP 6.9.4, Social admin page blank):**

<img width="2704" height="1752" alt="before-social-admin-wp694" src="https://github.com/user-attachments/assets/f85a8a63-964b-4fbe-880b-73981e6afb62" />

**After (fix applied, Social dashboard renders):**

<img width="2704" height="1752" alt="after-social-admin-wp694" src="https://github.com/user-attachments/assets/280c5e68-3653-4d6b-8f6b-1bc83d771f1c" />

### Console note (not a regression)

On the test site the console shows `Store "jetpack-connection" is already registered.` This is a **dual-plugin test-environment artifact**: the sandbox has both the main `jetpack` plugin and the standalone `jetpack-social` plugin active at once, each registering the `jetpack-connection` store. It does not occur on a real site running one of the two, and it is not related to this change.

## Does this pull request change what data or activity we track or use?

No.

## Reviewed locally

Reviewed with `/jetpack-review-pr` before flipping to ready. The fix area was re-scoped after CI E2E (editor + Social) flagged a regression in the first iteration; this version is verified against those surfaces on JN. Local lint/tests rely on CI (this clone's `node_modules` is mid-reinstall).

---

## Notes

This PR was created during Bug Blitz via the jetpack-bug-blitz Claude skill. The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.

#jetpack-happy-ai-updates
