### PR TITLE
Premium Analytics: port the Sales by coupon usage widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-sales-by-coupon-usage-widget
+++ b/projects/packages/premium-analytics/changelog/add-sales-by-coupon-usage-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add sales by coupon usage widget.

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/package.json
@@ -7,6 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-sales-by-coupon-usage",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
@@ -1,13 +1,12 @@
-import {
-	SalesByCouponWidget,
-	WidgetRoot,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { SalesByCouponWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ComponentProps } from 'react';
 
-type SalesByCouponUsageRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
->;
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type SalesByCouponUsageRenderProps = {
+	attributes?: WidgetRootProps[ 'attributes' ];
+	setError?: WidgetRootProps[ 'setError' ];
+};
 
 /**
  * Sales by coupon usage widget.

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
@@ -1,0 +1,28 @@
+import {
+	SalesByCouponWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type SalesByCouponUsageRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
+
+/**
+ * Sales by coupon usage widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; SalesByCouponWidget fetches
+ * the coupons report and renders the coupon sales breakdown.
+ */
+export default function SalesByCouponUsageRender( {
+	attributes,
+	setError,
+}: SalesByCouponUsageRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<SalesByCouponWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/render.tsx
@@ -1,11 +1,25 @@
-import { SalesByCouponWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	SalesByCouponWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { SalesByCouponUsageAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SalesByCouponUsageRenderAttributes = SalesByCouponUsageAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type SalesByCouponUsageRenderProps = {
-	attributes?: WidgetRootProps[ 'attributes' ];
-	setError?: WidgetRootProps[ 'setError' ];
+type SalesByCouponUsageRenderProps = WidgetRenderProps< SalesByCouponUsageRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -16,7 +30,7 @@ type SalesByCouponUsageRenderProps = {
  * the coupons report and renders the coupon sales breakdown.
  */
 export default function SalesByCouponUsageRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: SalesByCouponUsageRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -1,0 +1,68 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SalesByCouponUsageRender from '../render';
+import widgetDefinition from '../widget';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const SALES_BY_COUPON_USAGE_RENDER_MODULE = 'storybook/sales-by-coupon-usage';
+
+interface SalesByCouponUsageDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function SalesByCouponUsageDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: SalesByCouponUsageDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ SALES_BY_COUPON_USAGE_RENDER_MODULE }
+			renderComponent={ SalesByCouponUsageRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SalesByCouponUsage',
+	component: SalesByCouponUsageDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays the coupon sales breakdown for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof SalesByCouponUsageDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -1,4 +1,5 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -8,20 +9,83 @@ import {
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponUsageRender from '../render';
 import widgetDefinition from '../widget';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const SALES_BY_COUPON_USAGE_RENDER_MODULE = 'storybook/sales-by-coupon-usage';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 
-interface SalesByCouponUsageDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+type SalesByCouponUsageRenderProps = ComponentProps< typeof SalesByCouponUsageRender >;
+
+interface SalesByCouponUsageStoryControls {
 	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type SalesByCouponUsageStoryProps = SalesByCouponUsageRenderProps & SalesByCouponUsageStoryControls;
+
+interface SalesByCouponUsageDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SalesByCouponUsageStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getSalesByCouponUsageAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): SalesByCouponUsageRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< SalesByCouponUsageStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getSalesByCouponUsageSource( args: Partial< SalesByCouponUsageStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<SalesByCouponUsageRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderSalesByCouponUsage( { withComparison, preset }: SalesByCouponUsageStoryControls ) {
+	return (
+		<SalesByCouponUsageRender
+			attributes={ getSalesByCouponUsageAttributes( withComparison, preset ) }
+		/>
+	);
 }
 
 function SalesByCouponUsageDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: SalesByCouponUsageDashboardStoryProps ) {
 	return (
@@ -30,25 +94,24 @@ function SalesByCouponUsageDashboardStory( {
 			widgetType={ widgetDefinition }
 			renderModule={ SALES_BY_COUPON_USAGE_RENDER_MODULE }
 			renderComponent={ SalesByCouponUsageRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
+			attributes={ getSalesByCouponUsageAttributes( withComparison, preset ) }
 		/>
 	);
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SalesByCouponUsage',
-	component: SalesByCouponUsageDashboardStory,
+	component: SalesByCouponUsageRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -59,10 +122,93 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof SalesByCouponUsageDashboardStory >;
+} satisfies Meta< SalesByCouponUsageStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< SalesByCouponUsageDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderSalesByCouponUsage,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByCouponUsageStoryControls > }
+				) => getSalesByCouponUsageSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period coupon sales data.
+ */
+export const WithComparison: Story = {
+	render: renderSalesByCouponUsage,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByCouponUsageStoryControls > }
+				) => getSalesByCouponUsageSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <SalesByCouponUsageDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/sales-by-coupon-usage"
+\trenderComponent={ SalesByCouponUsageRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/sales-by-coupon-usage",
+	"title": "Sales by coupon usage",
+	"description": "Sales by coupon usage over the selected time period.",
+	"category": "coupons"
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
@@ -5,9 +5,17 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type SalesByCouponUsageAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
- * Ported from the WooCommerce Analytics sales by coupon usage widget.
+ * Ported from `woocommerce-analytics/sales-by-coupon-usage` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
  *
  * Report params intentionally come from the analytics dashboard's global
  * date-range state for now. Adding widget-level overrides needs a host-level

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the WooCommerce Analytics sales by coupon usage widget.
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/sales-by-coupon-usage',
+	title: __( 'Sales by coupon usage', 'jetpack-premium-analytics' ),
+	description: __(
+		'Sales by coupon usage over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1469

## Proposed changes
* Port the **Sales by coupon usage** widget into Premium Analytics.
* Register the `jpa/sales-by-coupon-usage` widget and render the shared `SalesByCouponWidget` inside `WidgetRoot`, using dashboard-level report params.
* Add Storybook coverage for the widget:
  * standalone `Default`
  * standalone `WithComparison`
  * dashboard-hosted `WidgetDashboardWithWidget`

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Sales by coupon usage Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1469-port-woo-widget-sales-by-coupon-usage/sales-by-coupon-usage.png)

## Related product discussion/links
* WOOA7S-1469; parent WOOA7S-1457.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the built Storybook iframe for `packages-premium-analytics-widgets-salesbycouponusage--widget-dashboard-with-widget`: the dashboard title rendered, the widget title rendered, coupon labels rendered, and chart SVGs rendered with no visible widget error state.
