### PR TITLE
Premium Analytics: port the Store conversion rate - Bookings widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-store-conversion-rate-bookings-widget
+++ b/projects/packages/premium-analytics/changelog/add-store-conversion-rate-bookings-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add store conversion rate bookings widget.

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-store-conversion-rate-bookings",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
@@ -4,13 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@jetpack-premium-analytics/data": "link:../../packages/data",
-		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
-		"@wordpress/api-fetch": "7.48.1",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/api-fetch": "7.48.1",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/package.json
@@ -4,7 +4,9 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/api-fetch": "7.48.1",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
@@ -1,12 +1,27 @@
+/**
+ * External dependencies
+ */
 import {
 	BookingConversionRateWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { StoreConversionRateBookingsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type StoreConversionRateBookingsRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-};
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type StoreConversionRateBookingsRenderAttributes = StoreConversionRateBookingsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type StoreConversionRateBookingsRenderProps =
+	WidgetRenderProps< StoreConversionRateBookingsRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * Store conversion rate bookings widget.
@@ -15,16 +30,13 @@ type StoreConversionRateBookingsRenderProps = {
  * client, chart theme, and resolved report params; BookingConversionRateWidget
  * fetches the conversion-rate report with bookings filters and renders the
  * funnel.
- *
- * @param root0            - Render props.
- * @param root0.attributes - Widget attributes supplied by the dashboard.
- * @return Store conversion rate bookings widget element.
  */
 export default function StoreConversionRateBookingsRender( {
-	attributes,
+	attributes = {},
+	setError,
 }: StoreConversionRateBookingsRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<BookingConversionRateWidget />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
@@ -1,0 +1,27 @@
+import {
+	BookingConversionRateWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type StoreConversionRateBookingsRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Store conversion rate bookings widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; BookingConversionRateWidget
+ * fetches the conversion-rate report with bookings filters and renders the
+ * funnel.
+ */
+export default function StoreConversionRateBookingsRender( {
+	attributes,
+}: StoreConversionRateBookingsRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+			<BookingConversionRateWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/render.tsx
@@ -15,6 +15,10 @@ type StoreConversionRateBookingsRenderProps = {
  * client, chart theme, and resolved report params; BookingConversionRateWidget
  * fetches the conversion-rate report with bookings filters and renders the
  * funnel.
+ *
+ * @param root0            - Render props.
+ * @param root0.attributes - Widget attributes supplied by the dashboard.
+ * @return Store conversion rate bookings widget element.
  */
 export default function StoreConversionRateBookingsRender( {
 	attributes,

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -1,4 +1,5 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import apiFetch from '@wordpress/api-fetch';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
@@ -9,16 +10,41 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import StoreConversionRateBookingsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
 const CONVERSION_RATE_PATH = `${ API_BASE }/sessions/by-conversion-rate`;
+const STORE_CONVERSION_RATE_BOOKINGS_RENDER_MODULE = 'storybook/store-conversion-rate-bookings';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 
 let conversionRateMocksRegistered = false;
 let conversionRateRequestCount = 0;
+
+type StoreConversionRateBookingsRenderProps = ComponentProps<
+	typeof StoreConversionRateBookingsRender
+>;
+
+interface StoreConversionRateBookingsStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type StoreConversionRateBookingsStoryProps = StoreConversionRateBookingsRenderProps &
+	StoreConversionRateBookingsStoryControls;
+
+interface StoreConversionRateBookingsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		StoreConversionRateBookingsStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
 
 /**
  * Builds a mock conversion-rate report response.
@@ -75,13 +101,62 @@ function registerConversionRateMocks(): void {
 	apiFetch.use( conversionRateMiddleware );
 }
 
-registerReportMocks();
-registerConversionRateMocks();
+function getStoreConversionRateBookingsAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): StoreConversionRateBookingsRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
 
-const STORE_CONVERSION_RATE_BOOKINGS_RENDER_MODULE = 'storybook/store-conversion-rate-bookings';
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< StoreConversionRateBookingsStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
 
-interface StoreConversionRateBookingsDashboardStoryProps extends WidgetDashboardWithWidgetControls {
-	withComparison: boolean;
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getStoreConversionRateBookingsSource(
+	args: Partial< StoreConversionRateBookingsStoryControls >
+) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<StoreConversionRateBookingsRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+/**
+ * Renders the standalone store conversion rate bookings widget story.
+ *
+ * @param root0                - Story controls.
+ * @param root0.withComparison - Whether to include comparison report params.
+ * @param root0.preset         - Date-range preset to use for report params.
+ * @return Store conversion rate bookings widget story element.
+ */
+function renderStoreConversionRateBookings( {
+	withComparison,
+	preset,
+}: StoreConversionRateBookingsStoryControls ) {
+	return (
+		<StoreConversionRateBookingsRender
+			attributes={ getStoreConversionRateBookingsAttributes( withComparison, preset ) }
+		/>
+	);
 }
 
 /**
@@ -89,10 +164,12 @@ interface StoreConversionRateBookingsDashboardStoryProps extends WidgetDashboard
  *
  * @param root0                - Story controls.
  * @param root0.withComparison - Whether to include comparison report params.
+ * @param root0.preset         - Date-range preset to use for report params.
  * @return Store conversion rate bookings dashboard story element.
  */
 function StoreConversionRateBookingsDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: StoreConversionRateBookingsDashboardStoryProps ) {
 	return (
@@ -103,25 +180,27 @@ function StoreConversionRateBookingsDashboardStory( {
 			renderComponent={
 				StoreConversionRateBookingsRender as ComponentType< WidgetRenderProps< unknown > >
 			}
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
+			attributes={ getStoreConversionRateBookingsAttributes( withComparison, preset ) }
 		/>
 	);
 }
 
+registerReportMocks();
+registerConversionRateMocks();
+
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/StoreConversionRateBookings',
-	component: StoreConversionRateBookingsDashboardStory,
+	component: StoreConversionRateBookingsRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -132,10 +211,93 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof StoreConversionRateBookingsDashboardStory >;
+} satisfies Meta< StoreConversionRateBookingsStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< StoreConversionRateBookingsDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderStoreConversionRateBookings,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< StoreConversionRateBookingsStoryControls > }
+				) => getStoreConversionRateBookingsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period conversion change.
+ */
+export const WithComparison: Story = {
+	render: renderStoreConversionRateBookings,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< StoreConversionRateBookingsStoryControls > }
+				) => getStoreConversionRateBookingsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <StoreConversionRateBookingsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/store-conversion-rate-bookings"
+\trenderComponent={ StoreConversionRateBookingsRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -1,0 +1,125 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import StoreConversionRateBookingsRender from '../render';
+import widgetDefinition from '../widget';
+import type { APIFetchMiddleware } from '@wordpress/api-fetch';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
+const CONVERSION_RATE_PATH = `${ API_BASE }/sessions/by-conversion-rate`;
+
+let conversionRateMocksRegistered = false;
+let conversionRateRequestCount = 0;
+
+function buildConversionRateMockResponse( isComparison: boolean ) {
+	const activeSessions = isComparison ? 4860 : 5480;
+	const visitors = isComparison ? 3920 : 4410;
+	const withCartAddition = isComparison ? 970 : 1215;
+	const reachedCheckout = isComparison ? 430 : 560;
+	const completedCheckout = isComparison ? 218 : 310;
+
+	const summary = {
+		active_sessions: String( activeSessions ),
+		visitors: String( visitors ),
+		with_cart_addition: String( withCartAddition ),
+		reached_checkout: String( reachedCheckout ),
+		completed_checkout: String( completedCheckout ),
+		date_start: '2026-05-01T00:00:00.000Z',
+		date_end: '2026-05-31T23:59:59.999Z',
+	};
+
+	return {
+		summary,
+		data: [ summary ],
+	};
+}
+
+function registerConversionRateMocks(): void {
+	if ( conversionRateMocksRegistered ) {
+		return;
+	}
+
+	conversionRateMocksRegistered = true;
+
+	const conversionRateMiddleware: APIFetchMiddleware = async ( options, next ) => {
+		const requestPath = String( options.path ?? options.url ?? '' );
+
+		if ( ! requestPath.startsWith( CONVERSION_RATE_PATH ) ) {
+			return next( options );
+		}
+
+		const isComparison = conversionRateRequestCount % 2 === 1;
+		conversionRateRequestCount += 1;
+
+		return buildConversionRateMockResponse( isComparison );
+	};
+
+	apiFetch.use( conversionRateMiddleware );
+}
+
+registerReportMocks();
+registerConversionRateMocks();
+
+const STORE_CONVERSION_RATE_BOOKINGS_RENDER_MODULE = 'storybook/store-conversion-rate-bookings';
+
+interface StoreConversionRateBookingsDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function StoreConversionRateBookingsDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: StoreConversionRateBookingsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ STORE_CONVERSION_RATE_BOOKINGS_RENDER_MODULE }
+			renderComponent={
+				StoreConversionRateBookingsRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/StoreConversionRateBookings',
+	component: StoreConversionRateBookingsDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays the booking product conversion funnel for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof StoreConversionRateBookingsDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -1,16 +1,16 @@
-import apiFetch from '@wordpress/api-fetch';
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import apiFetch from '@wordpress/api-fetch';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import StoreConversionRateBookingsRender from '../render';
 import widgetDefinition from '../widget';
-import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
 
@@ -20,6 +20,12 @@ const CONVERSION_RATE_PATH = `${ API_BASE }/sessions/by-conversion-rate`;
 let conversionRateMocksRegistered = false;
 let conversionRateRequestCount = 0;
 
+/**
+ * Builds a mock conversion-rate report response.
+ *
+ * @param isComparison - Whether the response is for the comparison range.
+ * @return Mock conversion-rate report response.
+ */
 function buildConversionRateMockResponse( isComparison: boolean ) {
 	const activeSessions = isComparison ? 4860 : 5480;
 	const visitors = isComparison ? 3920 : 4410;
@@ -43,6 +49,9 @@ function buildConversionRateMockResponse( isComparison: boolean ) {
 	};
 }
 
+/**
+ * Registers the conversion-rate report mock once for the story.
+ */
 function registerConversionRateMocks(): void {
 	if ( conversionRateMocksRegistered ) {
 		return;
@@ -75,6 +84,13 @@ interface StoreConversionRateBookingsDashboardStoryProps extends WidgetDashboard
 	withComparison: boolean;
 }
 
+/**
+ * Renders the store conversion rate bookings widget inside the dashboard story shell.
+ *
+ * @param root0                - Story controls.
+ * @param root0.withComparison - Whether to include comparison report params.
+ * @return Store conversion rate bookings dashboard story element.
+ */
 function StoreConversionRateBookingsDashboardStory( {
 	withComparison,
 	...dashboardStoryArgs

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -143,9 +143,9 @@ function getStoreConversionRateBookingsSource(
 /**
  * Renders the standalone store conversion rate bookings widget story.
  *
- * @param root0                - Story controls.
- * @param root0.withComparison - Whether to include comparison report params.
- * @param root0.preset         - Date-range preset to use for report params.
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether to include comparison report params.
+ * @param props.preset         - Date-range preset to use for report params.
  * @return Store conversion rate bookings widget story element.
  */
 function renderStoreConversionRateBookings( {
@@ -162,9 +162,9 @@ function renderStoreConversionRateBookings( {
 /**
  * Renders the store conversion rate bookings widget inside the dashboard story shell.
  *
- * @param root0                - Story controls.
- * @param root0.withComparison - Whether to include comparison report params.
- * @param root0.preset         - Date-range preset to use for report params.
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether to include comparison report params.
+ * @param props.preset         - Date-range preset to use for report params.
  * @return Store conversion rate bookings dashboard story element.
  */
 function StoreConversionRateBookingsDashboardStory( {

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/store-conversion-rate-bookings",
+	"title": "Store conversion rate - Bookings",
+	"description": "Store conversion rate for booking products over the selected time period.",
+	"category": "bookings"
+}

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the WooCommerce Analytics bookings conversion rate widget.
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/store-conversion-rate-bookings',
+	title: __( 'Store conversion rate - Bookings', 'jetpack-premium-analytics' ),
+	description: __(
+		'Store conversion rate for booking products over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type StoreConversionRateBookingsAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from the WooCommerce Analytics bookings conversion rate widget.

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -83,14 +83,6 @@ interface WidgetDashboardWithWidgetProps extends WidgetDashboardWithWidgetContro
 	widgetUuid?: string;
 }
 
-/**
- * Applies the target host root font size while the story is mounted.
- *
- * @param root0                 - Component props.
- * @param root0.children        - Story content.
- * @param root0.hostEnvironment - Host environment to emulate.
- * @return Story content wrapped with root font-size behavior.
- */
 function HostRootFontSize( {
 	children,
 	hostEnvironment,
@@ -114,21 +106,6 @@ function HostRootFontSize( {
 	return children;
 }
 
-/**
- * Renders one widget inside a lightweight dashboard-like shell.
- *
- * @param root0                 - Component props.
- * @param root0.widgetType      - Widget metadata.
- * @param root0.renderComponent - Widget render component.
- * @param root0.attributes      - Widget attributes.
- * @param root0.dashboardWidth  - Dashboard width for the story viewport.
- * @param root0.widgetWidth     - Widget width in dashboard columns.
- * @param root0.widgetHeight    - Widget height in dashboard rows.
- * @param root0.rowHeight       - Dashboard row height.
- * @param root0.hostEnvironment - Host environment to emulate.
- * @param root0.pageTitle       - Story page title.
- * @return Widget dashboard story element.
- */
 export function WidgetDashboardWithWidget( {
 	widgetType,
 	renderModule,

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -83,6 +83,14 @@ interface WidgetDashboardWithWidgetProps extends WidgetDashboardWithWidgetContro
 	widgetUuid?: string;
 }
 
+/**
+ * Applies the target host root font size while the story is mounted.
+ *
+ * @param root0                 - Component props.
+ * @param root0.children        - Story content.
+ * @param root0.hostEnvironment - Host environment to emulate.
+ * @return Story content wrapped with root font-size behavior.
+ */
 function HostRootFontSize( {
 	children,
 	hostEnvironment,
@@ -106,6 +114,21 @@ function HostRootFontSize( {
 	return children;
 }
 
+/**
+ * Renders one widget inside a lightweight dashboard-like shell.
+ *
+ * @param root0                 - Component props.
+ * @param root0.widgetType      - Widget metadata.
+ * @param root0.renderComponent - Widget render component.
+ * @param root0.attributes      - Widget attributes.
+ * @param root0.dashboardWidth  - Dashboard width for the story viewport.
+ * @param root0.widgetWidth     - Widget width in dashboard columns.
+ * @param root0.widgetHeight    - Widget height in dashboard rows.
+ * @param root0.rowHeight       - Dashboard row height.
+ * @param root0.hostEnvironment - Host environment to emulate.
+ * @param root0.pageTitle       - Story page title.
+ * @return Widget dashboard story element.
+ */
 export function WidgetDashboardWithWidget( {
 	widgetType,
 	renderModule,


### PR DESCRIPTION
Fixes: WOOA7S-1467

## Proposed changes

- Ports the **Store conversion rate - Bookings** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/store-conversion-rate-bookings` widget and renders the shared booking conversion-rate widget inside `WidgetRoot` using dashboard-level report params.
- Adds the widget package manifest, render module, widget metadata, and Premium Analytics package links needed for the widget build.
- Adds Storybook mock coverage for booking conversion-rate funnel data so the stories render the chart state.
- Adds standalone `Default` and `WithComparison` stories plus a `WidgetDashboardWithWidget` dashboard story with dashboard sizing, edit mode, host environment, comparison, and preset controls.

### Finishing pass (conform to widget contract)

- Rebased on trunk.
- `widget.ts` exports `StoreConversionRateBookingsAttributes = Record< never, never >`; `render.tsx` types props with `WidgetRenderProps<T>` (composed with `Partial<ReportParamsFieldAttributes>`), defaults `attributes = {}`, and threads `setError` through to `WidgetRoot` — matching the merged sibling ports.
- Trimmed `package.json` to the runtime dependency set (dropped story-only/unused `data`, `datetime`, `api-fetch`, `ui`; added `@wordpress/widget-primitives`).
- Story render-helper JSDoc uses `@param props` (was `root0`).
- No behavior change — the funnel renders identically.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Store conversion rate - Bookings Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1467-port-woo-widget-store-conversion-rate-bookings/store-conversion-rate-bookings.png)

## Related product discussion/links

- WOOA7S-1467; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `pnpm install --frozen-lockfile --config.confirmModulesPurge=false`
- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `pnpm --filter @automattic/jetpack-premium-analytics build`
- From `projects/js-packages/storybook`, run `pnpm exec storybook dev -c ./storybook -p 50240`, then open the `Packages/Premium Analytics/Widgets/StoreConversionRateBookings` stories (`Default`, `WithComparison`, `WidgetDashboardWithWidget`).
- Confirm the booking conversion funnel renders (metric, comparison delta, and Sessions/Cart/Checkout/Purchase steps), with no `NaN`/`undefined` and no widget-specific console errors.
