### PR TITLE
Social: detect blocked connection popups and harden the v2 connect flow

### DIFF
--- a/projects/packages/publicize/_inc/components/services/use-request-access.ts
+++ b/projects/packages/publicize/_inc/components/services/use-request-access.ts
@@ -143,7 +143,16 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 				getAdminUrl( 'admin-post.php?action=jetpack_social_keyring_done' )
 			);
 
-			requestExternalAccess( url.toString(), () => onConfirm( requestId ) );
+			const opened = requestExternalAccess( url.toString(), () => onConfirm( requestId ) );
+
+			if ( ! opened ) {
+				createErrorNotice(
+					__(
+						'Could not open the connection window. Please allow pop-ups for this site and try again.',
+						'jetpack-publicize-pkg'
+					)
+				);
+			}
 		},
 		[
 			createErrorNotice,

--- a/projects/packages/publicize/_inc/components/services/use-request-access.ts
+++ b/projects/packages/publicize/_inc/components/services/use-request-access.ts
@@ -148,7 +148,7 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 			if ( ! opened ) {
 				createErrorNotice(
 					__(
-						'Could not open the connection window. Please allow pop-ups for this site and try again.',
+						'The connection window could not be opened. Please allow pop-ups for this site then try connecting the account again.',
 						'jetpack-publicize-pkg'
 					)
 				);

--- a/projects/packages/publicize/_inc/utils/request-external-access.js
+++ b/projects/packages/publicize/_inc/utils/request-external-access.js
@@ -54,34 +54,20 @@ export const requestExternalAccess = ( url, cb ) => {
 	if ( requestId && typeof BroadcastChannel !== 'undefined' ) {
 		const channel = new BroadcastChannel( KEYRING_BROADCAST_CHANNEL );
 
-		let settled = false;
-
-		const finish = () => {
-			if ( settled ) {
-				return;
-			}
-			settled = true;
-			channel.close();
-			cb();
-		};
-
 		channel.addEventListener( 'message', event => {
 			if ( event.data?.type === 'keyring-result' && event.data?.requestId === requestId ) {
-				finish();
+				clearTimeout( cleanupTimer );
+				channel.close();
+				cb();
 			}
 		} );
 
-		// Safety net: stop listening if the channel is never used (e.g. the user abandons the flow).
-		popupMonitor.once( 'close', () => {
-			// The close event is unreliable under COOP (it can fire before auth completes),
-			// so it is only used to release the channel after a grace period — never as success.
-			setTimeout( () => {
-				if ( ! settled ) {
-					settled = true;
-					channel.close();
-				}
-			}, 5000 );
-		} );
+		// Give up after the server transient's TTL; we don't watch the popup 'close' event
+		// because COOP makes it fire at the login screen, before auth completes.
+		const cleanupTimer = setTimeout(
+			() => channel.close(),
+			5 * 60 * 1000 // 5 minutes
+		);
 
 		return true;
 	}

--- a/projects/packages/publicize/_inc/utils/request-external-access.js
+++ b/projects/packages/publicize/_inc/utils/request-external-access.js
@@ -27,17 +27,28 @@ export const KEYRING_BROADCAST_CHANNEL = 'jetpack-social-keyring';
  *
  * @param {string}          url - The URL to be loaded in the newly opened window.
  * @param {requestCallback} cb  - The callback that handles the response.
+ *
+ * @return {boolean} `true` if the popup opened, `false` if it was blocked by the browser.
  */
 export const requestExternalAccess = ( url, cb ) => {
 	const popupMonitor = new PopupMonitor();
-
-	const requestId = new URL( url ).searchParams.get( 'request_id' );
 
 	popupMonitor.open(
 		url,
 		null,
 		'toolbar=0,location=0,status=0,menubar=0,' + popupMonitor.getScreenCenterSpecs( 780, 700 )
 	);
+
+	/*
+	 * When the browser blocks the popup, window.open returns null (or, in some browsers, a window
+	 * that is immediately closed). Bail out so the caller can let the user know what happened.
+	 */
+	const popup = popupMonitor.windowInstance;
+	if ( ! popup || popup.closed || typeof popup.closed === 'undefined' ) {
+		return false;
+	}
+
+	const requestId = new URL( url ).searchParams.get( 'request_id' );
 
 	// auth_flow=v2: wait for the same-origin completion page to broadcast the request_id.
 	if ( requestId && typeof BroadcastChannel !== 'undefined' ) {
@@ -72,7 +83,7 @@ export const requestExternalAccess = ( url, cb ) => {
 			}, 5000 );
 		} );
 
-		return;
+		return true;
 	}
 
 	// Legacy flow: the popup posts the keyring result back via window.opener.postMessage.
@@ -85,4 +96,6 @@ export const requestExternalAccess = ( url, cb ) => {
 	popupMonitor.on( 'message', message => {
 		lastMessage = message?.data;
 	} );
+
+	return true;
 };

--- a/projects/packages/publicize/changelog/add-social-detect-blocked-popup
+++ b/projects/packages/publicize/changelog/add-social-detect-blocked-popup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Social: Detect when the browser blocks the connection popup and notify the user.


### PR DESCRIPTION
Fixes SOCIAL-510

Follow-up to #49615 (now merged), addressing review feedback on the v2 connect flow.

## Proposed changes

* **Notify the user when the connection popup is blocked.** `requestExternalAccess` now reports whether `window.open` actually returned a usable window. When the browser blocks the popup, the `useRequestAccess` hook surfaces an error notice ("Could not open the connection window. Please allow pop-ups for this site and try again.") instead of leaving the user staring at a screen where nothing happened.
* **Settle the v2 flow on the broadcast, not the popup `close` event.** Per [review feedback](https://github.com/Automattic/jetpack/pull/49615#discussion_r3426755289), the popup `close` event is unreliable under COOP — it fires when the popup reaches the network's login screen, before authentication completes — so the previous 5s grace-period teardown could close the `BroadcastChannel` before the result arrived on slow connections. The `close` listener is removed; the channel is now bounded by a single timeout matching the server transient's 5-minute TTL.

## Related product discussion/links

* Fixes SOCIAL-510 
* Follow-up to #49615

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Build the package: `jetpack build packages/publicize`.
- **Blocked-popup notice:** enable the browser's popup blocker for your site (or use a browser profile that blocks popups by default). 
- Simulate broken connections using the diff below

<details><summary>Diff (click to expand></summary>

```diff
diff --git a/projects/packages/publicize/src/rest-api/class-connections-controller.php b/projects/packages/publicize/src/rest-api/class-connections-controller.php
index 441515af263..d8ceaa1396a 100644
--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -288,7 +288,11 @@ class Connections_Controller extends Base_Controller {
 		foreach ( $connections as $item ) {
 			$data = $this->prepare_item_for_response( $item, $request );
 
-			$items[] = $this->prepare_response_for_collection( $data );
+			$conn = $this->prepare_response_for_collection( $data );
+
+			$conn['status'] = 'broken';
+
+			$items[] = $conn;
 		}
 
 		$response = rest_ensure_response( $items );
```

</details>

- Go to **Jetpack → Social** and wait for connection tests to finish to see the broken connections
- Click on Reconnect for a connection
- Confirm an error notice appears telling you pop-ups are blocked, rather than nothing happening.
- **Normal flow still works:** allow pop-ups, then connect a network (e.g. Threads or Facebook) and confirm the popup opens, authentication completes, and the account appears on the confirmation screen.
- **Slow-connection settling:** optionally throttle your network in devtools and confirm the connection still completes — the result is no longer at the mercy of the 5s grace period.



https://github.com/user-attachments/assets/d43af1c0-092c-41dc-b8c0-0a935c571ac0

