### PR TITLE
Markdown block: add "Learn more" support link to description

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-markdown-block-description-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-markdown-block-description-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a "Learn more" support link to the Markdown block description

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -273,6 +273,10 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/opentable-block/',
 		postId: 162208,
 	},
+	'jetpack/markdown': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/markdown-block/',
+		postId: 149871,
+	},
 	'jetpack/map': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/map-block/',
 		postId: 149684,


### PR DESCRIPTION
Fixes DOTCOM-16177

## Proposed changes
* Add the Markdown block (`jetpack/markdown`) to the block description links map, so its block inspector description shows a "Learn more" link to the support article.
* Like other blocks, the link opens the article in the Help Center and loads the localized version where available.

## Related product discussion/links
* DOTCOM-16177

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Build/run `jetpack-mu-wpcom` on a WordPress.com (Simple or Atomic) site where the block description links feature is active.
* In the block editor, insert a **Markdown** block and select it.
* Open the block settings sidebar (block inspector) and look at the block description card.
* Confirm a **Learn more** link appears below the description.
* Click it and confirm it opens the [Markdown block support article](https://wordpress.com/support/wordpress-editor/blocks/markdown-block/) in the Help Center.
* With the site/user set to a non-English locale that has a translated article, confirm the localized version loads.
