### PR TITLE
Premium Analytics: port the Payment status widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-payment-status-widget
+++ b/projects/packages/premium-analytics/changelog/add-payment-status-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the Payment status dashboard widget.

--- a/projects/packages/premium-analytics/eslint.config.mjs
+++ b/projects/packages/premium-analytics/eslint.config.mjs
@@ -107,18 +107,18 @@ export default defineConfig(
 		},
 	},
 	{
-		// Ported widget code keeps the upstream next-woocommerce-analytics
-		// JSDoc style, and imports internal `@jetpack-premium-analytics/*`
-		// link: packages whose deps are declared on the parent manifest.
-		files: [ 'widgets/**' ],
+		// Ported widget wrappers and stories keep the upstream JSDoc style, and
+		// import internal link packages whose deps are declared on the parent
+		// manifest.
+		files: [ 'widgets/**', 'projects/packages/premium-analytics/widgets/**' ],
 		rules: {
 			'import/order': 'off',
+			'jsdoc/require-jsdoc': 'off',
 			'jsdoc/require-description': 'off',
+			'jsdoc/require-param': 'off',
 			'jsdoc/require-param-description': 'off',
 			'jsdoc/require-returns': 'off',
 			'jsdoc/check-indentation': 'off',
-			'jsdoc/require-param': 'off',
-			'jsdoc/require-jsdoc': 'off',
 			'jsdoc/escape-inline-tags': 'off',
 			'import/no-extraneous-dependencies': 'off',
 		},

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.module.scss
@@ -1,15 +1,13 @@
 .reference {
+	position: relative;
 	width: 100%;
 	height: 100%;
-	position: relative;
+	min-height: 0;
 }
 
 .wrapper {
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
+	height: 100%;
+	min-height: 0;
 }
 
 .chart {
@@ -17,14 +15,28 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-width: 96px;
-	max-width: 192px;
+	min-width: 0;
+	max-width: 100%;
+	flex: 0 0 auto;
+}
+
+.pieChart {
+	position: relative;
+	display: flex;
+	align-items: stretch;
+	justify-content: center;
 	width: 100%;
+	height: 100%;
 }
 
 .metricContainer {
 	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	pointer-events: none;
+	text-align: center;
+	white-space: nowrap;
 }
 
 .noChart {
@@ -32,5 +44,8 @@
 }
 
 .legendContainer {
+	position: relative;
 	width: 200px;
+	max-width: 100%;
+	flex: 0 0 auto;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.module.scss
@@ -5,16 +5,8 @@
 	min-height: 0;
 }
 
-.wrapper {
-	height: 100%;
-	min-height: 0;
-}
-
 .chart {
 	position: relative;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 	min-width: 0;
 	max-width: 100%;
 	flex: 0 0 auto;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { PieChartUnresponsive as PieChart } from '@automattic/charts';
+import { useResizeObserver } from '@wordpress/compose';
 import { Icon, Stack } from '@wordpress/ui';
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -40,6 +41,15 @@ type ElementSize = {
 	height: number;
 };
 
+function getElementSize( element: Element ): ElementSize {
+	const { width, height } = element.getBoundingClientRect();
+
+	return {
+		width: Math.round( width ),
+		height: Math.round( height ),
+	};
+}
+
 function useElementSize< T extends HTMLElement >() {
 	const elementRef = useRef< T | null >( null );
 	const [ size, setSize ] = useState< ElementSize >( {
@@ -47,18 +57,7 @@ function useElementSize< T extends HTMLElement >() {
 		height: 0,
 	} );
 
-	const updateSize = useCallback( () => {
-		const element = elementRef.current;
-		if ( ! element ) {
-			return;
-		}
-
-		const { width, height } = element.getBoundingClientRect();
-		const nextSize = {
-			width: Math.round( width ),
-			height: Math.round( height ),
-		};
-
+	const updateSize = useCallback( ( nextSize: ElementSize ) => {
 		setSize( previousSize =>
 			previousSize.width === nextSize.width && previousSize.height === nextSize.height
 				? previousSize
@@ -66,26 +65,30 @@ function useElementSize< T extends HTMLElement >() {
 		);
 	}, [] );
 
+	const observerRef = useResizeObserver< T >( entries => {
+		const element = entries[ 0 ]?.target ?? elementRef.current;
+
+		if ( ! element ) {
+			return;
+		}
+
+		updateSize( getElementSize( element ) );
+	} );
+
 	const setElementRef = useCallback(
 		( element: T | null ) => {
 			elementRef.current = element;
-			updateSize();
+
+			if ( typeof ResizeObserver !== 'undefined' ) {
+				observerRef( element );
+			}
+
+			if ( element ) {
+				updateSize( getElementSize( element ) );
+			}
 		},
-		[ updateSize ]
+		[ observerRef, updateSize ]
 	);
-
-	useLayoutEffect( () => {
-		const element = elementRef.current;
-		if ( ! element || typeof ResizeObserver === 'undefined' ) {
-			return undefined;
-		}
-
-		updateSize();
-		const observer = new ResizeObserver( updateSize );
-		observer.observe( element );
-
-		return () => observer.disconnect();
-	}, [ updateSize ] );
 
 	return [ setElementRef, size ] as const;
 }
@@ -262,57 +265,61 @@ export function DonutChart( {
 	}
 
 	return (
-		<div className={ styles.reference } ref={ containerRef }>
+		<Stack
+			className={ styles.reference }
+			direction="column"
+			align="center"
+			justify="center"
+			gap={ stackGap }
+			ref={ containerRef }
+		>
 			<Stack
-				className={ styles.wrapper }
-				direction="column"
+				className={ styles.chart }
 				align="center"
 				justify="center"
-				gap={ stackGap }
+				style={ { width: chartSize, height: chartSize } }
 			>
-				<div className={ styles.chart } style={ { width: chartSize, height: chartSize } }>
-					<PieChart
-						data={ styledChartData }
-						className={ styles.pieChart }
-						width={ chartSize }
-						height={ chartSize }
-						thickness={ thickness }
-						cornerScale={ DEFAULT_CORNER_SCALE }
-						gapScale={ DEFAULT_GAP_SCALE }
-						padding={ 0 }
-						size={ chartSize }
-						showLegend={ false }
-						withTooltips={ withTooltips }
-						{ ...( tooltipOffsetX !== undefined && {
-							tooltipOffsetX,
-						} ) }
-						{ ...( tooltipOffsetY !== undefined && {
-							tooltipOffsetY,
-						} ) }
-						renderTooltip={ ( { tooltipData } ) => (
-							<PieChartTooltip
-								tooltipData={ tooltipData }
-								dataFormat={ tooltipDataFormat ?? dataFormat }
-							/>
-						) }
-						showLabels={ false }
-					/>
-					<MetricWithComparison
-						className={ styles.metricContainer }
-						value={ value }
-						dataFormat={ dataFormat }
-						previousValue={ hasComparison ? comparisonValue : null }
-						direction="column"
-						align="center"
-					/>
-				</div>
-
-				{ hasLegend && styledLegendData && (
-					<div className={ styles.legendContainer } ref={ legendRef }>
-						<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
-					</div>
-				) }
+				<PieChart
+					data={ styledChartData }
+					className={ styles.pieChart }
+					width={ chartSize }
+					height={ chartSize }
+					thickness={ thickness }
+					cornerScale={ DEFAULT_CORNER_SCALE }
+					gapScale={ DEFAULT_GAP_SCALE }
+					padding={ 0 }
+					size={ chartSize }
+					showLegend={ false }
+					withTooltips={ withTooltips }
+					{ ...( tooltipOffsetX !== undefined && {
+						tooltipOffsetX,
+					} ) }
+					{ ...( tooltipOffsetY !== undefined && {
+						tooltipOffsetY,
+					} ) }
+					renderTooltip={ ( { tooltipData } ) => (
+						<PieChartTooltip
+							tooltipData={ tooltipData }
+							dataFormat={ tooltipDataFormat ?? dataFormat }
+						/>
+					) }
+					showLabels={ false }
+				/>
+				<MetricWithComparison
+					className={ styles.metricContainer }
+					value={ value }
+					dataFormat={ dataFormat }
+					previousValue={ hasComparison ? comparisonValue : null }
+					direction="column"
+					align="center"
+				/>
 			</Stack>
-		</div>
+
+			{ hasLegend && styledLegendData && (
+				<Stack className={ styles.legendContainer } ref={ legendRef }>
+					<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
+				</Stack>
+			) }
+		</Stack>
 	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import { PieChartUnresponsive as PieChart } from '@automattic/charts';
-import { useResizeObserver } from '@wordpress/compose';
 import { Icon, Stack } from '@wordpress/ui';
-import { useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -31,6 +30,65 @@ const DEFAULT_GAP_SCALE = 0.01;
 export type DonutChartData = ComponentProps< typeof PieChart >[ 'data' ];
 
 const DEFAULT_SIZE = 164;
+const MIN_SIZE = 64;
+const MAX_SIZE = 192;
+const COMPACT_LEGEND_GAP_SIZE = 8;
+const DEFAULT_LEGEND_GAP_SIZE = 24;
+
+type ElementSize = {
+	width: number;
+	height: number;
+};
+
+function useElementSize< T extends HTMLElement >() {
+	const elementRef = useRef< T | null >( null );
+	const [ size, setSize ] = useState< ElementSize >( {
+		width: 0,
+		height: 0,
+	} );
+
+	const updateSize = useCallback( () => {
+		const element = elementRef.current;
+		if ( ! element ) {
+			return;
+		}
+
+		const { width, height } = element.getBoundingClientRect();
+		const nextSize = {
+			width: Math.round( width ),
+			height: Math.round( height ),
+		};
+
+		setSize( previousSize =>
+			previousSize.width === nextSize.width && previousSize.height === nextSize.height
+				? previousSize
+				: nextSize
+		);
+	}, [] );
+
+	const setElementRef = useCallback(
+		( element: T | null ) => {
+			elementRef.current = element;
+			updateSize();
+		},
+		[ updateSize ]
+	);
+
+	useLayoutEffect( () => {
+		const element = elementRef.current;
+		if ( ! element || typeof ResizeObserver === 'undefined' ) {
+			return undefined;
+		}
+
+		updateSize();
+		const observer = new ResizeObserver( updateSize );
+		observer.observe( element );
+
+		return () => observer.disconnect();
+	}, [ updateSize ] );
+
+	return [ setElementRef, size ] as const;
+}
 
 export type DonutChartProps = {
 	/**
@@ -76,6 +134,13 @@ export type DonutChartProps = {
 	 * @default 0.3
 	 */
 	thickness?: number;
+
+	/**
+	 * Maximum chart diameter in pixels. Pass `null` to let the chart grow to
+	 * the available container size.
+	 * @default 192
+	 */
+	maxSize?: number | null;
 
 	/**
 	 * Icon to display in the empty state
@@ -131,6 +196,7 @@ export function DonutChart( {
 	legendData,
 	showLegend = true,
 	thickness = DEFAULT_THICKNESS,
+	maxSize = MAX_SIZE,
 	emptyStateIcon,
 	emptyStateText,
 	withTooltips = false,
@@ -140,27 +206,8 @@ export function DonutChart( {
 }: DonutChartProps ) {
 	const hasComparison = comparisonValue !== null && comparisonValue !== undefined;
 
-	const [ widgetHeight, setWidgetHeight ] = useState< number >( 0 );
-
-	/**
-	 * Chart width will pick the width of the chart element
-	 * via CSS, following the `chart` class name
-	 */
-	const [ chartWidth, setChartWidth ] = useState< number >( 0 );
-
-	const ref = useResizeObserver( entries => {
-		const entry = entries?.[ 0 ];
-		if ( ! entry?.contentRect ) {
-			return;
-		}
-
-		setWidgetHeight( entry.contentRect.height );
-
-		const chartElement = entry.target.children[ 0 ];
-		if ( chartElement ) {
-			setChartWidth( chartElement.clientWidth );
-		}
-	} );
+	const [ containerRef, containerSize ] = useElementSize< HTMLDivElement >();
+	const [ legendRef, legendSize ] = useElementSize< HTMLDivElement >();
 
 	/**
 	 * Resolve styles: prop takes priority, fallback to chartData colors.
@@ -191,6 +238,23 @@ export function DonutChart( {
 	}, [ legendData, resolvedStyles ] );
 
 	const isEmptyData = isEmptyPieChartData( chartData );
+	const hasLegend = showLegend && Boolean( styledLegendData?.length );
+	const availableWidth =
+		typeof containerSize.width === 'number' ? containerSize.width : DEFAULT_SIZE;
+	const availableHeight =
+		typeof containerSize.height === 'number' ? containerSize.height : DEFAULT_SIZE;
+	const legendHeight = typeof legendSize.height === 'number' ? legendSize.height : 0;
+	const maxChartSize = maxSize ?? Number.POSITIVE_INFINITY;
+	const targetChartSize = Math.min( maxChartSize, availableWidth );
+	const isCompactLayout =
+		hasLegend && availableHeight < targetChartSize + legendHeight + DEFAULT_LEGEND_GAP_SIZE;
+	const legendGapSize = isCompactLayout ? COMPACT_LEGEND_GAP_SIZE : DEFAULT_LEGEND_GAP_SIZE;
+	const reservedLegendHeight = hasLegend && legendHeight ? legendHeight + legendGapSize : 0;
+	const chartSize = Math.max(
+		MIN_SIZE,
+		Math.min( maxChartSize, availableWidth, availableHeight - reservedLegendHeight )
+	);
+	const stackGap = isCompactLayout ? 'sm' : 'xl';
 
 	// Render empty state when no data is available
 	if ( isEmptyData ) {
@@ -198,17 +262,25 @@ export function DonutChart( {
 	}
 
 	return (
-		<div className={ styles.reference } style={ { height: widgetHeight ?? DEFAULT_SIZE } }>
-			<div className={ styles.wrapper }>
-				<Stack direction="column" align="center" justify="center" gap="xl" ref={ ref }>
+		<div className={ styles.reference } ref={ containerRef }>
+			<Stack
+				className={ styles.wrapper }
+				direction="column"
+				align="center"
+				justify="center"
+				gap={ stackGap }
+			>
+				<div className={ styles.chart } style={ { width: chartSize, height: chartSize } }>
 					<PieChart
 						data={ styledChartData }
-						className={ styles.chart }
+						className={ styles.pieChart }
+						width={ chartSize }
+						height={ chartSize }
 						thickness={ thickness }
 						cornerScale={ DEFAULT_CORNER_SCALE }
 						gapScale={ DEFAULT_GAP_SCALE }
 						padding={ 0 }
-						size={ chartWidth ?? DEFAULT_SIZE }
+						size={ chartSize }
 						showLegend={ false }
 						withTooltips={ withTooltips }
 						{ ...( tooltipOffsetX !== undefined && {
@@ -224,24 +296,23 @@ export function DonutChart( {
 							/>
 						) }
 						showLabels={ false }
-					>
-						<MetricWithComparison
-							className={ styles.metricContainer }
-							value={ value }
-							dataFormat={ dataFormat }
-							previousValue={ hasComparison ? comparisonValue : null }
-							direction="column"
-							align="center"
-						/>
-					</PieChart>
+					/>
+					<MetricWithComparison
+						className={ styles.metricContainer }
+						value={ value }
+						dataFormat={ dataFormat }
+						previousValue={ hasComparison ? comparisonValue : null }
+						direction="column"
+						align="center"
+					/>
+				</div>
 
-					{ showLegend && styledLegendData && (
-						<div className={ styles.legendContainer }>
-							<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
-						</div>
-					) }
-				</Stack>
-			</div>
+				{ hasLegend && styledLegendData && (
+					<div className={ styles.legendContainer } ref={ legendRef }>
+						<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
+					</div>
+				) }
+			</Stack>
 		</div>
 	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -5,9 +5,11 @@ export {
 	MetricDelta,
 	MetricWithComparison,
 	ComparativeLineChart,
+	DonutChart,
 	Legend,
 	WidgetRoot,
 	useWidgetRootContext,
+	type DonutChartData,
 	type LegendItem,
 	type SeriesStyle,
 	LeaderboardChart,
@@ -53,6 +55,8 @@ export {
 	FULFILLED_ORDERS_FILTER,
 	UNFULFILLED_ORDERS_FILTER,
 	PAYMENT_STATUS_FILTERS,
+	buildPaymentStatusData,
+	type PaymentStatusData,
 } from './helpers';
 
 /**
@@ -64,6 +68,7 @@ export {
 	useSeriesStyles,
 	useWidgetError,
 } from './hooks';
+export { useSegmentStyles } from './widgets/common';
 
 /**
  * Widget components
@@ -79,7 +84,6 @@ export {
 	RevenueByCustomerTypeWidget,
 	NewVsReturningCustomerWidget,
 	OrderMetricWidget,
-	PaymentStatusWidget,
 	OrdersFulfillmentWidget,
 	SalesByCouponWidget,
 	TotalReturnsWidget,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -49,6 +49,16 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
  * package (`@jetpack-premium-analytics/data`).
  */
 const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
+const WP_SETTINGS_PATH = '/wp/v2/settings';
+
+const coreSettingsMock = {
+	timezone: 'UTC',
+	gmt_offset: 0,
+	date_format: 'F j, Y',
+	time_format: 'g:i a',
+	start_of_week: 1,
+	title: 'Storybook',
+};
 
 /**
  * Days of mock data to generate (covering past requests).
@@ -360,6 +370,10 @@ function routeReport( subPath: string, query: URLSearchParams ): unknown {
 
 const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
+
+	if ( requestPath.startsWith( WP_SETTINGS_PATH ) ) {
+		return coreSettingsMock;
+	}
 
 	if ( ! requestPath.startsWith( API_BASE ) ) {
 		return next( options );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/donut-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/donut-widget.module.scss
@@ -1,6 +1,6 @@
 /**
  * Shared styles for DonutChart-based widgets.
- * Used by: CouponUseWidget, PaymentStatusWidget, BookingsByAttendanceWidget
+ * Used by: CouponUseWidget, BookingsByAttendanceWidget
  */
 .container {
 	min-width: 120px;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/index.ts
@@ -22,6 +22,5 @@ export {
 	type TopPerformingBookingsWidgetProps,
 } from './product-leaderboard';
 export { CouponUseWidget } from './coupon-use';
-export { PaymentStatusWidget } from './payment-status';
 export { OrdersFulfillmentWidget } from './orders-fulfillment';
 export { VisitorsByLocationWidget } from './visitors-by-location';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/payment-status/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/payment-status/index.ts
@@ -1,1 +1,0 @@
-export { PaymentStatusWidget } from './payment-status-widget';

--- a/projects/packages/premium-analytics/widgets/payment-status/package.json
+++ b/projects/packages/premium-analytics/widgets/payment-status/package.json
@@ -4,9 +4,12 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/payment-status/package.json
+++ b/projects/packages/premium-analytics/widgets/payment-status/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-payment-status",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.module.scss
+++ b/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.module.scss
@@ -1,0 +1,7 @@
+.container {
+	width: 100%;
+	min-width: 120px;
+	height: 100%;
+	min-height: 0;
+	margin: 0 auto;
+}

--- a/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.tsx
@@ -3,18 +3,21 @@
  */
 import { useReportOrders } from '@jetpack-premium-analytics/data';
 import { payment } from '@jetpack-premium-analytics/icons';
+import {
+	DonutChart,
+	PAYMENT_STATUS_FILTERS,
+	WidgetLoadingOverlay,
+	buildPaymentStatusData,
+	useSegmentStyles,
+	useWidgetError,
+	useWidgetRootContext,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 import { Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
-import { DonutChart } from '../../components';
-import { WidgetLoadingOverlay } from '../../components/widget-loading-overlay';
 /**
  * Internal dependencies
  */
-import { useWidgetRootContext } from '../../components/widget-root';
-import { buildPaymentStatusData, PAYMENT_STATUS_FILTERS } from '../../helpers';
-import { useWidgetError } from '../../hooks';
-import { useSegmentStyles } from '../common';
-import styles from '../common/donut-widget.module.scss';
+import styles from './payment-status-widget.module.scss';
 
 /**
  * Payment Status Widget Component
@@ -82,6 +85,7 @@ export function PaymentStatusWidget() {
 						type: 'currency',
 						options: { useMultipliers: true, decimals: 1 },
 					} }
+					maxSize={ null }
 					emptyStateIcon={ payment }
 					withTooltips
 				/>

--- a/projects/packages/premium-analytics/widgets/payment-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/render.tsx
@@ -1,5 +1,12 @@
-import { PaymentStatusWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import { WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ComponentProps } from 'react';
+/**
+ * Internal dependencies
+ */
+import { PaymentStatusWidget } from './payment-status-widget';
 
 type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
 
@@ -10,9 +17,9 @@ type PaymentStatusRenderProps = Pick< WidgetRootProps, 'attributes' > & {
 /**
  * Payment status widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; PaymentStatusWidget renders
- * the paid vs unpaid order revenue donut chart.
+ * Thin composition over WidgetRoot: WidgetRoot provides the query client,
+ * chart theme, and resolved report params; PaymentStatusWidget renders the
+ * paid vs unpaid order revenue donut chart.
  */
 export default function PaymentStatusRender( { attributes, setError }: PaymentStatusRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/payment-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/render.tsx
@@ -1,0 +1,23 @@
+import { PaymentStatusWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type PaymentStatusRenderProps = Pick< WidgetRootProps, 'attributes' > & {
+	setError?: WidgetRootProps[ 'setError' ];
+};
+
+/**
+ * Payment status widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; PaymentStatusWidget renders
+ * the paid vs unpaid order revenue donut chart.
+ */
+export default function PaymentStatusRender( { attributes, setError }: PaymentStatusRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<PaymentStatusWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
@@ -1,0 +1,213 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import PaymentStatusRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const PAYMENT_STATUS_RENDER_MODULE = 'storybook/payment-status';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type PaymentStatusRenderProps = ComponentProps< typeof PaymentStatusRender >;
+
+interface PaymentStatusStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type PaymentStatusStoryProps = PaymentStatusRenderProps & PaymentStatusStoryControls;
+
+interface PaymentStatusDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		PaymentStatusStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getPaymentStatusAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): PaymentStatusRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< PaymentStatusStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getPaymentStatusSource( args: Partial< PaymentStatusStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<PaymentStatusRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderPaymentStatus( { withComparison, preset }: PaymentStatusStoryControls ) {
+	return (
+		<PaymentStatusRender attributes={ getPaymentStatusAttributes( withComparison, preset ) } />
+	);
+}
+
+function PaymentStatusDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: PaymentStatusDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ PAYMENT_STATUS_RENDER_MODULE }
+			renderComponent={ PaymentStatusRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getPaymentStatusAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/PaymentStatus',
+	component: PaymentStatusRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays paid and unpaid order revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< PaymentStatusStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< PaymentStatusDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderPaymentStatus,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< PaymentStatusStoryControls > }
+				) => getPaymentStatusSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing paid and unpaid order revenue for the
+ * selected period and previous period.
+ */
+export const WithComparison: Story = {
+	render: renderPaymentStatus,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< PaymentStatusStoryControls > }
+				) => getPaymentStatusSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <PaymentStatusDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/payment-status"
+\trenderComponent={ PaymentStatusRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.json
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/payment-status",
+	"title": "Payment status",
+	"description": "Shows the breakdown of paid vs unpaid order revenue over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/payment-status` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/payment-status',
+	title: __( 'Payment status', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the breakdown of paid vs unpaid order revenue over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1475

## Proposed changes
* Ports the **Payment status** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/payment-status` widget and renders the shared payment status widget inside `WidgetRoot` using dashboard-level report params and error handling.
* Adds standalone Storybook coverage for default and comparison states, plus a `WidgetDashboardWithWidget` dashboard-hosted story using the shared dashboard scaffolding.
* Extends the shared Storybook report mocks with the WordPress settings response required by the dashboard host.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Payment status Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1475-port-woo-widget-payment-status/payment-status.png)

## Related product discussion/links
* WOOA7S-1475; parent WOOA7S-1457.
* Rebased onto `trunk` after the shared Premium Analytics dashboard scaffolding landed separately.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Using Node 24.15.0 and pnpm 11.5.2:

* `pnpm install --frozen-lockfile --config.confirmModulesPurge=false`
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* `git diff --check origin/trunk...HEAD`
* Verified the Storybook story `packages-premium-analytics-widgets-paymentstatus--widget-dashboard-with-widget` with a local Playwright smoke pass: title rendered, chart SVG rendered, expected paid/unpaid values rendered, no `NaN`/`undefined`, and no bad network responses.
* The only console error in the local smoke pass was the existing shared dashboard-host `Store "core/notices" is already registered.` warning, which also reproduces on a current `trunk` dashboard story.
