### PR TITLE
My Jetpack: migrate ProductDetailCard typography to @wordpress/ui Text

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -1,8 +1,7 @@
 import {
 	CheckmarkIcon,
 	getIconBySlug,
-	Text,
-	H3,
+	Text as JetpackText,
 	TermsOfService,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
@@ -10,7 +9,7 @@ import { getCurrencyObject } from '@automattic/number-formatters';
 import { Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, plus, starFilled } from '@wordpress/icons';
-import { Link, Text as WPText } from '@wordpress/ui';
+import { Link, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { Fragment, useCallback, useState, useEffect } from 'react';
 import useProduct from '../../data/products/use-product';
@@ -45,29 +44,12 @@ function Price( { value, currency, isOld } ) {
 	const SupFraction = <sup>{ priceObject.fraction }</sup>;
 	const PriceTag = (
 		<p>
-			<WPText render={ SupSymbol } variant="heading-xl"></WPText>
+			<Text render={ SupSymbol } variant="heading-xl"></Text>
 			{ priceObject.integer }
-			<WPText render={ SupFraction } variant="heading-xl"></WPText>
+			<Text render={ SupFraction } variant="heading-xl"></Text>
 		</p>
 	);
-	return (
-		<>
-			<>
-				<Text className={ classNames } variant="headline-medium" component="p">
-					<Text component="sup" variant="title-medium">
-						{ priceObject.symbol }
-					</Text>
-					{ priceObject.integer }
-					<Text component="sup" variant="title-medium">
-						{ priceObject.fraction }
-					</Text>
-				</Text>
-			</>
-			<>
-				<WPText className={ classNames } variant="heading-2xl" render={ PriceTag }></WPText>
-			</>
-		</>
-	);
+	return <Text className={ classNames } variant="heading-2xl" render={ PriceTag }></Text>;
 }
 
 /**
@@ -313,42 +295,36 @@ const ProductDetailCard = ( {
 			{ isBundleUpsell && (
 				<div className={ styles[ 'card-header' ] }>
 					<Icon icon={ starFilled } className={ styles[ 'product-bundle-icon' ] } size={ 16 } />
-					<Text variant="label">{ __( 'Popular upgrade', 'jetpack-my-jetpack' ) }</Text>
-					{ /* WPText parity — jetpack "label": 12px/600/16px, renders <p> (reset margin). */ }
-					<WPText
+					<Text
 						variant="body-sm"
 						style={ { margin: 0 } }
 						render={ <p>{ __( 'Popular upgrade', 'jetpack-my-jetpack' ) }</p> }
-					></WPText>
+					></Text>
 				</div>
 			) }
 			<div className={ styles.container }>
 				{ isBundleUpsell && <div className={ styles[ 'product-bundle-icons' ] }>{ icons }</div> }
 				<ProductIcon slug={ slug } />
 
-				<H3>{ productMoniker }</H3>
-				{ /* WPText parity — jetpack H3 = Text variant="headline-small" (36/700/40, <h2>) + mb=3 (24px). */ }
-				<WPText
+				<Text
 					variant="heading-2xl"
 					style={ {
 						margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 					} }
 					render={ <h2>{ productMoniker }</h2> }
-				></WPText>
+				></Text>
 				{ isProductLoading ? (
 					<LoadingBlock width="100%" height="75px" spaceBelow />
 				) : (
 					<>
-						<Text mb={ 3 }>{ longDescription }</Text>
-						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>, mb=3 → 24px bottom. */ }
-						<WPText
+						<Text
 							variant="body-lg"
 							style={ {
 								margin: 0,
 								marginBottom: 'var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <p>{ longDescription }</p> }
-						></WPText>
+						></Text>
 					</>
 				) }
 
@@ -362,14 +338,9 @@ const ProductDetailCard = ( {
 					>
 						{ features.map( ( feature, id ) => (
 							<Fragment key={ `feature-${ id }` }>
-								<Text component="li" variant="body">
-									<Icon icon={ check } size={ 24 } />
-									{ feature }
-								</Text>
-								{ /* WPText parity — jetpack "body" as <li>: 16px/400/24px. NOTE: keep the
-							     consumer `.features li { margin-bottom: 8px }` row gap — inline style beats
-							     the class, so a blanket `margin: 0` would collapse it. Pin `0 0 8px`. */ }
-								<WPText
+								{ /* Inline bottom margin rather than the `.features li` rule: an inline
+								   style on Text wins over the stylesheet class, so the row gap lives here. */ }
+								<Text
 									variant="body-lg"
 									style={ {
 										margin: '0 0 var(--wpds-dimension-gap-sm, 8px)',
@@ -380,7 +351,7 @@ const ProductDetailCard = ( {
 											{ feature }
 										</li>
 									}
-								></WPText>
+								></Text>
 							</Fragment>
 						) ) }
 					</ul>
@@ -396,51 +367,32 @@ const ProductDetailCard = ( {
 								<Price value={ price } currency={ currencyCode } isOld={ true } />
 							) }
 						</div>
-						<Text className={ styles[ 'price-description' ] }>{ priceDescription }</Text>
-						{ /* WPText parity — jetpack default "body" + className: 16px/400/24px, <p>. */ }
-						<WPText
+						<Text
 							className={ styles[ 'price-description' ] }
 							variant="body-lg"
 							style={ {
 								margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <p>{ priceDescription }</p> }
-						></WPText>
+						></Text>
 					</>
 				) }
 
 				{ isFree && (
 					<>
-						<H3>{ __( 'Free', 'jetpack-my-jetpack' ) }</H3>
-						{ /* WPText parity — jetpack H3 = headline-small (36/700/40, <h2>) + mb=3 (24px). */ }
-						<WPText
+						<Text
 							variant="heading-2xl"
 							style={ {
 								margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <h2>{ __( 'Free', 'jetpack-my-jetpack' ) }</h2> }
-						></WPText>
+						></Text>
 					</>
 				) }
 
 				{ cantInstallPlugin && (
 					<Notice status="warning" isDismissible={ false }>
-						<Text>
-							{ sprintf(
-								// translators: %s is the plugin name.
-								__(
-									"Due to your server settings, we can't automatically install the plugin for you. Please manually install the %s plugin.",
-									'jetpack-my-jetpack'
-								),
-								productMoniker
-							) }
-							&nbsp;
-							<Link openInNewTab href={ `https://wordpress.org/plugins/${ pluginSlug }` }>
-								{ __( 'Get plugin', 'jetpack-my-jetpack' ) }
-							</Link>
-						</Text>
-						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p> (keeps inline Link child). */ }
-						<WPText
+						<Text
 							variant="body-lg"
 							style={ { margin: 0 } }
 							render={
@@ -459,7 +411,7 @@ const ProductDetailCard = ( {
 									</Link>
 								</p>
 							}
-						></WPText>
+						></Text>
 					</Notice>
 				) }
 
@@ -533,17 +485,13 @@ const ProductDetailCard = ( {
 
 							return (
 								<Fragment key={ `disclaimer-${ id }` }>
-									<Text component="p" variant="body-small">
-										{ disclaimerBody }
-									</Text>
-									{ /* WPText parity — jetpack "body-small": 14px/400/24px, <p>. */ }
-									<WPText
+									<Text
 										variant="body-sm"
 										style={ {
 											margin: 0,
 										} }
 										render={ <p>{ disclaimerBody }</p> }
-									></WPText>
+									></Text>
 								</Fragment>
 							);
 						} ) }
@@ -553,28 +501,22 @@ const ProductDetailCard = ( {
 				{ isBundleUpsell && hasPaidPlanForProduct && (
 					<div className={ styles[ 'product-has-required-plan' ] }>
 						<CheckmarkIcon size={ 36 } />
-						<Text>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</Text>
-						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>. */ }
-						<WPText
+						<Text
 							variant="body-lg"
 							style={ { margin: 0 } }
 							render={ <p>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</p> }
-						></WPText>
+						></Text>
 					</div>
 				) }
 
 				{ supportingInfo && (
 					<>
-						<Text className={ styles[ 'supporting-info' ] } variant="body-extra-small">
-							{ supportingInfo }
-						</Text>
-						{ /* WPText parity — jetpack "body-extra-small": 12px/400/20px, <p>. */ }
-						<WPText
+						<Text
 							className={ styles[ 'supporting-info' ] }
 							variant="body-sm"
 							style={ { margin: 0 } }
 							render={ <p>{ supportingInfo }</p> }
-						></WPText>
+						></Text>
 					</>
 				) }
 			</div>
@@ -622,7 +564,7 @@ const ProductDetailCardButton = ( {
 	// does not forward arbitrary props to the rendered element, so this site
 	// belongs to the Button migration track, not the Text one.
 	return (
-		<Text
+		<JetpackText
 			component={ component }
 			onClick={ handleClick }
 			isLoading={ shouldShowLoadingState }
@@ -632,7 +574,7 @@ const ProductDetailCardButton = ( {
 			variant="body"
 		>
 			{ label }
-		</Text>
+		</JetpackText>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -340,6 +340,17 @@ const ProductDetailCard = ( {
 				<ProductIcon slug={ slug } />
 
 				<H3>{ productMoniker }</H3>
+				{ /* WPText parity — jetpack H3 = Text variant="headline-small" (36/700/40, <h2>) + mb=3 (24px). */ }
+				<WPText
+					variant="heading-2xl"
+					style={ {
+						fontSize: '36px',
+						fontWeight: 700,
+						lineHeight: '40px',
+						margin: '0 0 24px',
+					} }
+					render={ <h2>{ productMoniker }</h2> }
+				></WPText>
 				{ isProductLoading ? (
 					<LoadingBlock width="100%" height="75px" spaceBelow />
 				) : (
@@ -423,7 +434,22 @@ const ProductDetailCard = ( {
 					</>
 				) }
 
-				{ isFree && <H3>{ __( 'Free', 'jetpack-my-jetpack' ) }</H3> }
+				{ isFree && (
+					<>
+						<H3>{ __( 'Free', 'jetpack-my-jetpack' ) }</H3>
+						{ /* WPText parity — jetpack H3 = headline-small (36/700/40, <h2>) + mb=3 (24px). */ }
+						<WPText
+							variant="heading-2xl"
+							style={ {
+								fontSize: '36px',
+								fontWeight: 700,
+								lineHeight: '40px',
+								margin: '0 0 24px',
+							} }
+							render={ <h2>{ __( 'Free', 'jetpack-my-jetpack' ) }</h2> }
+						></WPText>
+					</>
+				) }
 
 				{ cantInstallPlugin && (
 					<Notice status="warning" isDismissible={ false }>

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -45,17 +45,9 @@ function Price( { value, currency, isOld } ) {
 	const SupFraction = <sup>{ priceObject.fraction }</sup>;
 	const PriceTag = (
 		<p>
-			<WPText
-				render={ SupSymbol }
-				variant="heading-xl"
-				style={ { fontSize: '24px', fontWeight: '500', lineHeight: '32px' } }
-			></WPText>
+			<WPText render={ SupSymbol } variant="heading-xl"></WPText>
 			{ priceObject.integer }
-			<WPText
-				render={ SupFraction }
-				variant="heading-xl"
-				style={ { fontSize: '24px', fontWeight: '500', lineHeight: '32px' } }
-			></WPText>
+			<WPText render={ SupFraction } variant="heading-xl"></WPText>
 		</p>
 	);
 	return (
@@ -72,12 +64,7 @@ function Price( { value, currency, isOld } ) {
 				</Text>
 			</>
 			<>
-				<WPText
-					className={ classNames }
-					style={ { fontSize: '48px', fontWeight: '700', lineHeight: '52px' } }
-					variant="heading-2xl"
-					render={ PriceTag }
-				></WPText>
+				<WPText className={ classNames } variant="heading-2xl" render={ PriceTag }></WPText>
 			</>
 		</>
 	);
@@ -330,7 +317,7 @@ const ProductDetailCard = ( {
 					{ /* WPText parity — jetpack "label": 12px/600/16px, renders <p> (reset margin). */ }
 					<WPText
 						variant="body-sm"
-						style={ { fontSize: '12px', fontWeight: 600, lineHeight: '16px', margin: 0 } }
+						style={ { margin: 0 } }
 						render={ <p>{ __( 'Popular upgrade', 'jetpack-my-jetpack' ) }</p> }
 					></WPText>
 				</div>
@@ -344,10 +331,7 @@ const ProductDetailCard = ( {
 				<WPText
 					variant="heading-2xl"
 					style={ {
-						fontSize: '36px',
-						fontWeight: 700,
-						lineHeight: '40px',
-						margin: '0 0 24px',
+						margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 					} }
 					render={ <h2>{ productMoniker }</h2> }
 				></WPText>
@@ -358,13 +342,10 @@ const ProductDetailCard = ( {
 						<Text mb={ 3 }>{ longDescription }</Text>
 						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>, mb=3 → 24px bottom. */ }
 						<WPText
-							variant="body-md"
+							variant="body-lg"
 							style={ {
-								fontSize: '16px',
-								fontWeight: 400,
-								lineHeight: '24px',
 								margin: 0,
-								marginBottom: '24px',
+								marginBottom: 'var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <p>{ longDescription }</p> }
 						></WPText>
@@ -389,12 +370,9 @@ const ProductDetailCard = ( {
 							     consumer `.features li { margin-bottom: 8px }` row gap — inline style beats
 							     the class, so a blanket `margin: 0` would collapse it. Pin `0 0 8px`. */ }
 								<WPText
-									variant="body-md"
+									variant="body-lg"
 									style={ {
-										fontSize: '16px',
-										fontWeight: 400,
-										lineHeight: '24px',
-										margin: '0 0 8px',
+										margin: '0 0 var(--wpds-dimension-gap-sm, 8px)',
 									} }
 									render={
 										<li>
@@ -422,12 +400,9 @@ const ProductDetailCard = ( {
 						{ /* WPText parity — jetpack default "body" + className: 16px/400/24px, <p>. */ }
 						<WPText
 							className={ styles[ 'price-description' ] }
-							variant="body-md"
+							variant="body-lg"
 							style={ {
-								fontSize: '16px',
-								fontWeight: 400,
-								lineHeight: '24px',
-								margin: '0 0 calc(var(--spacing-base) * 3)',
+								margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <p>{ priceDescription }</p> }
 						></WPText>
@@ -441,10 +416,7 @@ const ProductDetailCard = ( {
 						<WPText
 							variant="heading-2xl"
 							style={ {
-								fontSize: '36px',
-								fontWeight: 700,
-								lineHeight: '40px',
-								margin: '0 0 24px',
+								margin: '0 0 var(--wpds-dimension-gap-xl, 24px)',
 							} }
 							render={ <h2>{ __( 'Free', 'jetpack-my-jetpack' ) }</h2> }
 						></WPText>
@@ -469,8 +441,8 @@ const ProductDetailCard = ( {
 						</Text>
 						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p> (keeps inline Link child). */ }
 						<WPText
-							variant="body-md"
-							style={ { fontSize: '16px', fontWeight: 400, lineHeight: '24px', margin: 0 } }
+							variant="body-lg"
+							style={ { margin: 0 } }
 							render={
 								<p>
 									{ sprintf(
@@ -568,9 +540,6 @@ const ProductDetailCard = ( {
 									<WPText
 										variant="body-sm"
 										style={ {
-											fontSize: '14px',
-											fontWeight: 400,
-											lineHeight: '24px',
 											margin: 0,
 										} }
 										render={ <p>{ disclaimerBody }</p> }
@@ -587,8 +556,8 @@ const ProductDetailCard = ( {
 						<Text>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</Text>
 						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>. */ }
 						<WPText
-							variant="body-md"
-							style={ { fontSize: '16px', fontWeight: 400, lineHeight: '24px', margin: 0 } }
+							variant="body-lg"
+							style={ { margin: 0 } }
 							render={ <p>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</p> }
 						></WPText>
 					</div>
@@ -603,7 +572,7 @@ const ProductDetailCard = ( {
 						<WPText
 							className={ styles[ 'supporting-info' ] }
 							variant="body-sm"
-							style={ { fontSize: '12px', fontWeight: 400, lineHeight: '20px', margin: 0 } }
+							style={ { margin: 0 } }
 							render={ <p>{ supportingInfo }</p> }
 						></WPText>
 					</>

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -10,9 +10,9 @@ import { getCurrencyObject } from '@automattic/number-formatters';
 import { Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, plus, starFilled } from '@wordpress/icons';
-import { Link } from '@wordpress/ui';
+import { Link, Text as WPText } from '@wordpress/ui';
 import clsx from 'clsx';
-import { useCallback, useState, useEffect } from 'react';
+import { Fragment, useCallback, useState, useEffect } from 'react';
 import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
@@ -41,16 +41,45 @@ function Price( { value, currency, isOld } ) {
 		[ styles[ 'is-old' ] ]: isOld,
 	} );
 
-	return (
-		<Text className={ classNames } variant="headline-medium" component="p">
-			<Text component="sup" variant="title-medium">
-				{ priceObject.symbol }
-			</Text>
+	const SupSymbol = <sup>{ priceObject.symbol }</sup>;
+	const SupFraction = <sup>{ priceObject.fraction }</sup>;
+	const PriceTag = (
+		<p>
+			<WPText
+				render={ SupSymbol }
+				variant="heading-xl"
+				style={ { fontSize: '24px', fontWeight: '500', lineHeight: '32px' } }
+			></WPText>
 			{ priceObject.integer }
-			<Text component="sup" variant="title-medium">
-				{ priceObject.fraction }
-			</Text>
-		</Text>
+			<WPText
+				render={ SupFraction }
+				variant="heading-xl"
+				style={ { fontSize: '24px', fontWeight: '500', lineHeight: '32px' } }
+			></WPText>
+		</p>
+	);
+	return (
+		<>
+			<>
+				<Text className={ classNames } variant="headline-medium" component="p">
+					<Text component="sup" variant="title-medium">
+						{ priceObject.symbol }
+					</Text>
+					{ priceObject.integer }
+					<Text component="sup" variant="title-medium">
+						{ priceObject.fraction }
+					</Text>
+				</Text>
+			</>
+			<>
+				<WPText
+					className={ classNames }
+					style={ { fontSize: '48px', fontWeight: '700', lineHeight: '52px' } }
+					variant="heading-2xl"
+					render={ PriceTag }
+				></WPText>
+			</>
+		</>
 	);
 }
 
@@ -298,6 +327,12 @@ const ProductDetailCard = ( {
 				<div className={ styles[ 'card-header' ] }>
 					<Icon icon={ starFilled } className={ styles[ 'product-bundle-icon' ] } size={ 16 } />
 					<Text variant="label">{ __( 'Popular upgrade', 'jetpack-my-jetpack' ) }</Text>
+					{ /* WPText parity — jetpack "label": 12px/600/16px, renders <p> (reset margin). */ }
+					<WPText
+						variant="body-sm"
+						style={ { fontSize: '12px', fontWeight: 600, lineHeight: '16px', margin: 0 } }
+						render={ <p>{ __( 'Popular upgrade', 'jetpack-my-jetpack' ) }</p> }
+					></WPText>
 				</div>
 			) }
 			<div className={ styles.container }>
@@ -308,7 +343,21 @@ const ProductDetailCard = ( {
 				{ isProductLoading ? (
 					<LoadingBlock width="100%" height="75px" spaceBelow />
 				) : (
-					<Text mb={ 3 }>{ longDescription }</Text>
+					<>
+						<Text mb={ 3 }>{ longDescription }</Text>
+						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>, mb=3 → 24px bottom. */ }
+						<WPText
+							variant="body-md"
+							style={ {
+								fontSize: '16px',
+								fontWeight: 400,
+								lineHeight: '24px',
+								margin: 0,
+								marginBottom: '24px',
+							} }
+							render={ <p>{ longDescription }</p> }
+						></WPText>
+					</>
 				) }
 
 				{ isProductLoading ? (
@@ -320,10 +369,30 @@ const ProductDetailCard = ( {
 						} ) }
 					>
 						{ features.map( ( feature, id ) => (
-							<Text component="li" key={ `feature-${ id }` } variant="body">
-								<Icon icon={ check } size={ 24 } />
-								{ feature }
-							</Text>
+							<Fragment key={ `feature-${ id }` }>
+								<Text component="li" variant="body">
+									<Icon icon={ check } size={ 24 } />
+									{ feature }
+								</Text>
+								{ /* WPText parity — jetpack "body" as <li>: 16px/400/24px. NOTE: keep the
+							     consumer `.features li { margin-bottom: 8px }` row gap — inline style beats
+							     the class, so a blanket `margin: 0` would collapse it. Pin `0 0 8px`. */ }
+								<WPText
+									variant="body-md"
+									style={ {
+										fontSize: '16px',
+										fontWeight: 400,
+										lineHeight: '24px',
+										margin: '0 0 8px',
+									} }
+									render={
+										<li>
+											<Icon icon={ check } size={ 24 } />
+											{ feature }
+										</li>
+									}
+								></WPText>
+							</Fragment>
 						) ) }
 					</ul>
 				) }
@@ -339,6 +408,18 @@ const ProductDetailCard = ( {
 							) }
 						</div>
 						<Text className={ styles[ 'price-description' ] }>{ priceDescription }</Text>
+						{ /* WPText parity — jetpack default "body" + className: 16px/400/24px, <p>. */ }
+						<WPText
+							className={ styles[ 'price-description' ] }
+							variant="body-md"
+							style={ {
+								fontSize: '16px',
+								fontWeight: 400,
+								lineHeight: '24px',
+								margin: '0 0 calc(var(--spacing-base) * 3)',
+							} }
+							render={ <p>{ priceDescription }</p> }
+						></WPText>
 					</>
 				) }
 
@@ -360,6 +441,27 @@ const ProductDetailCard = ( {
 								{ __( 'Get plugin', 'jetpack-my-jetpack' ) }
 							</Link>
 						</Text>
+						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p> (keeps inline Link child). */ }
+						<WPText
+							variant="body-md"
+							style={ { fontSize: '16px', fontWeight: 400, lineHeight: '24px', margin: 0 } }
+							render={
+								<p>
+									{ sprintf(
+										// translators: %s is the plugin name.
+										__(
+											"Due to your server settings, we can't automatically install the plugin for you. Please manually install the %s plugin.",
+											'jetpack-my-jetpack'
+										),
+										productMoniker
+									) }
+									&nbsp;
+									<Link openInNewTab href={ `https://wordpress.org/plugins/${ pluginSlug }` }>
+										{ __( 'Get plugin', 'jetpack-my-jetpack' ) }
+									</Link>
+								</p>
+							}
+						></WPText>
 					</Notice>
 				) }
 
@@ -412,8 +514,8 @@ const ProductDetailCard = ( {
 						{ disclaimers.map( ( disclaimer, id ) => {
 							const { text, link_text = null, url = null } = disclaimer;
 
-							return (
-								<Text key={ `disclaimer-${ id }` } component="p" variant="body-small">
+							const disclaimerBody = (
+								<>
 									{ `${ text } ` }
 									{ url && link_text && (
 										<Link
@@ -428,7 +530,26 @@ const ProductDetailCard = ( {
 											{ link_text }
 										</Link>
 									) }
-								</Text>
+								</>
+							);
+
+							return (
+								<Fragment key={ `disclaimer-${ id }` }>
+									<Text component="p" variant="body-small">
+										{ disclaimerBody }
+									</Text>
+									{ /* WPText parity — jetpack "body-small": 14px/400/24px, <p>. */ }
+									<WPText
+										variant="body-sm"
+										style={ {
+											fontSize: '14px',
+											fontWeight: 400,
+											lineHeight: '24px',
+											margin: 0,
+										} }
+										render={ <p>{ disclaimerBody }</p> }
+									></WPText>
+								</Fragment>
 							);
 						} ) }
 					</div>
@@ -438,13 +559,28 @@ const ProductDetailCard = ( {
 					<div className={ styles[ 'product-has-required-plan' ] }>
 						<CheckmarkIcon size={ 36 } />
 						<Text>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</Text>
+						{ /* WPText parity — jetpack default "body": 16px/400/24px, <p>. */ }
+						<WPText
+							variant="body-md"
+							style={ { fontSize: '16px', fontWeight: 400, lineHeight: '24px', margin: 0 } }
+							render={ <p>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</p> }
+						></WPText>
 					</div>
 				) }
 
 				{ supportingInfo && (
-					<Text className={ styles[ 'supporting-info' ] } variant="body-extra-small">
-						{ supportingInfo }
-					</Text>
+					<>
+						<Text className={ styles[ 'supporting-info' ] } variant="body-extra-small">
+							{ supportingInfo }
+						</Text>
+						{ /* WPText parity — jetpack "body-extra-small": 12px/400/20px, <p>. */ }
+						<WPText
+							className={ styles[ 'supporting-info' ] }
+							variant="body-sm"
+							style={ { fontSize: '12px', fontWeight: 400, lineHeight: '20px', margin: 0 } }
+							render={ <p>{ supportingInfo }</p> }
+						></WPText>
+					</>
 				) }
 			</div>
 		</div>
@@ -484,6 +620,12 @@ const ProductDetailCardButton = ( {
 		onClick();
 	};
 
+	// NOTE: intentionally NOT migrated to @wordpress/ui Text. This is not a
+	// typography use — Text is overloaded here as a render-passthrough that
+	// forwards button props (onClick, isLoading, disabled, isPrimary) to the
+	// `component` (ProductDetailButton). @wordpress/ui Text's `render` prop
+	// does not forward arbitrary props to the rendered element, so this site
+	// belongs to the Button migration track, not the Text one.
 	return (
 		<Text
 			component={ component }

--- a/projects/packages/my-jetpack/changelog/migrate-product-detail-card-text-wp-ui
+++ b/projects/packages/my-jetpack/changelog/migrate-product-detail-card-text-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: migrate ProductDetailCard typography from the in-house @automattic/jetpack-components Text to @wordpress/ui Text, adopting the closest design-system variants.

--- a/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
+++ b/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Proof of concept (not for merge): demonstrates migrating ProductDetailCard Text to @wordpress/ui Text.

--- a/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
+++ b/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Proof of concept (not for merge): demonstrates migrating ProductDetailCard Text to @wordpress/ui Text.

--- a/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
+++ b/projects/packages/my-jetpack/changelog/try-text-wp-ui-poc
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: changed
 
 Proof of concept (not for merge): demonstrates migrating ProductDetailCard Text to @wordpress/ui Text.


### PR DESCRIPTION
## Proposed changes

Migrates the typographic `Text`/`H3` usages in My Jetpack's `ProductDetailCard` from the in-house `@automattic/jetpack-components` `Text` to `@wordpress/ui` `Text`, following the design-system direction discussed on P2 — adopt the **closest** DS variant intent-based, rather than pixel-matching the legacy scale.

* Every typographic site now renders as `@wordpress/ui` `Text` with the closest variant and **no per-site `font-size` / `font-weight` / `line-height` overrides**.
* The semantic tag is preserved via `Text`'s `render` prop (`<h2>` / `<p>` / `<li>` / `<sup>`), since `@wordpress/ui` `Text` defaults to `<span>`.
* Layout margins are kept (a call-site concern, per DS guidance) but expressed with **WPDS spacing tokens** with px fallbacks — `var(--wpds-dimension-gap-xl, 24px)` and `var(--wpds-dimension-gap-sm, 8px)`.
* The single remaining `jetpack-components` `Text` (aliased `JetpackText`) is the `ProductDetailCardButton` render-passthrough — it forwards button props (`onClick` / `isLoading` / `disabled` / `isPrimary`) and belongs to the **Button** migration track, not this one.

<img width="922" height="708" alt="image" src="https://github.com/user-attachments/assets/f98f3316-61f1-4a10-953d-0dab19356a55" />

<img width="877" height="578" alt="image" src="https://github.com/user-attachments/assets/a855d2f1-c136-4578-8369-bcd3ed91be4c" />

<img width="881" height="566" alt="image" src="https://github.com/user-attachments/assets/76abe8c6-0c31-44ac-86d8-2093f725cfa4" />


### Variant map

| Legacy variant (size/weight) | `@wordpress/ui` variant | Notes |
| --- | --- | --- |
| `title-medium` 24/500 (price sup) | `heading-xl` | nearest (20px) |
| `headline-medium` 48/700 (price) | `heading-2xl` | nearest (32px) |
| `headline-small` (H3) 36/700 | `heading-2xl` | nearest (32 / 499) |
| `label` 12/600 | `body-sm` | nearest; 600 → default weight |
| `body` (default) 16/400 | `body-lg` | 15px — closest to 16 (vs `body-md` 13px) |
| `body-small` 14/400 (disclaimer) | `body-sm` | nearest (12px) |
| `body-extra-small` 12/400 (supporting info) | `body-sm` | 12px |

Part of the Jetpack UI modernization effort (#48160).

## Related product discussion/links

* #48160

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

`ProductDetailCard` renders on the My Jetpack product-interstitial routes.

* `pnpm jetpack build packages/my-jetpack`
* Visit **My Jetpack → `wp-admin/admin.php?page=my-jetpack#/add-scan`** (also `#/add-extras`, `#/add-growth`, `#/add-complete`, `#/add-security`).
* Confirm each card's price, heading, description, feature list, price description, disclaimers and supporting info render with the adopted DS variants and correct spacing. The typographic shift vs `trunk` is intentional (closest-variant adoption).
