### PR TITLE
Premium Analytics: port the Orders over time widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-orders-over-time-widget
+++ b/projects/packages/premium-analytics/changelog/add-orders-over-time-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add orders over time widget.

--- a/projects/packages/premium-analytics/widgets/orders-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/package.json
@@ -7,6 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/orders-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-orders-over-time",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/orders-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/render.tsx
@@ -1,11 +1,25 @@
-import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { OrdersOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type OrdersOverTimeRenderAttributes = OrdersOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type RenderProps = {
-	attributes?: WidgetRootProps[ 'attributes' ];
-	setError?: WidgetRootProps[ 'setError' ];
+type OrdersOverTimeRenderProps = WidgetRenderProps< OrdersOverTimeRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -15,9 +29,12 @@ type RenderProps = {
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders the order count metric over time.
  */
-export default function OrdersOverTimeRender( { attributes, setError }: RenderProps ) {
+export default function OrdersOverTimeRender( {
+	attributes = {},
+	setError,
+}: OrdersOverTimeRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } } setError={ setError }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<OrderMetricWidget metricKey="orders_no" />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/orders-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/render.tsx
@@ -1,0 +1,24 @@
+import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type RenderProps = {
+	attributes?: WidgetRootProps[ 'attributes' ];
+	setError?: WidgetRootProps[ 'setError' ];
+};
+
+/**
+ * Orders over time widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; OrderMetricWidget fetches
+ * the orders report and renders the order count metric over time.
+ */
+export default function OrdersOverTimeRender( { attributes, setError }: RenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } } setError={ setError }>
+			<OrderMetricWidget metricKey="orders_no" />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -1,0 +1,219 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import OrdersOverTimeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const ORDERS_OVER_TIME_RENDER_MODULE = 'storybook/orders-over-time';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+// Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
+const ensureLineChartComposition = () => LineChart.Legend;
+
+type OrdersOverTimeRenderProps = ComponentProps< typeof OrdersOverTimeRender >;
+
+interface OrdersOverTimeStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type OrdersOverTimeStoryProps = OrdersOverTimeRenderProps & OrdersOverTimeStoryControls;
+
+interface OrdersOverTimeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		OrdersOverTimeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getOrdersOverTimeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): OrdersOverTimeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< OrdersOverTimeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getOrdersOverTimeSource( args: Partial< OrdersOverTimeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<OrdersOverTimeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderOrdersOverTime( { withComparison, preset }: OrdersOverTimeStoryControls ) {
+	ensureLineChartComposition();
+
+	return (
+		<OrdersOverTimeRender attributes={ getOrdersOverTimeAttributes( withComparison, preset ) } />
+	);
+}
+
+function OrdersOverTimeDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: OrdersOverTimeDashboardStoryProps ) {
+	ensureLineChartComposition();
+
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ ORDERS_OVER_TIME_RENDER_MODULE }
+			renderComponent={ OrdersOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getOrdersOverTimeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/OrdersOverTime',
+	component: OrdersOverTimeRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: 'Dashboard widget that displays order counts over time for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< OrdersOverTimeStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< OrdersOverTimeDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderOrdersOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< OrdersOverTimeStoryControls > }
+				) => getOrdersOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change and line chart data.
+ */
+export const WithComparison: Story = {
+	render: renderOrdersOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< OrdersOverTimeStoryControls > }
+				) => getOrdersOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <OrdersOverTimeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/orders-over-time"
+\trenderComponent={ OrdersOverTimeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/orders-over-time",
+	"title": "Orders over time",
+	"description": "See a breakdown of when orders are placed to identify peak selling periods.",
+	"category": "orders"
+}

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type OrdersOverTimeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/orders-over-time` in

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/orders-over-time` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/orders-over-time',
+	title: __( 'Orders over time', 'jetpack-premium-analytics' ),
+	description: __(
+		'See a breakdown of when orders are placed to identify peak selling periods.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1474

## Proposed changes
* Ports the **Orders over time** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/orders-over-time` widget and renders the shared order metric widget inside `WidgetRoot` for `orders_no` using dashboard-level report params.
* Forwards dashboard `setError` through the widget render wrapper so widget errors can surface through the dashboard shell.
* Adds standalone `Default` and `WithComparison` Storybook stories plus a separate `WidgetDashboardWithWidget` dashboard story using the shared dashboard story helper.
* Uses selectable date-range presets for the Storybook controls and warms up the line chart composition so the static Storybook/Vite build renders the comparative line chart.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Orders over time Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1474-port-woo-widget-orders-over-time/orders-over-time.png)

## Related product discussion/links
* WOOA7S-1474; parent WOOA7S-1457.
* Common Premium Analytics dashboard scaffolding is already on `trunk` via #49793, so this PR is now widget-port-only.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `git diff --check origin/trunk...HEAD`
* `CI=true pnpm exec eslint projects/packages/premium-analytics/widgets/orders-over-time/render.tsx projects/packages/premium-analytics/widgets/orders-over-time/widget.ts projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx`
* `CI=true pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `CI=true pnpm --filter @automattic/jetpack-premium-analytics build`
* `CI=true pnpm --filter @automattic/jetpack-storybook storybook:build`
* Served the static Storybook build and verified `packages-premium-analytics-widgets-ordersovertime--widget-dashboard-with-widget` renders the widget title, metric value, comparison labels, and chart SVG.
