### PR TITLE
SEO: cohort-gate legacy Traffic SEO / Sitemaps / Verification sections (PR #5b, JETPACK-1682)

### DIFF
--- a/projects/packages/seo/changelog/add-jetpack-seo-surface-visible-script-data
+++ b/projects/packages/seo/changelog/add-jetpack-seo-surface-visible-script-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Expose `seo.surface_visible` on the admin script data so the legacy Traffic page can hide its SEO/Sitemaps sections for sites on the new SEO experience.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -321,6 +321,11 @@ class Initializer {
 		}
 
 		$data[ self::SCRIPT_DATA_KEY ]['optin_available'] = self::is_optin_available();
+		// Read by the legacy Traffic page to hide its SEO / Sitemaps sections once the
+		// site is on the new experience (fresh install / opted-in / WordPress.com), so the
+		// two surfaces never show at once. The legacy sections stay for self-hosted installs
+		// that haven't opted in.
+		$data[ self::SCRIPT_DATA_KEY ]['surface_visible'] = self::is_seo_surface_visible();
 
 		return $data;
 	}

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -334,18 +334,28 @@ class InitializerTest extends TestCase {
 	public function test_inject_optin_availability_surfaces_flag_state() {
 		delete_option( Initializer::VISIBILITY_OPTION );
 
-		// Flag off → false, and non-array input is normalized to an array.
+		// Flag off → false, and non-array input is normalized to an array. Surface is also
+		// hidden (no cohort option set on this self-hosted test site).
 		$data = Initializer::inject_optin_availability( null );
 		$this->assertFalse( $data[ Initializer::SCRIPT_DATA_KEY ]['optin_available'] );
+		$this->assertFalse( $data[ Initializer::SCRIPT_DATA_KEY ]['surface_visible'] );
 
-		// Flag on + surface hidden → true; existing keys are preserved.
+		// Flag on + surface hidden → opt-in offered, surface not yet visible; existing keys preserved.
 		add_filter( Initializer::FEATURE_FILTER, '__return_true' );
 		try {
 			$data = Initializer::inject_optin_availability( array( 'keep' => 1 ) );
 			$this->assertTrue( $data[ Initializer::SCRIPT_DATA_KEY ]['optin_available'] );
+			$this->assertFalse( $data[ Initializer::SCRIPT_DATA_KEY ]['surface_visible'] );
 			$this->assertSame( 1, $data['keep'] );
+
+			// Opted in → surface visible, opt-in no longer offered.
+			update_option( Initializer::VISIBILITY_OPTION, '1' );
+			$data = Initializer::inject_optin_availability( array() );
+			$this->assertTrue( $data[ Initializer::SCRIPT_DATA_KEY ]['surface_visible'] );
+			$this->assertFalse( $data[ Initializer::SCRIPT_DATA_KEY ]['optin_available'] );
 		} finally {
 			remove_filter( Initializer::FEATURE_FILTER, '__return_true' );
+			delete_option( Initializer::VISIBILITY_OPTION );
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -60,10 +60,16 @@ export class Traffic extends Component {
 			foundBlaze = this.props.isModuleFound( 'blaze' );
 
 		// Once the site is on the new SEO experience (fresh install / opted-in /
-		// WordPress.com), SEO + Sitemaps live in the dedicated SEO dashboard, so hide
-		// those legacy sections here and point to the new page. Existing self-hosted
-		// installs that haven't opted in keep the legacy sections (JETPACK-1682).
+		// WordPress.com), the SEO, Sitemaps, and Verification sections live in the
+		// dedicated SEO dashboard, so hide those legacy sections here and point to the
+		// new page. Existing self-hosted installs that haven't opted in keep them
+		// (JETPACK-1682).
 		const seoMovedToDashboard = getScriptData()?.seo?.surface_visible === true;
+		// The pointer notice stands in for every section we hide, so show it whenever
+		// any of them would have rendered — including a settings search for "sitemap"
+		// or "verification" that matches even when the SEO section itself does not.
+		const foundMovedToDashboard =
+			foundSeo || foundCanonicalUrls || foundSitemaps || foundVerification;
 
 		if (
 			! foundSeo &&
@@ -101,7 +107,7 @@ export class Traffic extends Component {
 						} ) }
 					/>
 				) }
-				{ seoMovedToDashboard && ( foundSeo || foundCanonicalUrls ) && (
+				{ seoMovedToDashboard && foundMovedToDashboard && (
 					<SimpleNotice status="is-info" showDismiss={ false } className="jp-seo-moved-banner">
 						<div className="jp-seo-moved-banner__content">
 							<strong>{ __( 'Jetpack SEO has its own dashboard', 'jetpack' ) }</strong>
@@ -111,7 +117,12 @@ export class Traffic extends Component {
 									'jetpack'
 								) }
 							</p>
-							<Button primary rna compact href="admin.php?page=jetpack-seo">
+							<Button
+								primary
+								rna
+								compact
+								href={ `${ this.props.siteAdminUrl }admin.php?page=jetpack-seo` }
+							>
 								{ __( 'Open the SEO dashboard', 'jetpack' ) }
 							</Button>
 						</div>

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -3,6 +3,7 @@ import { getScriptData, isWoASite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import Button from 'components/button';
 import QuerySite from 'components/data/query-site';
 import SimpleNotice from 'components/notice';
 import {
@@ -101,9 +102,19 @@ export class Traffic extends Component {
 					/>
 				) }
 				{ seoMovedToDashboard && ( foundSeo || foundCanonicalUrls ) && (
-					<SimpleNotice showDismiss={ false } status="is-info">
-						{ __( 'Jetpack SEO now has its own dashboard.', 'jetpack' ) }{ ' ' }
-						<a href="admin.php?page=jetpack-seo">{ __( 'Open the SEO dashboard', 'jetpack' ) }</a>
+					<SimpleNotice status="is-info" showDismiss={ false } className="jp-seo-moved-banner">
+						<div className="jp-seo-moved-banner__content">
+							<strong>{ __( 'Jetpack SEO has its own dashboard', 'jetpack' ) }</strong>
+							<p>
+								{ __(
+									'Manage your search engine optimization settings from the redesigned SEO dashboard.',
+									'jetpack'
+								) }
+							</p>
+							<Button primary rna compact href="admin.php?page=jetpack-seo">
+								{ __( 'Open the SEO dashboard', 'jetpack' ) }
+							</Button>
+						</div>
 					</SimpleNotice>
 				) }
 				{ foundStats && <SiteStats { ...commonProps } /> }
@@ -113,7 +124,9 @@ export class Traffic extends Component {
 				{ foundBlaze && <Blaze { ...commonProps } /> }
 				{ foundShortlinks && <Shortlinks { ...commonProps } /> }
 				{ ! seoMovedToDashboard && foundSitemaps && <Sitemaps { ...commonProps } /> }
-				{ foundVerification && <VerificationServices { ...commonProps } /> }
+				{ ! seoMovedToDashboard && foundVerification && (
+					<VerificationServices { ...commonProps } />
+				) }
 			</div>
 		);
 	}

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -1,9 +1,10 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { isWoASite } from '@automattic/jetpack-script-data';
+import { getScriptData, isWoASite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySite from 'components/data/query-site';
+import SimpleNotice from 'components/notice';
 import {
 	isSiteConnected,
 	isOfflineMode,
@@ -57,6 +58,12 @@ export class Traffic extends Component {
 			foundAnalytics = isWoASite(),
 			foundBlaze = this.props.isModuleFound( 'blaze' );
 
+		// Once the site is on the new SEO experience (fresh install / opted-in /
+		// WordPress.com), SEO + Sitemaps live in the dedicated SEO dashboard, so hide
+		// those legacy sections here and point to the new page. Existing self-hosted
+		// installs that haven't opted in keep the legacy sections (JETPACK-1682).
+		const seoMovedToDashboard = getScriptData()?.seo?.surface_visible === true;
+
 		if (
 			! foundSeo &&
 			! foundCanonicalUrls &&
@@ -84,7 +91,7 @@ export class Traffic extends Component {
 						  ) }
 				</h2>
 				{ foundRelated && <RelatedPosts { ...commonProps } /> }
-				{ ( foundSeo || foundCanonicalUrls ) && (
+				{ ! seoMovedToDashboard && ( foundSeo || foundCanonicalUrls ) && (
 					<SEO
 						{ ...commonProps }
 						configureUrl={ getRedirectUrl( 'calypso-marketing-traffic', {
@@ -93,13 +100,19 @@ export class Traffic extends Component {
 						} ) }
 					/>
 				) }
+				{ seoMovedToDashboard && ( foundSeo || foundCanonicalUrls ) && (
+					<SimpleNotice showDismiss={ false } status="is-info">
+						{ __( 'Jetpack SEO now has its own dashboard.', 'jetpack' ) }{ ' ' }
+						<a href="admin.php?page=jetpack-seo">{ __( 'Open the SEO dashboard', 'jetpack' ) }</a>
+					</SimpleNotice>
+				) }
 				{ foundStats && <SiteStats { ...commonProps } /> }
 				{ foundAnalytics && (
 					<GoogleAnalytics { ...commonProps } site={ this.props.blogID ?? this.props.siteRawUrl } />
 				) }
 				{ foundBlaze && <Blaze { ...commonProps } /> }
 				{ foundShortlinks && <Shortlinks { ...commonProps } /> }
-				{ foundSitemaps && <Sitemaps { ...commonProps } /> }
+				{ ! seoMovedToDashboard && foundSitemaps && <Sitemaps { ...commonProps } /> }
 				{ foundVerification && <VerificationServices { ...commonProps } /> }
 			</div>
 		);

--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-module-absorption
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-module-absorption
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SEO: hide the legacy Traffic-page SEO and Sitemaps sections once a site is on the new SEO dashboard (fresh install, opted-in, or WordPress.com), pointing to the new page; existing self-hosted installs that haven't opted in keep the legacy sections.


### PR DESCRIPTION
> **Part of the [Jetpack SEO product split](https://github.com/Automattic/jetpack/pull/48154).** PR #5b — tracks [JETPACK-1682](https://linear.app/a8c/issue/JETPACK-1682).
> **⚠️ Stacked on #49672 (discoverability).** Base is `add/jetpack-seo-discoverability`, not trunk — review/merge after it. Draft until #49672 lands + screenshots.

## Scope change (please read first)

Original #5b was "remove the standalone SEO module entries" (delete `seo-tools`/`sitemaps`/`canonical-urls` and absorb their serving). **Per direction from Devin Walker on how the new SEO page is surfaced to existing self-hosted users** — they *opt in* to the new experience rather than being force-migrated — **pure deletion is impossible**: deleting the modules would yank the legacy Traffic→SEO experience out from under users who haven't opted in, effectively forcing them onto the new page out of necessity.

So #5b is re-scoped to the **cohort-gated surface handoff**, and two things follow:
- **The module files stay.** Actual deletion / full serving-absorption is **deferred to a post-convergence follow-up** (tied to the `rsm_jetpack_seo` flag removal, [JETPACK-1702](https://linear.app/a8c/issue/JETPACK-1702)), once existing installs have converged onto the new experience.
- **#5b no longer depends on 5a.** 5a's durable-option migration only matters for the *deferred* deletion; with the modules kept, the dashboard reads live module state. #5b now depends on the discoverability work (#49672) instead — hence the stacking.

## Proposed changes

The legacy Traffic→SEO surface and the new SEO dashboard become **mutually exclusive per the discoverability cohort**:

- **`Initializer::inject_optin_availability()`** (jetpack-seo) now also exposes **`seo.surface_visible`** (= `is_seo_surface_visible()`) on the admin script data.
- **`_inc/client/traffic/index.jsx`** hides the **SEO**, **Sitemaps**, and **Site Verification** sections when `seo.surface_visible === true` (fresh install / opted-in / WordPress.com), and shows a small pointer notice in their place — "Jetpack SEO has its own dashboard" with an **Open the SEO dashboard** button. `verification_services_codes` is a shared option the new dashboard already reads, so hiding the Verification section needs no migration.
- For **existing self-hosted installs that haven't opted in** (`surface_visible` false/undefined, incl. pre-launch when the flag is off), the legacy sections render **exactly as today, fully functional**.

No module files deleted; no CLI/REST changes (the modules remain discoverable, so those paths are unaffected).

## Related product discussion/links

- [JETPACK-1682](https://linear.app/a8c/issue/JETPACK-1682) — this issue. Parent: [SEO product split #48154](https://github.com/Automattic/jetpack/pull/48154).
- [JETPACK-1700](https://linear.app/a8c/issue/JETPACK-1700) / #49672 — the discoverability work this stacks on and reuses (`is_seo_surface_visible`, script-data injection).
- [JETPACK-1681](https://linear.app/a8c/issue/JETPACK-1681) / #5a — state migration, now only needed for the deferred deletion.
- [JETPACK-1702](https://linear.app/a8c/issue/JETPACK-1702) — flag removal; the deferred module deletion converges here.

**Screenshots**


https://github.com/user-attachments/assets/1ef00e5d-4179-445d-b465-760a0c8d2cd0



## Other information

- [x] New tests — `InitializerTest::test_inject_optin_availability_surfaces_flag_state` now also asserts `surface_visible` (hidden when no cohort option, visible once opted in).
- [x] Changelog — yes, in `projects/plugins/jetpack` and `projects/packages/seo`.

> **On the `Covered by non-unit tests` label:** this PR's only new executable code is the legacy Traffic page JS (`_inc/client/traffic/index.jsx`), which has no unit-test harness in the `_inc/client` admin app and is verified via E2E/manual (see screenshots). The opt-in PHP it inherits from #49672 is covered there (by `SEO_Optin_Test` / `InitializerTest`).

## Does this pull request change what data or activity we track or use?

No. Reads the existing `jetpack_seo_surface_visible` cohort option; no new options or telemetry.

## Testing instructions

Behind the `rsm_jetpack_seo` flag (mu-plugin `add_filter( 'rsm_jetpack_seo', '__return_true' );`), on a self-hosted site:

1. **Not opted in** (`wp option delete jetpack_seo_surface_visible`): **Jetpack → Traffic → SEO** and **Sitemaps** sections render and work exactly as before.
2. **Opted in** (`wp option update jetpack_seo_surface_visible 1`): those sections are gone, replaced by the "Jetpack SEO now has its own dashboard → Open the SEO dashboard" pointer; the new SEO admin is the place to manage SEO.
3. **Flag off** (production default): no change to the Traffic page at all.


