### PR TITLE
RTC: remove the pinghub.rtc.* analytics pixels

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17555-remove-rtc-pinghub-pixels
+++ b/projects/packages/rtc/changelog/dotcom-17555-remove-rtc-pinghub-pixels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+RTC: remove the pinghub.rtc.* analytics pixels (room_peers, conn_open, conn_close_code, conn_err, jwt_fetch, jwt_fetch_error, send_drop), now superseded by the jetpack_rtc_* Tracks events. The generic pinghub.* pixels and the logConnectionEvent() logging are unchanged.

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -439,19 +439,14 @@ export class PingHubBridge {
 			return null;
 		}
 		const start = Date.now();
+		let response: { token: string } | undefined;
 		try {
-			const response = await apiFetch< { token: string } >( {
+			response = await apiFetch< { token: string } >( {
 				path: '/wpcom/v2/rtc/pinghub-token',
 				method: 'POST',
 			} );
-			this.cachedJwt = response?.token ?? null;
-			this.cachedJwtTimestamp = Date.now();
-			this.resetJwtState();
-			pixel( 'pinghub.rtc.jwt_fetch', Date.now() - start, 'ms' );
-			return this.cachedJwt;
 		} catch {
 			const elapsed = Date.now() - start;
-			pixel( 'pinghub.rtc.jwt_fetch_error', elapsed, 'ms' );
 			this.jwtFetchFailures++;
 			this.jwtBackoffUntil = Date.now() + this.jwtBackoffDelay;
 			this.jwtBackoffDelay = Math.min( this.jwtBackoffDelay * 2, JWT_BACKOFF_MAX_MS );
@@ -461,6 +456,10 @@ export class PingHubBridge {
 			} );
 			return null;
 		}
+		this.cachedJwt = response?.token ?? null;
+		this.cachedJwtTimestamp = Date.now();
+		this.resetJwtState();
+		return this.cachedJwt;
 	}
 
 	/**
@@ -487,7 +486,6 @@ export class PingHubBridge {
 			const elapsed = Date.now() - this.wsConnectStart;
 			this.wsState = 'open';
 			pixel( 'pinghub.conn_open', elapsed, 'ms' );
-			pixel( 'pinghub.rtc.conn_open', elapsed, 'ms' );
 			logConnectionEvent( 'connected', {
 				time_to_connect_ms: elapsed,
 				active_rooms: this.registeredRooms.size,
@@ -502,7 +500,6 @@ export class PingHubBridge {
 		ws.addEventListener( 'close', event => {
 			const elapsed = Date.now() - this.wsConnectStart;
 			pixel( 'pinghub.conn_close_code.' + event.code, elapsed, 'ms' );
-			pixel( 'pinghub.rtc.conn_close_code.' + event.code, elapsed, 'ms' );
 			logConnectionEvent( 'disconnected', {
 				close_code: event.code,
 				close_reason: event.reason,
@@ -525,7 +522,6 @@ export class PingHubBridge {
 
 		ws.addEventListener( 'error', () => {
 			pixel( 'pinghub.conn_err', Date.now() - this.wsConnectStart, 'ms' );
-			pixel( 'pinghub.rtc.conn_err', Date.now() - this.wsConnectStart, 'ms' );
 		} );
 
 		ws.addEventListener( 'message', event => {
@@ -629,7 +625,6 @@ export class PingHubBridge {
 	 */
 	send( room: string, data: Uint8Array ): void {
 		if ( ! this.ws || this.ws.readyState !== WebSocket.OPEN ) {
-			pixel( 'pinghub.rtc.send_drop', 1, 'c' );
 			return;
 		}
 

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -2,7 +2,7 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
-import { PingHubBridge, logConnectionEvent, pixel } from './pinghub-bridge';
+import { PingHubBridge, logConnectionEvent } from './pinghub-bridge';
 import type { Awareness, ConnectionStatus } from '@wordpress/sync';
 import type * as Y from 'yjs';
 
@@ -235,8 +235,6 @@ class PingHubConnection {
 			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
 			this.broadcastAwareness( update );
 		}
-
-		pixel( 'pinghub.rtc.room_peers', this.awareness.getStates().size, 'ms' );
 	};
 
 	/**
@@ -350,9 +348,6 @@ class PingHubConnection {
 	} ): void => {
 		if ( ! this.connected ) {
 			return;
-		}
-		if ( added.length > 0 ) {
-			pixel( 'pinghub.rtc.room_peers', this.awareness.getStates().size, 'ms' );
 		}
 		const changed = added.concat( updated ).concat( removed );
 		const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, changed );


### PR DESCRIPTION
Part of DOTCOM-17555

## Proposed changes
* Remove the `pinghub.rtc.*` analytics pixel beacons sent from the RTC PingHub provider — they are superseded by the `jetpack_rtc_*` Tracks events (`jetpack_rtc_join` #49559, `jetpack_rtc_blocked` #49579, `jetpack_rtc_connection_error` #49617). The peer-count metric (`room_peers`) in particular was inaccurate.
* Beacons removed (all the `.rtc.`-namespaced ones): `pinghub.rtc.room_peers` (×2), `pinghub.rtc.jwt_fetch`, `pinghub.rtc.jwt_fetch_error`, `pinghub.rtc.conn_open`, `pinghub.rtc.conn_close_code.<code>`, `pinghub.rtc.conn_err`, `pinghub.rtc.send_drop`.
* **Kept** the generic `pinghub.*` pixels (`pinghub.conn_open`, `pinghub.conn_close_code.<code>`, `pinghub.conn_err`) and the `logConnectionEvent()` Logstash logging — both unchanged.
* Dropped the now-unused `pixel` import from `pinghub-manager.ts`; `pinghub-bridge.ts` still exports/uses `pixel()` for the generic beacons.
* Minor refactor of `fetchPinghubJwt()` so the JWT-fetch error timing (`duration_ms`, still logged via `logConnectionEvent`) is preserved without the removed pixels.

Last of the RTC Tracks PRs (DOTCOM-17555). Should land after the new Tracks events are deployed and the Grafana dashboards are migrated to them.

## Related product discussion/links
* DOTCOM-17555

## Does this pull request change what data or activity we track or use?
Yes — this PR **removes** analytics, it does not add any. The `pinghub.rtc.*` pixel beacons (peer counts, connection/JWT timings, WebSocket close codes, dropped-send counters) previously sent to `pixel.wp.com` from the RTC PingHub provider are no longer sent. No new data is collected; the equivalent signal now comes from the `jetpack_rtc_*` Tracks events. The generic `pinghub.*` pixels and the `logConnectionEvent()` connection logging are unaffected.

## Testing instructions

Unit tests:
* `cd projects/packages/rtc && pnpm test` — all suites pass (39 tests).

Functional (requires a WordPress.com environment with RTC enabled on the PingHub transport):
* Open a post in the block editor on a PingHub (Simple) RTC site and filter the Network tab for `pixel.wp.com/boom.gif`.
* Confirm the generic beacons still fire: `pinghub.conn_open`, `pinghub.conn_close_code.<code>` (close the connection), `pinghub.conn_err` (force a socket error).
* Confirm **no** `pinghub.rtc.*` beacons are sent (no `room_peers` as peers join/leave, no `rtc.conn_open`, etc.).
* Confirm the `jetpack_rtc_join` / `jetpack_rtc_blocked` / `jetpack_rtc_connection_error` Tracks events still fire as before (these replace the removed pixels).
