### PR TITLE
Connection: Don't offer reconnect when the site is blocking the WP.com connection test

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-test-blocked-no-reconnect
+++ b/projects/packages/connection/changelog/fix-connection-test-blocked-no-reconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Do not offer to reconnect when the site is blocking WordPress.com's connection test (e.g. firewall/WAF).

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -498,12 +498,14 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		}
 
 		$message = isset( $result->message ) && '' !== $result->message
-			? $result->message . ': ' . $status_code
-			: sprintf(
-				/* translators: %s is the HTTP status code returned by WordPress.com. */
-				__( 'Connection test failed (status code: %s).', 'jetpack-connection' ),
-				$status_code
-			);
+			? $result->message
+			: __( 'Connection test failed.', 'jetpack-connection' );
+
+		$message .= ' ' . sprintf(
+			/* translators: %s is the HTTP status code returned by WordPress.com. */
+			__( '(status code: %s)', 'jetpack-connection' ),
+			$status_code
+		);
 
 		return self::connection_failing_test( $name, $message );
 	}

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -467,15 +467,73 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			);
 		}
 
-		$result       = json_decode( $body );
-		$is_connected = ! empty( $result->connected );
-		$message      = $result->message . ': ' . wp_remote_retrieve_response_code( $response );
+		return $this->evaluate_wpcom_connection_result( $name, json_decode( $body ), wp_remote_retrieve_response_code( $response ) );
+	}
 
-		if ( $is_connected ) {
+	/**
+	 * Turns a decoded WP.com test-connection response into a test result.
+	 *
+	 * Split out from test__wpcom_connection_test() so the decision logic can be
+	 * exercised without performing a signed remote request.
+	 *
+	 * @param string     $name        The test name.
+	 * @param object     $result      The JSON-decoded response body.
+	 * @param int|string $status_code The HTTP status code of the WP.com response.
+	 *
+	 * @return array Test results.
+	 */
+	protected function evaluate_wpcom_connection_result( $name, $result, $status_code ) {
+		if ( ! empty( $result->connected ) ) {
 			return self::passing_test( array( 'name' => $name ) );
 		}
 
+		// The site itself rejected WordPress.com's request (firewall, WAF, security
+		// plugin, or server rule). The connection token could be valid, but reconnecting would
+		// be rejected the same way - surface the real cause and don't offer a reconnect.
+		if ( isset( $result->error_code ) && 'xmlrpc_request_blocked' === $result->error_code ) {
+			return $this->blocked_request_failing_test(
+				$name,
+				isset( $result->site_http_status ) ? (int) $result->site_http_status : 0
+			);
+		}
+
+		$message = ( $result->message ?? '' ) . ': ' . $status_code;
+
 		return self::connection_failing_test( $name, $message );
+	}
+
+	/**
+	 * Builds a failing result for the case where the site is blocking WordPress.com's
+	 * connection test (e.g. firewall/WAF/security plugin).
+	 *
+	 * No reconnect action is offered because the connection token could be valid but
+	 * reconnecting would be rejected the same way.
+	 *
+	 * @param string $name             The test name.
+	 * @param int    $site_http_status The HTTP status the site returned, or 0 if unknown.
+	 *
+	 * @return array Test results.
+	 */
+	protected function blocked_request_failing_test( $name, $site_http_status = 0 ) {
+		$connection_error = $site_http_status
+			? sprintf(
+				/* translators: %d is the HTTP status code (e.g. 403) the site returned. */
+				__( 'WordPress.com reached your site but the request was blocked (HTTP %d). This is usually caused by a firewall, security plugin, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' ),
+				$site_http_status
+			)
+			: __( 'WordPress.com reached your site but the request was blocked. This is usually caused by a firewall, security plugin, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
+
+		$recommendation = __( 'Ask your host or security provider to allow requests from WordPress.com to your site\'s xmlrpc.php. Reconnecting will not resolve this.', 'jetpack-connection' );
+
+		return self::failing_test(
+			array(
+				'name'              => $name,
+				'short_description' => $connection_error,
+				'long_description'  => self::helper_get_reconnect_long_description( $connection_error, $recommendation ),
+				'action_label'      => $this->helper_get_support_text(),
+				'action'            => $this->helper_get_support_url(),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -482,7 +482,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 *
 	 * @return array Test results.
 	 */
-	protected function evaluate_wpcom_connection_result( $name, $result, $status_code ) {
+	public function evaluate_wpcom_connection_result( $name, $result, $status_code ) {
 		if ( ! empty( $result->connected ) ) {
 			return self::passing_test( array( 'name' => $name ) );
 		}

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -493,11 +493,17 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		if ( isset( $result->error_code ) && 'xmlrpc_request_blocked' === $result->error_code ) {
 			return $this->blocked_request_failing_test(
 				$name,
-				isset( $result->site_http_status ) ? (int) $result->site_http_status : 0
+				(int) ( $result->site_http_status ?? 0 )
 			);
 		}
 
-		$message = ( $result->message ?? '' ) . ': ' . $status_code;
+		$message = isset( $result->message ) && '' !== $result->message
+			? $result->message . ': ' . $status_code
+			: sprintf(
+				/* translators: %s is the HTTP status code returned by WordPress.com. */
+				__( 'Connection test failed (status code: %s).', 'jetpack-connection' ),
+				$status_code
+			);
 
 		return self::connection_failing_test( $name, $message );
 	}
@@ -523,7 +529,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			)
 			: __( 'WordPress.com reached your site but the request was blocked. This is usually caused by a firewall, security plugin, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
 
-		$recommendation = __( 'Ask your host or security provider to allow requests from WordPress.com to your site\'s xmlrpc.php. Reconnecting will not resolve this.', 'jetpack-connection' );
+		$recommendation = __( 'Ask your host or security provider to allow requests from WordPress.com to your site\'s xmlrpc.php file. Reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' );
 
 		return self::failing_test(
 			array(

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -624,6 +624,9 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$this->assertFalse( $result['pass'] );
 		$this->assertSame( 'https://example.com/reconnect', $result['action'] );
+		// WP.com's message is preserved and the status code is appended in a labeled form.
+		$this->assertStringContainsString( 'Invalid token.', $result['short_description'] );
+		$this->assertStringContainsString( '(status code: 200)', $result['short_description'] );
 	}
 
 	/**
@@ -636,7 +639,7 @@ class Connection_Health_Tests_Test extends TestCase {
 		$this->assertFalse( $result['pass'] );
 		// The message should not start with a stray colon when no message is present.
 		$this->assertStringStartsNotWith( ':', $result['short_description'] );
-		$this->assertStringContainsString( '500', $result['short_description'] );
+		$this->assertStringContainsString( '(status code: 500)', $result['short_description'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -541,22 +541,15 @@ class Connection_Health_Tests_Test extends TestCase {
 	 * @param int|string $status_code   HTTP status code of the WP.com response.
 	 * @return array Test result.
 	 */
-	private function evaluate_wpcom_connection_result( array $response_body, $status_code = 200 ) {
-		$method = new \ReflectionMethod( Connection_Health_Tests::class, 'evaluate_wpcom_connection_result' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			// setAccessible() has no effect (and is deprecated) on PHP 8.1+, but is required on older versions.
-			// @phan-suppress-next-line PhanDeprecatedFunctionInternal
-			$method->setAccessible( true );
-		}
-
-		return $method->invoke( $this->tests, 'test__wpcom_connection_test', (object) $response_body, $status_code );
+	private function evaluate_response( array $response_body, $status_code = 200 ) {
+		return $this->tests->evaluate_wpcom_connection_result( 'test__wpcom_connection_test', (object) $response_body, $status_code );
 	}
 
 	/**
 	 * Test wpcom_connection_test passes when WP.com reports the site as connected.
 	 */
 	public function test_wpcom_connection_test_passes_when_connected() {
-		$result = $this->evaluate_wpcom_connection_result( array( 'connected' => true ) );
+		$result = $this->evaluate_response( array( 'connected' => true ) );
 		$this->assertTrue( $result['pass'] );
 	}
 
@@ -578,7 +571,7 @@ class Connection_Health_Tests_Test extends TestCase {
 			}
 		);
 
-		$result = $this->evaluate_wpcom_connection_result(
+		$result = $this->evaluate_response(
 			array(
 				'connected'        => false,
 				'message'          => 'XML-RPC request was blocked.',
@@ -598,7 +591,7 @@ class Connection_Health_Tests_Test extends TestCase {
 	 * Test the blocked-request result omits the HTTP status when it is unknown.
 	 */
 	public function test_wpcom_connection_test_blocked_without_status_code() {
-		$result = $this->evaluate_wpcom_connection_result(
+		$result = $this->evaluate_response(
 			array(
 				'connected'  => false,
 				'message'    => 'XML-RPC request was blocked.',
@@ -622,7 +615,7 @@ class Connection_Health_Tests_Test extends TestCase {
 			}
 		);
 
-		$result = $this->evaluate_wpcom_connection_result(
+		$result = $this->evaluate_response(
 			array(
 				'connected' => false,
 				'message'   => 'Invalid token.',

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -626,6 +626,19 @@ class Connection_Health_Tests_Test extends TestCase {
 		$this->assertSame( 'https://example.com/reconnect', $result['action'] );
 	}
 
+	/**
+	 * Test wpcom_connection_test produces a readable message when WP.com returns
+	 * no message alongside a non-connected response.
+	 */
+	public function test_wpcom_connection_test_handles_missing_message() {
+		$result = $this->evaluate_response( array( 'connected' => false ), 500 );
+
+		$this->assertFalse( $result['pass'] );
+		// The message should not start with a stray colon when no message is present.
+		$this->assertStringStartsNotWith( ':', $result['short_description'] );
+		$this->assertStringContainsString( '500', $result['short_description'] );
+	}
+
 	// -------------------------------------------------------------------------
 	// test__server_port_value
 	// -------------------------------------------------------------------------

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -52,6 +52,8 @@ class Connection_Health_Tests_Test extends TestCase {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_offline_mode' );
 		remove_all_filters( 'jetpack_debugger_run_self_test' );
+		remove_all_filters( 'jetpack_connection_reconnect_url' );
+		remove_all_filters( 'jetpack_connection_support_url' );
 		remove_all_actions( 'jetpack_connection_tests_loaded' );
 	}
 
@@ -528,6 +530,107 @@ class Connection_Health_Tests_Test extends TestCase {
 	public function test_wpcom_connection_test_skipped_when_not_connected() {
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
 		$this->assertEquals( 'skipped', $result['pass'] );
+	}
+
+	/**
+	 * Evaluate a decoded WP.com test-connection response via the protected helper.
+	 *
+	 * Avoids performing a signed remote request, which can't be mocked in a unit test.
+	 *
+	 * @param array      $response_body Decoded response body.
+	 * @param int|string $status_code   HTTP status code of the WP.com response.
+	 * @return array Test result.
+	 */
+	private function evaluate_wpcom_connection_result( array $response_body, $status_code = 200 ) {
+		$method = new \ReflectionMethod( Connection_Health_Tests::class, 'evaluate_wpcom_connection_result' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// setAccessible() has no effect (and is deprecated) on PHP 8.1+, but is required on older versions.
+			// @phan-suppress-next-line PhanDeprecatedFunctionInternal
+			$method->setAccessible( true );
+		}
+
+		return $method->invoke( $this->tests, 'test__wpcom_connection_test', (object) $response_body, $status_code );
+	}
+
+	/**
+	 * Test wpcom_connection_test passes when WP.com reports the site as connected.
+	 */
+	public function test_wpcom_connection_test_passes_when_connected() {
+		$result = $this->evaluate_wpcom_connection_result( array( 'connected' => true ) );
+		$this->assertTrue( $result['pass'] );
+	}
+
+	/**
+	 * Test wpcom_connection_test does not offer a reconnect when the site itself
+	 * is blocking WordPress.com (error_code = xmlrpc_request_blocked).
+	 */
+	public function test_wpcom_connection_test_blocked_does_not_offer_reconnect() {
+		add_filter(
+			'jetpack_connection_reconnect_url',
+			static function () {
+				return 'https://example.com/reconnect';
+			}
+		);
+		add_filter(
+			'jetpack_connection_support_url',
+			static function () {
+				return 'https://example.com/support';
+			}
+		);
+
+		$result = $this->evaluate_wpcom_connection_result(
+			array(
+				'connected'        => false,
+				'message'          => 'XML-RPC request was blocked.',
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+
+		$this->assertFalse( $result['pass'] );
+		$this->assertStringContainsString( '403', $result['short_description'] );
+		// The action points to support, not the reconnect URL.
+		$this->assertSame( 'https://example.com/support', $result['action'] );
+		$this->assertNotSame( 'https://example.com/reconnect', $result['action'] );
+	}
+
+	/**
+	 * Test the blocked-request result omits the HTTP status when it is unknown.
+	 */
+	public function test_wpcom_connection_test_blocked_without_status_code() {
+		$result = $this->evaluate_wpcom_connection_result(
+			array(
+				'connected'  => false,
+				'message'    => 'XML-RPC request was blocked.',
+				'error_code' => 'xmlrpc_request_blocked',
+			)
+		);
+
+		$this->assertFalse( $result['pass'] );
+		$this->assertStringContainsString( 'blocked', $result['short_description'] );
+	}
+
+	/**
+	 * Test wpcom_connection_test still offers a reconnect when the connection itself
+	 * is invalid (no blocking error_code present).
+	 */
+	public function test_wpcom_connection_test_offers_reconnect_when_connection_invalid() {
+		add_filter(
+			'jetpack_connection_reconnect_url',
+			static function () {
+				return 'https://example.com/reconnect';
+			}
+		);
+
+		$result = $this->evaluate_wpcom_connection_result(
+			array(
+				'connected' => false,
+				'message'   => 'Invalid token.',
+			)
+		);
+
+		$this->assertFalse( $result['pass'] );
+		$this->assertSame( 'https://example.com/reconnect', $result['action'] );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Closes CONNECT-200

## Proposed changes

The WP.com `test-connection` endpoint now returns two extra fields when a site is reported as not connected (see 223035-ghe-Automattic/wpcom ): `error_code` and `site_http_status`. `error_code = xmlrpc_request_blocked` means the connection test reached the site but was rejected (e.g. firewall/WAF/security plugin), as opposed to an invalid connection token.

In that case the connection tokens are valid, so reconnecting would be rejected the same way. This PR teaches `test__wpcom_connection_test` to handle that scenario:

* Detect `error_code = xmlrpc_request_blocked` and return a dedicated failing result that explains the real cause (firewall/WAF/security plugin), including the HTTP status the site returned (`site_http_status`) when present.
* Offer a **support** link instead of a **"Reconnect now"** action, since reconnecting will not resolve a site that is blocking access.
* Unknown/other `error_code` values fall through to the existing reconnect path (safe default).
* Refactored the response-handling into a testable `evaluate_wpcom_connection_result()` method and added PHPUnit coverage for the blocked case (with/without status code), the connected case, and the existing "still offer reconnect" path.
<img width="845" height="268" alt="Screenshot 2026-06-16 at 12 54 16" src="https://github.com/user-attachments/assets/a5a72c41-11e6-4f53-af9a-f2cb6d97e1d2" />



## Related product discussion/links

* pbxlJb-7fc-p2#comment-4283 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a site to WordPress.com.
* Simulate the site blocking inbound requests. A simple [HTTP Auth plugin](https://wordpress.org/plugins/http-auth/) will do.
* Open **Tools → Site Health** (or run the connection health tests) and confirm the Jetpack Connection test fails with a message describing the firewall/WAF block (and the HTTP status), and that it offers a **support** link rather than a **Reconnect now** button.
* Confirm that a genuinely invalid/expired connection (no `error_code`) still shows the **Reconnect now** action. You can use Debug tools (broken token) for this. Store the connection data, disconnect, then restore the data you stored before so the local site believes it's connected while wpcom doesn't.
* Run the package tests: `jp test php packages/connection -- --filter Connection_Health_Tests_Test`.