### PR TITLE
Premium Analytics: port the Bookings revenue by customer type widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-bookings-revenue-by-customer-type-widget-story
+++ b/projects/js-packages/storybook/changelog/add-bookings-revenue-by-customer-type-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a Premium Analytics Bookings revenue by customer type widget story.

--- a/projects/js-packages/storybook/changelog/add-bookings-revenue-by-customer-type-widget-story
+++ b/projects/js-packages/storybook/changelog/add-bookings-revenue-by-customer-type-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add a Premium Analytics Bookings revenue by customer type widget story.

--- a/projects/packages/premium-analytics/changelog/add-bookings-revenue-by-customer-type-widget
+++ b/projects/packages/premium-analytics/changelog/add-bookings-revenue-by-customer-type-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Port the Bookings revenue by customer type dashboard widget from next-woocommerce-analytics, composed from the widgets-toolkit and data packages.

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-bookings-revenue-by-customer-type",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/package.json
@@ -4,10 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/render.tsx
@@ -1,0 +1,31 @@
+import {
+	BookingsRevenueByCustomerTypeWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+
+type BookingsRevenueByCustomerTypeRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+	setError?: Parameters< typeof WidgetRoot >[ 0 ][ 'setError' ];
+};
+
+/**
+ * Bookings revenue by customer type widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; BookingsRevenueByCustomerTypeWidget
+ * fetches the bookings customers report and renders the revenue breakdown.
+ */
+export default function BookingsRevenueByCustomerTypeRender( {
+	attributes,
+	setError,
+}: BookingsRevenueByCustomerTypeRenderProps ) {
+	return (
+		<GlobalErrorProvider>
+			<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+				<BookingsRevenueByCustomerTypeWidget />
+			</WidgetRoot>
+		</GlobalErrorProvider>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/render.tsx
@@ -1,14 +1,27 @@
+/**
+ * External dependencies
+ */
 import {
 	BookingsRevenueByCustomerTypeWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import type { BookingsRevenueByCustomerTypeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type BookingsRevenueByCustomerTypeRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-	setError?: Parameters< typeof WidgetRoot >[ 0 ][ 'setError' ];
-};
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type BookingsRevenueByCustomerTypeRenderAttributes = BookingsRevenueByCustomerTypeAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type BookingsRevenueByCustomerTypeRenderProps =
+	WidgetRenderProps< BookingsRevenueByCustomerTypeRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * Bookings revenue by customer type widget.
@@ -18,14 +31,12 @@ type BookingsRevenueByCustomerTypeRenderProps = {
  * fetches the bookings customers report and renders the revenue breakdown.
  */
 export default function BookingsRevenueByCustomerTypeRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: BookingsRevenueByCustomerTypeRenderProps ) {
 	return (
-		<GlobalErrorProvider>
-			<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
-				<BookingsRevenueByCustomerTypeWidget />
-			</WidgetRoot>
-		</GlobalErrorProvider>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<BookingsRevenueByCustomerTypeWidget />
+		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
@@ -1,0 +1,225 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import BookingsRevenueByCustomerTypeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const BOOKINGS_REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE =
+	'storybook/bookings-revenue-by-customer-type';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type BookingsRevenueByCustomerTypeRenderProps = ComponentProps<
+	typeof BookingsRevenueByCustomerTypeRender
+>;
+
+interface BookingsRevenueByCustomerTypeStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type BookingsRevenueByCustomerTypeStoryProps = BookingsRevenueByCustomerTypeRenderProps &
+	BookingsRevenueByCustomerTypeStoryControls;
+
+interface BookingsRevenueByCustomerTypeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		BookingsRevenueByCustomerTypeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getBookingsRevenueByCustomerTypeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): BookingsRevenueByCustomerTypeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< BookingsRevenueByCustomerTypeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getBookingsRevenueByCustomerTypeSource(
+	args: Partial< BookingsRevenueByCustomerTypeStoryControls >
+) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<BookingsRevenueByCustomerTypeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderBookingsRevenueByCustomerType( {
+	withComparison,
+	preset,
+}: BookingsRevenueByCustomerTypeStoryControls ) {
+	return (
+		<BookingsRevenueByCustomerTypeRender
+			attributes={ getBookingsRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function BookingsRevenueByCustomerTypeDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: BookingsRevenueByCustomerTypeDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ BOOKINGS_REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE }
+			renderComponent={
+				BookingsRevenueByCustomerTypeRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ getBookingsRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/BookingsRevenueByCustomerType',
+	component: BookingsRevenueByCustomerTypeRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays booking revenue from new customers versus returning customers.',
+			},
+		},
+	},
+} satisfies Meta< BookingsRevenueByCustomerTypeStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< BookingsRevenueByCustomerTypeDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderBookingsRevenueByCustomerType,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< BookingsRevenueByCustomerTypeStoryControls > }
+				) => getBookingsRevenueByCustomerTypeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period revenue changes.
+ */
+export const WithComparison: Story = {
+	render: renderBookingsRevenueByCustomerType,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< BookingsRevenueByCustomerTypeStoryControls > }
+				) => getBookingsRevenueByCustomerTypeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <BookingsRevenueByCustomerTypeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/bookings-revenue-by-customer-type"
+\trenderComponent={ BookingsRevenueByCustomerTypeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/bookings-revenue-by-customer-type",
+	"title": "Bookings revenue by customer type",
+	"description": "Revenue breakdown from new customers vs returning customers for bookings over the selected time period.",
+	"category": "bookings"
+}

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/bookings-revenue-by-customer-type` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/bookings-revenue-by-customer-type',
+	title: __( 'Bookings revenue by customer type', 'jetpack-premium-analytics' ),
+	description: __(
+		'Revenue breakdown from new customers vs returning customers for bookings over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type BookingsRevenueByCustomerTypeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/bookings-revenue-by-customer-type` in


### PR DESCRIPTION
Fixes: WOOA7S-1465

## Proposed changes

- Ports the **Bookings revenue by customer type** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/bookings-revenue-by-customer-type` widget and renders the shared `BookingsRevenueByCustomerTypeWidget` (bookings-filtered revenue-by-customer-type bar chart) from the widgets-toolkit inside `WidgetRoot`, driven by dashboard-level report params.
- Adds standalone Storybook stories for the default and comparison states, plus a dashboard-hosted story using the shared `WidgetDashboardWithWidget` helper.
- Keeps this branch rebased onto `trunk`; the shared dashboard/package scaffolding (including the toolkit chart component) already lives on trunk, so this PR diff is limited to the widget wrapper.

## Finishing changes (widget-contract conformance)

Brought the draft in line with the current merged widgets (reference: `bookings-by-status`, `payment-status`):

- `render.tsx` — dropped the `GlobalErrorProvider` wrapper (siblings don't wrap; `setError` is threaded through to `WidgetRoot`), adopted the `WidgetRenderProps<T>` contract, added External/Internal dependency comment blocks, and defaulted `attributes = {}`.
- `widget.ts` — declared the no-attribute type `BookingsRevenueByCustomerTypeAttributes = Record<never, never>`.
- `package.json` — dropped the unused `@jetpack-premium-analytics/data` runtime dep (story-only, resolved via the workspace) and added `@wordpress/widget-primitives`, matching the sibling wrappers.
- Removed the `js-packages/storybook` changelog entry (no Storybook source changes; the changelog check passes without it). Kept the `premium-analytics` entry.

## Related product discussion/links

- WOOA7S-1465; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `pnpm install --frozen-lockfile`
- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- From `projects/js-packages/storybook`: `pnpm exec storybook dev -c ./storybook` and open the `Packages/Premium Analytics/Widgets/BookingsRevenueByCustomerType` stories.
- Verify the `Default` (single-period bars), `WithComparison` (grouped two-period bars), and `WidgetDashboardWithWidget` (dashboard-embedded card) stories: the `Returning` / `New` bars render with currency axis labels and no `NaN`/`undefined`. The console shows only the shared-harness baseline warnings (`useRouter … RouterProvider`, `useGlobalError … GlobalErrorProvider`), identical to the `payment-status` sibling.
