### PR TITLE
Premium Analytics: port the Sales by UTM source widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-sales-by-utm-source-widget-story
+++ b/projects/js-packages/storybook/changelog/add-sales-by-utm-source-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add sales by UTM source widget story.

--- a/projects/packages/premium-analytics/changelog/add-sales-by-utm-source-widget
+++ b/projects/packages/premium-analytics/changelog/add-sales-by-utm-source-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add sales by UTM source widget.

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/helpers/build-sales-by-utm-data.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/helpers/build-sales-by-utm-data.ts
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	calculateDelta,
+	type LeaderboardChartData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ReportDataMap } from '@jetpack-premium-analytics/data';
+
+/**
+ * Builds leaderboard chart data for the Sales by UTM widget.
+ *
+ * Transforms order attribution data into the format required by LeaderboardChart.
+ *
+ * @param orderAttribution - Primary period order attribution data.
+ * @param maxEntries       - Maximum number of entries to include in the leaderboard.
+ * @return Processed data ready for LeaderboardChart.
+ */
+export function buildSalesByUtmData(
+	orderAttribution: ReportDataMap[ 'order-attribution' ] | undefined,
+	maxEntries = 4
+): LeaderboardChartData {
+	if ( ! orderAttribution?.data || orderAttribution.data.length === 0 ) {
+		return [];
+	}
+
+	const { data } = orderAttribution;
+
+	const maxValue = Math.max(
+		...data.map( item =>
+			Math.max( item.current_period.value || 0, item.previous_period?.value || 0 )
+		),
+		1
+	);
+
+	return data.slice( 0, maxEntries ).map( ( item, idx ) => {
+		const currentValue = item.current_period.value || 0;
+		const previousValue = item.previous_period?.value ?? 0;
+		const delta = calculateDelta( currentValue, previousValue );
+
+		return {
+			id: item.item ? String( item.item ) : String( idx ),
+			label: item.item || __( 'Unassigned', 'jetpack-premium-analytics' ),
+			currentValue,
+			previousValue,
+			currentShare: ( currentValue / maxValue ) * 100,
+			previousShare: ( previousValue / maxValue ) * 100,
+			delta,
+		};
+	} );
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
@@ -4,6 +4,8 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-sales-by-utm-source",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
-		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/package.json
@@ -9,7 +9,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
@@ -1,34 +1,95 @@
+/**
+ * External dependencies
+ */
+import { useReportOrderAttribution } from '@jetpack-premium-analytics/data';
+import { search } from '@jetpack-premium-analytics/icons';
 import {
-	SalesByUtmWidget,
+	LeaderboardChart,
+	WidgetLoadingOverlay,
 	WidgetRoot,
+	formatLegendLabels,
+	useWidgetError,
+	useWidgetRootContext,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import type { ComponentProps } from 'react';
+import { useMemo, type ComponentProps, type CSSProperties } from 'react';
+/**
+ * Internal dependencies
+ */
+import { buildSalesByUtmData } from './helpers/build-sales-by-utm-data';
+import type { SalesByUtmSourceAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-type SalesByUtmSourceRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SalesByUtmSourceRenderAttributes = SalesByUtmSourceAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type SalesByUtmSourceRenderProps = WidgetRenderProps< SalesByUtmSourceRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
+
+function SalesByUtmSourceWidget() {
+	const { reportParams } = useWidgetRootContext();
+
+	const params = useMemo(
+		() => ( {
+			...reportParams,
+			view: 'source' as const,
+		} ),
+		[ reportParams ]
+	);
+
+	const { primary, hasComparison, isLoading, isFetching, hasData, isError, error, refetch } =
+		useReportOrderAttribution( params );
+
+	const isInitialLoading = isLoading && ! hasData;
+	const isRefetching = isFetching && hasData;
+
+	const chartData = useMemo( () => buildSalesByUtmData( primary.data ), [ primary.data ] );
+	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const hasError = useWidgetError( isError, error, refetch );
+	if ( hasError ) {
+		return null;
+	}
+
+	if ( isInitialLoading ) {
+		return <WidgetLoadingOverlay />;
+	}
+
+	return (
+		<>
+			<LeaderboardChart
+				data={ chartData }
+				withComparison={ hasComparison }
+				legendLabels={ legendLabels }
+				emptyStateIcon={ search }
+				style={
+					{
+						'--a8c--charts--leaderboard--bar--border-radius': '0 1px 1px 0',
+					} as CSSProperties
+				}
+			/>
+			{ isRefetching && <WidgetLoadingOverlay /> }
+		</>
+	);
+}
 
 /**
  * Sales by UTM source widget.
  *
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; SalesByUtmWidget fetches
- * the order-attribution report and renders the source leaderboard.
- *
- * @param root0            - Render props from the widget dashboard.
- * @param root0.attributes - Widget attributes, including report params.
- * @param root0.setError   - Dashboard error reporter.
- * @return The rendered widget.
+ * WidgetRoot provides the query client, chart theme, and resolved report params;
+ * this render module fetches the order-attribution report and renders the
+ * source leaderboard.
  */
 export default function SalesByUtmSourceRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: SalesByUtmSourceRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
-			<SalesByUtmWidget view="source" />
+			<SalesByUtmSourceWidget />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
@@ -5,11 +5,9 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ComponentProps } from 'react';
 
-type SalesByUtmSourceRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
-> & {
+type SalesByUtmSourceRenderProps = {
 	attributes?: Partial< ReportParamsFieldAttributes >;
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/render.tsx
@@ -1,0 +1,36 @@
+import {
+	SalesByUtmWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type SalesByUtmSourceRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+> & {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Sales by UTM source widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; SalesByUtmWidget fetches
+ * the order-attribution report and renders the source leaderboard.
+ *
+ * @param root0            - Render props from the widget dashboard.
+ * @param root0.attributes - Widget attributes, including report params.
+ * @param root0.setError   - Dashboard error reporter.
+ * @return The rendered widget.
+ */
+export default function SalesByUtmSourceRender( {
+	attributes,
+	setError,
+}: SalesByUtmSourceRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<SalesByUtmWidget view="source" />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
@@ -1,0 +1,214 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SalesByUtmSourceRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SALES_BY_UTM_SOURCE_RENDER_MODULE = 'storybook/sales-by-utm-source';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type SalesByUtmSourceRenderProps = ComponentProps< typeof SalesByUtmSourceRender >;
+
+interface SalesByUtmSourceStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type SalesByUtmSourceStoryProps = SalesByUtmSourceRenderProps & SalesByUtmSourceStoryControls;
+
+interface SalesByUtmSourceDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SalesByUtmSourceStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getSalesByUtmSourceAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): SalesByUtmSourceRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< SalesByUtmSourceStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getSalesByUtmSourceSource( args: Partial< SalesByUtmSourceStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<SalesByUtmSourceRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderSalesByUtmSource( { withComparison, preset }: SalesByUtmSourceStoryControls ) {
+	return (
+		<SalesByUtmSourceRender
+			attributes={ getSalesByUtmSourceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function SalesByUtmSourceDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: SalesByUtmSourceDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ SALES_BY_UTM_SOURCE_RENDER_MODULE }
+			renderComponent={ SalesByUtmSourceRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getSalesByUtmSourceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SalesByUtmSource',
+	component: SalesByUtmSourceRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays top UTM sources by order revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< SalesByUtmSourceStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< SalesByUtmSourceDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderSalesByUtmSource,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByUtmSourceStoryControls > }
+				) => getSalesByUtmSourceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change and trend data.
+ */
+export const WithComparison: Story = {
+	render: renderSalesByUtmSource,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SalesByUtmSourceStoryControls > }
+				) => getSalesByUtmSourceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <SalesByUtmSourceDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/sales-by-utm-source"
+\trenderComponent={ SalesByUtmSourceRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/sales-by-utm-source",
+	"title": "Sales by UTM source",
+	"description": "Shows the top UTM sources by order revenue over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type SalesByUtmSourceAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/sales-by-utm-source` in

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/sales-by-utm-source` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/sales-by-utm-source',
+	title: __( 'Sales by UTM source', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the top UTM sources by order revenue over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1481

## Proposed changes
* Ports the **Sales by UTM source** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/sales-by-utm-source` widget and renders the shared sales by UTM widget inside `WidgetRoot` for the source view using dashboard-level report params.
* Forwards dashboard error state through `WidgetRoot` so report failures surface through the host error UI.
* Adds a Storybook dashboard story for the widget using report mocks.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Sales by UTM source Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1481-port-woo-widget-sales-by-utm-source/sales-by-utm-source.png)

## Related product discussion/links
* WOOA7S-1481; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `/Users/dethier/Library/pnpm/pnpm install --frozen-lockfile`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/charts build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/number-formatters build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-wp-build-polyfills build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-storybook storybook:build`
* Browser smoke against the built Storybook iframe for `packages-premium-analytics-widgets-salesbyutmsource--widget-dashboard-with-widget`: verified the widget title/region, mocked source rows (`google`, `facebook`, `instagram`), values, comparison legend, SVG chart rendering, and no `NaN`/`undefined`. The only console error observed was the known baseline duplicate `core/notices` registration.
