### PR TITLE
Replace `jetpack_is_mobile` with Device Detection in custom CSS

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/replace-jetpack-is-mobile-device-detection
+++ b/projects/packages/jetpack-mu-wpcom/changelog/replace-jetpack-is-mobile-device-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Custom CSS: Replace legacy mobile detection with the device detection package.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -15,6 +15,7 @@
 		"automattic/jetpack-classic-theme-helper": "@dev",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-google-analytics": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
 		"automattic/jetpack-podcast": "@dev",

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
@@ -10,6 +10,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Device_Detection;
 
 if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 	/**
@@ -345,8 +346,7 @@ if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 				'_jp_css_settings',
 				array(
 					/** This filter is documented in modules/custom-css/custom-css.php */
-					// @phan-suppress-next-line PhanUndeclaredFunction
-					'useRichEditor'        => ! jetpack_is_mobile() && apply_filters( 'safecss_use_ace', true ),
+					'useRichEditor'        => ! Device_Detection::is_phone() && apply_filters( 'safecss_use_ace', true ),
 					'areThereCssRevisions' => self::are_there_css_revisions(),
 					'revisionsUrl'         => self::get_revisions_url(),
 					'cssHelpUrl'           => '//en.support.wordpress.com/custom-design/editing-css/',

--- a/projects/plugins/mu-wpcom-plugin/changelog/codex-replace-jetpack-is-mobile
+++ b/projects/plugins/mu-wpcom-plugin/changelog/codex-replace-jetpack-is-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Custom CSS to use device detection

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1308,7 +1308,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "17cf4ffb6db2e468d015f3840acf680595023045"
+                "reference": "5959e9f55b6d22be3da4631ecb1a45764ace8533"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1318,6 +1318,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",

--- a/projects/plugins/wpcomsh/changelog/move-to-device-detection
+++ b/projects/plugins/wpcomsh/changelog/move-to-device-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move Custom CSS to Devcie Detection

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1495,7 +1495,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "17cf4ffb6db2e468d015f3840acf680595023045"
+                "reference": "5959e9f55b6d22be3da4631ecb1a45764ace8533"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1505,6 +1505,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",


### PR DESCRIPTION
Fixes JETPACK-1534

## Proposed changes
* Replace `jetpack_is_mobile()` in Custom CSS Customizer settings with `Automattic\Jetpack\Device_Detection::is_phone()`.
* Add `automattic/jetpack-device-detection` as a direct `jetpack-mu-wpcom` dependency.
* Add a changelog entry for the package.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* From `projects/packages/jetpack-mu-wpcom`, run `composer test-php`.
* From the repo root, run `php -l projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php`.
* From `projects/packages/jetpack-mu-wpcom`, run `composer validate --no-check-publish`.
* Confirm `Automattic\Jetpack\Device_Detection` autoloads from the package vendor autoloader.
