### PR TITLE
Premium Analytics: port the Top performing products widget

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4097,27 +4097,6 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
-  projects/packages/premium-analytics/widgets/top-performing-products:
-    dependencies:
-      '@jetpack-premium-analytics/data':
-        specifier: link:../../packages/data
-        version: link:../../packages/data
-      '@jetpack-premium-analytics/widgets-toolkit':
-        specifier: link:../../packages/widgets-toolkit
-        version: link:../../packages/widgets-toolkit
-      '@wordpress/i18n':
-        specifier: ^6.9.0
-        version: 6.21.1
-      '@wordpress/icons':
-        specifier: ^13.0.0
-        version: 13.1.0(react@18.3.1)
-      '@wordpress/ui':
-        specifier: 0.13.0
-        version: 0.13.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react:
-        specifier: 18.3.1
-        version: 18.3.1
-
   projects/packages/protect-models: {}
 
   projects/packages/protect-status: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4097,6 +4097,27 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  projects/packages/premium-analytics/widgets/top-performing-products:
+    dependencies:
+      '@jetpack-premium-analytics/data':
+        specifier: link:../../packages/data
+        version: link:../../packages/data
+      '@jetpack-premium-analytics/widgets-toolkit':
+        specifier: link:../../packages/widgets-toolkit
+        version: link:../../packages/widgets-toolkit
+      '@wordpress/i18n':
+        specifier: ^6.9.0
+        version: 6.21.1
+      '@wordpress/icons':
+        specifier: ^13.0.0
+        version: 13.1.0(react@18.3.1)
+      '@wordpress/ui':
+        specifier: 0.13.0
+        version: 0.13.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+
   projects/packages/protect-models: {}
 
   projects/packages/protect-status: {}

--- a/projects/packages/premium-analytics/changelog/add-top-performing-products-widget
+++ b/projects/packages/premium-analytics/changelog/add-top-performing-products-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add top performing products widget.

--- a/projects/packages/premium-analytics/widgets/top-performing-products/package.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-top-performing-products",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-products/package.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/package.json
@@ -4,11 +4,10 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/top-performing-products/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/render.tsx
@@ -1,13 +1,27 @@
+/**
+ * External dependencies
+ */
 import {
 	TopPerformingProductsWidget,
 	WidgetRoot,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { TopPerformingProductsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type TopPerformingProductsRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
->;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type TopPerformingProductsRenderAttributes = TopPerformingProductsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type TopPerformingProductsRenderProps =
+	WidgetRenderProps< TopPerformingProductsRenderAttributes > & {
+		setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+	};
 
 /**
  * Top performing products widget.
@@ -17,7 +31,7 @@ type TopPerformingProductsRenderProps = Pick<
  * fetches physical product data and renders a revenue leaderboard.
  */
 export default function TopPerformingProductsRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: TopPerformingProductsRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/top-performing-products/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/render.tsx
@@ -1,0 +1,28 @@
+import {
+	TopPerformingProductsWidget,
+	WidgetRoot,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type TopPerformingProductsRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
+
+/**
+ * Top performing products widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; TopPerformingProductsWidget
+ * fetches physical product data and renders a revenue leaderboard.
+ */
+export default function TopPerformingProductsRender( {
+	attributes,
+	setError,
+}: TopPerformingProductsRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<TopPerformingProductsWidget limit={ 5 } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -1,0 +1,187 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import TopPerformingProductsRender from '../render';
+import widgetDefinition from '../widget';
+import type { APIFetchMiddleware } from '@wordpress/api-fetch';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const REPORT_PRODUCTS_PATH = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/products';
+const PRODUCT_IMAGES_PATH = '/wc/v3/products';
+
+type ProductReportItem = {
+	product_id: string;
+	product_name: string;
+	product_net_revenue: string;
+	product_gross_revenue: string;
+	product_type: string;
+	orders_count: string;
+	sku: string;
+	total_quantity: string;
+	stock_status: string;
+};
+
+const physicalProducts: ProductReportItem[] = [
+	{
+		product_id: '701',
+		product_name: 'Performance hoodie',
+		product_net_revenue: '24880.00',
+		product_gross_revenue: '27620.00',
+		product_type: 'simple',
+		orders_count: '212',
+		sku: 'APP-HOODIE',
+		total_quantity: '254',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '702',
+		product_name: 'Merino travel tee',
+		product_net_revenue: '18240.00',
+		product_gross_revenue: '20480.00',
+		product_type: 'variation',
+		orders_count: '175',
+		sku: 'APP-TEE',
+		total_quantity: '220',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '703',
+		product_name: 'Canvas weekender',
+		product_net_revenue: '13650.00',
+		product_gross_revenue: '15120.00',
+		product_type: 'variable',
+		orders_count: '91',
+		sku: 'ACC-BAG',
+		total_quantity: '102',
+		stock_status: 'instock',
+	},
+	{
+		product_id: '704',
+		product_name: 'Insulated bottle',
+		product_net_revenue: '7425.00',
+		product_gross_revenue: '8125.00',
+		product_type: 'simple',
+		orders_count: '148',
+		sku: 'ACC-BOTTLE',
+		total_quantity: '180',
+		stock_status: 'instock',
+	},
+];
+
+let productMocksRegistered = false;
+
+function buildProductsResponse( products: ProductReportItem[] ) {
+	const summary = products.reduce(
+		( acc, product ) => ( {
+			total_orders: acc.total_orders + Number( product.orders_count ),
+			total_quantity: acc.total_quantity + Number( product.total_quantity ),
+			total_revenue: acc.total_revenue + Number( product.product_net_revenue ),
+		} ),
+		{ total_orders: 0, total_quantity: 0, total_revenue: 0 }
+	);
+
+	return {
+		data: products,
+		summary: {
+			total_orders: String( summary.total_orders ),
+			total_products: String( products.length ),
+			total_quantity: String( summary.total_quantity ),
+			total_revenue: summary.total_revenue.toFixed( 2 ),
+		},
+	};
+}
+
+function registerProductLeaderboardMocks( products: ProductReportItem[] ) {
+	if ( productMocksRegistered ) {
+		return;
+	}
+
+	productMocksRegistered = true;
+
+	const middleware: APIFetchMiddleware = async ( options, next ) => {
+		const requestPath = options.path ?? options.url ?? '';
+
+		if ( requestPath.startsWith( REPORT_PRODUCTS_PATH ) ) {
+			return buildProductsResponse( products );
+		}
+
+		if ( requestPath.startsWith( PRODUCT_IMAGES_PATH ) ) {
+			return products.map( product => ( {
+				id: Number( product.product_id ),
+				name: product.product_name,
+				images: [],
+			} ) );
+		}
+
+		return next( options );
+	};
+
+	apiFetch.use( middleware );
+}
+
+registerProductLeaderboardMocks( physicalProducts );
+
+const TOP_PERFORMING_PRODUCTS_RENDER_MODULE = 'storybook/top-performing-products';
+
+interface TopPerformingProductsDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function TopPerformingProductsDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: TopPerformingProductsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOP_PERFORMING_PRODUCTS_RENDER_MODULE }
+			renderComponent={
+				TopPerformingProductsRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/TopPerformingProducts',
+	component: TopPerformingProductsDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget that displays top products by net revenue for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof TopPerformingProductsDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -10,9 +11,9 @@ import {
 import TopPerformingProductsRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -132,13 +133,83 @@ function registerProductLeaderboardMocks( products: ProductReportItem[] ) {
 registerProductLeaderboardMocks( physicalProducts );
 
 const TOP_PERFORMING_PRODUCTS_RENDER_MODULE = 'storybook/top-performing-products';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 
-interface TopPerformingProductsDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+type TopPerformingProductsRenderProps = ComponentProps< typeof TopPerformingProductsRender >;
+const noopSetError: TopPerformingProductsRenderProps[ 'setError' ] = () => undefined;
+
+interface TopPerformingProductsStoryControls {
 	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type TopPerformingProductsStoryProps = TopPerformingProductsRenderProps &
+	TopPerformingProductsStoryControls;
+
+interface TopPerformingProductsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		TopPerformingProductsStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getTopPerformingProductsAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): TopPerformingProductsRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< TopPerformingProductsStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getTopPerformingProductsSource( args: Partial< TopPerformingProductsStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<TopPerformingProductsRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+\tsetError={ () => undefined }
+/>`;
+}
+
+function renderTopPerformingProducts( {
+	withComparison,
+	preset,
+}: TopPerformingProductsStoryControls ) {
+	return (
+		<TopPerformingProductsRender
+			attributes={ getTopPerformingProductsAttributes( withComparison, preset ) }
+			setError={ noopSetError }
+		/>
+	);
 }
 
 function TopPerformingProductsDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: TopPerformingProductsDashboardStoryProps ) {
 	return (
@@ -149,25 +220,24 @@ function TopPerformingProductsDashboardStory( {
 			renderComponent={
 				TopPerformingProductsRender as ComponentType< WidgetRenderProps< unknown > >
 			}
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
+			attributes={ getTopPerformingProductsAttributes( withComparison, preset ) }
 		/>
 	);
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TopPerformingProducts',
-	component: TopPerformingProductsDashboardStory,
+	component: TopPerformingProductsRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -178,10 +248,93 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof TopPerformingProductsDashboardStory >;
+} satisfies Meta< TopPerformingProductsStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< TopPerformingProductsDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderTopPerformingProducts,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TopPerformingProductsStoryControls > }
+				) => getTopPerformingProductsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled, showing period-over-period product revenue changes.
+ */
+export const WithComparison: Story = {
+	render: renderTopPerformingProducts,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TopPerformingProductsStoryControls > }
+				) => getTopPerformingProductsSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <TopPerformingProductsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/top-performing-products"
+\trenderComponent={ TopPerformingProductsRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/top-performing-products",
+	"title": "Top performing products",
+	"description": "Shows the top products by net revenue over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type TopPerformingProductsAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/top-performing-products` in

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/top-performing-products` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/top-performing-products',
+	title: __( 'Top performing products', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows the top products by net revenue over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1484

## Proposed changes

* Ports the **Top performing products** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/top-performing-products` widget and renders the shared top performing products widget inside `WidgetRoot` using dashboard-level report params.
* Adds story-local product report mocks so the product leaderboard renders without changing shared mock infrastructure.
* Adds standalone Storybook `Default` and `WithComparison` stories, plus a separate `WidgetDashboardWithWidget` dashboard story.

### Finishing changes (rebased on trunk, conformed to the current widget contract)

* `render.tsx`: replaced the hand-rolled `Pick<ComponentProps<typeof WidgetRoot>, …>` prop shape with the `WidgetRenderProps<T>` contract composed with `Partial<ReportParamsFieldAttributes>`, imported the widget's own attribute type from `./widget`, added the External/Internal import grouping, and defaulted `attributes = {}`.
* `widget.ts`: declared the widget attribute type `TopPerformingProductsAttributes = Record<never, never>` (the widget has no configurable attributes) to match the sibling convention.
* `package.json`: dropped unused deps (`@jetpack-premium-analytics/data` — story-only; `@wordpress/ui` — unused) and added `@wordpress/widget-primitives` used by the contract type. Now mirrors the `total-returns`/`bookings-by-status` dependency set.

This remains a thin wrapper over the merged `TopPerformingProductsWidget` toolkit component — no shared-toolkit changes.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Top performing products Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1484-port-woo-widget-top-performing-products/top-performing-products.png)

## Related product discussion/links

* WOOA7S-1484; parent WOOA7S-1457.
* Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Run Storybook (`cd projects/js-packages/storybook && pnpm exec storybook dev -c ./storybook`) and open the `TopPerformingProducts` stories — `Default`, `WithComparison`, and `WidgetDashboardWithWidget`. The Analytics shell renders, the widget title and product leaderboard render (values + per-row deltas), with no `NaN`/`undefined` and no console errors beyond the known shared-harness noise.
