### PR TITLE
Connection: Update and expand package documentation

### DIFF
--- a/projects/packages/connection/README.md
+++ b/projects/packages/connection/README.md
@@ -16,12 +16,16 @@ Package is published in [Packagist](https://packagist.org/packages/automattic/je
 
 ## Guides
 * [Connection package guide](docs/register-site.md)
+* [Authorizing a user](docs/authorize-user.md)
 * [Connection health tests](docs/connection-health-tests.md)
+* [Connectors screen card](docs/connectors.md)
+* [Connection Abilities (Abilities API)](docs/abilities.md)
 
 ## Tools
 
 1. [Making Authenticated async XML-RPC calls](docs/xmlrpc-async-calls.md)
 1. [Customizing error messages](docs/error-handling.md)
+1. [Partner tools](docs/partner-tools.md)
 
 ## Using this package in your WordPress plugin
 

--- a/projects/packages/connection/changelog/update-connection-package-docs
+++ b/projects/packages/connection/changelog/update-connection-package-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update and expand the connection package documentation (fix broken links, add Connectors, Abilities, and user-authorization guides).
+
+

--- a/projects/packages/connection/docs/abilities.md
+++ b/projects/packages/connection/docs/abilities.md
@@ -1,0 +1,57 @@
+# Connection Abilities (WordPress Abilities API)
+
+The Connection package registers abilities with the [WordPress Abilities API](https://make.wordpress.org/core/) so that AI agents and other consumers can inspect a site's Jetpack connection state through the standard `wp-abilities/v1` REST surface (and as an MCP tool) instead of reverse-engineering `Jetpack_Options` keys.
+
+The relevant class is `Automattic\Jetpack\Connection\Abilities\Connection_Abilities`, which extends the shared `Registrar` from the `automattic/jetpack-wp-abilities` package.
+
+> **Requirements:** The Abilities API ships with WordPress 6.9+. On older versions the registration hooks never fire, so initialization is a safe no-op.
+
+## Registered abilities
+
+| Ability | Type | Description |
+|---------|------|-------------|
+| `jetpack/get-connection-status` | read-only | Returns the site-level Jetpack connection state in one zero-argument call. |
+
+All abilities are registered under the shared `jetpack` ability category (label `Jetpack`), which the Jetpack plugin also contributes to.
+
+### `jetpack/get-connection-status`
+
+A read-only, idempotent ability that is safe to poll. It takes no input and returns:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `site_registered` | `boolean` | `true` when the site has a blog id and a blog token. |
+| `user_connected` | `boolean` | `true` when at least one user has linked their WordPress.com account. |
+| `master_user` | `integer\|null` | Local user id of the connection owner (the user who registered the site), or `null` if there is no owner. |
+| `blog_id` | `integer\|null` | The WordPress.com site id, or `null` when the site has not been registered. |
+| `registration_url` | `string\|null` | The wp-admin URL the site owner should visit to register the site when `site_registered` is `false`; `null` once the site is registered. |
+| `connection_version` | `string` | The running Jetpack Connection package version. |
+
+**Permissions:** Access is gated on `current_user_can( 'jetpack_admin_page' )`, mirroring the capability used by the Jetpack admin page.
+
+**MCP:** This ability is opted into the MCP tool surface (`meta.mcp.public = true`), so it is exposed as a public MCP tool.
+
+## Initialization
+
+The abilities are not registered automatically when you configure the connection package — a consumer must call `init()` once. The Jetpack plugin does this during its own setup:
+
+```php
+\Automattic\Jetpack\Connection\Abilities\Connection_Abilities::init();
+```
+
+`init()` hooks the category and ability registration onto the `wp_abilities_api_categories_init` and `wp_abilities_api_init` actions respectively, so it is safe to call early (for example on `plugins_loaded`).
+
+## Filters
+
+| Filter | Description |
+|--------|-------------|
+| `jetpack_connection_abilities_manager` | Filters the `Manager` instance used to resolve connection state. Primarily a testing seam — production callers should leave the default. Non-`Manager` return values are discarded. |
+
+## Unit tests
+
+The abilities are covered by PHPUnit tests in `tests/php/abilities/Connection_Abilities_Test.php`:
+
+```bash
+cd projects/packages/connection
+composer phpunit -- --filter Connection_Abilities_Test
+```

--- a/projects/packages/connection/docs/authorize-user.md
+++ b/projects/packages/connection/docs/authorize-user.md
@@ -1,0 +1,86 @@
+# Authorize a user / Create a user token
+
+Once the site is [registered](register-site.md) (it has a blog token), you can authorize a user. This links a local WordPress user to their WordPress.com account and creates a "user token", which lets the Connection package make authenticated requests on that user's behalf.
+
+The first user to be authorized becomes the **connection owner** (also called the "master user"). A site can have a site-level connection with no authorized users (see `is_site_connection()`), but many features require at least one connected user.
+
+## The authorization flow
+
+Authorizing a user means redirecting them to WordPress.com, where they approve the connection, and then back to your site. The Connection package builds the correct, signed URL for you — you should never construct it by hand, because it carries a signed representation of the user's role.
+
+### Using the JS connection components
+
+The JS connection package (see the `js-packages/connection` folder in the monorepo) ships React components that handle the entire connect + authorize flow out of the box. If you can, prefer those.
+
+### Using the REST API
+
+If you registered the site via `jetpack/v4/connection/register`, the response already includes an `authorizeUrl` — send the user there to authorize.
+
+To fetch an authorization URL on its own, make a GET request to `jetpack/v4/connection/authorize_url`. It accepts optional `redirect_uri` and `from` query arguments.
+
+### Authorizing a user manually in PHP
+
+To send the current user off to Calypso to authorize (this redirects and exits):
+
+```php
+use Automattic\Jetpack\Connection\Manager;
+
+$manager = new Manager( 'plugin-slug' );
+$manager->connect_user();
+```
+
+`connect_user()` accepts an optional user ID and redirect URL:
+
+```php
+$manager->connect_user( $user_id, $redirect_url );
+```
+
+Or, if you'd rather render your own link or button, fetch the URL instead of redirecting:
+
+```php
+$auth_url = $manager->get_authorization_url();
+```
+
+`get_authorization_url()` accepts optional `$user`, `$redirect`, `$from`, and `$raw` arguments:
+
+```php
+$auth_url = $manager->get_authorization_url( $user, $redirect_url, 'my-plugin-banner' );
+```
+
+## Checking user connection status
+
+The `Manager` class exposes several helpers for reasoning about user authorization:
+
+* `is_user_connected()`: Checks if the current user (or a given user ID) is connected (authorized in WordPress.com).
+* `has_connected_owner()`: Checks if the site has a connection owner (a connected admin marked as the owner).
+* `is_connection_owner()`: Checks if the current user (or a given user ID) is the connection owner.
+* `get_connection_owner()`: Returns the `WP_User` of the connection owner, or `false`.
+
+```php
+$manager = new Manager( 'plugin-slug' );
+
+if ( $manager->is_user_connected() ) {
+	// The current user has authorized their WordPress.com account.
+}
+
+if ( ! $manager->has_connected_owner() ) {
+	// The site is registered but nobody owns the connection yet.
+}
+```
+
+## Changing the connection owner
+
+If the connection owner needs to be changed to another connected user, make a POST request to `jetpack/v4/connection/owner` with the target user ID. Only an existing connected admin can transfer ownership, and the new owner must already be a connected user.
+
+## Disconnecting a user
+
+To disconnect (deauthorize) a user, removing their user token:
+
+```php
+$manager = new Manager( 'plugin-slug' );
+$manager->disconnect_user();
+```
+
+`disconnect_user()` accepts an optional user ID. Note that disconnecting the connection owner has site-wide implications — prefer transferring ownership first if other users are still connected.
+
+To remove the entire connection (blog token plus all user tokens), see the [Disconnect the site](register-site.md#disconnect-the-site) section of the registration guide.

--- a/projects/packages/connection/docs/connectors.md
+++ b/projects/packages/connection/docs/connectors.md
@@ -1,0 +1,36 @@
+# Connectors screen card
+
+WordPress 7.0 introduces a core **Connectors** screen (`wp-admin/options-connectors.php`) where sites manage their connections to external cloud services. The Connection package registers a Jetpack card on that screen so users can view and manage their WordPress.com connection from a single, native location.
+
+The relevant class is `Automattic\Jetpack\Connection\Jetpack_Connector`.
+
+> **Requirements:** The Connectors registry (`wp_connectors_init` / `WP_Connector_Registry`) ships with WordPress 7.0+. On older versions the registration hook never fires and the script module is never enqueued, so everything below is a safe no-op. The card also works with the Connectors screen provided by the Gutenberg plugin.
+
+## How it works
+
+`Jetpack_Connector::init()` is called automatically when you configure the connection package (it runs from `Manager::configure()`), so no extra setup is required in your plugin. Initialization wires up three things:
+
+1. **Connector registration** — on `wp_connectors_init`, registers a `wordpress_com` connector (a `cloud_service` type with `authentication.method = none`) in the core registry.
+2. **Script module** — on the Connectors admin screen, enqueues the `@automattic/jetpack-connection-connectors` script module (and its stylesheet), which provides a custom render function for the card.
+3. **Auth error capture** — on `jetpack_client_authorize_error`, stores the error so it can be surfaced in the card after an authorization attempt.
+
+## What the card shows
+
+The card's render function receives data via the `script_module_data_@automattic/jetpack-connection-connectors` filter. Depending on connection state, it surfaces:
+
+- **Connection / registration status** — `isRegistered` (site has a blog token), `isConnected` (registered *and* has a connected owner), and `isOfflineMode`.
+- **Site details** — blog id, site URL, and home URL once registered.
+- **Connection owner and current user** — display name, login, email, and avatar, sourced from WordPress.com data where available, plus whether the current user is the owner.
+- **Connected plugins** — the plugins currently sharing the connection.
+- **SSO status** — when the Jetpack plugin is connected.
+- **Safe Mode / Identity Crisis** — when the site is in Safe Mode, the status badge swaps to "Safe Mode" and the card renders the resolution options (migrate / start fresh / stay in safe mode).
+- **Hosting context** — `isWoaSite` and `isVipSite` flags.
+- **Auth errors** — any error captured from the last authorization attempt.
+
+Connect and disconnect actions performed from the card go through the package's existing connection REST endpoints. Connecting and disconnecting are disabled while the site is in offline mode.
+
+## Customization
+
+The card data is assembled server-side in `Jetpack_Connector::get_connector_data()` and passed through the `script_module_data_@automattic/jetpack-connection-connectors` filter, so consumers can adjust the payload by hooking that filter if needed.
+
+The Safe Mode / Identity Crisis data mirrors what `\Automattic\Jetpack\IdentityCrisis\UI::get_initial_state_data()` provides, and is only added when the `Identity_Crisis` class is available and the site is actually in Safe Mode.

--- a/projects/packages/connection/docs/register-site.md
+++ b/projects/packages/connection/docs/register-site.md
@@ -2,7 +2,7 @@
 
 This means registering the site with WordPress.com. It will create a "site (or 'blog') token" on both sides, establishing a secure two-way communication path.
 
-The blog token is required in order to [authenticate at a user level](authorize-user.md) later (link to user auth docs here), so let's learn the simplest way we can do that in your plugin.
+The blog token is required in order to [authenticate at a user level](authorize-user.md) later, so let's learn the simplest way we can do that in your plugin.
 
 ## Install the right packages
 
@@ -52,7 +52,7 @@ function jpcs_load_plugin() {
         array(
             'slug' => 'plugin-slug', // Required, slug of your plugin, should be unique.
             'name' => 'Plugin Name', // Required, your plugin name.
-            'url_info' => 'https://example.org/conneciton-info', // Optional, URL of the connection info page.
+            'url_info' => 'https://example.org/connection-info', // Optional, URL of the connection info page.
         )
     );
 }


### PR DESCRIPTION
Closes CONNECT-194

## Proposed changes

The connection package has grown a lot (connectors, abilities, webhooks, identity-crisis, SSO) but the docs hadn't kept pace. This PR audits the existing docs and fills the gaps.

* **Fix `register-site.md`**: the `authorize-user.md` link was broken (target never existed) and carried a leftover `(link to user auth docs here)` placeholder; also fixed a `conneciton-info` typo in the `url_info` example.
* **README hygiene**: linked the previously-orphaned `partner-tools.md` and the new guides.
* **New `docs/connectors.md`**: documents `Jetpack_Connector` and the WP 7.0+ Connectors screen card — auto-init via `Manager::configure()`, connector registration, the script module, the data surfaced (status, owner, connected plugins, SSO, Safe Mode/IDC), and the `script_module_data_` customization hook.
* **New `docs/abilities.md`**: documents `Connection_Abilities` and the `jetpack/get-connection-status` ability — output shape, permissions (`jetpack_admin_page`), MCP exposure, `init()` wiring, and the `jetpack_connection_abilities_manager` filter.
* **New `docs/authorize-user.md`**: the user-authorization guide the old broken link pointed at — REST `authorize_url`, `connect_user()`/`get_authorization_url()`, status helpers, changing the connection owner, and disconnecting a user.

Every PHP API, REST endpoint, filter, and method referenced was verified against the current source.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No. Documentation-only change.

## Testing instructions

* This is a documentation-only change — no code paths are affected.
* Review the rendered Markdown in `projects/packages/connection/docs/` and `README.md`.
* Confirm internal links resolve: `register-site.md` → `authorize-user.md`, and `authorize-user.md` → `register-site.md#disconnect-the-site`.
* Spot-check the documented APIs (e.g. `Manager::connect_user()`, `jetpack/get-connection-status`, `Jetpack_Connector`) against the source.

Made with [Cursor](https://cursor.com)