### PR TITLE
Admin bar: add Dashboard link to the site-name menu in wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-to-wp-admin-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-to-wp-admin-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: add a Dashboard link to the site-name menu in wp-admin.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -382,8 +382,8 @@ add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 41 );
  *
  * Core only adds a Dashboard link to this menu on the front end (in wp-admin it
  * shows "Visit Site" instead), so add one in wp-admin to match Calypso and the
- * multi-site dashboard. The priority is below core's site menu (30) so the node
- * is the first child of the menu.
+ * multi-site dashboard. The priority is above core's site menu (30) so the node
+ * is added after the "Visit Site" link.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
@@ -402,7 +402,7 @@ function wpcom_add_dashboard_to_site_menu( $wp_admin_bar ) {
 		)
 	);
 }
-add_action( 'admin_bar_menu', 'wpcom_add_dashboard_to_site_menu', 29 );
+add_action( 'admin_bar_menu', 'wpcom_add_dashboard_to_site_menu', 31 );
 
 /**
  * Adds site badges and plan information to the site title dropdown menu.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -378,6 +378,33 @@ function wpcom_edit_site_menu_override( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 41 );
 
 /**
+ * Adds a Dashboard link to the site-name menu in wp-admin.
+ *
+ * Core only adds a Dashboard link to this menu on the front end (in wp-admin it
+ * shows "Visit Site" instead), so add one in wp-admin to match Calypso and the
+ * multi-site dashboard. The priority is below core's site menu (30) so the node
+ * is the first child of the menu.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_add_dashboard_to_site_menu( $wp_admin_bar ) {
+	// Core already provides a Dashboard link on the front end.
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'site-name',
+			'id'     => 'wpcom-dashboard',
+			'title'  => __( 'Dashboard', 'jetpack-mu-wpcom' ),
+			'href'   => admin_url(),
+		)
+	);
+}
+add_action( 'admin_bar_menu', 'wpcom_add_dashboard_to_site_menu', 29 );
+
+/**
  * Adds site badges and plan information to the site title dropdown menu.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -104,4 +104,64 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 			}
 		}
 	}
+
+	/**
+	 * In wp-admin, a Dashboard link should be added as the first child of the
+	 * site-name menu and point to wp-admin.
+	 */
+	public function test_dashboard_link_added_first_in_wp_admin() {
+		set_current_screen( 'dashboard' ); // is_admin() === true.
+
+		// Simulate core's site menu, added at priority 30 (after our priority-29 node).
+		$core_site_menu = static function ( $bar ) {
+			$bar->add_node(
+				array(
+					'id'    => 'site-name',
+					'title' => 'My Site',
+				)
+			);
+			$bar->add_node(
+				array(
+					'parent' => 'site-name',
+					'id'     => 'view-site',
+					'title'  => 'Visit Site',
+					'href'   => 'https://example.org',
+				)
+			);
+		};
+		add_action( 'admin_bar_menu', $core_site_menu, 30 );
+
+		$admin_bar = new \WP_Admin_Bar();
+		do_action( 'admin_bar_menu', $admin_bar );
+
+		remove_action( 'admin_bar_menu', $core_site_menu, 30 );
+		set_current_screen( 'front' );
+
+		$dashboard = $admin_bar->get_node( 'wpcom-dashboard' );
+		$this->assertNotNull( $dashboard, 'A Dashboard node should be added in wp-admin.' );
+		$this->assertSame( 'site-name', $dashboard->parent );
+		$this->assertSame( admin_url(), $dashboard->href );
+
+		$children = array_keys( self::get_all_admin_bar_nodes( $admin_bar, 'site-name' ) );
+		$this->assertSame( 'wpcom-dashboard', $children[0] ?? null, 'The Dashboard link should be first.' );
+	}
+
+	/**
+	 * On the front end core already provides a Dashboard link, so we must not add
+	 * a duplicate.
+	 */
+	public function test_dashboard_link_not_added_on_front_end() {
+		set_current_screen( 'front' ); // is_admin() === false.
+
+		$admin_bar = new \WP_Admin_Bar();
+		$admin_bar->add_node(
+			array(
+				'id'    => 'site-name',
+				'title' => 'My Site',
+			)
+		);
+		do_action( 'admin_bar_menu', $admin_bar );
+
+		$this->assertNull( $admin_bar->get_node( 'wpcom-dashboard' ), 'No Dashboard node should be added on the front end.' );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -106,13 +106,13 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * In wp-admin, a Dashboard link should be added as the first child of the
-	 * site-name menu and point to wp-admin.
+	 * In wp-admin, a Dashboard link should be added to the site-name menu after
+	 * the "Visit Site" link and point to wp-admin.
 	 */
-	public function test_dashboard_link_added_first_in_wp_admin() {
+	public function test_dashboard_link_added_after_visit_site_in_wp_admin() {
 		set_current_screen( 'dashboard' ); // is_admin() === true.
 
-		// Simulate core's site menu, added at priority 30 (after our priority-29 node).
+		// Simulate core's site menu, added at priority 30 (before our priority-31 node).
 		$core_site_menu = static function ( $bar ) {
 			$bar->add_node(
 				array(
@@ -143,7 +143,11 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( admin_url(), $dashboard->href );
 
 		$children = array_keys( self::get_all_admin_bar_nodes( $admin_bar, 'site-name' ) );
-		$this->assertSame( 'wpcom-dashboard', $children[0] ?? null, 'The Dashboard link should be first.' );
+		$view_pos = array_search( 'view-site', $children, true );
+		$dash_pos = array_search( 'wpcom-dashboard', $children, true );
+		$this->assertNotFalse( $view_pos );
+		$this->assertNotFalse( $dash_pos );
+		$this->assertGreaterThan( $view_pos, $dash_pos, 'The Dashboard link should come after Visit Site.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a Dashboard link to the site-name menu in wp-admin, so it matches Calypso and the multi-site dashboard.
* The link points to wp-admin and appears as the first item in the menu.
* Only added in wp-admin — the front end already shows a Dashboard link, so no duplicate.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open wp-admin and click the site name in the admin bar to open the dropdown.
* Confirm a Dashboard link appears as the first item and opens wp-admin.
* On the front end, confirm there is still a single Dashboard link (no duplicate).
