### PR TITLE
Podcast: remove stale untangle/bridge doc references

### DIFF
--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -2,4 +2,4 @@
 
 Hosts the wp-admin Podcast experience for the Jetpack plugin (Simple and Atomic only).
 
-The package owns the wp-admin SPA, REST integration, and feed customization for podcasting on Simple and Atomic sites. The legacy stack it replaced — the `Automattic_Podcasting` code in the wpcom mu-plugin and the Atomic-side `at-pressable-podcasting` bridge — has been removed.
+The package owns the wp-admin SPA, REST integration, and feed customization for podcasting on Simple and Atomic sites.

--- a/projects/packages/podcast/changelog/remove-untangle-doc-references
+++ b/projects/packages/podcast/changelog/remove-untangle-doc-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: drop stale references to the removed jetpack_podcast_untangle gate and at-pressable-podcasting bridge from package docs.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -13,9 +13,7 @@ use Automattic\Jetpack\Status\Host;
 
 /**
  * Loads Jetpack Podcast on Simple and Atomic sites. The package owns the
- * podcasting experience outright now that the legacy stack — the wpcom
- * mu-plugin `Automattic_Podcasting` code and the Atomic-side
- * at-pressable-podcasting bridge — has been removed.
+ * podcasting experience outright.
  */
 class Podcast {
 


### PR DESCRIPTION
## Proposed changes

* Removes stale `jetpack_podcast_untangle` / `at-pressable-podcasting` references from the Podcast package README and a class docblock. Both were already removed in #49548; this is doc cleanup only.

## Testing instructions

* Docs/comment-only change — no runtime behavior affected.
