### PR TITLE
VideoPress: persist TUS upload offset once per request

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tus-receive-buffer
+++ b/projects/packages/videopress/changelog/update-videopress-tus-receive-buffer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-VideoPress: reduce memcache writes and read/write syscalls when receiving resumable uploads by buffering 1 MB per iteration and persisting the upload offset once per request instead of every 8 KB.
+VideoPress: Improve performance when receiving resumable video uploads.

--- a/projects/packages/videopress/changelog/update-videopress-tus-receive-buffer
+++ b/projects/packages/videopress/changelog/update-videopress-tus-receive-buffer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: reduce memcache writes and read/write syscalls when receiving resumable uploads by buffering 1 MB per iteration and persisting the upload offset once per request instead of every 8 KB.

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package VideoPressUploader
  */
 class Tus_File {
-	const CHUNK_SIZE    = 8192; // 8 kilobytes.
+	const CHUNK_SIZE    = MB_IN_BYTES;
 	const INPUT_STREAM  = 'php://input';
 	const READ_BINARY   = 'rb';
 	const APPEND_BINARY = 'ab';
@@ -415,8 +415,6 @@ class Tus_File {
 
 				$this->offset += $bytes;
 
-				$this->cache->set( $key, array( 'offset' => $this->offset ) );
-
 				if ( $this->offset > $total_bytes ) {
 					throw new \Out_Of_Range_Exception( 'The uploaded file is corrupt.' );
 				}
@@ -428,6 +426,12 @@ class Tus_File {
 		} finally {
 			$this->close( $input );
 			$this->close( $output );
+
+			try {
+				$this->cache->set( $key, array( 'offset' => $this->offset ) );
+			} catch ( \Exception $e ) {
+				Logger::log( 'error', $e );
+			}
 		}
 
 		return $this->offset;

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package VideoPressUploader
  */
 class Tus_File {
-	const CHUNK_SIZE    = MB_IN_BYTES;
+	const CHUNK_SIZE    = 8192; // 8 kilobytes.
 	const INPUT_STREAM  = 'php://input';
 	const READ_BINARY   = 'rb';
 	const APPEND_BINARY = 'ab';

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -429,7 +429,7 @@ class Tus_File {
 
 			try {
 				$this->cache->set( $key, array( 'offset' => $this->offset ) );
-			} catch ( \Exception $e ) {
+			} catch ( \Throwable $e ) {
 				Logger::log( 'error', $e );
 			}
 		}

--- a/projects/packages/videopress/tests/php/Tus_File_Test.php
+++ b/projects/packages/videopress/tests/php/Tus_File_Test.php
@@ -72,9 +72,31 @@ class Tus_File_Test extends BaseTestCase {
 
 		$input_file  = tempnam( sys_get_temp_dir(), 'videopress-tus-input-' );
 		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
-		$cache       = new Transient_Store( 1 );
 		$key         = 'test-upload-success';
 		$contents    = 'hello videopress';
+
+		// A cache that counts set() calls, to assert the offset is persisted only once per upload.
+		$cache = new class( 1 ) extends Transient_Store {
+			/**
+			 * Number of times set() was called.
+			 *
+			 * @var int
+			 */
+			public $set_calls = 0;
+
+			/**
+			 * Count and delegate.
+			 *
+			 * @param string      $key   The key.
+			 * @param array|mixed $value The value.
+			 *
+			 * @return bool
+			 */
+			public function set( $key, $value ) {
+				++$this->set_calls;
+				return parent::set( $key, $value );
+			}
+		};
 
 		try {
 			$this->assertNotFalse( $input_file );
@@ -101,6 +123,7 @@ class Tus_File_Test extends BaseTestCase {
 			$cached = $cache->get( $key );
 			$this->assertIsArray( $cached );
 			$this->assertSame( strlen( $contents ), $cached['offset'] );
+			$this->assertSame( 1, $cache->set_calls, 'The offset should be persisted exactly once per upload.' );
 		} finally {
 			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
 			$cache->delete( $key );

--- a/projects/packages/videopress/tests/php/Tus_File_Test.php
+++ b/projects/packages/videopress/tests/php/Tus_File_Test.php
@@ -63,4 +63,55 @@ class Tus_File_Test extends BaseTestCase {
 			}
 		}
 	}
+
+	/**
+	 * Tests that a successful upload writes the full body and persists the final offset once.
+	 */
+	public function test_upload_writes_body_and_persists_final_offset() {
+		global $wp_filesystem;
+
+		$input_file  = tempnam( sys_get_temp_dir(), 'videopress-tus-input-' );
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-upload-success';
+		$contents    = 'hello videopress';
+
+		try {
+			$this->assertNotFalse( $input_file );
+			$this->assertNotFalse( $output_file );
+
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+
+			$this->assertTrue( WP_Filesystem() );
+			$this->assertTrue( $wp_filesystem->put_contents( $input_file, $contents ) );
+			set_transient( $cache->build_key( $key ), wp_json_encode( array(), JSON_UNESCAPED_SLASHES ) );
+
+			$file = new Tus_File( $key, $cache );
+			$file->set_key( $key );
+			$file->set_meta( 0, strlen( $contents ), $output_file );
+			Tus_File::set_input_stream( $input_file );
+
+			$offset = $file->upload( strlen( $contents ) );
+
+			$this->assertSame( strlen( $contents ), $offset );
+			$this->assertSame( $contents, $wp_filesystem->get_contents( $output_file ) );
+
+			$cached = $cache->get( $key );
+			$this->assertIsArray( $cached );
+			$this->assertSame( strlen( $contents ), $cached['offset'] );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			$cache->delete( $key );
+
+			if ( is_string( $input_file ) && file_exists( $input_file ) ) {
+				wp_delete_file( $input_file );
+			}
+
+			if ( is_string( $output_file ) && file_exists( $output_file ) ) {
+				wp_delete_file( $output_file );
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
The VideoPress TUS receiver (`VideoPressUploader\Tus_File::upload()`, the package source that wpcom's resumable upload server runs) drained each incoming PATCH body in 8 KB reads **and persisted the upload offset to the cache on every iteration**. On the wpcom receiver, where the cache is memcache, that is ~1 cache write per 8 KB — roughly 1,280 writes for a single 10 MB chunk, and ~128k for a 1 GB upload — purely for resume bookkeeping. Each of those is a network round-trip to the memcache cluster, which dominated the cost of receiving a chunk. (The cache only ever holds the small offset record, not file data; this is about write frequency, not size.)

* Persist the offset **once** after the request body has been consumed (in `finally`) instead of on every read-loop iteration. This collapses ~1,280 memcache writes per 10 MB chunk down to one and is the entire performance win.
* Close the file handles **before** the cache write, and guard the write, so a cache-backend hiccup can't leak file handles or mask the real upload exception (`Connection_Exception` / `Out_Of_Range_Exception` / `File_Exception`).
* Add a happy-path unit test asserting a full upload writes the complete body and persists the correct final offset exactly once.

Behavior is preserved: the offset is still persisted on every exit path (normal completion, connection abort, corrupt-file), and the connection-abort and over-range corruption guards still run. The value persisted on each path is the same as before — only the frequency of writes changes.

### Why the read buffer stays at 8 KB
An earlier revision of this PR also raised the read/write buffer from `8192` to `MB_IN_BYTES` (1 MB). That was dropped: once the per-read cache write is gone, the loop body is just a local `fread`/`fwrite` plus offset arithmetic — cheap operations whose total cost is a few milliseconds per chunk, negligible next to the memcache round-trips we eliminated. Bumping the buffer would only have trimmed those cheap iterations while raising peak per-connection memory 128× (8 KB → 1 MB per in-flight upload), so it is not worth it. The `8192 // 8 kilobytes.` value is the upstream [`ankitpokhrel/tus-php`](https://github.com/ankitpokhrel/tus-php) default (`TusPhp\File::CHUNK_SIZE`) that `VideoPressUploader\Tus_File` is a WordPress-coding-standards port of, and it is left unchanged.

Note: this is package source vendored into wpcom, so the win lands on the wpcom receiver once the package version is published and pulled in. `Tus_File::upload()` is not exercised by the Jetpack plugin's own client path (which uses `Tus_Client::get_data()` with 5 MB reads).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Upload a video through VideoPress — both the block editor flow and the media-library "upload to VideoPress" flow — and confirm uploads complete successfully.
* Interrupt an in-progress upload (e.g. reload mid-upload) and confirm it resumes correctly from where it left off.
* Run the package unit tests:
  * `cd projects/packages/videopress && composer phpunit -- --filter Tus_File_Test`
  * Expected: `OK (2 tests, 14 assertions)`.
