### PR TITLE
Premium Analytics: port the Net sales over time widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-net-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-net-sales-over-time-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add net sales over time widget story.

--- a/projects/js-packages/storybook/changelog/add-net-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-net-sales-over-time-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add net sales over time widget story.

--- a/projects/packages/premium-analytics/changelog/add-net-sales-over-time-widget
+++ b/projects/packages/premium-analytics/changelog/add-net-sales-over-time-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add net sales over time widget.

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-net-sales-over-time",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/render.tsx
@@ -1,0 +1,25 @@
+import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type NetSalesOverTimeRenderProps = {
+	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Net sales over time widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; OrderMetricWidget fetches
+ * the orders report and renders the net sales metric over time.
+ */
+export default function NetSalesOverTimeRender( {
+	attributes,
+	setError,
+}: NetSalesOverTimeRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<OrderMetricWidget metricKey="orders_value_net" />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/render.tsx
@@ -1,8 +1,24 @@
-import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { NetSalesOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type NetSalesOverTimeRenderProps = {
-	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type NetSalesOverTimeRenderAttributes = NetSalesOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type NetSalesOverTimeRenderProps = WidgetRenderProps< NetSalesOverTimeRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -14,7 +30,7 @@ type NetSalesOverTimeRenderProps = {
  * the orders report and renders the net sales metric over time.
  */
 export default function NetSalesOverTimeRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: NetSalesOverTimeRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -1,0 +1,225 @@
+import { GlobalErrorProvider, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import NetSalesOverTimeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const NET_SALES_OVER_TIME_RENDER_MODULE = 'storybook/net-sales-over-time';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+// Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
+const ensureLineChartComposition = () => LineChart.Legend;
+
+type NetSalesOverTimeRenderProps = ComponentProps< typeof NetSalesOverTimeRender >;
+
+interface NetSalesOverTimeStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type NetSalesOverTimeStoryProps = NetSalesOverTimeRenderProps & NetSalesOverTimeStoryControls;
+
+interface NetSalesOverTimeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		NetSalesOverTimeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<GlobalErrorProvider>
+		<div style={ { width: '100%', height: '300px' } }>
+			<Story />
+		</div>
+	</GlobalErrorProvider>
+);
+
+function getNetSalesOverTimeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): NetSalesOverTimeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< NetSalesOverTimeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getNetSalesOverTimeSource( args: Partial< NetSalesOverTimeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<NetSalesOverTimeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderNetSalesOverTime( { withComparison, preset }: NetSalesOverTimeStoryControls ) {
+	ensureLineChartComposition();
+
+	return (
+		<NetSalesOverTimeRender
+			attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function NetSalesOverTimeDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: NetSalesOverTimeDashboardStoryProps ) {
+	ensureLineChartComposition();
+
+	return (
+		<GlobalErrorProvider>
+			<WidgetDashboardWithWidgetStory
+				{ ...dashboardStoryArgs }
+				widgetType={ widgetDefinition }
+				renderModule={ NET_SALES_OVER_TIME_RENDER_MODULE }
+				renderComponent={ NetSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+				attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }
+			/>
+		</GlobalErrorProvider>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/NetSalesOverTime',
+	component: NetSalesOverTimeRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Net sales over time" widget. Fetches the orders report and displays net sales for the selected period with optional period-over-period comparison and a line chart.',
+			},
+		},
+	},
+} satisfies Meta< NetSalesOverTimeStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< NetSalesOverTimeDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderNetSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< NetSalesOverTimeStoryControls > }
+				) => getNetSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change and line chart data.
+ */
+export const WithComparison: Story = {
+	render: renderNetSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< NetSalesOverTimeStoryControls > }
+				) => getNetSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <NetSalesOverTimeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/net-sales-over-time"
+\trenderComponent={ NetSalesOverTimeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { GlobalErrorProvider, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -36,11 +36,9 @@ interface NetSalesOverTimeDashboardStoryProps
 		NetSalesOverTimeStoryControls {}
 
 const withWidgetCanvas: Decorator = Story => (
-	<GlobalErrorProvider>
-		<div style={ { width: '100%', height: '300px' } }>
-			<Story />
-		</div>
-	</GlobalErrorProvider>
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
 );
 
 function getNetSalesOverTimeAttributes(
@@ -98,15 +96,13 @@ function NetSalesOverTimeDashboardStory( {
 	ensureLineChartComposition();
 
 	return (
-		<GlobalErrorProvider>
-			<WidgetDashboardWithWidgetStory
-				{ ...dashboardStoryArgs }
-				widgetType={ widgetDefinition }
-				renderModule={ NET_SALES_OVER_TIME_RENDER_MODULE }
-				renderComponent={ NetSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
-				attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }
-			/>
-		</GlobalErrorProvider>
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ NET_SALES_OVER_TIME_RENDER_MODULE }
+			renderComponent={ NetSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }
+		/>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/net-sales-over-time",
+	"title": "Net sales over time",
+	"description": "Monitor your total revenue after discounts, returns, or adjustments over a set period of time.",
+	"category": "orders"
+}

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/net-sales-over-time` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/net-sales-over-time',
+	title: __( 'Net sales over time', 'jetpack-premium-analytics' ),
+	description: __(
+		'Monitor your total revenue after discounts, returns, or adjustments over a set period of time.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type NetSalesOverTimeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/net-sales-over-time` in


### PR DESCRIPTION
Fixes: WOOA7S-1471

## Proposed changes
* Ports the **Net sales over time** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/net-sales-over-time` widget and renders the shared order metric widget inside `WidgetRoot` for `orders_value_net` using dashboard-level report params.
* Forwards dashboard error handling from the widget render props into `WidgetRoot`.
* Adds standalone `Default` and `WithComparison` Storybook stories with selectable date presets.
* Adds a dashboard Storybook story through `WidgetDashboardWithWidget`, with dashboard sizing/edit-mode controls plus widget-specific preset/comparison controls.
* Keeps the static Storybook line-chart composition warm-up needed by the comparative line chart.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Net sales over time Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1471-port-woo-widget-net-sales-over-time/net-sales-over-time.png)

## Related product discussion/links
* WOOA7S-1471; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Validated locally with Node 24.15.0 and pnpm 11.5.2:

* `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @automattic/jetpack-premium-analytics build`
* `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @automattic/jetpack-storybook storybook:build`
* `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm exec eslint . --max-warnings=0`
* Verified the static Storybook iframe story `packages-premium-analytics-widgets-netsalesovertime--widget-dashboard-with-widget`: title rendered, chart SVGs rendered, no visible Storybook error display, and no `NaN`/`undefined` output.
