### PR TITLE
Premium Analytics: port the Conversion rate widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-conversion-rate-widget-story
+++ b/projects/js-packages/storybook/changelog/add-conversion-rate-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add conversion rate widget story.

--- a/projects/js-packages/storybook/changelog/add-conversion-rate-widget-story
+++ b/projects/js-packages/storybook/changelog/add-conversion-rate-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add conversion rate widget story.

--- a/projects/packages/premium-analytics/changelog/add-conversion-rate-widget
+++ b/projects/packages/premium-analytics/changelog/add-conversion-rate-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add conversion rate widget.

--- a/projects/packages/premium-analytics/widgets/conversion-rate/package.json
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/package.json
@@ -8,6 +8,7 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/conversion-rate/package.json
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-conversion-rate",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/conversion-rate/render.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/render.tsx
@@ -1,27 +1,36 @@
+/**
+ * External dependencies
+ */
 import {
 	ConversionRateWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { ConversionRateAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type ConversionRateRenderProps = Omit<
-	WidgetRenderProps< Partial< ReportParamsFieldAttributes > >,
-	'attributes'
-> & {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-	setError?: Parameters< typeof WidgetRoot >[ 0 ][ 'setError' ];
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type ConversionRateRenderAttributes = ConversionRateAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type ConversionRateRenderProps = WidgetRenderProps< ConversionRateRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
  * Conversion rate widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; ConversionRateWidget fetches
- * the conversion-rate report and renders the funnel.
+ * Thin composition over WidgetRoot: WidgetRoot provides the query client,
+ * chart theme, and resolved report params; ConversionRateWidget fetches the
+ * conversion-rate report and renders the funnel.
  */
 export default function ConversionRateRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: ConversionRateRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/conversion-rate/render.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/render.tsx
@@ -1,0 +1,32 @@
+import {
+	ConversionRateWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type ConversionRateRenderProps = Omit<
+	WidgetRenderProps< Partial< ReportParamsFieldAttributes > >,
+	'attributes'
+> & {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+	setError?: Parameters< typeof WidgetRoot >[ 0 ][ 'setError' ];
+};
+
+/**
+ * Conversion rate widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; ConversionRateWidget fetches
+ * the conversion-rate report and renders the funnel.
+ */
+export default function ConversionRateRender( {
+	attributes,
+	setError,
+}: ConversionRateRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<ConversionRateWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -1,0 +1,273 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import ConversionRateRender from '../render';
+import widgetDefinition from '../widget';
+import type { APIFetchMiddleware } from '@wordpress/api-fetch';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
+const CONVERSION_RATE_PATH = `${ API_BASE }/sessions/by-conversion-rate`;
+const CONVERSION_RATE_RENDER_MODULE = 'storybook/conversion-rate';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+let conversionRateMocksRegistered = false;
+let conversionRatePrimaryTo: string | undefined;
+
+function buildConversionRateMockResponse( isComparison: boolean ) {
+	const activeSessions = isComparison ? 11840 : 13260;
+	const visitors = isComparison ? 9350 : 10480;
+	const withCartAddition = isComparison ? 2160 : 2680;
+	const reachedCheckout = isComparison ? 940 : 1160;
+	const completedCheckout = isComparison ? 455 : 625;
+
+	const summary = {
+		active_sessions: String( activeSessions ),
+		visitors: String( visitors ),
+		with_cart_addition: String( withCartAddition ),
+		reached_checkout: String( reachedCheckout ),
+		completed_checkout: String( completedCheckout ),
+		date_start: '2026-05-01T00:00:00.000Z',
+		date_end: '2026-05-31T23:59:59.999Z',
+	};
+
+	return {
+		summary,
+		data: [ summary ],
+	};
+}
+
+function registerConversionRateMocks(): void {
+	if ( conversionRateMocksRegistered ) {
+		return;
+	}
+
+	conversionRateMocksRegistered = true;
+
+	const conversionRateMiddleware: APIFetchMiddleware = async ( options, next ) => {
+		const requestPath = String( options.path ?? options.url ?? '' );
+
+		if ( ! requestPath.startsWith( CONVERSION_RATE_PATH ) ) {
+			return next( options );
+		}
+
+		const query = new URL( requestPath, 'https://storybook.local' ).searchParams;
+		const requestTo = query.get( 'to' ) ?? undefined;
+		const isComparison = Boolean(
+			conversionRatePrimaryTo && requestTo && requestTo !== conversionRatePrimaryTo
+		);
+
+		return buildConversionRateMockResponse( isComparison );
+	};
+
+	apiFetch.use( conversionRateMiddleware );
+}
+
+registerReportMocks();
+registerConversionRateMocks();
+
+type ConversionRateRenderProps = ComponentProps< typeof ConversionRateRender >;
+
+interface ConversionRateStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type ConversionRateStoryProps = ConversionRateRenderProps & ConversionRateStoryControls;
+
+interface ConversionRateDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getConversionRateAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): ConversionRateRenderProps[ 'attributes' ] {
+	const reportParams = getDefaultQueryParams( withComparison, preset );
+	conversionRatePrimaryTo = reportParams.to;
+
+	return {
+		reportParams,
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< ConversionRateStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getConversionRateSource( args: Partial< ConversionRateStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<ConversionRateRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderConversionRate( { withComparison, preset }: ConversionRateStoryControls ) {
+	return (
+		<ConversionRateRender attributes={ getConversionRateAttributes( withComparison, preset ) } />
+	);
+}
+
+function ConversionRateDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: ConversionRateDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ CONVERSION_RATE_RENDER_MODULE }
+			renderComponent={ ConversionRateRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getConversionRateAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/ConversionRate',
+	component: ConversionRateRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Store conversion rate" widget. Fetches the sessions conversion-rate report and displays the store funnel with optional period-over-period comparison.',
+			},
+		},
+	},
+} satisfies Meta< ConversionRateStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< ConversionRateDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderConversionRate,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< ConversionRateStoryControls > }
+				) => getConversionRateSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period conversion changes.
+ */
+export const WithComparison: Story = {
+	render: renderConversionRate,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< ConversionRateStoryControls > }
+				) => getConversionRateSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <ConversionRateDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/conversion-rate"
+\trenderComponent={ ConversionRateRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -85,10 +85,9 @@ interface ConversionRateStoryControls {
 
 type ConversionRateStoryProps = ConversionRateRenderProps & ConversionRateStoryControls;
 
-interface ConversionRateDashboardStoryProps extends WidgetDashboardWithWidgetControls {
-	withComparison: boolean;
-	preset: SelectablePresetId;
-}
+interface ConversionRateDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		ConversionRateStoryControls {}
 
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '300px' } }>

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.json
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/conversion-rate",
+	"title": "Store conversion rate",
+	"description": "Store conversion rate over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type ConversionRateAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from the WooCommerce Analytics store conversion rate widget.

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the WooCommerce Analytics store conversion rate widget.
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/conversion-rate',
+	title: __( 'Store conversion rate', 'jetpack-premium-analytics' ),
+	description: __(
+		'Store conversion rate over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1466

## Proposed changes

- Ports the **Conversion rate** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/conversion-rate` widget and renders the shared conversion-rate widget inside `WidgetRoot` using dashboard-level report params.
- Adds Storybook mock coverage for conversion-rate funnel data so the story renders the chart state.
- Adds standalone `Default` and `WithComparison` stories plus a dashboard `WidgetDashboardWithWidget` story for the widget.
- Conforms the port to the current widget contract/convention (see the finishing commit): declares the widget attribute type in `widget.ts` as `Record<never, never>`, types `render.tsx` via `WidgetRenderProps<T>` composed from that imported type instead of a hand-rolled shape, defaults `attributes = {}`, adds the missing `@wordpress/widget-primitives` dependency, and drops the redundant `js-packages/storybook` changelog entry.

## Related product discussion/links

- WOOA7S-1466; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From the monorepo root (Node 24, per `.nvmrc`):

- `pnpm install`
- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `pnpm exec eslint projects/packages/premium-analytics/widgets/conversion-rate`
- Run Storybook (`cd projects/js-packages/storybook && pnpm exec storybook dev -c ./storybook`) and open the three stories:
  - `packages-premium-analytics-widgets-conversionrate--default`
  - `packages-premium-analytics-widgets-conversionrate--with-comparison`
  - `packages-premium-analytics-widgets-conversionrate--widget-dashboard-with-widget`
- Confirm the conversion funnel renders (overall rate + Sessions/Cart/Checkout/Purchase steps) and, in the dashboard story, fills the widget card. Console shows only the shared-harness baseline warnings (`useRouter`/`useGlobalError`).
