### PR TITLE
Premium Analytics: add AGENTS.md / CLAUDE.md for coding agents

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this package.
+
+## Overview
+
+Jetpack Premium Analytics is the unified analytics dashboard for Jetpack-connected sites — a
+full-page React SPA in wp-admin. It is the successor to two older surfaces being consolidated
+here: **Jetpack Stats** (`stats-admin` package, Odyssey dashboard — traffic, posts,
+subscribers, WordAds, notices) and **Woo Analytics** (`woocommerce-analytics` package — store
+reports: orders, products, customers, coupons, order attribution).
+
+- Composer package: `automattic/jetpack-premium-analytics`
+- PHP namespace: `Automattic\Jetpack\PremiumAnalytics`
+- Text domain / REST namespace: `jetpack-premium-analytics` / `jetpack-premium-analytics/v1`
+
+## How it works
+
+`Analytics::init()` loads the generated `build/build.php`, which registers an `admin_init`
+interceptor for `?page=jetpack-premium-analytics`. The interceptor takes over the request
+before WordPress renders the admin chrome; `@wordpress/boot` provides the SPA shell and
+routing; each route under `routes/<name>/` is a lazy-loaded ES module discovered at build time
+from its `package.json`. Requires the Gutenberg plugin (for `@wordpress/boot` / `@wordpress/route`)
+until WordPress 7.0+ ships them natively.
+
+## Structure
+
+```text
+src/class-analytics.php                 # entry: loads build, registers menu + routes
+src/REST/class-api-proxy-controller.php # the WPCOM data proxy (PREFIX_CONFIG)
+src/REST/class-notices-controller.php   # /notices route
+src/Sync/                               # interim woocommerce_analytics sync (WOOA7S-1550)
+packages/data/src/api/                  # frontend fetch helpers (apiFetch)
+routes/                                 # lazy-loaded SPA pages; build/ is generated
+```
+
+## Development
+
+```bash
+composer phpunit              # PHP tests
+pnpm run build / watch        # frontend build (one-off / on change)
+jetpack build packages/premium-analytics
+```
+
+Add a route: create `routes/<name>/package.json` (with `route.path` + `route.page`) and a
+`stage.tsx` exporting `stage()`; rebuild — routes are auto-discovered.
+
+Depends on `jetpack-connection`, `jetpack-stats`, `jetpack-sync`, `jetpack-config`.
+
+## API
+
+Two local REST surfaces; almost all data comes from WordPress.com via one agnostic proxy.
+
+### Data proxy
+
+`GET|POST /jetpack-premium-analytics/v1/proxy/v<version>/<prefix>/<sub-path>` forwards to
+`public-api.wordpress.com/.../sites/<blog-id>/<prefix>/<sub-path>` signed as the connected blog
+(no cross-origin or user-authed call).
+
+- `<version>` is the WPCOM version (`1.1`, `1.2`, `2`); base derives from it (`v2`→`wpcom/`,
+  `v1.x`→`rest/`). Use the version the old call used — the proxy does not normalise.
+- `<blog-id>` is injected server-side — never put it in the path.
+- `<prefix>` must be allowlisted in `PREFIX_CONFIG` or the route 404s. This is the security
+  boundary — the blog token is only forwarded for these.
+
+| Prefix | Capability | Writes (POST) |
+| --- | --- | --- |
+| `analytics` (Woo store reports) | `manage_options` | — |
+| `stats` | `view_stats` | `stats/referrers/spam/` |
+| `wordads` | `activate_wordads` | — |
+| `subscribers` / `site-has-never-published-post` / `jetpack-stats` | `view_stats` | — |
+| `jetpack-stats-dashboard` | `view_stats` | whole prefix (busts read cache) |
+| `commercial-classification` | `view_stats` | exact path |
+| `upgrades` (not under `/sites/`) | `view_stats` | — |
+
+`manage_options` is always accepted too. `POST` is rejected (`405 rest_read_only`) outside the
+Writes column. Query params pass through except control params (`endpoint`, `version`,
+`force_refresh`) and `site`. Successful `GET`s are cached 5 min (key: path+version+params); add
+`force_refresh` to bypass. `x-wp-total` / `x-wp-totalpages` are forwarded back. Errors:
+`403 no_connection`, `500`/`502 api_error`, `405 rest_read_only`, `401`/`403` on a failed cap.
+
+### Notices
+
+`GET|POST /jetpack-premium-analytics/v1/notices` (`{ id, status, postponed_for }`). Not proxied
+because GET merges WPCOM dismissal state with local flags. Anything needing local processing
+gets its own route outside `proxy/`, like this.
+
+### Adding a proxied endpoint
+
+To add a transparent forward, add a key to `PREFIX_CONFIG` (at least `capability`; add
+`writes` / `cache_bust` as needed) and cover it in `data_endpoint_matrix()`.
+
+### Migrating from Stats / Woo Analytics
+
+Re-point a screen's data layer at the proxy instead of re-implementing old routes: `stats-admin`
+routes (`jetpack/v4/stats-app/*`) → `stats` / `jetpack-stats` / `subscribers` / `wordads`
+prefixes; Woo `analytics/reports/*` → `proxy/v2/analytics/reports/*`. The dashboard UI lives in
+`routes/` here, not in Calypso. Frontend helpers go under `packages/data/src/api/`.
+
+## Pitfalls
+
+- Never put the blog ID in a proxy path — it's injected server-side.
+- A proxy 404 usually means the prefix isn't in `PREFIX_CONFIG`, not a missing WPCOM endpoint.
+- Reads are cached 5 min; add `force_refresh` if a screen looks stale.
+- `v2` vs `v1.x` changes the WPCOM base — a wrong version silently hits a different endpoint.
+- Sync code under `src/Sync/` is interim (WOOA7S-1550); don't build on it.
+- Don't edit dashboard React in Calypso — it lives here now.

--- a/projects/packages/premium-analytics/CLAUDE.md
+++ b/projects/packages/premium-analytics/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/projects/packages/premium-analytics/changelog/add-premium-analytics-agents-md
+++ b/projects/packages/premium-analytics/changelog/add-premium-analytics-agents-md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add AGENTS.md / CLAUDE.md documenting the package architecture and REST API for coding agents (dev-only, excluded from production builds).
+


### PR DESCRIPTION
Fixes #

## Proposed changes

Coding agents (and humans) picking up Premium Analytics work — especially anyone migrating a screen off **Jetpack Stats** or **Woo Analytics** — currently have no single place that explains how the package is wired or how its REST API works. This adds that reference so they can re-point a screen's data layer at the new endpoints instead of re-implementing the old per-endpoint routes.

* Add `AGENTS.md` to `projects/packages/premium-analytics` — a concise package guide: overview, how the SPA boots, project structure, development, the REST API, and pitfalls. The **API** section documents the one agnostic WPCOM data proxy (`jetpack-premium-analytics/v1/proxy/v<version>/<prefix>/<sub-path>`), the prefix/capability allowlist, caching/error behaviour, the local `/notices` route, how to add a proxied endpoint, and how to migrate from `stats-admin` / Woo Analytics calls.
* Add `CLAUDE.md` that simply imports it (`@AGENTS.md`), matching the repo-wide convention.
* Both files are dev-only and already excluded from production/mirror builds via the monorepo root `.gitattributes`, so nothing ships in the released package.

## Related product discussion/links

* Project: Premium Analytics (Linear team WOOA7S)

## Does this pull request change what data or activity we track or use?

No. Documentation only — no code, no runtime behaviour, no data collection changes.

## Testing instructions

* Read `projects/packages/premium-analytics/AGENTS.md` and confirm the API description matches `src/REST/class-api-proxy-controller.php` (`PREFIX_CONFIG`) and `src/REST/class-notices-controller.php`.
* Confirm `CLAUDE.md` contains `@AGENTS.md`.
* No build/test impact — the files are `production-exclude`.
