### PR TITLE
Charts: Leaderboard — add interactive item action (CHARTS-219)

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-219-leaderboard-item-action
+++ b/projects/js-packages/charts/changelog/add-charts-219-leaderboard-item-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: Leaderboard items can be made interactive via a per-entry onClick, rendering the row as a keyboard-accessible button with a hover chevron.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -136,7 +136,7 @@
 	}
 
 	&:focus-visible {
-		outline: 2px solid var(--wpds-color-fg-interactive-brand);
+		outline: 2px solid var(--wpds-color-fg-interactive-brand, var(--wp-admin-theme-color, #3858e9));
 		outline-offset: -2px;
 	}
 }
@@ -147,7 +147,7 @@
 	top: 50%;
 	transform: translateY(-50%) translateX(4px);
 	opacity: 0;
-	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	transition: opacity 0.15s ease, transform 0.15s ease;
 	pointer-events: none;
 }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -100,12 +100,14 @@
 	text-align: inherit;
 	cursor: pointer;
 
-	// Full-row rounded highlight that bleeds slightly past the content edges,
-	// drawn behind the content so it never shifts the grid tracks.
+	// Full-row rounded highlight, drawn behind the content so it never shifts
+	// the grid tracks. Inset 0 (no horizontal bleed): the row button spans the
+	// full content width, so any negative inset would overflow the
+	// `overflow: auto` content container and add a horizontal scrollbar.
 	&::before {
 		content: "";
 		position: absolute;
-		inset: 0 calc(-1 * var(--wpds-dimension-padding-sm, 8px));
+		inset: 0;
 		border-radius: var(--wpds-border-radius-md, 4px);
 		background-color: transparent;
 		transition: background-color 0.15s ease;

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -100,22 +100,14 @@
 	text-align: inherit;
 	cursor: pointer;
 
-	// Full-row rounded highlight, drawn behind the content so it never shifts
-	// the grid tracks. Inset 0 (no horizontal bleed): the row button spans the
-	// full content width, so any negative inset would overflow the
-	// `overflow: auto` content container and add a horizontal scrollbar.
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		border-radius: var(--wpds-border-radius-md, 4px);
-		background-color: transparent;
-		transition: background-color 0.15s ease;
-		pointer-events: none;
-		z-index: -1;
+	// On hover/focus the bars dim and scale back (toward their left origin) and
+	// the value/delta slides left, clearing room for the chevron revealed at the
+	// right edge. No row background — the bars themselves carry the hover state.
+	.bar {
+		transform-origin: left center;
+		transition: opacity 0.15s ease, transform 0.15s ease;
 	}
 
-	// The value/delta block slides left on hover to open room for the chevron.
 	.valueContainer {
 		transition: transform 0.15s ease;
 	}
@@ -123,12 +115,13 @@
 	&:hover,
 	&:focus-visible {
 
-		&::before {
-			background-color: var(--wpds-color-bg-interactive-neutral-weak-active, #ededed);
+		.bar {
+			opacity: 0.5;
+			transform: scaleX(0.9);
 		}
 
 		.valueContainer {
-			transform: translateX(-20px);
+			transform: translateX(-40px);
 		}
 
 		.chevron {
@@ -145,9 +138,9 @@
 
 .chevron {
 	position: absolute;
-	right: var(--wpds-dimension-padding-xs, 4px);
+	right: var(--wpds-dimension-padding-sm, 8px);
 	top: 50%;
-	transform: translateY(-50%) translateX(4px);
+	transform: translateY(-50%) translateX(8px);
 	opacity: 0;
 	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	transition: opacity 0.15s ease, transform 0.15s ease;
@@ -158,7 +151,7 @@
 
 	.interactiveRow {
 
-		&::before,
+		.bar,
 		.valueContainer,
 		.chevron {
 			transition: none;

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -82,12 +82,11 @@
 }
 
 .interactiveRow {
-	// Span the whole row and inherit the parent grid's two tracks so the
-	// label/bar and value columns stay aligned with non-interactive rows.
 	display: grid;
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
 	align-items: center;
+	position: relative;
 
 	// Native button reset.
 	appearance: none;
@@ -100,4 +99,67 @@
 	font: inherit;
 	text-align: inherit;
 	cursor: pointer;
+
+	// Full-row rounded highlight that bleeds slightly past the content edges,
+	// drawn behind the content so it never shifts the grid tracks.
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0 calc(-1 * var(--wpds-dimension-padding-sm, 8px));
+		border-radius: var(--wpds-border-radius-md, 4px);
+		background-color: transparent;
+		transition: background-color 0.15s ease;
+		pointer-events: none;
+		z-index: -1;
+	}
+
+	// The value/delta block slides left on hover to open room for the chevron.
+	.valueContainer {
+		transition: transform 0.15s ease;
+	}
+
+	&:hover,
+	&:focus-visible {
+
+		&::before {
+			background-color: var(--wpds-color-bg-interactive-neutral-weak-active, #ededed);
+		}
+
+		.valueContainer {
+			transform: translateX(-20px);
+		}
+
+		.chevron {
+			opacity: 1;
+			transform: translateY(-50%) translateX(0);
+		}
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wpds-color-fg-interactive-brand);
+		outline-offset: -2px;
+	}
+}
+
+.chevron {
+	position: absolute;
+	right: var(--wpds-dimension-padding-xs, 4px);
+	top: 50%;
+	transform: translateY(-50%) translateX(4px);
+	opacity: 0;
+	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
+	transition: opacity 0.15s ease, transform 0.15s ease;
+	pointer-events: none;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+
+	.interactiveRow {
+
+		&::before,
+		.valueContainer,
+		.chevron {
+			transition: none;
+		}
+	}
 }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -80,3 +80,24 @@
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-style: italic;
 }
+
+.interactiveRow {
+	// Span the whole row and inherit the parent grid's two tracks so the
+	// label/bar and value columns stay aligned with non-interactive rows.
+	display: grid;
+	grid-column: 1 / -1;
+	grid-template-columns: subgrid;
+	align-items: center;
+
+	// Native button reset.
+	appearance: none;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	background: none;
+	color: inherit;
+	font: inherit;
+	text-align: inherit;
+	cursor: pointer;
+}

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -103,11 +103,14 @@
 	text-align: inherit;
 	cursor: pointer;
 
-	// On hover/focus the bar dims and its right edge pulls back by a fixed amount
-	// while the value/delta slides left by the same amount, clearing room for the
-	// chevron revealed at the right edge. Because both move by the same fixed
-	// pixels (not a percentage scale), the bar↔value gap stays identical at rest
-	// and on hover for every row. No row background — the bar carries the state.
+	// On hover/focus the bar dims and its inline-end edge pulls back by a fixed
+	// amount while the value/delta slides toward the inline start by the same
+	// amount, clearing room for the chevron revealed at the inline-end edge.
+	// Because both move by the same fixed pixels (not a percentage scale), the
+	// bar↔value gap stays identical at rest and on hover for every row. The bar
+	// width (set in leaderboard-chart.tsx) is a grid item aligned to the inline
+	// start, so its inset mirrors automatically in RTL; the value slide is given
+	// an RTL override below. No row background — the bar carries the state.
 	.bar {
 		transition: opacity 0.15s ease, width 0.15s ease;
 	}
@@ -128,12 +131,18 @@
 		}
 
 		.valueContainer {
-			transform: translateX(calc(-1 * var(--a8c--charts--leaderboard--bar--hover-inset)));
+			transform: translateX(calc(var(--a8c--charts--leaderboard--bar--hover-inset) * -1));
 		}
 
 		.chevron {
 			opacity: 1;
 		}
+	}
+
+	// In RTL the value slides toward the inline start the other way (rightward).
+	[dir="rtl"] &:hover .valueContainer,
+	[dir="rtl"] &:focus-visible .valueContainer {
+		transform: translateX(var(--a8c--charts--leaderboard--bar--hover-inset));
 	}
 
 	&:focus-visible {
@@ -144,7 +153,7 @@
 
 .chevron {
 	position: absolute;
-	right: var(--wpds-dimension-padding-xs, 4px);
+	inset-inline-end: var(--wpds-dimension-padding-xs, 4px);
 	top: 0;
 	bottom: 0;
 	margin-block: auto;
@@ -152,6 +161,11 @@
 	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	transition: opacity 0.15s ease;
 	pointer-events: none;
+
+	// The glyph points toward the inline end, so flip it to point left in RTL.
+	[dir="rtl"] & {
+		transform: scaleX(-1);
+	}
 }
 
 @media ( prefers-reduced-motion: reduce ) {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -45,6 +45,9 @@
 	.bar {
 		height: 100%;
 		min-height: 6px;
+		// Keeps a sliver of bar visible for tiny shares, and stops the interactive
+		// row's fixed-pixel hover inset from collapsing a narrow bar to nothing.
+		min-width: 2px;
 
 		border-radius: var(--a8c--charts--leaderboard--bar--border-radius, 9999px);
 		z-index: -1; /* places it behind the label */

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -47,7 +47,7 @@
 		min-height: 6px;
 		// Keeps a sliver of bar visible for tiny shares, and stops the interactive
 		// row's fixed-pixel hover inset from collapsing a narrow bar to nothing.
-		min-width: 2px;
+		min-width: var(--wpds-dimension-size-5xs, 4px);
 
 		border-radius: var(--a8c--charts--leaderboard--bar--border-radius, 9999px);
 		z-index: -1; /* places it behind the label */
@@ -119,9 +119,9 @@
 	&:hover,
 	&:focus-visible {
 
-		// Fixed pixel reserve for the chevron — shared by the bar width inset
+		// Fixed reserve for the chevron — shared by the bar width inset
 		// (see leaderboard-chart.tsx) and the value slide so their gap is constant.
-		--a8c--charts--leaderboard--bar--hover-inset: 32px;
+		--a8c--charts--leaderboard--bar--hover-inset: var(--wpds-dimension-gap-2xl, 32px);
 
 		.bar {
 			opacity: 0.5;

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -100,12 +100,13 @@
 	text-align: inherit;
 	cursor: pointer;
 
-	// On hover/focus the bars dim and scale back (toward their left origin) and
-	// the value/delta slides left, clearing room for the chevron revealed at the
-	// right edge. No row background — the bars themselves carry the hover state.
+	// On hover/focus the bar dims and its right edge pulls back by a fixed amount
+	// while the value/delta slides left by the same amount, clearing room for the
+	// chevron revealed at the right edge. Because both move by the same fixed
+	// pixels (not a percentage scale), the bar↔value gap stays identical at rest
+	// and on hover for every row. No row background — the bar carries the state.
 	.bar {
-		transform-origin: left center;
-		transition: opacity 0.15s ease, transform 0.15s ease;
+		transition: opacity 0.15s ease, width 0.15s ease;
 	}
 
 	.valueContainer {
@@ -115,18 +116,20 @@
 	&:hover,
 	&:focus-visible {
 
+		// Fixed pixel reserve for the chevron — shared by the bar width inset
+		// (see leaderboard-chart.tsx) and the value slide so their gap is constant.
+		--a8c--charts--leaderboard--bar--hover-inset: 32px;
+
 		.bar {
 			opacity: 0.5;
-			transform: scaleX(0.9);
 		}
 
 		.valueContainer {
-			transform: translateX(-40px);
+			transform: translateX(calc(-1 * var(--a8c--charts--leaderboard--bar--hover-inset)));
 		}
 
 		.chevron {
 			opacity: 1;
-			transform: translateY(-50%) translateX(0);
 		}
 	}
 
@@ -138,12 +141,13 @@
 
 .chevron {
 	position: absolute;
-	right: var(--wpds-dimension-padding-sm, 8px);
-	top: 50%;
-	transform: translateY(-50%) translateX(8px);
+	right: var(--wpds-dimension-padding-xs, 4px);
+	top: 0;
+	bottom: 0;
+	margin-block: auto;
 	opacity: 0;
 	color: var(--wpds-color-fg-content-neutral-weak, #707070);
-	transition: opacity 0.15s ease, transform 0.15s ease;
+	transition: opacity 0.15s ease;
 	pointer-events: none;
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -26,6 +26,22 @@ import type { LeaderboardChartProps } from './types';
 import type { LeaderboardEntry } from '../../types';
 
 /**
+ * Build an accessible name for an interactive leaderboard row. The label may be
+ * JSX (image/markup), so fall back to the formatted value when it is not a string.
+ *
+ * @param entry          - The leaderboard entry.
+ * @param valueFormatter - Formatter for the entry's current value.
+ * @return Accessible label string for the row button.
+ */
+const getEntryAccessibleLabel = (
+	entry: LeaderboardEntry,
+	valueFormatter: ( value: number ) => string
+): string =>
+	typeof entry.label === 'string'
+		? `${ entry.label }: ${ valueFormatter( entry.currentValue ) }`
+		: valueFormatter( entry.currentValue );
+
+/**
  * Default value formatter using formatMetricValue
  *
  * @param value - The numeric value to format
@@ -324,8 +340,8 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 								const colorIndex = Math.sign( entry.delta ) + 1;
 								const deltaColor = deltaColors[ colorIndex ];
 
-								return (
-									<Fragment key={ entry.id }>
+								const rowCells = (
+									<>
 										<Stack direction="column" gap={ labelSpacing }>
 											<BarWithLabel
 												entry={ entry }
@@ -354,8 +370,24 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 												</Text>
 											) }
 										</Stack>
-									</Fragment>
+									</>
 								);
+
+								if ( entry.onClick ) {
+									return (
+										<button
+											key={ entry.id }
+											type="button"
+											className={ styles.interactiveRow }
+											onClick={ entry.onClick }
+											aria-label={ getEntryAccessibleLabel( entry, valueFormatter ) }
+										>
+											{ rowCells }
+										</button>
+									);
+								}
+
+								return <Fragment key={ entry.id }>{ rowCells }</Fragment>;
 							} ) }
 						</Grid>
 					) }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -2,6 +2,7 @@
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Icon, chevronRight } from '@wordpress/icons';
 import { Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useContext, useMemo, type FC } from 'react';
@@ -383,6 +384,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 											aria-label={ getEntryAccessibleLabel( entry, valueFormatter ) }
 										>
 											{ rowCells }
+											<Icon className={ styles.chevron } icon={ chevronRight } size={ 24 } />
 										</button>
 									);
 								}

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
@@ -42,7 +42,12 @@ const getEntryAccessibleLabel = (
 	valueFormatter: ( value: number ) => string
 ): string | undefined =>
 	typeof entry.label === 'string'
-		? `${ entry.label }: ${ valueFormatter( entry.currentValue ) }`
+		? sprintf(
+				/* translators: 1: Leaderboard item label. 2: The item's formatted value. */
+				__( '%1$s: %2$s', 'jetpack-charts' ),
+				entry.label,
+				valueFormatter( entry.currentValue )
+		  )
 		: undefined;
 
 /**

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
@@ -25,30 +25,6 @@ import { useLeaderboardLegendItems } from './hooks';
 import styles from './leaderboard-chart.module.scss';
 import type { LeaderboardChartProps } from './types';
 import type { LeaderboardEntry } from '../../types';
-
-/**
- * Build an accessible name for an interactive leaderboard row. The label may be
- * JSX (image/markup). For a string label we build an explicit name; for a JSX
- * label we return undefined so the button derives its accessible name from its
- * rendered content (label markup/alt text plus the value), rather than an
- * aria-label that would override and hide that content.
- *
- * @param entry          - The leaderboard entry.
- * @param valueFormatter - Formatter for the entry's current value.
- * @return Accessible label string for a string label, or undefined for JSX.
- */
-const getEntryAccessibleLabel = (
-	entry: LeaderboardEntry,
-	valueFormatter: ( value: number ) => string
-): string | undefined =>
-	typeof entry.label === 'string'
-		? sprintf(
-				/* translators: 1: Leaderboard item label. 2: The item's formatted value. */
-				__( '%1$s: %2$s', 'jetpack-charts' ),
-				entry.label,
-				valueFormatter( entry.currentValue )
-		  )
-		: undefined;
 
 /**
  * Default value formatter using formatMetricValue
@@ -400,7 +376,6 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 											type="button"
 											className={ styles.interactiveRow }
 											onClick={ entry.onClick }
-											aria-label={ getEntryAccessibleLabel( entry, valueFormatter ) }
 										>
 											{ rowCells }
 											<Icon className={ styles.chevron } icon={ chevronRight } size={ 24 } />

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -71,6 +71,17 @@ const defaultDeltaFormatter = ( value: number ): string => {
 	} );
 };
 
+/**
+ * Build a bar's width. A hover-inset CSS variable (0 by default) is subtracted
+ * so interactive rows can pull the bar's right edge back by a fixed pixel amount
+ * on hover — instead of a percentage scale — keeping the bar↔value gap constant.
+ *
+ * @param share - The bar's share of the row width, as a percentage.
+ * @return A CSS width value.
+ */
+const getBarWidth = ( share: number ): string =>
+	`calc(${ share }% - var(--a8c--charts--leaderboard--bar--hover-inset, 0px))`;
+
 const BarLabel = ( { label }: { label: string | JSX.Element } ) => (
 	<>{ typeof label === 'string' ? <Text className={ styles.label }>{ label }</Text> : label }</>
 );
@@ -107,7 +118,7 @@ const BarWithLabel = ( {
 					[ styles[ 'bar--animated' ] ]: animation,
 				} ) }
 				style={ {
-					width: entry.currentShare + '%',
+					width: getBarWidth( entry.currentShare ),
 					backgroundColor: primaryColor,
 				} }
 			></div>
@@ -119,7 +130,7 @@ const BarWithLabel = ( {
 					[ styles[ 'bar--animated' ] ]: animation,
 				} ) }
 				style={ {
-					width: entry.previousShare + '%',
+					width: getBarWidth( entry.previousShare ),
 					backgroundColor: secondaryColor,
 				} }
 			></div>

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -28,19 +28,22 @@ import type { LeaderboardEntry } from '../../types';
 
 /**
  * Build an accessible name for an interactive leaderboard row. The label may be
- * JSX (image/markup), so fall back to the formatted value when it is not a string.
+ * JSX (image/markup). For a string label we build an explicit name; for a JSX
+ * label we return undefined so the button derives its accessible name from its
+ * rendered content (label markup/alt text plus the value), rather than an
+ * aria-label that would override and hide that content.
  *
  * @param entry          - The leaderboard entry.
  * @param valueFormatter - Formatter for the entry's current value.
- * @return Accessible label string for the row button.
+ * @return Accessible label string for a string label, or undefined for JSX.
  */
 const getEntryAccessibleLabel = (
 	entry: LeaderboardEntry,
 	valueFormatter: ( value: number ) => string
-): string =>
+): string | undefined =>
 	typeof entry.label === 'string'
 		? `${ entry.label }: ${ valueFormatter( entry.currentValue ) }`
-		: valueFormatter( entry.currentValue );
+		: undefined;
 
 /**
  * Default value formatter using formatMetricValue

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -43,7 +43,7 @@ interface LeaderboardEntry {
 	previousShare: number;       // Previous bar width (0-100)
 	delta: number;               // Percentage change
 	imageColor?: string;         // Optional color for the entry's image/icon
-	onClick?: ( event: MouseEvent ) => void; // Optional. Makes the whole row an interactive button (click + keyboard); the consuming widget supplies the action.
+	onClick?: ( event: MouseEvent ) => void; // Optional. Makes the whole row an interactive button (click + keyboard); the consumer supplies the action.
 }
 ```
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -43,6 +43,7 @@ interface LeaderboardEntry {
 	previousShare: number;       // Previous bar width (0-100)
 	delta: number;               // Percentage change
 	imageColor?: string;         // Optional color for the entry's image/icon
+	onClick?: ( event: MouseEvent ) => void; // Optional. Makes the whole row an interactive button (click + keyboard); the consuming widget supplies the action.
 }
 ```
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -204,6 +204,24 @@ Handle different value ranges with conditional formatting:
 	/>` }
 />
 
+## Interactive Items
+
+Any entry with an `onClick` field becomes a clickable, keyboard-accessible row. The row renders as a `<button>` (activatable with Enter or Space) and reveals a chevron on hover or focus. Rows without `onClick` remain inert.
+
+Configuring what happens on click — for example, drilling down into a sub-view — is the consuming widget's responsibility, not the chart's:
+
+<Canvas of={ LeaderboardChartStories.Interactive } />
+
+<Source
+	language="tsx"
+	code={ `<LeaderboardChart
+	data={ data.map( d => ( {
+		...d,
+		onClick: () => drillDown( d.id ),
+	} ) ) }
+/>` }
+/>
+
 ## Data States
 
 ### Loading State
@@ -544,6 +562,7 @@ The Leaderboard Chart component supports an optional entry animation that create
 
 - Interactive legends are keyboard accessible when `legend.interactive` is enabled.
 - Legend items can be toggled via keyboard using standard button interaction.
+- Rows with `onClick` render as native `<button>` elements and are activatable with Enter or Space.
 
 ### Screen Reader Support
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -208,7 +208,7 @@ Handle different value ranges with conditional formatting:
 
 Any entry with an `onClick` field becomes a clickable, keyboard-accessible row. The row renders as a `<button>` (activatable with Enter or Space) and reveals a chevron on hover or focus. Rows without `onClick` remain inert.
 
-Configuring what happens on click — for example, drilling down into a sub-view — is the consuming widget's responsibility, not the chart's:
+Configuring what happens on click — for example, drilling down into a sub-view — is the consumer's responsibility, not the chart's:
 
 <Canvas of={ LeaderboardChartStories.Interactive } />
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -213,7 +213,7 @@ export const Interactive: Story = {
 		docs: {
 			description: {
 				story:
-					'Rows with an `onClick` become interactive: the whole row is clickable and keyboard-focusable (Enter/Space), with a chevron revealed on hover/focus. The consuming widget supplies the action (e.g. drill-down).',
+					'Rows with an `onClick` become interactive: the whole row is clickable and keyboard-focusable (Enter/Space), with a chevron revealed on hover/focus. The consumer supplies the action (e.g. drill-down).',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -180,6 +180,25 @@ export const Loading: Story = {
 	},
 };
 
+export const Interactive: Story = {
+	args: {
+		data: sampleData.map( entry => ( {
+			...entry,
+			// eslint-disable-next-line no-console
+			onClick: () => console.log( `Clicked: ${ entry.id }` ),
+		} ) ),
+		withComparison: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Rows with an `onClick` become interactive: the whole row is clickable and keyboard-focusable (Enter/Space), with a chevron revealed on hover/focus. The consuming widget supplies the action (e.g. drill-down).',
+			},
+		},
+	},
+};
+
 export const Animation: Story = {
 	args: {
 		...Default.args,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -1,4 +1,5 @@
 import { Stack } from '@wordpress/ui';
+import { action } from 'storybook/actions';
 import { defaultTheme, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
@@ -180,12 +181,13 @@ export const Loading: Story = {
 	},
 };
 
+const onLeaderboardItemClick = action( 'leaderboard-item-click' );
+
 export const Interactive: Story = {
 	args: {
 		data: sampleData.map( entry => ( {
 			...entry,
-			// eslint-disable-next-line no-console
-			onClick: () => console.log( `Clicked: ${ entry.id }` ),
+			onClick: () => onLeaderboardItemClick( entry.id ),
 		} ) ),
 		withComparison: true,
 	},

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -187,10 +187,28 @@ export const Interactive: Story = {
 	args: {
 		data: sampleData.map( entry => ( {
 			...entry,
+			label: (
+				<span
+					style={ {
+						display: 'flex',
+						alignItems: 'center',
+						minHeight: '40px',
+						padding: '0 6px',
+						fontSize: '13px',
+					} }
+				>
+					{ entry.label }
+				</span>
+			),
 			onClick: () => onLeaderboardItemClick( entry.id ),
 		} ) ),
 		withComparison: true,
+		withOverlayLabel: true,
+		style: {
+			'--a8c--charts--leaderboard--bar--border-radius': '4px',
+		},
 	},
+	render: args => <LeaderboardChartWithOverlayLabelImage { ...args } />,
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import LeaderboardChart from '../leaderboard-chart';
 import type { LeaderboardEntry } from '../../../types';
 
@@ -365,6 +365,40 @@ describe( 'LeaderboardChart', () => {
 			const chartContainer = screen.getByTestId( 'leaderboard-chart-container' );
 
 			expect( chartContainer ).toHaveStyle( { width: '500px', height: '240px' } );
+		} );
+	} );
+
+	describe( 'Interactive items', () => {
+		it( 'renders a button for an entry with onClick', () => {
+			render( <LeaderboardChart data={ [ { ...mockData[ 0 ], onClick: jest.fn() } ] } /> );
+			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button' ).tagName ).toBe( 'BUTTON' );
+		} );
+
+		it( 'calls onClick when the row is clicked', () => {
+			const onClick = jest.fn();
+			render( <LeaderboardChart data={ [ { ...mockData[ 0 ], onClick } ] } /> );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.click( screen.getByRole( 'button' ) );
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'gives the interactive row an accessible name from the label and value', () => {
+			render( <LeaderboardChart data={ [ { ...mockData[ 0 ], onClick: jest.fn() } ] } /> );
+			// mockData[0] label is 'Direct', currentValue 12500 → '12.5K'
+			expect( screen.getByRole( 'button' ) ).toHaveAccessibleName( /Direct.*12\.5K/ );
+		} );
+
+		it( 'does not render a button for entries without onClick', () => {
+			render( <LeaderboardChart data={ [ mockData[ 0 ] ] } /> );
+			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'renders a button only for interactive entries in mixed data', () => {
+			render(
+				<LeaderboardChart data={ [ { ...mockData[ 0 ], onClick: jest.fn() }, mockData[ 1 ] ] } />
+			);
+			expect( screen.getAllByRole( 'button' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -393,6 +393,15 @@ export const trafficSourcesData: LeaderboardEntry[] = [
 		previousShare: 33,
 		delta: 4.2,
 	},
+	{
+		id: 'referral',
+		label: 'Referral',
+		currentValue: 180,
+		previousValue: 150,
+		currentShare: 4,
+		previousShare: 3,
+		delta: 20,
+	},
 ];
 
 /**

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -8,7 +8,7 @@ import type { ScaleInput, ScaleType } from '@visx/scale';
 import type { TextProps } from '@visx/text/lib/Text';
 import type { EventHandlerParams, GlyphProps, GridStyles, LineStyles } from '@visx/xychart';
 import type { GapSize } from '@wordpress/theme';
-import type { CSSProperties, PointerEvent, ReactNode } from 'react';
+import type { CSSProperties, MouseEvent, PointerEvent, ReactNode } from 'react';
 import type { GoogleDataTableColumn, GoogleDataTableRow } from 'react-google-charts';
 
 type ValueOf< T > = T[ keyof T ];
@@ -132,6 +132,15 @@ export type LeaderboardEntry = {
 	 * Optional color for the entry's image/icon
 	 */
 	imageColor?: string;
+
+	/**
+	 * Optional click handler. When provided, the entire row becomes an
+	 * interactive button: clickable and keyboard-focusable (Enter/Space),
+	 * with a chevron affordance revealed on hover/focus. The consuming widget
+	 * decides what the action does (e.g. drill-down). Rows without onClick are
+	 * inert and render unchanged.
+	 */
+	onClick?: ( event: MouseEvent< HTMLButtonElement > ) => void;
 };
 
 export type GradientStop = {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -136,7 +136,7 @@ export type LeaderboardEntry = {
 	/**
 	 * Optional click handler. When provided, the entire row becomes an
 	 * interactive button: clickable and keyboard-focusable (Enter/Space),
-	 * with a chevron affordance revealed on hover/focus. The consuming widget
+	 * with a chevron affordance revealed on hover/focus. The consumer
 	 * decides what the action does (e.g. drill-down). Rows without onClick are
 	 * inert and render unchanged.
 	 */

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -135,10 +135,15 @@ export type LeaderboardEntry = {
 
 	/**
 	 * Optional click handler. When provided, the entire row becomes an
-	 * interactive button: clickable and keyboard-focusable (Enter/Space),
+	 * interactive `<button>`: clickable and keyboard-focusable (Enter/Space),
 	 * with a chevron affordance revealed on hover/focus. The consumer
 	 * decides what the action does (e.g. drill-down). Rows without onClick are
 	 * inert and render unchanged.
+	 *
+	 * For links or other interactive affordances (external-link icons, info
+	 * tooltips), put them in the `label` render prop instead of using onClick —
+	 * a row is either a button (onClick) or carries interactive label content,
+	 * never both, since interactive elements cannot be nested in HTML.
 	 */
 	onClick?: ( event: MouseEvent< HTMLButtonElement > ) => void;
 };


### PR DESCRIPTION
Fixes CHARTS-219

## Why

The Leaderboard chart had no way for an individual row to trigger an action. Premium Analytics widgets need each row to be clickable to drive drill-down — transitioning to a new leaderboard filtered by the clicked item. This adds the interaction mechanism (clickable, keyboard-accessible rows with a hover affordance) to the chart, while keeping *what* the action does the consumer's responsibility, per the issue.

## Proposed changes

* Add an optional `onClick` to `LeaderboardEntry`. A row that declares it renders as a native `<button>` spanning the whole row via CSS `subgrid` (preserving cross-row bar/value alignment) — clickable and keyboard-accessible (Enter/Space); its accessible name is derived from the row's rendered content (label text/markup plus the formatted value and delta), so nothing visible is hidden from assistive tech. Rows **without** `onClick` render exactly as before (backward compatible; `href`/links intentionally deferred).
* On hover/focus the bar dims and its right edge pulls back by a fixed pixel inset while the value/delta slide left by the same amount, so the bar↔value gap is identical at rest and on hover for every row (a shared `--…-hover-inset` CSS variable feeds both the bar `width` `calc()` and the value `translateX`). A `chevronRight` then fades in at the right edge. Includes a focus-visible ring and `prefers-reduced-motion` handling; the value slide is `transform`-based so neighbouring rows never reflow. All colors use WPDS tokens with spec-matching fallbacks.
* Add an interactive Storybook story — overlay-label styled to match the drill-down look, logging clicks via a Storybook `action` — plus MDX docs (API field + behavior), RTL tests, and a changelog entry.

https://github.com/user-attachments/assets/7c4e97c7-ea4a-4ac3-9125-4edb374ee7c0

## Related product discussion/links

* Linear: [CHARTS-219](https://linear.app/a8c/issue/CHARTS-219/leaderboard-add-item-action)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* In Storybook, open **JS Packages / Charts Library → Charts → Leaderboard Chart → Interactive**.
* **Hover** a row: the bar dims and pulls back slightly, the value/delta slide left by the same amount (the gap between bar and value stays constant), and a chevron fades in on the right. Other rows are unaffected (no reflow).
* **Click** a row: the **Actions** panel logs `leaderboard-item-click: "<id>"`.
* **Keyboard**: Tab to a row (visible focus ring), then press **Enter** and **Space** — each fires the action.
* Confirm non-interactive stories (e.g. **Default**) are visually unchanged.
* Run `pnpm --filter @automattic/charts test` (887/887 pass), plus `typecheck` and `build` (both clean).


