### PR TITLE
Premium Analytics: port the Sessions by device widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-sessions-by-device-widget
+++ b/projects/packages/premium-analytics/changelog/add-sessions-by-device-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add sessions by device widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import { PieChartUnresponsive as PieChart } from '@automattic/charts';
-import { useResizeObserver } from '@wordpress/compose';
 import { Icon, Stack } from '@wordpress/ui';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
@@ -14,6 +13,7 @@ import {
 	isEmptyPieChartData,
 	type SegmentStyle,
 } from '../../helpers';
+import { useElementSize } from '../../hooks';
 import { ChartEmptyState } from '../chart-empty-state';
 import { PieChartTooltip } from '../chart-tooltip';
 import { Legend as LegendPure } from '../legend/legend';
@@ -35,63 +35,6 @@ const MIN_SIZE = 64;
 const MAX_SIZE = 192;
 const COMPACT_LEGEND_GAP_SIZE = 8;
 const DEFAULT_LEGEND_GAP_SIZE = 24;
-
-type ElementSize = {
-	width: number;
-	height: number;
-};
-
-function getElementSize( element: Element ): ElementSize {
-	const { width, height } = element.getBoundingClientRect();
-
-	return {
-		width: Math.round( width ),
-		height: Math.round( height ),
-	};
-}
-
-function useElementSize< T extends HTMLElement >() {
-	const elementRef = useRef< T | null >( null );
-	const [ size, setSize ] = useState< ElementSize >( {
-		width: 0,
-		height: 0,
-	} );
-
-	const updateSize = useCallback( ( nextSize: ElementSize ) => {
-		setSize( previousSize =>
-			previousSize.width === nextSize.width && previousSize.height === nextSize.height
-				? previousSize
-				: nextSize
-		);
-	}, [] );
-
-	const observerRef = useResizeObserver< T >( entries => {
-		const element = entries[ 0 ]?.target ?? elementRef.current;
-
-		if ( ! element ) {
-			return;
-		}
-
-		updateSize( getElementSize( element ) );
-	} );
-
-	const setElementRef = useCallback(
-		( element: T | null ) => {
-			elementRef.current = element;
-
-			if ( typeof ResizeObserver !== 'undefined' ) {
-				observerRef( element );
-			}
-
-			if ( element ) {
-				updateSize( getElementSize( element ) );
-			}
-		},
-		[ observerRef, updateSize ]
-	);
-
-	return [ setElementRef, size ] as const;
-}
 
 export type DonutChartProps = {
 	/**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.module.scss
@@ -1,5 +1,14 @@
-.container,
+.container {
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+}
+
 .wrapper {
+	width: 100%;
+}
+
+.legendContainer {
 	width: 100%;
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import { PieSemiCircleChart } from '@automattic/charts';
-import { useResizeObserver } from '@wordpress/compose';
 import { Icon, Stack } from '@wordpress/ui';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { RESIZE_DEBOUNCE_MS } from '../../constants';
 import {
 	resolveSegmentStyles,
@@ -12,6 +11,7 @@ import {
 	isEmptyPieChartData,
 	type SegmentStyle,
 } from '../../helpers';
+import { useElementSize } from '../../hooks';
 import { ChartEmptyState } from '../chart-empty-state';
 import { PieChartTooltip } from '../chart-tooltip';
 /**
@@ -37,48 +37,6 @@ const DEFAULT_CONTAINER_SIZE = 240;
 // tokens applied to the wrapper Stack (24px / 8px).
 const DEFAULT_LEGEND_GAP_SIZE = 24;
 const COMPACT_LEGEND_GAP_SIZE = 8;
-
-type ElementSize = { width: number; height: number };
-
-function getElementSize( element: Element ): ElementSize {
-	const { width, height } = element.getBoundingClientRect();
-	return { width: Math.round( width ), height: Math.round( height ) };
-}
-
-/**
- * Tracks an element's rendered size via ResizeObserver, so the chart can be
- * bounded by the height its tile actually offers (not only its width).
- */
-function useElementSize< T extends HTMLElement >() {
-	const elementRef = useRef< T | null >( null );
-	const [ size, setSize ] = useState< ElementSize >( { width: 0, height: 0 } );
-
-	const updateSize = useCallback( ( next: ElementSize ) => {
-		setSize( prev => ( prev.width === next.width && prev.height === next.height ? prev : next ) );
-	}, [] );
-
-	const observerRef = useResizeObserver< T >( entries => {
-		const element = entries[ 0 ]?.target ?? elementRef.current;
-		if ( element ) {
-			updateSize( getElementSize( element ) );
-		}
-	} );
-
-	const setElementRef = useCallback(
-		( element: T | null ) => {
-			elementRef.current = element;
-			if ( typeof ResizeObserver !== 'undefined' ) {
-				observerRef( element );
-			}
-			if ( element ) {
-				updateSize( getElementSize( element ) );
-			}
-		},
-		[ observerRef, updateSize ]
-	);
-
-	return [ setElementRef, size ] as const;
-}
 
 export type SemiCircleChartData = ComponentProps< typeof PieSemiCircleChart >[ 'data' ];
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { PieSemiCircleChart } from '@automattic/charts';
+import { useResizeObserver } from '@wordpress/compose';
 import { Icon, Stack } from '@wordpress/ui';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { RESIZE_DEBOUNCE_MS } from '../../constants';
 import {
 	resolveSegmentStyles,
@@ -26,6 +27,58 @@ import type { ComponentProps } from 'react';
 // Default chart configuration
 const DEFAULT_THICKNESS = 0.3;
 const DEFAULT_ASPECT_RATIO = 0.5;
+
+// Smallest chart width we allow before letting the tile scroll instead of
+// shrinking the semi-circle into illegibility.
+const MIN_CHART_WIDTH = 120;
+// Fallback container dimension used before the ResizeObserver reports a size.
+const DEFAULT_CONTAINER_SIZE = 240;
+// Vertical gap between the chart and the legend, matching the `xl`/`sm` gap
+// tokens applied to the wrapper Stack (24px / 8px).
+const DEFAULT_LEGEND_GAP_SIZE = 24;
+const COMPACT_LEGEND_GAP_SIZE = 8;
+
+type ElementSize = { width: number; height: number };
+
+function getElementSize( element: Element ): ElementSize {
+	const { width, height } = element.getBoundingClientRect();
+	return { width: Math.round( width ), height: Math.round( height ) };
+}
+
+/**
+ * Tracks an element's rendered size via ResizeObserver, so the chart can be
+ * bounded by the height its tile actually offers (not only its width).
+ */
+function useElementSize< T extends HTMLElement >() {
+	const elementRef = useRef< T | null >( null );
+	const [ size, setSize ] = useState< ElementSize >( { width: 0, height: 0 } );
+
+	const updateSize = useCallback( ( next: ElementSize ) => {
+		setSize( prev => ( prev.width === next.width && prev.height === next.height ? prev : next ) );
+	}, [] );
+
+	const observerRef = useResizeObserver< T >( entries => {
+		const element = entries[ 0 ]?.target ?? elementRef.current;
+		if ( element ) {
+			updateSize( getElementSize( element ) );
+		}
+	} );
+
+	const setElementRef = useCallback(
+		( element: T | null ) => {
+			elementRef.current = element;
+			if ( typeof ResizeObserver !== 'undefined' ) {
+				observerRef( element );
+			}
+			if ( element ) {
+				updateSize( getElementSize( element ) );
+			}
+		},
+		[ observerRef, updateSize ]
+	);
+
+	return [ setElementRef, size ] as const;
+}
 
 export type SemiCircleChartData = ComponentProps< typeof PieSemiCircleChart >[ 'data' ];
 
@@ -88,7 +141,9 @@ export type SemiCircleChartProps = {
 	aspectRatio?: number;
 
 	/**
-	 * Width of the chart.
+	 * Hard upper bound for the chart width, in pixels. The chart otherwise grows
+	 * to fill its container while staying bounded by the tile height (so it never
+	 * overflows a short cell). Leave unset to only be bounded by the tile.
 	 * @default Infinity
 	 */
 	maxWidth?: number;
@@ -159,6 +214,9 @@ export function SemiCircleChart( {
 }: SemiCircleChartProps ) {
 	const hasComparison = comparisonValue !== null && comparisonValue !== undefined;
 
+	const [ containerRef, containerSize ] = useElementSize< HTMLDivElement >();
+	const [ legendRef, legendSize ] = useElementSize< HTMLDivElement >();
+
 	/**
 	 * Resolve styles: prop takes priority, fallback to chartData colors.
 	 */
@@ -194,13 +252,43 @@ export function SemiCircleChart( {
 		return <ChartEmptyState icon={ emptyStateIcon } text={ emptyStateText } />;
 	}
 
+	const hasLegend = showLegend && Boolean( styledLegendData?.length );
+	const hardMaxWidth = Number.isFinite( maxWidth ) ? maxWidth : Number.POSITIVE_INFINITY;
+	const availableWidth = containerSize.width || DEFAULT_CONTAINER_SIZE;
+	const availableHeight = containerSize.height || DEFAULT_CONTAINER_SIZE;
+	const legendHeight = legendSize.height;
+
+	// Natural chart height when only the width constrains it; used to decide
+	// whether the tile is too short to afford the default chart-to-legend gap.
+	const widthBoundedHeight = Math.min( availableWidth, hardMaxWidth ) * aspectRatio;
+	const isCompactLayout =
+		hasLegend && availableHeight < widthBoundedHeight + legendHeight + DEFAULT_LEGEND_GAP_SIZE;
+	const legendGapSize = isCompactLayout ? COMPACT_LEGEND_GAP_SIZE : DEFAULT_LEGEND_GAP_SIZE;
+	const reservedLegendHeight = hasLegend && legendHeight ? legendHeight + legendGapSize : 0;
+
+	// Cap the width so the derived height (width * aspectRatio) fits the space
+	// left after the legend, keeping the whole widget contained in a short tile
+	// while still growing to fill taller/wider cells.
+	const availableChartHeight = availableHeight - reservedLegendHeight;
+	const heightBoundedWidth =
+		availableChartHeight > 0 ? availableChartHeight / aspectRatio : MIN_CHART_WIDTH;
+	const chartMaxWidth = Math.max( MIN_CHART_WIDTH, Math.min( hardMaxWidth, heightBoundedWidth ) );
+	const stackGap = isCompactLayout ? 'sm' : 'xl';
+
 	return (
-		<Stack direction="column" align="center" justify="center" className={ styles.container }>
+		<Stack
+			direction="column"
+			align="center"
+			justify="safe center"
+			className={ styles.container }
+			ref={ containerRef }
+		>
 			<Stack
 				direction="column"
+				align="center"
 				className={ styles.wrapper }
-				style={ Number.isFinite( maxWidth ) ? { maxWidth } : undefined }
-				gap="xl"
+				style={ { maxWidth: chartMaxWidth } }
+				gap={ stackGap }
 			>
 				<PieSemiCircleChart
 					data={ styledChartData }
@@ -235,8 +323,10 @@ export function SemiCircleChart( {
 					) }
 				</PieSemiCircleChart>
 
-				{ showLegend && styledLegendData && (
-					<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
+				{ hasLegend && styledLegendData && (
+					<div ref={ legendRef } className={ styles.legendContainer }>
+						<LegendPure items={ styledLegendData } withComparison={ hasComparison } />
+					</div>
 				) }
 			</Stack>
 		</Stack>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useAttributesWithSearchFallback } from './use-attributes-with-search-fallback';
 export { useChartTheme, type WooChartTheme } from './use-chart-theme';
+export { useElementSize, type ElementSize } from './use-element-size';
 export { useSegmentStyles } from '../widgets/common';
 export { useSeriesStyles } from './use-series-styles';
 export { useWidgetError } from './use-widget-error';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-element-size.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-element-size.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useResizeObserver } from '@wordpress/compose';
+import { useCallback, useRef, useState } from 'react';
+
+export type ElementSize = { width: number; height: number };
+
+function getElementSize( element: Element ): ElementSize {
+	const { width, height } = element.getBoundingClientRect();
+	return { width: Math.round( width ), height: Math.round( height ) };
+}
+
+/**
+ * Tracks an element's rendered size via ResizeObserver, so a chart can be
+ * bounded by the width and height its tile actually offers (not only its width).
+ *
+ * @return A tuple of a ref callback to attach to the element and its current size.
+ */
+export function useElementSize< T extends HTMLElement >() {
+	const elementRef = useRef< T | null >( null );
+	const [ size, setSize ] = useState< ElementSize >( { width: 0, height: 0 } );
+
+	const updateSize = useCallback( ( next: ElementSize ) => {
+		setSize( prev => ( prev.width === next.width && prev.height === next.height ? prev : next ) );
+	}, [] );
+
+	const observerRef = useResizeObserver< T >( entries => {
+		const element = entries[ 0 ]?.target ?? elementRef.current;
+		if ( element ) {
+			updateSize( getElementSize( element ) );
+		}
+	} );
+
+	const setElementRef = useCallback(
+		( element: T | null ) => {
+			elementRef.current = element;
+			if ( typeof ResizeObserver !== 'undefined' ) {
+				observerRef( element );
+			}
+			if ( element ) {
+				updateSize( getElementSize( element ) );
+			}
+		},
+		[ observerRef, updateSize ]
+	);
+
+	return [ setElementRef, size ] as const;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
@@ -72,7 +72,13 @@ export function SessionsByDeviceWidget() {
 
 	return (
 		<>
-			<Stack className={ styles.container } direction="column" align="center" justify="center">
+			{ /*
+			 * `safe center` centers the chart in tall cells but falls back to
+			 * top-start when the chart + legend are taller than the tile, so the
+			 * top stays reachable within the dashboard's scroll area instead of
+			 * being clipped above the scroll origin.
+			 */ }
+			<Stack className={ styles.container } direction="column" align="center" justify="safe center">
 				<SemiCircleChart
 					chartData={ chartData }
 					value={ total }
@@ -86,7 +92,6 @@ export function SessionsByDeviceWidget() {
 						options: { useMultipliers: true, decimals: 0 },
 					} }
 					withTooltips
-					maxWidth={ 220 }
 				/>
 			</Stack>
 			{ isRefetching && <WidgetLoadingOverlay /> }

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/package.json
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/package.json
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-sessions-by-device",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/render.tsx
@@ -1,8 +1,24 @@
-import { SessionsByDeviceWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	SessionsByDeviceWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { SessionsByDeviceAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type SessionsByDeviceRenderProps = {
-	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SessionsByDeviceRenderAttributes = SessionsByDeviceAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type SessionsByDeviceRenderProps = WidgetRenderProps< SessionsByDeviceRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -14,7 +30,7 @@ type SessionsByDeviceRenderProps = {
  * fetches the sessions-by-device report and renders the device breakdown.
  */
 export default function SessionsByDeviceRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: SessionsByDeviceRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/render.tsx
@@ -1,0 +1,25 @@
+import { SessionsByDeviceWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type SessionsByDeviceRenderProps = {
+	attributes?: ComponentProps< typeof WidgetRoot >[ 'attributes' ];
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Sessions by device widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; SessionsByDeviceWidget
+ * fetches the sessions-by-device report and renders the device breakdown.
+ */
+export default function SessionsByDeviceRender( {
+	attributes,
+	setError,
+}: SessionsByDeviceRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<SessionsByDeviceWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
@@ -1,0 +1,214 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SessionsByDeviceRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SESSIONS_BY_DEVICE_RENDER_MODULE = 'storybook/sessions-by-device';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type SessionsByDeviceRenderProps = ComponentProps< typeof SessionsByDeviceRender >;
+
+interface SessionsByDeviceStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type SessionsByDeviceStoryProps = SessionsByDeviceRenderProps & SessionsByDeviceStoryControls;
+
+interface SessionsByDeviceDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SessionsByDeviceStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getSessionsByDeviceAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): SessionsByDeviceRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< SessionsByDeviceStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getSessionsByDeviceSource( args: Partial< SessionsByDeviceStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<SessionsByDeviceRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderSessionsByDevice( { withComparison, preset }: SessionsByDeviceStoryControls ) {
+	return (
+		<SessionsByDeviceRender
+			attributes={ getSessionsByDeviceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function SessionsByDeviceDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: SessionsByDeviceDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ SESSIONS_BY_DEVICE_RENDER_MODULE }
+			renderComponent={ SessionsByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getSessionsByDeviceAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SessionsByDevice',
+	component: SessionsByDeviceRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays sessions by device type for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< SessionsByDeviceStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< SessionsByDeviceDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderSessionsByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SessionsByDeviceStoryControls > }
+				) => getSessionsByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing previous-period context in the widget data.
+ */
+export const WithComparison: Story = {
+	render: renderSessionsByDevice,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< SessionsByDeviceStoryControls > }
+				) => getSessionsByDeviceSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <SessionsByDeviceDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/sessions-by-device"
+\trenderComponent={ SessionsByDeviceRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/sessions-by-device",
+	"title": "Sessions by device",
+	"description": "Shows the sessions breakdown by device type over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type SessionsByDeviceAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/sessions-by-device` in

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/sessions-by-device` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/sessions-by-device',
+	title: __( 'Sessions by device', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the sessions breakdown by device type over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1482

## Proposed changes
* Ports the **Sessions by device** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/sessions-by-device` widget and renders the shared sessions-by-device widget inside `WidgetRoot` using dashboard-level report params and dashboard error reporting.
* Adds standalone `Default` and `WithComparison` Storybook stories plus a dashboard-host `WidgetDashboardWithWidget` story with report mocks.
* Wraps the shared dashboard Storybook helper in `GlobalErrorProvider` so widget error handling runs with the expected dashboard error context.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Sessions by device Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1482-port-woo-widget-sessions-by-device/sessions-by-device.png)

## Related product discussion/links
* WOOA7S-1482; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-storybook storybook:build`
* Browser smoke on the built Storybook iframe story `packages-premium-analytics-widgets-sessionsbydevice--widget-dashboard-with-widget`: verified the widget title, Mobile/Desktop/Tablet labels, SVG chart elements, no `NaN`/`undefined`, and only the known baseline `core/notices` duplicate-registration console noise.
