### PR TITLE
VideoPress: surface the admin dashboard in the Jetpack plugin

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-videopress-admin-ui
+++ b/projects/plugins/jetpack/changelog/add-jetpack-videopress-admin-ui
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-VideoPress: make the VideoPress admin dashboard available in the Jetpack plugin (previously only in the standalone Jetpack VideoPress plugin), respecting the modernization filter for the legacy vs. new UI.
+VideoPress: make the VideoPress admin dashboard available in the Jetpack plugin (previously only in the standalone Jetpack VideoPress plugin).

--- a/projects/plugins/jetpack/changelog/add-jetpack-videopress-admin-ui
+++ b/projects/plugins/jetpack/changelog/add-jetpack-videopress-admin-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: make the VideoPress admin dashboard available in the Jetpack plugin (previously only in the standalone Jetpack VideoPress plugin), respecting the modernization filter for the legacy vs. new UI.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -795,9 +795,7 @@ class Jetpack {
 
 		// Enable the VideoPress admin UI (the "Jetpack > VideoPress" dashboard) inside the
 		// Jetpack plugin, mirroring the standalone Jetpack VideoPress plugin. The page only
-		// renders when the VideoPress module is active (Status::is_active()), and respects the
-		// rsm_jetpack_ui_modernization_videopress filter to switch between the legacy React app
-		// and the modernized wp-build dashboard.
+		// renders when the VideoPress module is active (Status::is_active()).
 		$config->ensure( 'videopress', array( 'admin_ui' => true ) );
 
 		$config->ensure(

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -784,7 +784,6 @@ class Jetpack {
 				'sync',
 				'account_protection',
 				'waf',
-				'videopress',
 				'stats',
 				'stats_admin',
 				'import',
@@ -793,6 +792,13 @@ class Jetpack {
 		) {
 			$config->ensure( $feature );
 		}
+
+		// Enable the VideoPress admin UI (the "Jetpack > VideoPress" dashboard) inside the
+		// Jetpack plugin, mirroring the standalone Jetpack VideoPress plugin. The page only
+		// renders when the VideoPress module is active (Status::is_active()), and respects the
+		// rsm_jetpack_ui_modernization_videopress filter to switch between the legacy React app
+		// and the modernized wp-build dashboard.
+		$config->ensure( 'videopress', array( 'admin_ui' => true ) );
 
 		$config->ensure(
 			'connection',


### PR DESCRIPTION
## Proposed changes

The **Jetpack > VideoPress** admin dashboard has, until now, only ever appeared in the standalone *Jetpack VideoPress* plugin — even though the dashboard itself lives entirely in the `automattic/jetpack-videopress` package that the Jetpack plugin already bundles.

The reason is a single init option. The package's `Admin_UI::init()` only runs when `Initializer::should_initialize_admin_ui()` is true, which is only the case when a consumer passes `admin_ui => true` to `$config->ensure( 'videopress', … )`. The standalone plugin does that; `Jetpack::configure()` lumped `'videopress'` into a bare loop that called `$config->ensure( $feature )` with no options, so the flag was never set and the menu never registered.

This PR pulls `'videopress'` out of that no-options loop and ensures it with `array( 'admin_ui' => true )`, mirroring the standalone plugin.

* `projects/plugins/jetpack/class.jetpack.php`: ensure the `videopress` feature with `admin_ui => true`.

Behavior is unchanged unless the VideoPress module is active:

* The page is still gated by `Status::is_active()`, which inside the Jetpack plugin means the **VideoPress module must be active** (Jetpack, unlike the standalone plugin, does not force-activate the module).
* The existing `rsm_jetpack_ui_modernization_videopress` filter continues to select the UI: **off → legacy React app**, **on → modernized wp-build dashboard**. No new enablement mechanism is introduced.

All required assets (the legacy `build/admin` bundle and the full modernized `build/` wp-build tree) and the `jetpack-wp-build-polyfills` dependency already ship in the Jetpack plugin's `jetpack_vendor/` mirror, so no build changes are needed.

## Related product discussion/links

* VIDP-251 (modernized VideoPress dashboard) — this PR makes that dashboard reachable from the Jetpack plugin, not just the standalone plugin.

## Does this pull request change what data or activity we track or use?

No. No new tracking is introduced. The package's existing Tracks usage is unchanged and still gated by the standard analytics/consent checks.

## Testing instructions

Prerequisite: a site with the **Jetpack plugin only** (the standalone *Jetpack VideoPress* plugin **deactivated**), and the **VideoPress module active** (`wp jetpack module activate videopress`).

1. Go to **wp-admin → Jetpack**. Confirm a **VideoPress** entry appears in the Jetpack submenu.
2. Visit **admin.php?page=jetpack-videopress**.
   * With `rsm_jetpack_ui_modernization_videopress` **off** (default), the legacy React app renders (mount node `#jetpack-videopress-root`, `jetpack-videopress-pkg` bundle).
   * With the filter **on** (e.g. `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`), the modernized wp-build dashboard renders (mount node `#jetpack-videopress-dashboard-wp-admin-app`, `@wordpress/boot` script module).
3. With the VideoPress module **inactive**, confirm the page/menu does **not** appear (expected).

Verified locally in Docker with the standalone plugin deactivated: filter off → legacy app, filter on → modernized dashboard, both served by the Jetpack plugin alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
