### PR TITLE
Premium Analytics: port the Gross sales over time widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-gross-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-gross-sales-over-time-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add gross sales over time widget story.

--- a/projects/js-packages/storybook/changelog/add-gross-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-gross-sales-over-time-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add gross sales over time widget story.

--- a/projects/packages/premium-analytics/changelog/add-gross-sales-over-time-widget
+++ b/projects/packages/premium-analytics/changelog/add-gross-sales-over-time-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add gross sales over time widget.

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-gross-sales-over-time",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
@@ -1,0 +1,24 @@
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type GrossSalesOverTimeRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Gross sales over time widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; OrderMetricWidget fetches
+ * the orders report and renders the gross sales metric over time.
+ */
+export default function GrossSalesOverTimeRender( { attributes }: GrossSalesOverTimeRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+			<OrderMetricWidget metricKey="orders_value_gross" />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
@@ -1,11 +1,25 @@
-import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { GrossSalesOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type GrossSalesOverTimeRenderAttributes = GrossSalesOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type GrossSalesOverTimeRenderProps = {
-	attributes?: WidgetRootProps[ 'attributes' ];
-	setError?: WidgetRootProps[ 'setError' ];
+type GrossSalesOverTimeRenderProps = WidgetRenderProps< GrossSalesOverTimeRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -16,7 +30,7 @@ type GrossSalesOverTimeRenderProps = {
  * the orders report and renders the gross sales metric over time.
  */
 export default function GrossSalesOverTimeRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: GrossSalesOverTimeRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
@@ -1,10 +1,12 @@
 import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ComponentProps } from 'react';
 
-type GrossSalesOverTimeRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
->;
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type GrossSalesOverTimeRenderProps = {
+	attributes?: WidgetRootProps[ 'attributes' ];
+	setError?: WidgetRootProps[ 'setError' ];
+};
 
 /**
  * Gross sales over time widget.

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/render.tsx
@@ -1,12 +1,10 @@
-import {
-	OrderMetricWidget,
-	WidgetRoot,
-	type ReportParamsFieldAttributes,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
 
-type GrossSalesOverTimeRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-};
+type GrossSalesOverTimeRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
 
 /**
  * Gross sales over time widget.
@@ -15,9 +13,12 @@ type GrossSalesOverTimeRenderProps = {
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders the gross sales metric over time.
  */
-export default function GrossSalesOverTimeRender( { attributes }: GrossSalesOverTimeRenderProps ) {
+export default function GrossSalesOverTimeRender( {
+	attributes,
+	setError,
+}: GrossSalesOverTimeRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<OrderMetricWidget metricKey="orders_value_gross" />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -1,4 +1,5 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -9,22 +10,87 @@ import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/l
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import GrossSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const GROSS_SALES_OVER_TIME_RENDER_MODULE = 'storybook/gross-sales-over-time';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 // Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
 const ensureLineChartComposition = () => LineChart.Legend;
 
-interface GrossSalesOverTimeDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+type GrossSalesOverTimeRenderProps = ComponentProps< typeof GrossSalesOverTimeRender >;
+
+interface GrossSalesOverTimeStoryControls {
 	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type GrossSalesOverTimeStoryProps = GrossSalesOverTimeRenderProps & GrossSalesOverTimeStoryControls;
+
+interface GrossSalesOverTimeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		GrossSalesOverTimeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getGrossSalesOverTimeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): GrossSalesOverTimeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< GrossSalesOverTimeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getGrossSalesOverTimeSource( args: Partial< GrossSalesOverTimeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<GrossSalesOverTimeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderGrossSalesOverTime( { withComparison, preset }: GrossSalesOverTimeStoryControls ) {
+	ensureLineChartComposition();
+
+	return (
+		<GrossSalesOverTimeRender
+			attributes={ getGrossSalesOverTimeAttributes( withComparison, preset ) }
+		/>
+	);
 }
 
 function GrossSalesOverTimeDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: GrossSalesOverTimeDashboardStoryProps ) {
 	ensureLineChartComposition();
@@ -35,25 +101,24 @@ function GrossSalesOverTimeDashboardStory( {
 			widgetType={ widgetDefinition }
 			renderModule={ GROSS_SALES_OVER_TIME_RENDER_MODULE }
 			renderComponent={ GrossSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
+			attributes={ getGrossSalesOverTimeAttributes( withComparison, preset ) }
 		/>
 	);
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/GrossSalesOverTime',
-	component: GrossSalesOverTimeDashboardStory,
+	component: GrossSalesOverTimeRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -63,10 +128,93 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof GrossSalesOverTimeDashboardStory >;
+} satisfies Meta< GrossSalesOverTimeStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< GrossSalesOverTimeDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderGrossSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< GrossSalesOverTimeStoryControls > }
+				) => getGrossSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change and line chart data.
+ */
+export const WithComparison: Story = {
+	render: renderGrossSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< GrossSalesOverTimeStoryControls > }
+				) => getGrossSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <GrossSalesOverTimeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/gross-sales-over-time"
+\trenderComponent={ GrossSalesOverTimeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -1,0 +1,72 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import GrossSalesOverTimeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const GROSS_SALES_OVER_TIME_RENDER_MODULE = 'storybook/gross-sales-over-time';
+// Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
+const ensureLineChartComposition = () => LineChart.Legend;
+
+interface GrossSalesOverTimeDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function GrossSalesOverTimeDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: GrossSalesOverTimeDashboardStoryProps ) {
+	ensureLineChartComposition();
+
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ GROSS_SALES_OVER_TIME_RENDER_MODULE }
+			renderComponent={ GrossSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/GrossSalesOverTime',
+	component: GrossSalesOverTimeDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: 'Dashboard widget that displays gross sales over time for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof GrossSalesOverTimeDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/gross-sales-over-time",
+	"title": "Gross sales over time",
+	"description": "Gross sales over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
@@ -5,9 +5,17 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type GrossSalesOverTimeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
- * Ported from the WooCommerce Analytics gross sales over time widget.
+ * Ported from `woocommerce-analytics/gross-sales-over-time` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
  *
  * Report params intentionally come from the analytics dashboard's global
  * date-range state for now. Adding widget-level overrides needs a host-level

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the WooCommerce Analytics gross sales over time widget.
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/gross-sales-over-time',
+	title: __( 'Gross sales over time', 'jetpack-premium-analytics' ),
+	description: __( 'Gross sales over the selected time period.', 'jetpack-premium-analytics' ),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1470

## Proposed changes
* Ports the **Gross sales over time** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/gross-sales-over-time` widget and renders the shared order metric widget inside `WidgetRoot` for `orders_value_gross` using dashboard-level report params.
* Threads the dashboard widget error channel through `WidgetRoot` using the current trunk widget render prop pattern.
* Adds standalone Storybook `Default` and `WithComparison` stories plus a separate `WidgetDashboardWithWidget` dashboard story with dashboard sizing and date preset controls.
* Warms up the line chart composition in the Storybook story so the static Storybook/Vite build renders the comparative line chart.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Gross sales over time Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1470-port-woo-widget-gross-sales-over-time/gross-sales-over-time.png)

## Related product discussion/links
* WOOA7S-1470; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Static Storybook iframe smoke for `packages-premium-analytics-widgets-grosssalesovertime--widget-dashboard-with-widget`: verified the dashboard title, widget title, currency value, chart SVGs, and no `NaN` or `undefined` text.
