### PR TITLE
Write editor: add media library image selection

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-media-library-image-selection
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-media-library-image-selection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: add a media library browser to the image insert modal so users can pick existing images alongside upload and paste-URL.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1636,6 +1636,14 @@
 }
 
 /* ===== Image modal ===== */
+
+/* Lock page scroll while the Add image modal is open so the editor doesn't
+ * slide under the dimmed backdrop. The non-modal Edit image panel doesn't
+ * set this class — the editor stays scrollable while editing an image. */
+body.bw-modal-open {
+	overflow: hidden;
+}
+
 .bw-image-overlay {
 	position: fixed;
 	inset: 0;
@@ -1643,8 +1651,15 @@
 	background: rgba(0, 0, 0, 0.4);
 	backdrop-filter: blur(4px);
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: center;
+
+	/* Anchor the modal below the disclaimer banner (~56px) + toolbar (~88px
+	 * incl. its shifted top), with a small breathing gap. Pairs with the
+	 * modal's max-height: calc(100vh - 200px) so the modal can't grow
+	 * behind the toolbar even when both expanders + a preview are open. */
+	padding: 168px 0 32px;
+	box-sizing: border-box;
 	animation: bw-fade-in 0.15s ease;
 }
 
@@ -1658,6 +1673,15 @@
 	padding: 32px;
 	width: 420px;
 	max-width: 90vw;
+
+	/* Hard cap below "banner + toolbar height + bottom breathing room" so the
+	 * modal never grows behind the toolbar. With the disclaimer banner
+	 * visible the toolbar's bottom sits at ~144px; we leave ~24px of air
+	 * above and below the modal — anything taller scrolls internally.
+	 * border-box so max-height includes the padding. */
+	box-sizing: border-box;
+	max-height: calc(100vh - 200px);
+	overflow-y: auto;
 	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
 }
 
@@ -1788,22 +1812,177 @@
 	}
 }
 
+/* RSM-3983: when a preview is set, the upload zone grows to fit the image's
+ * natural aspect ratio (capped) and switches to contain so portrait/wide
+ * images aren't centre-cropped. The image is a normal flow child so its
+ * intrinsic height drives the zone height. */
 .bw-upload-preview {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
+	display: none;
+	max-width: 100%;
+	max-height: 320px;
+	width: auto;
+	height: auto;
+	object-fit: contain;
 	border-radius: 6px;
 	animation: bw-fade-in 0.2s ease;
-	position: absolute;
-	top: 0;
-	left: 0;
-	display: none;
+	background: #f3f4f6;
 }
 
 .bw-upload-has-preview {
 	border: none;
 	padding: 0;
 	overflow: hidden;
+	height: auto;
+	min-height: 160px;
+}
+
+.bw-library-section[hidden],
+.bw-url-section[hidden] {
+	display: none;
+}
+
+.bw-source-expanders {
+	margin-top: 20px;
+	border-top: 1px solid #f0f0f0;
+	padding-top: 8px;
+}
+
+.bw-source-expander + .bw-source-expander {
+	margin-top: 2px;
+}
+
+.bw-source-trigger {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 10px 0;
+	background: transparent;
+	border: none;
+	font-size: 14px;
+	color: #444;
+	cursor: pointer;
+	font-family: inherit;
+	text-align: left;
+	border-radius: 4px;
+}
+
+.bw-source-trigger:hover {
+	color: #2171b1;
+}
+
+.bw-source-trigger:focus-visible {
+	outline: 2px solid #2171b1;
+	outline-offset: 2px;
+}
+
+.bw-source-chevron {
+	display: inline-block;
+	width: 0;
+	height: 0;
+	border-left: 5px solid currentColor;
+	border-top: 4px solid transparent;
+	border-bottom: 4px solid transparent;
+	transition: transform 0.15s ease;
+	flex-shrink: 0;
+}
+
+.bw-source-trigger[aria-expanded="true"] .bw-source-chevron {
+	transform: rotate(90deg);
+}
+
+.bw-library-section,
+.bw-url-section {
+	padding: 6px 0 10px;
+	animation: bw-fade-in 0.18s ease;
+}
+
+.bw-library-search {
+	width: 100%;
+	border: 1px solid #ddd;
+	border-radius: 8px;
+	padding: 10px 14px;
+	font-size: 14px;
+	outline: none;
+	font-family: inherit;
+	box-sizing: border-box;
+	margin-bottom: 10px;
+}
+
+.bw-library-search:focus {
+	border-color: #2171b1;
+}
+
+/* Single horizontally-scrolling row of thumbs. Browser-native scrollbar is
+ * thin and only appears on hover/scroll on macOS; keyboard users get
+ * scroll-into-view when a focused thumb reaches the edge.
+ */
+.bw-library-strip {
+	display: flex;
+	gap: 6px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	padding: 2px;
+	scrollbar-width: thin;
+	scroll-snap-type: x proximity;
+}
+
+.bw-library-strip:empty {
+	display: none;
+}
+
+.bw-library-thumb {
+	flex: 0 0 auto;
+	width: 64px;
+	height: 64px;
+	padding: 0;
+	border: 2px solid transparent;
+	border-radius: 6px;
+	background: #f3f4f6;
+	cursor: pointer;
+	overflow: hidden;
+	transition: border-color 0.15s ease, transform 0.1s ease;
+	scroll-snap-align: start;
+}
+
+.bw-library-thumb:hover {
+	border-color: #c7d7e8;
+}
+
+.bw-library-thumb:focus-visible {
+	border-color: #2171b1;
+	outline: 2px solid #2171b1;
+	outline-offset: 1px;
+}
+
+.bw-library-thumb:active {
+	transform: scale(0.97);
+}
+
+.bw-library-thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.bw-library-status {
+	color: #777;
+	font-size: 13px;
+	margin-top: 8px;
+	min-height: 18px;
+}
+
+.bw-library-status:empty {
+	display: none;
+}
+
+@media (max-width: 480px) {
+
+	.bw-library-thumb {
+		width: 56px;
+		height: 56px;
+	}
 }
 
 .bw-image-divider {
@@ -1836,6 +2015,15 @@
 
 .bw-image-url-input:focus {
 	border-color: #2171b1;
+}
+
+.bw-image-alt-input {
+	margin-top: 12px;
+}
+
+.bw-insert-image-btn {
+	width: 100%;
+	margin-top: 12px;
 }
 
 .bw-featured-toggle {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2130,7 +2130,6 @@ async function fetchLibrary() {
 	const myToken = ++libraryFetchToken;
 	const search = state.librarySearch.trim();
 
-	state.libraryLoading = true;
 	state.libraryStatus = strings.libraryLoading || 'Loading…';
 
 	try {
@@ -2143,8 +2142,6 @@ async function fetchLibrary() {
 		if ( myToken !== libraryFetchToken ) return;
 
 		libraryItems = items;
-		state.libraryHasItems = libraryItems.length > 0;
-		state.libraryLoading = false;
 
 		if ( libraryItems.length === 0 ) {
 			state.libraryStatus = search
@@ -2157,7 +2154,6 @@ async function fetchLibrary() {
 		renderLibraryGrid();
 	} catch {
 		if ( myToken !== libraryFetchToken ) return;
-		state.libraryLoading = false;
 		state.libraryStatus = strings.libraryLoadFailed || "Couldn't load your library.";
 	}
 }
@@ -4590,6 +4586,13 @@ const { state } = store( 'wpcom-write', {
 			state.uploadedMediaId = item.id;
 			mediaSizesCache.set( item.id, item.media_details?.sizes || null );
 			showUploadPreview( item.source_url );
+
+			// Announce the selection through the modal's aria-live region so
+			// screen-reader users get audible confirmation that the click
+			// registered (the preview itself is purely visual).
+			const label = item.alt_text || item.title?.rendered || '';
+			const template = window.wpcomWriteStrings?.librarySelected || 'Selected %s';
+			state.libraryStatus = template.replace( '%s', label );
 		},
 
 		editImage( figure, triggerEl ) {
@@ -4929,21 +4932,14 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		insertImage() {
-			// Slash-menu image insert: close any open edit panel first so
-			// the in-progress edit session is committed as a discrete undo
-			// entry before the insert overlay takes over.
-			endEditSession();
+			// Slash-menu image insert: clean up the slash UI, then delegate
+			// to openImageModal so the modal opens in the same reset state as
+			// the toolbar entry (collapsed expanders + scroll lock).
 			flushUndoDebounce();
 			clearSlashText();
 			clearSlashActive();
 			state.showSlashMenu = false;
-			saveSelection();
-			state.imageUrl = '';
-			state.imageAlt = '';
-			resetImageModalInputs();
-			resetUploadZone();
-			state.showImageModal = true;
-			focusModalInput();
+			store( 'wpcom-write' ).actions.openImageModal();
 		},
 
 		insertBulletedList() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2068,6 +2068,100 @@ async function uploadFileToMedia( file ) {
 	}
 }
 
+// Media library browser state. Kept in module scope so list rendering can
+// look up the chosen media item by id when a thumbnail is clicked, without
+// re-fetching. Refreshed on every modal open so newly-uploaded images appear.
+// The strip is a single horizontally-scrolling row; we fetch one page and
+// rely on search for older items rather than offering Load more.
+let libraryItems = [];
+let librarySearchTimer = 0;
+let libraryFetchToken = 0;
+const LIBRARY_PER_PAGE = 24;
+
+/**
+ * Pick the smallest reasonable thumbnail URL for the grid. Falls back to the
+ * full-size source_url for images without registered sizes (e.g. uploads that
+ * pre-date a media setting change).
+ *
+ * @param {object} media - Media item from /wp/v2/media.
+ * @return {string} The thumbnail URL to render.
+ */
+function libraryThumbUrl( media ) {
+	const sizes = media.media_details?.sizes;
+	return sizes?.thumbnail?.source_url || sizes?.medium?.source_url || media.source_url || '';
+}
+
+/**
+ * Render the library strip into #bw-library-grid. Always replaces — the strip
+ * holds the most recent items (or current search results) only.  Thumbnails
+ * are <button>s; the container has aria-label, so individual items use plain
+ * `aria-label` with the media's alt or filename.
+ */
+function renderLibraryGrid() {
+	const grid = document.getElementById( 'bw-library-grid' );
+	if ( ! grid ) return;
+	grid.textContent = '';
+
+	for ( const item of libraryItems ) {
+		const btn = document.createElement( 'button' );
+		btn.type = 'button';
+		btn.className = 'bw-library-thumb';
+		btn.dataset.mediaId = String( item.id );
+		const label = item.alt_text || item.title?.rendered || '';
+		if ( label ) btn.setAttribute( 'aria-label', label );
+		const img = document.createElement( 'img' );
+		img.src = libraryThumbUrl( item );
+		img.alt = '';
+		img.loading = 'lazy';
+		btn.appendChild( img );
+		grid.appendChild( btn );
+	}
+}
+
+/**
+ * Fetch the most recent (or search-filtered) page of the user's media library
+ * and render it as a single-row strip.
+ *
+ * Concurrent requests are coalesced via a monotonically increasing token —
+ * only the most recent fetch's result is applied to state.
+ */
+async function fetchLibrary() {
+	const strings = window.wpcomWriteStrings || {};
+	const myToken = ++libraryFetchToken;
+	const search = state.librarySearch.trim();
+
+	state.libraryLoading = true;
+	state.libraryStatus = strings.libraryLoading || 'Loading…';
+
+	try {
+		const path =
+			`${ state.mediaPath }?media_type=image&per_page=${ LIBRARY_PER_PAGE }` +
+			`&orderby=date&order=desc` +
+			( search ? `&search=${ encodeURIComponent( search ) }` : '' );
+		const items = await window.wp.apiFetch( { path } );
+		// A newer fetch superseded this one — drop the result silently.
+		if ( myToken !== libraryFetchToken ) return;
+
+		libraryItems = items;
+		state.libraryHasItems = libraryItems.length > 0;
+		state.libraryLoading = false;
+
+		if ( libraryItems.length === 0 ) {
+			state.libraryStatus = search
+				? strings.libraryNoResults || 'No matching images.'
+				: strings.libraryEmpty || 'No images in your library yet.';
+		} else {
+			state.libraryStatus = '';
+		}
+
+		renderLibraryGrid();
+	} catch {
+		if ( myToken !== libraryFetchToken ) return;
+		state.libraryLoading = false;
+		state.libraryStatus = strings.libraryLoadFailed || "Couldn't load your library.";
+	}
+}
+
 /**
  * Show a preview image in the upload zone.
  *
@@ -4431,7 +4525,71 @@ const { state } = store( 'wpcom-write', {
 			state.uploadedMediaId = 0;
 			resetUploadZone();
 			state.showImageModal = true;
+			// Every open starts from the upload-default state; library/URL
+			// expanders collapse and search resets so the next open looks
+			// identical to the first.
+			state.showLibraryPicker = false;
+			state.showUrlInput = false;
+			state.librarySearch = '';
+			// Lock the page behind the modal so the editor can't scroll under
+			// the dimmed backdrop. The non-modal edit panel (editImage) does
+			// not lock — it docks bottom-right and the editor stays usable.
+			document.body.classList.add( 'bw-modal-open' );
 			focusModalInput();
+		},
+
+		toggleLibraryPicker() {
+			state.showLibraryPicker = ! state.showLibraryPicker;
+			// Lazy-fetch the library on first expand, and refresh on every
+			// reopen so a just-uploaded image appears at the top.
+			if ( state.showLibraryPicker ) {
+				state.librarySearch = '';
+				fetchLibrary();
+			}
+		},
+
+		toggleUrlInput() {
+			state.showUrlInput = ! state.showUrlInput;
+			// When opening, focus the URL field for immediate typing.
+			if ( state.showUrlInput ) {
+				requestAnimationFrame( () => {
+					document.querySelector( '.bw-url-section input[type="url"]' )?.focus();
+				} );
+			}
+		},
+
+		searchLibrary() {
+			const el = getElement();
+			state.librarySearch = el.ref.value;
+			clearTimeout( librarySearchTimer );
+			// 250ms debounce keeps us under the WP REST rate even while typing
+			// quickly without feeling laggy on a fast network.
+			librarySearchTimer = setTimeout( fetchLibrary, 250 );
+		},
+
+		selectLibraryImage( event ) {
+			// Delegated handler on the grid container — find the actual
+			// thumbnail button regardless of whether the click landed on the
+			// button, its inner <img>, or some descendant.
+			const btn = event.target.closest( '.bw-library-thumb' );
+			if ( ! btn ) return;
+			const id = parseInt( btn.dataset.mediaId, 10 );
+			if ( ! id ) return;
+			const item = libraryItems.find( m => m.id === id );
+			if ( ! item ) return;
+
+			// Match the upload-success path: populate the URL/alt fields and
+			// stamp the media id so insertImageFromUrl tags the figure with
+			// wp-image-<id> and applies the Large size preset.  Alt only
+			// overwrites a blank field so a user who already typed alt for a
+			// different image they were considering doesn't lose their work.
+			state.imageUrl = item.source_url;
+			if ( ! state.imageAlt && item.alt_text ) {
+				state.imageAlt = item.alt_text;
+			}
+			state.uploadedMediaId = item.id;
+			mediaSizesCache.set( item.id, item.media_details?.sizes || null );
+			showUploadPreview( item.source_url );
 		},
 
 		editImage( figure, triggerEl ) {
@@ -4501,6 +4659,7 @@ const { state } = store( 'wpcom-write', {
 			state.imageAlt = '';
 			state.setAsFeatured = false;
 			state.uploadedMediaId = 0;
+			document.body.classList.remove( 'bw-modal-open' );
 			resetUploadZone();
 			restoreSelection();
 			if ( triggerToRefocus && document.contains( triggerToRefocus ) ) {
@@ -4600,6 +4759,7 @@ const { state } = store( 'wpcom-write', {
 			}
 
 			state.showImageModal = false;
+			document.body.classList.remove( 'bw-modal-open' );
 			resetUploadZone();
 			pushToUndoHistory();
 		},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -4681,9 +4681,16 @@ const { state } = store( 'wpcom-write', {
 			if ( event.key === 'Tab' ) {
 				const modal = event.currentTarget.querySelector( '.bw-image-modal' );
 				if ( ! modal ) return;
-				const focusable = modal.querySelectorAll(
-					'input:not([hidden]), button, [tabindex]:not([tabindex="-1"])'
-				);
+				// Filter to currently-rendered elements only. The collapsible
+				// library/URL sections live inside the modal but use the
+				// `hidden` attribute on their wrapper — `:not([hidden])` on
+				// the input itself doesn't catch that, so without the
+				// offsetParent check those inputs would land in the trap's
+				// boundaries even though Tab can't actually reach them, and
+				// focus would fall out of the modal.
+				const focusable = Array.from(
+					modal.querySelectorAll( 'input:not([hidden]), button, [tabindex]:not([tabindex="-1"])' )
+				).filter( el => el.offsetParent !== null && ! el.disabled );
 				if ( ! focusable.length ) return;
 				const first = focusable[ 0 ];
 				const last = focusable[ focusable.length - 1 ];

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -133,6 +133,8 @@ add_action(
 			'libraryEmpty'         => __( 'No images in your library yet.', 'jetpack-mu-wpcom' ),
 			'libraryNoResults'     => __( 'No matching images.', 'jetpack-mu-wpcom' ),
 			'libraryLoadFailed'    => __( "Couldn't load your library.", 'jetpack-mu-wpcom' ),
+			// translators: %s is the alt text or filename of the selected library image.
+			'librarySelected'      => __( 'Selected %s', 'jetpack-mu-wpcom' ),
 			'invalidVideoUrl'      => __( 'Please paste a valid YouTube or Vimeo URL', 'jetpack-mu-wpcom' ),
 			'pleaseAddTitle'       => __( 'Please add a title', 'jetpack-mu-wpcom' ),
 			'pleaseWriteSomething' => __( 'Please write something', 'jetpack-mu-wpcom' ),
@@ -850,8 +852,6 @@ function wpcom_write_render_admin_page() {
 			'showLibraryPicker'      => false,
 			'showUrlInput'           => false,
 			'librarySearch'          => '',
-			'libraryLoading'         => false,
-			'libraryHasItems'        => false,
 			'libraryStatus'          => '',
 			'categories'             => $categories_data,
 			'catLabel'               => $cat_label,

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -129,6 +129,10 @@ add_action(
 			'writeCaption'         => __( 'Write a caption...', 'jetpack-mu-wpcom' ),
 			// translators: %s is the error message from the upload failure.
 			'uploadFailed'         => __( 'Upload failed: %s', 'jetpack-mu-wpcom' ),
+			'libraryLoading'       => __( 'Loading your library…', 'jetpack-mu-wpcom' ),
+			'libraryEmpty'         => __( 'No images in your library yet.', 'jetpack-mu-wpcom' ),
+			'libraryNoResults'     => __( 'No matching images.', 'jetpack-mu-wpcom' ),
+			'libraryLoadFailed'    => __( "Couldn't load your library.", 'jetpack-mu-wpcom' ),
 			'invalidVideoUrl'      => __( 'Please paste a valid YouTube or Vimeo URL', 'jetpack-mu-wpcom' ),
 			'pleaseAddTitle'       => __( 'Please add a title', 'jetpack-mu-wpcom' ),
 			'pleaseWriteSomething' => __( 'Please write something', 'jetpack-mu-wpcom' ),
@@ -843,6 +847,12 @@ function wpcom_write_render_admin_page() {
 			'editingImageSize'       => '',
 			'editingImageHasMediaId' => false,
 			'isUploading'            => false,
+			'showLibraryPicker'      => false,
+			'showUrlInput'           => false,
+			'librarySearch'          => '',
+			'libraryLoading'         => false,
+			'libraryHasItems'        => false,
+			'libraryStatus'          => '',
 			'categories'             => $categories_data,
 			'catLabel'               => $cat_label,
 			'existingTagIds'         => $existing_tag_ids,
@@ -1182,27 +1192,76 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				<span class="bw-upload-saving" style="display:none;"><?php echo esc_html__( 'Uploading...', 'jetpack-mu-wpcom' ); ?></span>
 				<input type="file" accept="image/*" data-wp-on--change="actions.uploadImage" class="bw-visually-hidden" />
 			</label>
-			<div class="bw-image-divider"><span><?php echo esc_html__( 'or', 'jetpack-mu-wpcom' ); ?></span></div>
-			<input
-				type="url"
-				class="bw-image-url-input"
-				placeholder="<?php echo esc_attr__( 'Paste an image URL...', 'jetpack-mu-wpcom' ); ?>"
-				data-wp-on--input="actions.updateImageUrl"
-				data-wp-bind--value="state.imageUrl"
-			/>
 			<input
 				type="text"
-				class="bw-image-url-input"
+				class="bw-image-url-input bw-image-alt-input"
 				placeholder="<?php echo esc_attr__( 'Alt text (describe the image)...', 'jetpack-mu-wpcom' ); ?>"
 				data-wp-on--input="actions.updateImageAlt"
 				data-wp-bind--value="state.imageAlt"
-				style="margin-top:12px;"
 			/>
 			<label class="bw-featured-toggle">
 				<input type="checkbox" data-wp-on--change="actions.toggleFeaturedImage" data-wp-bind--checked="state.setAsFeatured" />
 				<span><?php echo esc_html__( 'Set as featured image', 'jetpack-mu-wpcom' ); ?></span>
 			</label>
-			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertImageFromUrl" style="width:100%;margin-top:12px;"><?php echo esc_html__( 'Insert image', 'jetpack-mu-wpcom' ); ?></button>
+			<button class="bw-btn bw-btn-publish bw-insert-image-btn" data-wp-on--click="actions.insertImageFromUrl"><?php echo esc_html__( 'Insert image', 'jetpack-mu-wpcom' ); ?></button>
+
+			<!-- Secondary sources: collapsed by default. -->
+			<div class="bw-source-expanders">
+				<div class="bw-source-expander">
+					<button
+						type="button"
+						class="bw-source-trigger"
+						aria-controls="bw-library-section"
+						data-wp-bind--aria-expanded="state.showLibraryPicker"
+						data-wp-on--click="actions.toggleLibraryPicker"
+					>
+						<span class="bw-source-chevron" aria-hidden="true"></span>
+						<?php echo esc_html__( 'From your library', 'jetpack-mu-wpcom' ); ?>
+					</button>
+					<div id="bw-library-section" class="bw-library-section" hidden data-wp-bind--hidden="!state.showLibraryPicker">
+						<label class="bw-visually-hidden" for="bw-library-search"><?php echo esc_html__( 'Search your media library', 'jetpack-mu-wpcom' ); ?></label>
+						<input
+							id="bw-library-search"
+							type="search"
+							class="bw-library-search"
+							placeholder="<?php echo esc_attr__( 'Search your library…', 'jetpack-mu-wpcom' ); ?>"
+							autocomplete="off"
+							data-wp-on--input="actions.searchLibrary"
+							data-wp-bind--value="state.librarySearch"
+						/>
+						<div
+							id="bw-library-grid"
+							class="bw-library-strip"
+							role="group"
+							aria-label="<?php echo esc_attr__( 'Your media library', 'jetpack-mu-wpcom' ); ?>"
+							data-wp-on--click="actions.selectLibraryImage"
+						></div>
+						<div class="bw-library-status" role="status" aria-live="polite" data-wp-text="state.libraryStatus"></div>
+					</div>
+				</div>
+				<div class="bw-source-expander">
+					<button
+						type="button"
+						class="bw-source-trigger"
+						aria-controls="bw-url-section"
+						data-wp-bind--aria-expanded="state.showUrlInput"
+						data-wp-on--click="actions.toggleUrlInput"
+					>
+						<span class="bw-source-chevron" aria-hidden="true"></span>
+						<?php echo esc_html__( 'Paste an image URL', 'jetpack-mu-wpcom' ); ?>
+					</button>
+					<div id="bw-url-section" class="bw-url-section" hidden data-wp-bind--hidden="!state.showUrlInput">
+						<input
+							type="url"
+							class="bw-image-url-input"
+							placeholder="<?php echo esc_attr__( 'https://…', 'jetpack-mu-wpcom' ); ?>"
+							data-wp-on--input="actions.updateImageUrl"
+							data-wp-bind--value="state.imageUrl"
+						/>
+					</div>
+				</div>
+			</div>
+
 		</div>
 	</div>
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -166,6 +166,53 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the admin_enqueue_scripts callback emits the JS i18n strings
+	 * Write relies on, including the media-library strings added in RSM-594.
+	 * Other tests render the template directly, which bypasses this callback —
+	 * covering it here keeps the strings in lockstep with the JS.
+	 *
+	 * Invokes the registered closure directly instead of do_action() so
+	 * unrelated WordPress callbacks (site-health, etc.) don't pollute the
+	 * test with their own warnings.
+	 */
+	public function test_admin_enqueue_emits_library_strings() {
+		global $wp_filter;
+
+		wp_set_current_user( $this->admin_id );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_GET['page'] = 'write';
+
+		$output = '';
+		$hooks  = $wp_filter['admin_enqueue_scripts']->callbacks ?? array();
+		foreach ( $hooks as $callbacks ) {
+			foreach ( $callbacks as $cb ) {
+				if ( ! ( $cb['function'] instanceof \Closure ) ) {
+					continue;
+				}
+				$ref = new \ReflectionFunction( $cb['function'] );
+				if ( false === strpos( $ref->getFileName(), 'features/write/write.php' ) ) {
+					continue;
+				}
+				ob_start();
+				( $cb['function'] )();
+				$output .= ob_get_clean();
+			}
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		unset( $_GET['page'] );
+
+		// The four media-library strings added in RSM-594 must be in the
+		// inline script tag so view.js can reach them via window.wpcomWriteStrings.
+		$this->assertStringContainsString( 'libraryLoading', $output );
+		$this->assertStringContainsString( 'libraryEmpty', $output );
+		$this->assertStringContainsString( 'libraryNoResults', $output );
+		$this->assertStringContainsString( 'libraryLoadFailed', $output );
+		$this->assertStringContainsString( 'window.wpcomWriteStrings', $output );
+	}
+
+	/**
 	 * Test that the image modal renders the media library section alongside
 	 * the existing upload zone and URL paste — the three sources Write supports
 	 * after RSM-594.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -166,6 +166,32 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the image modal renders the media library section alongside
+	 * the existing upload zone and URL paste — the three sources Write supports
+	 * after RSM-594.
+	 */
+	public function test_template_includes_media_library_section() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		// Search input + horizontal strip container.
+		$this->assertStringContainsString( 'id="bw-library-search"', $output );
+		$this->assertStringContainsString( 'id="bw-library-grid"', $output );
+		$this->assertStringContainsString( 'actions.searchLibrary', $output );
+		$this->assertStringContainsString( 'actions.selectLibraryImage', $output );
+		// Collapsed-by-default expanders for library + URL.
+		$this->assertStringContainsString( 'actions.toggleLibraryPicker', $output );
+		$this->assertStringContainsString( 'actions.toggleUrlInput', $output );
+		// Existing upload + URL paste paths still present.
+		$this->assertStringContainsString( 'id="bw-upload-zone"', $output );
+		$this->assertStringContainsString( 'actions.insertImageFromUrl', $output );
+		// Grid is keyboard- and screen-reader-labelled.
+		$this->assertStringContainsString( 'aria-label="Your media library"', $output );
+		$this->assertStringContainsString( 'aria-live="polite"', $output );
+	}
+
+	/**
 	 * Test that the Interactivity API state includes required fields.
 	 */
 	public function test_interactivity_state_is_seeded() {


### PR DESCRIPTION
Fixes [RSM-594](https://linear.app/a8c/issue/RSM-594/add-media-library-image-selection) and [RSM-3983](https://linear.app/a8c/issue/RSM-3983/add-an-image-modal-preview-is-too-small-to-confirm-the-image-before).

## Proposed changes
* Add a "From your library" expandable section to the Add image modal, backed by `/wp/v2/media`. Single horizontal strip of recent images with debounced search.
* Add a "Paste an image URL" expander next to it. Both collapse by default so the modal opens in upload-only mode.
* Picking a library item populates `state.uploadedMediaId` / `state.imageUrl` / alt — the inserted figure round-trips to `wp:image` with the same `wp-image-<id>` tagging as a fresh upload (size presets and Featured toggle work identically).
* RSM-3983: the post-upload preview now scales to the image's natural aspect ratio (capped at 320px tall) instead of centre-cropping to a 120px box, so portraits / wide images are usable.
* Cap the modal at `calc(100vh - 200px)` with `box-sizing: border-box` so it can never grow behind the toolbar even with both expanders open and a preview showing.
* Lock page scroll while the Add image modal is open (the docked Edit image side panel is intentionally unaffected).

<img width="838" height="851" alt="Screenshot 2026-06-16 at 3 15 10 PM" src="https://github.com/user-attachments/assets/70454c9e-1f14-42de-bf6c-23fe782addc8" />

## Related product discussion/links
* Linear: [RSM-594](https://linear.app/a8c/issue/RSM-594/add-media-library-image-selection)
* Linear: [RSM-3983](https://linear.app/a8c/issue/RSM-3983/add-an-image-modal-preview-is-too-small-to-confirm-the-image-before)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the Write editor (`/wp-admin/admin.php?page=write`) on a site with at least one media item.
2. Click the image button in the toolbar (or press `/` and pick Image).
3. The modal opens in upload-only mode. Verify the page behind the modal cannot scroll.
4. Click **From your library** — it expands to show a search input and a horizontal strip of recent images. Click a thumbnail. Verify a preview appears in the upload zone, alt populates from the media item's alt text, and the modal stays compact.
5. Click **Insert image**. Verify the figure is inserted into the editor with `wp-image-<id>` class on the `<img>`.
6. Open the modal again, expand **From your library**, type a search query (e.g. part of an existing filename). Verify the strip filters server-side; an empty result shows "No matching images."
7. Click **Paste an image URL** to expand the URL field. Paste an external URL, set alt, click Insert. Verify the figure is inserted without `wp-image-*` tagging.
8. Drop a file onto the upload zone. Verify the preview grows to fit the image's natural aspect (RSM-3983), capped at 320px.
9. On a short viewport (~700px), expand both the library and URL sections. Verify the modal scrolls internally rather than extending behind the toolbar.
10. Open the Edit image panel on an existing image and verify the editor body remains scrollable while the panel is open.

### Tests added
* `Write_Test::test_template_includes_media_library_section` asserts the rendered modal includes the search input, grid container, library/URL toggle actions, upload zone, and required aria attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)