### PR TITLE
Podcast: gate Posts to Podcast to wpcom hosts (Simple/WoA)

### DIFF
--- a/projects/packages/podcast/changelog/post-to-podcast-only-for-wpcom
+++ b/projects/packages/podcast/changelog/post-to-podcast-only-for-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: gate the Posts to Podcast sub-feature to WordPress.com Simple and WoA hosts so it does not load on self-hosted Jetpack once the rest of the package becomes available there.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -64,45 +64,26 @@ class Podcast {
 			New_Episode_Prefill::init();
 		}
 
-		// Posts to Podcast is a WordPress.com-only sub-feature: its REST proxy
-		// relays generation requests to a wpcom-side endpoint as the current
-		// user. The rest of the package now loads on self-hosted Jetpack too,
-		// but this sub-feature must not — keep it gated to Simple/WoA hosts
-		// regardless of how the package was loaded.
-		if ( self::is_posts_to_podcast_supported_host() ) {
-			// Register the local REST routes before request-local rollout
-			// gates. Requests from public-api.wordpress.com may not satisfy
-			// those gates, but the wpcom/v2 routes still need to exist so
-			// permission and callback checks can handle the request.
+		if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
+			// Register the local REST routes before request-local rollout gates.
+			// Requests from public-api.wordpress.com may not satisfy those gates,
+			// but the wpcom/v2 routes still need to exist so permission and
+			// callback checks can handle the request.
 			Posts_To_Podcast_Endpoint::init();
 
-			// Create AI Podcast page lives behind its own filter so it can ship
-			// independently of the rest of the package.
+			// Posts to Podcast lives behind its own filter so the Create AI
+			// Podcast page can ship independently of the rest of the package.
 			//
-			// Note: no `is_admin()` guard here. The submenu must also register
-			// when Calypso builds its nav via the `wpcom/v2/admin-menu` REST
-			// endpoint, which fires `admin_menu` by loading `wp-admin/menu.php`
-			// but runs as a REST request where `is_admin()` is false. The hooks
-			// `init()` wires (`admin_menu`, `enqueue_block_editor_assets`)
-			// self-gate, so this is a no-op on non-admin/non-editor requests.
+			// Note: no `is_admin()` guard here. The submenu must also register when
+			// Calypso builds its nav via the `wpcom/v2/admin-menu` REST endpoint,
+			// which fires `admin_menu` by loading `wp-admin/menu.php` but runs as a
+			// REST request where `is_admin()` is false. The hooks `init()` wires
+			// (`admin_menu`, `enqueue_block_editor_assets`) self-gate, so this is a
+			// no-op on non-admin/non-editor requests.
 			if ( self::is_posts_to_podcast_enabled() ) {
 				Create_AI_Podcast_Page::init();
 			}
 		}
-	}
-
-	/**
-	 * Whether the current host may run Posts to Podcast.
-	 *
-	 * The feature relays to a wpcom-side endpoint, so it is offered only on
-	 * WordPress.com Simple and WoA (Atomic) sites — never on self-hosted
-	 * Jetpack, even now that the rest of the podcast package loads there.
-	 *
-	 * @return bool
-	 */
-	private static function is_posts_to_podcast_supported_host() {
-		$host = new Host();
-		return $host->is_wpcom_simple() || $host->is_woa_site();
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -44,11 +44,6 @@ class Podcast {
 
 		Podcast_Episode_Block::register_hooks();
 
-		// Register the local REST routes before request-local rollout gates.
-		// Requests from public-api.wordpress.com may not satisfy those gates,
-		// but the wpcom/v2 routes still need to exist so permission and
-		// callback checks can handle the request.
-		Posts_To_Podcast_Endpoint::init();
 		Podcast_Stats_Endpoint::init();
 		Podcast_Distribution_Endpoint::init();
 		Podcast_Settings_Endpoint::init();
@@ -69,18 +64,45 @@ class Podcast {
 			New_Episode_Prefill::init();
 		}
 
-		// Posts to Podcast lives behind its own filter so the Create AI
-		// Podcast page can ship independently of the rest of the package.
-		//
-		// Note: no `is_admin()` guard here. The submenu must also register when
-		// Calypso builds its nav via the `wpcom/v2/admin-menu` REST endpoint,
-		// which fires `admin_menu` by loading `wp-admin/menu.php` but runs as a
-		// REST request where `is_admin()` is false. The hooks `init()` wires
-		// (`admin_menu`, `enqueue_block_editor_assets`) self-gate, so this is a
-		// no-op on non-admin/non-editor requests.
-		if ( self::is_posts_to_podcast_enabled() ) {
-			Create_AI_Podcast_Page::init();
+		// Posts to Podcast is a WordPress.com-only sub-feature: its REST proxy
+		// relays generation requests to a wpcom-side endpoint as the current
+		// user. The rest of the package now loads on self-hosted Jetpack too,
+		// but this sub-feature must not — keep it gated to Simple/WoA hosts
+		// regardless of how the package was loaded.
+		if ( self::is_posts_to_podcast_supported_host() ) {
+			// Register the local REST routes before request-local rollout
+			// gates. Requests from public-api.wordpress.com may not satisfy
+			// those gates, but the wpcom/v2 routes still need to exist so
+			// permission and callback checks can handle the request.
+			Posts_To_Podcast_Endpoint::init();
+
+			// Create AI Podcast page lives behind its own filter so it can ship
+			// independently of the rest of the package.
+			//
+			// Note: no `is_admin()` guard here. The submenu must also register
+			// when Calypso builds its nav via the `wpcom/v2/admin-menu` REST
+			// endpoint, which fires `admin_menu` by loading `wp-admin/menu.php`
+			// but runs as a REST request where `is_admin()` is false. The hooks
+			// `init()` wires (`admin_menu`, `enqueue_block_editor_assets`)
+			// self-gate, so this is a no-op on non-admin/non-editor requests.
+			if ( self::is_posts_to_podcast_enabled() ) {
+				Create_AI_Podcast_Page::init();
+			}
 		}
+	}
+
+	/**
+	 * Whether the current host may run Posts to Podcast.
+	 *
+	 * The feature relays to a wpcom-side endpoint, so it is offered only on
+	 * WordPress.com Simple and WoA (Atomic) sites — never on self-hosted
+	 * Jetpack, even now that the rest of the podcast package loads there.
+	 *
+	 * @return bool
+	 */
+	private static function is_posts_to_podcast_supported_host() {
+		$host = new Host();
+		return $host->is_wpcom_simple() || $host->is_woa_site();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/PODS-184/ensure-create-ai-podcast-stays-off

## Proposed changes

Add a redundant check for host to ensure post to podcast is only loaded on Simple or Atomic sites.

I am preparing Jetpack Podcast to be released to self-hosted sites and I do not want to cause any problems. This check is redundant as of now, but in following PR's we will be loading podcast in all environments behind a flag.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

Make sure post to podcast still loads in Simple and Atomic.