### PR TITLE
Premium Analytics: port the Visitors by location widget

### DIFF
--- a/projects/js-packages/storybook/changelog/add-visitors-by-location-widget-story
+++ b/projects/js-packages/storybook/changelog/add-visitors-by-location-widget-story
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Premium Analytics: Add visitors by location widget story.

--- a/projects/js-packages/storybook/changelog/add-visitors-by-location-widget-story
+++ b/projects/js-packages/storybook/changelog/add-visitors-by-location-widget-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Add visitors by location widget story.

--- a/projects/packages/premium-analytics/changelog/add-visitors-by-location-widget
+++ b/projects/packages/premium-analytics/changelog/add-visitors-by-location-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Widgets: Add visitors by location widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -28,7 +28,8 @@ export const WithComparison: Story = {
 };
 
 /**
- * Simulate a single-column dashboard tile (map only)
+ * Simulate a narrow single-column dashboard tile: the map is hidden and only
+ * the leaderboard is shown.
  */
 export const SingleColumnTile: Story = {
 	decorators: [
@@ -50,7 +51,8 @@ export const SingleColumnTile: Story = {
 };
 
 /**
- * Simulate being rendered inside 'Add widget' DataViews picker grid (map only)
+ * Simulate being rendered inside the 'Add widget' DataViews picker grid: the
+ * narrow tile hides the map and shows only the leaderboard.
  */
 export const WidgetPickerGrid: Story = {
 	decorators: [

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -1,31 +1,30 @@
 .root {
+	// Establish an inline-size query container so the layout can respond to the
+	// rendered tile width (single- vs two-column dashboard tile) with pure CSS,
+	// instead of measuring the tile from JS.
+	container-type: inline-size;
 	height: 100%;
-	overflow: hidden;
+	// No `overflow: hidden` here: the toggle sits at the left edge of this box,
+	// and clipping would shave off its border/focus ring. The map has its own
+	// `overflow: hidden` to contain the GeoChart SVG.
 }
 
 .container {
+	display: grid;
+	// Leaderboard on the left, map on the right — matching the Locations widget.
+	grid-template-columns: 280fr 400fr;
+	grid-template-rows: auto 1fr;
+	column-gap: var(--wpds-dimension-gap-lg);
+	// Separate the toggle from the leaderboard below it.
+	row-gap: var(--wpds-dimension-gap-md, 16px);
+	align-items: stretch;
 	height: 100%;
-}
-
-.geoChart {
-	// Fill the grid column but never exceed it. The map keeps the US aspect
-	// ratio (~1.9:1), so capping the width at the ~250px-tall map's natural
-	// width keeps the box aspect matched: the map fills the box instead of
-	// letterboxing with a large empty gap in wider tiles.
-	min-width: 0;
-	width: 100%;
-	max-width: 475px;
-	max-height: 250px;
-
-	// GeoChart renders a fixed pixel-sized SVG that Google redraws on a resize
-	// debounce. While a tile shrinks the previous (wider) SVG lingers briefly;
-	// clip it to the column so it can never spill over the leaderboard or get
-	// cut off by the widget's outer overflow.
-	overflow: hidden;
+	min-height: 0;
 }
 
 .toggleControl {
-	grid-column: 2;
+	grid-column: 1;
+	grid-row: 1;
 
 	// The upstream widget content container
 	// (.next-admin-dashboard-widget__content) sets overflow: auto, which
@@ -38,10 +37,68 @@
 }
 
 .leaderboardChart {
-	// bar border-radius now comes from chartTheme.leaderboardChart.barBorderRadius
+	grid-column: 1;
+	grid-row: 2;
+	align-self: start;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
 
 	.leaderboardImage {
 		height: 20px;
 		border-radius: var(--wpds-border-radius-sm, 2px);
 	}
+}
+
+.geoChart {
+	// Map sits in the content row (beside the leaderboard), so it centers
+	// against the data rather than the toggle above them — matching Locations.
+	grid-column: 2;
+	grid-row: 2;
+
+	// Let the responsive GeoChart fill the cell and scale to fit: it keeps the
+	// map's aspect ratio and letterboxes inside the box, so a short single-row
+	// tile shrinks the map instead of clipping it. Avoid fixed max-width/height
+	// caps, which forced the map larger than a short cell and cut it off.
+	min-width: 0;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	// GeoChart renders a fixed pixel-sized SVG that Google redraws on a resize
+	// debounce. While a tile shrinks the previous (wider) SVG lingers briefly;
+	// clip it to the column so it can never spill over the leaderboard.
+	overflow: hidden;
+}
+
+// Narrow tiles (single-column dashboard tile): hide the map and show only the
+// leaderboard. The threshold sits between a single-column tile (~381px) and a
+// two-column tile (~786px) so the two-column layout keeps both.
+@container (max-width: 480px) {
+
+	.container {
+		grid-template-columns: 1fr;
+	}
+
+	.geoChart {
+		display: none;
+	}
+}
+
+// Widget picker preview: the picker renders the tile inert. Constrain it to a
+// sensible aspect ratio so the preview doesn't collapse.
+:global([inert]:not([inert="true"])) .root {
+	height: auto;
+	aspect-ratio: 4 / 3;
+	overflow: hidden;
+}
+
+// The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
+// to all images inside the media cell, overriding our 20px flag height.
+// Restore correct sizing for flag images in any inert context.
+:global([inert]) .leaderboardChart .leaderboardImage {
+	width: auto;
+	height: 20px;
+	object-fit: initial;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -8,8 +8,20 @@
 }
 
 .geoChart {
+	// Fill the grid column but never exceed it. The map keeps the US aspect
+	// ratio (~1.9:1), so capping the width at the ~250px-tall map's natural
+	// width keeps the box aspect matched: the map fills the box instead of
+	// letterboxing with a large empty gap in wider tiles.
 	min-width: 0;
+	width: 100%;
+	max-width: 475px;
 	max-height: 250px;
+
+	// GeoChart renders a fixed pixel-sized SVG that Google redraws on a resize
+	// debounce. While a tile shrinks the previous (wider) SVG lingers briefly;
+	// clip it to the column so it can never spill over the leaderboard or get
+	// cut off by the widget's outer overflow.
+	overflow: hidden;
 }
 
 .toggleControl {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
@@ -6,11 +6,9 @@ import { location } from '@jetpack-premium-analytics/icons';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	__experimentalGrid as Grid,
 } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChartEmptyState } from '../../components';
 import { LeaderboardChart, LeaderboardLabel } from '../../components/chart-leaderboard';
 import { WidgetLoadingOverlay } from '../../components/widget-loading-overlay';
@@ -28,27 +26,9 @@ function isRegion( value: unknown ): value is Region {
 	return value === 'US' || value === 'world';
 }
 
-function closestHTMLElement(
-	el: Element | null | undefined,
-	selector: string
-): HTMLElement | null {
-	const match = el?.closest( selector );
-	return match instanceof HTMLElement ? match : null;
-}
-
-// Below this rendered tile width the side-by-side map + leaderboard layout is
-// too cramped, so we collapse to the map-only ("minimized") layout. This
-// roughly corresponds to a single-column dashboard tile (~381px) while the
-// two-column layout (~786px) stays above it.
-const MAP_ONLY_MAX_TILE_WIDTH = 480;
-
 export function VisitorsByLocationWidget() {
 	const { reportParams } = useWidgetRootContext();
 	const [ region, setRegion ] = useState< Region >( 'US' );
-	const [ isMinimized, setIsMinimized ] = useState( false );
-	const rootRef = useRef< HTMLDivElement | null >( null );
-	const tileButtonRef = useRef< HTMLElement | null >( null );
-	const resizeDebounceTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 
 	const {
 		geoData,
@@ -94,82 +74,6 @@ export function VisitorsByLocationWidget() {
 		[ leaderboardData, region ]
 	);
 
-	const updateIsMinimized = useCallback( () => {
-		// Measure the dashboard tile when present, otherwise the widget root.
-		// The rendered width is a reliable signal across the real dashboard grid
-		// (where the grid span lives on a parent wrapper, not the sortable tile),
-		// the mobile stacked layout, and standalone embeddings.
-		const measuredEl = tileButtonRef.current ?? rootRef.current;
-		if ( ! measuredEl ) {
-			return;
-		}
-
-		const width = measuredEl.getBoundingClientRect().width;
-		const nextIsMinimized = width > 0 && width < MAP_ONLY_MAX_TILE_WIDTH;
-
-		// Avoid scheduling React state updates when nothing changes.
-		setIsMinimized( prev => ( prev === nextIsMinimized ? prev : nextIsMinimized ) );
-	}, [] );
-
-	const debouncedResizeUpdate = useCallback( () => {
-		// ResizeObserver can fire very frequently while the tile is being resized.
-		// Debounce to reduce rerenders, mirroring GeoChart's internal resize debounce.
-		if ( resizeDebounceTimeoutRef.current ) {
-			clearTimeout( resizeDebounceTimeoutRef.current );
-		}
-		resizeDebounceTimeoutRef.current = setTimeout( updateIsMinimized, RESIZE_DEBOUNCE_MS );
-	}, [ updateIsMinimized ] );
-
-	const resizeObserverRef = useResizeObserver( () => {
-		debouncedResizeUpdate();
-	} );
-
-	useEffect( () => {
-		const root = rootRef.current;
-
-		// DataViews picker grid: always render the simplified (map-only) tile
-		// and avoid attaching any observers/listeners.
-		const dataViewsPickerGrid = closestHTMLElement( root, '.dataviews-view-picker-grid' );
-
-		if ( dataViewsPickerGrid ) {
-			tileButtonRef.current = null;
-			setIsMinimized( true );
-			return;
-		}
-
-		// Dashboard tile: react to changes in the tile's rendered width. Fall
-		// back to the widget root for standalone embeddings that aren't wrapped
-		// in a sortable dashboard tile.
-		const tileButton = closestHTMLElement(
-			root,
-			'[role="button"][aria-roledescription="sortable"]'
-		);
-
-		tileButtonRef.current = tileButton;
-
-		const observedEl = tileButton ?? root;
-		if ( ! observedEl ) {
-			setIsMinimized( false );
-			return;
-		}
-
-		updateIsMinimized();
-
-		// `useResizeObserver` returns a ref callback. We can attach it
-		// programmatically to `observedEl` even though it may be outside this
-		// component's render tree.
-		resizeObserverRef( observedEl );
-
-		return () => {
-			resizeObserverRef( null );
-			tileButtonRef.current = null;
-			if ( resizeDebounceTimeoutRef.current ) {
-				clearTimeout( resizeDebounceTimeoutRef.current );
-				resizeDebounceTimeoutRef.current = null;
-			}
-		};
-	}, [ resizeObserverRef, updateIsMinimized, leaderboardData ] );
-
 	const geoChartProps =
 		region === 'US'
 			? ( {
@@ -203,56 +107,46 @@ export function VisitorsByLocationWidget() {
 
 	return (
 		<>
-			<div ref={ rootRef } className={ styles.root }>
-				{ isMinimized ? (
-					<div className={ styles.container }>{ geoChart }</div>
-				) : (
-					<Grid
-						columns={ 2 }
-						gap={ 6 }
-						className={ styles.container }
-						templateColumns="400fr 280fr"
-						templateRows="auto 1fr"
-					>
-						<div className={ styles.toggleControl }>
-							<ToggleGroupControl
-								__next40pxDefaultSize
-								isBlock
-								hideLabelFromVision
-								label={ __( 'Location', 'jetpack-premium-analytics' ) }
-								onChange={ value => {
-									if ( isRegion( value ) ) {
-										setRegion( value );
-									}
-								} }
-								value={ region }
-							>
-								<ToggleGroupControlOption
-									value="US"
-									label={ __( 'United States', 'jetpack-premium-analytics' ) }
-								/>
-								<ToggleGroupControlOption
-									value="world"
-									label={ __( 'Worldwide', 'jetpack-premium-analytics' ) }
-								/>
-							</ToggleGroupControl>
-						</div>
-
-						<div className={ styles.geoChart }>{ geoChart }</div>
-
-						<LeaderboardChart
-							data={ leaderboardDataWithImages }
-							withOverlayLabel={ true }
-							withComparison={ hasComparison }
-							showLegend={ false }
-							dataFormat={ {
-								type: 'number',
-								options: { useMultipliers: true, decimals: 0 },
+			<div className={ styles.root }>
+				<div className={ styles.container }>
+					<div className={ styles.toggleControl }>
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							isBlock
+							hideLabelFromVision
+							label={ __( 'Location', 'jetpack-premium-analytics' ) }
+							onChange={ value => {
+								if ( isRegion( value ) ) {
+									setRegion( value );
+								}
 							} }
-							className={ styles.leaderboardChart }
-						/>
-					</Grid>
-				) }
+							value={ region }
+						>
+							<ToggleGroupControlOption
+								value="US"
+								label={ __( 'United States', 'jetpack-premium-analytics' ) }
+							/>
+							<ToggleGroupControlOption
+								value="world"
+								label={ __( 'Worldwide', 'jetpack-premium-analytics' ) }
+							/>
+						</ToggleGroupControl>
+					</div>
+
+					<LeaderboardChart
+						data={ leaderboardDataWithImages }
+						withOverlayLabel={ true }
+						withComparison={ hasComparison }
+						showLegend={ false }
+						dataFormat={ {
+							type: 'number',
+							options: { useMultipliers: true, decimals: 0 },
+						} }
+						className={ styles.leaderboardChart }
+					/>
+
+					<div className={ styles.geoChart }>{ geoChart }</div>
+				</div>
 			</div>
 			{ isRefetching && <WidgetLoadingOverlay /> }
 		</>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
@@ -36,14 +36,11 @@ function closestHTMLElement(
 	return match instanceof HTMLElement ? match : null;
 }
 
-function isSingleColumnTileFromGridColumnEnd( gridColumnEnd: string ) {
-	const raw = ( gridColumnEnd || '' ).trim();
-	const match = raw.match( /^span\s+(\d+)$/ );
-	if ( ! match ) {
-		return false;
-	}
-	return Number( match[ 1 ] ) === 1;
-}
+// Below this rendered tile width the side-by-side map + leaderboard layout is
+// too cramped, so we collapse to the map-only ("minimized") layout. This
+// roughly corresponds to a single-column dashboard tile (~381px) while the
+// two-column layout (~786px) stays above it.
+const MAP_ONLY_MAX_TILE_WIDTH = 480;
 
 export function VisitorsByLocationWidget() {
 	const { reportParams } = useWidgetRootContext();
@@ -98,12 +95,17 @@ export function VisitorsByLocationWidget() {
 	);
 
 	const updateIsMinimized = useCallback( () => {
-		const tileButton = tileButtonRef.current;
-		if ( ! tileButton ) {
+		// Measure the dashboard tile when present, otherwise the widget root.
+		// The rendered width is a reliable signal across the real dashboard grid
+		// (where the grid span lives on a parent wrapper, not the sortable tile),
+		// the mobile stacked layout, and standalone embeddings.
+		const measuredEl = tileButtonRef.current ?? rootRef.current;
+		if ( ! measuredEl ) {
 			return;
 		}
 
-		const nextIsMinimized = isSingleColumnTileFromGridColumnEnd( tileButton.style.gridColumnEnd );
+		const width = measuredEl.getBoundingClientRect().width;
+		const nextIsMinimized = width > 0 && width < MAP_ONLY_MAX_TILE_WIDTH;
 
 		// Avoid scheduling React state updates when nothing changes.
 		setIsMinimized( prev => ( prev === nextIsMinimized ? prev : nextIsMinimized ) );
@@ -135,35 +137,30 @@ export function VisitorsByLocationWidget() {
 			return;
 		}
 
-		// Dashboard tile: react to changes in the tile's grid span.
+		// Dashboard tile: react to changes in the tile's rendered width. Fall
+		// back to the widget root for standalone embeddings that aren't wrapped
+		// in a sortable dashboard tile.
 		const tileButton = closestHTMLElement(
 			root,
 			'[role="button"][aria-roledescription="sortable"]'
 		);
 
-		if ( ! tileButton ) {
-			tileButtonRef.current = null;
+		tileButtonRef.current = tileButton;
+
+		const observedEl = tileButton ?? root;
+		if ( ! observedEl ) {
 			setIsMinimized( false );
 			return;
 		}
 
-		tileButtonRef.current = tileButton;
-
 		updateIsMinimized();
 
-		const mutationObserver = new MutationObserver( updateIsMinimized );
-		mutationObserver.observe( tileButton, {
-			attributes: true,
-			attributeFilter: [ 'style', 'class' ],
-		} );
-
 		// `useResizeObserver` returns a ref callback. We can attach it
-		// programmatically to `tileButton` even though it's outside this component's
-		// render tree.
-		resizeObserverRef( tileButton );
+		// programmatically to `observedEl` even though it may be outside this
+		// component's render tree.
+		resizeObserverRef( observedEl );
 
 		return () => {
-			mutationObserver.disconnect();
 			resizeObserverRef( null );
 			tileButtonRef.current = null;
 			if ( resizeDebounceTimeoutRef.current ) {

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/package.json
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/package.json
@@ -7,7 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/package.json
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-visitors-by-location",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/render.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/render.tsx
@@ -1,0 +1,26 @@
+import {
+	VisitorsByLocationWidget,
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ComponentProps } from 'react';
+
+type RenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+/**
+ * Visitors by location widget.
+ *
+ * Thin composition over the widgets-toolkit: WidgetRoot provides the query
+ * client, chart theme, and resolved report params; VisitorsByLocationWidget
+ * fetches the visitors-by-location reports and renders the location map.
+ */
+export default function VisitorsByLocationRender( { attributes, setError }: RenderProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
+			<VisitorsByLocationWidget />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/render.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/render.tsx
@@ -1,12 +1,24 @@
+/**
+ * External dependencies
+ */
 import {
 	VisitorsByLocationWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { VisitorsByLocationAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type RenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type VisitorsByLocationRenderAttributes = VisitorsByLocationAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type VisitorsByLocationRenderProps = WidgetRenderProps< VisitorsByLocationRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -17,7 +29,10 @@ type RenderProps = {
  * client, chart theme, and resolved report params; VisitorsByLocationWidget
  * fetches the visitors-by-location reports and renders the location map.
  */
-export default function VisitorsByLocationRender( { attributes, setError }: RenderProps ) {
+export default function VisitorsByLocationRender( {
+	attributes = {},
+	setError,
+}: VisitorsByLocationRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<VisitorsByLocationWidget />

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -1,0 +1,220 @@
+import { getDefaultQueryParams, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import VisitorsByLocationRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const VISITORS_BY_LOCATION_RENDER_MODULE = 'storybook/visitors-by-location';
+const DEFAULT_PRESET = 'last-30-days' satisfies SelectablePresetId;
+const PRESET_OPTIONS = SELECTABLE_PRESETS;
+
+type VisitorsByLocationRenderProps = ComponentProps< typeof VisitorsByLocationRender >;
+
+interface VisitorsByLocationStoryControls {
+	withComparison: boolean;
+	preset: SelectablePresetId;
+}
+
+type VisitorsByLocationStoryProps = VisitorsByLocationRenderProps & VisitorsByLocationStoryControls;
+
+interface VisitorsByLocationDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		VisitorsByLocationStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<GlobalErrorProvider>
+		<div style={ { width: '100%', height: '300px' } }>
+			<Story />
+		</div>
+	</GlobalErrorProvider>
+);
+
+function getVisitorsByLocationAttributes(
+	withComparison = false,
+	preset: SelectablePresetId = DEFAULT_PRESET
+): VisitorsByLocationRenderProps[ 'attributes' ] {
+	return {
+		reportParams: getDefaultQueryParams( withComparison, preset ),
+	};
+}
+
+function getDefaultQueryParamsSource( {
+	withComparison,
+	preset,
+}: Partial< VisitorsByLocationStoryControls > ) {
+	const hasComparison = Boolean( withComparison );
+	const storyPreset = preset ?? DEFAULT_PRESET;
+
+	if ( ! hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams()';
+	}
+
+	if ( hasComparison && storyPreset === DEFAULT_PRESET ) {
+		return 'getDefaultQueryParams( true )';
+	}
+
+	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
+}
+
+function getVisitorsByLocationSource( args: Partial< VisitorsByLocationStoryControls > ) {
+	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<VisitorsByLocationRender
+\tattributes={ {
+\t\treportParams: ${ getDefaultQueryParamsSource( args ) },
+\t} }
+/>`;
+}
+
+function renderVisitorsByLocation( { withComparison, preset }: VisitorsByLocationStoryControls ) {
+	return (
+		<VisitorsByLocationRender
+			attributes={ getVisitorsByLocationAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+function VisitorsByLocationDashboardStory( {
+	withComparison,
+	preset,
+	...dashboardStoryArgs
+}: VisitorsByLocationDashboardStoryProps ) {
+	return (
+		<GlobalErrorProvider>
+			<WidgetDashboardWithWidgetStory
+				{ ...dashboardStoryArgs }
+				widgetType={ widgetDefinition }
+				renderModule={ VISITORS_BY_LOCATION_RENDER_MODULE }
+				renderComponent={
+					VisitorsByLocationRender as ComponentType< WidgetRenderProps< unknown > >
+				}
+				attributes={ getVisitorsByLocationAttributes( withComparison, preset ) }
+			/>
+		</GlobalErrorProvider>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/VisitorsByLocation',
+	component: VisitorsByLocationRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Visitors by location" widget. Fetches the visitors report and displays where store visitors are located geographically.',
+			},
+		},
+	},
+} satisfies Meta< VisitorsByLocationStoryProps >;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+type DashboardStory = StoryObj< VisitorsByLocationDashboardStoryProps >;
+
+/**
+ * Default state for the current report period.
+ */
+export const Default: Story = {
+	render: renderVisitorsByLocation,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: false,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< VisitorsByLocationStoryControls > }
+				) => getVisitorsByLocationSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Comparison period enabled for the same report period.
+ */
+export const WithComparison: Story = {
+	render: renderVisitorsByLocation,
+	args: {
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			source: {
+				transform: (
+					_source: string,
+					storyContext: { args: Partial< VisitorsByLocationStoryControls > }
+				) => getVisitorsByLocationSource( storyContext.args ),
+			},
+		},
+	},
+};
+
+/**
+ * Renders the widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <VisitorsByLocationDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		preset: DEFAULT_PRESET,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		preset: {
+			control: 'select',
+			options: PRESET_OPTIONS,
+			description: 'Date-range preset used to generate the widget report params.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			source: {
+				code: `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+
+<WidgetDashboardWithWidget
+\twidgetType={ widgetDefinition }
+\trenderModule="storybook/visitors-by-location"
+\trenderComponent={ VisitorsByLocationRender }
+\tattributes={ {
+\t\treportParams: getDefaultQueryParams( true ),
+\t} }
+/>`,
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.json
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.json
@@ -1,0 +1,6 @@
+{
+	"name": "jpa/visitors-by-location",
+	"title": "Visitors by location",
+	"description": "See where your store visitors are located geographically.",
+	"category": "visitors"
+}

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { mapMarker } from '@wordpress/icons';
+
+/**
+ * Widget type definition.
+ *
+ * Ported from `woocommerce-analytics/visitors-by-location` in
+ * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
+ *
+ * Report params intentionally come from the analytics dashboard's global
+ * date-range state for now. Adding widget-level overrides needs a host-level
+ * control registry so analytics dashboards can hide the field while other
+ * dashboards can opt in.
+ */
+export default {
+	name: 'jpa/visitors-by-location',
+	title: __( 'Visitors by location', 'jetpack-premium-analytics' ),
+	description: __(
+		'See where your store visitors are located geographically.',
+		'jetpack-premium-analytics'
+	),
+	icon: mapMarker,
+};

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { mapMarker } from '@wordpress/icons';
 
 /**
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
+ */
+export type VisitorsByLocationAttributes = Record< never, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/visitors-by-location` in


### PR DESCRIPTION
Fixes: WOOA7S-1487

## Proposed changes
* Ports the **Visitors by location** widget into the Premium Analytics customizable dashboard.
* Registers the `jpa/visitors-by-location` widget and renders the shared visitors by location widget inside `WidgetRoot` using dashboard-level report params.
* Adds standalone `Default` / `WithComparison` Storybook stories plus a `WidgetDashboardWithWidget` dashboard story for the widget.
* Keeps the final trunk diff scoped to the Visitors by location widget package, its Storybook story, and changelog entries.

## Storybook screenshot

Captured from the local Storybook widget dashboard story.

![Visitors by location Storybook screenshot](https://github.com/Automattic/jetpack/raw/screenshots/add/wooa7s-1487-port-woo-widget-visitors-by-location/visitors-by-location.png)

## Related product discussion/links
* WOOA7S-1487; parent WOOA7S-1457.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm run lint-file projects/packages/premium-analytics/widgets/visitors-by-location/package.json projects/packages/premium-analytics/widgets/visitors-by-location/render.tsx projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts`
* `pnpm --filter @automattic/jetpack-premium-analytics typecheck`
* `pnpm --filter @automattic/jetpack-premium-analytics build`
* `pnpm --filter @automattic/jetpack-storybook storybook:build`
* Verified the Storybook story `packages-premium-analytics-widgets-visitorsbylocation--widget-dashboard-with-widget` against the built Storybook iframe: title rendered, country data rendered, no `NaN`/`undefined`, and no unexpected widget console errors.
