### PR TITLE
Premium Analytics: port the Top performing bookings widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-top-performing-bookings-widget
+++ b/projects/packages/premium-analytics/changelog/add-top-performing-bookings-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add top performing bookings widget.

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/package.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-top-performing-bookings",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/render.tsx
@@ -1,15 +1,27 @@
+/**
+ * External dependencies
+ */
 import {
 	TopPerformingBookingsWidget,
 	WidgetRoot,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { TopPerformingBookingsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type TopPerformingBookingsRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes'
-> & {
-	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
-};
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type TopPerformingBookingsRenderAttributes = TopPerformingBookingsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type TopPerformingBookingsRenderProps =
+	WidgetRenderProps< TopPerformingBookingsRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * Top performing bookings widget.
@@ -19,7 +31,7 @@ type TopPerformingBookingsRenderProps = Pick<
  * fetches booking product data and renders a revenue leaderboard.
  */
 export default function TopPerformingBookingsRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: TopPerformingBookingsRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/render.tsx
@@ -1,0 +1,30 @@
+import {
+	TopPerformingBookingsWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type TopPerformingBookingsRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes'
+> & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Top performing bookings widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; TopPerformingBookingsWidget
+ * fetches booking product data and renders a revenue leaderboard.
+ */
+export default function TopPerformingBookingsRender( {
+	attributes,
+	setError,
+}: TopPerformingBookingsRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<TopPerformingBookingsWidget limit={ 5 } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -1,0 +1,346 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getDefaultQueryParams, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import TopPerformingBookingsRender from '../render';
+import widgetDefinition from '../widget';
+import type { APIFetchMiddleware } from '@wordpress/api-fetch';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const REPORT_PRODUCTS_PATH = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/products';
+const PRODUCT_IMAGES_PATH = '/wc/v3/products';
+
+type ProductReportItem = {
+	product_id: string;
+	product_name: string;
+	product_net_revenue: string;
+	product_gross_revenue: string;
+	product_type: string;
+	orders_count: string;
+	sku: string;
+	total_quantity: string;
+	stock_status: string;
+};
+
+const bookingProducts: ProductReportItem[] = [
+	{
+		product_id: '801',
+		product_name: 'City tasting tour',
+		product_net_revenue: '18640.00',
+		product_gross_revenue: '21320.00',
+		product_type: 'booking',
+		orders_count: '84',
+		sku: 'BOOK-CITY',
+		total_quantity: '112',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '802',
+		product_name: 'Private lesson',
+		product_net_revenue: '14220.00',
+		product_gross_revenue: '15960.00',
+		product_type: 'bookable-service',
+		orders_count: '61',
+		sku: 'BOOK-LESSON',
+		total_quantity: '73',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '803',
+		product_name: 'Weekend retreat',
+		product_net_revenue: '9350.00',
+		product_gross_revenue: '10450.00',
+		product_type: 'bookable-event',
+		orders_count: '38',
+		sku: 'BOOK-RETREAT',
+		total_quantity: '46',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '804',
+		product_name: 'Strategy session',
+		product_net_revenue: '5125.00',
+		product_gross_revenue: '5900.00',
+		product_type: 'booking',
+		orders_count: '22',
+		sku: 'BOOK-STRATEGY',
+		total_quantity: '27',
+		stock_status: 'instock',
+	},
+];
+
+let productMocksRegistered = false;
+
+function buildProductsResponse( products: ProductReportItem[] ) {
+	const summary = products.reduce(
+		( acc, product ) => ( {
+			total_orders: acc.total_orders + Number( product.orders_count ),
+			total_quantity: acc.total_quantity + Number( product.total_quantity ),
+			total_revenue: acc.total_revenue + Number( product.product_net_revenue ),
+		} ),
+		{ total_orders: 0, total_quantity: 0, total_revenue: 0 }
+	);
+
+	return {
+		data: products,
+		summary: {
+			total_orders: String( summary.total_orders ),
+			total_products: String( products.length ),
+			total_quantity: String( summary.total_quantity ),
+			total_revenue: summary.total_revenue.toFixed( 2 ),
+		},
+	};
+}
+
+function registerProductLeaderboardMocks( products: ProductReportItem[] ) {
+	if ( productMocksRegistered ) {
+		return;
+	}
+
+	productMocksRegistered = true;
+
+	const middleware: APIFetchMiddleware = async ( options, next ) => {
+		const requestPath = options.path ?? options.url ?? '';
+
+		if ( requestPath.startsWith( REPORT_PRODUCTS_PATH ) ) {
+			return buildProductsResponse( products );
+		}
+
+		if ( requestPath.startsWith( PRODUCT_IMAGES_PATH ) ) {
+			return products.map( product => ( {
+				id: Number( product.product_id ),
+				name: product.product_name,
+				images: [],
+			} ) );
+		}
+
+		return next( options );
+	};
+
+	apiFetch.use( middleware );
+}
+
+registerProductLeaderboardMocks( bookingProducts );
+
+const TOP_PERFORMING_BOOKINGS_RENDER_MODULE = 'storybook/top-performing-bookings';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type TopPerformingBookingsRenderProps = ComponentProps< typeof TopPerformingBookingsRender >;
+
+interface TopPerformingBookingsStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type TopPerformingBookingsStoryProps = TopPerformingBookingsRenderProps &
+	TopPerformingBookingsStoryControls;
+
+interface TopPerformingBookingsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		TopPerformingBookingsStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+const withGlobalErrorProvider: Decorator = Story => (
+	<GlobalErrorProvider>
+		<Story />
+	</GlobalErrorProvider>
+);
+
+function getTopPerformingBookingsAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): TopPerformingBookingsRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< TopPerformingBookingsStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getTopPerformingBookingsSource( args: Partial< TopPerformingBookingsStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<TopPerformingBookingsRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderTopPerformingBookings( {
+	withComparison,
+	preset,
+}: TopPerformingBookingsStoryControls ) {
+	return (
+		<TopPerformingBookingsRender
+			attributes={ getTopPerformingBookingsAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function TopPerformingBookingsDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: TopPerformingBookingsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOP_PERFORMING_BOOKINGS_RENDER_MODULE }
+			renderComponent={
+				TopPerformingBookingsRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison, preset ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/TopPerformingBookings',
+	component: TopPerformingBookingsRender,
+	tags: [ 'autodocs' ],
+	decorators: [ withGlobalErrorProvider ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays top booking products by net revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< TopPerformingBookingsStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< TopPerformingBookingsDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderTopPerformingBookings,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TopPerformingBookingsStoryControls > }
+				) => getTopPerformingBookingsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change for each booking product.
+ */
+export const WithComparison: Story = {
+	render: renderTopPerformingBookings,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TopPerformingBookingsStoryControls > }
+				) => getTopPerformingBookingsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <TopPerformingBookingsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/top-performing-bookings"
+\trenderComponent={ TopPerformingBookingsRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { getDefaultQueryParams, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
@@ -156,12 +156,6 @@ const withWidgetCanvas: Decorator = Story => (
 	</div>
 );
 
-const withGlobalErrorProvider: Decorator = Story => (
-	<GlobalErrorProvider>
-		<Story />
-	</GlobalErrorProvider>
-);
-
 function getTopPerformingBookingsAttributes(
 	withComparison = false,
 	preset: SelectablePresetId = DEFAULT_PRESET
@@ -210,6 +204,14 @@ function renderTopPerformingBookings( {
 	);
 }
 
+/**
+ * Story wrapper for rendering the top performing bookings widget in dashboard chrome.
+ *
+ * @param root0                - Story controls.
+ * @param root0.withComparison - Whether to include comparison report params.
+ * @param root0.preset         - Date-range preset used for report params.
+ * @return The rendered Storybook story.
+ */
 function TopPerformingBookingsDashboardStory( {
 	withComparison,
 	preset,
@@ -234,7 +236,6 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TopPerformingBookings',
 	component: TopPerformingBookingsRender,
 	tags: [ 'autodocs' ],
-	decorators: [ withGlobalErrorProvider ],
 	argTypes: {
 		preset: {
 			control: 'select',

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/top-performing-bookings",
+	"title": "Top performing bookings",
+	"description": "Shows the top booking products by net revenue over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type TopPerformingBookingsAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/top-performing-bookings` in

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/top-performing-bookings` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/top-performing-bookings',
+	title: __( 'Top performing bookings', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the top booking products by net revenue over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1483

## Proposed changes

- Ports the **Top performing bookings** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/top-performing-bookings` widget and renders the shared top performing bookings widget inside `WidgetRoot` using dashboard-level report params.
- Passes dashboard error reporting through to `WidgetRoot`.
- Adds standalone `Default` and `WithComparison` Storybook stories, plus a separate dashboard story using `WidgetDashboardWithWidget`.
- Adds story-local product report mocks so the dashboard story renders the booking leaderboard without changing shared mock infrastructure.

### Finishing changes (conform to widget contract)

- `render.tsx`: replaced the hand-rolled `Pick<ComponentProps<…>>` prop shape with the shared `WidgetRenderProps<T>` contract, composing the widget's own attribute type with `Partial<ReportParamsFieldAttributes>`; defaulted `attributes = {}` and added the External/Internal import grouping to match sibling widgets.
- `widget.ts`: declared the `TopPerformingBookingsAttributes = Record<never, never>` type reused by `render.tsx`.
- `package.json`: dropped the unused `@wordpress/ui` dependency and added the missing `@wordpress/widget-primitives` dependency (used by the stories).
- Stories: removed the local `GlobalErrorProvider` wrapper/decorator so the widget matches sibling render/story parity and no longer masks the shared-harness baseline.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Top performing bookings Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1483-port-woo-widget-top-performing-bookings/top-performing-bookings.png)

## Related product discussion/links

- WOOA7S-1483; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `pnpm install --frozen-lockfile`
- `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `pnpm --filter @automattic/jetpack-premium-analytics build`
- `pnpm --filter @automattic/jetpack-storybook storybook:build`
- Run Storybook (`cd projects/js-packages/storybook && pnpm exec storybook dev -c ./storybook`) and open the `packages-premium-analytics-widgets-topperformingbookings--default`, `--with-comparison`, and `--widget-dashboard-with-widget` stories. Confirm the booking leaderboard renders (product names, revenue, and comparison deltas), with no `NaN`/`undefined` and no widget-specific console errors. The duplicate `core/notices`/`core/commands`, `useRouter`, and `useGlobalError` messages are known shared-harness baseline noise.
