### PR TITLE
Premium Analytics: port the Sales by device widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-sales-by-device-widget
+++ b/projects/packages/premium-analytics/changelog/add-sales-by-device-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add sales by device widget.

--- a/projects/packages/premium-analytics/widgets/sales-by-device/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-sales-by-device",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/render.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import {
+	SalesByDeviceWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { SalesByDeviceAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
+
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SalesByDeviceRenderAttributes = SalesByDeviceAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type SalesByDeviceRenderProps = WidgetRenderProps< SalesByDeviceRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Sales by device widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; SalesByDeviceWidget fetches
+ * the order-attribution report and renders the device revenue breakdown.
+ */
+export default function SalesByDeviceRender( {
+	attributes = {},
+	setError,
+}: SalesByDeviceRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<SalesByDeviceWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
@@ -1,0 +1,220 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import SalesByDeviceRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SALES_BY_DEVICE_RENDER_MODULE = 'storybook/sales-by-device';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type SalesByDeviceRenderProps = ComponentProps< typeof SalesByDeviceRender >;
+
+interface SalesByDeviceStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type SalesByDeviceStoryProps = SalesByDeviceRenderProps & SalesByDeviceStoryControls;
+
+interface SalesByDeviceDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SalesByDeviceStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getSalesByDeviceAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): SalesByDeviceRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< SalesByDeviceStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getSalesByDeviceSource( args: Partial< SalesByDeviceStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<SalesByDeviceRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderSalesByDevice( { withComparison, preset }: SalesByDeviceStoryControls ) {
+	return (
+		<SalesByDeviceRender attributes={ getSalesByDeviceAttributes( withComparison, preset ) } />
+	);
+}
+
+/**
+ * Story wrapper for rendering the sales by device widget in dashboard chrome.
+ *
+ * @param root0                - Story controls.
+ * @param root0.withComparison - Whether to include comparison report params.
+ * @param root0.preset         - Date-range preset used for report params.
+ * @return The rendered Storybook story.
+ */
+function SalesByDeviceDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: SalesByDeviceDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ SALES_BY_DEVICE_RENDER_MODULE }
+			renderComponent={ SalesByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getSalesByDeviceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SalesByDevice',
+	component: SalesByDeviceRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Sales by device" widget. Fetches the order-attribution report and displays the sales breakdown by device type for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< SalesByDeviceStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< SalesByDeviceDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderSalesByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByDeviceStoryControls > }
+				) => getSalesByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period sales breakdown.
+ */
+export const WithComparison: Story = {
+	render: renderSalesByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByDeviceStoryControls > }
+				) => getSalesByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <SalesByDeviceDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/sales-by-device"
+\trenderComponent={ SalesByDeviceRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/sales-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/sales-by-device",
+	"title": "Sales by device",
+	"description": "Shows the sales breakdown by device type over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type SalesByDeviceAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/sales-by-device` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/sales-by-device',
+	title: __( 'Sales by device', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the sales breakdown by device type over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1478

## Proposed changes
* Ports the **Sales by device** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/sales-by-device` widget and renders the shared sales by device widget inside `WidgetRoot` using dashboard-level report params.
* Adds standalone `Default` / `WithComparison` stories plus a `WidgetDashboardWithWidget` dashboard story for the widget.
* Updates the shared Premium Analytics dashboard story helper to provide the dashboard error context and mock `/wp/v2/settings`, which keeps dashboard-hosted widget stories from emitting Storybook-only provider/settings errors.

## Related product discussion/links
* WOOA7S-1478; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `/Users/dethier/Library/pnpm/pnpm run lint-file projects/packages/premium-analytics/widgets/sales-by-device/render.tsx projects/packages/premium-analytics/widgets/sales-by-device/widget.ts projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the Storybook story `packages-premium-analytics-widgets-salesbydevice--widget-dashboard-with-widget` with a local Playwright screenshot pass: title rendered, chart SVGs rendered, device labels rendered, no `NaN`/`undefined`, and no widget/data request errors. The remaining console error was the existing global Storybook bootstrap `core/notices` duplicate registration.
