### PR TITLE
ToggleControl: migrate Boost + Protect from @automattic/jetpack-components to @wordpress/components

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
@@ -27,6 +27,12 @@
 	min-width: 36px;
 }
 
+// Render the smaller toggle variant (previously the jetpack-components
+// `size="small"` prop, which set `--base-width: 6px` on the form toggle).
+.small {
+	--base-width: 6px;
+}
+
 .content {
 	width: 100%;
 }

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -1,4 +1,6 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
+import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useSingleModuleState } from './lib/stores';
 import styles from './module.module.scss';
@@ -107,11 +109,11 @@ const Module = ( {
 			<div className={ styles.toggle }>
 				{ toggle && (
 					<ToggleControl
-						className={ `jb-feature-toggle-${ slug }` }
-						size="small"
+						className={ clsx( `jb-feature-toggle-${ slug }`, styles.small ) }
 						checked={ isModuleActive || isFakeActive }
 						disabled={ ! isModuleAvailable }
 						onChange={ handleToggle }
+						__nextHasNoMarginBottom={ true }
 					/>
 				) }
 			</div>

--- a/projects/plugins/boost/changelog/migrate-togglecontrol-wp-components
+++ b/projects/plugins/boost/changelog/migrate-togglecontrol-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate ToggleControl to @wordpress/components

--- a/projects/plugins/protect/changelog/migrate-togglecontrol-wp-components
+++ b/projects/plugins/protect/changelog/migrate-togglecontrol-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate ToggleControl to @wordpress/components

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-footer.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-footer.jsx
@@ -1,4 +1,5 @@
-import { Title, Text, Button, ToggleControl, Container, Col } from '@automattic/jetpack-components';
+import { Title, Text, Button, Container, Col } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import useModal from '../../hooks/use-modal';
@@ -73,24 +74,24 @@ const ShareData = () => {
 				checked={ !! jetpackWafShareData }
 				onChange={ handleShareDataChange }
 				disabled={ isUpdating }
-				size="small"
 				label={ __( 'Share basic data', 'jetpack-protect' ) }
 				help={ __(
 					'Allow Jetpack to collect basic data from blocked requests to improve firewall protection and accuracy.',
 					'jetpack-protect'
 				) }
+				__nextHasNoMarginBottom={ true }
 			/>
 			<ToggleControl
 				className={ styles[ 'share-data-toggle' ] }
 				checked={ !! jetpackWafShareDebugData }
 				onChange={ handleShareDebugDataChange }
 				disabled={ isUpdating }
-				size="small"
 				label={ __( 'Share detailed data', 'jetpack-protect' ) }
 				help={ __(
 					'Allow Jetpack to collect detailed data from blocked requests to enhance firewall protection and accuracy.',
 					'jetpack-protect'
 				) }
+				__nextHasNoMarginBottom={ true }
 			/>
 		</div>
 	);

--- a/projects/plugins/protect/src/js/routes/firewall/index.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/index.jsx
@@ -1,12 +1,5 @@
-import {
-	Button,
-	Col,
-	Container,
-	Text,
-	ToggleControl,
-	useBreakpointMatch,
-} from '@automattic/jetpack-components';
-import { Popover } from '@wordpress/components';
+import { Button, Col, Container, Text, useBreakpointMatch } from '@automattic/jetpack-components';
+import { Popover, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
@@ -251,6 +244,7 @@ const FirewallPage = () => {
 						checked={ canToggleAutomaticRules ? jetpackWafAutomaticRules : false }
 						onChange={ handleAutomaticRulesChange }
 						disabled={ ! canEditFirewallSettings || ! canToggleAutomaticRules || isUpdating }
+						__nextHasNoMarginBottom={ true }
 					/>
 					{ hasPlan && upgradeIsSeen === false && (
 						<Popover noArrow={ false } offset={ 8 } position={ 'top right' } inline={ true }>
@@ -385,6 +379,7 @@ const FirewallPage = () => {
 					onChange={ toggleBruteForceProtection }
 					disabled={ isUpdating }
 					aria-label={ __( 'Brute force protection', 'jetpack-protect' ) }
+					__nextHasNoMarginBottom={ true }
 				/>
 			</div>
 			<div className={ styles[ 'toggle-section__content' ] }>
@@ -413,6 +408,7 @@ const FirewallPage = () => {
 					onChange={ toggleIpBlockList }
 					disabled={ ! canEditFirewallSettings }
 					aria-label={ __( 'Block IP addresses', 'jetpack-protect' ) }
+					__nextHasNoMarginBottom={ true }
 				/>
 			</div>
 			<div className={ styles[ 'toggle-section__content' ] }>
@@ -469,6 +465,7 @@ const FirewallPage = () => {
 						onChange={ toggleIpAllowList }
 						disabled={ isUpdating }
 						aria-label={ __( 'Trusted IP addresses', 'jetpack-protect' ) }
+						__nextHasNoMarginBottom={ true }
 					/>
 				</div>
 				<div className={ styles[ 'toggle-section__content' ] }>

--- a/projects/plugins/protect/src/js/routes/firewall/styles.module.scss
+++ b/projects/plugins/protect/src/js/routes/firewall/styles.module.scss
@@ -204,6 +204,12 @@
 	}
 }
 
+// Render the smaller toggle variant (previously the jetpack-components
+// `size="small"` prop, which set `--base-width: 6px` on the form toggle).
+.share-data-toggle {
+	--base-width: 6px;
+}
+
 .icon-tooltip {
 	max-height: 20px;
 	margin-left: calc(var(--spacing-base) / 2); // 4px

--- a/projects/plugins/protect/src/js/routes/settings/index.jsx
+++ b/projects/plugins/protect/src/js/routes/settings/index.jsx
@@ -1,10 +1,5 @@
-import {
-	Col,
-	Container,
-	ToggleControl,
-	AdminSectionHero,
-	getRedirectUrl,
-} from '@automattic/jetpack-components';
+import { Col, Container, AdminSectionHero, getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
@@ -53,6 +48,7 @@ const SettingsPage = () => {
 						accountProtection.hasUnsupportedJetpackVersion ||
 						toggleAccountProtectionMutation.isPending
 					}
+					__nextHasNoMarginBottom={ true }
 				/>
 			</div>
 			<div className={ styles[ 'toggle-section__content' ] }>


### PR DESCRIPTION
Fixes #

## Proposed changes

Migrates `ToggleControl` usage in Boost and Protect from the custom `@automattic/jetpack-components` component to the canonical `@wordpress/components` `ToggleControl`. This is part of the ongoing `@automattic/jetpack-components` → `@wordpress/ui` / `@wordpress/components` modernization tracked in #48160.

* Replaces 5 toggles across the two packages:
  * **Boost** — module cards (1 file + scss).
  * **Protect** — firewall and settings (3 files + scss).
* **`size="small"` handling:** the custom `@automattic/jetpack-components` `ToggleControl` had a `size` prop, but `@wordpress/components` `ToggleControl` has no size prop. The small-size styling (`--base-width: 6px`) was ported into the consuming packages' SCSS, scoped to `.small` / `.share-data-toggle`, so the compact toggle dimensions are preserved.
* Adds `__nextHasNoMarginBottom` to each migrated control to opt into the current (margin-free) layout and silence the deprecation notice.
* Drops the custom `toggling` prop, which was unused.

<img width="1440" height="946" alt="boost-settings-after" src="https://github.com/user-attachments/assets/4a6d53eb-a722-4bd5-b44d-7464788553a7" />
<img width="1440" height="946" alt="protect-firewall-after" src="https://github.com/user-attachments/assets/8dacf2cc-3ad4-429a-9355-d29617beddf5" />
<img width="1440" height="900" alt="protect-firewall-footer-after" src="https://github.com/user-attachments/assets/d5360a7f-edc7-436d-b6f2-24f8c2f019c0" />
<img width="1440" height="946" alt="protect-settings-after" src="https://github.com/user-attachments/assets/ab6f55b2-b65b-48ee-8f06-3910ce0c3be0" />


## Related product discussion/links

* Part of #48160.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Boost and Protect.
* **Boost:** open the Boost dashboard and verify the module cards' toggles render at the small size, toggle on/off correctly, and reflect saved state.
* **Protect:** open the firewall and settings screens and verify each toggle (including the "share data" toggle) renders at the small size, toggles correctly, and persists state.
* Confirm there are no `__nextHasNoMarginBottom` / margin deprecation warnings in the console.

## Testing / Screenshots

Before/after were captured on a local dev site for the Boost module cards and the Protect firewall/settings toggles. The rendered output is visually pixel-identical — the small toggle size is preserved via the ported SCSS.

