### PR TITLE
VideoPress: enqueue player scripts instead of inlining per block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
+++ b/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-VideoPress: enqueue the player scripts instead of printing them inline so they load only once when a page contains multiple videos
+VideoPress: Enqueue the player scripts instead of printing them inline so they load only once when a page contains multiple videos.

--- a/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
+++ b/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-VideoPress: Enqueue the player scripts instead of printing them inline so they load only once when a page contains multiple videos.
+VideoPress: Enqueue the player scripts instead of printing them inline so they load only once when a page contains multiple videos, and enqueue the VideoJS player stylesheet on the non-iframe path so the player is sized correctly instead of overflowing the page.

--- a/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
+++ b/projects/plugins/jetpack/changelog/fix-videopress-duplicate-player-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: enqueue the player scripts instead of printing them inline so they load only once when a page contains multiple videos

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -736,10 +736,6 @@ class VideoPress_Player {
 			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$js_url             = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.js';
 
-			/*
-			 * Enqueue the player script once and attach each video's initialization
-			 * as an inline script so the loader is not duplicated per block.
-			 */
 			wp_enqueue_script( 'videopress-videojs', $js_url, array(), JETPACK__VERSION, true );
 			wp_add_inline_script(
 				'videopress-videojs',

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -714,7 +714,15 @@ class VideoPress_Player {
 
 			$cover  = $videopress_options['cover'] ? ' data-resize-to-parent="true"' : '';
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
-			// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+
+			/*
+			 * Enqueue the iframe API script rather than printing it inline so that
+			 * it is only loaded once when several VideoPress blocks are on the page.
+			 * The 'videopress-iframe' handle is shared with the VideoPress package's
+			 * block render so both paths de-duplicate against each other.
+			 */
+			wp_enqueue_script( 'videopress-iframe', $js_url, array(), JETPACK__VERSION, true );
+
 			return "<iframe title='" . __( 'VideoPress Video Player', 'jetpack' )
 				. "' aria-label='" . __( 'VideoPress Video Player', 'jetpack' )
 				. "' width='" . esc_attr( $videopress_options['width'] )
@@ -722,19 +730,23 @@ class VideoPress_Player {
 				. "' src='" . esc_attr( $iframe_url )
 				. "' frameborder='0' allowfullscreen"
 				. $cover
-				. " allow='clipboard-write'></iframe>"
-				. "<script src='" . esc_attr( $js_url ) . "'></script>";
+				. " allow='clipboard-write'></iframe>";
 
 		} else {
 			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$js_url             = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.js';
 
-			return "<div id='{$video_container_id}'></div>
-				<script src='{$js_url}'></script>
-				<script>
-					videopress('{$this->video->guid}', document.querySelector('#{$video_container_id}'), {$videopress_options});
-				</script>";
-			// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+			/*
+			 * Enqueue the player script once and attach each video's initialization
+			 * as an inline script so the loader is not duplicated per block.
+			 */
+			wp_enqueue_script( 'videopress-videojs', $js_url, array(), JETPACK__VERSION, true );
+			wp_add_inline_script(
+				'videopress-videojs',
+				"videopress('{$this->video->guid}', document.querySelector('#{$video_container_id}'), {$videopress_options});"
+			);
+
+			return "<div id='{$video_container_id}'></div>";
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -713,7 +713,7 @@ class VideoPress_Player {
 			}
 
 			$cover  = $videopress_options['cover'] ? ' data-resize-to-parent="true"' : '';
-			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
+			$js_url = 'https://videopress.com/videopress-iframe.js';
 
 			wp_enqueue_script( 'videopress-iframe', $js_url, array(), JETPACK__VERSION, true );
 

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -729,14 +729,16 @@ class VideoPress_Player {
 		} else {
 			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$js_url             = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.js';
+			$guid_js            = wp_json_encode( (string) $this->video->guid, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+			$selector_js        = wp_json_encode( '#' . $video_container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 
 			wp_enqueue_script( 'videopress-videojs', $js_url, array(), JETPACK__VERSION, true );
 			wp_add_inline_script(
 				'videopress-videojs',
-				"videopress('{$this->video->guid}', document.querySelector('#{$video_container_id}'), {$videopress_options});"
+				"videopress({$guid_js}, document.querySelector({$selector_js}), {$videopress_options});"
 			);
 
-			return "<div id='{$video_container_id}'></div>";
+			return "<div id='" . esc_attr( $video_container_id ) . "'></div>";
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -712,10 +712,9 @@ class VideoPress_Player {
 				}
 			}
 
-			$cover  = $videopress_options['cover'] ? ' data-resize-to-parent="true"' : '';
-			$js_url = 'https://videopress.com/videopress-iframe.js';
+			$cover = $videopress_options['cover'] ? ' data-resize-to-parent="true"' : '';
 
-			wp_enqueue_script( 'videopress-iframe', $js_url, array(), JETPACK__VERSION, true );
+			wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), JETPACK__VERSION, true );
 
 			return "<iframe title='" . __( 'VideoPress Video Player', 'jetpack' )
 				. "' aria-label='" . __( 'VideoPress Video Player', 'jetpack' )

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -728,9 +728,12 @@ class VideoPress_Player {
 		} else {
 			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$js_url             = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.js';
+			$css_url            = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.css';
 			$guid_js            = wp_json_encode( (string) $this->video->guid, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$selector_js        = wp_json_encode( '#' . $video_container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 
+			// Without the player styles the <video> renders at its native size and overflows the page.
+			wp_enqueue_style( 'videopress-videojs', $css_url, array(), JETPACK__VERSION );
 			wp_enqueue_script( 'videopress-videojs', $js_url, array(), JETPACK__VERSION, true );
 			wp_add_inline_script(
 				'videopress-videojs',

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -715,12 +715,6 @@ class VideoPress_Player {
 			$cover  = $videopress_options['cover'] ? ' data-resize-to-parent="true"' : '';
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
 
-			/*
-			 * Enqueue the iframe API script rather than printing it inline so that
-			 * it is only loaded once when several VideoPress blocks are on the page.
-			 * The 'videopress-iframe' handle is shared with the VideoPress package's
-			 * block render so both paths de-duplicate against each other.
-			 */
 			wp_enqueue_script( 'videopress-iframe', $js_url, array(), JETPACK__VERSION, true );
 
 			return "<iframe title='" . __( 'VideoPress Video Player', 'jetpack' )

--- a/projects/plugins/jetpack/tests/e2e/specs/videopress/scripts-loading.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/videopress/scripts-loading.test.ts
@@ -28,7 +28,7 @@ test.describe( 'VideoPress player script loading', () => {
 			'--porcelain',
 		] );
 
-		postId = ( output.match( /\d+/ ) || [] )[ 0 ];
+		postId = output.match( /\d+/ )?.[ 0 ] ?? '';
 		logger.debug( `Created VideoPress test post: ${ postId }` );
 		expect( postId, 'wp-cli returned a post ID' ).toBeTruthy();
 	} );

--- a/projects/plugins/jetpack/tests/e2e/specs/videopress/scripts-loading.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/videopress/scripts-loading.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@automattic/_jetpack-e2e-commons/fixtures/base-test';
+import logger from '@automattic/_jetpack-e2e-commons/logger';
+
+/**
+ * A real, publicly playable VideoPress video used purely for rendering checks.
+ * The player falls back to a default embed even if its metadata can't be
+ * fetched, so the test does not depend on the video data endpoint.
+ */
+const TEST_VIDEO_GUID = '3Nq0kSMu';
+
+test.describe( 'VideoPress player script loading', () => {
+	let postId: string;
+
+	test.beforeAll( async ( { testUtils } ) => {
+		await testUtils.activateModule( 'videopress' );
+
+		/*
+		 * Create a post with two VideoPress shortcodes so we can assert the
+		 * shared player script is only loaded once for the whole page.
+		 */
+		const output = await testUtils.executeWpCommand( [
+			'post',
+			'create',
+			'--post_type=post',
+			'--post_status=publish',
+			'--post_title=VideoPress script loading',
+			`--post_content=[videopress ${ TEST_VIDEO_GUID }]\n\n[videopress ${ TEST_VIDEO_GUID }]`,
+			'--porcelain',
+		] );
+
+		postId = ( output.match( /\d+/ ) || [] )[ 0 ];
+		logger.debug( `Created VideoPress test post: ${ postId }` );
+		expect( postId, 'wp-cli returned a post ID' ).toBeTruthy();
+	} );
+
+	test.afterAll( async ( { testUtils } ) => {
+		if ( postId ) {
+			await testUtils.executeWpCommand( [ 'post', 'delete', postId, '--force' ] );
+		}
+	} );
+
+	test( 'loads the iframe API script only once for multiple videos', async ( { page } ) => {
+		await page.goto( `/?p=${ postId }` );
+
+		await test.step( 'Both videos render', async () => {
+			const players = page.locator( `iframe[src*="videopress.com/embed/${ TEST_VIDEO_GUID }"]` );
+			await expect( players ).toHaveCount( 2 );
+			await expect( players.first() ).toBeVisible();
+			await expect( players.last() ).toBeVisible();
+		} );
+
+		await test.step( 'The iframe API script is enqueued exactly once', async () => {
+			const apiScript = page.locator( 'script[src*="videopress-iframe.js"]' );
+			await expect( apiScript ).toHaveCount( 1 );
+
+			// The "-js" id is only present when the script goes through wp_enqueue_script().
+			await expect( page.locator( '#videopress-iframe-js' ) ).toBeAttached();
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -114,6 +114,9 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 		$enqueued = array_keys( wp_scripts()->queue, 'videopress-videojs', true );
 		$this->assertCount( 1, $enqueued, 'videopress-videojs should be enqueued exactly once.' );
 
+		$styles = array_keys( wp_styles()->queue, 'videopress-videojs', true );
+		$this->assertCount( 1, $styles, 'The videopress-videojs stylesheet should be enqueued exactly once.' );
+
 		$inline = wp_scripts()->get_data( 'videopress-videojs', 'after' );
 		$inline = is_array( $inline ) ? implode( "\n", $inline ) : (string) $inline;
 		$this->assertStringContainsString(

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -91,9 +91,40 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 	 */
 	public function test_iframe_script_enqueued_once_for_multiple_players() {
 		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
-		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+		( new VideoPress_Player( 'otherguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
 
 		$enqueued = array_keys( wp_scripts()->queue, 'videopress-iframe', true );
 		$this->assertCount( 1, $enqueued, 'videopress-iframe should be enqueued exactly once.' );
+	}
+
+	/**
+	 * With the iframe embed disabled, the VideoJS player script should be
+	 * enqueued only once while each video still attaches its own inline
+	 * initialization. See #35926.
+	 */
+	public function test_non_iframe_path_enqueues_videojs_once_with_per_video_init() {
+		$use_iframe = '__return_false';
+		add_filter( 'jetpack_videopress_player_use_iframe', $use_iframe );
+
+		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+		( new VideoPress_Player( 'otherguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+
+		remove_filter( 'jetpack_videopress_player_use_iframe', $use_iframe );
+
+		$enqueued = array_keys( wp_scripts()->queue, 'videopress-videojs', true );
+		$this->assertCount( 1, $enqueued, 'videopress-videojs should be enqueued exactly once.' );
+
+		$inline = wp_scripts()->get_data( 'videopress-videojs', 'after' );
+		$inline = is_array( $inline ) ? implode( "\n", $inline ) : (string) $inline;
+		$this->assertStringContainsString(
+			'videopress("testguid", document.querySelector("#v-testguid")',
+			$inline,
+			'The first video should get its own inline initialization.'
+		);
+		$this->assertStringContainsString(
+			'videopress("otherguid", document.querySelector("#v-otherguid")',
+			$inline,
+			'The second video should get its own inline initialization.'
+		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -23,6 +23,30 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * Saved global WP_Scripts instance, restored after each test.
+	 *
+	 * @var WP_Scripts|null
+	 */
+	private $saved_wp_scripts;
+
+	/**
+	 * Start each test with an empty script queue so enqueue assertions are isolated.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->saved_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
+		$GLOBALS['wp_scripts']  = new WP_Scripts();
+	}
+
+	/**
+	 * Restore the original global WP_Scripts instance.
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = $this->saved_wp_scripts;
+		parent::tear_down();
+	}
+
+	/**
 	 * Gets the test data for test_output_html5_dynamic_next().
 	 *
 	 * @return array The test data.
@@ -33,21 +57,19 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 				array(
 					'cover' => true,
 				),
-				// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=1&amp;hd=0' frameborder='0' allowfullscreen data-resize-to-parent=\"true\" allow='clipboard-write'></iframe><script src='https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js'></script>",
+				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=1&amp;hd=0' frameborder='0' allowfullscreen data-resize-to-parent=\"true\" allow='clipboard-write'></iframe>",
 			),
 			'cover_disabled' => array(
 				array(
 					'cover' => false,
 				),
-				// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=0&amp;hd=0' frameborder='0' allowfullscreen allow='clipboard-write'></iframe><script src='https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js'></script>",
+				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=0&amp;hd=0' frameborder='0' allowfullscreen allow='clipboard-write'></iframe>",
 			),
 		);
 	}
 
 	/**
-	 * Tests the output of html5_dynamic_next().
+	 * Tests the output of html5_dynamic_next() and that the iframe API script is enqueued.
 	 *
 	 * @dataProvider get_html_test_data
 	 * @param array  $options The player options.
@@ -57,5 +79,21 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 	public function test_output_html5_dynamic_next( $options, $expected ) {
 		$player = new VideoPress_Player( 'testguid', 0, $options );
 		$this->assertEquals( $expected, $player->html5_dynamic_next() );
+		$this->assertTrue(
+			wp_script_is( 'videopress-iframe', 'enqueued' ),
+			'The iframe API script should be enqueued rather than printed inline.'
+		);
+	}
+
+	/**
+	 * The iframe API script should be enqueued only once, no matter how many
+	 * VideoPress players are rendered on the same page. See #35926.
+	 */
+	public function test_iframe_script_enqueued_once_for_multiple_players() {
+		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+
+		$enqueued = array_keys( wp_scripts()->queue, 'videopress-iframe', true );
+		$this->assertCount( 1, $enqueued, 'videopress-iframe should be enqueued exactly once.' );
 	}
 }


### PR DESCRIPTION
Fixes #35926

## Proposed changes
* `VideoPress_Player::html5_dynamic_next()` no longer prints a `<script src=…>` tag inline for each rendered video. With the previous code, a page containing multiple VideoPress blocks/shortcodes loaded the same iframe API (or VideoJS player) script once per block.
* The iframe path now enqueues the script via `wp_enqueue_script()` using the `videopress-iframe` handle — the same handle the VideoPress package's block render uses — so both rendering paths de-duplicate against each other and the script loads only once per page.
* The non-iframe path (used when the `jetpack_videopress_player_use_iframe` filter is `false`, or for IE11) enqueues the player script once and attaches each video's `videopress( … )` initialization through `wp_add_inline_script()` after the shared loader, so per-video init still runs but the loader is no longer duplicated.
* Removed the now-unnecessary `WordPress.WP.EnqueuedResources.NonEnqueuedScript` phpcs ignores.

## Related product discussion/links
* https://github.com/Automattic/jetpack/issues/35926

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Spin up a site with the Jetpack plugin and VideoPress active (Note: Not the VideoPress standalone plugin).
* Create a post and add **two or more** videos using the `[videopress <guid>]` / `[wpvideo <guid>]` shortcode (this routes through the dynamic "next" player).
* View the post on the front end and open the browser dev tools **Network** tab (filter for `videopress-iframe.js`).
* **Before:** `videopress-iframe.js` is requested once per video (e.g. 3 videos → 3 requests), each printed inline beneath its iframe.
* **After:** `videopress-iframe.js` is requested **only once**, enqueued in the page footer, regardless of how many videos are on the page. The videos still play and resize correctly.
* Optionally, confirm a page that mixes a `videopress/video` block (package render) and a `[videopress]` shortcode also loads the iframe script only once.
* For the non-iframe path: add `add_filter( 'jetpack_videopress_player_use_iframe', '__return_false' );`, place two videos, and verify the VideoJS player script loads once while each video still initializes.
