### PR TITLE
Charts: add comparison mode to the Bar Chart [CHARTS-217]

### DIFF
--- a/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
+++ b/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: add comparison mode to the Bar Chart — a translucent shadow bar (150% width, 50% opacity) rendered behind each primary bar, paired by group.

--- a/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
+++ b/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Charts: add comparison mode to the Bar Chart — a translucent shadow bar (standard slot width, 50% opacity) rendered behind each primary bar (narrowed to 60% of slot width, centered), paired by group.
+Charts: add comparison mode to the Bar Chart — a translucent shadow bar (standard slot width, 50% opacity) rendered behind each primary bar, paired by group. Primary bars are narrowed to 1/widthFactor of the slot (default widthFactor 1.5 → ~67% width, centered), with widthFactor as the single control.

--- a/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
+++ b/projects/js-packages/charts/changelog/charts-217-bar-chart-comparison-mode
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Charts: add comparison mode to the Bar Chart — a translucent shadow bar (150% width, 50% opacity) rendered behind each primary bar, paired by group.
+Charts: add comparison mode to the Bar Chart — a translucent shadow bar (standard slot width, 50% opacity) rendered behind each primary bar (narrowed to 60% of slot width, centered), paired by group.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -32,20 +32,22 @@
 		}
 	}
 
-	// Comparison mode: narrow primary bars to 60% of slot width, centered.
-	// Uses `scale` (not `transform: scaleX`) so it composes with the
-	// `transform`-based rise/stretch animation rather than overriding it.
-	// `transform-box: fill-box` is inherited from animation rules, but
-	// re-declared here for specificity clarity and to be safe when animation
-	// is disabled. Only targets .visx-bar-group bars, not the comparison
-	// shadow rects which live in .bar-chart__comparison-bars.
-	&--comparison .visx-bar-group .visx-bar {
+	// Comparison mode: narrow primary bars to 60% of slot width, centered, so
+	// the standard-width comparison shadow peeks on each side.
+	// `.visx-bar-group`/`.visx-bar` are global visx classes, so they MUST be
+	// wrapped in `:global()` — this is a CSS module, which would otherwise
+	// scope (hash) them and the selector would never match the rendered bars.
+	// Uses the `scale` property (not `transform: scaleX`) so it composes with
+	// the `transform`-based rise/stretch animation rather than overriding it.
+	// Only targets bars inside .visx-bar-group, not the comparison shadow
+	// rects which live in .bar-chart__comparison-bars.
+	&--comparison :global(.visx-bar-group .visx-bar) {
 		scale: 0.6 1;
 		transform-box: fill-box;
 		transform-origin: center;
 	}
 
-	&--comparison-horizontal .visx-bar-group .visx-bar {
+	&--comparison-horizontal :global(.visx-bar-group .visx-bar) {
 		scale: 1 0.6;
 		transform-box: fill-box;
 		transform-origin: center;

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -31,27 +31,4 @@
 			transform: scaleX(1);
 		}
 	}
-
-	// Comparison mode: narrow primary bars so the standard-width comparison shadow
-	// peeks on each side. The narrowing factor is 1/widthFactor (theme default
-	// 1.5 → ~0.667), supplied at runtime via `--comparison-primary-scale` set by
-	// bar-chart.tsx; 0.667 is the fallback.
-	// `.visx-bar-group`/`.visx-bar` are global visx classes, so they MUST be
-	// wrapped in `:global()` — this is a CSS module, which would otherwise
-	// scope (hash) them and the selector would never match the rendered bars.
-	// Uses the `scale` property (not `transform: scaleX`) so it composes with
-	// the `transform`-based rise/stretch animation rather than overriding it.
-	// Only targets bars inside .visx-bar-group, not the comparison shadow
-	// rects which live in .bar-chart__comparison-bars.
-	&--comparison :global(.visx-bar-group .visx-bar) {
-		scale: var(--comparison-primary-scale, 0.667) 1;
-		transform-box: fill-box;
-		transform-origin: center;
-	}
-
-	&--comparison-horizontal :global(.visx-bar-group .visx-bar) {
-		scale: 1 var(--comparison-primary-scale, 0.667);
-		transform-box: fill-box;
-		transform-origin: center;
-	}
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -32,8 +32,10 @@
 		}
 	}
 
-	// Comparison mode: narrow primary bars to 60% of slot width, centered, so
-	// the standard-width comparison shadow peeks on each side.
+	// Comparison mode: narrow primary bars so the standard-width comparison shadow
+	// peeks on each side. The narrowing factor is 1/widthFactor (theme default
+	// 1.5 → ~0.667), supplied at runtime via `--comparison-primary-scale` set by
+	// bar-chart.tsx; 0.667 is the fallback.
 	// `.visx-bar-group`/`.visx-bar` are global visx classes, so they MUST be
 	// wrapped in `:global()` — this is a CSS module, which would otherwise
 	// scope (hash) them and the selector would never match the rendered bars.
@@ -42,13 +44,13 @@
 	// Only targets bars inside .visx-bar-group, not the comparison shadow
 	// rects which live in .bar-chart__comparison-bars.
 	&--comparison :global(.visx-bar-group .visx-bar) {
-		scale: 0.6 1;
+		scale: var(--comparison-primary-scale, 0.667) 1;
 		transform-box: fill-box;
 		transform-origin: center;
 	}
 
 	&--comparison-horizontal :global(.visx-bar-group .visx-bar) {
-		scale: 1 0.6;
+		scale: 1 var(--comparison-primary-scale, 0.667);
 		transform-box: fill-box;
 		transform-origin: center;
 	}

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -31,4 +31,23 @@
 			transform: scaleX(1);
 		}
 	}
+
+	// Comparison mode: narrow primary bars to 60% of slot width, centered.
+	// Uses `scale` (not `transform: scaleX`) so it composes with the
+	// `transform`-based rise/stretch animation rather than overriding it.
+	// `transform-box: fill-box` is inherited from animation rules, but
+	// re-declared here for specificity clarity and to be safe when animation
+	// is disabled. Only targets .visx-bar-group bars, not the comparison
+	// shadow rects which live in .bar-chart__comparison-bars.
+	&--comparison .visx-bar-group .visx-bar {
+		scale: 0.6 1;
+		transform-box: fill-box;
+		transform-origin: center;
+	}
+
+	&--comparison-horizontal .visx-bar-group .visx-bar {
+		scale: 1 0.6;
+		transform-box: fill-box;
+		transform-origin: center;
+	}
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -32,7 +32,7 @@ import type { ComparisonSeriesEntry } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
 import type { ResponsiveConfig } from '../private/with-responsive';
-import type { CSSProperties, FC, ReactNode, ComponentType } from 'react';
+import type { FC, ReactNode, ComponentType } from 'react';
 
 export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	renderTooltip?: ( params: RenderTooltipParams< DataPointDate > ) => ReactNode;
@@ -209,18 +209,33 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		return entries;
 	}, [ seriesWithVisibility, primaryEntries, primaryKeys ] );
 
-	// Derive the primary bar scale factor from the comparison widthFactor theme value.
-	// When comparison series are present, this is passed as --comparison-primary-scale
-	// so SCSS can narrow primary bars to slot/widthFactor without a hardcoded value.
-	const comparisonPrimaryScale = useMemo( () => {
+	// Comparison widthFactor (how much wider the shadow is than the primary) drives both the
+	// shadow width (in ComparisonBars) and the primary narrowing.
+	const comparisonWidthFactor = useMemo( () => {
 		if ( comparisonEntries.length === 0 ) return undefined;
-		const wf =
+		return (
 			getElementStyles( {
 				data: comparisonEntries[ 0 ].series,
 				index: comparisonEntries[ 0 ].index,
-			} ).barStyles?.widthFactor ?? 1.5;
-		return 1 / wf;
+			} ).barStyles?.widthFactor ?? 1.5
+		);
 	}, [ comparisonEntries, getElementStyles ] );
+
+	// Narrow the primary bars by widening the visx group padding — a real geometry change, so
+	// pattern fills and borders are not distorted (unlike a CSS transform/scale). Solve for the
+	// padding where groupBandwidth(p) = groupBandwidth(basePadding) / widthFactor, so the shadow
+	// (drawn at slot × widthFactor) equals the default bar width and primary = 1/widthFactor of it.
+	// d3 band: groupBandwidth(p) = R(1-p)/(n+p) with padding applied to inner & outer.
+	const groupPadding = useMemo( () => {
+		const basePadding = chartOptions.barGroup.padding;
+		if ( ! comparisonWidthFactor || comparisonWidthFactor <= 1 ) {
+			return basePadding;
+		}
+		const n = Math.max( 1, primaryKeys.length );
+		const c = ( 1 - basePadding ) / ( n + basePadding ) / comparisonWidthFactor;
+		const p = ( 1 - c * n ) / ( 1 + c );
+		return Math.min( Math.max( p, basePadding ), 0.9 );
+	}, [ chartOptions.barGroup.padding, comparisonWidthFactor, primaryKeys.length ] );
 
 	const getBarBackground = useCallback(
 		( index: number ) => () =>
@@ -460,20 +475,10 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					{
 						[ styles[ `bar-chart--animated${ horizontal ? '-horizontal' : '' }` ] ]:
 							animation && ! prefersReducedMotion,
-						[ styles[ `bar-chart--comparison${ horizontal ? '-horizontal' : '' }` ] ]:
-							comparisonEntries.length > 0,
 					},
 					className
 				) }
-				style={
-					{
-						width,
-						height,
-						...( comparisonPrimaryScale !== undefined && {
-							'--comparison-primary-scale': comparisonPrimaryScale,
-						} ),
-					} as CSSProperties
-				}
+				style={ { width, height } }
 				data-testid="bar-chart"
 				data-chart-id={ `bar-chart-${ chartId }` }
 				trailingContent={ nonLegendChildren }
@@ -552,7 +557,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 										<ComparisonBars
 											comparisonEntries={ comparisonEntries }
 											primaryKeys={ primaryKeys }
-											groupPadding={ chartOptions.barGroup.padding }
+											groupPadding={ groupPadding }
 											horizontal={ horizontal }
 											xAccessor={ chartOptions.accessors.xAccessor }
 											yAccessor={
@@ -564,7 +569,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 											resolveFill={ resolveComparisonFill }
 										/>
 
-										<BarGroup padding={ chartOptions.barGroup.padding }>
+										<BarGroup padding={ groupPadding }>
 											{ primaryEntries.map( ( { series: seriesData, index } ) => (
 												<BarSeries
 													key={ seriesData?.label }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -27,7 +27,15 @@ import { SingleChartContext } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive } from '../private/with-responsive';
 import styles from './bar-chart.module.scss';
-import { useBarChartOptions, ComparisonBars } from './private';
+import {
+	useBarChartOptions,
+	ComparisonBars,
+	DEFAULT_COMPARISON_WIDTH_FACTOR,
+	COMPARISON_INNER_GAP,
+	MAX_GROUP_PADDING,
+	COMPARISON_TICK_GAP_FACTOR,
+	BASE_BAND_PADDING_INNER,
+} from './private';
 import type { ComparisonSeriesEntry } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
@@ -217,7 +225,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			getElementStyles( {
 				data: comparisonEntries[ 0 ].series,
 				index: comparisonEntries[ 0 ].index,
-			} ).barStyles?.widthFactor ?? 1.5
+			} ).barStyles?.widthFactor ?? DEFAULT_COMPARISON_WIDTH_FACTOR
 		);
 	}, [ comparisonEntries, getElementStyles ] );
 
@@ -233,13 +241,12 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		if ( ! comparisonWidthFactor || comparisonWidthFactor <= 1 ) {
 			return basePadding;
 		}
-		const innerGap = 0.1; // fraction of each per-series step left as a gap between bars in a tick
-		const p = 1 - ( 1 - innerGap ) / comparisonWidthFactor;
-		return Math.min( Math.max( p, basePadding ), 0.9 );
+		const p = 1 - ( 1 - COMPARISON_INNER_GAP ) / comparisonWidthFactor;
+		return Math.min( Math.max( p, basePadding ), MAX_GROUP_PADDING );
 	}, [ chartOptions.barGroup.padding, comparisonWidthFactor ] );
 
 	// In comparison mode, tighten the gap between ticks by reducing the category band's inner
-	// padding (the value axis is left untouched). 0.75 = a 25% reduction of the tick gap padding.
+	// padding (the value axis is left untouched). COMPARISON_TICK_GAP_FACTOR is the multiplier.
 	const { xScale, yScale } = useMemo( () => {
 		if ( comparisonEntries.length === 0 ) {
 			return { xScale: chartOptions.xScale, yScale: chartOptions.yScale };
@@ -247,7 +254,9 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		const tighten = < T extends object >( scale: T ): T =>
 			( {
 				...scale,
-				paddingInner: ( ( scale as { paddingInner?: number } ).paddingInner ?? 0.1 ) * 0.75,
+				paddingInner:
+					( ( scale as { paddingInner?: number } ).paddingInner ?? BASE_BAND_PADDING_INNER ) *
+					COMPARISON_TICK_GAP_FACTOR,
 			} ) as T;
 		return horizontal
 			? { xScale: chartOptions.xScale, yScale: tighten( chartOptions.yScale ) }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -230,20 +230,52 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			const nearestDatum = tooltipData?.nearestDatum?.datum;
 			if ( ! nearestDatum ) return null;
 
+			const primaryKey = tooltipData?.nearestDatum?.key;
+			const categoryLabel = chartOptions.tooltip.labelFormatter(
+				nearestDatum.label || ( nearestDatum.date ? nearestDatum.date.getTime() : 0 ),
+				0,
+				[]
+			);
+
+			// Find the comparison value paired with the hovered primary series (same group)
+			// at the same category, so the tooltip can show both periods at once.
+			const comparisonEntry = comparisonEntries.find( entry => entry.primaryKey === primaryKey );
+			const comparisonDatum = comparisonEntry?.series.data.find( point => {
+				const p = point as DataPointDate;
+				return nearestDatum.label != null
+					? p.label === nearestDatum.label
+					: !! nearestDatum.date && !! p.date && p.date.getTime() === nearestDatum.date.getTime();
+			} ) as DataPointDate | undefined;
+
+			// With a paired comparison value, show the category as the header and one row
+			// per period (primary + comparison).
+			if ( comparisonEntry && comparisonDatum && comparisonDatum.value != null ) {
+				return (
+					<div className={ styles[ 'bar-chart__tooltip' ] }>
+						<div className={ styles[ 'bar-chart__tooltip-header' ] }>{ categoryLabel }</div>
+						<div className={ styles[ 'bar-chart__tooltip-row' ] }>
+							<span className={ styles[ 'bar-chart__tooltip-label' ] }>{ primaryKey }:</span>
+							<span className={ styles[ 'bar-chart__tooltip-value' ] }>
+								{ formatNumber( nearestDatum.value as number ) }
+							</span>
+						</div>
+						<div className={ styles[ 'bar-chart__tooltip-row' ] }>
+							<span className={ styles[ 'bar-chart__tooltip-label' ] }>
+								{ comparisonEntry.series.label }:
+							</span>
+							<span className={ styles[ 'bar-chart__tooltip-value' ] }>
+								{ formatNumber( comparisonDatum.value as number ) }
+							</span>
+						</div>
+					</div>
+				);
+			}
+
 			return (
 				<div className={ styles[ 'bar-chart__tooltip' ] }>
-					<div className={ styles[ 'bar-chart__tooltip-header' ] }>
-						{ tooltipData?.nearestDatum?.key }
-					</div>
+					<div className={ styles[ 'bar-chart__tooltip-header' ] }>{ primaryKey }</div>
 					<div className={ styles[ 'bar-chart__tooltip-row' ] }>
-						<span className={ styles[ 'bar-chart__tooltip-label' ] }>
-							{ chartOptions.tooltip.labelFormatter(
-								nearestDatum.label || ( nearestDatum.date ? nearestDatum.date.getTime() : 0 ),
-								0,
-								[]
-							) }
-							:
-						</span>
+						<span className={ styles[ 'bar-chart__tooltip-label' ] }>{ categoryLabel }:</span>
 						<span className={ styles[ 'bar-chart__tooltip-value' ] }>
 							{ formatNumber( nearestDatum.value as number ) }
 						</span>
@@ -251,7 +283,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				</div>
 			);
 		},
-		[ chartOptions.tooltip ]
+		[ chartOptions.tooltip, comparisonEntries ]
 	);
 
 	const renderPattern = useCallback(

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -184,8 +184,11 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	);
 
 	const comparisonEntries = useMemo( () => {
-		const groupByPrimary = new Map< string | undefined, string >(
-			primaryEntries.map( ( { series } ) => [ series.group, series.label ] )
+		const primaryByGroup = new Map< string | undefined, { label: string; index: number } >(
+			primaryEntries.map( ( { series, index } ) => [
+				series.group,
+				{ label: series.label, index },
+			] )
 		);
 
 		const entries: ComparisonSeriesEntry[] = [];
@@ -193,13 +196,15 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			if ( ! isVisible || series.options?.type !== 'comparison' ) {
 				return;
 			}
-			const primaryKey =
-				groupByPrimary.get( series.group ) ??
-				( primaryKeys.length === 1 ? primaryKeys[ 0 ] : undefined );
-			if ( primaryKey === undefined || ! primaryKeys.includes( primaryKey ) ) {
+			const primary =
+				primaryByGroup.get( series.group ) ??
+				( primaryEntries.length === 1
+					? { label: primaryEntries[ 0 ].series.label, index: primaryEntries[ 0 ].index }
+					: undefined );
+			if ( ! primary || ! primaryKeys.includes( primary.label ) ) {
 				return;
 			}
-			entries.push( { series, index, primaryKey } );
+			entries.push( { series, index, primaryKey: primary.label, primaryIndex: primary.index } );
 		} );
 		return entries;
 	}, [ seriesWithVisibility, primaryEntries, primaryKeys ] );
@@ -223,6 +228,16 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				? `url(#${ getPatternId( chartId, index ) })`
 				: getElementStyles( { data: dataSorted[ index ], index } ).color,
 		[ withPatterns, getElementStyles, dataSorted, chartId ]
+	);
+
+	// Comparison shadow fill: when patterns are on, reuse the paired primary's pattern so the
+	// shadow reads as the same series; otherwise use the comparison series' resolved color.
+	const resolveComparisonFill = useCallback(
+		( entry: ComparisonSeriesEntry ) =>
+			withPatterns
+				? `url(#${ getPatternId( chartId, entry.primaryIndex ) })`
+				: getElementStyles( { data: entry.series, index: entry.index } ).color,
+		[ withPatterns, chartId, getElementStyles ]
 	);
 
 	const renderDefaultTooltip = useCallback(
@@ -325,8 +340,11 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const createPatternBorderStyle = useCallback(
 		( index: number, color: string ) => {
 			const patternId = getPatternId( chartId, index );
+			// Border the primary bars and any comparison shadow reusing the same pattern,
+			// so a patterned shadow gets the same outline as its primary bar.
 			return `
-			.visx-bar[fill="url(#${ patternId })"] {
+			.visx-bar[fill="url(#${ patternId })"],
+			.bar-chart__comparison-bars rect[fill="url(#${ patternId })"] {
 				stroke: ${ color };
 				stroke-width: 1;
 				}
@@ -543,6 +561,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 												) => number | undefined
 											}
 											getElementStyles={ getElementStyles }
+											resolveFill={ resolveComparisonFill }
 										/>
 
 										<BarGroup padding={ chartOptions.barGroup.padding }>

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -129,8 +129,12 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 	const [ isNavigating, setIsNavigating ] = useState( false );
 
+	// Comparison series have no .visx-bar elements; count only primary series so
+	// keyboard navigation doesn't cycle phantom indices into comparison-only slots.
+	const primarySeriesForNav = dataWithVisibleZeros.filter( s => s.options?.type !== 'comparison' );
 	const totalPoints =
-		Math.max( 0, ...data.map( series => series.data?.length || 0 ) ) * data.length;
+		Math.max( 0, ...primarySeriesForNav.map( s => s.data?.length || 0 ) ) *
+		primarySeriesForNav.length;
 
 	// Use the keyboard navigation hook
 	const { tooltipRef, onChartFocus, onChartBlur, onChartKeyDown } = useKeyboardNavigation( {
@@ -289,19 +293,21 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const createKeyboardHighlightStyle = useCallback( () => {
 		if ( selectedIndex === undefined ) return '';
 
-		// Calculate which bar should be highlighted based on selectedIndex
+		// Use only primary entries — comparison series have no .visx-bar elements so
+		// their indices must not appear in the nth-child selector.
 		// Pattern: [series1[0], series2[0], series3[0], series1[1], series2[1], series3[1], ...]
-		const maxDataPoints = Math.max( ...data.map( s => s.data.length ) );
-		const dataPointIndex = Math.floor( selectedIndex / data.length );
-		const seriesIndex = selectedIndex % data.length;
+		const primaryCount = primaryEntries.length;
+		const maxDataPoints = Math.max( ...primaryEntries.map( e => e.series.data.length ) );
+		const dataPointIndex = Math.floor( selectedIndex / primaryCount );
+		const seriesIndex = selectedIndex % primaryCount;
 
 		// Only highlight if we're within valid bounds
-		if ( dataPointIndex >= maxDataPoints || seriesIndex >= data.length ) {
+		if ( dataPointIndex >= maxDataPoints || seriesIndex >= primaryCount ) {
 			return '';
 		}
 
-		const seriesData = data[ seriesIndex ];
-		if ( dataPointIndex >= seriesData.data.length ) {
+		const seriesData = primaryEntries[ seriesIndex ]?.series;
+		if ( ! seriesData || dataPointIndex >= seriesData.data.length ) {
 			return '';
 		}
 
@@ -322,7 +328,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		`;
 
 		return generatedStyles;
-	}, [ selectedIndex, data, chartId ] );
+	}, [ selectedIndex, primaryEntries, chartId ] );
 
 	// Validate data first
 	const error = validateData( dataSorted );

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -233,10 +233,26 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		if ( ! comparisonWidthFactor || comparisonWidthFactor <= 1 ) {
 			return basePadding;
 		}
-		const innerGap = 0.15; // fraction of each per-series step left as a gap between bars in a tick
+		const innerGap = 0.1; // fraction of each per-series step left as a gap between bars in a tick
 		const p = 1 - ( 1 - innerGap ) / comparisonWidthFactor;
 		return Math.min( Math.max( p, basePadding ), 0.9 );
 	}, [ chartOptions.barGroup.padding, comparisonWidthFactor ] );
+
+	// In comparison mode, tighten the gap between ticks by reducing the category band's inner
+	// padding (the value axis is left untouched). 0.75 = a 25% reduction of the tick gap padding.
+	const { xScale, yScale } = useMemo( () => {
+		if ( comparisonEntries.length === 0 ) {
+			return { xScale: chartOptions.xScale, yScale: chartOptions.yScale };
+		}
+		const tighten = < T extends object >( scale: T ): T =>
+			( {
+				...scale,
+				paddingInner: ( ( scale as { paddingInner?: number } ).paddingInner ?? 0.1 ) * 0.75,
+			} ) as T;
+		return horizontal
+			? { xScale: chartOptions.xScale, yScale: tighten( chartOptions.yScale ) }
+			: { xScale: tighten( chartOptions.xScale ), yScale: chartOptions.yScale };
+	}, [ comparisonEntries.length, chartOptions.xScale, chartOptions.yScale, horizontal ] );
 
 	const getBarBackground = useCallback(
 		( index: number ) => () =>
@@ -507,8 +523,8 @@ const BarChartInternal: FC< BarChartProps > = ( {
 											...defaultMargin,
 											...margin,
 										} }
-										xScale={ chartOptions.xScale }
-										yScale={ chartOptions.yScale }
+										xScale={ xScale }
+										yScale={ yScale }
 										horizontal={ horizontal }
 										pointerEventsDataKey="nearest"
 									>

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -222,20 +222,21 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	}, [ comparisonEntries, getElementStyles ] );
 
 	// Narrow the primary bars by widening the visx group padding — a real geometry change, so
-	// pattern fills and borders are not distorted (unlike a CSS transform/scale). Solve for the
-	// padding where groupBandwidth(p) = groupBandwidth(basePadding) / widthFactor, so the shadow
-	// (drawn at slot × widthFactor) equals the default bar width and primary = 1/widthFactor of it.
-	// d3 band: groupBandwidth(p) = R(1-p)/(n+p) with padding applied to inner & outer.
+	// pattern fills and borders are not distorted (unlike a CSS transform/scale). The padding is
+	// set so the comparison shadow (drawn at slot × widthFactor) fills all but a small gap of each
+	// per-series step, leaving a small gap between series within a tick (the larger gap between
+	// ticks comes from the category band's own padding). Because shadow = step × (1 - p) ×
+	// widthFactor, choosing p = 1 - (1 - innerGap)/widthFactor makes the shadow span (1 - innerGap)
+	// of the step; the primary stays 1/widthFactor of the shadow.
 	const groupPadding = useMemo( () => {
 		const basePadding = chartOptions.barGroup.padding;
 		if ( ! comparisonWidthFactor || comparisonWidthFactor <= 1 ) {
 			return basePadding;
 		}
-		const n = Math.max( 1, primaryKeys.length );
-		const c = ( 1 - basePadding ) / ( n + basePadding ) / comparisonWidthFactor;
-		const p = ( 1 - c * n ) / ( 1 + c );
+		const innerGap = 0.15; // fraction of each per-series step left as a gap between bars in a tick
+		const p = 1 - ( 1 - innerGap ) / comparisonWidthFactor;
 		return Math.min( Math.max( p, basePadding ), 0.9 );
-	}, [ chartOptions.barGroup.padding, comparisonWidthFactor, primaryKeys.length ] );
+	}, [ chartOptions.barGroup.padding, comparisonWidthFactor ] );
 
 	const getBarBackground = useCallback(
 		( index: number ) => () =>

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -32,7 +32,7 @@ import type { ComparisonSeriesEntry } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
 import type { ResponsiveConfig } from '../private/with-responsive';
-import type { FC, ReactNode, ComponentType } from 'react';
+import type { CSSProperties, FC, ReactNode, ComponentType } from 'react';
 
 export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	renderTooltip?: ( params: RenderTooltipParams< DataPointDate > ) => ReactNode;
@@ -203,6 +203,19 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		} );
 		return entries;
 	}, [ seriesWithVisibility, primaryEntries, primaryKeys ] );
+
+	// Derive the primary bar scale factor from the comparison widthFactor theme value.
+	// When comparison series are present, this is passed as --comparison-primary-scale
+	// so SCSS can narrow primary bars to slot/widthFactor without a hardcoded value.
+	const comparisonPrimaryScale = useMemo( () => {
+		if ( comparisonEntries.length === 0 ) return undefined;
+		const wf =
+			getElementStyles( {
+				data: comparisonEntries[ 0 ].series,
+				index: comparisonEntries[ 0 ].index,
+			} ).barStyles?.widthFactor ?? 1.5;
+		return 1 / wf;
+	}, [ comparisonEntries, getElementStyles ] );
 
 	const getBarBackground = useCallback(
 		( index: number ) => () =>
@@ -402,7 +415,15 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					},
 					className
 				) }
-				style={ { width, height } }
+				style={
+					{
+						width,
+						height,
+						...( comparisonPrimaryScale !== undefined && {
+							'--comparison-primary-scale': comparisonPrimaryScale,
+						} ),
+					} as CSSProperties
+				}
 				data-testid="bar-chart"
 				data-chart-id={ `bar-chart-${ chartId }` }
 				trailingContent={ nonLegendChildren }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -27,7 +27,8 @@ import { SingleChartContext } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive } from '../private/with-responsive';
 import styles from './bar-chart.module.scss';
-import { useBarChartOptions } from './private';
+import { useBarChartOptions, ComparisonBars } from './private';
+import type { ComparisonSeriesEntry } from './private';
 import type { BaseChartProps, DataPointDate, SeriesData, Optional } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
 import type { ResponsiveConfig } from '../private/with-responsive';
@@ -163,6 +164,41 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const allSeriesHidden = useMemo( () => {
 		return seriesWithVisibility.every( ( { isVisible } ) => ! isVisible );
 	}, [ seriesWithVisibility ] );
+
+	// Derive primary vs comparison entries for comparison mode support.
+	const primaryEntries = useMemo(
+		() =>
+			seriesWithVisibility.filter(
+				( { isVisible, series } ) => isVisible && series.options?.type !== 'comparison'
+			),
+		[ seriesWithVisibility ]
+	);
+
+	const primaryKeys = useMemo(
+		() => primaryEntries.map( ( { series } ) => series.label ),
+		[ primaryEntries ]
+	);
+
+	const comparisonEntries = useMemo( () => {
+		const groupByPrimary = new Map< string | undefined, string >(
+			primaryEntries.map( ( { series } ) => [ series.group, series.label ] )
+		);
+
+		const entries: ComparisonSeriesEntry[] = [];
+		seriesWithVisibility.forEach( ( { series, index, isVisible } ) => {
+			if ( ! isVisible || series.options?.type !== 'comparison' ) {
+				return;
+			}
+			const primaryKey =
+				groupByPrimary.get( series.group ) ??
+				( primaryKeys.length === 1 ? primaryKeys[ 0 ] : undefined );
+			if ( primaryKey === undefined || ! primaryKeys.includes( primaryKey ) ) {
+				return;
+			}
+			entries.push( { series, index, primaryKey } );
+		} );
+		return entries;
+	}, [ seriesWithVisibility, primaryEntries, primaryKeys ] );
 
 	const getBarBackground = useCallback(
 		( index: number ) => () =>
@@ -434,24 +470,31 @@ const BarChartInternal: FC< BarChartProps > = ( {
 											</SvgEmptyState>
 										) : null }
 
-										<BarGroup padding={ chartOptions.barGroup.padding }>
-											{ seriesWithVisibility.map( ( { series: seriesData, index, isVisible } ) => {
-												// Skip rendering invisible series
-												if ( ! isVisible ) {
-													return null;
-												}
+										<ComparisonBars
+											comparisonEntries={ comparisonEntries }
+											primaryKeys={ primaryKeys }
+											groupPadding={ chartOptions.barGroup.padding }
+											horizontal={ horizontal }
+											xAccessor={ chartOptions.accessors.xAccessor }
+											yAccessor={
+												chartOptions.accessors.yAccessor as (
+													d: DataPointDate
+												) => number | undefined
+											}
+											getElementStyles={ getElementStyles }
+										/>
 
-												return (
-													<BarSeries
-														key={ seriesData?.label }
-														dataKey={ seriesData?.label }
-														data={ seriesData.data as DataPointDate[] }
-														yAccessor={ chartOptions.accessors.yAccessor }
-														xAccessor={ chartOptions.accessors.xAccessor }
-														colorAccessor={ getBarBackground( index ) }
-													/>
-												);
-											} ) }
+										<BarGroup padding={ chartOptions.barGroup.padding }>
+											{ primaryEntries.map( ( { series: seriesData, index } ) => (
+												<BarSeries
+													key={ seriesData?.label }
+													dataKey={ seriesData?.label }
+													data={ seriesData.data as DataPointDate[] }
+													yAccessor={ chartOptions.accessors.yAccessor }
+													xAccessor={ chartOptions.accessors.xAccessor }
+													colorAccessor={ getBarBackground( index ) }
+												/>
+											) ) }
 										</BarGroup>
 
 										<Axis { ...chartOptions.axis.x } />

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -397,6 +397,8 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					{
 						[ styles[ `bar-chart--animated${ horizontal ? '-horizontal' : '' }` ] ]:
 							animation && ! prefersReducedMotion,
+						[ styles[ `bar-chart--comparison${ horizontal ? '-horizontal' : '' }` ] ]:
+							comparisonEntries.length > 0,
 					},
 					className
 				) }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars-geometry.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars-geometry.ts
@@ -1,0 +1,68 @@
+export type ComparisonRect = { x: number; y: number; width: number; height: number };
+
+type ValueScale = ( ( v: number ) => number ) & { range: () => unknown[] };
+
+/**
+ * Output position of a value scale's baseline: zero if in-domain, else the
+ * nearest range edge. Mirrors visx's getScaleBaseline so comparison shadows
+ * sit on the same baseline as primary bars.
+ *
+ * @param {ValueScale} scale - The continuous value scale.
+ * @return {number} The baseline output position in pixels.
+ */
+export function getValueScaleBaseline( scale: ValueScale ): number {
+	const [ a, b ] = scale.range().map( r => Number( r ) || 0 );
+	const isDescending = b < a;
+	const maybeZero = scale( 0 );
+	const [ minOutput, maxOutput ] = isDescending ? [ b, a ] : [ a, b ];
+	if ( isDescending ) {
+		return Number.isFinite( maybeZero )
+			? Math.min( Math.max( minOutput, maybeZero ), maxOutput )
+			: maxOutput;
+	}
+	return Number.isFinite( maybeZero ) ? Math.max( maybeZero, minOutput ) : minOutput;
+}
+
+/**
+ * Compute the rect for a comparison "shadow" bar, centered on the paired
+ * primary bar slot and scaled by `widthFactor`.
+ *
+ * @param {object}  params               - Geometry inputs.
+ * @param {boolean} params.horizontal    - True for a horizontal bar chart, false for vertical.
+ * @param {number}  params.bandPosition  - bandScale(category): start px of the category band.
+ * @param {number}  params.slotOffset    - groupScale(primaryKey): offset of the primary slot within the band.
+ * @param {number}  params.slotThickness - groupScale.bandwidth(): primary bar thickness in px.
+ * @param {number}  params.valuePosition - valueScale(value): output px for the bar's data value.
+ * @param {number}  params.baseline      - getValueScaleBaseline(valueScale): zero-line output px.
+ * @param {number}  params.widthFactor   - Shadow thickness multiplier, e.g. 1.5 for 150% width.
+ * @return {ComparisonRect} The {x, y, width, height} of the shadow rect.
+ */
+export function computeComparisonRect( params: {
+	horizontal: boolean;
+	bandPosition: number;
+	slotOffset: number;
+	slotThickness: number;
+	valuePosition: number;
+	baseline: number;
+	widthFactor: number;
+} ): ComparisonRect {
+	const {
+		horizontal,
+		bandPosition,
+		slotOffset,
+		slotThickness,
+		valuePosition,
+		baseline,
+		widthFactor,
+	} = params;
+	const slotStart = bandPosition + slotOffset;
+	const shadowThickness = slotThickness * widthFactor;
+	const shadowStart = slotStart + slotThickness / 2 - shadowThickness / 2;
+	const valueStart = Math.min( valuePosition, baseline );
+	const valueLength = Math.abs( baseline - valuePosition );
+
+	if ( horizontal ) {
+		return { x: valueStart, y: shadowStart, width: valueLength, height: shadowThickness };
+	}
+	return { x: shadowStart, y: valueStart, width: shadowThickness, height: valueLength };
+}

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars-geometry.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars-geometry.ts
@@ -20,7 +20,9 @@ export function getValueScaleBaseline( scale: ValueScale ): number {
 			? Math.min( Math.max( minOutput, maybeZero ), maxOutput )
 			: maxOutput;
 	}
-	return Number.isFinite( maybeZero ) ? Math.max( maybeZero, minOutput ) : minOutput;
+	return Number.isFinite( maybeZero )
+		? Math.min( Math.max( maybeZero, minOutput ), maxOutput )
+		: minOutput;
 }
 
 /**

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -75,8 +75,9 @@ export const ComparisonBars: FC< {
 		}
 
 		const { color, barStyles } = getElementStyles( { data: series, index } );
-		const widthFactor = barStyles?.widthFactor ?? 1.5; // safety net; CompleteChartTheme guarantees this value
 		const opacity = barStyles?.opacity ?? 0.5; // safety net; CompleteChartTheme guarantees this value
+		// Note: barStyles.widthFactor governs PRIMARY bar narrowing, not shadow width.
+		// It is read in bar-chart.tsx and applied via --comparison-primary-scale.
 
 		( series.data as DataPointDate[] ).forEach( ( datum, i ) => {
 			const bandPosition = Number( bandScale( bandAccessor( datum ) as never ) );
@@ -95,6 +96,8 @@ export const ComparisonBars: FC< {
 				return;
 			}
 
+			// Comparison shadow is the standard slot width; the theme `widthFactor` governs the PRIMARY bar
+			// narrowing instead (applied in bar-chart.tsx via the --comparison-primary-scale CSS variable).
 			const rect = computeComparisonRect( {
 				horizontal,
 				bandPosition,
@@ -102,7 +105,7 @@ export const ComparisonBars: FC< {
 				slotThickness,
 				valuePosition,
 				baseline,
-				widthFactor,
+				widthFactor: 1,
 			} );
 
 			rects.push(

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -6,7 +6,13 @@ import type { ElementStyles, GetElementStylesParams } from '../../../providers';
 import type { DataPointDate, SeriesData } from '../../../types';
 import type { FC, ReactNode } from 'react';
 
-export type ComparisonSeriesEntry = { series: SeriesData; index: number; primaryKey: string };
+export type ComparisonSeriesEntry = {
+	series: SeriesData;
+	index: number;
+	primaryKey: string;
+	/** dataSorted index of the paired primary series (used to share its pattern fill). */
+	primaryIndex: number;
+};
 
 // Minimal shape we need from visx scales — avoids spreading `any` while
 // remaining compatible with both band and continuous scale return types.
@@ -27,6 +33,8 @@ export const ComparisonBars: FC< {
 	xAccessor: ( d: DataPointDate ) => string | number | Date | undefined;
 	yAccessor: ( d: DataPointDate ) => number | undefined;
 	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles;
+	/** Resolves the shadow fill — the paired primary's pattern when patterns are on, else a color. */
+	resolveFill: ( entry: ComparisonSeriesEntry ) => string;
 } > = ( {
 	comparisonEntries,
 	primaryKeys,
@@ -35,6 +43,7 @@ export const ComparisonBars: FC< {
 	xAccessor,
 	yAccessor,
 	getElementStyles,
+	resolveFill,
 } ) => {
 	const context = useContext( DataContext );
 	const xScale = context?.xScale as AnyScale | undefined;
@@ -68,14 +77,17 @@ export const ComparisonBars: FC< {
 
 	const rects: ReactNode[] = [];
 
-	comparisonEntries.forEach( ( { series, index, primaryKey } ) => {
+	comparisonEntries.forEach( entry => {
+		const { series, index, primaryKey } = entry;
 		const slotOffset = groupScale( primaryKey );
 		if ( slotOffset == null || ! Number.isFinite( slotOffset ) ) {
 			return;
 		}
 
-		const { color, barStyles } = getElementStyles( { data: series, index } );
+		const { barStyles } = getElementStyles( { data: series, index } );
 		const opacity = barStyles?.opacity ?? 0.5; // safety net; CompleteChartTheme guarantees this value
+		// Fill is the paired primary's pattern (when patterns are on) or its resolved color.
+		const fill = resolveFill( entry );
 		// Note: barStyles.widthFactor governs PRIMARY bar narrowing, not shadow width.
 		// It is read in bar-chart.tsx and applied via --comparison-primary-scale.
 
@@ -116,7 +128,7 @@ export const ComparisonBars: FC< {
 					y={ rect.y }
 					width={ rect.width }
 					height={ rect.height }
-					fill={ color }
+					fill={ fill }
 					opacity={ opacity }
 					rx={ barStyles?.rx }
 				/>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -1,0 +1,124 @@
+import { scaleBand } from '@visx/scale';
+import { DataContext } from '@visx/xychart';
+import { useContext } from 'react';
+import { computeComparisonRect, getValueScaleBaseline } from './comparison-bars-geometry';
+import type { ElementStyles, GetElementStylesParams } from '../../../providers';
+import type { DataPointDate, SeriesData } from '../../../types';
+import type { FC, ReactNode } from 'react';
+
+export type ComparisonSeriesEntry = { series: SeriesData; index: number; primaryKey: string };
+
+// Minimal shape we need from visx scales — avoids spreading `any` while
+// remaining compatible with both band and continuous scale return types.
+type AnyScale = ( ( input: unknown ) => number ) & {
+	bandwidth?: () => number;
+	range: () => unknown[];
+};
+
+export const ComparisonBars: FC< {
+	comparisonEntries: ComparisonSeriesEntry[];
+	primaryKeys: string[];
+	groupPadding: number;
+	horizontal: boolean;
+	xAccessor: ( d: DataPointDate ) => string | number | Date | undefined;
+	yAccessor: ( d: DataPointDate ) => number | undefined;
+	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles;
+} > = ( {
+	comparisonEntries,
+	primaryKeys,
+	groupPadding,
+	horizontal,
+	xAccessor,
+	yAccessor,
+	getElementStyles,
+} ) => {
+	const context = useContext( DataContext );
+	const xScale = context?.xScale as AnyScale | undefined;
+	const yScale = context?.yScale as AnyScale | undefined;
+
+	if ( ! xScale || ! yScale || primaryKeys.length === 0 ) {
+		return null;
+	}
+
+	// Vertical: band axis is x, value axis is y. Horizontal: reversed.
+	const bandScale = ( horizontal ? yScale : xScale ) as AnyScale;
+	const valueScale = ( horizontal ? xScale : yScale ) as AnyScale;
+
+	const bandwidth = bandScale.bandwidth ? bandScale.bandwidth() : 0;
+	if ( ! bandwidth ) {
+		return null;
+	}
+
+	// Rebuild visx's inner group scale exactly as BarGroup does.
+	const groupScale = scaleBand( {
+		domain: primaryKeys,
+		range: [ 0, bandwidth ],
+		padding: groupPadding,
+	} );
+	const slotThickness = groupScale.bandwidth();
+	const baseline = getValueScaleBaseline( valueScale );
+
+	// Vertical uses xAccessor for category label; horizontal uses yAccessor.
+	const bandAccessor = horizontal ? yAccessor : xAccessor;
+	const valueAccessor = horizontal ? xAccessor : yAccessor;
+
+	const rects: ReactNode[] = [];
+
+	comparisonEntries.forEach( ( { series, index, primaryKey } ) => {
+		const slotOffset = groupScale( primaryKey );
+		if ( slotOffset == null || ! Number.isFinite( slotOffset ) ) {
+			return;
+		}
+
+		const { color, barStyles } = getElementStyles( { data: series, index } );
+		const widthFactor = barStyles?.widthFactor ?? 1.5;
+		const opacity = barStyles?.opacity ?? 0.5;
+
+		( series.data as DataPointDate[] ).forEach( ( datum, i ) => {
+			const bandPosition = Number( bandScale( bandAccessor( datum ) as never ) );
+			const valuePosition = Number( valueScale( Number( valueAccessor( datum ) ) as never ) );
+
+			if ( ! Number.isFinite( bandPosition ) || ! Number.isFinite( valuePosition ) ) {
+				return;
+			}
+
+			const rect = computeComparisonRect( {
+				horizontal,
+				bandPosition,
+				slotOffset: slotOffset as number,
+				slotThickness,
+				valuePosition,
+				baseline,
+				widthFactor,
+			} );
+
+			rects.push(
+				<rect
+					key={ `${ index }-${ i }` }
+					data-testid={ `bar-chart-comparison-${ index }-${ i }` }
+					x={ rect.x }
+					y={ rect.y }
+					width={ rect.width }
+					height={ rect.height }
+					fill={ color }
+					opacity={ opacity }
+					rx={ barStyles?.rx }
+				/>
+			);
+		} );
+	} );
+
+	if ( rects.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<g
+			className="bar-chart__comparison-bars"
+			pointerEvents="none"
+			data-testid="bar-chart-comparison-bars"
+		>
+			{ rects }
+		</g>
+	);
+};

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -2,6 +2,10 @@ import { scaleBand } from '@visx/scale';
 import { DataContext } from '@visx/xychart';
 import { useContext } from 'react';
 import { computeComparisonRect, getValueScaleBaseline } from './comparison-bars-geometry';
+import {
+	DEFAULT_COMPARISON_OPACITY,
+	DEFAULT_COMPARISON_WIDTH_FACTOR,
+} from './comparison-constants';
 import type { ElementStyles, GetElementStylesParams } from '../../../providers';
 import type { DataPointDate, SeriesData } from '../../../types';
 import type { FC, ReactNode } from 'react';
@@ -85,8 +89,8 @@ export const ComparisonBars: FC< {
 		}
 
 		const { barStyles } = getElementStyles( { data: series, index } );
-		const opacity = barStyles?.opacity ?? 0.5; // safety net; CompleteChartTheme guarantees this value
-		const widthFactor = barStyles?.widthFactor ?? 1.5;
+		const opacity = barStyles?.opacity ?? DEFAULT_COMPARISON_OPACITY; // safety net; CompleteChartTheme guarantees this value
+		const widthFactor = barStyles?.widthFactor ?? DEFAULT_COMPARISON_WIDTH_FACTOR;
 		// Fill is the paired primary's pattern (when patterns are on) or its resolved color.
 		const fill = resolveFill( entry );
 		// The shadow is `widthFactor` × the (narrowed) primary slot. bar-chart.tsx narrows the

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -133,7 +133,6 @@ export const ComparisonBars: FC< {
 					height={ rect.height }
 					fill={ fill }
 					opacity={ opacity }
-					rx={ barStyles?.rx }
 				/>
 			);
 		} );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -86,10 +86,11 @@ export const ComparisonBars: FC< {
 
 		const { barStyles } = getElementStyles( { data: series, index } );
 		const opacity = barStyles?.opacity ?? 0.5; // safety net; CompleteChartTheme guarantees this value
+		const widthFactor = barStyles?.widthFactor ?? 1.5;
 		// Fill is the paired primary's pattern (when patterns are on) or its resolved color.
 		const fill = resolveFill( entry );
-		// Note: barStyles.widthFactor governs PRIMARY bar narrowing, not shadow width.
-		// It is read in bar-chart.tsx and applied via --comparison-primary-scale.
+		// The shadow is `widthFactor` × the (narrowed) primary slot. bar-chart.tsx narrows the
+		// primary bars by widening the group padding so this ratio holds with real geometry.
 
 		( series.data as DataPointDate[] ).forEach( ( datum, i ) => {
 			const bandPosition = Number( bandScale( bandAccessor( datum ) as never ) );
@@ -108,8 +109,6 @@ export const ComparisonBars: FC< {
 				return;
 			}
 
-			// Comparison shadow is the standard slot width; the theme `widthFactor` governs the PRIMARY bar
-			// narrowing instead (applied in bar-chart.tsx via the --comparison-primary-scale CSS variable).
 			const rect = computeComparisonRect( {
 				horizontal,
 				bandPosition,
@@ -117,7 +116,7 @@ export const ComparisonBars: FC< {
 				slotThickness,
 				valuePosition,
 				baseline,
-				widthFactor: 1,
+				widthFactor,
 			} );
 
 			rects.push(

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -15,6 +15,10 @@ type AnyScale = ( ( input: unknown ) => number ) & {
 	range: () => unknown[];
 };
 
+// Renders translucent "shadow" bars for comparison series behind their paired primary bars.
+// IMPORTANT: each comparison datum's category key (label or date) must exactly match a key
+// used by the primary series — if it doesn't, bandScale() returns undefined and the shadow
+// is silently skipped. Ensure comparison data reuses the same label/date values as primary.
 export const ComparisonBars: FC< {
 	comparisonEntries: ComparisonSeriesEntry[];
 	primaryKeys: string[];
@@ -71,14 +75,23 @@ export const ComparisonBars: FC< {
 		}
 
 		const { color, barStyles } = getElementStyles( { data: series, index } );
-		const widthFactor = barStyles?.widthFactor ?? 1.5;
-		const opacity = barStyles?.opacity ?? 0.5;
+		const widthFactor = barStyles?.widthFactor ?? 1.5; // safety net; CompleteChartTheme guarantees this value
+		const opacity = barStyles?.opacity ?? 0.5; // safety net; CompleteChartTheme guarantees this value
 
 		( series.data as DataPointDate[] ).forEach( ( datum, i ) => {
 			const bandPosition = Number( bandScale( bandAccessor( datum ) as never ) );
 			const valuePosition = Number( valueScale( Number( valueAccessor( datum ) ) as never ) );
 
 			if ( ! Number.isFinite( bandPosition ) || ! Number.isFinite( valuePosition ) ) {
+				if ( process.env.NODE_ENV !== 'production' && ! Number.isFinite( bandPosition ) ) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						`[Charts] ComparisonBars: datum key "${ String(
+							bandAccessor( datum )
+						) }" did not match any primary category. Shadow will not be rendered. ` +
+							'Ensure comparison series data uses the same label/date keys as the primary series.'
+					);
+				}
 				return;
 			}
 

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-constants.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-constants.ts
@@ -1,0 +1,33 @@
+// Shared comparison-mode tuning constants. These drive the geometry of the
+// translucent "shadow" bars and how the primary bars are narrowed to sit in front of them.
+
+/**
+ * How much wider the comparison shadow is than the primary bar. Fallback used when the
+ * theme value (`barChart.barStyles.comparison.widthFactor`) is absent. Also drives the
+ * primary narrowing — the primary stays `1 / widthFactor` of the shadow.
+ */
+export const DEFAULT_COMPARISON_WIDTH_FACTOR = 1.5;
+
+/**
+ * Opacity of the comparison shadow. Fallback used when the theme value
+ * (`barChart.barStyles.comparison.opacity`) is absent.
+ */
+export const DEFAULT_COMPARISON_OPACITY = 0.5;
+
+/**
+ * Fraction of each per-series step left as a gap between bars within a single tick.
+ * Larger = more space between adjacent series; the shadow spans `1 - COMPARISON_INNER_GAP` of the step.
+ */
+export const COMPARISON_INNER_GAP = 0.1;
+
+/**
+ * Upper clamp on the computed group padding, so bars can never collapse to zero width
+ * even at very large `widthFactor` values.
+ */
+export const MAX_GROUP_PADDING = 0.9;
+
+/**
+ * Factor applied to the category band's `paddingInner` in comparison mode to tighten the
+ * gap between ticks. `0.75` = a 25% reduction of the tick-gap padding.
+ */
+export const COMPARISON_TICK_GAP_FACTOR = 0.75;

--- a/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
@@ -1,2 +1,4 @@
 export { useBarChartOptions } from './use-bar-chart-options';
 export { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
+export { ComparisonBars } from './comparison-bars';
+export type { ComparisonSeriesEntry } from './comparison-bars';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/index.ts
@@ -2,3 +2,10 @@ export { useBarChartOptions } from './use-bar-chart-options';
 export { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
 export { ComparisonBars } from './comparison-bars';
 export type { ComparisonSeriesEntry } from './comparison-bars';
+export {
+	DEFAULT_COMPARISON_WIDTH_FACTOR,
+	COMPARISON_INNER_GAP,
+	MAX_GROUP_PADDING,
+	COMPARISON_TICK_GAP_FACTOR,
+} from './comparison-constants';
+export { BASE_BAND_PADDING_INNER } from './use-bar-chart-options';

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars-geometry.test.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars-geometry.test.ts
@@ -8,6 +8,14 @@ describe( 'getValueScaleBaseline', () => {
 		// scale(0) = 200 - (-10/90)*200 ≈ 222 -> clamped to 200
 		expect( getValueScaleBaseline( scale ) ).toBe( 200 );
 	} );
+
+	it( 'clamps to the end (range max) when 0 is outside an ascending range scale', () => {
+		// horizontal linear scale: range [0, 200], domain [-100, -10] (zero excluded)
+		const scale = ( ( v: number ) => ( ( v + 100 ) / 90 ) * 200 ) as never;
+		( scale as { range: () => number[] } ).range = () => [ 0, 200 ];
+		// scale(0) = (100/90)*200 ≈ 222 -> clamped to 200
+		expect( getValueScaleBaseline( scale ) ).toBe( 200 );
+	} );
 } );
 
 describe( 'computeComparisonRect', () => {

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars-geometry.test.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars-geometry.test.ts
@@ -1,0 +1,39 @@
+import { computeComparisonRect, getValueScaleBaseline } from '../comparison-bars-geometry';
+
+describe( 'getValueScaleBaseline', () => {
+	it( 'clamps to the bottom (range max) when 0 is below the domain (vertical, descending range)', () => {
+		// vertical linear scale: range [200, 0] (bottom -> top), domain [10, 100] (zero excluded)
+		const scale = ( ( v: number ) => 200 - ( ( v - 10 ) / 90 ) * 200 ) as never;
+		( scale as { range: () => number[] } ).range = () => [ 200, 0 ];
+		// scale(0) = 200 - (-10/90)*200 ≈ 222 -> clamped to 200
+		expect( getValueScaleBaseline( scale ) ).toBe( 200 );
+	} );
+} );
+
+describe( 'computeComparisonRect', () => {
+	const base = {
+		bandPosition: 100,
+		slotOffset: 10,
+		slotThickness: 40,
+		valuePosition: 50,
+		baseline: 200,
+		widthFactor: 1.5,
+	};
+
+	it( 'centers a 150% wide shadow on the primary slot (vertical)', () => {
+		const r = computeComparisonRect( { ...base, horizontal: false } );
+		// slotStart=110, center=110+20=130, shadowThickness=60, shadowStart=130-30=100
+		expect( r ).toEqual( { x: 100, y: 50, width: 60, height: 150 } );
+	} );
+
+	it( 'centers a 150% tall shadow on the primary slot (horizontal)', () => {
+		const r = computeComparisonRect( {
+			...base,
+			horizontal: true,
+			valuePosition: 150,
+			baseline: 0,
+		} );
+		// slotStart=110, center=130, shadowThickness=60, shadowStart=100
+		expect( r ).toEqual( { x: 0, y: 100, width: 150, height: 60 } );
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
@@ -56,7 +56,7 @@ const seriesData: SeriesData = {
 };
 
 const comparisonEntries: ComparisonSeriesEntry[] = [
-	{ series: seriesData, index: 0, primaryKey: 'current' },
+	{ series: seriesData, index: 0, primaryKey: 'current', primaryIndex: 0 },
 ];
 
 const getElementStyles = () => ( {
@@ -66,6 +66,8 @@ const getElementStyles = () => ( {
 	glyph: undefined as never,
 	shapeStyles: {} as never,
 } );
+
+const resolveFill = () => '#f00';
 
 const xAccessor = ( d: DataPointDate ) => d.label;
 const yAccessor = ( d: DataPointDate ) => d.value ?? undefined;
@@ -83,6 +85,7 @@ describe( 'ComparisonBars', () => {
 						xAccessor={ xAccessor }
 						yAccessor={ yAccessor }
 						getElementStyles={ getElementStyles }
+						resolveFill={ resolveFill }
 					/>
 				</DataContext.Provider>
 			</svg>
@@ -110,6 +113,7 @@ describe( 'ComparisonBars', () => {
 						xAccessor={ xAccessor }
 						yAccessor={ yAccessor }
 						getElementStyles={ getElementStyles }
+						resolveFill={ resolveFill }
 					/>
 				</DataContext.Provider>
 			</svg>
@@ -132,6 +136,7 @@ describe( 'ComparisonBars', () => {
 						xAccessor={ xAccessor }
 						yAccessor={ yAccessor }
 						getElementStyles={ getElementStyles }
+						resolveFill={ resolveFill }
 					/>
 				</DataContext.Provider>
 			</svg>
@@ -167,6 +172,7 @@ describe( 'ComparisonBars', () => {
 						xAccessor={ xAccessor }
 						yAccessor={ yAccessor }
 						getElementStyles={ getElementStyles }
+						resolveFill={ resolveFill }
 					/>
 				</DataContext.Provider>
 			</svg>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
@@ -120,6 +120,41 @@ describe( 'ComparisonBars', () => {
 		expect( g ).toHaveAttribute( 'pointer-events', 'none' );
 	} );
 
+	it( 'shadow rect is horizontally centered on the primary bar slot and 150% of its width', () => {
+		render(
+			<svg>
+				<DataContext.Provider value={ dataContextValue }>
+					<ComparisonBars
+						comparisonEntries={ comparisonEntries }
+						primaryKeys={ primaryKeys }
+						groupPadding={ groupPadding }
+						horizontal={ false }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						getElementStyles={ getElementStyles }
+					/>
+				</DataContext.Provider>
+			</svg>
+		);
+
+		const rects = screen.getAllByTestId( /^bar-chart-comparison-0-/ );
+		const rect = rects[ 0 ]; // 'Jan' datum
+
+		const slotThickness = groupScale.bandwidth();
+		const expectedWidth = 1.5 * slotThickness;
+		// Shadow x = bandStart + slotOffset + slotThickness/2 - shadowWidth/2
+		const bandStart = Number( xScale( 'Jan' ) );
+		const slotOffset = Number( groupScale( 'current' ) );
+		const expectedX = bandStart + slotOffset + slotThickness / 2 - expectedWidth / 2;
+		const expectedCenterX = expectedX + expectedWidth / 2;
+		const primarySlotCenterX = bandStart + slotOffset + slotThickness / 2;
+
+		expect( Number( rect.getAttribute( 'width' ) ) ).toBeCloseTo( expectedWidth );
+		expect( Number( rect.getAttribute( 'x' ) ) ).toBeCloseTo( expectedX );
+		// Center of shadow matches center of primary slot
+		expect( expectedCenterX ).toBeCloseTo( primarySlotCenterX );
+	} );
+
 	it( 'renders nothing when primaryKeys is empty', () => {
 		render(
 			<svg>

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import { scaleBand, scaleLinear } from '@visx/scale';
+import { DataContext } from '@visx/xychart';
+import { ComparisonBars } from '../comparison-bars';
+import type { DataPointDate, SeriesData } from '../../../../types';
+import type { ComparisonSeriesEntry } from '../comparison-bars';
+
+// Build the band scale over two categories (matches how BarGroup sets it up)
+const categories = [ 'Jan', 'Feb' ];
+const xScale = scaleBand( {
+	domain: categories,
+	range: [ 0, 200 ],
+	padding: 0.1,
+} );
+
+// Simple linear value scale: domain 0..100 -> range 200..0 (SVG coords, descending)
+const yScale = scaleLinear( { domain: [ 0, 100 ], range: [ 200, 0 ] } );
+
+// The primaryKeys in this test
+const primaryKeys = [ 'current' ];
+const groupPadding = 0.1;
+
+// Build the same groupScale so tests can compute expected width
+const groupScale = scaleBand( {
+	domain: primaryKeys,
+	range: [ 0, xScale.bandwidth() ],
+	padding: groupPadding,
+} );
+
+// Minimal DataContext value
+const dataContextValue = {
+	xScale: xScale as never,
+	yScale: yScale as never,
+	horizontal: false,
+	// Other DataContext fields the component doesn't use
+	width: 200,
+	height: 200,
+	margin: { top: 0, right: 0, bottom: 0, left: 0 },
+	dataRegistry: {} as never,
+	registerData: () => undefined,
+	unregisterData: () => undefined,
+	setDimensions: () => undefined,
+	innerWidth: 200,
+	innerHeight: 200,
+	theme: {} as never,
+	colorScale: {} as never,
+};
+
+const seriesData: SeriesData = {
+	label: 'Comparison',
+	data: [
+		{ label: 'Jan', value: 40 } as DataPointDate,
+		{ label: 'Feb', value: 70 } as DataPointDate,
+	] as DataPointDate[],
+	options: { type: 'comparison' },
+};
+
+const comparisonEntries: ComparisonSeriesEntry[] = [
+	{ series: seriesData, index: 0, primaryKey: 'current' },
+];
+
+const getElementStyles = () => ( {
+	color: '#f00',
+	barStyles: { widthFactor: 1.5, opacity: 0.5 },
+	lineStyles: {} as never,
+	glyph: undefined as never,
+	shapeStyles: {} as never,
+} );
+
+const xAccessor = ( d: DataPointDate ) => d.label;
+const yAccessor = ( d: DataPointDate ) => d.value ?? undefined;
+
+describe( 'ComparisonBars', () => {
+	it( 'renders two shadow rects for two data points', () => {
+		render(
+			<svg>
+				<DataContext.Provider value={ dataContextValue }>
+					<ComparisonBars
+						comparisonEntries={ comparisonEntries }
+						primaryKeys={ primaryKeys }
+						groupPadding={ groupPadding }
+						horizontal={ false }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						getElementStyles={ getElementStyles }
+					/>
+				</DataContext.Provider>
+			</svg>
+		);
+
+		const rects = screen.getAllByTestId( /^bar-chart-comparison-0-/ );
+		expect( rects ).toHaveLength( 2 );
+		expect( rects[ 0 ] ).toHaveAttribute( 'fill', '#f00' );
+		expect( rects[ 0 ] ).toHaveAttribute( 'opacity', '0.5' );
+		// width == 1.5 * groupScale.bandwidth()
+		expect( Number( rects[ 0 ].getAttribute( 'width' ) ) ).toBeCloseTo(
+			1.5 * groupScale.bandwidth()
+		);
+	} );
+
+	it( 'wraps rects in a g with correct class and pointerEvents', () => {
+		render(
+			<svg>
+				<DataContext.Provider value={ dataContextValue }>
+					<ComparisonBars
+						comparisonEntries={ comparisonEntries }
+						primaryKeys={ primaryKeys }
+						groupPadding={ groupPadding }
+						horizontal={ false }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						getElementStyles={ getElementStyles }
+					/>
+				</DataContext.Provider>
+			</svg>
+		);
+
+		const g = screen.getByTestId( 'bar-chart-comparison-bars' );
+		expect( g ).toHaveClass( 'bar-chart__comparison-bars', { exact: true } );
+		expect( g ).toHaveAttribute( 'pointer-events', 'none' );
+	} );
+
+	it( 'renders nothing when primaryKeys is empty', () => {
+		render(
+			<svg>
+				<DataContext.Provider value={ dataContextValue }>
+					<ComparisonBars
+						comparisonEntries={ comparisonEntries }
+						primaryKeys={ [] }
+						groupPadding={ groupPadding }
+						horizontal={ false }
+						xAccessor={ xAccessor }
+						yAccessor={ yAccessor }
+						getElementStyles={ getElementStyles }
+					/>
+				</DataContext.Provider>
+			</svg>
+		);
+
+		expect( screen.queryByTestId( 'bar-chart-comparison-bars' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
@@ -61,7 +61,7 @@ const comparisonEntries: ComparisonSeriesEntry[] = [
 
 const getElementStyles = () => ( {
 	color: '#f00',
-	barStyles: { widthFactor: 1.5, opacity: 0.5 },
+	barStyles: { widthFactor: 1.0, opacity: 0.5 },
 	lineStyles: {} as never,
 	glyph: undefined as never,
 	shapeStyles: {} as never,
@@ -92,9 +92,9 @@ describe( 'ComparisonBars', () => {
 		expect( rects ).toHaveLength( 2 );
 		expect( rects[ 0 ] ).toHaveAttribute( 'fill', '#f00' );
 		expect( rects[ 0 ] ).toHaveAttribute( 'opacity', '0.5' );
-		// width == 1.5 * groupScale.bandwidth()
+		// width == 1.0 * groupScale.bandwidth() (shadow = standard slot width)
 		expect( Number( rects[ 0 ].getAttribute( 'width' ) ) ).toBeCloseTo(
-			1.5 * groupScale.bandwidth()
+			1.0 * groupScale.bandwidth()
 		);
 	} );
 
@@ -120,7 +120,7 @@ describe( 'ComparisonBars', () => {
 		expect( g ).toHaveAttribute( 'pointer-events', 'none' );
 	} );
 
-	it( 'shadow rect is horizontally centered on the primary bar slot and 150% of its width', () => {
+	it( 'shadow rect is horizontally centered on the primary bar slot and equals its standard slot width', () => {
 		render(
 			<svg>
 				<DataContext.Provider value={ dataContextValue }>
@@ -141,7 +141,7 @@ describe( 'ComparisonBars', () => {
 		const rect = rects[ 0 ]; // 'Jan' datum
 
 		const slotThickness = groupScale.bandwidth();
-		const expectedWidth = 1.5 * slotThickness;
+		const expectedWidth = 1.0 * slotThickness; // shadow = standard slot width
 		// Shadow x = bandStart + slotOffset + slotThickness/2 - shadowWidth/2
 		const bandStart = Number( xScale( 'Jan' ) );
 		const slotOffset = Number( groupScale( 'current' ) );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/test/comparison-bars.test.tsx
@@ -61,7 +61,7 @@ const comparisonEntries: ComparisonSeriesEntry[] = [
 
 const getElementStyles = () => ( {
 	color: '#f00',
-	barStyles: { widthFactor: 1.0, opacity: 0.5 },
+	barStyles: { widthFactor: 1.5, opacity: 0.5 },
 	lineStyles: {} as never,
 	glyph: undefined as never,
 	shapeStyles: {} as never,
@@ -95,9 +95,9 @@ describe( 'ComparisonBars', () => {
 		expect( rects ).toHaveLength( 2 );
 		expect( rects[ 0 ] ).toHaveAttribute( 'fill', '#f00' );
 		expect( rects[ 0 ] ).toHaveAttribute( 'opacity', '0.5' );
-		// width == 1.0 * groupScale.bandwidth() (shadow = standard slot width)
+		// width == widthFactor (1.5) * groupScale.bandwidth()
 		expect( Number( rects[ 0 ].getAttribute( 'width' ) ) ).toBeCloseTo(
-			1.0 * groupScale.bandwidth()
+			1.5 * groupScale.bandwidth()
 		);
 	} );
 
@@ -124,7 +124,7 @@ describe( 'ComparisonBars', () => {
 		expect( g ).toHaveAttribute( 'pointer-events', 'none' );
 	} );
 
-	it( 'shadow rect is horizontally centered on the primary bar slot and equals its standard slot width', () => {
+	it( 'shadow rect is horizontally centered on the primary bar slot at widthFactor × slot width', () => {
 		render(
 			<svg>
 				<DataContext.Provider value={ dataContextValue }>
@@ -146,7 +146,7 @@ describe( 'ComparisonBars', () => {
 		const rect = rects[ 0 ]; // 'Jan' datum
 
 		const slotThickness = groupScale.bandwidth();
-		const expectedWidth = 1.0 * slotThickness; // shadow = standard slot width
+		const expectedWidth = 1.5 * slotThickness; // shadow = widthFactor × slot width
 		// Shadow x = bandStart + slotOffset + slotThickness/2 - shadowWidth/2
 		const bandStart = Number( xScale( 'Jan' ) );
 		const slotOffset = Number( groupScale( 'current' ) );

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -97,8 +97,44 @@ export function useBarChartOptions(
 			yScale: baseYScale,
 		} = defaultOptions[ orientationKey ];
 
-		const xScale = { ...baseXScale, ...( options.xScale || {} ) };
-		const yScale = { ...baseYScale, ...( options.yScale || {} ) };
+		// When comparison series are present, visx only sees primary BarSeries and computes
+		// a too-narrow domain. Compute an explicit domain spanning all series so comparison
+		// shadows aren't clipped. Skip when the user has already provided an explicit domain.
+		let valueScaleDomainOverride: { domain?: [ number, number ] } = {};
+		const hasComparisonSeries = data.some( s => s.options?.type === 'comparison' );
+		if ( hasComparisonSeries ) {
+			const valueAxisIsY = ! horizontal;
+			const userDomain = valueAxisIsY ? options.yScale?.domain : options.xScale?.domain;
+			if ( ! userDomain ) {
+				const allValues: number[] = [];
+				data.forEach( series => {
+					series.data.forEach( d => {
+						const enhanced = d as { visualValue?: number };
+						const v =
+							enhanced.visualValue !== undefined ? enhanced.visualValue : ( d.value as number );
+						if ( typeof v === 'number' && Number.isFinite( v ) ) {
+							allValues.push( v );
+						}
+					} );
+				} );
+				if ( allValues.length > 0 ) {
+					valueScaleDomainOverride = {
+						domain: [ Math.min( ...allValues ), Math.max( ...allValues ) ],
+					};
+				}
+			}
+		}
+
+		const xScale = {
+			...baseXScale,
+			...( options.xScale || {} ),
+			...( horizontal ? valueScaleDomainOverride : {} ),
+		};
+		const yScale = {
+			...baseYScale,
+			...( options.yScale || {} ),
+			...( ! horizontal ? valueScaleDomainOverride : {} ),
+		};
 		const providedToolTipLabelFormatter = horizontal
 			? options.axis?.y?.tickFormat
 			: options.axis?.x?.tickFormat;
@@ -137,5 +173,5 @@ export function useBarChartOptions(
 				labelFormatter: providedToolTipLabelFormatter || defaultTooltipLabelFormatter,
 			},
 		};
-	}, [ defaultOptions, options, horizontal ] );
+	}, [ defaultOptions, options, horizontal, data ] );
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -5,6 +5,11 @@ import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
 import type { DataPointDate, BaseChartProps, SeriesData } from '../../../types';
 import type { TickFormatter } from '@visx/axis';
 
+/** Outer padding of the category band scale (space at the chart edges). */
+export const BASE_BAND_PADDING = 0.2;
+/** Inner padding of the category band scale (the base gap between ticks). */
+export const BASE_BAND_PADDING_INNER = 0.1;
+
 const formatDateTick = ( timestamp: number ) => {
 	const date = new Date( timestamp );
 	return date.toLocaleDateString( undefined, {
@@ -39,8 +44,8 @@ export function useBarChartOptions(
 	const defaultOptions = useMemo( () => {
 		const bandScale = {
 			type: 'band' as const,
-			padding: 0.2,
-			paddingInner: 0.1,
+			padding: BASE_BAND_PADDING,
+			paddingInner: BASE_BAND_PADDING_INNER,
 		};
 		const linearScale = {
 			type: 'linear' as const,

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -52,10 +52,33 @@ Composition API component for displaying chart legends. Must be used as a child 
 type SeriesData = {
 	label: string;
 	data: DataPointDate[];
+	/** Groups a primary series with its comparison series (see Comparison Mode). */
+	group?: string;
 	options?: {
 		stroke?: string;
+		/** Render this series as a translucent "shadow" behind the primary bar in the same `group`. */
+		type?: 'comparison';
 	};
 };
+```
+
+## Comparison Styling (theme)
+
+Comparison shadow bars are styled via the chart theme at `barChart.barStyles.comparison`:
+
+| Key | Type | Default | Description |
+| --- | ---- | ------- | ----------- |
+| `widthFactor` | `number` | `1.5` | How much wider the comparison bar is than the primary. The comparison shadow is the standard slot width and the primary bar is narrowed to `1 / widthFactor` of the slot. |
+| `opacity` | `number` | `0.5` | Opacity of the comparison shadow bar. |
+
+```typescript
+<GlobalChartsProvider
+	theme={ {
+		barChart: { barStyles: { comparison: { widthFactor: 1.5, opacity: 0.5 } } },
+	} }
+>
+	<BarChart data={ data } />
+</GlobalChartsProvider>
 ```
 
 ## DataPointDate Type

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -160,6 +160,44 @@ The component handles large numbers of series gracefully with automatic color cy
 	/>` }
 />
 
+## Comparison Mode
+
+Add a comparison series — for example "this period vs. previous period" — by giving a series `options.type: 'comparison'`. It renders as a translucent "shadow" bar centered **behind** the primary series that shares its `group`. The shadow spans the standard slot width while the primary bar is narrowed (so the shadow peeks on each side and above), and gaps between bar groups are preserved.
+
+<Canvas of={ BarChartStories.Comparison } />
+
+<Source
+	language="jsx"
+	code={ `<BarChart
+		data={[
+			{
+				label: 'This period',
+				group: 'views',
+				data: thisPeriod,
+			},
+			{
+				label: 'Previous period',
+				group: 'views',
+				options: { type: 'comparison' },
+				data: previousPeriod,
+			},
+		]}
+		showLegend={true}
+	/>` }
+/>
+
+It composes with grouped bars: pair each primary series with its own `type: 'comparison'` series of the same `group`, and the groups render side by side, each with its own shadow.
+
+<Canvas of={ BarChartStories.ComparisonGroups } />
+
+**Notes:**
+
+- A comparison series pairs with the primary series that shares its `group` (when there is a single primary series, `group` can be omitted on both).
+- Comparison values are included in the value-axis domain, so a previous period taller than the current one is never clipped.
+- Comparison series must reuse the primary series' category keys (the `label`/`date` of each point) so each shadow lines up with its primary bar.
+- Shadows are decorative: they are excluded from tooltips and keyboard navigation.
+- Styling comes from the theme at `barChart.barStyles.comparison`. `widthFactor` (default `1.5`) controls how much wider the comparison bar is than the primary — the primary is narrowed to `1 / widthFactor` of the slot — and `opacity` (default `0.5`) sets the shadow translucency.
+
 ## Visual Features
 
 ### Pattern Fills

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -195,7 +195,7 @@ It composes with grouped bars: pair each primary series with its own `type: 'com
 - A comparison series pairs with the primary series that shares its `group` (when there is a single primary series, `group` can be omitted on both).
 - Comparison values are included in the value-axis domain, so a previous period taller than the current one is never clipped.
 - Comparison series must reuse the primary series' category keys (the `label`/`date` of each point) so each shadow lines up with its primary bar.
-- Shadows are decorative: they are excluded from tooltips and keyboard navigation.
+- The comparison shadow isn't a separate hover/keyboard target (the primary bar drives interaction), but the tooltip shows both the current and previous period values for the hovered category.
 - Styling comes from the theme at `barChart.barStyles.comparison`. `widthFactor` (default `1.5`) controls how much wider the comparison bar is than the primary — the primary is narrowed to `1 / widthFactor` of the slot — and `opacity` (default `0.5`) sets the shadow translucency.
 
 ## Visual Features

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -196,6 +196,7 @@ It composes with grouped bars: pair each primary series with its own `type: 'com
 - Comparison values are included in the value-axis domain, so a previous period taller than the current one is never clipped.
 - Comparison series must reuse the primary series' category keys (the `label`/`date` of each point) so each shadow lines up with its primary bar.
 - The comparison shadow isn't a separate hover/keyboard target (the primary bar drives interaction), but the tooltip shows both the current and previous period values for the hovered category.
+- With pattern fills enabled (`withPatterns`), the comparison shadow reuses its primary bar's pattern at the same reduced opacity, so the pair reads as one series.
 - Styling comes from the theme at `barChart.barStyles.comparison`. `widthFactor` (default `1.5`) controls how much wider the comparison bar is than the primary — the primary is narrowed to `1 / widthFactor` of the slot — and `opacity` (default `0.5`) sets the shadow translucency.
 
 ## Visual Features

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -162,7 +162,7 @@ The component handles large numbers of series gracefully with automatic color cy
 
 ## Comparison Mode
 
-Add a comparison series — for example "this period vs. previous period" — by giving a series `options.type: 'comparison'`. It renders as a translucent "shadow" bar centered **behind** the primary series that shares its `group`. The shadow spans the standard slot width while the primary bar is narrowed (so the shadow peeks on each side and above), and gaps between bar groups are preserved.
+Add a comparison series — for example "this period vs. previous period" — by giving a series `options.type: 'comparison'`. It renders as a translucent "shadow" bar centered **behind** the primary series that shares its `group`. The shadow is wider than the primary bar (the primary is narrowed) so it peeks on each side and above, while a small gap is kept between series and a larger gap between ticks.
 
 <Canvas of={ BarChartStories.Comparison } />
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -408,46 +408,41 @@ const longLabelData = [
 // Comparison mode: one primary series + one shadow series sharing the same group.
 // The shadow renders as a translucent bar (150% width, 50% opacity) centered behind
 // the primary bar, making it easy to compare the current period against a previous one.
-export const Comparison: StoryObj< typeof BarChart > = {
-	render: () => (
-		<div style={ { width: '600px', height: '400px' } }>
-			<BarChart
-				data={ [
-					{
-						label: 'This period',
-						group: 'views',
-						data: [
-							{ label: 'Mon', value: 420 },
-							{ label: 'Tue', value: 580 },
-							{ label: 'Wed', value: 310 },
-							{ label: 'Thu', value: 750 },
-							{ label: 'Fri', value: 640 },
-						],
-					},
-					{
-						label: 'Previous period',
-						group: 'views',
-						options: { type: 'comparison' as const },
-						data: [
-							{ label: 'Mon', value: 510 },
-							{ label: 'Tue', value: 490 },
-							{ label: 'Wed', value: 430 },
-							{ label: 'Thu', value: 620 },
-							{ label: 'Fri', value: 700 },
-						],
-					},
-				] }
-				withTooltips={ true }
-				gridVisibility="x"
-				showLegend={ true }
-			/>
-		</div>
-	),
+export const Comparison: Story = {
+	args: {
+		...Default.args,
+		showLegend: true,
+		data: [
+			{
+				label: 'This period',
+				group: 'views',
+				data: [
+					{ label: 'Mon', value: 420 },
+					{ label: 'Tue', value: 580 },
+					{ label: 'Wed', value: 310 },
+					{ label: 'Thu', value: 750 },
+					{ label: 'Fri', value: 640 },
+				],
+			},
+			{
+				label: 'Previous period',
+				group: 'views',
+				options: { type: 'comparison' as const },
+				data: [
+					{ label: 'Mon', value: 510 },
+					{ label: 'Tue', value: 490 },
+					{ label: 'Wed', value: 430 },
+					{ label: 'Thu', value: 620 },
+					{ label: 'Fri', value: 700 },
+				],
+			},
+		],
+	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'One primary series paired with a `type: "comparison"` series sharing the same `group`. The comparison series renders as a translucent shadow bar (150% width, 50% opacity) centered behind the primary bar, letting you compare the current period against a previous one at a glance.',
+					'One primary series paired with a `type: "comparison"` series sharing the same `group`. The comparison series renders as a translucent (50% opacity) shadow bar at the standard slot width, behind a primary bar narrowed to 60% — so it reads as a shadow peeking around the current period.',
 			},
 		},
 	},
@@ -456,69 +451,64 @@ export const Comparison: StoryObj< typeof BarChart > = {
 // Comparison mode with multiple groups side by side.
 // Each group has its own primary series and its own shadow series,
 // demonstrating that comparison mode works correctly across grouped bar layouts.
-export const ComparisonGroups: StoryObj< typeof BarChart > = {
-	render: () => (
-		<div style={ { width: '600px', height: '400px' } }>
-			<BarChart
-				data={ [
-					{
-						label: 'Views — this period',
-						group: 'views',
-						data: [
-							{ label: 'Mon', value: 420 },
-							{ label: 'Tue', value: 580 },
-							{ label: 'Wed', value: 310 },
-							{ label: 'Thu', value: 750 },
-							{ label: 'Fri', value: 640 },
-						],
-					},
-					{
-						label: 'Views — previous period',
-						group: 'views',
-						options: { type: 'comparison' as const },
-						data: [
-							{ label: 'Mon', value: 510 },
-							{ label: 'Tue', value: 490 },
-							{ label: 'Wed', value: 430 },
-							{ label: 'Thu', value: 620 },
-							{ label: 'Fri', value: 700 },
-						],
-					},
-					{
-						label: 'Visitors — this period',
-						group: 'visitors',
-						data: [
-							{ label: 'Mon', value: 280 },
-							{ label: 'Tue', value: 390 },
-							{ label: 'Wed', value: 220 },
-							{ label: 'Thu', value: 500 },
-							{ label: 'Fri', value: 430 },
-						],
-					},
-					{
-						label: 'Visitors — previous period',
-						group: 'visitors',
-						options: { type: 'comparison' as const },
-						data: [
-							{ label: 'Mon', value: 340 },
-							{ label: 'Tue', value: 320 },
-							{ label: 'Wed', value: 290 },
-							{ label: 'Thu', value: 410 },
-							{ label: 'Fri', value: 460 },
-						],
-					},
-				] }
-				withTooltips={ true }
-				gridVisibility="x"
-				showLegend={ true }
-			/>
-		</div>
-	),
+export const ComparisonGroups: Story = {
+	args: {
+		...Default.args,
+		showLegend: true,
+		data: [
+			{
+				label: 'Views — this period',
+				group: 'views',
+				data: [
+					{ label: 'Mon', value: 420 },
+					{ label: 'Tue', value: 580 },
+					{ label: 'Wed', value: 310 },
+					{ label: 'Thu', value: 750 },
+					{ label: 'Fri', value: 640 },
+				],
+			},
+			{
+				label: 'Views — previous period',
+				group: 'views',
+				options: { type: 'comparison' as const },
+				data: [
+					{ label: 'Mon', value: 510 },
+					{ label: 'Tue', value: 490 },
+					{ label: 'Wed', value: 430 },
+					{ label: 'Thu', value: 620 },
+					{ label: 'Fri', value: 700 },
+				],
+			},
+			{
+				label: 'Visitors — this period',
+				group: 'visitors',
+				data: [
+					{ label: 'Mon', value: 280 },
+					{ label: 'Tue', value: 390 },
+					{ label: 'Wed', value: 220 },
+					{ label: 'Thu', value: 500 },
+					{ label: 'Fri', value: 430 },
+				],
+			},
+			{
+				label: 'Visitors — previous period',
+				group: 'visitors',
+				options: { type: 'comparison' as const },
+				data: [
+					{ label: 'Mon', value: 340 },
+					{ label: 'Tue', value: 320 },
+					{ label: 'Wed', value: 290 },
+					{ label: 'Thu', value: 410 },
+					{ label: 'Fri', value: 460 },
+				],
+			},
+		],
+	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Two groups (`views` and `visitors`) rendered side by side, each paired with its own `type: "comparison"` series. Each group\'s shadow bar sits centered behind its primary bar, confirming that comparison mode composes correctly with grouped bar layouts.',
+					'Two groups (`views` and `visitors`) rendered side by side, each paired with its own `type: "comparison"` series. Each group\'s standard-width shadow bar sits behind its 60%-width primary bar, with clear gaps preserved between groups — confirming comparison mode composes correctly with grouped bar layouts.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -405,6 +405,125 @@ const longLabelData = [
 	},
 ];
 
+// Comparison mode: one primary series + one shadow series sharing the same group.
+// The shadow renders as a translucent bar (150% width, 50% opacity) centered behind
+// the primary bar, making it easy to compare the current period against a previous one.
+export const Comparison: StoryObj< typeof BarChart > = {
+	render: () => (
+		<div style={ { width: '600px', height: '400px' } }>
+			<BarChart
+				data={ [
+					{
+						label: 'This period',
+						group: 'views',
+						data: [
+							{ label: 'Mon', value: 420 },
+							{ label: 'Tue', value: 580 },
+							{ label: 'Wed', value: 310 },
+							{ label: 'Thu', value: 750 },
+							{ label: 'Fri', value: 640 },
+						],
+					},
+					{
+						label: 'Previous period',
+						group: 'views',
+						options: { type: 'comparison' as const },
+						data: [
+							{ label: 'Mon', value: 510 },
+							{ label: 'Tue', value: 490 },
+							{ label: 'Wed', value: 430 },
+							{ label: 'Thu', value: 620 },
+							{ label: 'Fri', value: 700 },
+						],
+					},
+				] }
+				withTooltips={ true }
+				gridVisibility="x"
+				showLegend={ true }
+			/>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'One primary series paired with a `type: "comparison"` series sharing the same `group`. The comparison series renders as a translucent shadow bar (150% width, 50% opacity) centered behind the primary bar, letting you compare the current period against a previous one at a glance.',
+			},
+		},
+	},
+};
+
+// Comparison mode with multiple groups side by side.
+// Each group has its own primary series and its own shadow series,
+// demonstrating that comparison mode works correctly across grouped bar layouts.
+export const ComparisonGroups: StoryObj< typeof BarChart > = {
+	render: () => (
+		<div style={ { width: '600px', height: '400px' } }>
+			<BarChart
+				data={ [
+					{
+						label: 'Views — this period',
+						group: 'views',
+						data: [
+							{ label: 'Mon', value: 420 },
+							{ label: 'Tue', value: 580 },
+							{ label: 'Wed', value: 310 },
+							{ label: 'Thu', value: 750 },
+							{ label: 'Fri', value: 640 },
+						],
+					},
+					{
+						label: 'Views — previous period',
+						group: 'views',
+						options: { type: 'comparison' as const },
+						data: [
+							{ label: 'Mon', value: 510 },
+							{ label: 'Tue', value: 490 },
+							{ label: 'Wed', value: 430 },
+							{ label: 'Thu', value: 620 },
+							{ label: 'Fri', value: 700 },
+						],
+					},
+					{
+						label: 'Visitors — this period',
+						group: 'visitors',
+						data: [
+							{ label: 'Mon', value: 280 },
+							{ label: 'Tue', value: 390 },
+							{ label: 'Wed', value: 220 },
+							{ label: 'Thu', value: 500 },
+							{ label: 'Fri', value: 430 },
+						],
+					},
+					{
+						label: 'Visitors — previous period',
+						group: 'visitors',
+						options: { type: 'comparison' as const },
+						data: [
+							{ label: 'Mon', value: 340 },
+							{ label: 'Tue', value: 320 },
+							{ label: 'Wed', value: 290 },
+							{ label: 'Thu', value: 410 },
+							{ label: 'Fri', value: 460 },
+						],
+					},
+				] }
+				withTooltips={ true }
+				gridVisibility="x"
+				showLegend={ true }
+			/>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Two groups (`views` and `visitors`) rendered side by side, each paired with its own `type: "comparison"` series. Each group\'s shadow bar sits centered behind its primary bar, confirming that comparison mode composes correctly with grouped bar layouts.',
+			},
+		},
+	},
+};
+
 export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 	render: () => (
 		<div style={ { display: 'grid', gap: '40px' } }>

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -754,6 +754,42 @@ describe( 'BarChart', () => {
 		} );
 	} );
 
+	describe( 'Comparison Series', () => {
+		it( 'renders a translucent shadow behind the primary bar for a comparison series', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [
+						{ label: 'Jan', value: 100 },
+						{ label: 'Feb', value: 120 },
+					],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [
+						{ label: 'Jan', value: 80 },
+						{ label: 'Feb', value: 140 },
+					],
+				},
+			];
+			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
+
+			// two comparison shadow rects (one per data point)
+			// Match individual rect testids like bar-chart-comparison-1-0 (not the group wrapper)
+			const shadows = screen.getAllByTestId( /^bar-chart-comparison-\d+-\d+$/ );
+			expect( shadows ).toHaveLength( 2 );
+			expect( shadows[ 0 ] ).toHaveAttribute( 'opacity', '0.5' );
+
+			// primary bars still render for the single primary series (visx .visx-bar)
+			// eslint-disable-next-line testing-library/no-node-access
+			const bars = document.querySelectorAll( '.visx-bar' );
+			expect( bars.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+	} );
+
 	describe( 'Interactive Legend', () => {
 		it( 'filters series when interactive legend is enabled and series is toggled', async () => {
 			const user = userEvent.setup();

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -816,6 +816,38 @@ describe( 'BarChart', () => {
 			expect( ( yScale.domain as number[] )[ 1 ] ).toBeGreaterThanOrEqual( 150 );
 		} );
 
+		it( 'adds bar-chart--comparison modifier class when a comparison series is present', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [ { label: 'Jan', value: 100 } ],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Jan', value: 80 } ],
+				},
+			];
+			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
+			const chart = screen.getByTestId( 'bar-chart' );
+			expect( chart.className ).toMatch( /bar-chart--comparison/ );
+		} );
+
+		it( 'does not add bar-chart--comparison modifier class when no comparison series is present', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [ { label: 'Jan', value: 100 } ],
+				},
+			];
+			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
+			const chart = screen.getByTestId( 'bar-chart' );
+			expect( chart.className ).not.toMatch( /bar-chart--comparison/ );
+		} );
+
 		it( 'counts only primary series for keyboard navigation when a comparison series is present', async () => {
 			const user = userEvent.setup();
 			// 2 primary + 1 comparison. totalPoints should be 2*2=4, not 3*2=6.

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -347,6 +347,45 @@ describe( 'BarChart', () => {
 			} );
 		} );
 
+		describe( 'Comparison tooltip', () => {
+			test( 'tooltip shows both the primary and comparison values', async () => {
+				const user = userEvent.setup();
+				renderWithTheme( {
+					withTooltips: true,
+					data: [
+						{
+							label: 'This period',
+							group: 'views',
+							data: [
+								{ date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' },
+								{ date: new Date( '2024-01-02' ), value: 20, label: 'Jan 2' },
+							],
+						},
+						{
+							label: 'Previous period',
+							group: 'views',
+							options: { type: 'comparison' as const },
+							data: [
+								{ date: new Date( '2024-01-01' ), value: 15, label: 'Jan 1' },
+								{ date: new Date( '2024-01-02' ), value: 25, label: 'Jan 2' },
+							],
+						},
+					],
+				} );
+
+				const chart = screen.getByRole( 'grid', { name: /bar chart/i } );
+				chart.focus();
+
+				await user.keyboard( '{ArrowRight}' );
+				const tooltip = screen.getByTestId( 'chart-tooltip-0' );
+				// Both the current and previous period values are shown.
+				expect( tooltip ).toHaveTextContent( 'This period' );
+				expect( tooltip ).toHaveTextContent( '10' );
+				expect( tooltip ).toHaveTextContent( 'Previous period' );
+				expect( tooltip ).toHaveTextContent( '15' );
+			} );
+		} );
+
 		describe( 'Tab Key Navigation', () => {
 			test( 'tab key exits navigation when reaching end of data points', async () => {
 				const user = userEvent.setup();

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -886,59 +886,6 @@ describe( 'BarChart', () => {
 			expect( ( yScale.domain as number[] )[ 1 ] ).toBeGreaterThanOrEqual( 150 );
 		} );
 
-		it( 'adds bar-chart--comparison modifier class when a comparison series is present', () => {
-			const data = [
-				{
-					label: 'This year',
-					group: 'views',
-					data: [ { label: 'Jan', value: 100 } ],
-				},
-				{
-					label: 'Last year',
-					group: 'views',
-					options: { type: 'comparison' as const },
-					data: [ { label: 'Jan', value: 80 } ],
-				},
-			];
-			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
-			const chart = screen.getByTestId( 'bar-chart' );
-			expect( chart.className ).toMatch( /bar-chart--comparison/ );
-		} );
-
-		it( 'exposes --comparison-primary-scale CSS custom property when comparison series is present', () => {
-			const data = [
-				{
-					label: 'This year',
-					group: 'views',
-					data: [ { label: 'Jan', value: 100 } ],
-				},
-				{
-					label: 'Last year',
-					group: 'views',
-					options: { type: 'comparison' as const },
-					data: [ { label: 'Jan', value: 80 } ],
-				},
-			];
-			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
-			const chart = screen.getByTestId( 'bar-chart' );
-			const scale = ( chart as HTMLElement ).style.getPropertyValue( '--comparison-primary-scale' );
-			// widthFactor defaults to 1.5 → primaryScale = 1/1.5 ≈ 0.6667
-			expect( Number( scale ) ).toBeCloseTo( 1 / 1.5, 5 );
-		} );
-
-		it( 'does not add bar-chart--comparison modifier class when no comparison series is present', () => {
-			const data = [
-				{
-					label: 'This year',
-					group: 'views',
-					data: [ { label: 'Jan', value: 100 } ],
-				},
-			];
-			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
-			const chart = screen.getByTestId( 'bar-chart' );
-			expect( chart.className ).not.toMatch( /bar-chart--comparison/ );
-		} );
-
 		it( 'counts only primary series for keyboard navigation when a comparison series is present', async () => {
 			const user = userEvent.setup();
 			// 2 primary + 1 comparison. totalPoints should be 2*2=4, not 3*2=6.

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import BarChart from '../bar-chart';
+import { useBarChartOptions } from '../private';
 
 // Mock useElementSize to return non-zero dimensions in jsdom so charts render
 const mockRefCallback = jest.fn();
@@ -787,6 +788,89 @@ describe( 'BarChart', () => {
 			// eslint-disable-next-line testing-library/no-node-access
 			const bars = document.querySelectorAll( '.visx-bar' );
 			expect( bars.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+
+		it( 'expands value-axis domain to include comparison values exceeding the primary max', () => {
+			// Comparison value 150 exceeds primary max 100.
+			// Without domain expansion the value-axis scale config has no explicit domain,
+			// so visx derives it from primary BarSeries only (max=100).
+			// With the fix, an explicit domain [min,150] is set on the value-axis scale config.
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [ { label: 'Jan', value: 100 } ],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Jan', value: 150 } ],
+				},
+			];
+
+			const { result } = renderHook( () => useBarChartOptions( data, false, {} ) );
+			const yScale = result.current.yScale as { domain?: number[] };
+			// domain must be set explicitly and its max must be >= 150
+			expect( yScale.domain ).toBeDefined();
+			expect( ( yScale.domain as number[] )[ 1 ] ).toBeGreaterThanOrEqual( 150 );
+		} );
+
+		it( 'counts only primary series for keyboard navigation when a comparison series is present', async () => {
+			const user = userEvent.setup();
+			// 2 primary + 1 comparison. totalPoints should be 2*2=4, not 3*2=6.
+			// If comparison is counted, the 5th ArrowRight would reference a phantom series
+			// and could throw or show an undefined tooltip key.
+			const data = [
+				{
+					label: 'Series A',
+					group: 'g',
+					data: [
+						{ label: 'Jan', value: 10 },
+						{ label: 'Feb', value: 20 },
+					],
+				},
+				{
+					label: 'Series B',
+					group: 'g2',
+					data: [
+						{ label: 'Jan', value: 15 },
+						{ label: 'Feb', value: 25 },
+					],
+				},
+				{
+					label: 'Last year',
+					group: 'g',
+					options: { type: 'comparison' as const },
+					data: [
+						{ label: 'Jan', value: 8 },
+						{ label: 'Feb', value: 18 },
+					],
+				},
+			];
+			render(
+				<GlobalChartsProvider>
+					<BarChart data={ data } width={ 400 } height={ 300 } withTooltips />
+				</GlobalChartsProvider>
+			);
+
+			const chart = screen.getByRole( 'grid', { name: /bar chart/i } );
+			chart.focus();
+
+			// Navigate through all 4 primary slots (2 series × 2 data points)
+			for ( let i = 0; i < 4; i++ ) {
+				await user.keyboard( '{ArrowRight}' );
+			}
+
+			// If totalPoints was 6 (counted comparison), tooltip 4 would still show.
+			// With correct totalPoints=4, navigation wraps and tooltip 0 is shown again,
+			// not phantom slot 4 (which would reference data[2], a comparison series).
+			// Either way, there must be no crash and navigation must stay in bounds.
+			const tooltips = screen.queryAllByTestId( /^chart-tooltip-/ );
+			expect( tooltips ).toHaveLength( 1 );
+			// The visible tooltip must belong to a primary series
+			const tooltipText = tooltips[ 0 ].textContent ?? '';
+			expect( [ 'Series A', 'Series B' ].some( k => tooltipText.includes( k ) ) ).toBe( true );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -835,6 +835,27 @@ describe( 'BarChart', () => {
 			expect( chart.className ).toMatch( /bar-chart--comparison/ );
 		} );
 
+		it( 'exposes --comparison-primary-scale CSS custom property when comparison series is present', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [ { label: 'Jan', value: 100 } ],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Jan', value: 80 } ],
+				},
+			];
+			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
+			const chart = screen.getByTestId( 'bar-chart' );
+			const scale = ( chart as HTMLElement ).style.getPropertyValue( '--comparison-primary-scale' );
+			// widthFactor defaults to 1.5 → primaryScale = 1/1.5 ≈ 0.6667
+			expect( Number( scale ) ).toBeCloseTo( 1 / 1.5, 5 );
+		} );
+
 		it( 'does not add bar-chart--comparison modifier class when no comparison series is present', () => {
 			const data = [
 				{

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -234,6 +234,37 @@ describe( 'BarChart', () => {
 			// Check that no pattern definitions container is present
 			expect( screen.queryByTestId( 'bar-chart-patterns' ) ).not.toBeInTheDocument();
 		} );
+
+		test( 'comparison shadow reuses the primary bar pattern when patterns are enabled', () => {
+			renderWithTheme( {
+				withPatterns: true,
+				data: [
+					{
+						label: 'This period',
+						group: 'views',
+						data: [
+							{ label: 'Mon', value: 10 },
+							{ label: 'Tue', value: 20 },
+						],
+					},
+					{
+						label: 'Previous period',
+						group: 'views',
+						options: { type: 'comparison' as const },
+						data: [
+							{ label: 'Mon', value: 15 },
+							{ label: 'Tue', value: 25 },
+						],
+					},
+				],
+			} );
+
+			const shadow = screen.getAllByTestId( /^bar-chart-comparison-\d+-\d+$/ )[ 0 ];
+			const shadowFill = shadow.getAttribute( 'fill' );
+			// Shadow is filled with a pattern, not a solid color, and it references the PRIMARY
+			// series' pattern (index 0) rather than the comparison series' own index.
+			expect( shadowFill ).toMatch( /^url\(#bar-pattern-.+-0\)$/ );
+		} );
 	} );
 
 	describe( 'Keyboard Navigation Accessibility', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import {
 	getItemShapeStyles,
+	getSeriesBarStyles,
 	getSeriesLineStyles,
 	mergeThemes,
 	resolveCssVariable,
@@ -206,6 +207,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 						( isPointPercentageData && data?.color ),
 				} ),
 				lineStyles: isSeriesData ? getSeriesLineStyles( data, index, providerTheme ) : {},
+				barStyles: isSeriesData ? getSeriesBarStyles( data, index, providerTheme ) : {},
 				glyph: providerTheme.glyphs?.[ index ],
 				shapeStyles: isSeriesData
 					? getItemShapeStyles( data, index, providerTheme, legendShape )

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -67,4 +67,4 @@ type ElementStyles = {
 };
 ```
 
-`barStyles` carries bar-specific styling resolved from the theme by semantic series type (e.g. `barChart.barStyles.comparison`) — `{ widthFactor?, opacity?, fill?, rx? }`. It is `{}` for series with no matching bar style and for non-`SeriesData` inputs.
+`barStyles` carries bar-specific styling resolved from the theme by semantic series type (e.g. `barChart.barStyles.comparison`) — `{ widthFactor?, opacity? }`. It is `{}` for series with no matching bar style and for non-`SeriesData` inputs.

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -61,7 +61,10 @@ interface ChartRegistration {
 type ElementStyles = {
 	color: string;
 	lineStyles: LineStyles;
+	barStyles: BarStyles;
 	glyph: <Datum extends object>(props: GlyphProps<Datum>) => ReactNode;
 	shapeStyles: CSSProperties & LineStyles;
 };
 ```
+
+`barStyles` carries bar-specific styling resolved from the theme by semantic series type (e.g. `barChart.barStyles.comparison`) — `{ widthFactor?, opacity?, fill?, rx? }`. It is `{}` for series with no matching bar style and for non-`SeriesData` inputs.

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -4,6 +4,7 @@ import { GlobalChartsProvider } from '../global-charts-provider';
 import { useChartId } from '../hooks/use-chart-id';
 import { useChartRegistration } from '../hooks/use-chart-registration';
 import { useGlobalChartsContext } from '../hooks/use-global-charts-context';
+import { defaultTheme } from '../themes';
 import type { BaseLegendItem } from '../../../components/legend';
 import type { ChartTheme, SeriesData } from '../../../types';
 import type { GlobalChartsContextValue } from '../types';
@@ -2531,6 +2532,15 @@ describe( 'ChartContext', () => {
 				// Colors should remain stable
 				expect( afterRerenderColor ).toBe( initialColor );
 				expect( afterRerenderColor ).toBe( '#ff0000' );
+			} );
+		} );
+	} );
+
+	describe( 'defaultTheme', () => {
+		it( 'exposes default barChart comparison styles', () => {
+			expect( defaultTheme.barChart.barStyles.comparison ).toEqual( {
+				widthFactor: 1.5,
+				opacity: 0.5,
 			} );
 		} );
 	} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -1166,10 +1166,12 @@ describe( 'ChartContext', () => {
 				legendShape: 'rect',
 			} );
 
-			// Should get theme legend shape styles, not line styles
+			// Should get theme legend shape styles (not line styles), with the comparison bar
+			// opacity layered on so the swatch matches the translucent comparison bar.
 			expect( styles.shapeStyles ).toEqual( {
 				fill: '#LEGEND1',
 				stroke: '#BORDER1',
+				opacity: 0.5,
 			} );
 		} );
 	} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -2539,7 +2539,7 @@ describe( 'ChartContext', () => {
 	describe( 'defaultTheme', () => {
 		it( 'exposes default barChart comparison styles', () => {
 			expect( defaultTheme.barChart.barStyles.comparison ).toEqual( {
-				widthFactor: 1.5,
+				widthFactor: 1.0,
 				opacity: 0.5,
 			} );
 		} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -2539,7 +2539,7 @@ describe( 'ChartContext', () => {
 	describe( 'defaultTheme', () => {
 		it( 'exposes default barChart comparison styles', () => {
 			expect( defaultTheme.barChart.barStyles.comparison ).toEqual( {
-				widthFactor: 1.0,
+				widthFactor: 1.5,
 				opacity: 0.5,
 			} );
 		} );

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -72,7 +72,7 @@ const defaultTheme: CompleteChartTheme = {
 	barChart: {
 		barStyles: {
 			comparison: {
-				widthFactor: 1.5,
+				widthFactor: 1.0,
 				opacity: 0.5,
 			},
 		},

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -69,6 +69,14 @@ const defaultTheme: CompleteChartTheme = {
 			},
 		},
 	},
+	barChart: {
+		barStyles: {
+			comparison: {
+				widthFactor: 1.5,
+				opacity: 0.5,
+			},
+		},
+	},
 	sparkline: {
 		margin: { top: 2, right: 2, bottom: 2, left: 2 },
 		strokeWidth: 1.5,

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -72,7 +72,7 @@ const defaultTheme: CompleteChartTheme = {
 	barChart: {
 		barStyles: {
 			comparison: {
-				widthFactor: 1.0,
+				widthFactor: 1.5,
 				opacity: 0.5,
 			},
 		},

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode } from 'react';
 import type { BaseLegendItem } from '../../components/legend';
 import type {
+	BarStyles,
 	ChartType,
 	CompleteChartTheme,
 	DataPointPercentage,
@@ -25,6 +26,7 @@ export type GetElementStylesParams = {
 export type ElementStyles = {
 	color: string;
 	lineStyles: LineStyles;
+	barStyles: BarStyles;
 	glyph: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode;
 	shapeStyles: CSSProperties & LineStyles;
 };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -259,13 +259,12 @@ export type SeriesData = {
 
 /**
  * Visual styling for a bar series of a given semantic type (e.g. 'comparison').
- * `widthFactor` is the bar width relative to the primary bar slot (1.5 = 150%).
+ * `widthFactor` is the bar width relative to the primary bar slot (1.5 = 150%);
+ * `opacity` sets the shadow translucency.
  */
 export type BarStyles = {
 	widthFactor?: number;
 	opacity?: number;
-	fill?: string;
-	rx?: number;
 };
 
 export type MultipleDataPointsDate = {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -257,6 +257,17 @@ export type SeriesData = {
 	options?: SeriesDataOptions;
 };
 
+/**
+ * Visual styling for a bar series of a given semantic type (e.g. 'comparison').
+ * `widthFactor` is the bar width relative to the primary bar slot (1.5 = 150%).
+ */
+export type BarStyles = {
+	widthFactor?: number;
+	opacity?: number;
+	fill?: string;
+	rx?: number;
+};
+
 export type MultipleDataPointsDate = {
 	label: string;
 	data: DataPointDate[];
@@ -377,6 +388,9 @@ export type ChartTheme = {
 	lineChart?: {
 		lineStyles?: Partial< Record< NonNullable< SeriesDataOptions[ 'type' ] >, LineStyles > >;
 	};
+	barChart?: {
+		barStyles?: Partial< Record< NonNullable< SeriesDataOptions[ 'type' ] >, BarStyles > >;
+	};
 	/** Sparkline specific settings */
 	sparkline?: {
 		/** Margin around the sparkline chart */
@@ -408,6 +422,9 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 		Pick< NonNullable< ChartTheme[ 'conversionFunnelChart' ] >, 'primaryColor' >;
 	lineChart: {
 		lineStyles: Record< NonNullable< SeriesDataOptions[ 'type' ] >, LineStyles >;
+	};
+	barChart: {
+		barStyles: Record< NonNullable< SeriesDataOptions[ 'type' ] >, BarStyles >;
 	};
 	legend: Required< NonNullable< ChartTheme[ 'legend' ] > >;
 	sparkline: Required< NonNullable< ChartTheme[ 'sparkline' ] > > & {

--- a/projects/js-packages/charts/src/utils/get-styles.ts
+++ b/projects/js-packages/charts/src/utils/get-styles.ts
@@ -1,4 +1,4 @@
-import type { ChartTheme, LegendShape, SeriesData } from '../types';
+import type { BarStyles, ChartTheme, LegendShape, SeriesData } from '../types';
 import type { LineStyles } from '@visx/xychart';
 
 /**
@@ -26,6 +26,25 @@ export function getSeriesLineStyles(
 	return (
 		seriesData.options?.seriesLineStyle ?? themeSemanticLineStyle ?? themeSeriesLineStyle ?? {}
 	);
+}
+
+/**
+ * Utility to get consolidated bar styles for a series by semantic type.
+ * Mirrors getSeriesLineStyles: a series with `options.type` (e.g. 'comparison')
+ * resolves to `theme.barChart.barStyles[ type ]`.
+ *
+ * @param {SeriesData} seriesData    - The series data containing styling options
+ * @param {number}     index         - The index of the series in the data array
+ * @param {ChartTheme} providerTheme - The chart theme configuration
+ * @return {BarStyles} The consolidated bar styles for the series
+ */
+export function getSeriesBarStyles(
+	seriesData: SeriesData,
+	index: number,
+	providerTheme: ChartTheme
+): BarStyles {
+	const type = seriesData.options?.type;
+	return ( type && providerTheme?.barChart?.barStyles?.[ type ] ) ?? {};
 }
 
 /**

--- a/projects/js-packages/charts/src/utils/get-styles.ts
+++ b/projects/js-packages/charts/src/utils/get-styles.ts
@@ -80,11 +80,18 @@ export function getItemShapeStyles(
 ): Record< string, unknown > {
 	const seriesShapeStyles = series.options?.legendShapeStyle ?? {};
 	const lineStyles = legendShape === 'line' ? getSeriesLineStyles( series, index, theme ) : {};
+	// For non-line legends (e.g. bar 'rect'), reflect the comparison bar's opacity on the
+	// swatch so the legend marker matches the translucent comparison bar. Line-type legends
+	// convey comparison via the dashed stroke (lineStyles) instead.
+	const barOpacity =
+		legendShape !== 'line' ? getSeriesBarStyles( series, index, theme ).opacity : undefined;
+	const barShapeStyles = barOpacity !== undefined ? { opacity: barOpacity } : {};
 	const themeShapeStyles = theme.legend?.shapeStyles?.[ index ];
 
 	const itemShapeStyles = {
 		...seriesShapeStyles,
 		...lineStyles,
+		...barShapeStyles,
 	};
 
 	// Return item shape styles if they are not empty

--- a/projects/js-packages/charts/src/utils/get-styles.ts
+++ b/projects/js-packages/charts/src/utils/get-styles.ts
@@ -88,21 +88,18 @@ export function getItemShapeStyles(
 	const barShapeStyles = barOpacity !== undefined ? { opacity: barOpacity } : {};
 	const themeShapeStyles = theme.legend?.shapeStyles?.[ index ];
 
-	const itemShapeStyles = {
+	// Series-level styles (custom shape style + line styles) take precedence; otherwise fall
+	// back to the per-index theme shape styles.
+	const explicitStyles = {
 		...seriesShapeStyles,
 		...lineStyles,
-		...barShapeStyles,
 	};
+	const hasExplicitStyles = Object.values( explicitStyles ).some(
+		value => value !== undefined && value !== null && value !== ''
+	);
+	const baseShapeStyles = hasExplicitStyles ? explicitStyles : themeShapeStyles ?? {};
 
-	// Return item shape styles if they are not empty
-	if (
-		Object.values( itemShapeStyles ).some(
-			value => value !== undefined && value !== null && value !== ''
-		)
-	) {
-		return itemShapeStyles;
-	}
-
-	// Fallback to theme shape styles if defined
-	return themeShapeStyles ?? {};
+	// Layer the comparison bar opacity on top so the swatch matches the translucent bar
+	// without discarding the base (custom or theme) shape styles.
+	return { ...baseShapeStyles, ...barShapeStyles };
 }

--- a/projects/js-packages/charts/src/utils/index.ts
+++ b/projects/js-packages/charts/src/utils/index.ts
@@ -13,7 +13,12 @@ export { formatPercentage } from './format-percentage';
 export { getLongestTickWidth } from './get-longest-tick-width';
 
 // Style and theming utilities
-export { getSeriesLineStyles, getSeriesStroke, getItemShapeStyles } from './get-styles';
+export {
+	getSeriesBarStyles,
+	getSeriesLineStyles,
+	getSeriesStroke,
+	getItemShapeStyles,
+} from './get-styles';
 
 // Browser detection utilities
 export { isSafari } from './is-safari';

--- a/projects/js-packages/charts/src/utils/test/get-styles.test.ts
+++ b/projects/js-packages/charts/src/utils/test/get-styles.test.ts
@@ -166,6 +166,8 @@ describe( 'Series styling utility functions', () => {
 			const themeWithBar = {
 				...mockTheme,
 				barChart: { barStyles: { comparison: { widthFactor: 1.5, opacity: 0.5 } } },
+				// No per-index legend shape styles, so the swatch reflects only the comparison opacity.
+				legend: { shapeStyles: [] },
 			} as ChartTheme;
 			const comparisonSeries = {
 				...mockSeriesData,

--- a/projects/js-packages/charts/src/utils/test/get-styles.test.ts
+++ b/projects/js-packages/charts/src/utils/test/get-styles.test.ts
@@ -1,5 +1,10 @@
 import { ChartTheme } from '../../types';
-import { getSeriesLineStyles, getSeriesStroke, getItemShapeStyles } from '../get-styles';
+import {
+	getSeriesBarStyles,
+	getSeriesLineStyles,
+	getSeriesStroke,
+	getItemShapeStyles,
+} from '../get-styles';
 
 describe( 'Series styling utility functions', () => {
 	const mockSeriesData = {
@@ -328,6 +333,25 @@ describe( 'Series styling utility functions', () => {
 				strokeLinecap: 'square',
 				strokeWidth: 1.5,
 			} );
+		} );
+	} );
+
+	describe( 'getSeriesBarStyles', () => {
+		const themeWithBar = {
+			...mockTheme,
+			barChart: { barStyles: { comparison: { widthFactor: 1.5, opacity: 0.5 } } },
+		} as ChartTheme;
+
+		it( 'returns comparison bar styles when type is comparison', () => {
+			const comparisonSeries = { ...mockSeriesData, options: { type: 'comparison' as const } };
+			expect( getSeriesBarStyles( comparisonSeries, 0, themeWithBar ) ).toEqual( {
+				widthFactor: 1.5,
+				opacity: 0.5,
+			} );
+		} );
+
+		it( 'returns empty styles for a series with no type', () => {
+			expect( getSeriesBarStyles( mockSeriesData, 0, themeWithBar ) ).toEqual( {} );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/utils/test/get-styles.test.ts
+++ b/projects/js-packages/charts/src/utils/test/get-styles.test.ts
@@ -162,6 +162,26 @@ describe( 'Series styling utility functions', () => {
 			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 0 ] );
 		} );
 
+		it( 'applies the comparison bar opacity to the swatch for non-line legends', () => {
+			const themeWithBar = {
+				...mockTheme,
+				barChart: { barStyles: { comparison: { widthFactor: 1.5, opacity: 0.5 } } },
+			} as ChartTheme;
+			const comparisonSeries = {
+				...mockSeriesData,
+				options: { type: 'comparison' as const },
+			};
+
+			// rect (bar) legend: swatch picks up the comparison opacity to match the bar.
+			const rectResult = getItemShapeStyles( comparisonSeries, 0, themeWithBar, 'rect' );
+			expect( rectResult ).toEqual( { opacity: 0.5 } );
+
+			// line legend: comparison is conveyed via the dashed stroke, not opacity.
+			const lineResult = getItemShapeStyles( comparisonSeries, 0, themeWithBar, 'line' );
+			expect( lineResult.opacity ).toBeUndefined();
+			expect( lineResult ).toMatchObject( { strokeDasharray: '4 4' } );
+		} );
+
 		it( 'merges custom shape styles with line styles for line shape', () => {
 			const customShapeStyle = { fill: '#CUSTOM' };
 			const comparisonSeries = {


### PR DESCRIPTION
Fixes CHARTS-217

## Why

The Bar Chart had no way to show a comparison period, unlike the Line Chart (which already supports `type: 'comparison'`). Stats/analytics surfaces want to show "this period vs. previous period" on bar charts. This adds that capability, mirroring the Line Chart's API so consumers learn a single pattern across chart types.

## Proposed changes

* Add comparison mode to `BarChart`: a series with `options: { type: 'comparison' }` renders as a translucent (50% opacity) "shadow" bar centered **behind** the primary bar it pairs with. The shadow is wider than the primary, so it peeks on each side and above.
* `widthFactor` (theme `barChart.barStyles.comparison.widthFactor`, default **1.5**) is the single control for how much wider the comparison shadow is than the primary. The primary bar is narrowed to `1 / widthFactor` of the slot by **widening the visx group padding** — a real geometry change, so pattern fills and borders aren't distorted (an earlier CSS-`scale` approach stretched the pattern). The overlay draws the shadow at `slot × widthFactor`.
* Spacing: a small gap is kept between series within a tick, and the gap between ticks is tightened (comparison mode reduces the category band's inner padding by 25%); the larger gap between ticks still reads clearly.
* Comparison series pair with the primary series sharing their `group`. Works across multiple groups side by side (e.g. `views` + `visitors`), each group getting its own shadow.
* Comparison values are folded into the value-axis domain, so a previous period taller than the current one isn't clipped.
* **Tooltip** shows both periods: hovering a bar gives the category as the header with a row for the current and the previous period value. Non-comparison charts keep the existing single-value tooltip.
* **Patterns** (`withPatterns`): the comparison shadow reuses its primary bar's pattern and border, at the comparison opacity, so the pair reads as one series.
* **Legend**: the comparison series' swatch is rendered at the comparison opacity so it matches the translucent bar.
* New theme section `barChart.barStyles.comparison = { widthFactor: 1.5, opacity: 0.5 }`, resolved through the existing `getElementStyles` path (parallels `lineChart.lineStyles.comparison`).
* Implemented as a custom SVG overlay (`ComparisonBars`) that reads visx `DataContext` scales and rebuilds visx's grouped-bar inner band scale, so each shadow centers exactly on its primary's slot — the same overlay pattern `area-chart` and the line-chart annotations already use (visx `BarGroup`/`BarSeries` expose no public hook for overlapping bars). Comparison series are excluded from `BarGroup` and painted before it (behind).
* The comparison shadow isn't a separate hover/keyboard target (`pointer-events: none`; keyboard nav / highlight indexing counts only primary bars) — but its value is surfaced in the tooltip as above.
* Docs (`index.docs.mdx` Comparison Mode section + `index.api.mdx` `SeriesData.type`/`group` and a `barChart.barStyles.comparison` table) and Storybook stories (`Comparison`, `ComparisonGroups`, responsive) included.

### Scope notes
* Legend treatment otherwise unchanged — comparison series appear as labelled series (e.g. "Views — previous period"), matching the Line Chart.

### Screenshots

| Single series | Multi series |
|-|-|
| <img width="1588" height="786" alt="Screenshot 2026-06-18 at 4 54 19 PM" src="https://github.com/user-attachments/assets/2f0ff6d5-2790-42c8-a9f2-ebaac42115b9" /> | <img width="1590" height="788" alt="Screenshot 2026-06-18 at 4 54 30 PM" src="https://github.com/user-attachments/assets/f51ca4ec-e3e5-44fa-a825-ed672e4c53f2" /> |

## Related product discussion/links
* Linear: CHARTS-217

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

In `projects/js-packages/charts`, run Storybook (`pnpm run storybook`) and open **JS Packages → Charts Library → Charts → Bar Chart**:

* **Comparison** story: each narrowed primary bar has a wider translucent shadow centered behind it, peeking on the sides; hover a bar to see both the current and previous period values. Toggle the **withPatterns** control — the shadow takes the primary's pattern + border (undistorted).
* **Comparison Groups** story: two groups (`views`, `visitors`) side by side, each primary backed by its own shadow, with a small gap between series and a larger gap between ticks.
* Existing bar chart stories (Default, With Patterns, Horizontal, Animation, etc.) render unchanged — comparison mode is opt-in via `options.type`.

Automated (from `projects/js-packages/charts`):
* `pnpm test` → 899 tests pass (47 suites) — geometry, overlay, BarChart comparison/tooltip/pattern/keyboard, style resolution.
* `pnpm run typecheck` → clean.

Verified the rendered ratio in Storybook: primary bar ÷ comparison shadow = 0.667 (= 1/1.5), patterns/borders undistorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

