### PR TITLE
Premium Analytics: add server-side chart-formatting layer to the API proxy

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-proxy-chart-formatter-layer
+++ b/projects/packages/premium-analytics/changelog/add-pa-proxy-chart-formatter-layer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: Add a server-side formatter layer to the analytics proxy that reshapes stats/top-posts into a consistent leaderboard contract.

--- a/projects/packages/premium-analytics/src/REST/Formatters/class-formatter-registry.php
+++ b/projects/packages/premium-analytics/src/REST/Formatters/class-formatter-registry.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Resolves proxy endpoints to their area formatter.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+/**
+ * Maps an analytics area (the first endpoint segment, e.g. `stats`) to the single
+ * formatter that owns it. One formatter per area; per-resource differences are
+ * the formatter's concern. Endpoints in an unregistered area get no formatter and
+ * are proxied unchanged.
+ */
+class Formatter_Registry {
+
+	/**
+	 * Area => formatter class.
+	 *
+	 * @var array<string, class-string<Widget_Formatter>>
+	 */
+	private const FORMATTERS = array(
+		'stats' => Stats_Formatter::class,
+	);
+
+	/**
+	 * The formatter for an endpoint's area, or null when the area is unregistered.
+	 *
+	 * @param string $endpoint Proxied analytics sub-path (e.g. `stats/top-posts`).
+	 *
+	 * @return Widget_Formatter|null
+	 */
+	public static function for_endpoint( string $endpoint ): ?Widget_Formatter {
+		$area = self::area( $endpoint );
+		if ( '' === $area || ! isset( self::FORMATTERS[ $area ] ) ) {
+			return null;
+		}
+
+		$class = self::FORMATTERS[ $area ];
+
+		return new $class();
+	}
+
+	/**
+	 * The area segment (the first path segment) of an endpoint.
+	 *
+	 * @param string $endpoint Proxied analytics sub-path.
+	 *
+	 * @return string
+	 */
+	private static function area( string $endpoint ): string {
+		$segments = explode( '/', trim( $endpoint, '/' ) );
+
+		return $segments[0] ?? '';
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/Formatters/class-leaderboard-formatter.php
+++ b/projects/packages/premium-analytics/src/REST/Formatters/class-leaderboard-formatter.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Shared leaderboard-shaping logic for proxy formatters.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+use WP_REST_Request;
+
+/**
+ * Abstract base that turns flat rows into the leaderboard contract: optional
+ * filtering, ranking, share math computed over the filtered set, zeroed
+ * comparison fields, and an enveloped `{ data, meta }` body. Subclasses only
+ * supply the resource-specific row extraction (and, optionally, the field the
+ * `name` param filters on).
+ */
+abstract class Leaderboard_Formatter implements Widget_Formatter {
+
+	/**
+	 * Extract flat rows from the raw body. Each row is
+	 * `array{ id, label, value, ...extras }`, where the extras (e.g. `href`,
+	 * `type`) become the per-entry `meta` bag. Return `null` to pass the raw
+	 * body through unchanged.
+	 *
+	 * @param array           $raw     Decoded WPCOM response body.
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array<int, array>|null
+	 */
+	abstract protected function extract_rows( array $raw, WP_REST_Request $request ): ?array;
+
+	/**
+	 * Row field the `name` query param filters on, or null to ignore `name`.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return string|null
+	 */
+	protected function filter_field( WP_REST_Request $request ): ?string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Overridable hook; the default ignores the request.
+		return null;
+	}
+
+	/**
+	 * Format the body into the leaderboard contract, or pass it through.
+	 *
+	 * @param array           $raw     Decoded WPCOM response body.
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array
+	 */
+	public function format( array $raw, WP_REST_Request $request ): array {
+		$rows = $this->extract_rows( $raw, $request );
+		if ( null === $rows ) {
+			return $raw;
+		}
+
+		$rows = $this->rank_rows( $this->filter_rows( $rows, $request ) );
+
+		$max = 0;
+		foreach ( $rows as $row ) {
+			$max = max( $max, (int) $row['value'] );
+		}
+
+		$entries = array();
+		$total   = 0;
+		foreach ( $rows as $row ) {
+			$value     = (int) $row['value'];
+			$total    += $value;
+			$entries[] = array(
+				'id'             => (string) $row['id'],
+				'label'          => (string) $row['label'],
+				'value'          => $value,
+				'previous_value' => 0,
+				'current_share'  => $max > 0 ? (float) $value / $max * 100 : 0.0,
+				'previous_share' => 0,
+				'delta'          => 0,
+				'meta'           => $this->entry_meta( $row ),
+			);
+		}
+
+		return array(
+			'data' => $entries,
+			'meta' => array(
+				'period' => (string) $request->get_param( 'period' ),
+				'date'   => (string) $request->get_param( 'date' ),
+				'total'  => $total,
+				'count'  => count( $entries ),
+			),
+		);
+	}
+
+	/**
+	 * Per-entry meta bag: every extracted field that is not a core column.
+	 *
+	 * @param array $row Extracted row.
+	 *
+	 * @return array
+	 */
+	protected function entry_meta( array $row ): array {
+		unset( $row['id'], $row['label'], $row['value'] );
+
+		return $row;
+	}
+
+	/**
+	 * Keep only rows whose filter field matches the requested `name`(s). When the
+	 * resource has no filter field or no `name` is requested, all rows are kept.
+	 *
+	 * @param array<int, array> $rows    Extracted rows.
+	 * @param WP_REST_Request   $request Incoming proxy request.
+	 *
+	 * @return array<int, array>
+	 */
+	protected function filter_rows( array $rows, WP_REST_Request $request ): array {
+		$field = $this->filter_field( $request );
+		if ( null === $field ) {
+			return $rows;
+		}
+
+		$names = $this->requested_names( $request );
+		if ( null === $names ) {
+			return $rows;
+		}
+
+		$filtered = array();
+		foreach ( $rows as $row ) {
+			if ( isset( $row[ $field ] ) && in_array( (string) $row[ $field ], $names, true ) ) {
+				$filtered[] = $row;
+			}
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Sort rows by value, descending, preserving input order on ties.
+	 *
+	 * @param array<int, array> $rows Filtered rows.
+	 *
+	 * @return array<int, array>
+	 */
+	protected function rank_rows( array $rows ): array {
+		$indexed = array();
+		foreach ( $rows as $i => $row ) {
+			$indexed[] = array( $i, $row );
+		}
+
+		usort(
+			$indexed,
+			static function ( $a, $b ) {
+				$av = (int) $a[1]['value'];
+				$bv = (int) $b[1]['value'];
+
+				return $av === $bv ? $a[0] <=> $b[0] : $bv <=> $av;
+			}
+		);
+
+		return array_map(
+			static function ( $pair ) {
+				return $pair[1];
+			},
+			$indexed
+		);
+	}
+
+	/**
+	 * Normalize the `name` query param into a list of allowed values, or null
+	 * when nothing usable was supplied. Accepts a comma-separated string or an
+	 * array.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array<int, string>|null
+	 */
+	protected function requested_names( WP_REST_Request $request ): ?array {
+		$name = $request->get_param( 'name' );
+		if ( null === $name || '' === $name ) {
+			return null;
+		}
+
+		$names = is_array( $name ) ? $name : explode( ',', (string) $name );
+		$names = array_filter(
+			array_map( 'trim', array_map( 'strval', $names ) ),
+			static function ( $value ) {
+				return '' !== $value;
+			}
+		);
+
+		return empty( $names ) ? null : array_values( $names );
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/Formatters/class-stats-formatter.php
+++ b/projects/packages/premium-analytics/src/REST/Formatters/class-stats-formatter.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Leaderboard formatter for the `stats/*` area.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+use WP_REST_Request;
+
+/**
+ * Formats `stats/*` responses into the leaderboard contract. The per-resource
+ * differences (which summary bucket holds the items, which fields map to
+ * label/value/href/meta, and any upstream param defaults) live in a small
+ * declarative spec keyed by resource — the segment after `stats/`. Adding a
+ * flat-list leaderboard resource is one spec row, not a new class.
+ *
+ * Resources absent from the spec (e.g. `stats/visits`, a time-series) are
+ * passed through unchanged.
+ */
+class Stats_Formatter extends Leaderboard_Formatter {
+
+	/**
+	 * Per-resource formatting spec, keyed by the segment after `stats/`.
+	 *
+	 * Each row declares:
+	 * - `items`        Summary bucket key holding the list of items.
+	 * - `label`        Item field used as the entry label.
+	 * - `value`        Item field used as the (numeric) entry value.
+	 * - `href`         Item field surfaced as `meta.href` (optional).
+	 * - `meta`         Extra item fields copied verbatim into the entry `meta` bag.
+	 * - `filter_field` Item field the `name` query param filters on (optional).
+	 * - `params`       Upstream WPCOM query defaults for this resource.
+	 *
+	 * @var array<string, array>
+	 */
+	private const SPEC = array(
+		'top-posts' => array(
+			'items'        => 'postviews',
+			'label'        => 'title',
+			'value'        => 'views',
+			'href'         => 'href',
+			'meta'         => array( 'type' ),
+			'filter_field' => 'type',
+			'params'       => array( 'summarize' => true ),
+		),
+		// Future flat-list resources are one row each, e.g. search-terms (items
+		// "search_terms", label "term", value "views") or video-plays (items
+		// "plays", label "title", value "plays").
+	);
+
+	/**
+	 * Upstream query defaults for the resolved resource (e.g. `summarize=true`).
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array<string, scalar>
+	 */
+	public function upstream_params( WP_REST_Request $request ): array {
+		$spec = $this->spec( $request );
+		if ( null === $spec || empty( $spec['params'] ) || ! is_array( $spec['params'] ) ) {
+			return array();
+		}
+
+		return $spec['params'];
+	}
+
+	/**
+	 * Read `summary[ items ]` and map each item to a flat leaderboard row. A
+	 * response without that bucket (e.g. a `days`-shaped body) yields an empty
+	 * leaderboard and a logged notice. Returns null for unconfigured resources.
+	 *
+	 * @param array           $raw     Decoded WPCOM response body.
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array<int, array>|null
+	 */
+	protected function extract_rows( array $raw, WP_REST_Request $request ): ?array {
+		$spec = $this->spec( $request );
+		if ( null === $spec ) {
+			return null;
+		}
+
+		$items_key = $spec['items'];
+		$summary   = isset( $raw['summary'] ) && is_array( $raw['summary'] ) ? $raw['summary'] : null;
+		if ( null === $summary || ! isset( $summary[ $items_key ] ) || ! is_array( $summary[ $items_key ] ) ) {
+			$this->log_missing_summary( $request );
+
+			return array();
+		}
+
+		$rows = array();
+		foreach ( $summary[ $items_key ] as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$row = array(
+				'id'    => isset( $item['id'] ) ? (string) $item['id'] : '',
+				'label' => isset( $item[ $spec['label'] ] ) ? (string) $item[ $spec['label'] ] : '',
+				'value' => isset( $item[ $spec['value'] ] ) ? (int) $item[ $spec['value'] ] : 0,
+			);
+
+			if ( ! empty( $spec['href'] ) ) {
+				$row['href'] = isset( $item[ $spec['href'] ] ) ? (string) $item[ $spec['href'] ] : '';
+			}
+
+			foreach ( (array) ( $spec['meta'] ?? array() ) as $meta_field ) {
+				$row[ $meta_field ] = $item[ $meta_field ] ?? null;
+			}
+
+			$rows[] = $row;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * The field the `name` param filters on for the resolved resource.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return string|null
+	 */
+	protected function filter_field( WP_REST_Request $request ): ?string {
+		$spec = $this->spec( $request );
+
+		return ( null !== $spec && ! empty( $spec['filter_field'] ) ) ? (string) $spec['filter_field'] : null;
+	}
+
+	/**
+	 * Resolve the spec row for the request's resource, or null if unconfigured.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array|null
+	 */
+	private function spec( WP_REST_Request $request ): ?array {
+		$resource = $this->resource( $request );
+
+		return self::SPEC[ $resource ] ?? null;
+	}
+
+	/**
+	 * The resource segment (the part after `stats/`) of the proxied endpoint.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return string
+	 */
+	private function resource( WP_REST_Request $request ): string {
+		$segments = explode( '/', trim( (string) $request->get_param( 'endpoint' ), '/' ) );
+
+		// segments[0] is the area ('stats'); the resource is the next segment.
+		return $segments[1] ?? '';
+	}
+
+	/**
+	 * Log that a configured resource returned no summary bucket (e.g. a `days`
+	 * response), so the empty leaderboard is explained rather than silent.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return void
+	 */
+	private function log_missing_summary( WP_REST_Request $request ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log(
+				sprintf(
+					'Premium Analytics: no summary bucket for stats resource "%s"; returning an empty leaderboard.',
+					$this->resource( $request )
+				)
+			);
+		}
+	}
+}

--- a/projects/packages/premium-analytics/src/REST/Formatters/interface-widget-formatter.php
+++ b/projects/packages/premium-analytics/src/REST/Formatters/interface-widget-formatter.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contract for the proxy's per-widget response formatters.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+use WP_REST_Request;
+
+/**
+ * A formatter sits between the API proxy and the upstream WPCOM request: it can
+ * inject upstream query defaults and reshape the raw response body into a
+ * consistent, widget-friendly contract. Implementations are resolved per area
+ * (the first endpoint segment) by Formatter_Registry.
+ */
+interface Widget_Formatter {
+
+	/**
+	 * Upstream query defaults to merge into the WPCOM request. Caller-supplied
+	 * params take precedence over these.
+	 *
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array<string, scalar>
+	 */
+	public function upstream_params( WP_REST_Request $request ): array;
+
+	/**
+	 * Reshape the decoded WPCOM body. Return the body unchanged to pass through.
+	 *
+	 * @param array           $raw     Decoded (associative) WPCOM response body.
+	 * @param WP_REST_Request $request Incoming proxy request.
+	 *
+	 * @return array
+	 */
+	public function format( array $raw, WP_REST_Request $request ): array;
+}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\PremiumAnalytics\REST;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Formatter_Registry;
+use Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Widget_Formatter;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Controller;
@@ -451,6 +453,10 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			);
 		}
 
+		// Only reads are reshaped: a formatter would otherwise rewrite a write's response (e.g. a
+		// POST to a `stats/…` write endpoint, whose area still resolves to a formatter).
+		$formatter = $is_read ? Formatter_Registry::for_endpoint( (string) $request->get_param( 'endpoint' ) ) : null;
+
 		$args = array(
 			'method'  => $method,
 			'timeout' => self::API_TIMEOUT,
@@ -463,7 +469,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 
 		try {
 			$response = Client::wpcom_json_api_request_as_blog(
-				$this->append_forwarded_params( $request, $wpcom_path ),
+				$this->append_forwarded_params( $request, $wpcom_path, $formatter ),
 				$version,
 				$args,
 				$body,
@@ -487,7 +493,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 
 		$this->maybe_bust_read_cache( $response, ! $is_read, $opts, $wpcom_path, $version, $base );
 
-		return $this->cache_and_build_response( $response, $cache_key );
+		return $this->cache_and_build_response( $response, $cache_key, $request, $formatter );
 	}
 
 	/**
@@ -523,14 +529,19 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	/**
 	 * Cache a successful (200) response when a cache key is given, and return it to the caller.
 	 *
-	 * @param array       $http_response Raw response from the Jetpack client.
-	 * @param string|null $cache_key     Transient key, or null to skip caching.
+	 * When a read has a formatter, the decoded body is reshaped before it is cached, so the
+	 * cached payload is the already-formatted one.
+	 *
+	 * @param array                 $http_response Raw response from the Jetpack client.
+	 * @param string|null           $cache_key     Transient key, or null to skip caching.
+	 * @param WP_REST_Request|null  $request       Request, needed to run the formatter.
+	 * @param Widget_Formatter|null $formatter     Formatter for this endpoint, if any.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function cache_and_build_response( array $http_response, ?string $cache_key ) {
+	private function cache_and_build_response( array $http_response, ?string $cache_key, ?WP_REST_Request $request = null, ?Widget_Formatter $formatter = null ) {
 		$status = (int) wp_remote_retrieve_response_code( $http_response );
-		$data   = json_decode( wp_remote_retrieve_body( $http_response ), false );
+		$data   = json_decode( wp_remote_retrieve_body( $http_response ), true );
 
 		// A 200 with an undecodable body means the upstream is degraded; don't cache garbage.
 		if ( 200 === $status && null === $data && JSON_ERROR_NONE !== json_last_error() ) {
@@ -539,6 +550,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 				__( 'The data service returned an unreadable response.', 'jetpack-premium-analytics' ),
 				array( 'status' => 502 )
 			);
+		}
+
+		// Reshape the body before caching, so the cached payload is the formatted one.
+		if ( 200 === $status && null !== $formatter && null !== $request && is_array( $data ) ) {
+			$data = $formatter->format( $data, $request );
 		}
 
 		$payload = array(
@@ -595,13 +611,20 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	/**
 	 * Append the forwarded query params to a WPCOM path, choosing the right separator.
 	 *
-	 * @param WP_REST_Request $request    Request object.
-	 * @param string          $wpcom_path WPCOM path that may already carry a query string.
+	 * When a formatter applies, its upstream defaults are merged in first so that any
+	 * caller-supplied query param of the same name still wins.
+	 *
+	 * @param WP_REST_Request       $request    Request object.
+	 * @param string                $wpcom_path WPCOM path that may already carry a query string.
+	 * @param Widget_Formatter|null $formatter  Formatter for this endpoint, if any.
 	 *
 	 * @return string
 	 */
-	private function append_forwarded_params( WP_REST_Request $request, string $wpcom_path ): string {
+	private function append_forwarded_params( WP_REST_Request $request, string $wpcom_path, ?Widget_Formatter $formatter = null ): string {
 		$params = $this->get_forwarded_params( $request );
+		if ( null !== $formatter ) {
+			$params = array_merge( $formatter->upstream_params( $request ), $params );
+		}
 		if ( empty( $params ) ) {
 			return $wpcom_path;
 		}

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics\REST;
 
+use Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Formatter_Registry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -172,6 +173,84 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_stats_endpoint_returns_the_formatted_leaderboard_shape() {
+		$request   = $this->build_data_request(
+			'GET',
+			'stats/top-posts',
+			array(
+				'period' => 'day',
+				'date'   => '2026-06-15',
+			)
+		);
+		$formatter = Formatter_Registry::for_endpoint( 'stats/top-posts' );
+
+		$response = $this->cache_and_build_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => (string) wp_json_encode(
+					array(
+						'summary' => array(
+							'postviews'   => array(
+								array(
+									'id'    => '7',
+									'title' => 'Hello',
+									'views' => 12,
+									'type'  => 'post',
+									'href'  => 'https://ex.test/hello',
+								),
+							),
+							'total_views' => 12,
+						),
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+				'headers'  => array(),
+			),
+			$this->cache_key( $request ),
+			$request,
+			$formatter
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertSame( '7', $data['data'][0]['id'] );
+		$this->assertSame( 12, $data['data'][0]['value'] );
+		$this->assertSame( 1, $data['meta']['count'] );
+
+		// The cached payload is the formatted body, not the raw upstream shape.
+		$cached = get_transient( $this->cache_key( $request ) );
+		$this->assertSame( $data, $cached['data'] );
+	}
+
+	public function test_stats_endpoint_injects_summarize_into_the_upstream_url() {
+		$request   = $this->build_data_request( 'GET', 'stats/top-posts', array( 'period' => 'day' ) );
+		$formatter = Formatter_Registry::for_endpoint( 'stats/top-posts' );
+
+		$url = $this->append_forwarded_params( $request, '/sites/1/stats/top-posts', $formatter );
+		$this->assertStringContainsString( 'summarize=1', $url );
+	}
+
+	public function test_unregistered_area_passes_the_body_through_unchanged() {
+		$this->assertNull( Formatter_Registry::for_endpoint( 'reports/totals' ) );
+
+		$request  = $this->build_data_request( 'GET', 'reports/totals' );
+		$response = $this->cache_and_build_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"orders":42}',
+				'headers'  => array(),
+			),
+			$this->cache_key( $request ),
+			$request,
+			null
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( array( 'orders' => 42 ), $response->get_data() );
 	}
 
 	public function test_registers_data_route_with_read_and_write_methods() {
@@ -857,16 +936,36 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	/**
 	 * Invoke the controller's private cache_and_build_response().
 	 *
-	 * @param array       $http_response Raw HTTP response array.
-	 * @param string|null $cache_key     Transient key, or null to skip caching.
+	 * @param array                $http_response Raw HTTP response array.
+	 * @param string|null          $cache_key     Transient key, or null to skip caching.
+	 * @param WP_REST_Request|null $request       Request, when a formatter is exercised.
+	 * @param mixed                $formatter     Formatter for the endpoint, or null.
 	 *
 	 * @return WP_REST_Response|\WP_Error
 	 */
-	private function cache_and_build_response( array $http_response, ?string $cache_key ) {
-		$accessor = function ( array $resp, ?string $key ) {
-			return $this->cache_and_build_response( $resp, $key );
+	private function cache_and_build_response( array $http_response, ?string $cache_key, $request = null, $formatter = null ) {
+		$accessor = function ( array $resp, ?string $key, $req, $fmt ) {
+			return $this->cache_and_build_response( $resp, $key, $req, $fmt );
 		};
 
-		return $accessor->call( $this->controller, $http_response, $cache_key );
+		return $accessor->call( $this->controller, $http_response, $cache_key, $request, $formatter );
+	}
+
+	/**
+	 * Invoke the controller's private append_forwarded_params() with an optional formatter, so a
+	 * formatter's upstream defaults (e.g. stats `summarize`) can be asserted on the built path.
+	 *
+	 * @param WP_REST_Request $request    Request object.
+	 * @param string          $wpcom_path WPCOM path the params are appended to.
+	 * @param mixed           $formatter  Formatter for the endpoint, or null.
+	 *
+	 * @return string
+	 */
+	private function append_forwarded_params( WP_REST_Request $request, string $wpcom_path, $formatter = null ): string {
+		$accessor = function ( WP_REST_Request $req, string $path, $fmt ) {
+			return $this->append_forwarded_params( $req, $path, $fmt );
+		};
+
+		return $accessor->call( $this->controller, $request, $wpcom_path, $formatter );
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/REST/Formatters/Formatter_Registry_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Formatters/Formatter_Registry_Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for Formatter_Registry.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Formatter_Registry
+ */
+#[CoversClass( Formatter_Registry::class )]
+class Formatter_Registry_Test extends BaseTestCase {
+
+	public function test_returns_the_area_formatter_for_a_registered_endpoint() {
+		$formatter = Formatter_Registry::for_endpoint( 'stats/top-posts' );
+
+		$this->assertInstanceOf( Stats_Formatter::class, $formatter );
+		$this->assertInstanceOf( Widget_Formatter::class, $formatter );
+	}
+
+	public function test_resolves_the_area_from_the_first_segment_regardless_of_sub_path() {
+		// Any resource under a registered area resolves to that area's formatter.
+		$this->assertInstanceOf( Stats_Formatter::class, Formatter_Registry::for_endpoint( 'stats/visits' ) );
+		// The bare area (no resource) resolves too.
+		$this->assertInstanceOf( Stats_Formatter::class, Formatter_Registry::for_endpoint( 'stats' ) );
+	}
+
+	public function test_ignores_surrounding_slashes_when_resolving_the_area() {
+		$this->assertInstanceOf( Stats_Formatter::class, Formatter_Registry::for_endpoint( '/stats/top-posts/' ) );
+	}
+
+	public function test_returns_null_for_an_unregistered_area() {
+		$this->assertNull( Formatter_Registry::for_endpoint( 'reports/totals' ) );
+	}
+
+	public function test_returns_null_for_an_empty_endpoint() {
+		$this->assertNull( Formatter_Registry::for_endpoint( '' ) );
+		$this->assertNull( Formatter_Registry::for_endpoint( '/' ) );
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/REST/Formatters/Stats_Formatter_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Formatters/Stats_Formatter_Test.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Tests for Stats_Formatter.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\REST\Formatters;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Stats_Formatter
+ * @covers \Automattic\Jetpack\PremiumAnalytics\REST\Formatters\Leaderboard_Formatter
+ */
+#[CoversClass( Stats_Formatter::class )]
+#[CoversClass( Leaderboard_Formatter::class )]
+class Stats_Formatter_Test extends BaseTestCase {
+
+	/**
+	 * Formatter under test.
+	 *
+	 * @var Stats_Formatter
+	 */
+	private $formatter;
+
+	/**
+	 * Set up the formatter.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->formatter = new Stats_Formatter();
+	}
+
+	public function test_maps_summary_postviews_to_leaderboard_entries() {
+		$raw    = $this->top_posts_body(
+			array(
+				$this->postview( '11', 'Home', 90, 'page', 'https://ex.test/' ),
+				$this->postview( '22', 'About', 30, 'page', 'https://ex.test/about' ),
+			)
+		);
+		$result = $this->formatter->format(
+			$raw,
+			$this->request(
+				'stats/top-posts',
+				array(
+					'period' => 'day',
+					'date'   => '2026-06-15',
+				)
+			)
+		);
+
+		$this->assertCount( 2, $result['data'] );
+
+		$first = $result['data'][0];
+		$this->assertSame( '11', $first['id'] );
+		$this->assertSame( 'Home', $first['label'] );
+		$this->assertSame( 90, $first['value'] );
+		$this->assertSame( 0, $first['previous_value'] );
+		$this->assertSame( 0, $first['previous_share'] );
+		$this->assertSame( 0, $first['delta'] );
+		$this->assertSame(
+			array(
+				'href' => 'https://ex.test/',
+				'type' => 'page',
+			),
+			$first['meta']
+		);
+
+		$this->assertSame(
+			array(
+				'period' => 'day',
+				'date'   => '2026-06-15',
+				'total'  => 120,
+				'count'  => 2,
+			),
+			$result['meta']
+		);
+	}
+
+	public function test_current_share_is_relative_to_the_top_value() {
+		$raw    = $this->top_posts_body(
+			array(
+				$this->postview( '1', 'Top', 200, 'post' ),
+				$this->postview( '2', 'Half', 100, 'post' ),
+			)
+		);
+		$result = $this->formatter->format( $raw, $this->request( 'stats/top-posts' ) );
+
+		$this->assertSame( 100.0, $result['data'][0]['current_share'] );
+		$this->assertSame( 50.0, $result['data'][1]['current_share'] );
+	}
+
+	public function test_ranks_entries_by_value_descending() {
+		$raw    = $this->top_posts_body(
+			array(
+				$this->postview( '1', 'Low', 5, 'post' ),
+				$this->postview( '2', 'High', 50, 'post' ),
+				$this->postview( '3', 'Mid', 20, 'post' ),
+			)
+		);
+		$result = $this->formatter->format( $raw, $this->request( 'stats/top-posts' ) );
+
+		$this->assertSame( array( 'High', 'Mid', 'Low' ), array_column( $result['data'], 'label' ) );
+	}
+
+	public function test_name_param_filters_on_type_and_rescopes_the_share_denominator() {
+		$raw    = $this->top_posts_body(
+			array(
+				$this->postview( '1', 'Big page', 100, 'page' ),
+				$this->postview( '2', 'Top post', 40, 'post' ),
+				$this->postview( '3', 'Small post', 10, 'post' ),
+			)
+		);
+		$result = $this->formatter->format(
+			$raw,
+			$this->request( 'stats/top-posts', array( 'name' => 'post' ) )
+		);
+
+		$this->assertSame( array( 'Top post', 'Small post' ), array_column( $result['data'], 'label' ) );
+		// Share is over the filtered max (40), not the unfiltered page (100).
+		$this->assertSame( 100.0, $result['data'][0]['current_share'] );
+		$this->assertSame( 25.0, $result['data'][1]['current_share'] );
+		$this->assertSame( 50, $result['meta']['total'] );
+	}
+
+	public function test_name_param_accepts_a_comma_separated_list() {
+		$raw    = $this->top_posts_body(
+			array(
+				$this->postview( '1', 'A page', 10, 'page' ),
+				$this->postview( '2', 'A post', 20, 'post' ),
+				$this->postview( '3', 'A product', 5, 'product' ),
+			)
+		);
+		$result = $this->formatter->format(
+			$raw,
+			$this->request( 'stats/top-posts', array( 'name' => 'post,page' ) )
+		);
+
+		$this->assertSame( array( 'A post', 'A page' ), array_column( $result['data'], 'label' ) );
+	}
+
+	public function test_days_shaped_body_yields_empty_data_and_zeroed_meta() {
+		$raw = array(
+			'date' => '2026-06-15',
+			'days' => array(
+				'2026-06-15' => array(
+					'postviews'   => array( $this->postview( '1', 'Ignored', 10, 'post' ) ),
+					'total_views' => 10,
+				),
+			),
+		);
+
+		$result = $this->formatter->format(
+			$raw,
+			$this->request(
+				'stats/top-posts',
+				array(
+					'period' => 'day',
+					'date'   => '2026-06-15',
+				)
+			)
+		);
+
+		$this->assertSame( array(), $result['data'] );
+		$this->assertSame(
+			array(
+				'period' => 'day',
+				'date'   => '2026-06-15',
+				'total'  => 0,
+				'count'  => 0,
+			),
+			$result['meta']
+		);
+	}
+
+	public function test_empty_summary_bucket_yields_empty_leaderboard() {
+		$result = $this->formatter->format( $this->top_posts_body( array() ), $this->request( 'stats/top-posts' ) );
+
+		$this->assertSame( array(), $result['data'] );
+		$this->assertSame( 0, $result['meta']['total'] );
+		$this->assertSame( 0, $result['meta']['count'] );
+	}
+
+	public function test_unconfigured_resource_passes_the_body_through_unchanged() {
+		$raw = array(
+			'fields' => array( 'views' ),
+			'data'   => array( array( '2026-06-15', 5 ) ),
+		);
+
+		$result = $this->formatter->format( $raw, $this->request( 'stats/visits' ) );
+
+		$this->assertSame( $raw, $result );
+	}
+
+	public function test_upstream_params_injects_summarize_for_top_posts() {
+		$this->assertSame(
+			array( 'summarize' => true ),
+			$this->formatter->upstream_params( $this->request( 'stats/top-posts' ) )
+		);
+	}
+
+	public function test_upstream_params_is_empty_for_an_unconfigured_resource() {
+		$this->assertSame( array(), $this->formatter->upstream_params( $this->request( 'stats/visits' ) ) );
+	}
+
+	/**
+	 * A WPCOM top-posts body wrapping the given postviews in a `summary` bucket.
+	 *
+	 * @param array $postviews Postview item rows.
+	 *
+	 * @return array
+	 */
+	private function top_posts_body( array $postviews ): array {
+		$total = 0;
+		foreach ( $postviews as $item ) {
+			$total += $item['views'];
+		}
+
+		return array(
+			'date'    => '2026-06-15',
+			'summary' => array(
+				'postviews'   => $postviews,
+				'total_views' => $total,
+			),
+		);
+	}
+
+	/**
+	 * Build a single WPCOM postview item.
+	 *
+	 * @param string $id    Post id.
+	 * @param string $title Post title.
+	 * @param int    $views View count.
+	 * @param string $type  Post type.
+	 * @param string $href  Post URL.
+	 *
+	 * @return array
+	 */
+	private function postview( string $id, string $title, int $views, string $type, string $href = 'https://ex.test/p' ): array {
+		return array(
+			'id'     => $id,
+			'href'   => $href,
+			'date'   => '2026-06-10',
+			'title'  => $title,
+			'type'   => $type,
+			'views'  => $views,
+			'public' => true,
+		);
+	}
+
+	/**
+	 * Build a proxy request with the endpoint capture and query params set.
+	 *
+	 * @param string $endpoint Analytics endpoint.
+	 * @param array  $params   Query params.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function request( string $endpoint, array $params = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET', '/jetpack-premium-analytics/v1/proxy/' . $endpoint );
+		// Set query params before the endpoint capture: set_query_params() replaces
+		// the GET bag, which would otherwise drop a previously-set endpoint param.
+		$request->set_query_params( $params );
+		$request->set_param( 'endpoint', $endpoint );
+
+		return $request;
+	}
+}


### PR DESCRIPTION
## Reason

Currently we have to create new formatting functions on the front-end for each widget to render correctly. This  means we require quite a bit of set up for each new widget, which we did want to minimize, also in the case where AI could generate charts/widgets for us.
This PR is an initial step to create a standard data layout for the front-end and currently does the parsing on the back-end.

## Proposed changes
Introduces a **server-side formatter layer** in the Premium Analytics API proxy (`Api_Proxy_Controller`) that turns raw `stats/*` responses into a consistent, leaderboard-shaped contract — so the front end becomes a thin adapter and new widgets are cheap to add. `stats/top-posts` is the first configured resource. PHP only; the front-end adaptation is a follow-up PR. Design is recorded in `docs/adr/0001-chart-formatting-layer.md`.

* **Registry, one formatter per area, config-driven per resource.** `Formatter_Registry` maps an area (the first endpoint segment, e.g. `stats`) to a single formatter class — no class per endpoint. Per-resource differences live in a small declarative `SPEC` (item key + label/value/href/meta fields + upstream param defaults). Adding a flat-list leaderboard endpoint is one `SPEC` row.
* **Abstract `Leaderboard_Formatter` base** owns the shared work: filter by the spec's `filter_field` (driven by the `name` query param) → rank by value → compute `current_share` over the filtered set's max → zero the comparison fields → build the `{ data, meta }` envelope. Widget-specific extras (`href`, `type`) live in a per-entry `meta` bag, so future fields don't change the core contract.
* **`Stats_Formatter`** supplies the per-resource spec (v1: `top-posts` only → `summary.postviews`, label `title`, value `views`, filter on `type`), injects `summarize=true` upstream, and reads `summary[items]`. A `days`-shaped or empty response yields empty `data` + zeroed `meta`.
* **Proxy wiring.** The formatter's `upstream_params()` are merged into the WPCOM request before the call (caller params still win); the response is reshaped right after JSON-decode, so the **cached** payload is the formatted body.
* **Backwards compatible.** Unconfigured resources (e.g. `stats/visits`) and unregistered areas (e.g. `reports/*`) pass through unchanged. The decoded body is now an associative array; `WP_REST_Response` serializes it identically to the previous object form.
* **Output contract** is snake_case (`{ id, label, value, previous_value, current_share, previous_share, delta, meta }` + envelope `meta: { period, date, total, count }`); comparison fields are zeroed in v1 but the shape already supports a future previous-period fetch.

### How the formatter layer works

The formatter sits between the proxy and the WPCOM response. It does two things: optionally inject query params on the way out, and reshape the body on the way back. Unrecognized endpoints skip it entirely (transparent pass-through).

The request flow

 For a read like GET `…/proxy/v1.1/stats/top-posts`:

    1. Resolve — `Formatter_Registry::for_endpoint(stats/top-posts)` looks at the first segment (stats) and returns a Stats_Formatter. An unregistered area (e.g. wordads/…) returns null → body
    passes through untouched. (Reads only — writes never get a formatter.)
    2. Outbound — append_forwarded_params() merges $formatter->upstream_params() into the query string. Stats_Formatter adds summarize=1. Caller-supplied params win on conflict.
    3. Inbound — cache_and_build_response() decodes the body to an assoc array and calls $formatter->format($data, $request) before caching, so the cached payload is already the reshaped one.

The two classes

    - Leaderboard_Formatter (abstract) — owns the shared mechanics, driven by a per-resource SPEC (which item key to read, and which fields map to label / value / href / meta). It filters,
    ranks, computes current_share across the filtered set, zeroes comparison fields, and builds the { data, meta } envelope with a per-entry meta bag. It knows how to build a leaderboard, not
    which endpoints.
    - Stats_Formatter (concrete) — extends the above and supplies the what: the stats-area SPEC (currently just top-posts) plus the summarize=1 upstream param. It's the thin, config-only layer.

Adding a new formatted endpoint

Because it's config-driven, a new flat-list leaderboard is usually a single SPEC row in the relevant formatter — map the resource's item key and its label/value/href/meta fields, and the abstract base does the rest. A whole new area means a new Widget_Formatter subclass plus one line in Formatter_Registry.

Example

Request: GET `/proxy/v1.1/stats/top-posts?period=day` → proxy forwards `/sites/<id>/stats/top-posts?period=day&summarize=1`. WPCOM returns `{ summary: { postviews: [ { id, title, views, … } ] } }`, and the formatter reshapes it to:

```
    { "data": [ { "id": "7", "label": "Hello", "value": 12, "href": "…", "meta": { … } } ],
      "meta": { "count": 1 } }
```

## Does this pull request change what data or activity we track or use?
No. This reshapes existing analytics responses already served by the proxy; it does not collect or transmit any new data.

## Testing instructions

**Prerequisite for end-to-end:** the `stats/*` → v1.1 routing fix (`565868cf6b`, separate open PR) is not yet on trunk. Until it lands, `stats/top-posts` won't route to the v1.1 Stats API. The formatter logic is independent and is fully covered by unit tests below.

You can test using the apiFetch in your browser console:
```
wp.apiFetch( {
      path: wp.url.addQueryArgs( '/jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts', {
          period: 'day',
          date: '2026-06-17',
          start_date: '2026-06-11', // trailing 7 days
          max: 10,
          skip_archives: 1,
          // name: 'post',          // optional: server-side type filter
      } ),
  } ).then( console.log );
```

Unit tests:
* From `projects/packages/premium-analytics`, run `composer phpunit` — all PHP tests pass (`Stats_Formatter_Test` + extended `Api_Proxy_Controller_Test`).
* `composer phpcs:lint` and `jetpack phan packages/premium-analytics` are clean for the new files.

What to verify in the tests / by inspection:
* `GET jetpack-premium-analytics/v1/proxy/stats/top-posts` returns `{ data: [ … ], meta: { period, date, total, count } }`, and `summarize=1` is injected into the upstream WPCOM request.
* `current_share` is `value / max * 100` over the **filtered** set; passing `?name=post` (or `?name=post,page`) filters by post type before ranking and rescopes the share denominator.
* `GET …/proxy/stats/visits` (unconfigured) and `GET …/proxy/reports/totals` (unregistered area) are passed through unchanged.
* A `days`-shaped or empty top-posts body yields empty `data` with zeroed `meta`.
