### PR TITLE
Premium Analytics: port the Revenue by customer type widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-revenue-by-customer-type-widget-story
+++ b/projects/js-packages/storybook/changelog/add-revenue-by-customer-type-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add revenue by customer type widget story.

--- a/projects/js-packages/storybook/changelog/add-revenue-by-customer-type-widget-story
+++ b/projects/js-packages/storybook/changelog/add-revenue-by-customer-type-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add revenue by customer type widget story.

--- a/projects/packages/premium-analytics/changelog/add-revenue-by-customer-type-widget
+++ b/projects/packages/premium-analytics/changelog/add-revenue-by-customer-type-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add revenue by customer type widget.

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/package.json
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/package.json
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-revenue-by-customer-type",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/render.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/render.tsx
@@ -1,25 +1,37 @@
+/**
+ * External dependencies
+ */
 import {
 	RevenueByCustomerTypeWidget,
 	WidgetRoot,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { RevenueByCustomerTypeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type RevenueByCustomerTypeRenderAttributes = RevenueByCustomerTypeAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type RevenueByCustomerTypeRenderProps = {
-	attributes?: WidgetRootProps[ 'attributes' ];
-	setError?: WidgetRootProps[ 'setError' ];
-};
+type RevenueByCustomerTypeRenderProps =
+	WidgetRenderProps< RevenueByCustomerTypeRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * Revenue by customer type widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; RevenueByCustomerTypeWidget
- * fetches the customers report and renders the revenue breakdown.
+ * Thin composition over WidgetRoot: WidgetRoot provides the query client,
+ * chart theme, and resolved report params; RevenueByCustomerTypeWidget fetches
+ * the customers report and renders the new vs returning revenue breakdown.
  */
 export default function RevenueByCustomerTypeRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: RevenueByCustomerTypeRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/render.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/render.tsx
@@ -1,0 +1,30 @@
+import {
+	RevenueByCustomerTypeWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+
+type RevenueByCustomerTypeRenderProps = {
+	attributes?: WidgetRootProps[ 'attributes' ];
+	setError?: WidgetRootProps[ 'setError' ];
+};
+
+/**
+ * Revenue by customer type widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; RevenueByCustomerTypeWidget
+ * fetches the customers report and renders the revenue breakdown.
+ */
+export default function RevenueByCustomerTypeRender( {
+	attributes,
+	setError,
+}: RevenueByCustomerTypeRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<RevenueByCustomerTypeWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
@@ -1,0 +1,220 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import RevenueByCustomerTypeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE = 'storybook/revenue-by-customer-type';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type RevenueByCustomerTypeRenderProps = ComponentProps< typeof RevenueByCustomerTypeRender >;
+
+interface RevenueByCustomerTypeStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type RevenueByCustomerTypeStoryProps = RevenueByCustomerTypeRenderProps &
+	RevenueByCustomerTypeStoryControls;
+
+interface RevenueByCustomerTypeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		RevenueByCustomerTypeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getRevenueByCustomerTypeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): RevenueByCustomerTypeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< RevenueByCustomerTypeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getRevenueByCustomerTypeSource( args: Partial< RevenueByCustomerTypeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<RevenueByCustomerTypeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderRevenueByCustomerType( {
+	withComparison,
+	preset,
+}: RevenueByCustomerTypeStoryControls ) {
+	return (
+		<RevenueByCustomerTypeRender
+			attributes={ getRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function RevenueByCustomerTypeDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: RevenueByCustomerTypeDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE }
+			renderComponent={
+				RevenueByCustomerTypeRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ getRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/RevenueByCustomerType',
+	component: RevenueByCustomerTypeRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays new and returning customer revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< RevenueByCustomerTypeStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< RevenueByCustomerTypeDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderRevenueByCustomerType,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< RevenueByCustomerTypeStoryControls > }
+				) => getRevenueByCustomerTypeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period revenue changes.
+ */
+export const WithComparison: Story = {
+	render: renderRevenueByCustomerType,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< RevenueByCustomerTypeStoryControls > }
+				) => getRevenueByCustomerTypeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <RevenueByCustomerTypeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/revenue-by-customer-type"
+\trenderComponent={ RevenueByCustomerTypeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.json
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/revenue-by-customer-type",
+	"title": "Revenue by customer type",
+	"description": "Shows the breakdown of order revenue from new and returning customers over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/revenue-by-customer-type` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/revenue-by-customer-type',
+	title: __( 'Revenue by customer type', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the breakdown of order revenue from new and returning customers over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type RevenueByCustomerTypeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/revenue-by-customer-type` in


### PR DESCRIPTION
Fixes: WOOA7S-1476

## Proposed changes

- Ports the **Revenue by customer type** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/revenue-by-customer-type` widget and renders the shared revenue by customer type widget inside `WidgetRoot` using dashboard-level report params.
- Forwards the dashboard `setError` callback through `WidgetRoot` so widget query failures surface through dashboard error UI.
- Adds Premium Analytics Storybook coverage for standalone default, standalone comparison, and dashboard harness states, including selectable date presets.

### Finishing changes (takeover)

- Rebased on `trunk` and conformed the port to the current widget contract:
  - `render.tsx` now types props with `WidgetRenderProps< RevenueByCustomerTypeAttributes & Partial< ReportParamsFieldAttributes > >` and defaults `attributes = {}` (was a hand-rolled prop shape).
  - `widget.ts` exports `RevenueByCustomerTypeAttributes = Record< never, never >` so the render props import the attribute shape instead of redeclaring it.
  - `package.json`: dropped unused `@wordpress/ui`, added `@wordpress/widget-primitives`.
  - Removed the spurious `js-packages/storybook` changelog entry (no code change there); kept the `premium-analytics` entry.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Revenue by customer type Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1476-port-woo-widget-revenue-by-customer-type/revenue-by-customer-type.png)

## Related product discussion/links

- WOOA7S-1476; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `pnpm --filter @automattic/jetpack-premium-analytics build`
- `cd projects/packages/premium-analytics && pnpm exec eslint widgets/revenue-by-customer-type`
- `pnpm --filter @automattic/jetpack-storybook storybook:build`
- In Storybook, open the `Packages/Premium Analytics/Widgets/RevenueByCustomerType` stories (`Default`, `WithComparison`, `WidgetDashboardWithWidget`): the bar chart renders `Returning` and `New` bars, the comparison story adds the previous-period series, the dashboard story renders the widget card with title + icon, and the console shows only the shared-harness baseline noise.
