### PR TITLE
Premium Analytics: port the Total sales over time widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-total-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-total-sales-over-time-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add total sales over time widget story.

--- a/projects/js-packages/storybook/changelog/add-total-sales-over-time-widget-story
+++ b/projects/js-packages/storybook/changelog/add-total-sales-over-time-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add total sales over time widget story.

--- a/projects/packages/premium-analytics/changelog/add-total-sales-over-time-widget
+++ b/projects/packages/premium-analytics/changelog/add-total-sales-over-time-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add total sales over time widget.

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-total-sales-over-time",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
@@ -1,9 +1,25 @@
-import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * External dependencies
+ */
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { TotalSalesOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
-type RenderProps = Pick< WidgetRootProps, 'attributes' > & {
-	setError?: WidgetRootProps[ 'setError' ];
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type TotalSalesOverTimeRenderAttributes = TotalSalesOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type TotalSalesOverTimeRenderProps = WidgetRenderProps< TotalSalesOverTimeRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -13,7 +29,10 @@ type RenderProps = Pick< WidgetRootProps, 'attributes' > & {
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders total sales over time.
  */
-export default function TotalSalesOverTimeRender( { attributes, setError }: RenderProps ) {
+export default function TotalSalesOverTimeRender( {
+	attributes = {},
+	setError,
+}: TotalSalesOverTimeRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<OrderMetricWidget metricKey="total_sales" />

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
@@ -1,11 +1,9 @@
-import {
-	OrderMetricWidget,
-	WidgetRoot,
-	type ReportParamsFieldAttributes,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { OrderMetricWidget, WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
 
-type TotalSalesOverTimeRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+type RenderProps = Pick< WidgetRootProps, 'attributes' > & {
+	setError?: WidgetRootProps[ 'setError' ];
 };
 
 /**
@@ -15,9 +13,9 @@ type TotalSalesOverTimeRenderProps = {
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders total sales over time.
  */
-export default function TotalSalesOverTimeRender( { attributes }: TotalSalesOverTimeRenderProps ) {
+export default function TotalSalesOverTimeRender( { attributes, setError }: RenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<OrderMetricWidget metricKey="total_sales" />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/render.tsx
@@ -1,0 +1,24 @@
+import {
+	OrderMetricWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+
+type TotalSalesOverTimeRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
+
+/**
+ * Total sales over time widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; OrderMetricWidget fetches
+ * the orders report and renders total sales over time.
+ */
+export default function TotalSalesOverTimeRender( { attributes }: TotalSalesOverTimeRenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+			<OrderMetricWidget metricKey="total_sales" />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -1,0 +1,72 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import TotalSalesOverTimeRender from '../render';
+import widgetDefinition from '../widget';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@automattic/jetpack-widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const TOTAL_SALES_OVER_TIME_RENDER_MODULE = 'storybook/total-sales-over-time';
+// Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
+const ensureLineChartComposition = () => LineChart.Legend;
+
+interface TotalSalesOverTimeDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+	withComparison: boolean;
+}
+
+function TotalSalesOverTimeDashboardStory( {
+	withComparison,
+	...dashboardStoryArgs
+}: TotalSalesOverTimeDashboardStoryProps ) {
+	ensureLineChartComposition();
+
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
+			renderComponent={ TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/TotalSalesOverTime',
+	component: TotalSalesOverTimeDashboardStory,
+	tags: [ 'autodocs' ],
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: 'Dashboard widget that displays total sales over time for the selected period.',
+			},
+		},
+	},
+} satisfies Meta< typeof TotalSalesOverTimeDashboardStory >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+export const WidgetDashboardWithWidget: Story = {};

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -143,6 +143,9 @@ export default meta;
 type Story = StoryObj< typeof meta >;
 type DashboardStory = StoryObj< TotalSalesOverTimeDashboardStoryProps >;
 
+/**
+ * Default state for the current report period.
+ */
 export const Default: Story = {
 	render: renderTotalSalesOverTime,
 	args: {
@@ -162,6 +165,9 @@ export const Default: Story = {
 	},
 };
 
+/**
+ * Comparison period enabled, showing period-over-period change and line chart data.
+ */
 export const WithComparison: Story = {
 	render: renderTotalSalesOverTime,
 	args: {
@@ -181,6 +187,9 @@ export const WithComparison: Story = {
 	},
 };
 
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
 export const WidgetDashboardWithWidget: DashboardStory = {
 	render: args => <TotalSalesOverTimeDashboardStory { ...args } />,
 	args: {

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -1,59 +1,132 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { GlobalErrorProvider, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import TotalSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@automattic/jetpack-widget-primitives';
-import type { ComponentType } from 'react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const TOTAL_SALES_OVER_TIME_RENDER_MODULE = 'storybook/total-sales-over-time';
 // Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
 const ensureLineChartComposition = () => LineChart.Legend;
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
 
-interface TotalSalesOverTimeDashboardStoryProps extends WidgetDashboardWithWidgetControls {
+type TotalSalesOverTimeRenderProps = ComponentProps< typeof TotalSalesOverTimeRender >;
+
+interface TotalSalesOverTimeStoryControls {
 	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type TotalSalesOverTimeStoryProps = TotalSalesOverTimeRenderProps & TotalSalesOverTimeStoryControls;
+
+interface TotalSalesOverTimeDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		TotalSalesOverTimeStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getTotalSalesOverTimeAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): TotalSalesOverTimeRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< TotalSalesOverTimeStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getTotalSalesOverTimeSource( args: Partial< TotalSalesOverTimeStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<TotalSalesOverTimeRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderTotalSalesOverTime( { withComparison, preset }: TotalSalesOverTimeStoryControls ) {
+	ensureLineChartComposition();
+
+	return (
+		<GlobalErrorProvider>
+			<TotalSalesOverTimeRender
+				attributes={ getTotalSalesOverTimeAttributes( withComparison, preset ) }
+			/>
+		</GlobalErrorProvider>
+	);
 }
 
 function TotalSalesOverTimeDashboardStory( {
 	withComparison,
+	preset,
 	...dashboardStoryArgs
 }: TotalSalesOverTimeDashboardStoryProps ) {
 	ensureLineChartComposition();
 
 	return (
-		<WidgetDashboardWithWidgetStory
-			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
-			renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
-			renderComponent={ TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-			} }
-		/>
+		<GlobalErrorProvider>
+			<WidgetDashboardWithWidgetStory
+				{ ...dashboardStoryArgs }
+				widgetType={ widgetDefinition }
+				renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
+				renderComponent={
+					TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > >
+				}
+				attributes={ {
+					reportParams: getDefaultQueryParams( withComparison, preset ),
+				} }
+			/>
+		</GlobalErrorProvider>
 	);
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TotalSalesOverTime',
-	component: TotalSalesOverTimeDashboardStory,
+	component: TotalSalesOverTimeRender,
 	tags: [ 'autodocs' ],
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
 	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
 		withComparison: {
 			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
 		},
 	},
 	parameters: {
@@ -63,10 +136,84 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< typeof TotalSalesOverTimeDashboardStory >;
+} satisfies Meta< TotalSalesOverTimeStoryProps >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< TotalSalesOverTimeDashboardStoryProps >;
 
-export const WidgetDashboardWithWidget: Story = {};
+export const Default: Story = {
+	render: renderTotalSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TotalSalesOverTimeStoryControls > }
+				) => getTotalSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+export const WithComparison: Story = {
+	render: renderTotalSalesOverTime,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< TotalSalesOverTimeStoryControls > }
+				) => getTotalSalesOverTimeSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <TotalSalesOverTimeDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/total-sales-over-time"
+\trenderComponent={ TotalSalesOverTimeRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/total-sales-over-time",
+	"title": "Total sales over time",
+	"description": "Track total sales including all orders and transactions.",
+	"category": "store"
+}

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type TotalSalesOverTimeAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/total-sales-over-time` in

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/total-sales-over-time` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/total-sales-over-time',
+	title: __( 'Total sales over time', 'jetpack-premium-analytics' ),
+	description: __(
+		'Track total sales including all orders and transactions.',
+		'jetpack-premium-analytics'
+	),
+	icon: chartBar,
+};


### PR DESCRIPTION
Fixes: WOOA7S-1486

## Proposed changes
* Ports the **Total sales over time** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/total-sales-over-time` widget and renders the shared order metric widget inside `WidgetRoot` using dashboard-level report params.
* Adds standalone Storybook `Default` and `WithComparison` stories plus the dashboard-hosted `WidgetDashboardWithWidget` story with report mock wiring and date preset controls.
* Keeps the trunk diff scoped to the widget port, Storybook story, changelogs, and minimal package metadata needed for the widget/story build.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Total sales over time Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1486-port-woo-widget-total-sales-over-time/total-sales-over-time.png)

## Related product discussion/links
* WOOA7S-1486; parent WOOA7S-1457.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-premium-analytics build`
* `/Users/dethier/Library/pnpm/pnpm --filter @automattic/jetpack-storybook storybook:build`
* Browser-smoked the built Storybook iframe for `packages-premium-analytics-widgets-totalsalesovertime--widget-dashboard-with-widget`: title, currency value, percent delta, and SVG chart rendered; no `NaN`, `undefined`, or missing-story output. The only current-load console error was the known duplicate `core/notices` baseline.
