### PR TITLE
Premium Analytics: port the New vs returning customer widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-new-vs-returning-customer-widget-story
+++ b/projects/js-packages/storybook/changelog/add-new-vs-returning-customer-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add new vs returning customer widget story.

--- a/projects/js-packages/storybook/changelog/add-new-vs-returning-customer-widget-story
+++ b/projects/js-packages/storybook/changelog/add-new-vs-returning-customer-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add new vs returning customer widget story.

--- a/projects/packages/premium-analytics/changelog/add-new-vs-returning-customer-widget
+++ b/projects/packages/premium-analytics/changelog/add-new-vs-returning-customer-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add new vs returning customer widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
@@ -78,6 +78,7 @@ export function NewVsReturningCustomerWidget() {
 						type: 'number',
 						options: { useMultipliers: true, decimals: 0 },
 					} }
+					maxSize={ null }
 					emptyStateIcon={ customer }
 					withTooltips
 				/>

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/package.json
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/package.json
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-new-vs-returning-customer",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/render.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/render.tsx
@@ -1,0 +1,34 @@
+import {
+	NewVsReturningCustomerWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+export type NewVsReturningCustomerRenderProps = {
+	attributes?: WidgetRootProps[ 'attributes' ];
+	setError?: WidgetRootProps[ 'setError' ];
+};
+
+/**
+ * New vs returning customer widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; NewVsReturningCustomerWidget
+ * renders the customer breakdown donut chart.
+ *
+ * @param props            - Dashboard render props.
+ * @param props.attributes - Widget attributes from the dashboard.
+ * @param props.setError   - Dashboard error callback.
+ * @return Widget render output.
+ */
+export default function NewVsReturningCustomerRender( props: NewVsReturningCustomerRenderProps ) {
+	const { attributes, setError } = props;
+
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<NewVsReturningCustomerWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/render.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/render.tsx
@@ -1,31 +1,39 @@
+/**
+ * External dependencies
+ */
 import {
 	NewVsReturningCustomerWidget,
 	WidgetRoot,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { NewVsReturningCustomerAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type NewVsReturningCustomerRenderAttributes = NewVsReturningCustomerAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-export type NewVsReturningCustomerRenderProps = {
-	attributes?: WidgetRootProps[ 'attributes' ];
-	setError?: WidgetRootProps[ 'setError' ];
-};
+type NewVsReturningCustomerRenderProps =
+	WidgetRenderProps< NewVsReturningCustomerRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * New vs returning customer widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; NewVsReturningCustomerWidget
- * renders the customer breakdown donut chart.
- *
- * @param props            - Dashboard render props.
- * @param props.attributes - Widget attributes from the dashboard.
- * @param props.setError   - Dashboard error callback.
- * @return Widget render output.
+ * Thin composition over WidgetRoot: WidgetRoot provides the query client, chart
+ * theme, and resolved report params; NewVsReturningCustomerWidget renders the
+ * customer breakdown donut chart.
  */
-export default function NewVsReturningCustomerRender( props: NewVsReturningCustomerRenderProps ) {
-	const { attributes, setError } = props;
-
+export default function NewVsReturningCustomerRender( {
+	attributes = {},
+	setError,
+}: NewVsReturningCustomerRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<NewVsReturningCustomerWidget />

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -1,0 +1,225 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import NewVsReturningCustomerRender, { type NewVsReturningCustomerRenderProps } from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const NEW_VS_RETURNING_CUSTOMER_RENDER_MODULE = 'storybook/new-vs-returning-customer';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+interface NewVsReturningCustomerStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type NewVsReturningCustomerStoryProps = NewVsReturningCustomerRenderProps &
+	NewVsReturningCustomerStoryControls;
+
+interface NewVsReturningCustomerDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getNewVsReturningCustomerAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): NewVsReturningCustomerRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< NewVsReturningCustomerStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getNewVsReturningCustomerSource( args: Partial< NewVsReturningCustomerStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<NewVsReturningCustomerRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderNewVsReturningCustomer( {
+	withComparison,
+	preset,
+}: NewVsReturningCustomerStoryControls ) {
+	return (
+		<NewVsReturningCustomerRender
+			attributes={ getNewVsReturningCustomerAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+/**
+ * Render the dashboard story for the new vs returning customer widget.
+ *
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether to include comparison report params.
+ * @param props.preset         - Date-range preset to generate report params.
+ * @return Story render output.
+ */
+function NewVsReturningCustomerDashboardStory( props: NewVsReturningCustomerDashboardStoryProps ) {
+	const { withComparison, preset, ...dashboardStoryArgs } = props;
+
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ NEW_VS_RETURNING_CUSTOMER_RENDER_MODULE }
+			renderComponent={
+				NewVsReturningCustomerRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ getNewVsReturningCustomerAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/NewVsReturningCustomer',
+	component: NewVsReturningCustomerRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays new and returning customer counts for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< NewVsReturningCustomerStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< NewVsReturningCustomerDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderNewVsReturningCustomer,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< NewVsReturningCustomerStoryControls > }
+				) => getNewVsReturningCustomerSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period customer deltas.
+ */
+export const WithComparison: Story = {
+	render: renderNewVsReturningCustomer,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< NewVsReturningCustomerStoryControls > }
+				) => getNewVsReturningCustomerSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <NewVsReturningCustomerDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/new-vs-returning-customer"
+\trenderComponent={ NewVsReturningCustomerRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -1,23 +1,25 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import NewVsReturningCustomerRender, { type NewVsReturningCustomerRenderProps } from '../render';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import NewVsReturningCustomerRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const NEW_VS_RETURNING_CUSTOMER_RENDER_MODULE = 'storybook/new-vs-returning-customer';
 const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
 const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type NewVsReturningCustomerRenderProps = ComponentProps< typeof NewVsReturningCustomerRender >;
 
 interface NewVsReturningCustomerStoryControls {
 	withComparison: boolean;
@@ -27,10 +29,9 @@ interface NewVsReturningCustomerStoryControls {
 type NewVsReturningCustomerStoryProps = NewVsReturningCustomerRenderProps &
 	NewVsReturningCustomerStoryControls;
 
-interface NewVsReturningCustomerDashboardStoryProps extends WidgetDashboardWithWidgetControls {
-	withComparison: boolean;
-	preset: SelectablePresetId;
-}
+interface NewVsReturningCustomerDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		NewVsReturningCustomerStoryControls {}
 
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '300px' } }>
@@ -86,17 +87,11 @@ function renderNewVsReturningCustomer( {
 	);
 }
 
-/**
- * Render the dashboard story for the new vs returning customer widget.
- *
- * @param props                - Story controls.
- * @param props.withComparison - Whether to include comparison report params.
- * @param props.preset         - Date-range preset to generate report params.
- * @return Story render output.
- */
-function NewVsReturningCustomerDashboardStory( props: NewVsReturningCustomerDashboardStoryProps ) {
-	const { withComparison, preset, ...dashboardStoryArgs } = props;
-
+function NewVsReturningCustomerDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: NewVsReturningCustomerDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.json
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/new-vs-returning-customer",
+	"title": "New vs returning customer",
+	"description": "Unique customer counts broken down by new vs returning customers over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/new-vs-returning` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/new-vs-returning-customer',
+	title: __( 'New vs returning customer', 'jetpack-premium-analytics' ),
+	description: __(
+		'Unique customer counts broken down by new vs returning customers over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type NewVsReturningCustomerAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/new-vs-returning` in


### PR DESCRIPTION
Fixes: WOOA7S-1472

## Proposed changes

- Ports the **New vs returning customer** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/new-vs-returning-customer` widget and renders the shared new-vs-returning customer widget inside `WidgetRoot` using dashboard-level report params.
- Forwards dashboard widget errors through `WidgetRoot` via the widget render `setError` prop.
- Adds Storybook coverage for the standalone `Default` and `WithComparison` states plus the shared `WidgetDashboardWithWidget` dashboard harness.

### Finishing changes (conform to widget contract)

- Types `render.tsx` props with `WidgetRenderProps<T>` from `@wordpress/widget-primitives` and declares the widget attribute type in `widget.ts` (`Record<never, never>`); defaults `attributes = {}`.
- Aligns import grouping, JSDoc density, and story structure to the `payment-status` sibling.
- Fixes `package.json` deps (drop unused `@wordpress/ui`, add `@wordpress/widget-primitives`).
- Passes `maxSize={ null }` to the toolkit `NewVsReturningCustomerWidget`'s `DonutChart` so the donut fills its card (single-consumer toolkit component; contained blast radius).
- Removes the extra `js-packages/storybook` changelog entry (changelog check passes without it).

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![New vs returning customer Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1472-port-woo-widget-new-vs-returning-customer/new-vs-returning-customer.png)

## Related product discussion/links

- WOOA7S-1472; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `pnpm --filter @automattic/jetpack-premium-analytics build`
- `pnpm --filter @automattic/jetpack-storybook storybook:build`
- Open the Premium Analytics Storybook stories:
  - `packages-premium-analytics-widgets-newvsreturningcustomer--default`
  - `packages-premium-analytics-widgets-newvsreturningcustomer--with-comparison`
  - `packages-premium-analytics-widgets-newvsreturningcustomer--widget-dashboard-with-widget`
- Verify the dashboard story renders the widget title, donut chart (filling the card), legend rows, and comparison deltas.
