### PR TITLE
Premium Analytics: port the Bookings by status widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-bookings-by-status-widget
+++ b/projects/packages/premium-analytics/changelog/add-bookings-by-status-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Port the Bookings by status dashboard widget from next-woocommerce-analytics, composed from the widgets-toolkit and data packages.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
@@ -81,6 +81,7 @@ export function BookingsByAttendanceWidget() {
 						type: 'number',
 						options: { useMultipliers: false, decimals: 0 },
 					} }
+					maxSize={ null }
 					emptyStateIcon={ calendar }
 					withTooltips
 				/>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/donut-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/donut-widget.module.scss
@@ -4,7 +4,7 @@
  */
 .container {
 	min-width: 120px;
-	max-width: 240px;
+	width: 100%;
 	height: 100%;
 	margin: 0 auto;
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-bookings-by-status",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/package.json
@@ -4,10 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/render.tsx
@@ -1,0 +1,26 @@
+import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import {
+	BookingsByAttendanceWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type BookingsByStatusRenderProps = WidgetRenderProps< Partial< ReportParamsFieldAttributes > >;
+
+/**
+ * Bookings by status widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; BookingsByAttendanceWidget
+ * fetches the bookings report and renders the status breakdown.
+ */
+export default function BookingsByStatusRender( { attributes }: BookingsByStatusRenderProps ) {
+	return (
+		<GlobalErrorProvider>
+			<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+				<BookingsByAttendanceWidget />
+			</WidgetRoot>
+		</GlobalErrorProvider>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/render.tsx
@@ -1,12 +1,26 @@
-import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+/**
+ * External dependencies
+ */
 import {
 	BookingsByAttendanceWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { BookingsByStatusAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type BookingsByStatusRenderProps = WidgetRenderProps< Partial< ReportParamsFieldAttributes > >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type BookingsByStatusRenderAttributes = BookingsByStatusAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type BookingsByStatusRenderProps = WidgetRenderProps< BookingsByStatusRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
 
 /**
  * Bookings by status widget.
@@ -15,12 +29,13 @@ type BookingsByStatusRenderProps = WidgetRenderProps< Partial< ReportParamsField
  * client, chart theme, and resolved report params; BookingsByAttendanceWidget
  * fetches the bookings report and renders the status breakdown.
  */
-export default function BookingsByStatusRender( { attributes }: BookingsByStatusRenderProps ) {
+export default function BookingsByStatusRender( {
+	attributes = {},
+	setError,
+}: BookingsByStatusRenderProps ) {
 	return (
-		<GlobalErrorProvider>
-			<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
-				<BookingsByAttendanceWidget />
-			</WidgetRoot>
-		</GlobalErrorProvider>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<BookingsByAttendanceWidget />
+		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
@@ -1,0 +1,189 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import BookingsByStatusRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const BOOKINGS_BY_STATUS_RENDER_MODULE = 'storybook/bookings-by-status';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type BookingsByStatusRenderProps = ComponentProps< typeof BookingsByStatusRender >;
+
+interface BookingsByStatusStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type BookingsByStatusStoryProps = BookingsByStatusRenderProps & BookingsByStatusStoryControls;
+
+interface BookingsByStatusDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		BookingsByStatusStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getBookingsByStatusAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): BookingsByStatusRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< BookingsByStatusStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getBookingsByStatusSource( args: Partial< BookingsByStatusStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<BookingsByStatusRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderBookingsByStatus( { withComparison, preset }: BookingsByStatusStoryControls ) {
+	return (
+		<BookingsByStatusRender
+			attributes={ getBookingsByStatusAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function BookingsByStatusDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: BookingsByStatusDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ BOOKINGS_BY_STATUS_RENDER_MODULE }
+			renderComponent={ BookingsByStatusRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison, preset ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/BookingsByStatus',
+	component: BookingsByStatusRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays the bookings status breakdown for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< BookingsByStatusStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< BookingsByStatusDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderBookingsByStatus,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				code: getBookingsByStatusSource( { withComparison: false, preset: DEFAULT_PRESET } ),
+			},
+		},
+	},
+};
+
+/**
+ * Current period with previous-period comparison data.
+ */
+export const WithComparison: Story = {
+	render: renderBookingsByStatus,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				code: getBookingsByStatusSource( { withComparison: true, preset: DEFAULT_PRESET } ),
+			},
+		},
+	},
+};
+
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <BookingsByStatusDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+		},
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/bookings-by-status",
+	"title": "Bookings by status",
+	"description": "Number of bookings by status over the selected time period.",
+	"category": "bookings"
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/bookings-by-attendance` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/bookings-by-status',
+	title: __( 'Bookings by status', 'jetpack-premium-analytics' ),
+	description: __(
+		'Number of bookings by status over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type BookingsByStatusAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/bookings-by-attendance` in


### PR DESCRIPTION
Fixes: WOOA7S-1462

## Proposed changes
* Ports the **Bookings by status** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/bookings-by-status` widget and renders the shared bookings attendance widget inside `WidgetRoot` using dashboard-level report params.
* Wraps the widget with the shared global error provider used by the widgets-toolkit, without adding widget-local error notice UI.
* Adds standalone Storybook `Default` / `WithComparison` stories plus a dashboard-hosted `WidgetDashboardWithWidget` story using the shared Premium Analytics Storybook dashboard helper.
* Uses the shared Storybook report/settings mocks from trunk for dashboard rendering.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Bookings by status Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1462-port-woo-widget-bookings-by-status/bookings-by-status.png)

## Related product discussion/links
* WOOA7S-1462; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm install --frozen-lockfile`
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the built Storybook iframe story `packages-premium-analytics-widgets-bookingsbystatus--widget-dashboard-with-widget` with a local Playwright smoke pass: title rendered, status labels rendered, chart SVGs rendered, and no widget-specific console errors.
