### PR TITLE
Premium Analytics: port the Sales by coupon widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-sales-by-coupon-widget-story
+++ b/projects/js-packages/storybook/changelog/add-sales-by-coupon-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add sales by coupon widget story.

--- a/projects/js-packages/storybook/changelog/add-sales-by-coupon-widget-story
+++ b/projects/js-packages/storybook/changelog/add-sales-by-coupon-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add sales by coupon widget story.

--- a/projects/packages/premium-analytics/changelog/add-sales-by-coupon-widget
+++ b/projects/packages/premium-analytics/changelog/add-sales-by-coupon-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add sales by coupon widget.

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
@@ -4,11 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@jetpack-premium-analytics/data": "link:../../packages/data",
-		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-sales-by-coupon",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/package.json
@@ -4,10 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
@@ -1,0 +1,24 @@
+import {
+	SalesByCouponWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type SalesByCouponRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Sales by coupon widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; SalesByCouponWidget fetches
+ * the coupons report and renders the coupon revenue breakdown.
+ */
+export default function SalesByCouponRender( { attributes }: SalesByCouponRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+			<SalesByCouponWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
@@ -1,10 +1,26 @@
-import { SalesByCouponWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	SalesByCouponWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { SalesByCouponAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type SalesByCouponRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
->;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SalesByCouponRenderAttributes = SalesByCouponAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type SalesByCouponRenderProps = WidgetRenderProps< SalesByCouponRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
 
 /**
  * Sales by coupon widget.
@@ -12,13 +28,11 @@ type SalesByCouponRenderProps = Pick<
  * Thin composition over the widgets-toolkit: WidgetRoot provides the query
  * client, chart theme, and resolved report params; SalesByCouponWidget fetches
  * the coupons report and renders the coupon revenue breakdown.
- *
- * @param root0            - Widget render props.
- * @param root0.attributes - Dashboard-provided widget attributes.
- * @param root0.setError   - Dashboard error-state setter.
- * @return The rendered Sales by coupon widget.
  */
-export default function SalesByCouponRender( { attributes, setError }: SalesByCouponRenderProps ) {
+export default function SalesByCouponRender( {
+	attributes = {},
+	setError,
+}: SalesByCouponRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<SalesByCouponWidget />

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx
@@ -1,12 +1,10 @@
-import {
-	SalesByCouponWidget,
-	WidgetRoot,
-	type ReportParamsFieldAttributes,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { SalesByCouponWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
 
-type SalesByCouponRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-};
+type SalesByCouponRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
 
 /**
  * Sales by coupon widget.
@@ -14,10 +12,15 @@ type SalesByCouponRenderProps = {
  * Thin composition over the widgets-toolkit: WidgetRoot provides the query
  * client, chart theme, and resolved report params; SalesByCouponWidget fetches
  * the coupons report and renders the coupon revenue breakdown.
+ *
+ * @param root0            - Widget render props.
+ * @param root0.attributes - Dashboard-provided widget attributes.
+ * @param root0.setError   - Dashboard error-state setter.
+ * @return The rendered Sales by coupon widget.
  */
-export default function SalesByCouponRender( { attributes }: SalesByCouponRenderProps ) {
+export default function SalesByCouponRender( { attributes, setError }: SalesByCouponRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<SalesByCouponWidget />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -1,23 +1,60 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponRender from '../render';
 import widgetDefinition from '../widget';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const SALES_BY_COUPON_RENDER_MODULE = 'storybook/sales-by-coupon';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 
-interface SalesByCouponDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+type SalesByCouponRenderProps = ComponentProps< typeof SalesByCouponRender >;
+const setStoryError: SalesByCouponRenderProps[ 'setError' ] = () => undefined;
+
+interface SalesByCouponStoryControls {
 	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type SalesByCouponStoryProps = SalesByCouponRenderProps & SalesByCouponStoryControls;
+
+interface SalesByCouponDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SalesByCouponStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getSalesByCouponAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): SalesByCouponRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function renderSalesByCoupon( { withComparison, preset }: SalesByCouponStoryControls ) {
+	return (
+		<SalesByCouponRender
+			attributes={ getSalesByCouponAttributes( withComparison, preset ) }
+			setError={ setStoryError }
+		/>
+	);
 }
 
 /**
@@ -25,10 +62,12 @@ interface SalesByCouponDashboardStoryProps extends WidgetDashboardWithWidgetCont
  *
  * @param root0                - Story controls.
  * @param root0.withComparison - Whether comparison report params are enabled.
+ * @param root0.preset         - Date-range preset used for report params.
  * @return The dashboard story surface with the widget rendered inside it.
  */
 function SalesByCouponDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: SalesByCouponDashboardStoryProps ) {
 	return (
@@ -37,25 +76,24 @@ function SalesByCouponDashboardStory( {
 			widgetType={ widgetDefinition }
 			renderModule={ SALES_BY_COUPON_RENDER_MODULE }
 			renderComponent={ SalesByCouponRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
+			attributes={ getSalesByCouponAttributes( withComparison, preset ) }
 		/>
 	);
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SalesByCoupon',
-	component: SalesByCouponDashboardStory,
+	component: SalesByCouponRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -66,10 +104,57 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof SalesByCouponDashboardStory >;
+} satisfies Meta< SalesByCouponStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< SalesByCouponDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderSalesByCoupon,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison period enabled, showing period-over-period coupon revenue.
+ */
+export const WithComparison: Story = {
+	render: renderSalesByCoupon,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <SalesByCouponDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -60,9 +60,9 @@ function renderSalesByCoupon( { withComparison, preset }: SalesByCouponStoryCont
 /**
  * Storybook dashboard wrapper for the Sales by coupon widget.
  *
- * @param root0                - Story controls.
- * @param root0.withComparison - Whether comparison report params are enabled.
- * @param root0.preset         - Date-range preset used for report params.
+ * @param props                - Story controls.
+ * @param props.withComparison - Whether comparison report params are enabled.
+ * @param props.preset         - Date-range preset used for report params.
  * @return The dashboard story surface with the widget rendered inside it.
  */
 function SalesByCouponDashboardStory( {

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -1,0 +1,68 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SalesByCouponRender from '../render';
+import widgetDefinition from '../widget';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@automattic/jetpack-widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const SALES_BY_COUPON_RENDER_MODULE = 'storybook/sales-by-coupon';
+
+interface SalesByCouponDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function SalesByCouponDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: SalesByCouponDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ SALES_BY_COUPON_RENDER_MODULE }
+			renderComponent={ SalesByCouponRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SalesByCoupon',
+	component: SalesByCouponDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays top coupon codes by order revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof SalesByCouponDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -1,15 +1,15 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@automattic/jetpack-widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
 
 registerReportMocks();
@@ -20,6 +20,13 @@ interface SalesByCouponDashboardStoryProps extends WidgetDashboardWithWidgetCont
 	withComparison: boolean;
 }
 
+/**
+ * Storybook dashboard wrapper for the Sales by coupon widget.
+ *
+ * @param root0                - Story controls.
+ * @param root0.withComparison - Whether comparison report params are enabled.
+ * @return The dashboard story surface with the widget rendered inside it.
+ */
 function SalesByCouponDashboardStory( {
 	withComparison,
 	...dashboardStoryArgs

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/sales-by-coupon",
+	"title": "Sales by coupon",
+	"description": "Shows the top coupon codes by order revenue over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type SalesByCouponAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/sales-by-coupon` in

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/sales-by-coupon` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/sales-by-coupon',
+	title: __( 'Sales by coupon', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the top coupon codes by order revenue over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1477

## Proposed changes
* Ports the **Sales by coupon** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/sales-by-coupon` widget and renders the shared sales by coupon widget inside `WidgetRoot` using dashboard-level report params.
* Adds a Storybook dashboard story for the widget.
* Retargets the PR to `trunk`; the shared dashboard/package scaffolding is already present there, so this diff is limited to the Sales by coupon widget port.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Sales by coupon Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1477-port-woo-widget-sales-by-coupon/sales-by-coupon.png)

## Related product discussion/links
* WOOA7S-1477; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm install --frozen-lockfile`
* `pnpm --filter @automattic/charts build`
* `pnpm --filter @automattic/number-formatters build`
* `pnpm --filter @automattic/jetpack-wp-build-polyfills build`
* `pnpm exec eslint projects/packages/premium-analytics/widgets/sales-by-coupon/render.tsx projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx --max-warnings=0`
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --dir projects/js-packages/storybook run storybook:build`
* Verified the Storybook story `packages-premium-analytics-widgets-salesbycoupon--widget-dashboard-with-widget` in a browser smoke test: title rendered, chart SVG rendered, coupon labels rendered, and no `NaN`/`undefined` output.
