### PR TITLE
Forms: Add hCaptcha support

### DIFF
--- a/projects/packages/forms/changelog/add-forms-hcaptcha-support
+++ b/projects/packages/forms/changelog/add-forms-hcaptcha-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add hCaptcha protection for form submissions.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -20,7 +20,10 @@ class Jetpack_Forms {
 	 * Load the contact form module.
 	 */
 	public static function load_contact_form() {
+		require_once __DIR__ . '/contact-form/class-hcaptcha.php';
+
 		Util::init();
+		ContactForm\HCaptcha::init();
 
 		if ( self::is_feedback_dashboard_enabled() ) {
 			$dashboard = new Dashboard();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1474,9 +1474,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 			$r .= "<input type='hidden' name='jetpack_contact_form_jwt' value='" . esc_attr( $form->get_jwt() ) . "' />\n";
 			$r .= $form->body;
+			$has_manual_hcaptcha  = false;
+			if ( class_exists( HCaptcha::class ) ) {
+				$updated_form_body    = HCaptcha::replace_manual_widget( $r, $form->hash );
+				$has_manual_hcaptcha  = $updated_form_body !== $r;
+				$r                    = $updated_form_body;
+			}
+			$hcaptcha             = ( class_exists( HCaptcha::class ) && ! $has_manual_hcaptcha ) ? HCaptcha::render_widget( $form->hash ) : '';
+			$submit_error_wrapper = self::render_error_wrapper();
+			$before_submit_button = $submit_error_wrapper . $hcaptcha . ' ';
 
 			if ( $is_multistep ) {
-				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
+				$r = preg_replace(
+					'/<div class="wp-block-jetpack-form-step-navigation__wrapper/',
+					$before_submit_button . '<div class="wp-block-jetpack-form-step-navigation__wrapper',
+					$r,
+					1
+				);
 			} elseif ( $has_submit_button_block ) {
 				$r = self::prepare_submit_button( $r );
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
@@ -1485,14 +1499,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				if ( $is_forced_horizontal || $is_single_input_form ) {
 					// When user forced a horizontal layout, place the error wrapper
 					// after the form body.
-					$r .= self::render_error_wrapper( 'is-horizontal' );
+					$r .= $hcaptcha . self::render_error_wrapper( 'is-horizontal' );
 				} else {
 					// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
-					// Replace only the first occurrence.
-					$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );
-					if ( str_contains( $r, 'wp-block-button' ) ) {
-						$r = preg_replace( '/<div class="wp-block-button/', self::render_error_wrapper() . ' <div class="wp-block-button', $r, 1 );
-					}
+					$r = self::prepend_before_first_submit_button_block( $r, $before_submit_button );
 				}
 			}
 
@@ -1530,7 +1540,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$submit_button_text = $form->get_attribute( 'submit_button_text' );
 				}
 
-				$r .= self::render_error_wrapper();
+				$r .= $submit_error_wrapper;
+				$r .= $hcaptcha;
 				$r .= "\t\t<button type='submit' class='" . esc_attr( $submit_button_class ) . "'";
 				if ( ! empty( $submit_button_styles ) ) {
 					$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
@@ -1600,6 +1611,42 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		return $p->get_updated_html();
+	}
+
+	/**
+	 * Prepend markup before the first submit button block.
+	 *
+	 * The block wrapper may contain classes in any order, depending on how the
+	 * button block was produced or migrated.
+	 *
+	 * @param string $content Markup to update.
+	 * @param string $prepend Markup to prepend.
+	 * @return string
+	 */
+	private static function prepend_before_first_submit_button_block( $content, $prepend ) {
+		if ( '' === $prepend ) {
+			return $content;
+		}
+
+		$updated_content = preg_replace(
+			'~<div\b(?=[^>]*\bclass=(["\'])[^"\']*\bwp-block-(?:jetpack-)?button\b[^"\']*\1)~',
+			$prepend . '<div',
+			$content,
+			1
+		);
+
+		if ( null !== $updated_content && $updated_content !== $content ) {
+			return $updated_content;
+		}
+
+		$updated_content = preg_replace(
+			'~<button\b(?=[^>]*(?:\btype=(["\'])submit\1|\bclass=(["\'])[^"\']*\b(?:is-submit|form-button-submit)\b[^"\']*\2))~',
+			$prepend . '<button',
+			$content,
+			1
+		);
+
+		return null === $updated_content ? $content : $updated_content;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-hcaptcha.php
+++ b/projects/packages/forms/src/contact-form/class-hcaptcha.php
@@ -1,0 +1,754 @@
+<?php
+/**
+ * hCaptcha support for Jetpack Forms.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Adds hCaptcha rendering, settings, and verification to Jetpack Forms.
+ */
+class HCaptcha {
+
+	const OPTION_NAME   = 'jetpack_forms_hcaptcha';
+	const OPTION_GROUP  = 'jetpack_forms_hcaptcha';
+	const SETTINGS_PAGE = 'jetpack-forms-hcaptcha';
+	const SCRIPT_HANDLE = 'jetpack-forms-hcaptcha';
+	const VERIFY_URL    = 'https://api.hcaptcha.com/siteverify';
+	const API_SCRIPT    = 'https://js.hcaptcha.com/1/api.js';
+	const SHORTCODE     = 'hcaptcha';
+
+	/**
+	 * hCaptcha error messages.
+	 *
+	 * These strings intentionally match the hCaptcha plugin's verification
+	 * messages so Jetpack Forms shows the same submission errors.
+	 *
+	 * @return array
+	 */
+	private static function get_error_messages() {
+		return array(
+			'missing-input-secret'     => __( 'Your secret key is missing.', 'jetpack-forms' ),
+			'invalid-input-secret'     => __( 'Your secret key is invalid or malformed.', 'jetpack-forms' ),
+			'missing-input-response'   => __( 'The response parameter (verification token) is missing.', 'jetpack-forms' ),
+			'invalid-input-response'   => __( 'The response parameter (verification token) is invalid or malformed.', 'jetpack-forms' ),
+			'expired-input-response'   => __( 'The response parameter (verification token) is expired. (120s default)', 'jetpack-forms' ),
+			'already-seen-response'    => __( 'The response parameter (verification token) was already verified once.', 'jetpack-forms' ),
+			'bad-request'              => __( 'The request is invalid or malformed.', 'jetpack-forms' ),
+			'missing-remoteip'         => __( 'The remoteip parameter is missing.', 'jetpack-forms' ),
+			'invalid-remoteip'         => __( 'The remoteip parameter is not a valid IP address or blinded value.', 'jetpack-forms' ),
+			'not-using-dummy-passcode' => __( 'You have used a testing sitekey but have not used its matching secret.', 'jetpack-forms' ),
+			'sitekey-secret-mismatch'  => __( 'The sitekey is not registered with the provided secret.', 'jetpack-forms' ),
+			'empty'                    => __( 'Please complete the hCaptcha.', 'jetpack-forms' ),
+			'fail'                     => __( 'The hCaptcha is invalid.', 'jetpack-forms' ),
+		);
+	}
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var HCaptcha|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Whether the frontend hCaptcha styles have been queued.
+	 *
+	 * @var bool
+	 */
+	private static $styles_queued = false;
+
+	/**
+	 * Initialize hCaptcha integration hooks.
+	 *
+	 * @return HCaptcha
+	 */
+	public static function init() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_menu', array( $this, 'add_settings_menu' ), 11 );
+		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'verify' ), 5, 2 );
+		add_filter( 'script_loader_tag', array( $this, 'add_script_attributes' ), 10, 3 );
+	}
+
+	/**
+	 * Register settings for hCaptcha.
+	 */
+	public function register_settings() {
+		register_setting(
+			self::OPTION_GROUP,
+			self::OPTION_NAME,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				'default'           => self::get_default_settings(),
+			)
+		);
+
+		add_settings_section(
+			'jetpack_forms_hcaptcha_settings',
+			__( 'hCaptcha', 'jetpack-forms' ),
+			array( $this, 'render_settings_section' ),
+			self::SETTINGS_PAGE
+		);
+
+		add_settings_field(
+			'enabled',
+			__( 'Enable hCaptcha', 'jetpack-forms' ),
+			array( $this, 'render_enabled_field' ),
+			self::SETTINGS_PAGE,
+			'jetpack_forms_hcaptcha_settings'
+		);
+
+		add_settings_field(
+			'site_key',
+			__( 'Site key', 'jetpack-forms' ),
+			array( $this, 'render_site_key_field' ),
+			self::SETTINGS_PAGE,
+			'jetpack_forms_hcaptcha_settings'
+		);
+
+		add_settings_field(
+			'secret_key',
+			__( 'Secret key', 'jetpack-forms' ),
+			array( $this, 'render_secret_key_field' ),
+			self::SETTINGS_PAGE,
+			'jetpack_forms_hcaptcha_settings'
+		);
+	}
+
+	/**
+	 * Add the hCaptcha settings page to the Jetpack admin menu.
+	 */
+	public function add_settings_menu() {
+		Admin_Menu::add_menu(
+			__( 'Jetpack Forms hCaptcha', 'jetpack-forms' ),
+			__( 'Forms hCaptcha', 'jetpack-forms' ),
+			'manage_options',
+			self::SETTINGS_PAGE,
+			array( $this, 'render_settings_page' ),
+			11
+		);
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage hCaptcha settings.', 'jetpack-forms' ) );
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Jetpack Forms hCaptcha', 'jetpack-forms' ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( self::OPTION_GROUP );
+				do_settings_sections( self::SETTINGS_PAGE );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the settings section description.
+	 */
+	public function render_settings_section() {
+		$description = __(
+			'Add an hCaptcha challenge to Jetpack Forms and verify submissions before responses are saved.',
+			'jetpack-forms'
+		);
+
+		echo '<p>';
+		echo esc_html( $description );
+		echo '</p>';
+	}
+
+	/**
+	 * Render the enabled checkbox.
+	 */
+	public function render_enabled_field() {
+		$settings = self::get_settings();
+		?>
+		<label>
+			<input
+				type="checkbox"
+				name="<?php echo esc_attr( self::OPTION_NAME ); ?>[enabled]"
+				value="1"
+				<?php checked( $settings['enabled'] ); ?>
+			/>
+			<?php esc_html_e( 'Require hCaptcha on Jetpack Forms.', 'jetpack-forms' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Render the site key input.
+	 */
+	public function render_site_key_field() {
+		$settings = self::get_settings();
+		?>
+		<input
+			type="text"
+			class="regular-text"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[site_key]"
+			value="<?php echo esc_attr( $settings['site_key'] ); ?>"
+			autocomplete="off"
+		/>
+		<?php
+	}
+
+	/**
+	 * Render the secret key input.
+	 */
+	public function render_secret_key_field() {
+		$settings = self::get_settings();
+		?>
+		<input
+			type="password"
+			class="regular-text"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[secret_key]"
+			value="<?php echo esc_attr( $settings['secret_key'] ); ?>"
+			autocomplete="off"
+		/>
+		<?php
+	}
+
+	/**
+	 * Sanitize hCaptcha settings.
+	 *
+	 * @param array|mixed $settings Raw settings.
+	 * @return array
+	 */
+	public function sanitize_settings( $settings ) {
+		$settings = is_array( $settings ) ? $settings : array();
+
+		$sanitized = array(
+			'enabled'    => ! empty( $settings['enabled'] ),
+			'site_key'   => self::sanitize_setting_value( $settings, 'site_key' ),
+			'secret_key' => self::sanitize_setting_value( $settings, 'secret_key' ),
+		);
+
+		if ( $sanitized['enabled'] && ( '' === $sanitized['site_key'] || '' === $sanitized['secret_key'] ) ) {
+			add_settings_error(
+				self::OPTION_NAME,
+				'jetpack_forms_hcaptcha_missing_keys',
+				__( 'Enter both the hCaptcha site key and secret key before enabling hCaptcha for Jetpack Forms.', 'jetpack-forms' )
+			);
+			$sanitized['enabled'] = false;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Get default hCaptcha settings.
+	 *
+	 * @return array
+	 */
+	private static function get_default_settings() {
+		return array(
+			'enabled'    => false,
+			'site_key'   => '',
+			'secret_key' => '',
+		);
+	}
+
+	/**
+	 * Get hCaptcha settings.
+	 *
+	 * @return array
+	 */
+	public static function get_settings() {
+		$settings = get_option( self::OPTION_NAME, array() );
+		$settings = is_array( $settings ) ? $settings : array();
+		$settings = wp_parse_args( $settings, self::get_default_settings() );
+
+		/**
+		 * Filters Jetpack Forms hCaptcha settings.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $settings hCaptcha settings.
+		 */
+		return apply_filters( 'jetpack_forms_hcaptcha_settings', $settings );
+	}
+
+	/**
+	 * Whether hCaptcha is fully configured and enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		$settings = self::get_settings();
+		$enabled  = ! empty( $settings['enabled'] ) && ! empty( $settings['site_key'] ) && ! empty( $settings['secret_key'] );
+
+		/**
+		 * Filters whether hCaptcha protection is enabled for Jetpack Forms.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool  $enabled  Whether hCaptcha protection is enabled.
+		 * @param array $settings hCaptcha settings.
+		 */
+		return (bool) apply_filters( 'jetpack_forms_hcaptcha_enabled', $enabled, $settings );
+	}
+
+	/**
+	 * Render the hCaptcha widget for a form.
+	 *
+	 * @param string $form_hash  Form hash.
+	 * @param array  $attributes Optional hCaptcha widget attributes.
+	 * @return string
+	 */
+	public static function render_widget( $form_hash = '', $attributes = array() ) {
+		if ( ! self::is_enabled() ) {
+			return '';
+		}
+
+		$settings = self::get_settings();
+
+		self::enqueue_scripts();
+		self::enqueue_styles();
+
+		$widget_attributes = array_merge(
+			array(
+				'class'        => 'h-captcha',
+				'data-sitekey' => $settings['site_key'],
+			),
+			self::get_widget_data_attributes( $attributes )
+		);
+
+		return sprintf(
+			'<div class="grunion-field-hcaptcha-wrap grunion-field-wrap" data-jetpack-forms-hcaptcha="%1$s">' .
+				'<div%2$s></div>' .
+			'</div>',
+			esc_attr( $form_hash ),
+			self::build_html_attributes( $widget_attributes )
+		);
+	}
+
+	/**
+	 * Replace a manually inserted hCaptcha shortcode or widget with native Jetpack markup.
+	 *
+	 * @param string $html      Form markup.
+	 * @param string $form_hash Form hash.
+	 * @return string
+	 */
+	public static function replace_manual_widget( $html, $form_hash = '' ) {
+		if ( ! is_string( $html ) || '' === $html ) {
+			return $html;
+		}
+
+		$updated_html = self::replace_hcaptcha_shortcode( $html, $form_hash );
+		if ( $updated_html !== $html ) {
+			return $updated_html;
+		}
+
+		return self::replace_hcaptcha_markup( $html, $form_hash );
+	}
+
+	/**
+	 * Replace a manually inserted hCaptcha shortcode with native Jetpack markup.
+	 *
+	 * @param string $html      Form markup.
+	 * @param string $form_hash Form hash.
+	 * @return string
+	 */
+	private static function replace_hcaptcha_shortcode( $html, $form_hash ) {
+		if ( ! str_contains( $html, '[' . self::SHORTCODE ) ) {
+			return $html;
+		}
+
+		$shortcode_regex = get_shortcode_regex( array( self::SHORTCODE ) );
+
+		$updated_html = preg_replace_callback(
+			'~<p>\s*(' . $shortcode_regex . ')\s*</p>~s',
+			function ( $matches ) use ( $form_hash ) {
+				return self::render_widget( $form_hash, self::parse_shortcode_attributes( $matches[1] ) );
+			},
+			$html,
+			1
+		);
+
+		if ( null !== $updated_html && $updated_html !== $html ) {
+			return $updated_html;
+		}
+
+		$updated_html = preg_replace_callback(
+			'~' . $shortcode_regex . '~s',
+			function ( $matches ) use ( $form_hash ) {
+				return self::render_widget( $form_hash, self::parse_shortcode_attributes( $matches[0] ) );
+			},
+			$html,
+			1
+		);
+
+		return null === $updated_html ? $html : $updated_html;
+	}
+
+	/**
+	 * Replace a manually inserted hCaptcha custom element or div with native Jetpack markup.
+	 *
+	 * @param string $html      Form markup.
+	 * @param string $form_hash Form hash.
+	 * @return string
+	 */
+	private static function replace_hcaptcha_markup( $html, $form_hash ) {
+		if ( ! str_contains( $html, 'h-captcha' ) && ! str_contains( $html, 'hcaptcha-widget-id' ) ) {
+			return $html;
+		}
+
+		$hcaptcha      = self::render_widget( $form_hash, self::get_hcaptcha_markup_attributes( $html ) );
+		$error_message = '(?:\s*<div\b(?=[^>]*\bclass=["\'][^"\']*\bcontact-form__input-error\b)[^>]*>[\s\S]*?</div>\s*)?';
+		$patterns      = array(
+			'~<div\b(?=[^>]*\bclass=(["\'])[^"\']*\bgrunion-field-hcaptcha-wrap\b[^"\']*\1)[^>]*>\s*<(?:div|h-captcha)\b[\s\S]*?</(?:div|h-captcha)>\s*</div>' . $error_message . '~',
+			'~(?:\s*<input\b(?=[^>]*\bname=(["\'])hcaptcha-widget-id\1)[^>]*>\s*)?<h-captcha\b[\s\S]*?</h-captcha>(?:\s*<input\b(?=[^>]*\bname=(["\'])(?:hcaptcha(?:_[^"\']+)?_nonce|_wp_http_referer|hcap_hp_[^"\']+|hcap_hp_sig)\2)[^>]*>)*' . $error_message . '~',
+			'~<div\b(?=[^>]*\bclass=(["\'])[^"\']*\bh-captcha\b[^"\']*\1)[^>]*>\s*</div>' . $error_message . '~',
+		);
+
+		foreach ( $patterns as $pattern ) {
+			$updated_html = preg_replace( $pattern, $hcaptcha, $html, 1 );
+			if ( null !== $updated_html && $updated_html !== $html ) {
+				return $updated_html;
+			}
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Parse hCaptcha shortcode attributes.
+	 *
+	 * @param string $shortcode Shortcode markup.
+	 * @return array
+	 */
+	private static function parse_shortcode_attributes( $shortcode ) {
+		if ( ! preg_match( '/^\[' . preg_quote( self::SHORTCODE, '/' ) . '\b([^\]]*)\]/i', $shortcode, $matches ) ) {
+			return array();
+		}
+
+		$attributes = shortcode_parse_atts( $matches[1] );
+		return is_array( $attributes ) ? self::sanitize_attribute_array( $attributes ) : array();
+	}
+
+	/**
+	 * Extract hCaptcha widget attributes from existing markup.
+	 *
+	 * @param string $html Form markup.
+	 * @return array
+	 */
+	private static function get_hcaptcha_markup_attributes( $html ) {
+		$tag_attributes = '';
+
+		if ( preg_match( '~<h-captcha\b([^>]*)>~', $html, $matches ) ) {
+			$tag_attributes = $matches[1];
+		} elseif ( preg_match( '~<div\b(?=[^>]*\bclass=(["\'])[^"\']*\bh-captcha\b[^"\']*\1)([^>]*)>~', $html, $matches ) ) {
+			$tag_attributes = $matches[2];
+		}
+
+		if ( '' === $tag_attributes ) {
+			return array();
+		}
+
+		$attributes = array();
+		foreach ( array( 'theme', 'size', 'tabindex' ) as $attribute ) {
+			$data_attribute = 'data-' . $attribute;
+			if ( preg_match( '/\s' . preg_quote( $data_attribute, '/' ) . '=(["\'])(.*?)\1/', $tag_attributes, $matches ) ) {
+				$attributes[ $attribute ] = html_entity_decode( $matches[2], ENT_QUOTES | ENT_HTML5, get_bloginfo( 'charset' ) );
+			}
+		}
+
+		return self::sanitize_attribute_array( $attributes );
+	}
+
+	/**
+	 * Convert supported hCaptcha attributes into data attributes.
+	 *
+	 * @param array $attributes hCaptcha attributes.
+	 * @return array
+	 */
+	private static function get_widget_data_attributes( $attributes ) {
+		if ( ! is_array( $attributes ) ) {
+			return array();
+		}
+
+		$attribute_map = array(
+			'theme'    => 'data-theme',
+			'size'     => 'data-size',
+			'tabindex' => 'data-tabindex',
+		);
+		$data_attributes = array();
+
+		foreach ( $attribute_map as $source => $target ) {
+			if ( ! isset( $attributes[ $source ] ) || ! is_scalar( $attributes[ $source ] ) ) {
+				continue;
+			}
+
+			$value = sanitize_text_field( wp_unslash( (string) $attributes[ $source ] ) );
+			if ( '' !== $value ) {
+				$data_attributes[ $target ] = $value;
+			}
+		}
+
+		return $data_attributes;
+	}
+
+	/**
+	 * Build an HTML attribute string.
+	 *
+	 * @param array $attributes HTML attributes.
+	 * @return string
+	 */
+	private static function build_html_attributes( $attributes ) {
+		$html = '';
+
+		foreach ( $attributes as $name => $value ) {
+			$html .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Sanitize a shortcode or markup attribute array.
+	 *
+	 * @param array $attributes Raw attributes.
+	 * @return array
+	 */
+	private static function sanitize_attribute_array( $attributes ) {
+		$sanitized = array();
+
+		foreach ( $attributes as $name => $value ) {
+			if ( ! is_string( $name ) || ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$sanitized[ sanitize_key( $name ) ] = sanitize_text_field( wp_unslash( (string) $value ) );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Get hCaptcha error message by code.
+	 *
+	 * @param string $code Error code.
+	 * @return string
+	 */
+	private static function get_error_message_by_code( $code ) {
+		$messages = self::get_error_messages();
+
+		return $messages[ $code ] ?? '';
+	}
+
+	/**
+	 * Get hCaptcha API error message by response codes.
+	 *
+	 * @param array $error_codes Error codes returned by hCaptcha.
+	 * @return string
+	 */
+	private static function get_api_error_message( $error_codes ) {
+		$messages      = self::get_error_messages();
+		$error_codes   = (array) $error_codes;
+		$message_parts = array();
+
+		foreach ( $error_codes as $error_code ) {
+			if ( isset( $messages[ $error_code ] ) ) {
+				$message_parts[] = $messages[ $error_code ];
+			}
+		}
+
+		if ( ! $message_parts ) {
+			return '';
+		}
+
+		$header = _n( 'hCaptcha error:', 'hCaptcha errors:', count( $message_parts ), 'jetpack-forms' );
+
+		return $header . ' ' . implode( '; ', $message_parts );
+	}
+
+	/**
+	 * Create a hCaptcha submission error.
+	 *
+	 * @param string $message Error message.
+	 * @return WP_Error
+	 */
+	private static function create_submission_error( $message ) {
+		return new WP_Error( 'invalid_hcaptcha', esc_html( $message ) );
+	}
+
+	/**
+	 * Verify the hCaptcha token for a submitted form.
+	 *
+	 * @param bool|WP_Error $is_spam Current spam status.
+	 * @param array         $form    Submitted form values prepared for spam checks.
+	 * @return bool|WP_Error
+	 */
+	public function verify( $is_spam = false, $form = array() ) {
+		unset( $form );
+
+		if ( $is_spam || ! self::is_enabled() ) {
+			return $is_spam;
+		}
+
+		$token = self::get_post_value( 'h-captcha-response' );
+
+		if ( '' === $token ) {
+			return self::create_submission_error( self::get_error_message_by_code( 'empty' ) );
+		}
+
+		$settings = self::get_settings();
+		$body     = array(
+			'secret'   => $settings['secret_key'],
+			'response' => $token,
+			'sitekey'  => $settings['site_key'],
+		);
+		$remoteip = Contact_Form_Plugin::get_ip_address();
+
+		if ( $remoteip ) {
+			$body['remoteip'] = $remoteip;
+		}
+
+		/**
+		 * Filters the hCaptcha verification URL used by Jetpack Forms.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $url hCaptcha siteverify endpoint.
+		 */
+		$verify_url = apply_filters( 'jetpack_forms_hcaptcha_verify_url', self::VERIFY_URL );
+
+		$response = wp_remote_post(
+			$verify_url,
+			array(
+				'timeout' => 10,
+				'body'    => $body,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return self::create_submission_error( implode( "\n", $response->get_error_messages() ) );
+		}
+
+		$response_body_raw = wp_remote_retrieve_body( $response );
+
+		if ( '' === $response_body_raw ) {
+			return self::create_submission_error( self::get_error_message_by_code( 'fail' ) );
+		}
+
+		$response_body = json_decode( $response_body_raw, true );
+
+		if ( is_array( $response_body ) && ! empty( $response_body['success'] ) ) {
+			return false;
+		}
+
+		$error_codes = is_array( $response_body ) ? ( $response_body['error-codes'] ?? array() ) : array();
+		$message     = self::get_api_error_message( $error_codes );
+
+		return self::create_submission_error( $message ? $message : self::get_error_message_by_code( 'fail' ) );
+	}
+
+	/**
+	 * Add async and defer attributes to the hCaptcha API script.
+	 *
+	 * @param string $tag    Script tag.
+	 * @param string $handle Script handle.
+	 * @param string $src    Script source.
+	 * @return string
+	 */
+	public function add_script_attributes( $tag, $handle, $src ) {
+		unset( $src );
+
+		if ( self::SCRIPT_HANDLE !== $handle ) {
+			return $tag;
+		}
+
+		return str_replace( ' src', ' async defer src', $tag );
+	}
+
+	/**
+	 * Enqueue the hCaptcha API script.
+	 */
+	private static function enqueue_scripts() {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_script(
+			self::SCRIPT_HANDLE,
+			self::API_SCRIPT,
+			array(),
+			null,
+			true
+		);
+	}
+
+	/**
+	 * Enqueue hCaptcha alignment styles.
+	 */
+	private static function enqueue_styles() {
+		if ( self::$styles_queued ) {
+			return;
+		}
+
+		wp_add_inline_style(
+			'grunion.css',
+			'
+form.contact-form .grunion-field-hcaptcha-wrap.grunion-field-wrap {
+	flex-direction: row;
+}
+
+form.contact-form .grunion-field-hcaptcha-wrap .h-captcha {
+	margin-block-end: 0;
+}
+'
+		);
+
+		self::$styles_queued = true;
+	}
+
+	/**
+	 * Get a sanitized POST value.
+	 *
+	 * @param string $key POST key.
+	 * @return string
+	 */
+	private static function get_post_value( $key ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
+	}
+
+	/**
+	 * Sanitize a scalar settings value.
+	 *
+	 * @param array  $settings Settings array.
+	 * @param string $key      Setting key.
+	 * @return string
+	 */
+	private static function sanitize_setting_value( array $settings, $key ) {
+		if ( ! isset( $settings[ $key ] ) || ! is_scalar( $settings[ $key ] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( wp_unslash( (string) $settings[ $key ] ) );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4299,6 +4299,25 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test submit button block detection when the block class is not first.
+	 */
+	public function test_prepend_before_first_submit_button_block_matches_button_class_in_any_position() {
+		$reflection = new \ReflectionClass( Contact_Form::class );
+		$method     = $reflection->getMethod( 'prepend_before_first_submit_button_block' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$content = '<div class="aligncenter wp-block-button is-style-outline"><button type="submit">Submit</button></div>';
+		$result  = $method->invoke( null, $content, '<span class="captcha"></span>' );
+
+		$this->assertSame(
+			'<span class="captcha"></span><div class="aligncenter wp-block-button is-style-outline"><button type="submit">Submit</button></div>',
+			$result
+		);
+	}
+
+	/**
 	 * Data provider for prepare_submit_button tests.
 	 */
 	public static function data_provider_prepare_submit_button() {

--- a/projects/packages/forms/tests/php/contact-form/HCaptcha_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/HCaptcha_Test.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Unit Tests for hCaptcha support.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+require_once __DIR__ . '/../../../src/contact-form/class-hcaptcha.php';
+
+/**
+ * Test class for HCaptcha.
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\HCaptcha
+ */
+#[CoversClass( HCaptcha::class )]
+class HCaptcha_Test extends BaseTestCase {
+
+	/**
+	 * Tear down test state.
+	 */
+	public function tear_down() {
+		delete_option( HCaptcha::OPTION_NAME );
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'jetpack_forms_hcaptcha_settings' );
+		remove_all_filters( 'jetpack_forms_hcaptcha_enabled' );
+		remove_all_filters( 'jetpack_forms_hcaptcha_verify_url' );
+		wp_dequeue_script( HCaptcha::SCRIPT_HANDLE );
+		wp_deregister_script( HCaptcha::SCRIPT_HANDLE );
+		unset( $_POST['h-captcha-response'] );
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	/**
+	 * Test that no widget is rendered when hCaptcha is disabled.
+	 */
+	public function test_render_widget_returns_empty_when_disabled() {
+		$this->assertSame( '', HCaptcha::render_widget( 'abc123' ) );
+		$this->assertFalse( wp_script_is( HCaptcha::SCRIPT_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the widget renders when hCaptcha is configured.
+	 */
+	public function test_render_widget_outputs_hcaptcha_markup_when_enabled() {
+		$this->enable_hcaptcha();
+
+		$html = HCaptcha::render_widget( 'abc123' );
+
+		$this->assertStringContainsString( 'class="h-captcha"', $html );
+		$this->assertStringContainsString( 'data-sitekey="site-key"', $html );
+		$this->assertStringContainsString( 'data-jetpack-forms-hcaptcha="abc123"', $html );
+		$this->assertTrue( wp_script_is( HCaptcha::SCRIPT_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Test that supported widget attributes are rendered as hCaptcha data attributes.
+	 */
+	public function test_render_widget_outputs_optional_hcaptcha_attributes() {
+		$this->enable_hcaptcha();
+
+		$html = HCaptcha::render_widget(
+			'abc123',
+			array(
+				'size'     => 'compact',
+				'theme'    => 'dark',
+				'tabindex' => '2',
+				'onload'   => 'ignored',
+			)
+		);
+
+		$this->assertStringContainsString( 'data-size="compact"', $html );
+		$this->assertStringContainsString( 'data-theme="dark"', $html );
+		$this->assertStringContainsString( 'data-tabindex="2"', $html );
+		$this->assertStringNotContainsString( 'onload', $html );
+	}
+
+	/**
+	 * Test that manually inserted hCaptcha shortcodes are replaced by native markup.
+	 */
+	public function test_replace_manual_shortcode_outputs_hcaptcha_markup() {
+		$this->enable_hcaptcha();
+
+		$html = '<div class="field">Name</div><p>[hcaptcha size="compact" theme="dark"]</p>';
+
+		$result = HCaptcha::replace_manual_widget( $html, 'abc123' );
+
+		$this->assertStringContainsString( 'data-jetpack-forms-hcaptcha="abc123"', $result );
+		$this->assertStringContainsString( 'class="h-captcha"', $result );
+		$this->assertStringContainsString( 'data-size="compact"', $result );
+		$this->assertStringContainsString( 'data-theme="dark"', $result );
+		$this->assertStringNotContainsString( '[hcaptcha', $result );
+	}
+
+	/**
+	 * Test that manual hCaptcha shortcodes are removed when hCaptcha is disabled.
+	 */
+	public function test_replace_manual_shortcode_removes_placeholder_when_hcaptcha_is_disabled() {
+		$html = '<div class="field">Name</div><p>[hcaptcha size="compact"]</p>';
+
+		$result = HCaptcha::replace_manual_widget( $html, 'abc123' );
+
+		$this->assertStringContainsString( '<div class="field">Name</div>', $result );
+		$this->assertStringNotContainsString( '[hcaptcha', $result );
+		$this->assertStringNotContainsString( 'h-captcha', $result );
+	}
+
+	/**
+	 * Test that manually inserted hCaptcha markup is replaced by native markup.
+	 */
+	public function test_replace_manual_markup_outputs_hcaptcha_markup() {
+		$this->enable_hcaptcha();
+
+		$html = '<input type="hidden" name="hcaptcha-widget-id" value="widget"><h-captcha data-size="compact" data-theme="dark"></h-captcha>';
+
+		$result = HCaptcha::replace_manual_widget( $html, 'abc123' );
+
+		$this->assertStringContainsString( 'data-jetpack-forms-hcaptcha="abc123"', $result );
+		$this->assertStringContainsString( 'class="h-captcha"', $result );
+		$this->assertStringContainsString( 'data-size="compact"', $result );
+		$this->assertStringContainsString( 'data-theme="dark"', $result );
+		$this->assertStringNotContainsString( '<h-captcha', $result );
+		$this->assertStringNotContainsString( 'hcaptcha-widget-id', $result );
+	}
+
+	/**
+	 * Test that stale hCaptcha error markup is removed when normalizing markup.
+	 */
+	public function test_replace_manual_markup_removes_existing_hcaptcha_error_message() {
+		$this->enable_hcaptcha();
+
+		$html = '<h-captcha data-size="compact"></h-captcha><div class="contact-form__input-error">Old error</div>';
+
+		$result = HCaptcha::replace_manual_widget( $html, 'abc123' );
+
+		$this->assertStringContainsString( 'data-jetpack-forms-hcaptcha="abc123"', $result );
+		$this->assertStringNotContainsString( 'Old error', $result );
+		$this->assertStringNotContainsString( 'contact-form__input-error', $result );
+	}
+
+	/**
+	 * Test that verification is skipped when hCaptcha is disabled.
+	 */
+	public function test_verify_returns_current_status_when_disabled() {
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return false;
+			}
+		);
+
+		$result = HCaptcha::init()->verify( false, array() );
+
+		$this->assertFalse( $result );
+		$this->assertFalse( $http_request_made );
+	}
+
+	/**
+	 * Test that a missing token aborts the submission.
+	 */
+	public function test_verify_fails_when_response_token_is_missing() {
+		$this->enable_hcaptcha();
+
+		$result = HCaptcha::init()->verify( false, array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_hcaptcha', $result->get_error_code() );
+		$this->assertSame( 'Please complete the hCaptcha.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that successful hCaptcha verification allows the submission to continue.
+	 */
+	public function test_verify_allows_successful_hcaptcha_response() {
+		$this->enable_hcaptcha();
+
+		$_POST['h-captcha-response'] = 'token';
+		$_SERVER['REMOTE_ADDR']      = '203.0.113.10';
+
+		$captured_url  = null;
+		$captured_args = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_url, &$captured_args ) {
+				$captured_url  = $url;
+				$captured_args = $args;
+
+				return array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => wp_json_encode(
+						array(
+							'success' => true,
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$result = HCaptcha::init()->verify( false, array() );
+
+		$this->assertFalse( $result );
+		$this->assertSame( HCaptcha::VERIFY_URL, $captured_url );
+		$this->assertSame( 'secret-key', $captured_args['body']['secret'] );
+		$this->assertSame( 'token', $captured_args['body']['response'] );
+		$this->assertSame( 'site-key', $captured_args['body']['sitekey'] );
+		$this->assertSame( '203.0.113.10', $captured_args['body']['remoteip'] );
+	}
+
+	/**
+	 * Test that unsuccessful hCaptcha verification aborts the submission.
+	 */
+	public function test_verify_fails_when_hcaptcha_rejects_response() {
+		$this->enable_hcaptcha();
+
+		$_POST['h-captcha-response'] = 'bad-token';
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => wp_json_encode(
+						array(
+							'success'     => false,
+							'error-codes' => array( 'invalid-input-response' ),
+						)
+					),
+				);
+			}
+		);
+
+		$result = HCaptcha::init()->verify( false, array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_hcaptcha', $result->get_error_code() );
+		$this->assertSame(
+			'hCaptcha error: The response parameter (verification token) is invalid or malformed.',
+			$result->get_error_message()
+		);
+	}
+
+	/**
+	 * Test that an empty hCaptcha verification response uses the generic hCaptcha failure message.
+	 */
+	public function test_verify_fails_with_hcaptcha_failure_message_when_response_body_is_empty() {
+		$this->enable_hcaptcha();
+
+		$_POST['h-captcha-response'] = 'bad-token';
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '',
+				);
+			}
+		);
+
+		$result = HCaptcha::init()->verify( false, array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_hcaptcha', $result->get_error_code() );
+		$this->assertSame( 'The hCaptcha is invalid.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that settings cannot enable hCaptcha without both keys.
+	 */
+	public function test_sanitize_settings_disables_hcaptcha_when_keys_are_missing() {
+		$result = HCaptcha::init()->sanitize_settings(
+			array(
+				'enabled'  => '1',
+				'site_key' => 'site-key',
+			)
+		);
+
+		$this->assertFalse( $result['enabled'] );
+		$this->assertSame( 'site-key', $result['site_key'] );
+		$this->assertSame( '', $result['secret_key'] );
+	}
+
+	/**
+	 * Enable hCaptcha for tests.
+	 */
+	private function enable_hcaptcha() {
+		update_option(
+			HCaptcha::OPTION_NAME,
+			array(
+				'enabled'    => true,
+				'site_key'   => 'site-key',
+				'secret_key' => 'secret-key',
+			)
+		);
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add optional native hCaptcha support for Jetpack Forms.
* Add Jetpack Forms hCaptcha settings for enabling the integration and storing the site key and secret key.
* Render the hCaptcha widget in Jetpack Forms near the submit button, including manually inserted `[hcaptcha]` placeholders in classic and block forms.
* Verify hCaptcha server-side before feedback is saved, returning `WP_Error` on hCaptcha failures so submissions are aborted instead of being marked as spam.
* Add focused tests for hCaptcha rendering, manual placeholder handling, submit-button insertion, and verification outcomes.

## Related product discussion/links
* This contribution was previously discussed with Jetpack/Product leadership; this is intended as a coordinated contribution, not an unsolicited vendor proposal.

## Does this pull request change what data or activity we track or use?
When hCaptcha is explicitly enabled for Jetpack Forms, form submissions are verified with hCaptcha's siteverify endpoint. That request includes the submitted hCaptcha response token, the configured hCaptcha site key and secret key, and the visitor IP address when available.

No new Automattic analytics or tracking events are added.

## Testing instructions
* Build or install Jetpack from this branch.
* Activate Jetpack and deactivate any standalone hCaptcha plugin to test the native integration.
* Go to the Jetpack Forms hCaptcha settings page.
* Enable hCaptcha and enter a valid hCaptcha site key and secret key.
* Create or open Jetpack Forms covering:
  * A classic contact form shortcode.
  * A legacy block form.
  * A newer synced/ref block form.
  * A classic form with a manually inserted `[hcaptcha]` shortcode.
  * A block form with a manually inserted `[hcaptcha]` shortcode.
* Confirm the hCaptcha widget appears once per form and raw `[hcaptcha]` shortcode text is not displayed.
* Submit a form without completing hCaptcha and confirm the submission is rejected with the hCaptcha error message.
* Complete hCaptcha and submit the form, then confirm the feedback is saved.
* Run `php -l projects/packages/forms/src/contact-form/class-hcaptcha.php`.
* Run `php -l projects/packages/forms/tests/php/contact-form/HCaptcha_Test.php`.
* Run `git diff --check`.
* Run `vendor/bin/phpunit-select-config phpunit.#.xml.dist --filter HCaptcha_Test` from `projects/packages/forms`.
