### PR TITLE
Newsletter: tailor Paid Subscribers setup modal to the missing prerequisite

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-705-paid-subscribers-modal-content
+++ b/projects/plugins/jetpack/changelog/fix-nl-705-paid-subscribers-modal-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: when prompting the user to set up paid subscriptions, only ask for the steps that are actually missing (Stripe connection and/or a newsletter tier).

--- a/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/index.jsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { getPaidPlanLink } from '../../memberships/utils';
 
 export default function PlansSetupDialog( { showDialog, closeDialog } ) {
-	const { hasTierPlans } = useSelect( select => {
+	const { hasTierPlans, stripeConnectUrl } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
 		return {
 			stripeConnectUrl: getConnectUrl(),
@@ -17,6 +17,46 @@ export default function PlansSetupDialog( { showDialog, closeDialog } ) {
 
 	const paidLink = getPaidPlanLink( hasTierPlans );
 	const { autosaveAndRedirect } = useAutosaveAndRedirect( paidLink );
+
+	const needsStripe = !! stripeConnectUrl;
+	const needsTier = ! hasTierPlans;
+
+	let title;
+	let body;
+	if ( needsStripe && needsTier ) {
+		title = __( 'Set up payments', 'jetpack' );
+		body = (
+			<>
+				<p>{ __( 'To start collecting payments, you’ll just need to:', 'jetpack' ) }</p>
+				<ol>
+					<li>
+						{ __(
+							'Create a newsletter tier and choose a price for access to paid content',
+							'jetpack'
+						) }
+					</li>
+					<li>{ __( 'Set up or connect your Stripe account', 'jetpack' ) }</li>
+				</ol>
+			</>
+		);
+	} else if ( needsTier ) {
+		title = __( 'Add a newsletter tier', 'jetpack' );
+		body = (
+			<p>
+				{ __(
+					'To offer paid subscriptions, create a newsletter tier and choose a price for access to paid content.',
+					'jetpack'
+				) }
+			</p>
+		);
+	} else {
+		title = __( 'Connect Stripe', 'jetpack' );
+		body = (
+			<p>
+				{ __( 'To start collecting payments, set up or connect your Stripe account.', 'jetpack' ) }
+			</p>
+		);
+	}
 
 	return (
 		<ConfirmDialog
@@ -28,17 +68,8 @@ export default function PlansSetupDialog( { showDialog, closeDialog } ) {
 			onConfirm={ autosaveAndRedirect }
 			style={ { maxWidth: 400 } }
 		>
-			<h2>{ __( 'Set up payments', 'jetpack' ) }</h2>
-			<p>{ __( 'To start collecting payments, you’ll just need to:', 'jetpack' ) }</p>
-			<ol>
-				<li>
-					{ __(
-						'Create a payment offer and choose a price for access to paid content',
-						'jetpack'
-					) }
-				</li>
-				<li>{ __( 'Set up or connect your Stripe account', 'jetpack' ) }</li>
-			</ol>
+			<h2>{ title }</h2>
+			{ body }
 		</ConfirmDialog>
 	);
 }

--- a/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/test/index.test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/plans-setup-dialog/test/index.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import * as wpData from '@wordpress/data';
+import PlansSetupDialog from '../index';
+
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAutosaveAndRedirect: () => ( { autosaveAndRedirect: jest.fn() } ),
+} ) );
+
+const TIER_COPY = 'create a newsletter tier and choose a price for access to paid content';
+const STRIPE_COPY = 'set up or connect your Stripe account';
+
+const mockStore = ( { hasTierPlans, stripeConnectUrl } ) => {
+	jest.spyOn( wpData, 'useSelect' ).mockImplementation( selector =>
+		selector( () => ( {
+			getNewsletterTierProducts: () => ( hasTierPlans ? [ { id: 1 } ] : [] ),
+			getConnectUrl: () => stripeConnectUrl,
+		} ) )
+	);
+};
+
+describe( 'PlansSetupDialog', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'when Stripe is not connected and no newsletter tiers exist, shows both setup steps', () => {
+		mockStore( { hasTierPlans: false, stripeConnectUrl: 'https://stripe-connect.example' } );
+
+		render( <PlansSetupDialog showDialog={ true } closeDialog={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'heading', { name: /Set up payments/i } ) ).toBeInTheDocument();
+		expect( screen.getByText( /Create a newsletter tier/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Set up or connect your Stripe account/i ) ).toBeInTheDocument();
+	} );
+
+	test( 'when Stripe is connected but no newsletter tiers exist, shows only the tier step (NL-705)', () => {
+		mockStore( { hasTierPlans: false, stripeConnectUrl: null } );
+
+		render( <PlansSetupDialog showDialog={ true } closeDialog={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'heading', { name: /Add a newsletter tier/i } ) ).toBeInTheDocument();
+		expect( screen.getByText( new RegExp( TIER_COPY, 'i' ) ) ).toBeInTheDocument();
+		expect( screen.queryByText( new RegExp( STRIPE_COPY, 'i' ) ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'when newsletter tiers exist but Stripe is not connected, shows only the Stripe step', () => {
+		mockStore( { hasTierPlans: true, stripeConnectUrl: 'https://stripe-connect.example' } );
+
+		render( <PlansSetupDialog showDialog={ true } closeDialog={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'heading', { name: /Connect Stripe/i } ) ).toBeInTheDocument();
+		expect( screen.getByText( new RegExp( STRIPE_COPY, 'i' ) ) ).toBeInTheDocument();
+		expect( screen.queryByText( new RegExp( TIER_COPY, 'i' ) ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes NL-705.

## Proposed changes

When a writer selects **Paid subscribers only** in post Access settings, the editor shows a modal listing the prerequisites for accepting payments. The modal was triggered by `stripeConnectUrl || ! hasTierPlans` but always rendered the same two-step body ("Create a payment offer" + "Set up or connect your Stripe account") regardless of which prerequisite was actually missing.

For sites that had Stripe connected but no newsletter tier (NL-705's scenario), the modal still told the user to set up Stripe — conflating two separate states and making the real problem (no tier product) invisible.

This PR makes `PlansSetupDialog` branch on `stripeConnectUrl` and `hasTierPlans` and render one of three states:

| State | Title | Body |
|---|---|---|
| Both missing | _Set up payments_ | Ordered list with both steps (existing copy, with step 1 reworded to "newsletter tier") |
| Stripe connected, no tier | _Add a newsletter tier_ | "To offer paid subscriptions, create a newsletter tier and choose a price for access to paid content." |
| Tiers exist, no Stripe | _Connect Stripe_ | "To start collecting payments, set up or connect your Stripe account." |

The dialog's confirm-button destination (`getPaidPlanLink( hasTierPlans )`) already routes correctly between `#add-tier-plan` and the Stripe section, so no link changes were needed. "Newsletter tier" is the term the editor's existing tier selector uses — matches the radio label "Choose Newsletter Tier" and the `getNewsletterTierProducts` selector.

The trigger condition in the three call sites (`settings.js`, `command-palette.js`, `paywall/edit.js`) is unchanged — the modal still shows when either prerequisite is missing; only its content adapts.
<img width="421" height="307" alt="Screenshot 2026-06-17 at 12 04 21 PM" src="https://github.com/user-attachments/assets/7113164b-2623-4067-bffa-cad68d5af029" />
<img width="425" height="252" alt="Screenshot 2026-06-17 at 12 03 05 PM" src="https://github.com/user-attachments/assets/e1251ee8-fd77-4156-9484-6173d7c92397" />

<img width="412" height="247" alt="Screenshot 2026-06-17 at 12 07 28 PM" src="https://github.com/user-attachments/assets/8fb7bedf-cce2-4d78-98a0-d772b64f249e" />


## Related product discussion/links

* NL-705
* Related: CM-113 (root cause of how membership connection state is derived — out of scope here)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Unit tests cover the three branches. To verify in the editor:

1. On a site with **no Stripe connection and no newsletter tier**, open the post editor, expand the document settings panel, and under **Access** select _Paid subscribers_. Expect the modal titled **Set up payments** with both bullets.
2. On a site with **Stripe connected but no newsletter tier** (the NL-705 case), repeat. Expect the modal titled **Add a newsletter tier** with a single sentence about creating a tier — no Stripe copy.
3. On a site with **a newsletter tier but no Stripe connection**, repeat. Expect the modal titled **Connect Stripe** with a single sentence about Stripe — no tier copy.
4. In all three cases, _Get started_ should still deep-link correctly (Stripe section when a tier exists, `#add-tier-plan` when no tier exists).