### PR TITLE
Revert wpcomsh lock file change

### DIFF
--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1495,7 +1495,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "5959e9f55b6d22be3da4631ecb1a45764ace8533"
+                "reference": "17cf4ffb6db2e468d015f3840acf680595023045"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1505,7 +1505,6 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",


### PR DESCRIPTION
## Proposed changes

- Revert accidental changes to `projects/plugins/wpcomsh/composer.lock` from `ee76507c379d896ca3fe8ab33ee08cff037bbbe3`.
- Keep the PR scoped to the branch that contains the accidental commit: `codex/charts-react-19-compatibility`.

## Testing instructions

- Verified the PR diff contains only `projects/plugins/wpcomsh/composer.lock`.
- The pre-push hook passed, including lockfile and changelog checks.
