### PR TITLE
Premium Analytics: port the Total returns widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-total-returns-widget-story
+++ b/projects/js-packages/storybook/changelog/add-total-returns-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add total returns widget story.

--- a/projects/js-packages/storybook/changelog/add-total-returns-widget-story
+++ b/projects/js-packages/storybook/changelog/add-total-returns-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add total returns widget story.

--- a/projects/packages/premium-analytics/changelog/add-total-returns-widget
+++ b/projects/packages/premium-analytics/changelog/add-total-returns-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add total returns widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.module.scss
@@ -9,9 +9,14 @@
 	}
 
 	.legend {
-		height: var(--wpds-typography-line-height-lg);
+		width: 100%;
+		height: auto;
 		min-height: var(--wpds-typography-line-height-lg);
-		flex-wrap: nowrap;
+		align-content: center;
+		align-items: center;
+		justify-content: center;
+		flex-wrap: wrap;
+		row-gap: var(--wpds-dimension-gap-xs) !important;
 
 		// Vertically center the legend shape.
 		// The Charts package applies a non-zero transform to legend circles,
@@ -25,13 +30,16 @@
 
 	.legendItem {
 		min-width: 0;
+		max-width: 100%;
+		flex: 0 1 auto;
 		gap: var(--wpds-dimension-gap-sm);
+		justify-content: flex-start;
 		padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm); // 4px 6px->8px
 	}
 
 	.legendLabel {
 		min-width: 0;
-		flex: 1 1 0 !important; // Override the 0 0 auto default value
+		flex: 0 1 auto !important; // Allow the label to shrink so items wrap cleanly
 	}
 
 	.emptyState {

--- a/projects/packages/premium-analytics/widgets/total-returns/package.json
+++ b/projects/packages/premium-analytics/widgets/total-returns/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/total-returns/package.json
+++ b/projects/packages/premium-analytics/widgets/total-returns/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-total-returns",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/total-returns/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/render.tsx
@@ -1,0 +1,22 @@
+import { TotalReturnsWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type TotalReturnsRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
+
+/**
+ * Total returns widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; TotalReturnsWidget renders
+ * refunds and net sales for the selected period.
+ */
+export default function TotalReturnsRender( { attributes, setError }: TotalReturnsRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<TotalReturnsWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/total-returns/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/render.tsx
@@ -1,10 +1,25 @@
-import { TotalReturnsWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	TotalReturnsWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { TotalReturnsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type TotalReturnsRenderProps = Pick<
-	ComponentProps< typeof WidgetRoot >,
-	'attributes' | 'setError'
->;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type TotalReturnsRenderAttributes = TotalReturnsAttributes & Partial< ReportParamsFieldAttributes >;
+
+type TotalReturnsRenderProps = WidgetRenderProps< TotalReturnsRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
 
 /**
  * Total returns widget.
@@ -13,7 +28,10 @@ type TotalReturnsRenderProps = Pick<
  * client, chart theme, and resolved report params; TotalReturnsWidget renders
  * refunds and net sales for the selected period.
  */
-export default function TotalReturnsRender( { attributes, setError }: TotalReturnsRenderProps ) {
+export default function TotalReturnsRender( {
+	attributes = {},
+	setError,
+}: TotalReturnsRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<TotalReturnsWidget />

--- a/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
@@ -1,0 +1,151 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import TotalReturnsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const TOTAL_RETURNS_RENDER_MODULE = 'storybook/total-returns';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type TotalReturnsRenderProps = ComponentProps< typeof TotalReturnsRender >;
+const noopSetError: TotalReturnsRenderProps[ 'setError' ] = () => undefined;
+
+interface TotalReturnsStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type TotalReturnsStoryProps = TotalReturnsRenderProps & TotalReturnsStoryControls;
+
+interface TotalReturnsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		TotalReturnsStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getTotalReturnsAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): TotalReturnsRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function renderTotalReturns( { withComparison, preset }: TotalReturnsStoryControls ) {
+	return (
+		<TotalReturnsRender
+			attributes={ getTotalReturnsAttributes( withComparison, preset ) }
+			setError={ noopSetError }
+		/>
+	);
+}
+
+function TotalReturnsDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: TotalReturnsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOTAL_RETURNS_RENDER_MODULE }
+			renderComponent={ TotalReturnsRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getTotalReturnsAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/TotalReturns',
+	component: TotalReturnsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: 'Dashboard widget that displays refunds and net sales for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< TotalReturnsStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< TotalReturnsDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderTotalReturns,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison period enabled, showing period-over-period change data.
+ */
+export const WithComparison: Story = {
+	render: renderTotalReturns,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <TotalReturnsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.json
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/total-returns",
+	"title": "Total returns",
+	"description": "Shows refunds and net sales over the selected time period.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/total-returns` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/total-returns',
+	title: __( 'Total returns', 'jetpack-premium-analytics' ),
+	description: __(
+		'Shows refunds and net sales over the selected time period.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type TotalReturnsAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/total-returns` in


### PR DESCRIPTION
Fixes: WOOA7S-1485

## Proposed changes

- Ports the **Total returns** widget into the Premium Analytics customizable dashboard.
- Registers the `jpa/total-returns` widget and renders the shared total returns widget inside `WidgetRoot` using dashboard-level report params.
- Adds standalone and dashboard-hosted Storybook stories for the widget.

### Review finishing changes

- Conforms `render.tsx` to the `WidgetRenderProps<T>` contract (instead of a hand-rolled prop shape) and declares `TotalReturnsAttributes = Record<never, never>` in `widget.ts`, matching the normalized widget convention; `attributes` is now defaulted.
- Drops the unused `@wordpress/ui` dependency and adds `@wordpress/widget-primitives`, so `package.json` mirrors the widget's actual imports.
- Makes the shared `widgets-toolkit` bar-chart legend responsive (wrap + center + auto height) so it no longer overflows and forces a scrollbar in small dashboard tiles. This matches the existing comparative-line-chart legend behavior and improves every bar-chart widget.
- Removes a stray `js-packages/storybook` changelog entry (the PR does not modify that package).
- Rebased onto the latest trunk.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Total returns Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1485-port-woo-widget-total-returns/total-returns.png)

## Related product discussion/links

- WOOA7S-1485; parent WOOA7S-1457.
- Follows the widget port structure from #49505.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- `mise x node@24.15.0 -- pnpm install --frozen-lockfile`
- `mise x node@24.15.0 -- pnpm --filter @automattic/charts build`
- `mise x node@24.15.0 -- pnpm --filter @automattic/number-formatters build`
- `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-wp-build-polyfills build`
- `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-premium-analytics typecheck`
- `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-premium-analytics build`
- Run Storybook (`pnpm --filter @automattic/jetpack-storybook storybook:dev`, port 50240) and open the `Default`, `WithComparison`, and `WidgetDashboardWithWidget` stories under **Packages/Premium Analytics/Widgets/TotalReturns**. The chart renders Total sales and Refunds (with a comparison series where enabled) and the dashboard-tile legend fits on one line with no scrollbar.
- Console is clean aside from the shared-harness `useRouter`/`GlobalErrorProvider` warnings and the known duplicate `core/notices` registration, all of which also appear on other widgets' stories.
