### PR TITLE
docs: Direct "do we have this" queries to #jetpack-developers

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -513,7 +513,7 @@ Within a single project, changelogger’s `version next` command can tell you th
 ## New Projects
 
 To begin,
-* For Automatticians, drop us a line in #jetpack-monorepo to discuss your needs, just to be sure we don't have something already. For others, it would probably be best to open an issue to discuss it.
+* For Automatticians, drop us a line in #jetpack-developers to discuss your needs, just to be sure we don't have something already. For others, it would probably be best to open an issue to discuss it.
 * Use the `jetpack generate` command to create a skeleton project.
 * Create your project based on the skeleton and submit a PR as usual.
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The line in docs/monorepo.md used to point people to `#jetpack-crew`, where members of Ground Control and Kernel hung out and would have a good chance of answering the question "do we already have something like this".

A few reorgs later, we wound up with the doc pointing to `#jetpack-monorepo`, which is more of a channel for people working on the monorepo tooling and build and CI infrastructure, rather than packages. At the same time, developers have grown much freer about creating new things.

Given all that, it'd probably be better to direct the questions to the more general `#jetpack-developers` channel, where all devs should have a chance to see and answer.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1781720943863429-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Proofread?