### PR TITLE
chore(premium-analytics): clean up leftover WooCommerce/standalone naming from the ports

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1556-cleanup-leftover-naming
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1556-cleanup-leftover-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Clean up leftover WooCommerce/standalone naming in comments, docs, and the search route key.

--- a/projects/packages/premium-analytics/packages/fields/src/helpers/store-info.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/helpers/store-info.ts
@@ -6,8 +6,7 @@ type StoreInfo = {
 };
 
 /**
- * Local stand-in for `getStoreInfo` from `@woocommerce-next/data` (next-admin),
- * which is not published to npm. Only `launchedDate` is consumed here, where
+ * Local stand-in for `getStoreInfo`. Only `launchedDate` is consumed here, where
  * it feeds `getDefaultPreset( launchedDate )` — that helper falls back to its
  * default preset when `launchedDate` is undefined.
  *

--- a/projects/packages/premium-analytics/packages/routing/README.md
+++ b/projects/packages/premium-analytics/packages/routing/README.md
@@ -1,7 +1,7 @@
 # @automattic/jetpack-premium-analytics-routing
 
 Utilities for handling **routing and URL search parameters** in
-WooCommerce Analytics with TypeScript integration.
+Jetpack Premium Analytics with TypeScript integration.
 
 This package centralizes logic for encoding and decoding route params so
 that date ranges, filters, comparison parameters, and other query
@@ -36,7 +36,7 @@ function DateRangeSelector() {
 	const handleRangeChange = nextRange => {
 		writeDateRangeToSearch( {
 			navigate,
-			to: '/wc-analytics/dashboard',
+			to: '/',
 			range: nextRange,
 			search: { interval: 'day' }, // Preserve other params
 		} );
@@ -55,7 +55,7 @@ function ComparisonSelector() {
 	const handleComparisonChange = ( range, presetId ) => {
 		writeComparisonToSearch( {
 			navigate,
-			to: '/wc-analytics/dashboard',
+			to: '/',
 			range,
 			presetId,
 			enabled: !! range,
@@ -73,7 +73,7 @@ Writes a `DateRange` to the URL using the provided `navigate` function.
 **Parameters:**
 
 - **`navigate`** – Navigation function from `useNavigate()` (`@wordpress/route`)
-- **`to`** – Destination path (e.g., `'/wc-analytics/dashboard'`)
+- **`to`** – Destination path (e.g., `'/'`)
 - **`range`** – `{ from: Date | undefined; to?: Date | undefined }`
 - **`timezone?`** _(optional)_ – Override timezone for date conversion
 - **`search?`** _(optional)_ – Additional search params to preserve/set
@@ -120,7 +120,7 @@ Low-level function to convert a Date to an ISO string with timezone.
 ### URL Parameter Structure
 
 ```
-/wc-analytics/dashboard?
+/?
   from=2025-01-01T00:00:00-08:00&        # Primary date range
   to=2025-01-31T23:59:59-08:00&
   interval=day&                          # Data granularity

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/README.md
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/README.md
@@ -64,8 +64,8 @@ type Search = {
 };
 
 export function DashboardHeader() {
-	const { effective, stage, commit } = useStagedSearch< Search, '/wc-analytics/dashboard' >( {
-		from: '/wc-analytics/dashboard',
+	const { effective, stage, commit } = useStagedSearch< Search, '/' >( {
+		from: '/',
 		// autoCommitDebounceMs: 250,
 	} );
 
@@ -116,7 +116,7 @@ export function DashboardHeader() {
 
 ```ts
 const { effective, isSyncing } = useStagedSearch< Search >( {
-	from: '/wc-analytics/dashboard',
+	from: '/',
 } );
 
 const query = useQuery( {

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 type AnyObject = Record< string, unknown >;
 
 export type UseStagedSearchOptions< TFrom extends string > = {
-	from: TFrom; // e.g., '/wc-analytics/dashboard',
+	from: TFrom; // e.g., '/',
 
 	/**
 	 * If provided, stage() will schedule an automatic debounced commit

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/README.md
@@ -56,7 +56,7 @@ export function MyWidget() {
 | -------------- | -------------------------------------- | --------------------------------------------------------------- |
 | `attributes`   | `Partial<ReportParamsFieldAttributes>` | Widget attributes, may include `reportParams`                   |
 | `children`     | `ReactNode`                            | Child components (widgets)                                      |
-| `options.from` | `string`                               | Router path for URL params (default: `/wc-analytics/dashboard`) |
+| `options.from` | `string`                               | Router path for URL params (default: `/`)                       |
 
 ### useWidgetRootContext
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
@@ -43,13 +43,13 @@ type WidgetRootProps = {
 	options?: {
 		/**
 		 * The source of the search params.
-		 * @default '/wc-analytics/dashboard'
+		 * @default '/'
 		 */
 		from?: string;
 	};
 };
 
-const DEFAULT_SEARCH_FROM = '/wc-analytics/dashboard';
+const DEFAULT_SEARCH_FROM = '/';
 
 /**
  * Hook that resolves widget attributes:

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/README.md
@@ -7,10 +7,10 @@ Form control for editing a widget's date-range parameters
 
 This field depends on two external data providers:
 
-| Provider             | Package                                                            | Purpose                                               |
-| -------------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
-| `getStoreInfo()`     | `helpers/store-info` (local stand-in for `@woocommerce-next/data`) | Reads `launchedDate` from the store profile           |
-| `getDefaultPreset()` | `@jetpack-premium-analytics/data`                                  | Resolves a smart date-range preset based on store age |
+| Provider             | Package                               | Purpose                                               |
+| -------------------- | ------------------------------------- | ----------------------------------------------------- |
+| `getStoreInfo()`     | `helpers/store-info` (local stand-in) | Reads `launchedDate` from the store profile           |
+| `getDefaultPreset()` | `@jetpack-premium-analytics/data`     | Resolves a smart date-range preset based on store age |
 
 ### Why the coupling exists
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/store-info.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/store-info.ts
@@ -6,8 +6,7 @@ type StoreInfo = {
 };
 
 /**
- * Local stand-in for `getStoreInfo` from `@woocommerce-next/data` (next-admin),
- * which is not published to npm. Only `launchedDate` is consumed by this
+ * Local stand-in for `getStoreInfo`. Only `launchedDate` is consumed by this
  * package, where it feeds `getDefaultPreset( launchedDate )` — that helper
  * falls back to its default preset when `launchedDate` is undefined, so
  * returning an empty object keeps the behavior correct until real store info

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-attributes-with-search-fallback.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-attributes-with-search-fallback.ts
@@ -40,7 +40,7 @@ export function useAttributesWithSearchFallback(
 	try {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		search = useSearch( {
-			from: '/wc-analytics/dashboard',
+			from: '/',
 		} );
 	} catch {
 		/*

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -11,7 +11,7 @@ import type { ChartTheme } from '@automattic/charts';
  */
 
 /**
- * Extended chart theme with WooCommerce-specific properties.
+ * Extended chart theme with analytics-specific properties.
  * Extends the base ChartTheme from @automattic/charts.
  */
 export type WooChartTheme = ChartTheme & {
@@ -25,7 +25,7 @@ export function useChartTheme(): WooChartTheme {
 
 	return useMemo( () => {
 		// If the user is using a custom color theme, use colors generated from the design system accent
-		// color token, otherwise use the default Woo theme colors.
+		// color token, otherwise use the default analytics theme colors.
 		const colors =
 			preferences.interfaceTheme === 'custom'
 				? [ '--wpds-color-fg-interactive-brand' ]

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -2,13 +2,13 @@
  * Storybook report-data mocking via a `@wordpress/api-fetch` middleware.
  *
  * The shared Jetpack Storybook config cannot be modified, and there is no
- * analytics backend in Storybook. Upstream (woocommerce-analytics) solves this
- * with MSW handlers that intercept its report REST paths.
+ * analytics backend in Storybook, so report requests have nothing to resolve
+ * against.
  *
- * Here we achieve the same effect by registering an `apiFetch` middleware that
- * intercepts the proxy report paths and returns generated mock data. The data
- * package fetches every report through `apiFetch( { path } )` using the same
- * base path (`reportsPath`), so a single middleware covers all widget stories.
+ * To mock report data we register an `apiFetch` middleware that intercepts the
+ * proxy report paths and returns generated mock data. The data package fetches
+ * every report through `apiFetch( { path } )` using the same base path
+ * (`reportsPath`), so a single middleware covers all widget stories.
  *
  * The middleware is registered exactly once (guarded by a module-level flag) and
  * is triggered automatically when `with-widget-root.tsx` is imported.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/README.md
@@ -1,6 +1,6 @@
 # Widgets
 
-Dashboard widget components for WooCommerce Analytics.
+Dashboard widget components for Jetpack Premium Analytics.
 
 ## Available Widgets
 


### PR DESCRIPTION
## Proposed changes

Cleans up leftover WooCommerce/standalone naming that the Premium Analytics packages carried over from the `next-woocommerce-analytics` port, so the package reads as Jetpack Premium Analytics.

**Why** — the ports left WooCommerce/standalone branding in comments and docs, plus a stale router key (`/wc-analytics/dashboard`) that no longer matches the package's actual route.

**How**

- Replaced the `@woocommerce-next/data` references in the `getStoreInfo` doc comments with provider-neutral wording (`packages/fields`, `packages/widgets-toolkit`, date-report field README).
- De-branded "WooCommerce Analytics" / "Woo theme" / "WooCommerce-specific" wording in `use-chart-theme`, the Storybook report mock, and the routing / widgets READMEs.
- Aligned the `useSearch`/`useNavigate` `from:` route key to the real registered route. The only route registered in this package is `path: "/"` (`routes/dashboard/package.json`), but the code used `from: '/wc-analytics/dashboard'`, which never matched — `useSearch` threw and silently fell back to `{}` (both call sites wrap it in try/catch). Changing it to `from: '/'` makes the key match the live route so the URL-param fallback resolves instead of being a no-op.

**What**

- Comment/doc wording: store-info stand-ins, chart theme, Storybook report mock, routing README, widgets README, date-report-params README, widget-root README + docstring.
- Route key `/wc-analytics/dashboard` → `/` across `use-staged-search`, `use-attributes-with-search-fallback`, `widget-root` (`DEFAULT_SEARCH_FROM`), and the routing/use-staged-search docs.
- Added a `changed`/patch changelog entry.

**Behavior note** — aligning the route key to `/` is a deliberate behavior change: the URL-param fallback now resolves instead of throwing-and-falling-back-to-empty.

**Intentionally left unchanged (real protocol / API names)**

- `woocommerce_analytics` Jetpack Sync module id and the sync-progress bucket key (`packages/site-sync` constants + tests).
- `/wc/v3/woocommerce-analytics/...` and other `/wc/v3/...` REST paths and the descriptions naming that REST API.
- WooCommerce hook/filter/option names (e.g. `woocommerce_excluded_report_order_statuses`) and references to real WooCommerce products/extensions (Bookings).
- `src/Sync/*` interim sync-module port and `.phan` stubs (tracked under WOOA7S-1550).
- Code identifiers `WOO_COLORS` / `WooChartTheme` — renaming these exported identifiers is a cross-file refactor beyond this cosmetic cleanup.
- `changelog/*` port entries and `AGENTS.md` references to `next-woocommerce-analytics` (accurate historical references to the source project).
- Generic "standalone usage" wording in `legend-with-theme.tsx` (component usage, not app branding).

## Related product discussion/links

- WOOA7S-1556

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run `pnpm typecheck` and `pnpm test` in `projects/packages/premium-analytics` — both pass (159 tests).
- The change is mostly comments/docs; the one behavioral change is the route-key alignment. To verify it:
  - Open the Jetpack Premium Analytics dashboard (`?page=jetpack-premium-analytics`).

