### PR TITLE
Fix ShellCheck installation URL in dev environment check

### DIFF
--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -327,7 +327,7 @@ fi
 checking '[optional] ShellCheck is available'
 BIN="$(command -v shellcheck)"
 if [[ -z "$BIN" ]]; then
-	warning "no" '' "ShellCheck is used to lint shell scripts. See https://www.shellcheck.net/ for installation instructions."
+	warning "no" '' "ShellCheck is used to lint shell scripts. See https://github.com/koalaman/shellcheck#installing for installation instructions."
 else
 	success "yes"
 fi

--- a/tools/js-tools/git-hooks/pre-commit-hook.mjs
+++ b/tools/js-tools/git-hooks/pre-commit-hook.mjs
@@ -507,7 +507,9 @@ function runShellcheck( shellFilesToLint ) {
 
 	if ( shellcheckResult.error?.code === 'ENOENT' ) {
 		console.log(
-			chalk.yellow( 'Skipping shellcheck: not installed. See https://www.shellcheck.net/' )
+			chalk.yellow(
+				'Skipping shellcheck: not installed. See https://github.com/koalaman/shellcheck#installing for installation instructions'
+			)
 		);
 		return;
 	}


### PR DESCRIPTION
## Summary

`tools/check-development-environment.sh` pointed users to the ShellCheck homepage (`https://www.shellcheck.net/`) when ShellCheck was missing. This updates it to the canonical installation instructions at `https://github.com/koalaman/shellcheck#installing`.

## Testing instructions

- Run `tools/check-development-environment.sh` on a machine without ShellCheck installed.
- Confirm the warning links to `https://github.com/koalaman/shellcheck#installing`.

## Does this pull request change what data or activity we track or use?

No. This only changes a help URL printed by a developer tooling script. It does not affect any user-facing functionality, tracking, data collection, or privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)