### PR TITLE
Premium Analytics: port the Coupon usage over time widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-coupon-usage-over-time-widget
+++ b/projects/packages/premium-analytics/changelog/add-coupon-usage-over-time-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add coupon usage over time widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/coupons.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/coupons.ts
@@ -28,6 +28,28 @@ export type MockCouponsResponse = {
 	data: MockCouponsItem[];
 };
 
+export type MockCouponsByDateItem = {
+	time_interval: string;
+	date_start: string;
+	date_end: string;
+	total_orders: string;
+	orders_with_coupon: string;
+	orders_without_coupon: string;
+	total_sales: string;
+	sales_with_coupon: string;
+	sales_without_coupon: string;
+	total_discount_amount: string;
+	net_sales_after_discount: string;
+	coupon_usage_percentage: string;
+};
+
+export type MockCouponsByDateSummary = Omit< MockCouponsByDateItem, 'time_interval' >;
+
+export type MockCouponsByDateResponse = {
+	summary: MockCouponsByDateSummary;
+	data: MockCouponsByDateItem[];
+};
+
 /**
  * Primary period mock data for coupons
  */
@@ -102,6 +124,132 @@ export const mockCouponsComparisonData: MockCouponsResponse = {
 			discount_amount: '431.12',
 			total_sales: '6839.50',
 			orders_count: '34',
+		},
+	],
+};
+
+/**
+ * Primary period mock data for coupons/by-date.
+ */
+export const mockCouponsByDateData: MockCouponsByDateResponse = {
+	summary: {
+		total_orders: '234',
+		orders_with_coupon: '95',
+		orders_without_coupon: '139',
+		total_sales: '45678.90',
+		sales_with_coupon: '17840.50',
+		sales_without_coupon: '27838.40',
+		total_discount_amount: '3456.78',
+		net_sales_after_discount: '42222.12',
+		coupon_usage_percentage: '40.60',
+		date_start: '2024-01-01',
+		date_end: '2024-01-31',
+	},
+	data: [
+		{
+			time_interval: '2024-01-01',
+			date_start: '2024-01-01',
+			date_end: '2024-01-10',
+			total_orders: '78',
+			orders_with_coupon: '31',
+			orders_without_coupon: '47',
+			total_sales: '14980.25',
+			sales_with_coupon: '5640.75',
+			sales_without_coupon: '9339.50',
+			total_discount_amount: '1098.20',
+			net_sales_after_discount: '13882.05',
+			coupon_usage_percentage: '39.74',
+		},
+		{
+			time_interval: '2024-01-11',
+			date_start: '2024-01-11',
+			date_end: '2024-01-20',
+			total_orders: '81',
+			orders_with_coupon: '34',
+			orders_without_coupon: '47',
+			total_sales: '15876.35',
+			sales_with_coupon: '6250.40',
+			sales_without_coupon: '9625.95',
+			total_discount_amount: '1210.75',
+			net_sales_after_discount: '14665.60',
+			coupon_usage_percentage: '41.98',
+		},
+		{
+			time_interval: '2024-01-21',
+			date_start: '2024-01-21',
+			date_end: '2024-01-31',
+			total_orders: '75',
+			orders_with_coupon: '30',
+			orders_without_coupon: '45',
+			total_sales: '14822.30',
+			sales_with_coupon: '5949.35',
+			sales_without_coupon: '8872.95',
+			total_discount_amount: '1147.83',
+			net_sales_after_discount: '13674.47',
+			coupon_usage_percentage: '40.00',
+		},
+	],
+};
+
+/**
+ * Comparison period mock data for coupons/by-date.
+ */
+export const mockCouponsByDateComparisonData: MockCouponsByDateResponse = {
+	summary: {
+		total_orders: '198',
+		orders_with_coupon: '76',
+		orders_without_coupon: '122',
+		total_sales: '38765.40',
+		sales_with_coupon: '14220.15',
+		sales_without_coupon: '24545.25',
+		total_discount_amount: '2890.12',
+		net_sales_after_discount: '35875.28',
+		coupon_usage_percentage: '38.38',
+		date_start: '2023-12-01',
+		date_end: '2023-12-31',
+	},
+	data: [
+		{
+			time_interval: '2023-12-01',
+			date_start: '2023-12-01',
+			date_end: '2023-12-10',
+			total_orders: '64',
+			orders_with_coupon: '25',
+			orders_without_coupon: '39',
+			total_sales: '12675.20',
+			sales_with_coupon: '4720.50',
+			sales_without_coupon: '7954.70',
+			total_discount_amount: '948.35',
+			net_sales_after_discount: '11726.85',
+			coupon_usage_percentage: '39.06',
+		},
+		{
+			time_interval: '2023-12-11',
+			date_start: '2023-12-11',
+			date_end: '2023-12-20',
+			total_orders: '68',
+			orders_with_coupon: '26',
+			orders_without_coupon: '42',
+			total_sales: '13104.90',
+			sales_with_coupon: '4811.25',
+			sales_without_coupon: '8293.65',
+			total_discount_amount: '960.41',
+			net_sales_after_discount: '12144.49',
+			coupon_usage_percentage: '38.24',
+		},
+		{
+			time_interval: '2023-12-21',
+			date_start: '2023-12-21',
+			date_end: '2023-12-31',
+			total_orders: '66',
+			orders_with_coupon: '25',
+			orders_without_coupon: '41',
+			total_sales: '12985.30',
+			sales_with_coupon: '4688.40',
+			sales_without_coupon: '8296.90',
+			total_discount_amount: '981.36',
+			net_sales_after_discount: '12003.94',
+			coupon_usage_percentage: '37.88',
 		},
 	],
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -46,7 +46,13 @@ export {
 	mockSessionsByDeviceExtremeData,
 } from './sessions-by-device';
 
-export { mockCouponsData, mockCouponsComparisonData, mockCouponsEmptyData } from './coupons';
+export {
+	mockCouponsData,
+	mockCouponsComparisonData,
+	mockCouponsEmptyData,
+	mockCouponsByDateData,
+	mockCouponsByDateComparisonData,
+} from './coupons';
 
 export {
 	mockCustomersData,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -39,6 +39,8 @@ import {
 	mockSessionsByDeviceComparisonData,
 	mockCouponsData,
 	mockCouponsComparisonData,
+	mockCouponsByDateData,
+	mockCouponsByDateComparisonData,
 	mockCustomersData,
 	mockCustomersComparisonData,
 	mockCustomersByDateData,
@@ -466,6 +468,10 @@ function routeReport( subPath: string, query: URLSearchParams ): unknown {
 		case '/coupons/':
 		case '/coupons':
 			return nextIsComparison( 'coupons' ) ? mockCouponsComparisonData : mockCouponsData;
+		case '/coupons/by-date':
+			return nextIsComparison( 'coupons/by-date' )
+				? mockCouponsByDateComparisonData
+				: mockCouponsByDateData;
 		case '/customers/new-returning':
 			return nextIsComparison( 'customers/new-returning' )
 				? mockCustomersComparisonData

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
@@ -78,6 +78,7 @@ export function CouponUseWidget() {
 						type: 'currency',
 						options: { useMultipliers: true, decimals: 0 },
 					} }
+					maxSize={ null }
 					emptyStateIcon={ coupon }
 					withTooltips
 				/>

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-coupon-usage-over-time",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/render.tsx
@@ -1,0 +1,29 @@
+import type { ComponentProps } from 'react';
+import {
+	CouponUseWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type CouponUsageOverTimeRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Coupon usage over time widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; CouponUseWidget fetches the
+ * coupons-by-date report and renders the coupon usage breakdown.
+ */
+export default function CouponUsageOverTimeRender( {
+	attributes,
+	setError,
+}: CouponUsageOverTimeRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<CouponUseWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/render.tsx
@@ -1,12 +1,24 @@
-import type { ComponentProps } from 'react';
+/**
+ * External dependencies
+ */
 import {
 	CouponUseWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { CouponUsageOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type CouponUsageOverTimeRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type CouponUsageOverTimeRenderAttributes = CouponUsageOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type CouponUsageOverTimeRenderProps = WidgetRenderProps< CouponUsageOverTimeRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -18,7 +30,7 @@ type CouponUsageOverTimeRenderProps = {
  * coupons-by-date report and renders the coupon usage breakdown.
  */
 export default function CouponUsageOverTimeRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: CouponUsageOverTimeRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -1,0 +1,211 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import CouponUsageOverTimeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const COUPON_USAGE_OVER_TIME_RENDER_MODULE = 'storybook/coupon-usage-over-time';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type CouponUsageOverTimeRenderProps = ComponentProps< typeof CouponUsageOverTimeRender >;
+
+interface CouponUsageOverTimeStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type CouponUsageOverTimeStoryProps = CouponUsageOverTimeRenderProps &
+	CouponUsageOverTimeStoryControls;
+
+interface CouponUsageOverTimeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		CouponUsageOverTimeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getCouponUsageOverTimeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): CouponUsageOverTimeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< CouponUsageOverTimeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getCouponUsageOverTimeSource( args: Partial< CouponUsageOverTimeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<CouponUsageOverTimeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderCouponUsageOverTime( {
+	withComparison,
+	preset,
+}: CouponUsageOverTimeStoryControls ) {
+	return (
+		<CouponUsageOverTimeRender
+			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function CouponUsageOverTimeDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: CouponUsageOverTimeDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ COUPON_USAGE_OVER_TIME_RENDER_MODULE }
+			renderComponent={
+				CouponUsageOverTimeRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/CouponUsageOverTime',
+	component: CouponUsageOverTimeRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Coupon usage over time" widget. Fetches coupon usage for the selected period and displays sales with and without coupons in a donut chart.',
+			},
+		},
+	},
+} satisfies Meta< CouponUsageOverTimeStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< CouponUsageOverTimeDashboardStoryProps >;
+
+export const Default: Story = {
+	render: renderCouponUsageOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< CouponUsageOverTimeStoryControls > }
+				) => getCouponUsageOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+export const WithComparison: Story = {
+	render: renderCouponUsageOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< CouponUsageOverTimeStoryControls > }
+				) => getCouponUsageOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <CouponUsageOverTimeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/coupon-usage-over-time"
+\trenderComponent={ CouponUsageOverTimeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -76,10 +76,7 @@ function getCouponUsageOverTimeSource( args: Partial< CouponUsageOverTimeStoryCo
 />`;
 }
 
-function renderCouponUsageOverTime( {
-	withComparison,
-	preset,
-}: CouponUsageOverTimeStoryControls ) {
+function renderCouponUsageOverTime( { withComparison, preset }: CouponUsageOverTimeStoryControls ) {
 	return (
 		<CouponUsageOverTimeRender
 			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }
@@ -97,9 +94,7 @@ function CouponUsageOverTimeDashboardStory( {
 			{ ...dashboardStoryArgs }
 			widgetType={ widgetDefinition }
 			renderModule={ COUPON_USAGE_OVER_TIME_RENDER_MODULE }
-			renderComponent={
-				CouponUsageOverTimeRender as ComponentType< WidgetRenderProps< unknown > >
-			}
+			renderComponent={ CouponUsageOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }
 		/>
 	);

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/coupon-usage-over-time",
+	"title": "Coupon usage over time",
+	"description": "Coupon usage over the selected time period.",
+	"category": "coupons"
+}

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the WooCommerce Analytics coupon usage widget.
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/coupon-usage-over-time',
+	title: __( 'Coupon usage over time', 'jetpack-premium-analytics' ),
+	description: __( 'Coupon usage over the selected time period.', 'jetpack-premium-analytics' ),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type CouponUsageOverTimeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from the WooCommerce Analytics coupon usage widget.


### PR DESCRIPTION
Fixes: WOOA7S-1468

## Proposed changes
* Ports the **Coupon usage over time** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/coupon-usage-over-time` widget and renders the shared coupon use widget inside `WidgetRoot` using dashboard-level report params.
* Adds `coupons/by-date` Storybook report mocks so the widget can render without a live API call.
* Adds standalone `Default` and `WithComparison` Storybook stories plus a separate dashboard-host story using the shared `WidgetDashboardWithWidget` helper.
* Rebases the widget port onto `trunk`; shared dashboard/package scaffolding is already present from earlier work and is no longer part of this PR diff.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Coupon usage over time Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1468-port-woo-widget-coupon-usage-over-time/coupon-usage-over-time.png)

## Related product discussion/links
* WOOA7S-1468; parent WOOA7S-1457.
* Follows the Premium Analytics widget port structure now present on `trunk`.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the Storybook story `packages-premium-analytics-widgets-couponusageovertime--widget-dashboard-with-widget` with a local Playwright smoke pass: title rendered, chart rendered, `With coupons` / `No coupons` legend labels rendered, no `NaN` / `undefined`, and no coupon-specific console or page errors.
