### PR TITLE
VideoPress: pad the Processing badge in the video details view

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-processing-badge-padding
+++ b/projects/packages/videopress/changelog/fix-videopress-processing-badge-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress dashboard: add padding to the "Processing" badge in the video details view so its label is no longer flush against the badge background.

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -74,14 +74,16 @@
 	flex-shrink: 0;
 }
 
-// "Processing" placeholder shown in place of the poster <img> while
-// the VideoPress backend is still transcoding the upload. Shares the
-// .vp-video-details__thumbnail class for size and border-radius, plus
-// this modifier for the centered text + neutral background.
+// "Processing" badge shown in place of the poster <img> while the
+// VideoPress backend is still transcoding the upload. With no poster to
+// size it, the box hugs its label, so it needs its own padding to read as
+// a tidy pill instead of text pressed against the neutral background.
+// (Inherits the 4px border-radius from .vp-video-details__thumbnail.)
 .vp-video-details__thumbnail-processing {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 4px 12px;
 	background: #f0f0f0;
 	color: #1e1e1e;
 }


### PR DESCRIPTION
## Proposed changes

The "Processing" badge in the modernized VideoPress **video details** view had no padding, so its label sat flush against the badge's grey background (CFT item VP12, reported by @obenland).

* `routes/video/style.scss`: add `padding: 4px 12px` to `.vp-video-details__thumbnail-processing`. This badge stands in for the poster `<img>` while a video is still transcoding; with no poster to size it, the box hugs its label, so it needs its own padding to read as a tidy pill. The value matches the `4px 12px` pill spacing already used by the library route's `open-details-label`.

This is the narrow padding fix only — the thumbnail aspect-ratio question (VP13) is a separate item and untouched here.

### Before / After

| Before | After |
| --- | --- |
| ![Before — label flush against the badge background](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-processing-badge-padding/before.png) | ![After — padded, tidy pill](https://github.com/Automattic/jetpack/raw/screenshots/fix/videopress-processing-badge-padding/after.png) |

## Related product discussion/links

* VIDP-254
* CFT Feedback Inventory: Automattic/jetpack#49485 (item VP12)
* Source: p8oabR-1P8-p2#comment-9039

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The "Processing" badge only appears in the video details view while a VideoPress upload is still transcoding (no poster yet), which is hard to hit by hand — so I validated it locally by mocking the media REST response into the processing state.

* Open the modernized VideoPress dashboard (`wp-admin/admin.php?page=jetpack-videopress`) and open the details for a video whose thumbnail area shows the grey "Processing" placeholder instead of a poster.
* Confirm the "Processing" label now has even padding on all sides (a tidy pill) rather than text pressed against the grey background.

**What I tested:** built `packages/videopress`, confirmed the compiled CSS carries `padding: 4px 12px`, and captured before/after of the badge via Playwright against a REST-mocked, poster-less VideoPress media item. The badge grows 66.84×20px → 90.84×28px — exactly +12px×2 horizontally and +4px×2 vertically. See screenshots above.

**What I did NOT test:** a real end-to-end transcode on a connected site (the processing window is transient). Other details-view states (poster present, "Updating…") don't use this selector and are unaffected.
