### PR TITLE
Podcast: fix Create episode button hover state

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-create-episode-button-hover
+++ b/projects/packages/podcast/changelog/fix-podcast-create-episode-button-hover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the "Create episode" button hover state to match standard Jetpack primary buttons.

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,10 +1,10 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';
-import { Button, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Tabs } from '@wordpress/ui';
+import { Button, Tabs } from '@wordpress/ui';
 import ErrorBoundary from './error-boundary';
 import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
@@ -175,8 +175,13 @@ const App = () => {
 	const headerActions = isSetUp ? (
 		<Button
 			size="compact"
-			variant="primary"
-			href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
+			variant="solid"
+			render={
+				<a
+					className="podcast__header-cta"
+					href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
+				/>
+			}
 		>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,10 +1,10 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';
-import { Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Button, Tabs } from '@wordpress/ui';
+import { Tabs } from '@wordpress/ui';
 import ErrorBoundary from './error-boundary';
 import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
@@ -175,13 +175,8 @@ const App = () => {
 	const headerActions = isSetUp ? (
 		<Button
 			size="compact"
-			variant="solid"
-			render={
-				<a
-					className="podcast__header-cta"
-					href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
-				/>
-			}
+			variant="primary"
+			href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
 		>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -12,14 +12,6 @@ body.jetpack_page_jetpack-podcast {
 	padding: 48px 0;
 }
 
-// The header CTA is a WP UI solid Button rendered as an `<a>`. wp-admin's
-// global, unlayered `a { color: #2271b1 }` beats the button's layered
-// foreground color, tinting the label blue. Restore it with an unlayered rule
-// pointing at the button's own variable so it tracks the variant.
-.podcast__header-cta {
-	color: var(--wp-ui-button-foreground-color);
-}
-
 .podcast__tab-content {
 	padding-block: 8px;
 }

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -13,17 +13,14 @@ body.jetpack_page_jetpack-podcast {
 }
 
 // The header CTA is a WP UI solid Button rendered as an `<a>`. wp-admin's
-// global, unlayered `a` / `a:hover` color beats the button's layered foreground,
-// tinting the label blue. Re-pin it to the button's own variable across states;
-// the `:hover`/`:focus`/`:active` selectors add the specificity to outrank
-// `a:hover`, and a solid Button keeps one foreground color throughout.
-.podcast__header-cta {
-	&,
-	&:hover,
-	&:focus,
-	&:active {
-		color: var(--wp-ui-button-foreground-color);
-	}
+// unlayered `a`/`a:hover` color beats the button's layered foreground, so
+// re-pin its own color across states with enough specificity to win out. A
+// solid Button keeps one foreground color throughout.
+.podcast__header-cta,
+.podcast__header-cta:hover,
+.podcast__header-cta:focus,
+.podcast__header-cta:active {
+	color: var(--wp-ui-button-foreground-color);
 }
 
 .podcast__tab-content {

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -12,6 +12,20 @@ body.jetpack_page_jetpack-podcast {
 	padding: 48px 0;
 }
 
+// The header CTA is a WP UI solid Button rendered as an `<a>`. wp-admin's
+// global, unlayered `a` / `a:hover` color beats the button's layered foreground,
+// tinting the label blue. Re-pin it to the button's own variable across states;
+// the `:hover`/`:focus`/`:active` selectors add the specificity to outrank
+// `a:hover`, and a solid Button keeps one foreground color throughout.
+.podcast__header-cta {
+	&,
+	&:hover,
+	&:focus,
+	&:active {
+		color: var(--wp-ui-button-foreground-color);
+	}
+}
+
 .podcast__tab-content {
 	padding-block: 8px;
 }


### PR DESCRIPTION
## Proposed changes

The "Create episode" button in the Podcast dashboard header turned link-blue on hover. wp-admin's global `a:hover` color was overriding the button's own color, and the existing CSS override wasn't specific enough to win.

This fixes it in CSS by re-pinning the button's foreground color across hover/focus/active. No component changes — it stays a `@wordpress/ui` Button.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with Podcast set up, open the Podcast dashboard (**Jetpack → Podcast**).
* Hover over the **Create episode** button in the header.
* **Before:** the label turned link-blue on hover.
* **After:** it keeps the solid button's color, matching the other dashboard buttons.
* Confirm the button still links to `post-new.php?podcast_episode=1`.
