### PR TITLE
Cookie Consent: configure mirror repo and autotagger

### DIFF
--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-mirror-repo
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-mirror-repo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set up mirror repository and autotagger for package publishing.

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -31,6 +31,8 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-cookie-consent",
 		"textdomain": "jetpack-cookie-consent",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"


### PR DESCRIPTION
## Proposed changes

Configures the `cookie-consent` package for mirror-repo publishing so other plugins (e.g. premium-analytics) can consume it via Composer/Packagist.

**Why:** The package had no mirror-repo configuration, so the monorepo tooling had nowhere to push a built version for deployment/consumption.

**How:** The mirror repo `Automattic/jetpack-cookie-consent` has been created and configured per the [mirror repo guidelines](https://github.com/Automattic/jetpack/blob/trunk/docs/monorepo.md#mirror-repositories) (read-only description, issues/wikis/projects disabled, Actions permissions locked down, default branch `trunk`, `API_TOKEN_GITHUB` secret added for Autotagger).

**What:** This PR adds the monorepo-side config to `composer.json`:
* `extra.mirror-repo` → `Automattic/jetpack-cookie-consent`
* `extra.autotagger` → `true`

The `.gitattributes` `production-include`/`production-exclude` tags were already in place, so no change was needed there.

## Related product discussion/links

* WOOA7S-1570

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On the PR's Build workflow, download the `jetpack-build` artifact and confirm it contains `packages/jetpack-cookie-consent` with the expected files (and no extra/missing files), per `docs/monorepo.md`.
* After merge, confirm the mirror's `trunk` at https://github.com/Automattic/jetpack-cookie-consent is populated with the built package.
