### PR TITLE
Google Fonts: retire the Beta module and preserve in-use fonts

### DIFF
--- a/projects/plugins/jetpack/changelog/retire-google-fonts-preserve-in-use
+++ b/projects/plugins/jetpack/changelog/retire-google-fonts-preserve-in-use
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Google Fonts: retire the Google Fonts (Beta) module now that block themes support fonts natively via the WordPress Font Library. Fonts already in use are preserved into the site's global styles when the module is deactivated, so existing typography keeps rendering.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2107,6 +2107,7 @@ class Jetpack {
 			'minileven'             => null,  // Closed out in 8.3 -- Responsive themes are common now, and so is AMP.
 			'lazy-images'           => null, // Closed out in 12.8 -- WordPress core now has native lazy loading.
 			'enhanced-distribution' => null, // Closed out in 13.3 -- WP.com is winding down the firehose.
+			'google-fonts'          => null, // Closed out in 16.0 -- now native via the WordPress Font Library; in-use fonts are preserved into global styles on deactivation.
 		);
 
 		// Don't activate SSO if they never completed activating WPCC.

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -90,6 +90,30 @@ class Jetpack_Google_Font_Face {
 	}
 
 	/**
+	 * Get the slugs of the fonts referenced by the site's saved global styles.
+	 *
+	 * Unlike print_font_faces(), this ignores block-level usage (which lives in
+	 * post content and isn't enumerable globally) and is safe to call outside the
+	 * front-end render — e.g. when preserving in-use fonts as the module retires.
+	 *
+	 * @return string[] Formatted, alias-resolved font slugs that are in use.
+	 */
+	public function get_global_styles_fonts_in_use() {
+		$this->fonts_in_use = array();
+		$this->collect_global_styles_fonts();
+
+		$font_slug_aliases = $this->get_font_slug_aliases();
+		$fonts_in_use      = array_map(
+			function ( $font_slug ) use ( $font_slug_aliases ) {
+				return $font_slug_aliases[ $font_slug ] ?? $font_slug;
+			},
+			$this->fonts_in_use
+		);
+
+		return array_values( array_unique( $fonts_in_use, SORT_STRING ) );
+	}
+
+	/**
 	 * Collect fonts used for global styles settings.
 	 */
 	public function collect_global_styles_fonts() {

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -216,9 +216,97 @@ add_filter( 'wp_theme_json_data_theme', 'jetpack_unregister_deprecated_google_fo
 add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data' );
 
 /**
- * Clean up the Google Fonts data if either google fonts module is disabled or Jetpack is disabled.
+ * Build the list of Google Font family definitions that the site actually uses,
+ * ready to be persisted so the typography keeps rendering once the module is gone.
+ *
+ * The module registers the whole collection in the 'default' origin at runtime,
+ * but a font selection only stores a slug reference — the @font-face definition
+ * lives in that runtime origin and disappears with the module. To preserve the
+ * fonts in use we copy their full definitions out of the collection so they can
+ * be saved into the site's own global styles.
+ *
+ * Block-level font usage (set on individual blocks rather than global styles) is
+ * not enumerable site-wide and is therefore out of scope here.
+ *
+ * @return array<int, array> Font family definitions from the Google Fonts collection.
+ */
+function jetpack_get_in_use_google_font_families() {
+	$google_fonts_data = jetpack_get_google_fonts_data();
+	if ( ! $google_fonts_data || empty( $google_fonts_data['fontFamilies'] ) ) {
+		return array();
+	}
+
+	$font_face    = new Jetpack_Google_Font_Face();
+	$fonts_in_use = $font_face->get_global_styles_fonts_in_use();
+	if ( empty( $fonts_in_use ) ) {
+		return array();
+	}
+
+	$families = array();
+	foreach ( $google_fonts_data['fontFamilies'] as $font_family ) {
+		if ( empty( $font_family['fontFace'] ) ) {
+			continue;
+		}
+
+		$name = Jetpack_Google_Font_Face::get_font_family_name( $font_family );
+		if ( in_array( $font_face->format_font( $name ), $fonts_in_use, true ) ) {
+			$families[] = $font_family;
+		}
+	}
+
+	return $families;
+}
+
+/**
+ * Merge preserved font family definitions into an existing list, de-duplicating by slug.
+ *
+ * @param array $existing  Existing font family definitions.
+ * @param array $preserved Font family definitions to add when not already present.
+ * @return array The merged, de-duplicated list.
+ */
+function jetpack_merge_preserved_font_families( $existing, $preserved ) {
+	$slug_of = function ( $font_family ) {
+		if ( ! empty( $font_family['slug'] ) ) {
+			return $font_family['slug'];
+		}
+		$name = Jetpack_Google_Font_Face::get_font_family_name( $font_family );
+		return _wp_to_kebab_case( strtolower( $name ) );
+	};
+
+	$by_slug = array();
+	foreach ( (array) $existing as $font_family ) {
+		$by_slug[ $slug_of( $font_family ) ] = $font_family;
+	}
+	foreach ( $preserved as $font_family ) {
+		$slug = $slug_of( $font_family );
+		if ( ! isset( $by_slug[ $slug ] ) ) {
+			$by_slug[ $slug ] = $font_family;
+		}
+	}
+
+	return array_values( $by_slug );
+}
+
+/**
+ * Preserve in-use Google Fonts, then clean up the module's runtime font data,
+ * when the google-fonts module is disabled or Jetpack is disabled.
+ *
+ * Persisting the in-use families into the site's own global styles lets the
+ * fonts keep rendering natively (via core's wp_print_font_faces) after the
+ * module — and its runtime 'default' origin registration — is gone.
  */
 function jetpack_unregister_google_fonts() {
+	// Resolving global styles requires the theme to be set up. If we're called
+	// during bootstrap (e.g. while handling deprecated modules), defer until the
+	// theme is ready so the in-use fonts are detected correctly.
+	if ( ! did_action( 'after_setup_theme' ) ) {
+		add_action( 'after_setup_theme', __FUNCTION__, 99 );
+		return;
+	}
+
+	// Capture the fonts in use before we touch any of the stored data.
+	$preserved_families = jetpack_get_in_use_google_font_families();
+
 	$post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 
 	// Get user config
@@ -226,15 +314,21 @@ function jetpack_unregister_google_fonts() {
 	$user_config_raw_data = $user_config->get_raw_data();
 	$user_config_raw_data['isGlobalStylesUserThemeJSON'] = true;
 
-	// Prepare data for saving
+	// The module populated the 'default' origin at runtime; drop any persisted copy.
 	if ( ! empty( $user_config_raw_data['settings']['typography']['fontFamilies']['default'] ) ) {
 		$user_config_raw_data['settings']['typography']['fontFamilies']['default'] = array();
 	}
 
-	if ( ! empty( $user_config_raw_data['settings']['typography']['fontFamilies']['theme'] ) ) {
-		$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] = jetpack_google_fonts_filter_out_deprecated_font_data(
-			$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] // @phan-suppress-current-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument
-		);
+	$theme_fonts = $user_config_raw_data['settings']['typography']['fontFamilies']['theme'] ?? array();
+
+	// Drop the legacy jetpack-google-fonts provider entries that predate the Font Library.
+	$theme_fonts = jetpack_google_fonts_filter_out_deprecated_font_data( $theme_fonts );
+
+	// Persist the in-use families so core prints them without the module.
+	$theme_fonts = jetpack_merge_preserved_font_families( $theme_fonts, $preserved_families );
+
+	if ( ! empty( $theme_fonts ) ) {
+		$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] = $theme_fonts;
 	}
 
 	// Prepare changes
@@ -244,6 +338,9 @@ function jetpack_unregister_google_fonts() {
 
 	// Update user config
 	wp_update_post( wp_slash( (array) $changes ), true );
+
+	// Drop cached global styles so the rest of the request sees the saved fonts.
+	WP_Theme_JSON_Resolver::clean_cached_data();
 }
 add_action( 'jetpack_deactivate_module_google-fonts', 'jetpack_unregister_google_fonts' );
 

--- a/projects/plugins/jetpack/tests/php/modules/google-font-face/Jetpack_Google_Font_Face_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/google-font-face/Jetpack_Google_Font_Face_Test.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\Attributes\DataProvider;
-require_once JETPACK__PLUGIN_DIR . 'modules/google-fonts/current/class-jetpack-google-font-face.php.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/google-fonts/current/class-jetpack-google-font-face.php';
 
 class Jetpack_Google_Font_Face_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;

--- a/projects/plugins/jetpack/tests/php/modules/google-fonts/Jetpack_Google_Fonts_Preservation_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/google-fonts/Jetpack_Google_Fonts_Preservation_Test.php
@@ -1,0 +1,159 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . 'modules/google-fonts/current/load-google-fonts.php';
+
+/**
+ * Tests that deactivating the Google Fonts module preserves the fonts that are
+ * actually in use so they keep rendering once the module's runtime registration
+ * is gone.
+ */
+class Jetpack_Google_Fonts_Preservation_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_jetpack_get_google_fonts_data', array( $this, 'mock_collection' ) );
+	}
+
+	public function tear_down() {
+		remove_filter( 'pre_jetpack_get_google_fonts_data', array( $this, 'mock_collection' ) );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+		parent::tear_down();
+	}
+
+	/**
+	 * A small stand-in for the curated Google Fonts collection.
+	 */
+	public function mock_collection() {
+		return array(
+			'fontFamilies' => array(
+				array(
+					'name'       => 'Roboto',
+					'slug'       => 'roboto',
+					'fontFamily' => 'Roboto, sans-serif',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Roboto',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '400',
+							'src'        => array( 'https://fonts.gstatic.com/s/roboto/v1/roboto.woff2' ),
+						),
+					),
+				),
+				array(
+					'name'       => 'Lobster',
+					'slug'       => 'lobster',
+					'fontFamily' => 'Lobster, cursive',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Lobster',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '400',
+							'src'        => array( 'https://fonts.gstatic.com/s/lobster/v1/lobster.woff2' ),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Mark a font family as in use by referencing it from the site's global styles.
+	 *
+	 * @param string $slug Font family slug.
+	 */
+	private function use_font_in_global_styles( $slug ) {
+		$post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => wp_json_encode(
+					array(
+						'version'                     => 2,
+						'isGlobalStylesUserThemeJSON' => true,
+						'styles'                      => array(
+							'typography' => array(
+								'fontFamily' => "var:preset|font-family|$slug",
+							),
+						),
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+			)
+		);
+		WP_Theme_JSON_Resolver::clean_cached_data();
+	}
+
+	/**
+	 * Read the font family definitions persisted into the user global styles.
+	 *
+	 * @return array
+	 */
+	private function get_saved_theme_font_families() {
+		WP_Theme_JSON_Resolver::clean_cached_data();
+		$raw = WP_Theme_JSON_Resolver::get_user_data()->get_raw_data();
+		return $raw['settings']['typography']['fontFamilies']['theme'] ?? array();
+	}
+
+	public function test_only_the_in_use_collection_family_is_selected() {
+		$this->use_font_in_global_styles( 'roboto' );
+
+		$families = jetpack_get_in_use_google_font_families();
+
+		$this->assertCount( 1, $families );
+		$this->assertSame( 'Roboto', $families[0]['name'] );
+		$this->assertNotEmpty( $families[0]['fontFace'] );
+	}
+
+	public function test_no_fonts_in_use_preserves_nothing() {
+		$this->assertSame( array(), jetpack_get_in_use_google_font_families() );
+	}
+
+	public function test_deactivation_persists_in_use_font_with_font_face() {
+		$this->use_font_in_global_styles( 'roboto' );
+
+		jetpack_unregister_google_fonts();
+
+		$saved = $this->get_saved_theme_font_families();
+		$names = wp_list_pluck( $saved, 'name' );
+
+		$this->assertContains( 'Roboto', $names, 'The in-use font should be preserved.' );
+		$this->assertNotContains( 'Lobster', $names, 'Fonts that are not in use should not be preserved.' );
+
+		$roboto = $saved[ array_search( 'Roboto', $names, true ) ];
+		$this->assertNotEmpty( $roboto['fontFace'], 'The preserved font must keep its @font-face definition.' );
+	}
+
+	public function test_preserved_font_is_emitted_by_core() {
+		$this->use_font_in_global_styles( 'roboto' );
+
+		jetpack_unregister_google_fonts();
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		$fonts            = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		$printed_families = array();
+		foreach ( $fonts as $font_faces ) {
+			if ( isset( $font_faces[0]['font-family'] ) ) {
+				$printed_families[] = $font_faces[0]['font-family'];
+			}
+		}
+
+		$this->assertContains(
+			'Roboto',
+			$printed_families,
+			'Core should print the preserved font once the module is gone.'
+		);
+	}
+
+	public function test_deactivation_does_not_duplicate_already_saved_font() {
+		$this->use_font_in_global_styles( 'roboto' );
+
+		jetpack_unregister_google_fonts();
+		jetpack_unregister_google_fonts();
+
+		$saved = $this->get_saved_theme_font_families();
+		$names = wp_list_pluck( $saved, 'name' );
+
+		$this->assertCount( 1, array_keys( $names, 'Roboto', true ), 'The preserved font should not be duplicated.' );
+	}
+}


### PR DESCRIPTION
Fixes [JETPACK-1533](https://linear.app/a8c/issue/JETPACK-1533/retire-the-google-fonts-beta-module).

## What

Block themes now support fonts natively via the WordPress Font Library, so this retires the **Google Fonts (Beta)** module — while making sure fonts already in use on a site keep rendering after it's gone.

## Why retiring it naively breaks typography

The module registers the entire curated Google Fonts collection into the `default` theme.json origin **at runtime**. A font selection only stores a slug reference (e.g. `var:preset|font-family|roboto`) — the actual `@font-face` definition lives in that runtime origin and disappears the moment the module is deactivated. So a naive deactivation silently strips the fonts off every page that uses one.

## How

- **Turn it off:** add `google-fonts` to `Jetpack::handle_deprecated_modules()`, which force-deactivates it once per site. The module is `Auto Activate: No`, and the wpcomsh force-activation that previously kept it on for Atomic sites was already removed in trunk, so this no longer ping-pongs there.
- **Preserve in-use fonts:** the `jetpack_deactivate_module_google-fonts` hook now, *before* cleanup, captures the families actually referenced by the site's global styles and persists their full definitions (including `@font-face`) into the site's saved global styles. Core's `wp_print_font_faces` then emits them natively once the module's runtime registration is gone.
  - New helpers `jetpack_get_in_use_google_font_families()` and `jetpack_merge_preserved_font_families()` (dedupes by slug; idempotent).
  - An `after_setup_theme` timing guard handles being called during bootstrap (e.g. while handling deprecated modules), when global styles aren't resolvable yet.
- New accessor `Jetpack_Google_Font_Face::get_global_styles_fonts_in_use()` exposes the in-use slugs safely outside front-end render.

Block-level font usage (set on individual blocks rather than global styles) is not enumerable site-wide and is out of scope for preservation.

## Testing

- New `Jetpack_Google_Fonts_Preservation_Test` covers: only in-use families are selected, nothing preserved when no fonts are in use, deactivation persists the in-use font with its `@font-face`, **core emits the preserved font once the module is gone**, and running twice doesn't duplicate.
- Fixes a pre-existing broken `.php.php` require in `Jetpack_Google_Font_Face_Test`.
- These are WP integration tests and need the CI DB to run; `test_preserved_font_is_emitted_by_core` is the empirical check on the persisted data shape.

To test manually:
1. On a block theme, activate the Google Fonts (Beta) module and select a Google font in global styles (Styles → Typography). Confirm it renders on the front end.
2. Deactivate the module.
3. Reload the front end — the font should still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)