### PR TITLE
feat(premium-analytics): integrate cookie-consent

### DIFF
--- a/projects/plugins/premium-analytics/changelog/wooa7s-1569-integrate-cookie-consent
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1569-integrate-cookie-consent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Integrate the jetpack-cookie-consent package as a development consumer.

--- a/projects/plugins/premium-analytics/composer.json
+++ b/projects/plugins/premium-analytics/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-premium-analytics": "@dev",
+		"automattic/jetpack-cookie-consent": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev"
 	},

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9afaab222d7859aedc0fdf26ce8fa966",
+    "content-hash": "26a28963f05fd6563512fc376bb7fced",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -545,6 +545,48 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-cookie-consent",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/cookie-consent",
+                "reference": "97b443665fb0bee85076e0805bfe812a5a80e526"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "textdomain": "jetpack-cookie-consent",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "GDPR cookie-consent banner, CCPA opt-out, and consent logging for WordPress.",
             "transport-options": {
                 "relative": true
             }
@@ -2916,6 +2958,7 @@
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,
+        "automattic/jetpack-cookie-consent": 20,
         "automattic/jetpack-premium-analytics": 20,
         "automattic/phpunit-select-config": 20
     },

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -555,13 +555,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/cookie-consent",
-                "reference": "97b443665fb0bee85076e0805bfe812a5a80e526"
+                "reference": "ce46d635c3d3a1d2fb704440093bd52e6347cf0a"
             },
             "require": {
                 "php": ">=7.2"
             },
             "type": "jetpack-library",
             "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-cookie-consent",
                 "textdomain": "jetpack-cookie-consent",
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"

--- a/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
+++ b/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
+use Automattic\Jetpack\CookieConsent\Cookie_Consent;
 use Automattic\Jetpack\PremiumAnalytics\Analytics;
 
 /**
@@ -25,5 +26,6 @@ class Jetpack_Premium_Analytics {
 	 */
 	public function __construct() {
 		Analytics::init( array( 'menu_title' => 'Premium Analytics' ) );
+		Cookie_Consent::init();
 	}
 }


### PR DESCRIPTION

## Proposed changes

The `jetpack-cookie-consent` package has no consumer today, so `Cookie_Consent::init()` is never called and the package can't be exercised on a real site. The hardening work tracked in WOOA7S-1544 (open write endpoint, classic-theme link fallback, CMP coexistence, etc.) needs a running harness to test against. This PR wires the package into the `jetpack-premium-analytics` plugin as its consumer.

* Add `automattic/jetpack-cookie-consent` to the plugin's composer requirements (symlinked in the monorepo; lockfile updated).
* Call `Cookie_Consent::init()` from the plugin wrapper constructor.
* Init is unconditional (no enable gate): the premium-analytics plugin is development-only and not publicly released, so this is the simplest way to get the package running end-to-end. A per-site enable switch is tracked separately under WOOA7S-1544.

## Related product discussion/links
* WOOA7S-1569 (sub-issue of WOOA7S-1544)

## Does this pull request change what data or activity we track or use?

No new tracking is added by this PR. It does activate the existing cookie-consent package behavior (consent banner, CCPA opt-out, and the package's own consent-log table/REST routes) on sites running the dev premium-analytics plugin. The data handling itself is unchanged from the package.

## Testing instructions

* Build and activate the `jetpack-premium-analytics` plugin.
* Install `wp-consent-api` plugin
* Load the site front end with `/?preview_cookie_consent` — the cookie consent banner should render.

<img width="1711" height="1333" alt="Screenshot 2026-06-18 at 4 47 25 PM" src="https://github.com/user-attachments/assets/0a7277cf-662b-4f2f-8855-8b0ad9bf09e9" />

