### PR TITLE
Premium Analytics: port the Bookings by device widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-bookings-by-device-widget-story
+++ b/projects/js-packages/storybook/changelog/add-bookings-by-device-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a Premium Analytics Bookings by device widget story.

--- a/projects/packages/premium-analytics/changelog/add-bookings-by-device-widget
+++ b/projects/packages/premium-analytics/changelog/add-bookings-by-device-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Port the Bookings by device dashboard widget from next-woocommerce-analytics, composed from the widgets-toolkit and data packages.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report-order-attribution.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report-order-attribution.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { reportOrderAttributionSummaryQuery } from '../../queries';
+import { useReportOrderAttribution } from '../use-report-order-attribution';
+import type { ReportParams } from '../../utils/search';
+import type { ReactNode } from 'react';
+
+jest.mock( '../../queries', () => ( {
+	reportOrderAttributionSummaryQuery: jest.fn( () => ( {
+		queryKey: [ 'reports', 'order-attribution' ],
+		queryFn: async () => ( { data: [] } ),
+		enabled: false,
+	} ) ),
+} ) );
+
+const mockReportOrderAttributionSummaryQuery =
+	reportOrderAttributionSummaryQuery as jest.MockedFunction<
+		typeof reportOrderAttributionSummaryQuery
+	>;
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: {
+				queryFn: async () => ( { data: [] } ),
+				retry: false,
+			},
+		},
+	} );
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+describe( 'useReportOrderAttribution', () => {
+	it( 'forwards product filters to the order attribution summary query', () => {
+		const filters: ReportParams[ 'filters' ] = [
+			{
+				key: 'product_type',
+				value: [ 'booking', 'bookable-event', 'bookable-service' ],
+				compare: 'IN',
+			},
+		];
+
+		renderHook(
+			() =>
+				useReportOrderAttribution(
+					{
+						from: '2026-06-01',
+						to: '2026-06-07',
+						compare_from: '2026-05-25',
+						compare_to: '2026-05-31',
+						interval: 'day',
+						view: 'device',
+						filters,
+					},
+					{
+						enabled: false,
+					}
+				),
+			{ wrapper }
+		);
+
+		expect( mockReportOrderAttributionSummaryQuery ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				from: '2026-06-01',
+				to: '2026-06-07',
+				compare_from: '2026-05-25',
+				compare_to: '2026-05-31',
+				interval: 'day',
+				view: 'device',
+				filters,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report-order-attribution.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report-order-attribution.ts
@@ -50,6 +50,7 @@ export function useReportOrderAttribution(
 				compare_from: compareFrom,
 				compare_to: compareTo,
 				date_type: params.date_type,
+				filters: params.filters,
 			} );
 		},
 		params,

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/report-order-attribution-summary-query.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/report-order-attribution-summary-query.test.ts
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { reportOrderAttributionSummaryQuery } from '../report-order-attribution-summary-query';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+beforeEach( () => {
+	mockApiFetch.mockResolvedValue( {
+		view: 'device',
+		order_by: 'net_sales',
+		data: [],
+	} );
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'reportOrderAttributionSummaryQuery', () => {
+	it( 'uses the by-product endpoint when product filters are present', async () => {
+		const query = reportOrderAttributionSummaryQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			compare_from: '2026-05-25',
+			compare_to: '2026-05-31',
+			interval: 'day',
+			view: 'device',
+			filters: [
+				{
+					key: 'product_type',
+					value: [ 'booking', 'bookable-event', 'bookable-service' ],
+					compare: 'IN',
+				},
+			],
+		} );
+
+		const queryFn = query.queryFn as () => Promise< unknown >;
+		await queryFn();
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( mockApiFetch ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( {
+				path: expect.stringContaining( '/order-attribution-by-product/device/summary' ),
+			} )
+		);
+		expect( mockApiFetch ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( {
+				path: expect.stringContaining( '/order-attribution-by-product/device/summary' ),
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -91,7 +91,6 @@ export {
 	TotalReturnsWidget,
 	VisitorsByLocationWidget,
 	SalesByDeviceWidget,
-	BookingsByDeviceWidget,
 	SessionsByDeviceWidget,
 	TopPerformingProductLeaderboardWidget,
 	type TopPerformingProductLeaderboardWidgetProps,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -15,6 +15,8 @@
 export {
 	mockOrderAttributionData,
 	mockOrderAttributionDeviceData,
+	mockOrderAttributionByProductDeviceData,
+	mockOrderAttributionByProductDeviceComparisonData,
 	mockOrderAttributionChannelData,
 	mockOrderAttributionSourceData,
 	mockOrderAttributionCampaignData,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/order-attribution.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/order-attribution.ts
@@ -5,6 +5,7 @@
  * API format: /jetpack-premium-analytics/v1/proxy/v2/analytics/reports/order-attribution/:view/summary
  * Values are strings (the sanitizer converts them to numbers)
  */
+import type { OrderAttributionByProductResponse } from '../../../../../data/src/api/report-order-attribution-by-product-fetch/report-order-attribution-by-product-fetch';
 import type { fetchReportOrderAttributionSummary } from '../../../../../data/src/api/report-order-attribution-summary-fetch/report-order-attribution-summary-fetch';
 
 /**
@@ -62,6 +63,57 @@ export const mockOrderAttributionDeviceData: OrderAttributionSummaryResponse = {
 		},
 	],
 };
+
+/**
+ * Order Attribution by Product mock data for booking-filtered device requests.
+ *
+ * The filtered by-product endpoint returns a flat shape and is normalized by
+ * the data package before widgets consume it.
+ */
+export const mockOrderAttributionByProductDeviceData: OrderAttributionByProductResponse = {
+	view: 'device',
+	order_by: 'net_sales',
+	data: [
+		{
+			item: 'Desktop Browser',
+			value: '52842.10',
+			intervals: [],
+		},
+		{
+			item: 'Mobile App',
+			value: '41795.50',
+			intervals: [],
+		},
+		{
+			item: 'Tablet Safari',
+			value: '16240.75',
+			intervals: [],
+		},
+	],
+};
+
+export const mockOrderAttributionByProductDeviceComparisonData: OrderAttributionByProductResponse =
+	{
+		view: 'device',
+		order_by: 'net_sales',
+		data: [
+			{
+				item: 'Desktop Browser',
+				value: '47182.40',
+				intervals: [],
+			},
+			{
+				item: 'Mobile App',
+				value: '44320.20',
+				intervals: [],
+			},
+			{
+				item: 'Tablet Safari',
+				value: '13780.50',
+				intervals: [],
+			},
+		],
+	};
 
 /**
  * Order Attribution by Channel mock data

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -22,6 +22,8 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import {
 	mockOrderAttributionDeviceData,
+	mockOrderAttributionByProductDeviceData,
+	mockOrderAttributionByProductDeviceComparisonData,
 	mockOrderAttributionChannelData,
 	mockOrderAttributionSourceData,
 	mockOrderAttributionCampaignData,
@@ -408,6 +410,26 @@ function buildVisitorsByLocation( query: URLSearchParams ) {
  * @return The mock response body, or `null` if no specific handler matched.
  */
 function routeReport( subPath: string, query: URLSearchParams ): unknown {
+	// Product-filtered order attribution: /order-attribution-by-product/{view}/summary
+	const attributionByProductMatch = subPath.match(
+		/^\/order-attribution-by-product\/([^/]+)\/summary$/
+	);
+	if ( attributionByProductMatch ) {
+		const view = attributionByProductMatch[ 1 ];
+
+		if ( view === 'device' ) {
+			return nextIsComparison( 'order-attribution-by-product/device' )
+				? mockOrderAttributionByProductDeviceComparisonData
+				: mockOrderAttributionByProductDeviceData;
+		}
+
+		return {
+			view,
+			order_by: 'net_sales',
+			data: [],
+		};
+	}
+
 	// Order attribution: /order-attribution/{view}/summary
 	const attributionMatch = subPath.match( /^\/order-attribution\/([^/]+)\/summary$/ );
 	if ( attributionMatch ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/index.ts
@@ -7,7 +7,7 @@ export {
 	BookingsRevenueByCustomerTypeWidget,
 } from './revenue-by-customer-type';
 export { NewVsReturningCustomerWidget } from './new-vs-returning-customer';
-export { SalesByDeviceWidget, BookingsByDeviceWidget } from './sales-by-device';
+export { SalesByDeviceWidget } from './sales-by-device';
 export { SessionsByDeviceWidget } from './sessions-by-device';
 export { BookingsByAttendanceWidget } from './bookings-by-attendance';
 export { TotalReturnsWidget } from './total-returns';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/index.ts
@@ -1,1 +1,1 @@
-export { SalesByDeviceWidget, BookingsByDeviceWidget } from './sales-by-device-widget';
+export { SalesByDeviceWidget } from './sales-by-device-widget';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
@@ -10,7 +10,7 @@ import { WidgetLoadingOverlay } from '../../components/widget-loading-overlay';
  * Internal dependencies
  */
 import { useWidgetRootContext } from '../../components/widget-root';
-import { buildSalesByDeviceData, BOOKINGS_FILTER } from '../../helpers';
+import { buildSalesByDeviceData } from '../../helpers';
 import { useWidgetError } from '../../hooks';
 import { useBarStyles } from '../common';
 
@@ -99,24 +99,4 @@ export function SalesByDeviceWidget( { filter }: SalesByDeviceWidgetProps ) {
 			{ isRefetching && <WidgetLoadingOverlay /> }
 		</>
 	);
-}
-
-/**
- * Bookings by Device Widget Component
- *
- * Displays device breakdown data for booking products only.
- * This component automatically filters data to show only booking product types
- * (booking, bookable-event, bookable-service).
- *
- * Must be used within a WidgetRoot which provides reportParams via context.
- *
- * @example
- * ```tsx
- * <WidgetRoot attributes={ attributes }>
- *     <BookingsByDeviceWidget />
- * </WidgetRoot>
- * ```
- */
-export function BookingsByDeviceWidget() {
-	return <SalesByDeviceWidget filter={ BOOKINGS_FILTER } />;
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-bookings-by-device",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -1,11 +1,10 @@
-import {
-	BookingsByDeviceWidget,
-	WidgetRoot,
-	type ReportParamsFieldAttributes,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { BookingsByDeviceWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
 
-type BookingsByDeviceRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type BookingsByDeviceRenderProps = Pick< WidgetRootProps, 'attributes' > & {
+	setError?: WidgetRootProps[ 'setError' ];
 };
 
 /**
@@ -15,9 +14,12 @@ type BookingsByDeviceRenderProps = {
  * client, chart theme, and resolved report params; BookingsByDeviceWidget
  * fetches the bookings attribution report and renders the device breakdown.
  */
-export default function BookingsByDeviceRender( { attributes }: BookingsByDeviceRenderProps ) {
+export default function BookingsByDeviceRender( {
+	attributes,
+	setError,
+}: BookingsByDeviceRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<BookingsByDeviceWidget />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -1,0 +1,24 @@
+import {
+	BookingsByDeviceWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type BookingsByDeviceRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Bookings by device widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; BookingsByDeviceWidget
+ * fetches the bookings attribution report and renders the device breakdown.
+ */
+export default function BookingsByDeviceRender( { attributes }: BookingsByDeviceRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+			<BookingsByDeviceWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -1,4 +1,8 @@
-import { BookingsByDeviceWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import {
+	BOOKINGS_FILTER,
+	SalesByDeviceWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ComponentProps } from 'react';
 
 type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
@@ -7,12 +11,16 @@ type BookingsByDeviceRenderProps = Pick< WidgetRootProps, 'attributes' > & {
 	setError?: WidgetRootProps[ 'setError' ];
 };
 
+function BookingsByDeviceWidget() {
+	return <SalesByDeviceWidget filter={ BOOKINGS_FILTER } />;
+}
+
 /**
  * Bookings by device widget.
  *
  * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; BookingsByDeviceWidget
- * fetches the bookings attribution report and renders the device breakdown.
+ * client, chart theme, and resolved report params; SalesByDeviceWidget fetches
+ * the filtered bookings attribution report and renders the device breakdown.
  */
 export default function BookingsByDeviceRender( {
 	attributes,

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -1,0 +1,213 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import BookingsByDeviceRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const BOOKINGS_BY_DEVICE_RENDER_MODULE = 'storybook/bookings-by-device';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type BookingsByDeviceRenderProps = ComponentProps< typeof BookingsByDeviceRender >;
+
+interface BookingsByDeviceStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type BookingsByDeviceStoryProps = BookingsByDeviceRenderProps & BookingsByDeviceStoryControls;
+
+interface BookingsByDeviceDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		BookingsByDeviceStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getBookingsByDeviceAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): BookingsByDeviceRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< BookingsByDeviceStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getBookingsByDeviceSource( args: Partial< BookingsByDeviceStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<BookingsByDeviceRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderBookingsByDevice( { withComparison, preset }: BookingsByDeviceStoryControls ) {
+	return (
+		<BookingsByDeviceRender
+			attributes={ getBookingsByDeviceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function BookingsByDeviceDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: BookingsByDeviceDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ BOOKINGS_BY_DEVICE_RENDER_MODULE }
+			renderComponent={ BookingsByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getBookingsByDeviceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/BookingsByDevice',
+	component: BookingsByDeviceRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: 'Dashboard widget that displays which devices customers use to make bookings.',
+			},
+		},
+	},
+} satisfies Meta< BookingsByDeviceStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< BookingsByDeviceDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderBookingsByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< BookingsByDeviceStoryControls > }
+				) => getBookingsByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change and sparkline data.
+ */
+export const WithComparison: Story = {
+	render: renderBookingsByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< BookingsByDeviceStoryControls > }
+				) => getBookingsByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <BookingsByDeviceDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/bookings-by-device"
+\trenderComponent={ BookingsByDeviceRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/bookings-by-device",
+	"title": "Bookings by device",
+	"description": "See which devices your customers are using to make bookings in your store.",
+	"category": "bookings"
+}

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/bookings-by-device` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/bookings-by-device',
+	title: __( 'Bookings by device', 'jetpack-premium-analytics' ),
+	description: __(
+		'See which devices your customers are using to make bookings in your store.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1463

## Proposed changes
* Ports the **Bookings by device** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/bookings-by-device` widget and renders the shared bookings-by-device widget inside `WidgetRoot` using dashboard-level report params.
* Ensures booking product filters are forwarded through `useReportOrderAttribution()` so the widget uses the product-filtered order-attribution endpoint.
* Adds regression coverage for the hook-level product filter forwarding and product-filtered order-attribution query path.
* Adds Storybook mock coverage for booking-filtered order-attribution-by-product device data.
* Adds standalone `Default` and `WithComparison` stories plus a real-dashboard `WidgetDashboardWithWidget` story for the widget.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Bookings by device Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1463-port-woo-widget-bookings-by-device/bookings-by-device.png)

## Related product discussion/links
* WOOA7S-1463; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `git diff --check origin/trunk...HEAD`
* `CI=true /Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics test -- use-report-order-attribution`
* `CI=true /Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `CI=true /Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics build`
* `CI=true /Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the built Storybook iframe `packages-premium-analytics-widgets-bookingsbydevice--widget-dashboard-with-widget` in the browser: title rendered, Desktop/Mobile/Tablet labels rendered, chart elements rendered, and no visible Storybook render error appeared.
