### PR TITLE
Premium Analytics: port the Orders fulfillment widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-orders-fulfillment-widget-story
+++ b/projects/js-packages/storybook/changelog/add-orders-fulfillment-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add orders fulfillment widget story.

--- a/projects/js-packages/storybook/changelog/add-orders-fulfillment-widget-story
+++ b/projects/js-packages/storybook/changelog/add-orders-fulfillment-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add orders fulfillment widget story.

--- a/projects/packages/premium-analytics/changelog/add-orders-fulfillment-widget
+++ b/projects/packages/premium-analytics/changelog/add-orders-fulfillment-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add orders fulfillment widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
@@ -115,6 +115,7 @@ export function OrdersFulfillmentWidget() {
 						type: 'number',
 						options: { useMultipliers: true, decimals: 0 },
 					} }
+					maxSize={ null }
 					emptyStateIcon={ reports }
 					withTooltips
 				/>

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/package.json
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/package.json
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-orders-fulfillment",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/render.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/render.tsx
@@ -1,0 +1,25 @@
+import { OrdersFulfillmentWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type OrdersFulfillmentRenderProps = {
+	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Orders fulfillment widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; OrdersFulfillmentWidget
+ * renders the fulfilled vs unfulfilled orders donut chart.
+ */
+export default function OrdersFulfillmentRender( {
+	attributes,
+	setError,
+}: OrdersFulfillmentRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<OrdersFulfillmentWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/render.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/render.tsx
@@ -1,20 +1,36 @@
-import { OrdersFulfillmentWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	OrdersFulfillmentWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { OrdersFulfillmentAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type OrdersFulfillmentRenderProps = {
-	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type OrdersFulfillmentRenderAttributes = OrdersFulfillmentAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type OrdersFulfillmentRenderProps = WidgetRenderProps< OrdersFulfillmentRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
  * Orders fulfillment widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; OrdersFulfillmentWidget
- * renders the fulfilled vs unfulfilled orders donut chart.
+ * Thin composition over WidgetRoot: WidgetRoot provides the query client, chart
+ * theme, and resolved report params; OrdersFulfillmentWidget renders the
+ * fulfilled vs unfulfilled orders donut chart.
  */
 export default function OrdersFulfillmentRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: OrdersFulfillmentRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
@@ -1,0 +1,214 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import OrdersFulfillmentRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const ORDERS_FULFILLMENT_RENDER_MODULE = 'storybook/orders-fulfillment';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type OrdersFulfillmentRenderProps = ComponentProps< typeof OrdersFulfillmentRender >;
+
+interface OrdersFulfillmentStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type OrdersFulfillmentStoryProps = OrdersFulfillmentRenderProps & OrdersFulfillmentStoryControls;
+
+interface OrdersFulfillmentDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		OrdersFulfillmentStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getOrdersFulfillmentAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): OrdersFulfillmentRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< OrdersFulfillmentStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getOrdersFulfillmentSource( args: Partial< OrdersFulfillmentStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<OrdersFulfillmentRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderOrdersFulfillment( { withComparison, preset }: OrdersFulfillmentStoryControls ) {
+	return (
+		<OrdersFulfillmentRender
+			attributes={ getOrdersFulfillmentAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function OrdersFulfillmentDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: OrdersFulfillmentDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ ORDERS_FULFILLMENT_RENDER_MODULE }
+			renderComponent={ OrdersFulfillmentRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getOrdersFulfillmentAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/OrdersFulfillment',
+	component: OrdersFulfillmentRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays fulfilled and unfulfilled orders for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< OrdersFulfillmentStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< OrdersFulfillmentDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderOrdersFulfillment,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< OrdersFulfillmentStoryControls > }
+				) => getOrdersFulfillmentSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period fulfilled and unfulfilled totals.
+ */
+export const WithComparison: Story = {
+	render: renderOrdersFulfillment,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< OrdersFulfillmentStoryControls > }
+				) => getOrdersFulfillmentSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <OrdersFulfillmentDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/orders-fulfillment"
+\trenderComponent={ OrdersFulfillmentRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.json
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/orders-fulfillment",
+	"title": "Orders fulfillment",
+	"description": "Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/orders-fulfillment` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/orders-fulfillment',
+	title: __( 'Orders fulfillment', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type OrdersFulfillmentAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/orders-fulfillment` in


### PR DESCRIPTION
Fixes: WOOA7S-1473

## Proposed changes
* Ports the **Orders fulfillment** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/orders-fulfillment` widget and renders the shared orders fulfillment widget inside `WidgetRoot` using dashboard-level report params.
* Adds standalone `Default`/`WithComparison` Storybook stories plus a dashboard harness story, along with the widget/package metadata needed for this port.
* Rebases the widget port onto `trunk`; shared dashboard/core scaffolding is already present there and is not part of this PR diff.

### Finishing changes (conform to the widget contract)
* `render.tsx`: type props with `WidgetRenderProps<T>` from `@wordpress/widget-primitives` (composing the widget's own attribute type with `Partial<ReportParamsFieldAttributes>`) instead of a hand-rolled shape, and default `attributes = {}`. Matches the merged `payment-status` sibling.
* `widget.ts`: declare the attribute shape once as `export type OrdersFulfillmentAttributes = Record<never, never>` and reuse it in `render.tsx`.
* `package.json`: add the now-required `@wordpress/widget-primitives`; drop the unused `@wordpress/ui`.
* `widgets-toolkit` `orders-fulfillment-widget.tsx`: pass `maxSize={ null }` to `DonutChart` so the donut fills its card like `payment-status` (the shared container is already `width:100%` on trunk). This is the widget's own single-consumer toolkit component, so the blast radius is contained.
* Remove the extra `js-packages/storybook` changelog entry the draft added (the story lives in the premium-analytics package; the changelog check passes without it).

## Related product discussion/links
* WOOA7S-1473; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Check out the branch, then from the monorepo root with Node 24 active:
  * `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
  * `pnpm --filter @automattic/jetpack-premium-analytics build`
* Run Storybook (`cd projects/js-packages/storybook && pnpm exec storybook dev -c ./storybook`) and open the `Packages/Premium Analytics/Widgets/OrdersFulfillment` stories:
  * `Default`, `WithComparison`, and `WidgetDashboardWithWidget`.
  * Confirm the donut renders (fulfilled vs unfulfilled counts), fills its card in the dashboard story, shows the comparison deltas in `WithComparison`, and the console is free of widget-specific errors (only the shared-harness `useRouter`/`useGlobalError`/`core/*` baseline noise is expected).
