### PR TITLE
VideoPress: fix Divi extension fatal on wp-admin (VIDP-256)

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-divi-admin-enqueue-fatal
+++ b/projects/packages/videopress/changelog/fix-videopress-divi-admin-enqueue-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal error in the VideoPress Divi extension caused by hooking an undefined `admin_hook_enqueue_scripts` callback to `admin_enqueue_scripts`.

--- a/projects/packages/videopress/changelog/fix-videopress-divi-admin-enqueue-fatal
+++ b/projects/packages/videopress/changelog/fix-videopress-divi-admin-enqueue-fatal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a fatal error in the VideoPress Divi extension caused by hooking an undefined `admin_hook_enqueue_scripts` callback to `admin_enqueue_scripts`.
+Fix a wp-admin fatal error when using the VideoPress Divi extension with Divi Builder on PHP 8+.

--- a/projects/packages/videopress/src/videopress-divi/class-videopress-divi-extension.php
+++ b/projects/packages/videopress/src/videopress-divi/class-videopress-divi-extension.php
@@ -121,7 +121,6 @@ class VideoPress_Divi_Extension extends DiviExtension {
 
 		add_action( 'et_builder_ready', array( $this, 'hook_et_builder_ready' ), 9 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'wp_hook_enqueue_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_hook_enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_js_assets' ) );
 	}
 


### PR DESCRIPTION
Fixes VIDP-256

## Proposed changes
<!--- Explain what functional changes your PR includes -->

`VideoPress_Divi_Extension::_initialize()` registered `admin_enqueue_scripts` to an `admin_hook_enqueue_scripts` callback that was **never defined** on the class — and isn't inherited from the third-party parent `DiviExtension`. This has been present since the original Divi integration (`529a506411`, 2023).

On PHP 8.x, `call_user_func_array()` throws a fatal `TypeError` when the callback fires:

```
Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback,
class VideoPress_Divi_Extension does not have a method "admin_hook_enqueue_scripts"
```

Because `admin_enqueue_scripts` runs on every wp-admin request, this crashes the entire admin dashboard whenever the VideoPress package and Divi Builder are active (reported on WordPress 7.0 / PHP 8.3 with Divi Builder).

* Remove the orphaned `add_action( 'admin_enqueue_scripts', … )` registration. There is no admin-side asset to enqueue in this extension — the editor/frontend assets are registered via `register_js_assets` on `wp_enqueue_scripts`, which is untouched.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* VIDP-256
* Customer ticket: 11334503

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

* On a site running **PHP 8.x** with **Divi Builder** active and the Jetpack VideoPress package loaded, open any wp-admin page.
* Before this change: a fatal `TypeError` for the missing `admin_hook_enqueue_scripts` callback takes down the admin dashboard.
* After this change: wp-admin loads normally, and VideoPress frontend/editor asset registration is unchanged.
