### PR TITLE
Akismet admin chrome: hide #screen-meta-links gap + make registration idempotent

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -54,8 +54,20 @@ class Akismet_Admin_Chrome {
 	 *
 	 * Safe to call unconditionally: the header/footer callbacks are only ever fired by
 	 * Akismet's own admin views, and the inline stylesheet is printed alongside the header.
+	 *
+	 * Idempotent: this can be wired from more than one place depending on the platform —
+	 * `Jetpack_Admin` on Atomic/self-hosted, and `Akismet_Admin_WPCOM` on WordPress.com
+	 * Simple sites (the two run under different load orders). The static guard ensures the
+	 * `akismet_header` / `akismet_footer` callbacks are only ever registered once, so the
+	 * chrome can never render twice regardless of how many call sites fire.
 	 */
 	public function init_hooks() {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
 		add_action( 'akismet_header', array( $this, 'render_header' ) );
 		add_action( 'akismet_footer', array( $this, 'render_footer' ) );
 	}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -193,6 +193,19 @@ class Akismet_Admin_Chrome {
 			body[class*="_page_akismet-key-config"] #wpfooter {
 				display: none;
 			}
+			/* `#screen-meta-links` (the Screen Options / Help tabs container) is always
+				emitted by core's admin header even when empty, and core gives it
+				`margin: 0 10px 20px 0`. On wp.com Simple sites its contents are hidden
+				but the element — and its 20px bottom margin — remain, reserving a blank
+				slot at the very top of the page above the Jetpack header. The
+				`jetpack-admin-page-layout` mixin hides it for the same reason; do it here
+				too. Left UNSCOPED (not under `_page_akismet-key-config`) on purpose: the
+				inline stylesheet is only ever printed on Akismet admin views, and Simple
+				renders its stats UI under a different slug (`dashboard_page_akismet-stats`),
+				so an unscoped rule covers every page this chrome appears on. */
+			#screen-meta-links {
+				display: none;
+			}
 			body[class*="_page_akismet-key-config"] #wpbody-content {
 				box-sizing: border-box;
 				position: fixed;

--- a/projects/plugins/jetpack/changelog/fix-akismet-chrome-idempotent
+++ b/projects/plugins/jetpack/changelog/fix-akismet-chrome-idempotent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Akismet: make the admin header/footer chrome registration idempotent so it can't render twice if wired from more than one entry point.

--- a/projects/plugins/jetpack/changelog/fix-akismet-chrome-screen-meta-links
+++ b/projects/plugins/jetpack/changelog/fix-akismet-chrome-screen-meta-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Akismet: hide the empty #screen-meta-links container so it no longer reserves a blank slot above the Jetpack header (notably on WordPress.com Simple sites).


### PR DESCRIPTION
## Proposed changes

Follow-up to #49593. Two small robustness fixes to the Akismet admin chrome:

1. **Hide the `#screen-meta-links` blank slot.** Core always emits this container (the Screen Options / Help tabs slot) with a `margin-bottom: 20px`, even when empty; on WordPress.com Simple sites its contents are hidden but the element + margin remain, reserving a blank slot above the unified Jetpack header (most visible on mobile). We now hide it from the chrome's inline stylesheet, matching what the `jetpack-admin-page-layout` mixin already does on the other unified admin pages. The rule is intentionally unscoped within the chrome's inline stylesheet (which only ever prints on Akismet admin views), so it also covers the Simple-site stats slug `dashboard_page_akismet-stats`. Like the mixin, this also hides the Screen Options / Help tabs container on these pages.

2. **Make `Akismet_Admin_Chrome::init_hooks()` idempotent.** The chrome can be wired from more than one entry point depending on platform — `Jetpack_Admin` on Atomic/self-hosted, and `Akismet_Admin_WPCOM` on WordPress.com Simple sites — which run under different load orders. A function-level static guard ensures the `akismet_header` / `akismet_footer` callbacks register only once, so the chrome can never render twice regardless of how many call sites fire.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site that registers help tabs for the Akismet admin page (e.g. a WordPress.com Simple site), open the Akismet settings/stats page at a mobile viewport width. Confirm there is no blank gap between the admin bar and the "Akismet Anti-spam" Jetpack header.
* On a self-hosted site, confirm the Akismet admin page header/footer still render correctly, exactly once (no duplicate header/footer).
