### PR TITLE
Social: reconnect connections in place instead of delete + recreate

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
@@ -125,16 +125,18 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 		return null;
 	}
 
+	if ( isReconnecting ) {
+		// Make it non-interactive
+		return (
+			<Link href="#" variant={ 'unstyled' } aria-disabled>
+				{ __( 'Reconnecting…', 'jetpack-publicize-pkg' ) }
+			</Link>
+		);
+	}
+
 	return (
-		<Link
-			variant={ isReconnecting ? 'unstyled' : 'default' }
-			href="#"
-			aria-disabled={ isReconnecting || undefined }
-			onClick={ onClick }
-		>
-			{ isReconnecting
-				? __( 'Reconnecting…', 'jetpack-publicize-pkg' )
-				: _x( 'Reconnect', 'Reconnect a social media account', 'jetpack-publicize-pkg' ) }
+		<Link href="#" onClick={ onClick }>
+			{ _x( 'Reconnect', 'Reconnect a social media account', 'jetpack-publicize-pkg' ) }
 		</Link>
 	);
 }

--- a/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
@@ -1,3 +1,4 @@
+import { useGlobalNotices } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -28,6 +29,8 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 		completeReconnect,
 	} = useDispatch( socialStore );
 
+	const { createErrorNotice } = useGlobalNotices();
+
 	const { canManageConnection, isReconnectingThis } = useSelect(
 		select => {
 			const { canUserManageConnection, getReconnectingAccount } = select( socialStore );
@@ -57,6 +60,19 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 			const result = await fetchKeyringResult( requestId );
 
 			if ( ! result?.ID ) {
+				/*
+				 * The popup completed (so the connect-window abort cleanup won't run) but returned
+				 * no usable result. Clear the busy state here so the row doesn't stay stuck, and let
+				 * the user retry.
+				 */
+				setIsReconnecting( false );
+				setReconnectingAccount( undefined );
+				createErrorNotice(
+					__(
+						'The reconnection could not be completed. Please try again.',
+						'jetpack-publicize-pkg'
+					)
+				);
 				return;
 			}
 
@@ -73,7 +89,14 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 				openConnectionsModal();
 			}
 		},
-		[ completeReconnect, fetchKeyringResult, openConnectionsModal, setKeyringResult ]
+		[
+			completeReconnect,
+			createErrorNotice,
+			fetchKeyringResult,
+			openConnectionsModal,
+			setKeyringResult,
+			setReconnectingAccount,
+		]
 	);
 
 	const requestAccess = useRequestAccess( { service, onConfirm } );

--- a/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
@@ -20,45 +20,77 @@ export type ReconnectProps = {
  * @return {import('react').ReactNode} - React element
  */
 export function Reconnect( { connection, service }: ReconnectProps ) {
-	const { deleteConnectionById, fetchKeyringResult, openConnectionsModal, setReconnectingAccount } =
-		useDispatch( socialStore );
+	const {
+		fetchKeyringResult,
+		setKeyringResult,
+		openConnectionsModal,
+		setReconnectingAccount,
+		completeReconnect,
+	} = useDispatch( socialStore );
 
-	const { isDisconnecting, canManageConnection } = useSelect(
+	const { canManageConnection, isReconnectingThis } = useSelect(
 		select => {
-			const { getDeletingConnections, canUserManageConnection } = select( socialStore );
+			const { canUserManageConnection, getReconnectingAccount } = select( socialStore );
 
 			return {
-				isDisconnecting: getDeletingConnections().includes( connection.connection_id ),
 				canManageConnection: canUserManageConnection( connection ),
+				isReconnectingThis: getReconnectingAccount()?.connection_id === connection.connection_id,
 			};
 		},
 		[ connection ]
 	);
 
+	// Local busy state for the button. Kept separate from the store's reconnecting account so
+	// that resetting it (e.g. on an abandoned popup) can never disrupt the actual reconnect.
+	const [ isReconnecting, setIsReconnecting ] = useState( false );
+
+	// The flow has left this connection (completed in place, or the modal closed) — stop showing
+	// the busy state.
+	useEffect( () => {
+		if ( ! isReconnectingThis ) {
+			setIsReconnecting( false );
+		}
+	}, [ isReconnectingThis ] );
+
 	const onConfirm = useCallback(
 		async ( requestId: string ) => {
 			const result = await fetchKeyringResult( requestId );
 
-			if ( result?.ID ) {
+			if ( ! result?.ID ) {
+				return;
+			}
+
+			/*
+			 * Same account re-authed: keyring refreshed the token under the existing connection,
+			 * so it's valid again. A different account falls through to the confirmation modal,
+			 * where it shows up as a new account to add.
+			 */
+			const handled = await completeReconnect( result );
+
+			if ( ! handled ) {
+				// Different account — surface the result so the modal shows the confirmation view.
+				setKeyringResult( result );
 				openConnectionsModal();
 			}
 		},
-		[ openConnectionsModal, fetchKeyringResult ]
+		[ completeReconnect, fetchKeyringResult, openConnectionsModal, setKeyringResult ]
 	);
 
 	const requestAccess = useRequestAccess( { service, onConfirm } );
 
 	const onClickReconnect = useCallback( async () => {
-		const success = await deleteConnectionById( {
-			connectionId: connection.connection_id,
-			showSuccessNotice: false,
-		} );
+		setIsReconnecting( true );
+		await setReconnectingAccount( connection );
 
-		if ( ! success ) {
+		/*
+		 * Bluesky needs a fresh app password, so it reconnects through the modal's credential
+		 * form. Mastodon and the OAuth services re-auth the known account directly in a popup,
+		 * refreshing the token in place (no delete, no duplicate).
+		 */
+		if ( service.id === 'bluesky' ) {
+			openConnectionsModal();
 			return;
 		}
-
-		await setReconnectingAccount( connection );
 
 		const formData = new FormData();
 
@@ -66,28 +98,27 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 			formData.set( 'instance', connection.external_handle );
 		}
 
-		if ( service.id === 'bluesky' ) {
-			openConnectionsModal();
-		} else {
-			requestAccess( formData );
+		const opened = await requestAccess( formData, {
+			refresh: true,
+			// The user closed/dismissed the popup — drop the busy label (the reconnect itself
+			// is untouched, so a late result can still complete it).
+			onAbort: () => setIsReconnecting( false ),
+		} );
+
+		if ( ! opened ) {
+			setIsReconnecting( false );
+			setReconnectingAccount( undefined );
 		}
-	}, [
-		connection,
-		deleteConnectionById,
-		openConnectionsModal,
-		requestAccess,
-		service.id,
-		setReconnectingAccount,
-	] );
+	}, [ connection, openConnectionsModal, requestAccess, service.id, setReconnectingAccount ] );
 
 	const onClick = useCallback(
 		( event: React.MouseEvent ) => {
 			event.preventDefault();
-			if ( ! isDisconnecting ) {
+			if ( ! isReconnecting ) {
 				onClickReconnect();
 			}
 		},
-		[ isDisconnecting, onClickReconnect ]
+		[ isReconnecting, onClickReconnect ]
 	);
 
 	if ( ! canManageConnection ) {
@@ -96,13 +127,13 @@ export function Reconnect( { connection, service }: ReconnectProps ) {
 
 	return (
 		<Link
-			variant="default"
+			variant={ isReconnecting ? 'unstyled' : 'default' }
 			href="#"
-			aria-disabled={ isDisconnecting || undefined }
+			aria-disabled={ isReconnecting || undefined }
 			onClick={ onClick }
 		>
-			{ isDisconnecting
-				? __( 'Disconnecting…', 'jetpack-publicize-pkg' )
+			{ isReconnecting
+				? __( 'Reconnecting…', 'jetpack-publicize-pkg' )
 				: _x( 'Reconnect', 'Reconnect a social media account', 'jetpack-publicize-pkg' ) }
 		</Link>
 	);

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/reconnect.test.js
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/reconnect.test.js
@@ -33,27 +33,27 @@ describe( 'Reconnect', () => {
 		expect( screen.getByRole( 'link' ) ).toHaveTextContent( 'Reconnect' );
 	} );
 
-	test( 'disables the link when isDisconnecting is true', () => {
-		setup( { getDeletingConnections: [ mockConnection.connection_id ] } );
+	test( 'shows a non-interactive Reconnecting… label while a reconnect is in progress', async () => {
+		// A resolved-true requestAccess means the popup opened, so the busy state sticks.
+		useRequestAccess.mockReturnValue( jest.fn().mockResolvedValue( true ) );
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
-		const link = screen.getByRole( 'link' );
-		expect( link ).toHaveAttribute( 'aria-disabled', 'true' );
-		expect( link ).toHaveTextContent( 'Disconnecting…' );
+		await userEvent.click( screen.getByRole( 'link' ) );
+
+		await expect( screen.findByText( 'Reconnecting…' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'link' ) ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
-	test( 'calls deleteConnectionById and requestAccess on link click', async () => {
+	test( 'reconnects in place without disconnecting first', async () => {
+		const requestAccess = jest.fn().mockResolvedValue( true );
+		useRequestAccess.mockReturnValue( requestAccess );
 		const { stubDeleteConnectionById } = setup();
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
 		await userEvent.click( screen.getByRole( 'link' ) );
 
-		expect( stubDeleteConnectionById ).toHaveBeenCalledWith( {
-			connectionId: mockConnection.connection_id,
-			showSuccessNotice: false,
-		} );
-
-		expect( useRequestAccess ).toHaveBeenCalled();
+		expect( stubDeleteConnectionById ).not.toHaveBeenCalled();
+		expect( requestAccess ).toHaveBeenCalled();
 	} );
 
 	test( 'does not render the link if connection cannot be disconnected', () => {

--- a/projects/packages/publicize/_inc/components/services/connect-form.tsx
+++ b/projects/packages/publicize/_inc/components/services/connect-form.tsx
@@ -40,7 +40,7 @@ export function ConnectForm( {
 	compact,
 }: ConnectFormProps ) {
 	const isModernized = useIsModernized();
-	const { fetchKeyringResult } = useDispatch( store );
+	const { fetchKeyringResult, setKeyringResult, completeReconnect } = useDispatch( store );
 
 	// In the modernized chassis the submit button sits flush in a compact
 	// disclosure row unless it accompanies the custom-input fields. Legacy
@@ -51,6 +51,8 @@ export function ConnectForm( {
 	}
 
 	const { isConnectionsModalOpen } = useSelect( select => select( store ), [] );
+
+	const reconnectingAccount = useSelect( select => select( store ).getReconnectingAccount(), [] );
 
 	const [ isConnecting, setIsConnecting ] = useState( false );
 
@@ -65,13 +67,23 @@ export function ConnectForm( {
 	);
 
 	const onConfirm = useCallback(
-		( requestId: string ) => {
+		async ( requestId: string ) => {
 			// Fetch the keyring result only if the modal is open.
-			if ( isConnectionsModalOpen() ) {
-				fetchKeyringResult( requestId );
+			if ( ! isConnectionsModalOpen() ) {
+				return;
+			}
+
+			const result = await fetchKeyringResult( requestId );
+
+			// If this completed an in-place reconnect (same account), it's already handled;
+			// otherwise surface the result so it drives the regular confirmation view.
+			const handled = await completeReconnect( result );
+
+			if ( ! handled && result?.ID ) {
+				setKeyringResult( result );
 			}
 		},
-		[ fetchKeyringResult, isConnectionsModalOpen ]
+		[ completeReconnect, fetchKeyringResult, isConnectionsModalOpen, setKeyringResult ]
 	);
 
 	const requestAccess = useRequestAccess( {
@@ -93,9 +105,10 @@ export function ConnectForm( {
 
 			const formData = new FormData( event.target as HTMLFormElement );
 
-			await requestAccess( formData );
+			// Reconnecting re-auths the existing account, so refresh its token in place.
+			await requestAccess( formData, { refresh: Boolean( reconnectingAccount ) } );
 		},
-		[ onSubmit, requestAccess ]
+		[ onSubmit, reconnectingAccount, requestAccess ]
 	);
 
 	return (

--- a/projects/packages/publicize/_inc/components/services/service-item-modern.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item-modern.tsx
@@ -60,6 +60,13 @@ export function ModernServiceItem( {
 		[ brokenConnections ]
 	);
 
+	// While reconnecting a credential-based service (e.g. Bluesky), show its input form even
+	// though it has a broken connection, so the user can re-enter credentials in place.
+	const isReconnectingThisService = useSelect(
+		select => select( socialStore ).getReconnectingAccount()?.service_name === service.id,
+		[ service.id ]
+	);
+
 	const hideInitialConnectForm =
 		// For services with custom inputs, the initial Connect button opens the panel,
 		// so we don't want to show it if the panel is already open
@@ -124,9 +131,11 @@ export function ModernServiceItem( {
 				<div className={ styles[ 'service-panel-inner' ] }>
 					<ServiceItemDetails service={ service } serviceConnections={ serviceConnections } />
 					{
-						// Connect form for services that need custom inputs
-						// should be shown only if there are no broken connections
-						service.needsCustomInputs && ! hasOwnBrokenConnections ? (
+						// Connect form for services that need custom inputs. Normally hidden when a
+						// connection is broken (the "Fix connection" flow handles those), but shown
+						// while reconnecting this service so its credentials can be re-entered.
+						service.needsCustomInputs &&
+						( ! hasOwnBrokenConnections || isReconnectingThisService ) ? (
 							<div className={ styles[ 'connect-form-wrapper' ] }>
 								<ConnectForm
 									service={ service }

--- a/projects/packages/publicize/_inc/components/services/service-item.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item.tsx
@@ -53,6 +53,13 @@ export function ServiceItem( {
 		[ brokenConnections ]
 	);
 
+	// While reconnecting a credential-based service (e.g. Bluesky), show its input form even
+	// though it has a broken connection, so the user can re-enter credentials in place.
+	const isReconnectingThisService = useSelect(
+		select => select( socialStore ).getReconnectingAccount()?.service_name === service.id,
+		[ service.id ]
+	);
+
 	const hideInitialConnectForm =
 		// For services with custom inputs, the initial Connect button opens the panel,
 		// so we don't want to show it if the panel is already open
@@ -113,9 +120,11 @@ export function ServiceItem( {
 				<PanelBody opened={ isPanelOpen } onToggle={ togglePanel }>
 					<ServiceItemDetails service={ service } serviceConnections={ serviceConnections } />
 					{
-						// Connect form for services that need custom inputs
-						// should be shown only if there are no broken connections
-						service.needsCustomInputs && ! hasOwnBrokenConnections ? (
+						// Connect form for services that need custom inputs. Normally hidden when a
+						// connection is broken (the "Fix connection" flow handles those), but shown
+						// while reconnecting this service so its credentials can be re-entered.
+						service.needsCustomInputs &&
+						( ! hasOwnBrokenConnections || isReconnectingThisService ) ? (
 							<div className={ styles[ 'connect-form-wrapper' ] }>
 								<ConnectForm
 									service={ service }

--- a/projects/packages/publicize/_inc/components/services/use-request-access.ts
+++ b/projects/packages/publicize/_inc/components/services/use-request-access.ts
@@ -38,6 +38,20 @@ export type RequestAccessOptions = {
 };
 
 /**
+ * Per-request options for the function returned by {@link useRequestAccess}.
+ */
+export type RequestAccessArgs = {
+	/**
+	 * Append refresh=1 so keyring re-authorizes and refreshes the token in place.
+	 */
+	refresh?: boolean;
+	/**
+	 * Called when this auth_flow=v2 attempt looks abandoned (the user returned without a result, or the TTL elapsed).
+	 */
+	onAbort?: VoidFunction;
+};
+
+/**
  * Hook to request access to a service.
  *
  * @param {RequestAccessOptions} options - Options
@@ -61,17 +75,26 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 	const { getService } = useSelect( select => select( store ), [] );
 
 	return useCallback(
-		async ( formData: FormData ) => {
+		// Resolves to true when the connect popup opened, false on any early failure.
+		async ( formData: FormData, options: RequestAccessArgs = {} ): Promise< boolean > => {
 			let connectUrl = service.url;
 
 			if ( ! connectUrl ) {
+				// The connect URL is missing; refetch and read it once.
 				await refreshServicesList();
-				// Wait until the services list is refreshed
-				do {
-					await new Promise( resolve => setTimeout( resolve, 100 ) );
 
-					connectUrl = getService( service.id )?.url;
-				} while ( ! connectUrl );
+				connectUrl = getService( service.id )?.url;
+
+				if ( ! connectUrl ) {
+					createErrorNotice(
+						__(
+							'Could not start the connection. Please refresh the page and try again.',
+							'jetpack-publicize-pkg'
+						)
+					);
+
+					return false;
+				}
 			}
 
 			const url = new URL( connectUrl );
@@ -83,15 +106,17 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 					if ( ! isValidMastodonUsername( instance ) ) {
 						createErrorNotice( __( 'Invalid Mastodon username', 'jetpack-publicize-pkg' ) );
 
-						return;
+						return false;
 					}
 
-					if ( isMastodonAlreadyConnected?.( instance ) ) {
+					// A reconnect (refresh) re-auths an existing account in place, so only block
+					// genuine duplicates from a fresh connect.
+					if ( ! options.refresh && isMastodonAlreadyConnected?.( instance ) ) {
 						createErrorNotice(
 							__( 'This Mastodon account is already connected', 'jetpack-publicize-pkg' )
 						);
 
-						return;
+						return false;
 					}
 
 					url.searchParams.set( 'instance', instance );
@@ -105,15 +130,17 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 					if ( ! isValidBlueskyHandle( handle ) ) {
 						createErrorNotice( __( 'Invalid Bluesky handle', 'jetpack-publicize-pkg' ) );
 
-						return;
+						return false;
 					}
 
-					if ( isBlueskyAccountAlreadyConnected?.( handle ) ) {
+					// A reconnect (refresh) re-auths an existing account in place, so only block
+					// genuine duplicates from a fresh connect.
+					if ( ! options.refresh && isBlueskyAccountAlreadyConnected?.( handle ) ) {
 						createErrorNotice(
 							__( 'This Bluesky account is already connected', 'jetpack-publicize-pkg' )
 						);
 
-						return;
+						return false;
 					}
 
 					url.searchParams.set( 'handle', handle );
@@ -143,16 +170,30 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 				getAdminUrl( 'admin-post.php?action=jetpack_social_keyring_done' )
 			);
 
-			const opened = requestExternalAccess( url.toString(), () => onConfirm( requestId ) );
+			/*
+			 * refresh=1 tells keyring to re-authorize the account and refresh the token in
+			 * place (used for reconnect) rather than reuse an existing provider session.
+			 */
+			if ( options.refresh ) {
+				url.searchParams.set( 'refresh', '1' );
+			}
+
+			const opened = requestExternalAccess(
+				url.toString(),
+				() => onConfirm( requestId ),
+				options.onAbort
+			);
 
 			if ( ! opened ) {
 				createErrorNotice(
 					__(
-						'The connection window could not be opened. Please allow pop-ups for this site then try connecting the account again.',
+						'The reconnection window could not be opened. Please allow pop-ups for this site then try again.',
 						'jetpack-publicize-pkg'
 					)
 				);
 			}
+
+			return opened;
 		},
 		[
 			createErrorNotice,

--- a/projects/packages/publicize/_inc/components/services/use-request-access.ts
+++ b/projects/packages/publicize/_inc/components/services/use-request-access.ts
@@ -187,7 +187,7 @@ export function useRequestAccess( { service, onConfirm }: RequestAccessOptions )
 			if ( ! opened ) {
 				createErrorNotice(
 					__(
-						'The reconnection window could not be opened. Please allow pop-ups for this site then try again.',
+						'The connection window could not be opened. Please allow pop-ups for this site and try again.',
 						'jetpack-publicize-pkg'
 					)
 				);

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -95,8 +95,6 @@ export function fetchKeyringResult( requestId: string ) {
 			} );
 
 			if ( response?.code === 'success' && response.data ) {
-				dispatch( setKeyringResult( response.data ) );
-
 				return response.data;
 			}
 		} catch {
@@ -526,6 +524,47 @@ export function setReconnectingAccount( reconnectingAccount: Connection ) {
 	return {
 		type: SET_RECONNECTING_ACCOUNT,
 		reconnectingAccount,
+	};
+}
+
+/**
+ * Completes an in-place reconnect when the connect result matches the account being reconnected.
+ *
+ * @param keyringResult - The keyring result from the completed connect request.
+ *
+ * @return A thunk resolving to true if it handled an in-place reconnect, false otherwise.
+ */
+export function completeReconnect( keyringResult?: KeyringResult ) {
+	return async function ( { dispatch, select } ) {
+		const reconnectingAccount = select.getReconnectingAccount();
+
+		if ( ! reconnectingAccount || ! keyringResult?.ID ) {
+			return false;
+		}
+
+		const reconnectedIds = [
+			keyringResult.external_ID,
+			...( keyringResult.additional_external_users?.map( user => user.external_ID ) ?? [] ),
+		]
+			.filter( Boolean )
+			.map( String );
+
+		if ( ! reconnectedIds.includes( reconnectingAccount.external_id ) ) {
+			return false;
+		}
+
+		await dispatch( refreshConnectionTestResults() );
+
+		// Clear the reconnecting account only after the refresh, so the busy state stays until
+		// the connection list reflects the reconnection.
+		dispatch( setReconnectingAccount( undefined ) );
+
+		coreDispatch( globalNoticesStore ).createSuccessNotice(
+			__( 'Account reconnected successfully.', 'jetpack-publicize-pkg' ),
+			{ type: 'snackbar', isDismissible: true }
+		);
+
+		return true;
 	};
 }
 

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -555,14 +555,28 @@ export function completeReconnect( keyringResult?: KeyringResult ) {
 
 		await dispatch( refreshConnectionTestResults() );
 
+		// The account matched, but confirm the refreshed connection actually recovered before
+		// reporting success — re-authing doesn't guarantee the token now passes the test.
+		const recovered =
+			select.getConnectionById( reconnectingAccount.connection_id )?.status === 'ok';
+
 		// Clear the reconnecting account only after the refresh, so the busy state stays until
 		// the connection list reflects the reconnection.
 		dispatch( setReconnectingAccount( undefined ) );
 
-		coreDispatch( globalNoticesStore ).createSuccessNotice(
-			__( 'Account reconnected successfully.', 'jetpack-publicize-pkg' ),
-			{ type: 'snackbar', isDismissible: true }
-		);
+		const { createSuccessNotice, createErrorNotice } = coreDispatch( globalNoticesStore );
+
+		if ( recovered ) {
+			createSuccessNotice( __( 'Account reconnected successfully.', 'jetpack-publicize-pkg' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		} else {
+			createErrorNotice(
+				__( 'The account could not be reconnected. Please try again.', 'jetpack-publicize-pkg' ),
+				{ type: 'snackbar', isDismissible: true }
+			);
+		}
 
 		return true;
 	};

--- a/projects/packages/publicize/_inc/social-store/actions/services.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/services.ts
@@ -10,5 +10,8 @@ export function refreshServicesList() {
 		registry
 			.dispatch( coreStore )
 			.invalidateResolution( 'getEntityRecords', [ 'wpcom/v2', 'publicize/services' ] );
+
+		// Await the refetch so callers can read the fresh list right after.
+		await registry.resolveSelect( coreStore ).getEntityRecords( 'wpcom/v2', 'publicize/services' );
 	};
 }

--- a/projects/packages/publicize/_inc/utils/request-external-access.js
+++ b/projects/packages/publicize/_inc/utils/request-external-access.js
@@ -25,12 +25,15 @@ export const KEYRING_BROADCAST_CHANNEL = 'jetpack-social-keyring';
  * The legacy `window.opener.postMessage` path is kept as a fallback for URLs without a
  * `request_id`.
  *
- * @param {string}          url - The URL to be loaded in the newly opened window.
- * @param {requestCallback} cb  - The callback that handles the response.
+ * @param {string}          url       - The URL to be loaded in the newly opened window.
+ * @param {requestCallback} cb        - The callback that handles the response.
+ * @param {Function}        [onAbort] - Called for the auth_flow=v2 flow when the attempt looks
+ *                                    abandoned (the user returned to this window without a
+ *                                    result, or the TTL elapsed).
  *
  * @return {boolean} `true` if the popup opened, `false` if it was blocked by the browser.
  */
-export const requestExternalAccess = ( url, cb ) => {
+export const requestExternalAccess = ( url, cb, onAbort ) => {
 	const popupMonitor = new PopupMonitor();
 
 	popupMonitor.open(
@@ -54,18 +57,50 @@ export const requestExternalAccess = ( url, cb ) => {
 	if ( requestId && typeof BroadcastChannel !== 'undefined' ) {
 		const channel = new BroadcastChannel( KEYRING_BROADCAST_CHANNEL );
 
+		let resultReceived = false;
+
+		/*
+		 * Detect an abandoned attempt without watching the popup's 'close' event.
+		 */
+		const onWindowRefocused = () => {
+			// Grace period so a result delivered as the popup closes still wins the race.
+			setTimeout( () => {
+				if ( ! resultReceived ) {
+					onAbort?.();
+				}
+			}, 1000 );
+		};
+
+		const onPopupFocused = () => {
+			window.addEventListener( 'focus', onWindowRefocused, { once: true } );
+		};
+
+		const stopWatching = () => {
+			window.removeEventListener( 'blur', onPopupFocused );
+			window.removeEventListener( 'focus', onWindowRefocused );
+		};
+
 		channel.addEventListener( 'message', event => {
 			if ( event.data?.type === 'keyring-result' && event.data?.requestId === requestId ) {
+				resultReceived = true;
 				clearTimeout( cleanupTimer );
+				stopWatching();
 				channel.close();
 				cb();
 			}
 		} );
 
-		// Give up after the server transient's TTL; we don't watch the popup 'close' event
-		// because COOP makes it fire at the login screen, before auth completes.
+		window.addEventListener( 'blur', onPopupFocused, { once: true } );
+
+		// Backstop: give up after the server transient's TTL.
 		const cleanupTimer = setTimeout(
-			() => channel.close(),
+			() => {
+				stopWatching();
+				channel.close();
+				if ( ! resultReceived ) {
+					onAbort?.();
+				}
+			},
 			5 * 60 * 1000 // 5 minutes
 		);
 

--- a/projects/packages/publicize/changelog/update-social-reconnect-in-place
+++ b/projects/packages/publicize/changelog/update-social-reconnect-in-place
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: Reconnect accounts in place instead of disconnecting and recreating them, retaining connection settings.

--- a/projects/packages/publicize/src/rest-api/class-keyring-result-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-keyring-result-controller.php
@@ -118,7 +118,10 @@ class Keyring_Result_Controller extends Base_Controller {
 			return rest_ensure_response( $response );
 		}
 
-		$item = $external_connections->get_keyring_connection_item( $token_id );
+		// On reconnect of a broken connection, re-test so the cached failure is overwritten.
+		$force_connection_test = $external_connections->has_failing_cached_connection_test( $token_id );
+
+		$item = $external_connections->get_keyring_connection_item( $token_id, false, $force_connection_test );
 
 		if ( ! $item ) {
 			$response['code'] = 'token_not_found';


### PR DESCRIPTION
Fixes [SOCIAL-510](https://linear.app/a8c/issue/SOCIAL-510/linkedin-reconnect-silently-removes-the-connection-instead-of)

## Proposed changes

Reworks the Social "Reconnect" flow for a broken connection so it **refreshes the existing connection in place** instead of disconnecting it and creating a new one.

* **Connection settings are now retained across a reconnect.** Because the connection is no longer deleted and recreated, its **shared/global flag** and **per-connection message template** survive the reconnect (previously both were lost). This is the main user-facing benefit.
* Supporting changes that make the in-place flow work: re-authing refreshes the existing keyring token (same `token_id`, no duplicate-connection error, no re-create step); the "already connected" guard no longer blocks a reconnect (keyed off the `refresh` flow, which also fixes Mastodon's *"This account is already connected"* notice); Mastodon/OAuth services re-auth in the popup while **Bluesky** uses the modal's credential form (now shown for a broken connection so a fresh app password can be entered); the non-interactive "Reconnecting…" state spans the whole flow, survives the manage-connections modal, and recovers from an abandoned popup (via window-refocus detection plus the existing 5-minute TTL); and a stale cached "broken" test result is refreshed after reconnect so the account reports healthy.

### Dependencies

* The connection-test refresh depends on a small wpcom-side helper, added in a companion wpcom PR 223740-ghe-Automattic/wpcom

## Related product discussion/links

* [SOCIAL-510](https://linear.app/a8c/issue/SOCIAL-510/linkedin-reconnect-silently-removes-the-connection-instead-of)
* Follow-up to Automattic/jetpack#49688 — implements the reconnect-without-disconnecting approach floated in [this discussion](<https://github.com/Automattic/jetpack/pull/49688#discussion_r3427077095>).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Sandbox setup

The wpcom-side helper isn't deployed yet, so to test end to end: apply this PR's change **and** the accompanying wpcom change (223740-ghe-Automattic/wpcom) to your sandbox, then point both your test site and the public API to your sandbox.

### Setting up broken connections

Before reconnecting, set a **custom message template** on each connection and mark it **shared** so you can confirm those settings survive the reconnect.

To break a connection, revoke Jetpack / [WordPress.com](<http://WordPress.com>) access from the network itself, then have it re-tested:

* Instagram — [https://www.instagram.com/accounts/manage_access/](<https://www.instagram.com/accounts/manage_access/>)
* Facebook — [https://www.facebook.com/settings/?tab=business_tools](<https://www.facebook.com/settings/?tab=business_tools>)
* LinkedIn — [https://www.linkedin.com/mypreferences/d/data-sharing-for-permitted-services](<https://www.linkedin.com/mypreferences/d/data-sharing-for-permitted-services>)
* Threads — [https://www.threads.com/settings/website_permissions](<https://www.threads.com/settings/website_permissions>)
* Tumblr — [https://www.tumblr.com/settings/apps](<https://www.tumblr.com/settings/apps>)
* Mastodon — [https://mastodon.social/oauth/authorized_applications](<https://mastodon.social/oauth/authorized_applications>) (substitute your instance)

After revoking, open the site's **Social Report card** and **force-test the connections** so they're reported as broken.

Run through the scenarios in **both** surfaces — the **block editor** Jetpack Social panel and the **Social admin page**:

* **Reconnect a broken connection:**
  * The link shows a non-interactive "Reconnecting…" while in progress, then returns to "Reconnect" once the connection list finishes refreshing.
  * After completing the OAuth/credential flow, the connection is healthy again **and its message template + shared flag are retained**.
  * Confirm there is no "already connected" error and no duplicate connection is created.
* **Test Mastodon and Bluesky specifically** (they differ from the OAuth services):
  * **Mastodon** re-auths directly in the popup; confirm no *"This account is already connected"* notice.
  * **Bluesky** opens the manage-connections modal with the broken connection's handle pre-filled and an app-password field; entering a fresh app password reconnects it in place.
* **Reconnect from inside the manage-connections modal:** the modal stays open (it should not dismiss when the keyring result returns), and the connection's status updates in place.
* **Abandon the popup:** click Reconnect, then close the OAuth popup without finishing — the "Reconnecting…" state clears when you return to the tab (rather than staying stuck).
* **Regression — adding a new connection** (not a reconnect): connecting a brand-new account still works and still shows the account-confirmation step; no spurious forced re-tests.
* **Regression — updating and disconnecting:** toggling a connection's shared flag / editing its message template, and disconnecting a connection, all behave as before.

## Screencast

https://github.com/user-attachments/assets/97e82b95-34d1-4b97-885e-2e37f96ab514