### PR TITLE
Subscriptions: register transitional Subscribers announcement page on WordPress.com sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the transitional Subscribers announcement page under Jetpack → Subscribers on WordPress.com when the Newsletter modernization filter is enabled, instead of removing the entry entirely.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -391,13 +391,19 @@ function wpcom_add_jetpack_submenu() {
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
 	// Once the Newsletter modernization filter is on, the unified Newsletter
-	// page owns the Subscribers tab and this standalone submenu is retired.
-	// While the filter is off (the default) we keep the legacy Calypso
-	// "Subscribers" submenu. (The wp-admin subscriber-management variant was
-	// removed with the subscribers-dashboard package and isn't restored.)
-	// Referenced as a string literal (mirrors Newsletter\Settings::MODERNIZATION_FILTER):
-	// the newsletter package isn't a dependency of jetpack-mu-wpcom, and this runs
-	// unconditionally — ahead of the class_exists-guarded Settings use below.
+	// page owns the Subscribers tab and the legacy Calypso "Subscribers" submenu
+	// is retired, replaced by a transitional announcement page that points there.
+	// While the filter is off (the default) we keep the legacy Calypso submenu.
+	// (The wp-admin subscriber-management variant was removed with the
+	// subscribers-dashboard package and isn't restored.)
+	//
+	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
+	// Subscribers entry, so the announcement page is registered here for both
+	// platforms; the standalone plugin's subscriptions module defers to it on
+	// wpcom to avoid a duplicate. Referenced as a string literal (mirrors
+	// Newsletter\Settings::MODERNIZATION_FILTER): the newsletter package isn't a
+	// dependency of jetpack-mu-wpcom, and the filter runs unconditionally — ahead
+	// of the class_exists-guarded Subscribers_Announcement use.
 	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
 		add_submenu_page(
 			'jetpack',
@@ -407,6 +413,9 @@ function wpcom_add_jetpack_submenu() {
 			'https://wordpress.com/subscribers/' . $domain,
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
+	} elseif ( class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' ) ) {
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by the sibling autoloader (bundled Jetpack on Simple, standalone plugin on Atomic).
+		\Automattic\Jetpack\Newsletter\Subscribers_Announcement::add_wp_admin_submenu();
 	}
 
 	Podcast_Admin_Page::add_wp_admin_submenu();

--- a/projects/packages/newsletter/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
+++ b/projects/packages/newsletter/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Subscribers_Announcement::add_wp_admin_submenu() to register the transitional Subscribers announcement page directly under the Jetpack menu (used on WordPress.com sites).

--- a/projects/packages/newsletter/src/class-subscribers-announcement.php
+++ b/projects/packages/newsletter/src/class-subscribers-announcement.php
@@ -189,6 +189,41 @@ class Subscribers_Announcement {
 	}
 
 	/**
+	 * Register the announcement page directly under the Jetpack menu.
+	 *
+	 * Used on WordPress.com (Simple and WoA), where jetpack-mu-wpcom's
+	 * wpcom-admin-menu owns the Jetpack menu and registers submenus with the
+	 * core add_submenu_page() at a late priority — not the standalone plugin's
+	 * Admin_Menu wrapper. Mirrors Settings::add_wp_admin_submenu().
+	 *
+	 * As in add_menu(), an empty parent slug keeps the page reachable at its URL
+	 * (so the "remove from sidebar" choice can be undone) while hiding it from
+	 * the sidebar.
+	 *
+	 * @return void
+	 */
+	public static function add_wp_admin_submenu() {
+		$callback = function_exists( 'jetpack_newsletter_jetpack_subscribers_announcement_wp_admin_render_page' )
+			? 'jetpack_newsletter_jetpack_subscribers_announcement_wp_admin_render_page'
+			: array( __CLASS__, 'render_fallback' );
+
+		$parent_slug = get_option( self::REMOVED_OPTION ) ? '' : 'jetpack';
+
+		$page_suffix = add_submenu_page(
+			$parent_slug,
+			__( 'Subscribers', 'jetpack-newsletter' ),
+			__( 'Subscribers', 'jetpack-newsletter' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			$callback
+		);
+
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( __CLASS__, 'on_page_load' ) );
+		}
+	}
+
+	/**
 	 * Page-load actions: record the page view and expose the app data.
 	 *
 	 * @return void

--- a/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
+++ b/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
@@ -143,10 +143,11 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	 * (the wpcom path used by jetpack-mu-wpcom on Simple and WoA sites).
 	 */
 	public function test_add_wp_admin_submenu_registers_under_jetpack() {
-		global $menu, $submenu;
-		// WorDBless does not reset the admin menu globals between tests.
-		$menu    = array();
-		$submenu = array();
+		// WorDBless does not reset the admin menu globals between tests. Read and
+		// write them via $GLOBALS so Phan does not narrow the local to an empty
+		// array shape (it can't see add_submenu_page() mutate the global).
+		$GLOBALS['menu']    = array();
+		$GLOBALS['submenu'] = array();
 		// add_submenu_page() checks the current user's capability.
 		$this->login_as_admin();
 		// Provide the Jetpack parent menu that wpcom-admin-menu would have created.
@@ -154,7 +155,7 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 
 		Subscribers_Announcement::add_wp_admin_submenu();
 
-		$slugs = wp_list_pluck( $submenu['jetpack'] ?? array(), 2 );
+		$slugs = wp_list_pluck( (array) ( $GLOBALS['submenu']['jetpack'] ?? array() ), 2 );
 		$this->assertContains(
 			Subscribers_Announcement::PAGE_SLUG,
 			$slugs,
@@ -174,17 +175,17 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	 * sidebar when the user removed the menu item.
 	 */
 	public function test_add_wp_admin_submenu_hides_from_sidebar_when_removed() {
-		global $menu, $submenu;
-		// WorDBless does not reset the admin menu globals between tests.
-		$menu    = array();
-		$submenu = array();
+		// See note in test_add_wp_admin_submenu_registers_under_jetpack() on why
+		// the admin menu globals are accessed via $GLOBALS.
+		$GLOBALS['menu']    = array();
+		$GLOBALS['submenu'] = array();
 		$this->login_as_admin();
 		add_menu_page( 'Jetpack', 'Jetpack', 'manage_options', 'jetpack', '__return_null' );
 		update_option( Subscribers_Announcement::REMOVED_OPTION, 1 );
 
 		Subscribers_Announcement::add_wp_admin_submenu();
 
-		$slugs = wp_list_pluck( $submenu['jetpack'] ?? array(), 2 );
+		$slugs = wp_list_pluck( (array) ( $GLOBALS['submenu']['jetpack'] ?? array() ), 2 );
 		$this->assertNotContains(
 			Subscribers_Announcement::PAGE_SLUG,
 			$slugs,

--- a/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
+++ b/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
@@ -139,6 +139,67 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Confirms add_wp_admin_submenu() registers the page under the Jetpack menu
+	 * (the wpcom path used by jetpack-mu-wpcom on Simple and WoA sites).
+	 */
+	public function test_add_wp_admin_submenu_registers_under_jetpack() {
+		global $menu, $submenu;
+		// WorDBless does not reset the admin menu globals between tests.
+		$menu    = array();
+		$submenu = array();
+		// add_submenu_page() checks the current user's capability.
+		$this->login_as_admin();
+		// Provide the Jetpack parent menu that wpcom-admin-menu would have created.
+		add_menu_page( 'Jetpack', 'Jetpack', 'manage_options', 'jetpack', '__return_null' );
+
+		Subscribers_Announcement::add_wp_admin_submenu();
+
+		$slugs = wp_list_pluck( $submenu['jetpack'] ?? array(), 2 );
+		$this->assertContains(
+			Subscribers_Announcement::PAGE_SLUG,
+			$slugs,
+			'add_wp_admin_submenu() should register the announcement page under the Jetpack menu'
+		);
+		$this->assertNotFalse(
+			has_action(
+				'load-jetpack_page_' . Subscribers_Announcement::PAGE_SLUG,
+				array( Subscribers_Announcement::class, 'on_page_load' )
+			),
+			'The page load callback should be registered'
+		);
+	}
+
+	/**
+	 * Confirms add_wp_admin_submenu() keeps the page reachable but out of the
+	 * sidebar when the user removed the menu item.
+	 */
+	public function test_add_wp_admin_submenu_hides_from_sidebar_when_removed() {
+		global $menu, $submenu;
+		// WorDBless does not reset the admin menu globals between tests.
+		$menu    = array();
+		$submenu = array();
+		$this->login_as_admin();
+		add_menu_page( 'Jetpack', 'Jetpack', 'manage_options', 'jetpack', '__return_null' );
+		update_option( Subscribers_Announcement::REMOVED_OPTION, 1 );
+
+		Subscribers_Announcement::add_wp_admin_submenu();
+
+		$slugs = wp_list_pluck( $submenu['jetpack'] ?? array(), 2 );
+		$this->assertNotContains(
+			Subscribers_Announcement::PAGE_SLUG,
+			$slugs,
+			'The removed page should not appear under the Jetpack sidebar menu'
+		);
+		$this->assertNotFalse(
+			has_action(
+				'load-admin_page_' . Subscribers_Announcement::PAGE_SLUG,
+				array( Subscribers_Announcement::class, 'on_page_load' )
+			),
+			'The page should remain reachable (hidden) when the menu item is removed'
+		);
+	}
+
+	/**
 	 * Confirms maybe_load_wp_build() does nothing when the feature is disabled.
 	 */
 	public function test_maybe_load_wp_build_noop_when_disabled() {

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: register the transitional Subscribers announcement page on WordPress.com Simple and WoA sites when the Newsletter modernization filter is on.
+Subscriptions: register the transitional Subscribers announcement page on self-hosted Jetpack only; on WordPress.com it is owned by jetpack-mu-wpcom, avoiding a duplicate menu entry on Atomic.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernized-subscribers-announcement-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: register the transitional Subscribers announcement page on WordPress.com Simple and WoA sites when the Newsletter modernization filter is on.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1030,6 +1030,30 @@ class Jetpack_Subscriptions {
 	 */
 	public function add_subscribers_menu() {
 		/*
+		 * Once the Newsletter modernization filter is on, the unified Newsletter
+		 * page owns the Subscribers tab and this standalone Calypso shortcut is
+		 * retired. In its place, a transitional announcement page tells people
+		 * where subscriber management moved and lets them remove the menu item.
+		 *
+		 * This is evaluated first — before the WoA/Simple and connection guards
+		 * below — so the announcement page also reaches WordPress.com Simple and
+		 * WoA sites, where the modernized Newsletter UI it points to lives. Those
+		 * guards only gate the legacy Calypso shortcut further down. This mirrors
+		 * the pre-announcement behavior, where the modernization filter was the
+		 * first check in this method.
+		 *
+		 * Referenced as a string literal (mirrors Newsletter\Settings::MODERNIZATION_FILTER)
+		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
+		 * not expose the constant yet.
+		 */
+		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
+			if ( class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' ) ) {
+				\Automattic\Jetpack\Newsletter\Subscribers_Announcement::add_menu();
+			}
+			return;
+		}
+
+		/*
 		 * Do not display any menu on WoA and WordPress.com Simple sites (unless Classic wp-admin is enabled).
 		 * They already get a menu item under Users via nav-unification.
 		 */
@@ -1047,26 +1071,6 @@ class Jetpack_Subscriptions {
 			$status->is_offline_mode()
 			|| ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected()
 		) {
-			return;
-		}
-
-		/*
-		 * Once the Newsletter modernization filter is on, the unified Newsletter
-		 * page owns the Subscribers tab and this standalone Calypso shortcut is
-		 * retired. In its place, a transitional announcement page tells people
-		 * where subscriber management moved and lets them remove the menu item.
-		 * This takes precedence over the subscriber-management filter below,
-		 * mirroring the pre-announcement behavior where the modernization
-		 * filter was checked first.
-		 *
-		 * Referenced as a string literal (mirrors Newsletter\Settings::MODERNIZATION_FILTER)
-		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
-		 * not expose the constant yet.
-		 */
-		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
-			if ( class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' ) ) {
-				\Automattic\Jetpack\Newsletter\Subscribers_Announcement::add_menu();
-			}
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1036,18 +1036,24 @@ class Jetpack_Subscriptions {
 		 * where subscriber management moved and lets them remove the menu item.
 		 *
 		 * This is evaluated first — before the WoA/Simple and connection guards
-		 * below — so the announcement page also reaches WordPress.com Simple and
-		 * WoA sites, where the modernized Newsletter UI it points to lives. Those
-		 * guards only gate the legacy Calypso shortcut further down. This mirrors
-		 * the pre-announcement behavior, where the modernization filter was the
-		 * first check in this method.
+		 * below — and returns, so the legacy Calypso shortcut is never added once
+		 * the filter is on.
+		 *
+		 * The announcement page itself is registered here only on self-hosted
+		 * Jetpack. On WordPress.com (Simple and WoA) jetpack-mu-wpcom's
+		 * wpcom-admin-menu owns the Subscribers entry and registers the
+		 * announcement page there; doing it here as well would duplicate the menu
+		 * (and double the page-view tracking) on Atomic, where both run.
 		 *
 		 * Referenced as a string literal (mirrors Newsletter\Settings::MODERNIZATION_FILTER)
 		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
 		 * not expose the constant yet.
 		 */
 		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
-			if ( class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' ) ) {
+			if (
+				! ( new Host() )->is_wpcom_platform()
+				&& class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' )
+			) {
 				\Automattic\Jetpack\Newsletter\Subscribers_Announcement::add_menu();
 			}
 			return;

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -866,4 +866,41 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		}
 	}
+
+	/**
+	 * The transitional Subscribers announcement page must be registered on
+	 * WordPress.com Simple sites when the Newsletter modernization filter is on.
+	 *
+	 * Regression test for #49496: the wpcom-platform / connection guards were
+	 * hoisted above the modernization branch, so add_subscribers_menu() returned
+	 * early on Simple sites and the announcement menu was never added there.
+	 */
+	public function test_announcement_menu_is_added_on_wpcom_simple_when_modernization_filter_on() {
+		$announcement_class = 'Automattic\Jetpack\Newsletter\Subscribers_Announcement';
+		if ( ! class_exists( $announcement_class ) ) {
+			$this->markTestSkipped( 'Newsletter Subscribers_Announcement class is not available.' );
+		}
+
+		$load_hook = 'load-jetpack_page_' . $announcement_class::PAGE_SLUG;
+
+		// Simulate a WordPress.com Simple site in the default Calypso interface.
+		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
+		update_option( 'wpcom_admin_interface', 'calypso' );
+		delete_option( $announcement_class::REMOVED_OPTION );
+		add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );
+		remove_all_actions( $load_hook );
+
+		Jetpack_Subscriptions::init()->add_subscribers_menu();
+
+		$this->assertNotFalse(
+			has_action( $load_hook ),
+			'The Subscribers announcement menu should be registered on Simple wpcom sites when the modernization filter is on.'
+		);
+
+		// Cleanup so the simulated platform does not leak into later tests.
+		remove_all_actions( $load_hook );
+		remove_all_filters( 'rsm_jetpack_ui_modernization_newsletter' );
+		delete_option( 'wpcom_admin_interface' );
+		\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -868,14 +868,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The transitional Subscribers announcement page must be registered on
-	 * WordPress.com Simple sites when the Newsletter modernization filter is on.
-	 *
-	 * Regression test for #49496: the wpcom-platform / connection guards were
-	 * hoisted above the modernization branch, so add_subscribers_menu() returned
-	 * early on Simple sites and the announcement menu was never added there.
+	 * On self-hosted Jetpack, the transitional Subscribers announcement page is
+	 * registered by add_subscribers_menu() when the modernization filter is on.
 	 */
-	public function test_announcement_menu_is_added_on_wpcom_simple_when_modernization_filter_on() {
+	public function test_announcement_menu_is_added_on_self_hosted_when_modernization_filter_on() {
 		$announcement_class = 'Automattic\Jetpack\Newsletter\Subscribers_Announcement';
 		if ( ! class_exists( $announcement_class ) ) {
 			$this->markTestSkipped( 'Newsletter Subscribers_Announcement class is not available.' );
@@ -883,9 +879,7 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 
 		$load_hook = 'load-jetpack_page_' . $announcement_class::PAGE_SLUG;
 
-		// Simulate a WordPress.com Simple site in the default Calypso interface.
-		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
-		update_option( 'wpcom_admin_interface', 'calypso' );
+		// Self-hosted: not a wpcom platform (IS_WPCOM is not defined).
 		delete_option( $announcement_class::REMOVED_OPTION );
 		add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );
 		remove_all_actions( $load_hook );
@@ -894,13 +888,43 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 
 		$this->assertNotFalse(
 			has_action( $load_hook ),
-			'The Subscribers announcement menu should be registered on Simple wpcom sites when the modernization filter is on.'
+			'The Subscribers announcement menu should be registered on self-hosted Jetpack when the modernization filter is on.'
+		);
+
+		remove_all_actions( $load_hook );
+		remove_all_filters( 'rsm_jetpack_ui_modernization_newsletter' );
+	}
+
+	/**
+	 * On WordPress.com (Simple and WoA) the announcement page is owned by
+	 * jetpack-mu-wpcom's wpcom-admin-menu, so add_subscribers_menu() must NOT
+	 * register it — otherwise Atomic, where both run, gets a duplicate entry and
+	 * double page-view tracking.
+	 */
+	public function test_announcement_menu_is_not_added_on_wpcom_platform() {
+		$announcement_class = 'Automattic\Jetpack\Newsletter\Subscribers_Announcement';
+		if ( ! class_exists( $announcement_class ) ) {
+			$this->markTestSkipped( 'Newsletter Subscribers_Announcement class is not available.' );
+		}
+
+		$load_hook = 'load-jetpack_page_' . $announcement_class::PAGE_SLUG;
+
+		// Simulate a wpcom platform (Simple/WoA).
+		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
+		delete_option( $announcement_class::REMOVED_OPTION );
+		add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );
+		remove_all_actions( $load_hook );
+
+		Jetpack_Subscriptions::init()->add_subscribers_menu();
+
+		$this->assertFalse(
+			has_action( $load_hook ),
+			'On wpcom platforms the announcement menu is owned by jetpack-mu-wpcom; add_subscribers_menu() should not register it.'
 		);
 
 		// Cleanup so the simulated platform does not leak into later tests.
 		remove_all_actions( $load_hook );
 		remove_all_filters( 'rsm_jetpack_ui_modernization_newsletter' );
-		delete_option( 'wpcom_admin_interface' );
 		\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes

When the Newsletter modernization filter (`rsm_jetpack_ui_modernization_newsletter`) is on, the **Jetpack → Subscribers** entry disappeared on WordPress.com Simple sites instead of being replaced by the transitional announcement page added in #49496.

Root cause turned out to be deeper than a single code path:

* `#49496` added the announcement registration to the Jetpack plugin's `modules/subscriptions.php` (`add_subscribers_menu()`). That file **does not load on WordPress.com Simple sites** — `Jetpack_Subscriptions` is missing at runtime there. On Simple (and WoA), the `Jetpack → Subscribers` menu is owned by **jetpack-mu-wpcom**'s `wpcom-admin-menu.php`, which simply omitted the entry once the filter was on.
* On **Atomic/WoA**, *both* `modules/subscriptions.php` and `wpcom-admin-menu.php` run, so naively adding the page in both would produce a duplicate entry and double the page-view tracking.

This PR makes **jetpack-mu-wpcom the single owner** of the announcement page on all WordPress.com platforms, while the Jetpack plugin owns it only on self-hosted:

* **newsletter:** add `Subscribers_Announcement::add_wp_admin_submenu()`, which registers the page via core `add_submenu_page( 'jetpack', … )` (mirroring `Settings::add_wp_admin_submenu()`). This is the wpcom registration path; `add_menu()`'s `Admin_Menu` wrapper remains the self-hosted path.
* **jetpack-mu-wpcom:** when the filter is on, call that method instead of dropping the Subscribers submenu. The page lands in the existing `subscribers` slot via `wpcom_reorder_submenu` (substring match on the `jetpack-subscribers` slug).
* **jetpack plugin:** gate `add_subscribers_menu()`'s announcement branch on `! is_wpcom_platform()` so it registers only on self-hosted, avoiding the Atomic duplicate.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No. (It prevents the announcement page-view event from firing twice on Atomic.)

## Testing instructions

On a **WordPress.com Simple site**:

* Enable the filter, e.g. in a sandbox `0-sandbox.php` / mu-plugin: `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );`
* In wp-admin, confirm **Jetpack → Subscribers** is present and opens the transitional announcement page (before this PR the entry was missing).
* Turn the filter off and confirm the legacy Calypso "Subscribers" link returns.

On **Atomic/WoA**: confirm there is exactly **one** Subscribers entry with the filter on (no duplicate).

On **self-hosted Jetpack**: with the filter on, confirm the announcement page still appears under Jetpack.

Automated:
* `jetpack docker phpunit jetpack -- --filter Jetpack_Subscriptions_Test` (self-hosted registers; wpcom does not)
* newsletter package: `composer phpunit -- --filter Subscribers_Announcement_Test` (covers the new `add_wp_admin_submenu()`)
