### PR TITLE
Social: add image focal point to link previews

### DIFF
--- a/projects/js-packages/social-previews/changelog/add-social-image-focal-point-previews
+++ b/projects/js-packages/social-previews/changelog/add-social-image-focal-point-previews
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Render an image focal point in the link previews via object-position.

--- a/projects/js-packages/social-previews/src/bluesky-preview/post/card/index.tsx
+++ b/projects/js-packages/social-previews/src/bluesky-preview/post/card/index.tsx
@@ -1,15 +1,22 @@
 import { baseDomain, getTitleFromDescription, stripHtmlTags } from '../../../helpers';
+import { MediaImage } from '../../../shared/media-image';
 import { blueskyTitle } from '../../helpers';
 import { BlueskyPreviewProps } from '../../types';
 
 import './styles.scss';
 
-const BlueskyPostCard: React.FC< BlueskyPreviewProps > = ( { title, description, url, image } ) => {
+const BlueskyPostCard: React.FC< BlueskyPreviewProps > = ( {
+	title,
+	description,
+	url,
+	image,
+	imageFocalPoint,
+} ) => {
 	return (
 		<div className="bluesky-preview__card">
 			{ image ? (
 				<div className="bluesky-preview__card-image">
-					<img src={ image } alt="" />
+					<MediaImage src={ image } alt="" focalPoint={ imageFocalPoint } />
 				</div>
 			) : null }
 			<div className="bluesky-preview__card-text">

--- a/projects/js-packages/social-previews/src/facebook-preview/link-preview-details.tsx
+++ b/projects/js-packages/social-previews/src/facebook-preview/link-preview-details.tsx
@@ -1,4 +1,5 @@
 import { PORTRAIT_MODE } from '../constants';
+import { MediaImage } from '../shared/media-image';
 import CustomText from './custom-text';
 import useImage from './hooks/use-image-hook';
 import FacebookPostActions from './post/actions';
@@ -8,6 +9,7 @@ import type { FacebookPreviewProps } from './types';
 export const LinkPreviewDetails: React.FC< FacebookPreviewProps > = ( {
 	url,
 	customImage,
+	imageFocalPoint,
 	user,
 	customText,
 	imageMode,
@@ -25,8 +27,7 @@ export const LinkPreviewDetails: React.FC< FacebookPreviewProps > = ( {
 					}` }
 				>
 					<div className={ `facebook-preview__custom-image ${ modeClass }` }>
-						{ /* eslint-disable jsx-a11y/alt-text */ }
-						<img src={ customImage } { ...imgProps } />
+						<MediaImage src={ customImage } focalPoint={ imageFocalPoint } { ...imgProps } />
 					</div>
 					<FacebookPostHeader user={ user } timeElapsed hideOptions />
 					{ customText && <CustomText text={ customText } url={ url } forceUrlDisplay /> }

--- a/projects/js-packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/projects/js-packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { TYPE_ARTICLE, PORTRAIT_MODE } from '../constants';
 import { baseDomain } from '../helpers';
+import { MediaImage } from '../shared/media-image';
 import CustomText from './custom-text';
 import { facebookTitle, facebookDescription } from './helpers';
 import useImage from './hooks/use-image-hook';
@@ -20,6 +21,7 @@ export const FacebookLinkPreview: React.FC< FacebookLinkPreviewProps > = ( {
 	title,
 	description,
 	image,
+	imageFocalPoint,
 	user,
 	customText,
 	type,
@@ -45,8 +47,9 @@ export const FacebookLinkPreview: React.FC< FacebookLinkPreviewProps > = ( {
 						<div
 							className={ `facebook-preview__image ${ image ? '' : 'is-empty' } ${ modeClass }` }
 						>
-							{ /* eslint-disable jsx-a11y/alt-text */ }
-							{ image && <img src={ image } { ...imgProps } /> }
+							{ image && (
+								<MediaImage src={ image } focalPoint={ imageFocalPoint } { ...imgProps } />
+							) }
 						</div>
 					) }
 					<div className="facebook-preview__text">

--- a/projects/js-packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { AvatarWithFallback } from '../avatar-with-fallback';
 import { preparePreviewText } from '../helpers';
 import { ExpandableText } from '../shared/expandable-text';
+import { MediaImage } from '../shared/media-image';
 import { FEED_TEXT_MAX_LENGTH } from './constants';
 import { Bookmark as BookmarkIcon } from './icons/bookmark';
 import { Comment as CommentIcon } from './icons/comment';
@@ -20,6 +21,7 @@ import './style.scss';
  */
 export function InstagramPostPreview( {
 	image,
+	imageFocalPoint,
 	media,
 	name,
 	profileImage,
@@ -56,7 +58,12 @@ export function InstagramPostPreview( {
 							) }
 						</div>
 					) : (
-						<img className="instagram-preview__media--image" src={ image } alt="" />
+						<MediaImage
+							className="instagram-preview__media--image"
+							src={ image }
+							alt=""
+							focalPoint={ imageFocalPoint }
+						/>
 					) }
 				</div>
 				<div className="instagram-preview__content">

--- a/projects/js-packages/social-previews/src/instagram-preview/types.ts
+++ b/projects/js-packages/social-previews/src/instagram-preview/types.ts
@@ -1,6 +1,9 @@
 import { SocialPreviewBaseProps, SocialPreviewsBaseProps } from '../types';
 
-export type InstagramPreviewProps = Pick< SocialPreviewBaseProps, 'image' | 'media' | 'url' > & {
+export type InstagramPreviewProps = Pick<
+	SocialPreviewBaseProps,
+	'image' | 'imageFocalPoint' | 'media' | 'url'
+> & {
 	name: string;
 	profileImage: string;
 	caption?: string;

--- a/projects/js-packages/social-previews/src/linkedin-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/linkedin-preview/post-preview.tsx
@@ -2,6 +2,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { AvatarWithFallback } from '../avatar-with-fallback';
 import { baseDomain, getTitleFromDescription, preparePreviewText } from '../helpers';
 import { ExpandableText } from '../shared/expandable-text';
+import { MediaImage } from '../shared/media-image';
 import { FEED_TEXT_MAX_LENGTH } from './constants';
 import { LinkedInPreviewProps } from './types';
 import './style.scss';
@@ -16,6 +17,7 @@ import './style.scss';
 export function LinkedInPostPreview( {
 	articleReadTime = 5,
 	image,
+	imageFocalPoint,
 	jobTitle,
 	name,
 	profileImage,
@@ -106,7 +108,14 @@ export function LinkedInPostPreview( {
 						</div>
 					) : (
 						<article>
-							{ image ? <img className="linkedin-preview__image" src={ image } alt="" /> : null }
+							{ image ? (
+								<MediaImage
+									className="linkedin-preview__image"
+									src={ image }
+									alt=""
+									focalPoint={ imageFocalPoint }
+								/>
+							) : null }
 							{ url ? (
 								<div className="linkedin-preview__description">
 									<h2 className="linkedin-preview__description--title">

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/card/index.tsx
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/card/index.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { baseDomain, getTitleFromDescription, stripHtmlTags } from '../../../helpers';
+import { MediaImage } from '../../../shared/media-image';
 import { mastodonTitle } from '../../helpers';
 import { MastodonPreviewProps } from '../../types';
 
@@ -13,14 +14,16 @@ const MastodonPostCard: React.FC< MastodonPreviewProps > = ( {
 	url,
 	image,
 	customImage,
+	imageFocalPoint,
 } ) => {
 	return (
 		<div className={ clsx( 'mastodon-preview__card', { 'has-image': image } ) }>
 			<div className="mastodon-preview__card-img">
 				{ image || customImage ? (
-					<img
+					<MediaImage
 						src={ image || customImage }
 						alt={ __( 'Mastodon preview thumbnail', 'social-previews' ) }
+						focalPoint={ imageFocalPoint }
 					/>
 				) : (
 					<div className="mastodon-preview__card-img--fallback">

--- a/projects/js-packages/social-previews/src/nextdoor-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/nextdoor-preview/post-preview.tsx
@@ -8,6 +8,7 @@ import {
 	preparePreviewText,
 } from '../helpers';
 import { ExpandableText } from '../shared/expandable-text';
+import { MediaImage } from '../shared/media-image';
 import { FEED_TEXT_MAX_LENGTH } from './constants';
 import { FooterActions } from './footer-actions';
 import { ChevronIcon } from './icons/chevron-icon';
@@ -24,6 +25,7 @@ import './style.scss';
  */
 export function NextdoorPostPreview( {
 	image,
+	imageFocalPoint,
 	name,
 	profileImage,
 	description,
@@ -107,7 +109,12 @@ export function NextdoorPostPreview( {
 							} ) }
 						>
 							{ image ? (
-								<img className="nextdoor-preview__image" src={ image } alt="" />
+								<MediaImage
+									className="nextdoor-preview__image"
+									src={ image }
+									alt=""
+									focalPoint={ imageFocalPoint }
+								/>
 							) : (
 								<DefaultImage />
 							) }

--- a/projects/js-packages/social-previews/src/shared/media-image/index.tsx
+++ b/projects/js-packages/social-previews/src/shared/media-image/index.tsx
@@ -1,0 +1,146 @@
+/**
+ * MediaImage
+ *
+ * A thin wrapper over `<img>` that renders an optional focal point as an inline
+ * `object-position`, so the visible crop (under `object-fit: cover`) keeps the
+ * focal point in view.
+ *
+ * The crop model is "focal point at the center of the crop, clamped to the
+ * image edges" — the same model image CDNs use when they generate the cropped
+ * share image. CSS `object-position` percentages are *alignment*, not centering
+ * (they only match a centered crop at 50%), so we remap the focal point into the
+ * `object-position` value that reproduces a centered crop. The remap needs the
+ * image's natural aspect ratio and the rendered box's aspect ratio, both read
+ * from the element itself, so callers pass only a `focalPoint`.
+ *
+ * Before those sizes are known (initial render, or a non-layout environment like
+ * tests) it falls back to the raw focal point; the value is corrected once the
+ * image loads.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FocalPoint } from '../../types';
+
+export type MediaImageProps = React.ImgHTMLAttributes< HTMLImageElement > & {
+	/**
+	 * The focal point to keep in view, both axes 0-1. Omitted → centered.
+	 */
+	focalPoint?: FocalPoint;
+};
+
+const clamp = ( value: number ) => Math.min( Math.max( value, 0 ), 1 );
+
+/**
+ * Remaps one axis of a focal point into the `object-position` fraction that
+ * reproduces a centered-and-clamped crop, given that axis's overflow ratio.
+ *
+ * @param {number} focal - The focal coordinate on the overflowing axis (0-1).
+ * @param {number} ratio - Visible fraction of the image on that axis (boxShorter / imageLonger).
+ * @return {number} The object-position fraction (0-1).
+ */
+const remapAxis = ( focal: number, ratio: number ): number => {
+	// No overflow on this axis → object-position has no effect; pass through.
+	if ( ratio >= 1 ) {
+		return focal;
+	}
+
+	return clamp( ( focal - ratio / 2 ) / ( 1 - ratio ) );
+};
+
+/**
+ * Converts a focal point into the `object-position` point that reproduces a
+ * centered-and-clamped crop under `object-fit: cover`.
+ *
+ * @param {FocalPoint} focalPoint  - The focal point, both axes 0-1.
+ * @param {number}     imageAspect - The image's natural aspect ratio (w/h).
+ * @param {number}     boxAspect   - The rendered box's aspect ratio (w/h).
+ * @return {FocalPoint} The object-position point, both axes 0-1.
+ */
+export const focalPointToObjectPosition = (
+	focalPoint: FocalPoint,
+	imageAspect: number,
+	boxAspect: number
+): FocalPoint => {
+	if ( imageAspect < boxAspect ) {
+		// Image is taller than the box → height overflows → remap the y axis.
+		return { x: focalPoint.x, y: remapAxis( focalPoint.y, imageAspect / boxAspect ) };
+	}
+
+	if ( imageAspect > boxAspect ) {
+		// Image is wider than the box → width overflows → remap the x axis.
+		return { x: remapAxis( focalPoint.x, boxAspect / imageAspect ), y: focalPoint.y };
+	}
+
+	// Same aspect → the image fills the box exactly → focal point is irrelevant.
+	return focalPoint;
+};
+
+export const MediaImage: React.FC< MediaImageProps > = ( {
+	focalPoint,
+	style,
+	onLoad,
+	...props
+} ) => {
+	const ref = useRef< HTMLImageElement >( null );
+	const [ aspects, setAspects ] = useState< { image: number; box: number } | null >( null );
+
+	const measure = useCallback( () => {
+		const el = ref.current;
+
+		if ( ! el ) {
+			return;
+		}
+
+		const { naturalWidth, naturalHeight, clientWidth, clientHeight } = el;
+
+		if ( naturalWidth && naturalHeight && clientWidth && clientHeight ) {
+			setAspects( { image: naturalWidth / naturalHeight, box: clientWidth / clientHeight } );
+		}
+	}, [] );
+
+	useEffect( () => {
+		measure();
+
+		const el = ref.current;
+
+		if ( ! el || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+
+		const observer = new ResizeObserver( measure );
+		observer.observe( el );
+
+		return () => observer.disconnect();
+	}, [ measure ] );
+
+	const handleLoad = useCallback(
+		( event: React.SyntheticEvent< HTMLImageElement > ) => {
+			measure();
+			onLoad?.( event );
+		},
+		[ measure, onLoad ]
+	);
+
+	// Until the sizes are known, fall back to the raw focal point; it's corrected
+	// on load. With sizes, remap to reproduce a centered-and-clamped crop.
+	const position =
+		focalPoint && aspects
+			? focalPointToObjectPosition( focalPoint, aspects.image, aspects.box )
+			: focalPoint;
+
+	const focalPointStyle = position
+		? { objectPosition: `${ position.x * 100 }% ${ position.y * 100 }%` }
+		: undefined;
+
+	return (
+		// Callers supply `alt` via props (often through a spread), so the rule
+		// can't see the literal here.
+		// eslint-disable-next-line jsx-a11y/alt-text
+		<img
+			{ ...props }
+			ref={ ref }
+			onLoad={ handleLoad }
+			style={ focalPointStyle || style ? { ...style, ...focalPointStyle } : undefined }
+		/>
+	);
+};

--- a/projects/js-packages/social-previews/src/threads-preview/card.tsx
+++ b/projects/js-packages/social-previews/src/threads-preview/card.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
 import { baseDomain } from '../helpers';
+import { MediaImage } from '../shared/media-image';
 import { threadsTitle } from './helpers';
 import { ThreadsCardProps } from './types';
 
-export const Card: React.FC< ThreadsCardProps > = ( { image, title, url } ) => {
+export const Card: React.FC< ThreadsCardProps > = ( { image, imageFocalPoint, title, url } ) => {
 	const cardClassNames = clsx( {
 		'threads-preview__card-has-image': !! image,
 	} );
@@ -11,7 +12,14 @@ export const Card: React.FC< ThreadsCardProps > = ( { image, title, url } ) => {
 	return (
 		<div className="threads-preview__card">
 			<div className={ cardClassNames }>
-				{ image && <img className="threads-preview__card-image" src={ image } alt="" /> }
+				{ image && (
+					<MediaImage
+						className="threads-preview__card-image"
+						src={ image }
+						alt=""
+						focalPoint={ imageFocalPoint }
+					/>
+				) }
 				<div className="threads-preview__card-body">
 					<div className="threads-preview__card-url">{ baseDomain( url || '' ) }</div>
 					<div className="threads-preview__card-title">{ threadsTitle( title ) }</div>

--- a/projects/js-packages/social-previews/src/threads-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/threads-preview/post-preview.tsx
@@ -14,6 +14,7 @@ export const ThreadsPostPreview: React.FC< ThreadsPreviewProps > = ( {
 	caption,
 	date,
 	image,
+	imageFocalPoint,
 	media,
 	name,
 	profileImage,
@@ -45,7 +46,14 @@ export const ThreadsPostPreview: React.FC< ThreadsPreviewProps > = ( {
 							</div>
 						) : null }
 						{ hasMedia ? <Media media={ media } /> : null }
-						{ displayAsCard ? <Card image={ image } title={ title || '' } url={ url } /> : null }
+						{ displayAsCard ? (
+							<Card
+								image={ image }
+								imageFocalPoint={ imageFocalPoint }
+								title={ title || '' }
+								url={ url }
+							/>
+						) : null }
 					</div>
 					<Footer />
 				</div>

--- a/projects/js-packages/social-previews/src/tumblr-preview/link-preview.tsx
+++ b/projects/js-packages/social-previews/src/tumblr-preview/link-preview.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { baseDomain } from '../helpers';
+import { MediaImage } from '../shared/media-image';
 import { tumblrTitle, tumblrDescription } from './helpers';
 import TumblrPostActions from './post/actions';
 import TumblrPostHeader from './post/header';
@@ -13,6 +14,7 @@ export const TumblrLinkPreview: React.FC< TumblrPreviewProps > = ( {
 	image,
 	user,
 	url,
+	imageFocalPoint,
 } ) => {
 	const avatarUrl = user?.avatarUrl;
 
@@ -28,10 +30,11 @@ export const TumblrLinkPreview: React.FC< TumblrPreviewProps > = ( {
 								<div className="tumblr-preview__title">{ tumblrTitle( title ) }</div>
 							</div>
 
-							<img
+							<MediaImage
 								className="tumblr-preview__image"
 								src={ image }
 								alt={ __( 'Tumblr preview thumbnail', 'social-previews' ) }
+								focalPoint={ imageFocalPoint }
 							/>
 						</div>
 					) }

--- a/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/tumblr-preview/post-preview.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { AvatarWithFallback } from '../avatar-with-fallback';
 import { preparePreviewText } from '../helpers';
 import { ExpandableText } from '../shared/expandable-text';
+import { MediaImage } from '../shared/media-image';
 import { tumblrTitle, tumblrDescription } from './helpers';
 import TumblrPostActions from './post/actions';
 import TumblrPostHeader from './post/header';
@@ -16,6 +17,7 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 	url,
 	media,
 	hyperlinks,
+	imageFocalPoint,
 } ) => {
 	const avatarUrl = user?.avatarUrl;
 
@@ -52,10 +54,11 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 						</div>
 					) : (
 						image && (
-							<img
+							<MediaImage
 								className="tumblr-preview__image"
 								src={ image }
 								alt={ __( 'Tumblr preview thumbnail', 'social-previews' ) }
+								focalPoint={ imageFocalPoint }
 							/>
 						)
 					) }

--- a/projects/js-packages/social-previews/src/twitter-preview/card.tsx
+++ b/projects/js-packages/social-previews/src/twitter-preview/card.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { baseDomain, firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
+import { MediaImage } from '../shared/media-image';
 import { TwitterCardProps } from './types';
 
 const DESCRIPTION_LENGTH = 280;
@@ -12,6 +13,7 @@ const twitterDescription = firstValid(
 export const Card: React.FC< TwitterCardProps > = ( {
 	description,
 	image,
+	imageFocalPoint,
 	title,
 	cardType,
 	url,
@@ -23,7 +25,14 @@ export const Card: React.FC< TwitterCardProps > = ( {
 	return (
 		<div className="twitter-preview__card">
 			<div className={ cardClassNames }>
-				{ image && <img className="twitter-preview__card-image" src={ image } alt="" /> }
+				{ image && (
+					<MediaImage
+						className="twitter-preview__card-image"
+						src={ image }
+						alt=""
+						focalPoint={ imageFocalPoint }
+					/>
+				) }
 				<div className="twitter-preview__card-body">
 					<div className="twitter-preview__card-url">{ baseDomain( url || '' ) }</div>
 					<div className="twitter-preview__card-title">{ title }</div>

--- a/projects/js-packages/social-previews/src/twitter-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/twitter-preview/post-preview.tsx
@@ -13,6 +13,7 @@ export const TwitterPostPreview: React.FC< TwitterPreviewProps > = ( {
 	date,
 	description,
 	image,
+	imageFocalPoint,
 	media,
 	name,
 	profileImage,
@@ -40,6 +41,7 @@ export const TwitterPostPreview: React.FC< TwitterPreviewProps > = ( {
 							<Card
 								description={ description || '' }
 								image={ image }
+								imageFocalPoint={ imageFocalPoint }
 								title={ title || '' }
 								cardType={ cardType || '' }
 								url={ url }

--- a/projects/js-packages/social-previews/src/types.ts
+++ b/projects/js-packages/social-previews/src/types.ts
@@ -29,6 +29,13 @@ export interface SocialPreviewBaseProps {
 	image?: string;
 
 	/**
+	 * The focal point of the link-preview image (`image`/`customImage`), both
+	 * axes 0-1. When set, the preview crops around this point via
+	 * `object-position`. Omitted → centered, matching today's behavior.
+	 */
+	imageFocalPoint?: FocalPoint;
+
+	/**
 	 * The array of media items to use in the preview.
 	 */
 	media?: Array< MediaItem >;
@@ -55,6 +62,15 @@ export interface SocialPreviewsBaseProps {
 	 */
 	hideLinkPreview?: boolean;
 }
+
+/**
+ * A focal point on an image. Both axes are 0-1, where `{ x: 0, y: 0 }` is the
+ * top-left corner and `{ x: 1, y: 1 }` is the bottom-right.
+ */
+export type FocalPoint = {
+	x: number;
+	y: number;
+};
 
 export type MediaItem = {
 	/**

--- a/projects/js-packages/social-previews/tests/focal-point.test.tsx
+++ b/projects/js-packages/social-previews/tests/focal-point.test.tsx
@@ -1,0 +1,283 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import {
+	FacebookLinkPreview,
+	TwitterPostPreview,
+	ThreadsPostPreview,
+	LinkedInPostPreview,
+	InstagramPostPreview,
+	MastodonPostPreview,
+	BlueskyPostPreview,
+	TumblrLinkPreview,
+	NextdoorPostPreview,
+} from '../src';
+import { MediaImage, focalPointToObjectPosition } from '../src/shared/media-image';
+
+// Mock @wordpress/components SandBox to avoid iframe initialization issues in tests.
+// The mock prefix is required for jest to allow variable access in the factory.
+const mockReact = React;
+jest.mock( '@wordpress/components', () => {
+	return {
+		SandBox: ( { html, title }: { html: string; title: string } ) => {
+			const iframeRef = mockReact.useRef< HTMLIFrameElement >( null );
+
+			mockReact.useEffect( () => {
+				if ( iframeRef.current ) {
+					const doc = iframeRef.current.contentWindow?.document;
+					if ( doc ) {
+						doc.open();
+						doc.write( html );
+						doc.close();
+					}
+				}
+			}, [ html ] );
+
+			return mockReact.createElement( 'iframe', { ref: iframeRef, title } );
+		},
+	};
+} );
+
+const POST_URL = 'https://example.com/new-entry';
+const POST_TITLE = 'Hello World';
+const IMAGE_SRC = 'https://wordpress.com/someimagehere.png';
+
+const FOCAL = { x: 0.25, y: 0.75 };
+const FOCAL_POSITION = '25% 75%';
+
+/**
+ * Returns true when the element has an inline `object-position` style set.
+ *
+ * `not.toHaveStyle( 'object-position: X' )` passes even when a *different*
+ * object-position is set, so for asserting absence we inspect the raw style
+ * attribute directly.
+ *
+ * @param el - The element to inspect.
+ * @return Whether the element declares an inline object-position.
+ */
+function hasObjectPosition( el: Element | null ): boolean {
+	return !! el?.getAttribute( 'style' )?.includes( 'object-position' );
+}
+
+describe( 'MediaImage (unit)', () => {
+	it( 'renders object-position from a focal point', () => {
+		const { container } = render(
+			<MediaImage src={ IMAGE_SRC } alt="" focalPoint={ { x: 0.25, y: 0.75 } } />
+		);
+
+		const img = container.querySelector( 'img' );
+
+		expect( img ).toBeInTheDocument();
+		expect( img ).toHaveStyle( { objectPosition: '25% 75%' } );
+	} );
+
+	it( 'renders 50% 50% for a centered focal point', () => {
+		const { container } = render(
+			<MediaImage src={ IMAGE_SRC } alt="" focalPoint={ { x: 0.5, y: 0.5 } } />
+		);
+
+		const img = container.querySelector( 'img' );
+
+		expect( img ).toHaveStyle( { objectPosition: '50% 50%' } );
+	} );
+
+	it( 'emits no object-position when no focal point is given', () => {
+		const { container } = render( <MediaImage src={ IMAGE_SRC } alt="" /> );
+
+		const img = container.querySelector( 'img' );
+
+		expect( img ).toBeInTheDocument();
+		expect( hasObjectPosition( img ) ).toBe( false );
+	} );
+
+	it( 'passes through src, alt and className unchanged', () => {
+		const { container } = render(
+			<MediaImage src={ IMAGE_SRC } alt="my alt" className="my-class" />
+		);
+
+		const img = container.querySelector( 'img' );
+
+		expect( img ).toHaveAttribute( 'src', IMAGE_SRC );
+		expect( img ).toHaveAttribute( 'alt', 'my alt' );
+		expect( img ).toHaveClass( 'my-class' );
+	} );
+} );
+
+describe( 'focalPointToObjectPosition (centered-crop remap)', () => {
+	// Square image in a 2:1 box → height overflows, half the image visible (ratio 0.5).
+	it( 'remaps the overflowing vertical axis to center the crop on the focal point', () => {
+		expect( focalPointToObjectPosition( { x: 0.5, y: 0.5 }, 1, 2 ) ).toEqual( { x: 0.5, y: 0.5 } );
+		// 0.625 → (0.625 - 0.25) / 0.5 = 0.75 (a real shift, not just clamping).
+		expect( focalPointToObjectPosition( { x: 0.5, y: 0.625 }, 1, 2 ) ).toEqual( {
+			x: 0.5,
+			y: 0.75,
+		} );
+		// A low focal point reaches the bottom edge sooner than raw object-position would.
+		expect( focalPointToObjectPosition( { x: 0.3, y: 0.75 }, 1, 2 ) ).toEqual( { x: 0.3, y: 1 } );
+		expect( focalPointToObjectPosition( { x: 0.3, y: 0.25 }, 1, 2 ) ).toEqual( { x: 0.3, y: 0 } );
+	} );
+
+	// 2:1 image in a square box → width overflows.
+	it( 'remaps the overflowing horizontal axis when the image is wider than the box', () => {
+		expect( focalPointToObjectPosition( { x: 0.75, y: 0.4 }, 2, 1 ) ).toEqual( { x: 1, y: 0.4 } );
+		expect( focalPointToObjectPosition( { x: 0.5, y: 0.4 }, 2, 1 ) ).toEqual( { x: 0.5, y: 0.4 } );
+	} );
+
+	it( 'leaves the non-overflowing axis unchanged', () => {
+		expect( focalPointToObjectPosition( { x: 0.1, y: 0.5 }, 1, 2 ).x ).toBe( 0.1 );
+	} );
+
+	it( 'passes the focal point through when image and box share an aspect ratio', () => {
+		expect( focalPointToObjectPosition( { x: 0.2, y: 0.8 }, 1.5, 1.5 ) ).toEqual( {
+			x: 0.2,
+			y: 0.8,
+		} );
+	} );
+} );
+
+/**
+ * Focal point applies to the link/card (og) image only — never to user-attached
+ * media, which uploads full to the network. Each entry renders a platform's
+ * link-card image with `image` + `imageFocalPoint` and points at the rendered
+ * <img> to inspect.
+ */
+type PlatformCase = {
+	name: string;
+	render: ( imageFocalPoint?: { x: number; y: number } ) => React.ReactElement;
+	selector: string;
+};
+
+const platforms: PlatformCase[] = [
+	{
+		name: 'facebook',
+		render: imageFocalPoint => (
+			<FacebookLinkPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `.facebook-preview__image img[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'twitter',
+		// The card renders only when no media is present.
+		render: imageFocalPoint => (
+			<TwitterPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.twitter-preview__card-image[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'threads',
+		render: imageFocalPoint => (
+			<ThreadsPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.threads-preview__card-image[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'linkedin',
+		render: imageFocalPoint => (
+			<LinkedInPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				name="user"
+				profileImage=""
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.linkedin-preview__image[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'instagram',
+		// Instagram has no separate link card; the standalone `image`/`imageFocalPoint`
+		// renders in the same media slot.
+		render: imageFocalPoint => (
+			<InstagramPostPreview
+				url={ POST_URL }
+				name="user"
+				profileImage=""
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.instagram-preview__media--image[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'mastodon',
+		render: imageFocalPoint => (
+			<MastodonPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `.mastodon-preview__card-img img[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'bluesky',
+		render: imageFocalPoint => (
+			<BlueskyPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `.bluesky-preview__card-image img[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'tumblr',
+		render: imageFocalPoint => (
+			<TumblrLinkPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.tumblr-preview__image[src="${ IMAGE_SRC }"]`,
+	},
+	{
+		name: 'nextdoor',
+		render: imageFocalPoint => (
+			<NextdoorPostPreview
+				url={ POST_URL }
+				title={ POST_TITLE }
+				name="user"
+				profileImage=""
+				image={ IMAGE_SRC }
+				imageFocalPoint={ imageFocalPoint }
+			/>
+		),
+		selector: `img.nextdoor-preview__image[src="${ IMAGE_SRC }"]`,
+	},
+];
+
+describe.each( platforms )(
+	'$name link-card focal point (integration)',
+	( { render: renderPreview, selector } ) => {
+		it( 'applies object-position from imageFocalPoint', () => {
+			const { container } = render( renderPreview( FOCAL ) );
+
+			const img = container.querySelector( selector );
+
+			expect( img ).toBeInTheDocument();
+			expect( img ).toHaveStyle( { objectPosition: FOCAL_POSITION } );
+		} );
+	}
+);

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
@@ -54,18 +54,20 @@ export function PostPreview( { connection, previewData }: PostPreviewProps ) {
 		[ connection ]
 	);
 
-	const { image, media, title, description, url, excerpt, message, hyperlinks } = previewData;
+	const { image, imageFocalPoint, media, title, description, url, excerpt, message, hyperlinks } =
+		previewData;
 
 	const commonProps = useMemo(
 		() => ( {
 			description,
 			image,
+			imageFocalPoint,
 			media,
 			title,
 			url,
 			hyperlinks,
 		} ),
-		[ hyperlinks, description, image, media, title, url ]
+		[ hyperlinks, description, image, imageFocalPoint, media, title, url ]
 	);
 
 	const siteName = useSelect( select => {

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -197,6 +197,7 @@ export default function MediaSectionV2( {
 	const {
 		value: focalPointValue,
 		canEdit: canEditImage,
+		setPreviewFocalPoint,
 		setFocalPoint,
 	} = useMediaFocalPoint( previewData?.id ?? 0 );
 
@@ -457,6 +458,7 @@ export default function MediaSectionV2( {
 									url={ previewData.url }
 									value={ focalPointValue }
 									onChange={ setFocalPoint }
+									onDrag={ setPreviewFocalPoint }
 								/>
 							) : (
 								<MediaPreview media={ previewData } isLoading={ isPreviewingSig && sigIsLoading } />

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-focal-point.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-focal-point.tsx
@@ -10,23 +10,25 @@ import styles from './styles.module.scss';
 import { MediaFocalPointProps } from './types';
 import type { FocalPoint } from '../../utils/types';
 
+const roundPoint = ( point: FocalPoint ): FocalPoint => ( {
+	x: Math.round( point.x * 100 ) / 100,
+	y: Math.round( point.y * 100 ) / 100,
+} );
+
 /**
  * MediaFocalPoint component
  *
  * @param {MediaFocalPointProps} props - Component props
  * @return MediaFocalPoint component
  */
-export default function MediaFocalPoint( { url, value, onChange }: MediaFocalPointProps ) {
-	// Commit only on drag end (onChange); the picker tracks the marker during drag itself.
-	// Round to 2 decimals before handing the point up for persistence.
+export default function MediaFocalPoint( { url, value, onChange, onDrag }: MediaFocalPointProps ) {
 	const handleChange = useCallback(
-		( point: FocalPoint ) => {
-			onChange( {
-				x: Math.round( point.x * 100 ) / 100,
-				y: Math.round( point.y * 100 ) / 100,
-			} );
-		},
+		( point: FocalPoint ) => onChange( roundPoint( point ) ),
 		[ onChange ]
+	);
+	const handleDrag = useCallback(
+		( point: FocalPoint ) => onDrag?.( roundPoint( point ) ),
+		[ onDrag ]
 	);
 
 	return (
@@ -42,6 +44,8 @@ export default function MediaFocalPoint( { url, value, onChange }: MediaFocalPoi
 				url={ url }
 				value={ value }
 				onChange={ handleChange }
+				onDragStart={ handleDrag }
+				onDrag={ handleDrag }
 			/>
 		</div>
 	);

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -14,11 +14,14 @@ const mockOpenUnifiedModal = jest.fn();
 const mockApplyFilters = jest.fn();
 const mockSiteHasFeature = jest.fn< boolean, [ string ] >( () => true );
 const mockSetFocalPoint = jest.fn();
-const mockUseMediaFocalPoint = jest.fn( () => ( {
+const mockSetPreviewFocalPoint = jest.fn();
+const getMockMediaFocalPoint = ( canEdit: boolean | undefined = true ) => ( {
 	value: { x: 0.5, y: 0.5 },
-	canEdit: true as boolean | undefined,
+	canEdit,
+	setPreviewFocalPoint: mockSetPreviewFocalPoint,
 	setFocalPoint: mockSetFocalPoint,
-} ) );
+} );
+const mockUseMediaFocalPoint = jest.fn( () => getMockMediaFocalPoint() );
 
 jest.mock( '@automattic/jetpack-script-data', () => {
 	const actual = jest.requireActual( '@automattic/jetpack-script-data' );
@@ -429,11 +432,7 @@ describe( 'MediaSectionV2', () => {
 
 		afterEach( () => {
 			mockSiteHasFeature.mockReturnValue( true );
-			mockUseMediaFocalPoint.mockReturnValue( {
-				value: { x: 0.5, y: 0.5 },
-				canEdit: true,
-				setFocalPoint: mockSetFocalPoint,
-			} );
+			mockUseMediaFocalPoint.mockReturnValue( getMockMediaFocalPoint() );
 			( usePostMeta as jest.Mock ).mockReturnValue( {
 				attachedMedia: [],
 				imageGeneratorSettings: { enabled: false },
@@ -471,11 +470,7 @@ describe( 'MediaSectionV2', () => {
 		} );
 
 		it( 'should hide the picker when the user cannot edit the image', () => {
-			mockUseMediaFocalPoint.mockReturnValue( {
-				value: { x: 0.5, y: 0.5 },
-				canEdit: false,
-				setFocalPoint: mockSetFocalPoint,
-			} );
+			mockUseMediaFocalPoint.mockReturnValue( getMockMediaFocalPoint( false ) );
 
 			render( <MediaSectionV2 /> );
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/use-media-focal-point.test.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/use-media-focal-point.test.ts
@@ -1,5 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { FOCAL_POINT_META_KEY } from '../../../utils/focal-point';
+import {
+	clearFocalPointOverlay,
+	setFocalPointOverlay,
+	useFocalPointOverlay,
+} from '../../../utils/focal-point-overlay';
 import { useMediaFocalPoint } from '../use-media-focal-point';
 
 const mockGetEntityRecord = jest.fn();
@@ -17,11 +22,23 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { saveEntityRecord: mockSaveEntityRecord } ),
 } ) );
 
+jest.mock( '../../../utils/focal-point-overlay', () => ( {
+	...jest.requireActual( '../../../utils/focal-point-overlay' ),
+	useFocalPointOverlay: jest.fn(),
+	setFocalPointOverlay: jest.fn(),
+	clearFocalPointOverlay: jest.fn(),
+} ) );
+
+const mockUseFocalPointOverlay = useFocalPointOverlay as jest.Mock;
+const mockSetFocalPointOverlay = setFocalPointOverlay as jest.Mock;
+const mockClearFocalPointOverlay = clearFocalPointOverlay as jest.Mock;
+
 describe( 'useMediaFocalPoint', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockGetEntityRecord.mockReturnValue( undefined );
 		mockCanUser.mockReturnValue( true );
+		mockUseFocalPointOverlay.mockReturnValue( undefined );
 	} );
 
 	it( 'should return the centered default when the image has no stored point', () => {
@@ -51,6 +68,17 @@ describe( 'useMediaFocalPoint', () => {
 		expect( result.current.value ).toEqual( { x: 0.5, y: 0.5 } );
 	} );
 
+	it( 'should prefer the live overlay point over the stored one', () => {
+		mockGetEntityRecord.mockReturnValue( {
+			meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } },
+		} );
+		mockUseFocalPointOverlay.mockReturnValue( { x: 0.1, y: 0.9 } );
+
+		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
+
+		expect( result.current.value ).toEqual( { x: 0.1, y: 0.9 } );
+	} );
+
 	it( 'should report edit permission from canUser', () => {
 		mockCanUser.mockReturnValue( false );
 
@@ -69,13 +97,25 @@ describe( 'useMediaFocalPoint', () => {
 		expect( mockCanUser ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should save the point to the attachment', () => {
+	it( 'should show a point live via the overlay without saving', () => {
+		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
+
+		act( () => {
+			result.current.setPreviewFocalPoint( { x: 0.3, y: 0.6 } );
+		} );
+
+		expect( mockSetFocalPointOverlay ).toHaveBeenCalledWith( 123, { x: 0.3, y: 0.6 } );
+		expect( mockSaveEntityRecord ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should optimistically overlay the point and save it (setFocalPoint)', () => {
 		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
 
 		act( () => {
 			result.current.setFocalPoint( { x: 0.3, y: 0.6 } );
 		} );
 
+		expect( mockSetFocalPointOverlay ).toHaveBeenCalledWith( 123, { x: 0.3, y: 0.6 } );
 		expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'attachment',
@@ -87,29 +127,45 @@ describe( 'useMediaFocalPoint', () => {
 		);
 	} );
 
-	it( 'should show the new point optimistically before the store updates', () => {
-		// The store still returns the old (default) value.
+	it( 'should clear its overlay (by value) once the save succeeds', async () => {
 		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
 
 		act( () => {
 			result.current.setFocalPoint( { x: 0.3, y: 0.6 } );
 		} );
-
-		expect( result.current.value ).toEqual( { x: 0.3, y: 0.6 } );
-	} );
-
-	it( 'should revert the optimistic point when saving fails', async () => {
-		mockSaveEntityRecord.mockRejectedValueOnce( new Error( 'Unable to save focal point' ) );
-		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
-
-		act( () => {
-			result.current.setFocalPoint( { x: 0.3, y: 0.6 } );
-		} );
-
-		expect( result.current.value ).toEqual( { x: 0.3, y: 0.6 } );
 
 		await waitFor( () => {
-			expect( result.current.value ).toEqual( { x: 0.5, y: 0.5 } );
+			expect( mockClearFocalPointOverlay ).toHaveBeenCalledWith( 123, { x: 0.3, y: 0.6 } );
 		} );
+	} );
+
+	it( 'should revert (clear the overlay) when the save fails', async () => {
+		mockSaveEntityRecord.mockRejectedValueOnce( new Error( 'Unable to save focal point' ) );
+
+		const { result } = renderHook( () => useMediaFocalPoint( 123 ) );
+
+		act( () => {
+			result.current.setFocalPoint( { x: 0.3, y: 0.6 } );
+		} );
+
+		await waitFor( () => {
+			expect( mockClearFocalPointOverlay ).toHaveBeenCalledWith( 123, { x: 0.3, y: 0.6 } );
+		} );
+	} );
+
+	it( 'should clear its overlay when the attachment changes', () => {
+		const { rerender, unmount } = renderHook(
+			( { attachmentId } ) => useMediaFocalPoint( attachmentId ),
+			{
+				initialProps: { attachmentId: 123 },
+			}
+		);
+
+		rerender( { attachmentId: 456 } );
+
+		expect( mockClearFocalPointOverlay ).toHaveBeenCalledWith( 123 );
+
+		unmount();
+		expect( mockClearFocalPointOverlay ).toHaveBeenCalledWith( 456 );
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/use-media-focal-point.test.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/use-media-focal-point.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { FOCAL_POINT_META_KEY, useMediaFocalPoint } from '../use-media-focal-point';
+import { FOCAL_POINT_META_KEY } from '../../../utils/focal-point';
+import { useMediaFocalPoint } from '../use-media-focal-point';
 
 const mockGetEntityRecord = jest.fn();
 const mockCanUser = jest.fn();

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -170,9 +170,15 @@ export interface MediaFocalPointProps {
 	value: FocalPoint;
 
 	/**
-	 * Called with the rounded focal point when the user finishes dragging.
+	 * Called with the rounded focal point when the user commits it (release,
+	 * click, or keyboard).
 	 */
 	onChange: ( point: FocalPoint ) => void;
+
+	/**
+	 * Called with the rounded focal point while dragging, before it is committed.
+	 */
+	onDrag?: ( point: FocalPoint ) => void;
 }
 
 /**

--- a/projects/packages/publicize/_inc/components/media-section-v2/use-media-focal-point.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/use-media-focal-point.ts
@@ -8,17 +8,24 @@
 
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { FOCAL_POINT_META_KEY, readFocalPointMeta } from '../../utils/focal-point';
+import {
+	clearFocalPointOverlay,
+	setFocalPointOverlay,
+	useFocalPointOverlay,
+} from '../../utils/focal-point-overlay';
 import type { FocalPoint } from '../../utils/types';
 
 const DEFAULT_FOCAL_POINT: FocalPoint = { x: 0.5, y: 0.5 };
 
 export type UseMediaFocalPoint = {
-	/** The point to display: the optimistic value while saving, else the stored one. */
+	/** The point to display: the live overlay if set, else the stored one. */
 	value: FocalPoint;
 	/** Whether the current user can edit this image (undefined while resolving). */
 	canEdit: boolean | undefined;
+	/** Show a point live (e.g. while dragging) without persisting it. */
+	setPreviewFocalPoint: ( point: FocalPoint ) => void;
 	/** Persist a new point to the image. */
 	setFocalPoint: ( point: FocalPoint ) => void;
 };
@@ -27,7 +34,7 @@ export type UseMediaFocalPoint = {
  * Read and write the focal point stored on an image, and report edit permission.
  *
  * @param {number} attachmentId - The image's attachment ID (0/undefined → no image).
- * @return {UseMediaFocalPoint} The focal point, edit permission, and a setter.
+ * @return {UseMediaFocalPoint} The focal point, edit permission, and setters.
  */
 export function useMediaFocalPoint( attachmentId: number ): UseMediaFocalPoint {
 	const { storedValue, canEdit } = useSelect(
@@ -48,37 +55,52 @@ export function useMediaFocalPoint( attachmentId: number ): UseMediaFocalPoint {
 		[ attachmentId ]
 	);
 
+	// The live overlay wins while the user is adjusting the point; otherwise the
+	// persisted value is shown.
+	const overlayPoint = useFocalPointOverlay( attachmentId );
+	const value = overlayPoint ?? storedValue;
+
 	const { saveEntityRecord } = useDispatch( coreStore );
 
-	// The persisted store value lags the network round-trip, and FocalPointPicker
-	// snaps its marker to the value prop on release — so without an optimistic value
-	// the point jumps back to the old spot until the save lands. Keep the pending
-	// point keyed by image so switching images falls straight back to its stored value.
-	const [ pending, setPending ] = useState< { id: number; point: FocalPoint } | null >( null );
-	const value = pending && pending.id === attachmentId ? pending.point : storedValue;
+	const setPreviewFocalPoint = useCallback(
+		( point: FocalPoint ) => {
+			setFocalPointOverlay( attachmentId, point );
+		},
+		[ attachmentId ]
+	);
+
+	useEffect( () => () => clearFocalPointOverlay( attachmentId ), [ attachmentId ] );
 
 	const setFocalPoint = useCallback(
 		( point: FocalPoint ) => {
-			setPending( { id: attachmentId, point } );
+			if ( ! attachmentId ) {
+				return;
+			}
+
+			// Keep showing the point optimistically while the save is in flight.
+			setFocalPointOverlay( attachmentId, point );
 
 			// Saves directly to the image, separate from the post's save/undo.
 			Promise.resolve(
 				saveEntityRecord(
 					'postType',
 					'attachment',
-					{
-						id: attachmentId,
-						meta: { [ FOCAL_POINT_META_KEY ]: point },
-					},
+					{ id: attachmentId, meta: { [ FOCAL_POINT_META_KEY ]: point } },
 					{ throwOnError: true }
 				)
-			).catch( () => {
-				// Revert the optimistic value if the save fails.
-				setPending( current => ( current && current.id === attachmentId ? null : current ) );
-			} );
+			)
+				.catch( () => {
+					// Swallow; clearing below reverts to the persisted value.
+				} )
+				.finally( () => {
+					clearFocalPointOverlay( attachmentId, point );
+				} );
 		},
 		[ attachmentId, saveEntityRecord ]
 	);
 
-	return useMemo( () => ( { value, canEdit, setFocalPoint } ), [ value, canEdit, setFocalPoint ] );
+	return useMemo(
+		() => ( { value, canEdit, setPreviewFocalPoint, setFocalPoint } ),
+		[ value, canEdit, setPreviewFocalPoint, setFocalPoint ]
+	);
 }

--- a/projects/packages/publicize/_inc/components/media-section-v2/use-media-focal-point.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/use-media-focal-point.ts
@@ -9,31 +9,10 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
+import { FOCAL_POINT_META_KEY, readFocalPointMeta } from '../../utils/focal-point';
 import type { FocalPoint } from '../../utils/types';
 
-/** Attachment meta key — must match ATTACHMENT_IMAGE_FOCAL_POINT in PHP. */
-export const FOCAL_POINT_META_KEY = '_jetpack_social_image_focal_point';
-
 const DEFAULT_FOCAL_POINT: FocalPoint = { x: 0.5, y: 0.5 };
-
-const isValidFocalPoint = ( value: unknown ): value is FocalPoint => {
-	if ( ! value || typeof value !== 'object' || Array.isArray( value ) ) {
-		return false;
-	}
-
-	const point = value as Partial< Record< keyof FocalPoint, unknown > >;
-
-	return (
-		typeof point.x === 'number' &&
-		Number.isFinite( point.x ) &&
-		point.x >= 0 &&
-		point.x <= 1 &&
-		typeof point.y === 'number' &&
-		Number.isFinite( point.y ) &&
-		point.y >= 0 &&
-		point.y <= 1
-	);
-};
 
 export type UseMediaFocalPoint = {
 	/** The point to display: the optimistic value while saving, else the stored one. */
@@ -57,13 +36,12 @@ export function useMediaFocalPoint( attachmentId: number ): UseMediaFocalPoint {
 				return { storedValue: DEFAULT_FOCAL_POINT, canEdit: false };
 			}
 			const core = select( coreStore );
-			const record = core.getEntityRecord( 'postType', 'attachment', attachmentId ) as
-				| { meta?: { [ FOCAL_POINT_META_KEY ]?: unknown } }
-				| undefined;
-			const focalPoint = record?.meta?.[ FOCAL_POINT_META_KEY ];
+			const storedFocalPoint = readFocalPointMeta(
+				core.getEntityRecord( 'postType', 'attachment', attachmentId )
+			);
 
 			return {
-				storedValue: isValidFocalPoint( focalPoint ) ? focalPoint : DEFAULT_FOCAL_POINT,
+				storedValue: storedFocalPoint ?? DEFAULT_FOCAL_POINT,
 				canEdit: core.canUser( 'update', 'media', attachmentId ),
 			};
 		},

--- a/projects/packages/publicize/_inc/exports/link-preview/types.ts
+++ b/projects/packages/publicize/_inc/exports/link-preview/types.ts
@@ -1,3 +1,5 @@
+import type { FocalPoint } from '../../utils/types';
+
 export type LinkPreviewData = {
 	/**
 	 * The URL of the resource to preview.
@@ -28,6 +30,12 @@ export type LinkPreviewData = {
 	 * The URL of the image to use in the resource preview.
 	 */
 	image?: string;
+
+	/**
+	 * The focal point of the preview image, when it resolves to an attachment
+	 * with a stored point. Undefined → centered.
+	 */
+	imageFocalPoint?: FocalPoint;
 };
 
 export type LinkPreviewPlatform =

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { getSigImageUrl } from '../../hooks/use-sig-preview/utils';
 import { readFocalPointMeta } from '../../utils/focal-point';
+import { useFocalPointOverlay } from '../../utils/focal-point-overlay';
 import { LinkPreviewData } from './types';
 import { getMediaSourceUrl, getPostImageUrl } from './utils';
 
@@ -27,23 +28,24 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		).trim();
 	}, [] );
 
-	const { image, imageFocalPoint } = useSelect( select => {
+	const { image, persistedFocalPoint, featuredImageId, isFeaturedImage } = useSelect( select => {
 		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
 		const { getEntityRecord } = select( coreStore );
 
-		const featuredImageId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+		const featuredId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
-		const featuredImageRecord = featuredImageId
-			? getEntityRecord( 'postType', 'attachment', featuredImageId )
+		const featuredImageRecord = featuredId
+			? getEntityRecord( 'postType', 'attachment', featuredId )
 			: undefined;
 
 		// Use the featured image by default, if it's available.
-		let imageUrl = featuredImageId ? getMediaSourceUrl( featuredImageRecord ) : '';
+		let imageUrl = featuredId ? getMediaSourceUrl( featuredImageRecord ) : '';
 
-		// The focal point belongs to the featured image; clear it if another
-		// source (SIG, post content) ends up providing the preview image.
-		let focalPoint = readFocalPointMeta( featuredImageRecord );
+		// The focal point belongs to the featured image; it only applies while the
+		// featured image is the one being shown (SIG / post-content images clear it).
+		let showingFeaturedImage = !! imageUrl;
+		const persisted = readFocalPointMeta( featuredImageRecord );
 
 		const sigImageUrl = meta.jetpack_social_options?.image_generator_settings?.enabled
 			? getSigImageUrl( meta.jetpack_social_options.image_generator_settings.token )
@@ -52,7 +54,7 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		// If we have a SIG image, use it to generate the image URL.
 		if ( sigImageUrl ) {
 			imageUrl = sigImageUrl;
-			focalPoint = undefined;
+			showingFeaturedImage = false;
 		}
 
 		// If we still don't have an image, try to get it from the post content.
@@ -61,12 +63,22 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 
 			if ( postImageUrl ) {
 				imageUrl = postImageUrl;
-				focalPoint = undefined;
+				showingFeaturedImage = false;
 			}
 		}
 
-		return { image: imageUrl, imageFocalPoint: focalPoint };
+		return {
+			image: imageUrl,
+			persistedFocalPoint: persisted,
+			featuredImageId: featuredId,
+			isFeaturedImage: showingFeaturedImage,
+		};
 	}, [] );
+
+	// The live drag point wins over the saved point, but only while the
+	// featured image is the one being previewed.
+	const overlayPoint = useFocalPointOverlay( featuredImageId );
+	const imageFocalPoint = isFeaturedImage ? overlayPoint ?? persistedFocalPoint : undefined;
 
 	const { siteTitle, siteIcon } = useSelect( select => {
 		const { getUnstableBase } = select( coreStore );

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
@@ -5,6 +5,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { getSigImageUrl } from '../../hooks/use-sig-preview/utils';
+import { readFocalPointMeta } from '../../utils/focal-point';
 import { LinkPreviewData } from './types';
 import { getMediaSourceUrl, getPostImageUrl } from './utils';
 
@@ -26,17 +27,23 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		).trim();
 	}, [] );
 
-	const image = useSelect( select => {
+	const { image, imageFocalPoint } = useSelect( select => {
 		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
 		const { getEntityRecord } = select( coreStore );
 
 		const featuredImageId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
+		const featuredImageRecord = featuredImageId
+			? getEntityRecord( 'postType', 'attachment', featuredImageId )
+			: undefined;
+
 		// Use the featured image by default, if it's available.
-		let imageUrl = featuredImageId
-			? getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', featuredImageId ) )
-			: '';
+		let imageUrl = featuredImageId ? getMediaSourceUrl( featuredImageRecord ) : '';
+
+		// The focal point belongs to the featured image; clear it if another
+		// source (SIG, post content) ends up providing the preview image.
+		let focalPoint = readFocalPointMeta( featuredImageRecord );
 
 		const sigImageUrl = meta.jetpack_social_options?.image_generator_settings?.enabled
 			? getSigImageUrl( meta.jetpack_social_options.image_generator_settings.token )
@@ -45,6 +52,7 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		// If we have a SIG image, use it to generate the image URL.
 		if ( sigImageUrl ) {
 			imageUrl = sigImageUrl;
+			focalPoint = undefined;
 		}
 
 		// If we still don't have an image, try to get it from the post content.
@@ -53,10 +61,11 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 
 			if ( postImageUrl ) {
 				imageUrl = postImageUrl;
+				focalPoint = undefined;
 			}
 		}
 
-		return imageUrl;
+		return { image: imageUrl, imageFocalPoint: focalPoint };
 	}, [] );
 
 	const { siteTitle, siteIcon } = useSelect( select => {
@@ -87,10 +96,11 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		return {
 			description: decodeEntities( description ),
 			image,
+			imageFocalPoint,
 			siteIcon,
 			siteTitle: decodeEntities( siteTitle ),
 			title: decodeEntities( title ),
 			url,
 		};
-	}, [ description, image, siteIcon, siteTitle, title, url ] );
+	}, [ description, image, imageFocalPoint, siteIcon, siteTitle, title, url ] );
 }

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
@@ -1,4 +1,4 @@
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, type Attachment } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -36,11 +36,11 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		const featuredId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
 		const featuredImageRecord = featuredId
-			? getEntityRecord( 'postType', 'attachment', featuredId )
+			? getEntityRecord< Attachment >( 'postType', 'attachment', featuredId )
 			: undefined;
 
 		// Use the featured image by default, if it's available.
-		let imageUrl = featuredId ? getMediaSourceUrl( featuredImageRecord ) : '';
+		let imageUrl = featuredId ? getMediaSourceUrl( featuredImageRecord ?? null ) : '';
 
 		// The focal point belongs to the featured image; it only applies while the
 		// featured image is the one being shown (SIG / post-content images clear it).

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
@@ -1,7 +1,8 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useLinkPreviewPostData } from '../';
 import { FOCAL_POINT_META_KEY } from '../../../utils/focal-point';
+import { clearFocalPointOverlay, setFocalPointOverlay } from '../../../utils/focal-point-overlay';
 import { getSigImageUrl } from '../../use-sig-preview/utils';
 import { getMediaSourceUrl, getPostImageUrl } from '../utils';
 
@@ -300,5 +301,69 @@ describe( 'useLinkPreviewPostData', () => {
 
 		expect( result.current.image ).toBe( 'https://example.com/sig-generated.jpg' );
 		expect( result.current.imageFocalPoint ).toBeUndefined();
+	} );
+
+	it( 'should prefer the live overlay point over the stored one for the featured image', () => {
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		setupMocks( {
+			attributes: {
+				...getDefaultAttributes(),
+				featured_media: 456,
+			},
+			featuredMediaRecord: {
+				id: 456,
+				meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } },
+			},
+		} );
+
+		// Simulate the picker dragging a new point (not yet persisted).
+		setFocalPointOverlay( 456, { x: 0.1, y: 0.9 } );
+
+		try {
+			const { result } = renderHook( () => useLinkPreviewPostData() );
+
+			expect( result.current.imageFocalPoint ).toEqual( { x: 0.1, y: 0.9 } );
+		} finally {
+			act( () => {
+				clearFocalPointOverlay( 456 );
+			} );
+		}
+	} );
+
+	it( 'should not apply the overlay when a SIG image is shown instead of the featured image', () => {
+		mockGetSigImageUrl.mockReturnValue( 'https://example.com/sig-generated.jpg' );
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		setupMocks( {
+			attributes: {
+				...getDefaultAttributes(),
+				featured_media: 456,
+				meta: {
+					jetpack_social_options: {
+						image_generator_settings: { enabled: true, token: 'test-token' },
+					},
+				},
+			},
+			featuredMediaRecord: {
+				id: 456,
+				meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } },
+			},
+		} );
+
+		// Even with a live overlay on the featured image, the SIG image is the one
+		// being shown, so no focal point should leak through.
+		setFocalPointOverlay( 456, { x: 0.1, y: 0.9 } );
+
+		try {
+			const { result } = renderHook( () => useLinkPreviewPostData() );
+
+			expect( result.current.image ).toBe( 'https://example.com/sig-generated.jpg' );
+			expect( result.current.imageFocalPoint ).toBeUndefined();
+		} finally {
+			act( () => {
+				clearFocalPointOverlay( 456 );
+			} );
+		}
 	} );
 } );

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useLinkPreviewPostData } from '../';
+import { FOCAL_POINT_META_KEY } from '../../../utils/focal-point';
 import { getSigImageUrl } from '../../use-sig-preview/utils';
 import { getMediaSourceUrl, getPostImageUrl } from '../utils';
 
@@ -238,5 +239,66 @@ describe( 'useLinkPreviewPostData', () => {
 		const { result } = renderHook( () => useLinkPreviewPostData() );
 
 		expect( result.current.image ).toBe( '' );
+	} );
+
+	it( 'should resolve imageFocalPoint from the featured image meta', () => {
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		setupMocks( {
+			attributes: {
+				...getDefaultAttributes(),
+				featured_media: 456,
+			},
+			featuredMediaRecord: {
+				id: 456,
+				meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } },
+			},
+		} );
+
+		const { result } = renderHook( () => useLinkPreviewPostData() );
+
+		expect( result.current.imageFocalPoint ).toEqual( { x: 0.25, y: 0.75 } );
+	} );
+
+	it( 'should leave imageFocalPoint undefined when the featured image has no stored point', () => {
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		setupMocks( {
+			attributes: {
+				...getDefaultAttributes(),
+				featured_media: 456,
+			},
+			featuredMediaRecord: { id: 456, meta: {} },
+		} );
+
+		const { result } = renderHook( () => useLinkPreviewPostData() );
+
+		expect( result.current.imageFocalPoint ).toBeUndefined();
+	} );
+
+	it( 'should clear imageFocalPoint when a SIG image replaces the featured image', () => {
+		mockGetSigImageUrl.mockReturnValue( 'https://example.com/sig-generated.jpg' );
+		mockGetMediaSourceUrl.mockReturnValue( 'https://example.com/featured.jpg' );
+
+		setupMocks( {
+			attributes: {
+				...getDefaultAttributes(),
+				featured_media: 456,
+				meta: {
+					jetpack_social_options: {
+						image_generator_settings: { enabled: true, token: 'test-token' },
+					},
+				},
+			},
+			featuredMediaRecord: {
+				id: 456,
+				meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } },
+			},
+		} );
+
+		const { result } = renderHook( () => useLinkPreviewPostData() );
+
+		expect( result.current.image ).toBe( 'https://example.com/sig-generated.jpg' );
+		expect( result.current.imageFocalPoint ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/types.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/types.ts
@@ -1,3 +1,5 @@
+import type { FocalPoint } from '../../utils/types';
+
 export type LinkPreviewData = {
 	/**
 	 * The URL of the resource to preview.
@@ -23,4 +25,10 @@ export type LinkPreviewData = {
 	 * The URL of the image to use in the resource preview.
 	 */
 	image: string | undefined;
+
+	/**
+	 * The focal point of the preview image, when it resolves to an attachment
+	 * with a stored point (the featured image). Undefined → centered.
+	 */
+	imageFocalPoint?: FocalPoint;
 };

--- a/projects/packages/publicize/_inc/utils/focal-point-overlay.ts
+++ b/projects/packages/publicize/_inc/utils/focal-point-overlay.ts
@@ -1,0 +1,76 @@
+import { useSyncExternalStore } from 'react';
+import type { FocalPoint } from './types';
+
+// Shared draft point so previews can follow the picker without saving on every drag.
+const overlay = new Map< number, FocalPoint >();
+const listeners = new Set< () => void >();
+
+const isSamePoint = ( a: FocalPoint | undefined, b: FocalPoint ): boolean =>
+	a?.x === b.x && a?.y === b.y;
+
+const notify = () => listeners.forEach( listener => listener() );
+
+/**
+ * Sets the in-progress focal point for an attachment.
+ *
+ * @param {number}     attachmentId - The image's attachment id.
+ * @param {FocalPoint} point        - The point to show live.
+ */
+export function setFocalPointOverlay( attachmentId: number, point: FocalPoint ): void {
+	if ( ! attachmentId || isSamePoint( overlay.get( attachmentId ), point ) ) {
+		return;
+	}
+
+	overlay.set( attachmentId, point );
+	notify();
+}
+
+/**
+ * Clears the in-progress focal point for an attachment.
+ *
+ * @param {number}     attachmentId - The image's attachment id.
+ * @param {FocalPoint} point        - Optional point to match before clearing.
+ */
+export function clearFocalPointOverlay( attachmentId: number, point?: FocalPoint ): void {
+	const current = attachmentId ? overlay.get( attachmentId ) : undefined;
+
+	if ( ! current || ( point && ! isSamePoint( current, point ) ) ) {
+		return;
+	}
+
+	overlay.delete( attachmentId );
+	notify();
+}
+
+/**
+ * Gets the current in-progress focal point for an attachment.
+ *
+ * @param {number} attachmentId - The image's attachment id.
+ * @return {FocalPoint | undefined} The point to show live, or undefined.
+ */
+export function getFocalPointOverlay( attachmentId: number ): FocalPoint | undefined {
+	return attachmentId ? overlay.get( attachmentId ) : undefined;
+}
+
+/**
+ * Subscribes a listener to focal point overlay changes.
+ *
+ * @param {Function} listener - Called when an overlay point changes.
+ * @return {Function} A function that removes the listener.
+ */
+function subscribe( listener: () => void ): () => void {
+	listeners.add( listener );
+	return () => {
+		listeners.delete( listener );
+	};
+}
+
+/**
+ * Gets the current in-progress focal point for an attachment.
+ *
+ * @param {number} attachmentId - The image's attachment id.
+ * @return {FocalPoint | undefined} The point to show live, or undefined.
+ */
+export function useFocalPointOverlay( attachmentId: number ): FocalPoint | undefined {
+	return useSyncExternalStore( subscribe, () => getFocalPointOverlay( attachmentId ) );
+}

--- a/projects/packages/publicize/_inc/utils/focal-point-overlay.ts
+++ b/projects/packages/publicize/_inc/utils/focal-point-overlay.ts
@@ -72,5 +72,7 @@ function subscribe( listener: () => void ): () => void {
  * @return {FocalPoint | undefined} The point to show live, or undefined.
  */
 export function useFocalPointOverlay( attachmentId: number ): FocalPoint | undefined {
-	return useSyncExternalStore( subscribe, () => getFocalPointOverlay( attachmentId ) );
+	const getSnapshot = () => getFocalPointOverlay( attachmentId );
+
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
 }

--- a/projects/packages/publicize/_inc/utils/focal-point.ts
+++ b/projects/packages/publicize/_inc/utils/focal-point.ts
@@ -1,0 +1,54 @@
+/**
+ * Focal point helpers.
+ *
+ * The focal point of an image is stored on the attachment as post meta, so it is
+ * shared by every post and network that uses the image. These helpers read and
+ * validate that stored value for both the picker and the previews.
+ */
+
+import type { FocalPoint } from './types';
+
+/** Attachment meta key — must match ATTACHMENT_IMAGE_FOCAL_POINT in PHP. */
+export const FOCAL_POINT_META_KEY = '_jetpack_social_image_focal_point';
+
+/**
+ * Type guard for a valid focal point: an object with finite x/y both in 0-1.
+ *
+ * @param {unknown} value - The value to check.
+ * @return {boolean} Whether the value is a valid focal point.
+ */
+const isValidFocalPoint = ( value: unknown ): value is FocalPoint => {
+	if ( ! value || typeof value !== 'object' || Array.isArray( value ) ) {
+		return false;
+	}
+
+	const point = value as Partial< Record< keyof FocalPoint, unknown > >;
+
+	return (
+		typeof point.x === 'number' &&
+		Number.isFinite( point.x ) &&
+		point.x >= 0 &&
+		point.x <= 1 &&
+		typeof point.y === 'number' &&
+		Number.isFinite( point.y ) &&
+		point.y >= 0 &&
+		point.y <= 1
+	);
+};
+
+/**
+ * Reads the focal point stored on an attachment record's meta.
+ *
+ * Returns `undefined` when the record is missing or has no valid stored point,
+ * so previews fall back to the browser default (centered) instead of forcing a
+ * point. Pass the record from `getEntityRecord( 'postType', 'attachment', id )`.
+ *
+ * @param {unknown} record - The attachment entity record (or undefined).
+ * @return {FocalPoint | undefined} The stored focal point, or undefined.
+ */
+export function readFocalPointMeta( record: unknown ): FocalPoint | undefined {
+	const meta = ( record as { meta?: { [ FOCAL_POINT_META_KEY ]?: unknown } } | undefined )?.meta;
+	const focalPoint = meta?.[ FOCAL_POINT_META_KEY ];
+
+	return isValidFocalPoint( focalPoint ) ? focalPoint : undefined;
+}

--- a/projects/packages/publicize/_inc/utils/test/focal-point-overlay.test.ts
+++ b/projects/packages/publicize/_inc/utils/test/focal-point-overlay.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import {
+	clearFocalPointOverlay,
+	getFocalPointOverlay,
+	setFocalPointOverlay,
+	useFocalPointOverlay,
+} from '../focal-point-overlay';
+
+// The overlay is a module-level singleton; clear the ids used by each test.
+const USED_IDS = [ 0, 101, 102, 103 ];
+
+describe( 'focal point overlay', () => {
+	afterEach( () => {
+		USED_IDS.forEach( id => clearFocalPointOverlay( id ) );
+	} );
+
+	it( 'stores and reads a point per attachment id', () => {
+		setFocalPointOverlay( 101, { x: 0.2, y: 0.8 } );
+
+		expect( getFocalPointOverlay( 101 ) ).toEqual( { x: 0.2, y: 0.8 } );
+		expect( getFocalPointOverlay( 102 ) ).toBeUndefined();
+	} );
+
+	it( 'clears a point', () => {
+		setFocalPointOverlay( 101, { x: 0.2, y: 0.8 } );
+		clearFocalPointOverlay( 101 );
+
+		expect( getFocalPointOverlay( 101 ) ).toBeUndefined();
+	} );
+
+	it( 'does not clear a newer point when clearing by old value', () => {
+		setFocalPointOverlay( 101, { x: 0.8, y: 0.2 } );
+		clearFocalPointOverlay( 101, { x: 0.2, y: 0.8 } );
+
+		expect( getFocalPointOverlay( 101 ) ).toEqual( { x: 0.8, y: 0.2 } );
+	} );
+
+	it( 'ignores attachment id 0', () => {
+		setFocalPointOverlay( 0, { x: 0.2, y: 0.8 } );
+
+		expect( getFocalPointOverlay( 0 ) ).toBeUndefined();
+	} );
+
+	it( 're-renders a subscriber when its point changes', () => {
+		const { result } = renderHook( () => useFocalPointOverlay( 103 ) );
+
+		expect( result.current ).toBeUndefined();
+
+		act( () => setFocalPointOverlay( 103, { x: 0.4, y: 0.6 } ) );
+		expect( result.current ).toEqual( { x: 0.4, y: 0.6 } );
+
+		act( () => clearFocalPointOverlay( 103 ) );
+		expect( result.current ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/publicize/_inc/utils/test/focal-point.test.ts
+++ b/projects/packages/publicize/_inc/utils/test/focal-point.test.ts
@@ -1,0 +1,31 @@
+import { FOCAL_POINT_META_KEY, readFocalPointMeta } from '../focal-point';
+
+describe( 'readFocalPointMeta', () => {
+	it( 'returns the stored point from an attachment record', () => {
+		const record = { meta: { [ FOCAL_POINT_META_KEY ]: { x: 0.25, y: 0.75 } } };
+
+		expect( readFocalPointMeta( record ) ).toEqual( { x: 0.25, y: 0.75 } );
+
+		// Boundary values (0 and 1) are valid.
+		expect( readFocalPointMeta( { meta: { [ FOCAL_POINT_META_KEY ]: { x: 0, y: 1 } } } ) ).toEqual(
+			{ x: 0, y: 1 }
+		);
+	} );
+
+	it( 'returns undefined for a missing record or missing meta', () => {
+		expect( readFocalPointMeta( undefined ) ).toBeUndefined();
+		expect( readFocalPointMeta( {} ) ).toBeUndefined();
+		expect( readFocalPointMeta( { meta: {} } ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a malformed or out-of-range stored point', () => {
+		const wrap = ( value: unknown ) => ( { meta: { [ FOCAL_POINT_META_KEY ]: value } } );
+
+		expect( readFocalPointMeta( wrap( { x: 0.5 } ) ) ).toBeUndefined(); // missing axis
+		expect( readFocalPointMeta( wrap( { x: 1.1, y: 0.5 } ) ) ).toBeUndefined(); // out of range
+		expect( readFocalPointMeta( wrap( { x: -0.1, y: 0.5 } ) ) ).toBeUndefined(); // out of range
+		expect( readFocalPointMeta( wrap( { x: NaN, y: 0.5 } ) ) ).toBeUndefined(); // non-finite
+		expect( readFocalPointMeta( wrap( [ 0.5, 0.5 ] ) ) ).toBeUndefined(); // array
+		expect( readFocalPointMeta( wrap( 'nope' ) ) ).toBeUndefined(); // non-object
+	} );
+} );

--- a/projects/packages/publicize/changelog/add-social-image-focal-point-previews
+++ b/projects/packages/publicize/changelog/add-social-image-focal-point-previews
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Apply the stored image focal point to the social link previews.


### PR DESCRIPTION
Fixes SOCIAL-504
Fixes SOCIAL-505

## Proposed changes

* Add a shared `MediaImage` component to `@automattic/social-previews` that renders an image's focal point as a CSS `object-position`, remapped so the visible `object-fit: cover` crop is centered on the focal point (clamped to the edges). An optional `imageFocalPoint` prop is threaded through every link/card preview.
* In Publicize, resolve the post's featured-image stored focal point into the link-preview data (`imageFocalPoint`) so the previews crop toward it, and stay in sync as the point is changed via the picker.
* Focal point applies only to the link/og card image. User-attached media is uploaded full-size to the network (the platform crops it natively), so it is intentionally not focal-point-cropped here.
* Note: this is the preview + data side. Generating the cropped share image server-side is separate, future work tracked under SOCIAL-422.

## Related product discussion/links

* Part of SOCIAL-422.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the `social-image-focal-point` feature enabled, edit a post and set a featured image.
* In the Jetpack Social media section, set a focal point on the image with the picker.
* Open the social **Link preview** and confirm the card image crops toward the focal point, and updates as you move it.
* Confirm user-attached media (uploaded images) is shown full / uncropped (no focal-point crop).


https://github.com/user-attachments/assets/530f2d36-10d8-4f99-af71-e22d7684a578


