### PR TITLE
Premium Analytics: dashboard shell with admin-ui Page and section tabs

### DIFF
--- a/projects/packages/premium-analytics/changelog/premium-analytics-tabs
+++ b/projects/packages/premium-analytics/changelog/premium-analytics-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Add tabbed sections around the customizable widget grid.

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -1,0 +1,23 @@
+.dashboardSections {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-block-size: 0;
+}
+
+.tabList {
+	border-block-end:
+		var(--wpds-border-width-xs, 1px) solid
+		var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
+	flex: 0 0 auto;
+	margin-block-end: 16px;
+	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+}
+
+.tabList :global([role="tab"][aria-selected="true"]) {
+	color: var(--wp-admin-theme-color, #3858e9);
+}
+
+.tabList :global([role="tablist"] > [data-orientation="horizontal"]:not([role="tab"])) {
+	background-color: var(--wp-admin-theme-color, #3858e9);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -1,16 +1,8 @@
-.dashboardSections {
-	display: flex;
-	flex: 1 1 auto;
-	flex-direction: column;
-	min-block-size: 0;
-}
-
 .tabList {
 	border-block-end:
 		var(--wpds-border-width-xs, 1px) solid
 		var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
-	flex: 0 0 auto;
-	margin-block-end: 16px;
+	margin-block-end: var(--wpds-dimension-gap-lg, 16px);
 	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 }
 
@@ -18,6 +10,6 @@
 	color: var(--wp-admin-theme-color, #3858e9);
 }
 
-.tabList :global([role="tablist"] > [data-orientation="horizontal"]:not([role="tab"])) {
+.tabList > :global([data-orientation="horizontal"]:not([role="tab"])) {
 	background-color: var(--wp-admin-theme-color, #3858e9);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -10,6 +10,6 @@
 	color: var(--wp-admin-theme-color, #3858e9);
 }
 
-.tabList > :global([data-orientation="horizontal"]:not([role="tab"])) {
+.tabList :global([role="tablist"] > [data-orientation="horizontal"]:not([role="tab"])) {
 	background-color: var(--wp-admin-theme-color, #3858e9);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -1,0 +1,73 @@
+import { Tabs } from '@wordpress/ui';
+import { useCallback } from 'react';
+import styles from './dashboard-sections.module.scss';
+import type { DashboardSection, DashboardSectionId } from '../../config';
+import type { ReactNode } from 'react';
+
+export type DashboardSectionsProps = {
+	/**
+	 * The sections to render, in order.
+	 */
+	sections: DashboardSection[];
+
+	/**
+	 * The currently active section ID.
+	 */
+	value: DashboardSectionId;
+
+	/**
+	 * Called with the new section ID when the user selects a different section.
+	 */
+	onChange: ( id: DashboardSectionId ) => void;
+
+	/**
+	 * Section panel content.
+	 */
+	children?: ReactNode;
+};
+
+/**
+ * The analytics dashboard section tab bar.
+ *
+ * Purely presentational: it renders the section tab triggers and reports selection
+ * changes upward. Panel children are rendered inside the same Tabs.Root so the
+ * tablist and section content share a complete tab/panel relationship.
+ *
+ * @param props          - Component props.
+ * @param props.sections - The sections to render, in order.
+ * @param props.value    - The currently active section ID.
+ * @param props.onChange - Called with the new section ID when the user selects a different section.
+ * @param props.children - Section panel content.
+ * @return The section tab bar element.
+ */
+export function DashboardSections( {
+	sections,
+	value,
+	onChange,
+	children,
+}: DashboardSectionsProps ) {
+	// Hoisted so it isn't an inline arrow in JSX (react/jsx-no-bind is an error).
+	const handleValueChange = useCallback(
+		( sectionId: string ) => onChange( sectionId as DashboardSectionId ),
+		[ onChange ]
+	);
+
+	return (
+		<Tabs.Root
+			className={ styles.dashboardSections }
+			value={ value }
+			onValueChange={ handleValueChange }
+		>
+			<div className={ styles.tabList }>
+				<Tabs.List variant="minimal">
+					{ sections.map( section => (
+						<Tabs.Tab key={ section.id } value={ section.id }>
+							{ section.label }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
+			</div>
+			{ children }
+		</Tabs.Root>
+	);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -4,7 +4,7 @@ import styles from './dashboard-sections.module.scss';
 import type { DashboardSection, DashboardSectionId } from '../../config';
 import type { ReactNode } from 'react';
 
-export type DashboardSectionsProps = {
+type DashboardSectionsProps = {
 	/**
 	 * The sections to render, in order.
 	 */
@@ -53,20 +53,14 @@ export function DashboardSections( {
 	);
 
 	return (
-		<Tabs.Root
-			className={ styles.dashboardSections }
-			value={ value }
-			onValueChange={ handleValueChange }
-		>
-			<div className={ styles.tabList }>
-				<Tabs.List variant="minimal">
-					{ sections.map( section => (
-						<Tabs.Tab key={ section.id } value={ section.id }>
-							{ section.label }
-						</Tabs.Tab>
-					) ) }
-				</Tabs.List>
-			</div>
+		<Tabs.Root value={ value } onValueChange={ handleValueChange }>
+			<Tabs.List variant="minimal" className={ styles.tabList }>
+				{ sections.map( section => (
+					<Tabs.Tab key={ section.id } value={ section.id }>
+						{ section.label }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.List>
 			{ children }
 		</Tabs.Root>
 	);

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -54,13 +54,15 @@ export function DashboardSections( {
 
 	return (
 		<Tabs.Root value={ value } onValueChange={ handleValueChange }>
-			<Tabs.List variant="minimal" className={ styles.tabList }>
-				{ sections.map( section => (
-					<Tabs.Tab key={ section.id } value={ section.id }>
-						{ section.label }
-					</Tabs.Tab>
-				) ) }
-			</Tabs.List>
+			<div className={ styles.tabList }>
+				<Tabs.List variant="minimal">
+					{ sections.map( section => (
+						<Tabs.Tab key={ section.id } value={ section.id }>
+							{ section.label }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
+			</div>
 			{ children }
 		</Tabs.Root>
 	);

--- a/projects/packages/premium-analytics/routes/dashboard/components/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/index.ts
@@ -1,0 +1,4 @@
+export {
+	DashboardSections,
+	type DashboardSectionsProps,
+} from './dashboard-sections/dashboard-sections';

--- a/projects/packages/premium-analytics/routes/dashboard/components/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/index.ts
@@ -1,4 +1,1 @@
-export {
-	DashboardSections,
-	type DashboardSectionsProps,
-} from './dashboard-sections/dashboard-sections';
+export { DashboardSections } from './dashboard-sections/dashboard-sections';

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -1,0 +1,11 @@
+export {
+	DASHBOARD_SECTION_IDS,
+	DEFAULT_SECTION_ID,
+	getSectionLabel,
+	getDashboardSections,
+	resolveSectionId,
+	type DashboardSection,
+	type DashboardSectionId,
+} from './sections';
+
+export { isDashboardSectionLayouts, type DashboardSectionLayouts } from './section-layouts';

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { isDashboardSectionLayouts } from './section-layouts';
+
+describe( 'section layouts config', () => {
+	it( 'accepts a section-to-layout preference map', () => {
+		expect(
+			isDashboardSectionLayouts( {
+				traffic: [],
+				insights: [],
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects unknown section keys', () => {
+		expect(
+			isDashboardSectionLayouts( {
+				unknown: [],
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects non-array layouts', () => {
+		expect(
+			isDashboardSectionLayouts( {
+				traffic: {},
+			} )
+		).toBe( false );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
@@ -1,0 +1,23 @@
+import { DASHBOARD_SECTION_IDS } from './sections';
+import type { DashboardSectionId } from './sections';
+import type { DashboardWidget } from '@wordpress/widget-dashboard';
+
+export type DashboardSectionLayouts = Partial< Record< DashboardSectionId, DashboardWidget[] > >;
+
+const SECTION_IDS = new Set< string >( DASHBOARD_SECTION_IDS );
+
+/**
+ * Check whether a value can be used as the persisted section layout map.
+ *
+ * @param value - Candidate preference value.
+ * @return Whether the value is a valid section layout map.
+ */
+export function isDashboardSectionLayouts( value: unknown ): value is DashboardSectionLayouts {
+	if ( ! value || typeof value !== 'object' || Array.isArray( value ) ) {
+		return false;
+	}
+
+	return Object.entries( value ).every(
+		( [ sectionId, layout ] ) => SECTION_IDS.has( sectionId ) && Array.isArray( layout )
+	);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+import {
+	DASHBOARD_SECTION_IDS,
+	DEFAULT_SECTION_ID,
+	getDashboardSections,
+	resolveSectionId,
+} from './sections';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: jest.fn( ( text: string ) => text ),
+} ) );
+
+describe( 'dashboard sections', () => {
+	it( 'builds the ordered section definitions', () => {
+		expect( getDashboardSections() ).toEqual( [
+			{ id: 'traffic', label: 'Traffic' },
+			{ id: 'insights', label: 'Insights' },
+			{ id: 'subscribers', label: 'Subscribers' },
+			{ id: 'store', label: 'Store' },
+		] );
+
+		expect( __ ).toHaveBeenCalledWith( 'Traffic', 'jetpack-premium-analytics' );
+	} );
+
+	it( 'keeps the default section first', () => {
+		expect( DEFAULT_SECTION_ID ).toBe( 'traffic' );
+		expect( DASHBOARD_SECTION_IDS[ 0 ] ).toBe( DEFAULT_SECTION_ID );
+	} );
+
+	it( 'resolves unknown section search values to the default section', () => {
+		expect( resolveSectionId( 'insights' ) ).toBe( 'insights' );
+		expect( resolveSectionId( 'missing' ) ).toBe( DEFAULT_SECTION_ID );
+		expect( resolveSectionId( undefined ) ).toBe( DEFAULT_SECTION_ID );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -36,26 +36,30 @@ export type DashboardSection = {
 };
 
 /**
+ * Canonical section definitions with lazy label getters, in display order.
+ *
+ * Labels are defined once here, as getters resolved at call time, so translations
+ * are applied after the i18n locale data has loaded. Mirrors the datetime
+ * package's `PRESET_DEFINITIONS`.
+ */
+const SECTION_DEFINITIONS: ReadonlyArray< {
+	id: DashboardSectionId;
+	getLabel: () => string;
+} > = [
+	{ id: 'traffic', getLabel: () => __( 'Traffic', 'jetpack-premium-analytics' ) },
+	{ id: 'insights', getLabel: () => __( 'Insights', 'jetpack-premium-analytics' ) },
+	{ id: 'subscribers', getLabel: () => __( 'Subscribers', 'jetpack-premium-analytics' ) },
+	{ id: 'store', getLabel: () => __( 'Store', 'jetpack-premium-analytics' ) },
+];
+
+/**
  * Get the translated display label for a section.
  *
  * @param id - The section identifier.
  * @return Translated label for the section.
  */
 export function getSectionLabel( id: DashboardSectionId ): string {
-	switch ( id ) {
-		case 'traffic':
-			return __( 'Traffic', 'jetpack-premium-analytics' );
-		case 'insights':
-			return __( 'Insights', 'jetpack-premium-analytics' );
-		case 'subscribers':
-			return __( 'Subscribers', 'jetpack-premium-analytics' );
-		case 'store':
-			return __( 'Store', 'jetpack-premium-analytics' );
-		default: {
-			const exhaustiveCheck: never = id;
-			throw new Error( `Unknown section ID: ${ exhaustiveCheck }` );
-		}
-	}
+	return SECTION_DEFINITIONS.find( section => section.id === id )?.getLabel() ?? id;
 }
 
 /**
@@ -67,7 +71,7 @@ export function getSectionLabel( id: DashboardSectionId ): string {
  * @return Ordered list of section definitions.
  */
 export function getDashboardSections(): DashboardSection[] {
-	return DASHBOARD_SECTION_IDS.map( id => ( { id, label: getSectionLabel( id ) } ) );
+	return SECTION_DEFINITIONS.map( ( { id, getLabel } ) => ( { id, label: getLabel() } ) );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Ordered list of the dashboard section IDs.
+ *
+ * This is the single source of truth for which sections exist and in what order.
+ * Each section is surfaced as a tab and renders the customizable widget grid,
+ * so the IDs are kept stable and URL-friendly (they are persisted in the
+ * `?section=` search param).
+ */
+export const DASHBOARD_SECTION_IDS = [ 'traffic', 'insights', 'subscribers', 'store' ] as const;
+
+/**
+ * Dashboard section identifier.
+ * Derived from DASHBOARD_SECTION_IDS to keep the union in sync with the source list.
+ */
+export type DashboardSectionId = ( typeof DASHBOARD_SECTION_IDS )[ number ];
+
+/**
+ * Default section shown when the URL has no (or an unknown) `section` param.
+ */
+export const DEFAULT_SECTION_ID: DashboardSectionId = 'traffic';
+
+/**
+ * A dashboard section definition.
+ *
+ * For now a section is just an ID and a display label. This is the natural place
+ * to attach per-section metadata such as the default widget layout.
+ */
+export type DashboardSection = {
+	id: DashboardSectionId;
+	label: string;
+};
+
+/**
+ * Get the translated display label for a section.
+ *
+ * @param id - The section identifier.
+ * @return Translated label for the section.
+ */
+export function getSectionLabel( id: DashboardSectionId ): string {
+	switch ( id ) {
+		case 'traffic':
+			return __( 'Traffic', 'jetpack-premium-analytics' );
+		case 'insights':
+			return __( 'Insights', 'jetpack-premium-analytics' );
+		case 'subscribers':
+			return __( 'Subscribers', 'jetpack-premium-analytics' );
+		case 'store':
+			return __( 'Store', 'jetpack-premium-analytics' );
+		default: {
+			const exhaustiveCheck: never = id;
+			throw new Error( `Unknown section ID: ${ exhaustiveCheck }` );
+		}
+	}
+}
+
+/**
+ * Build the ordered list of section definitions ({ id, label }).
+ *
+ * Labels are resolved lazily (at call time) so translations are applied after
+ * the i18n locale data has loaded.
+ *
+ * @return Ordered list of section definitions.
+ */
+export function getDashboardSections(): DashboardSection[] {
+	return DASHBOARD_SECTION_IDS.map( id => ( { id, label: getSectionLabel( id ) } ) );
+}
+
+/**
+ * Narrow an arbitrary string to a known section ID, falling back to the default.
+ *
+ * @param value - The candidate section ID (e.g. from the URL).
+ * @return A valid section ID.
+ */
+export function resolveSectionId( value: string | undefined ): DashboardSectionId {
+	return value && ( DASHBOARD_SECTION_IDS as readonly string[] ).includes( value )
+		? ( value as DashboardSectionId )
+		: DEFAULT_SECTION_ID;
+}

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/index.ts
@@ -1,3 +1,7 @@
 export { DASHBOARD_NAME } from './constants';
-export { useDashboardLayout } from './use-dashboard-layout';
+export { useActiveSection } from './use-active-section';
 export { useDashboardGridSettings } from './use-dashboard-grid-settings';
+export { useDashboardLayout } from './use-dashboard-layout';
+export type { DashboardName } from './use-dashboard-layout';
+export { useDashboardSectionLayout } from './use-dashboard-section-layout';
+export { useDashboardSections } from './use-dashboard-sections';

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
@@ -7,11 +7,13 @@ import { useCallback } from 'react';
  * Internal dependencies
  */
 import { resolveSectionId, type DashboardSectionId } from '../config';
+import { route } from '../package.json';
 
 /**
- * The route path the dashboard is mounted on (see ./package.json `route.path`).
+ * Mirrors this route's `route.path` from package.json, so the staged-search
+ * `from` stays in sync if the mount path ever changes.
  */
-const ROUTE_FROM = '/';
+const ROUTE_FROM = route.path;
 
 type SectionSearch = {
 	section?: string;

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useStagedSearch } from '@jetpack-premium-analytics/routing';
+import { useCallback } from 'react';
+/**
+ * Internal dependencies
+ */
+import { resolveSectionId, type DashboardSectionId } from '../config';
+
+/**
+ * The route path the dashboard is mounted on (see ./package.json `route.path`).
+ */
+const ROUTE_FROM = '/';
+
+type SectionSearch = {
+	section?: string;
+};
+
+/**
+ * Read and update the active dashboard section via the `?section=` search param.
+ *
+ * Keeping the active section in the URL makes sections deep-linkable and gives the
+ * future Dashboard/widget integration a single, stable place to read the
+ * current section from. Built on the package's `useStagedSearch` so the section
+ * shares the same search-param model as the date filters; switching a section is an
+ * immediate stage + commit (one history entry per change).
+ *
+ * @return A tuple of the active section ID and a setter to change it.
+ */
+export function useActiveSection(): [ DashboardSectionId, ( id: DashboardSectionId ) => void ] {
+	const { effective, stage, commit } = useStagedSearch< SectionSearch, typeof ROUTE_FROM >( {
+		from: ROUTE_FROM,
+	} );
+
+	const activeSection = resolveSectionId( effective.section );
+
+	const setActiveSection = useCallback(
+		( id: DashboardSectionId ) => {
+			// Stage + atomic commit, pushing one history entry per section switch so
+			// Back/Forward moves between sections. See useStagedSearch README.
+			stage( { section: id } );
+			commit( { replace: false } );
+		},
+		[ stage, commit ]
+	);
+
+	return [ activeSection, setActiveSection ];
+}

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -1,0 +1,76 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useCallback, useMemo } from 'react';
+import { isDashboardSectionLayouts } from '../config';
+import { DASHBOARD_PREFERENCES_SCOPE, DASHBOARD_REST_NAMESPACE } from './constants';
+import { useDashboardLayout } from './use-dashboard-layout';
+import type { DashboardSectionId, DashboardSectionLayouts } from '../config';
+import type { DashboardName } from './use-dashboard-layout';
+import type { DashboardWidget } from '@wordpress/widget-dashboard';
+
+const PREFERENCES_KEY = 'dashboardSectionLayouts';
+const EMPTY_SECTION_LAYOUTS: DashboardSectionLayouts = {};
+
+type PreferencesActions = {
+	set: ( scope: string, key: string, value: DashboardSectionLayouts ) => Promise< void > | void;
+};
+
+/**
+ * Manage the customizable widget layout for the currently active dashboard section.
+ *
+ * The shared `useDashboardLayout` hook stores one dashboard-wide layout. This
+ * route layers a section map on top of that hook so each section can commit its
+ * own customized layout while still using the registered dashboard default as
+ * the initial/reset layout.
+ *
+ * @param dashboardName   - Dashboard registration name for fetching defaults.
+ * @param activeSectionId - Currently active section ID.
+ * @return Active section layout, setter, and reset action.
+ */
+export function useDashboardSectionLayout(
+	dashboardName: DashboardName,
+	activeSectionId: DashboardSectionId
+): [ DashboardWidget[], ( layout: DashboardWidget[] ) => void, () => Promise< void > ] {
+	const [ defaultLayout ] = useDashboardLayout( dashboardName );
+
+	const sectionLayouts = useSelect( select => {
+		const value = (
+			select( preferencesStore ) as unknown as {
+				get: ( scope: string, key: string ) => unknown;
+			}
+		 ).get( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY );
+
+		return isDashboardSectionLayouts( value ) ? value : EMPTY_SECTION_LAYOUTS;
+	}, [] );
+
+	const { set } = useDispatch( preferencesStore ) as unknown as PreferencesActions;
+
+	const layout = useMemo(
+		() => sectionLayouts[ activeSectionId ] ?? defaultLayout,
+		[ activeSectionId, defaultLayout, sectionLayouts ]
+	);
+
+	const setLayout = useCallback(
+		( nextLayout: DashboardWidget[] ) => {
+			void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+				...sectionLayouts,
+				[ activeSectionId ]: nextLayout,
+			} );
+		},
+		[ activeSectionId, sectionLayouts, set ]
+	);
+
+	const resetLayout = useCallback( async () => {
+		const fresh = ( await apiFetch( {
+			path: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ dashboardName }/default-layout`,
+		} ) ) as DashboardWidget[];
+
+		void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+			...sectionLayouts,
+			[ activeSectionId ]: fresh,
+		} );
+	}, [ activeSectionId, dashboardName, sectionLayouts, set ] );
+
+	return [ layout, setLayout, resetLayout ];
+}

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { getDashboardSections, type DashboardSection } from '../config';
+
+/**
+ * Get the ordered list of dashboard sections.
+ *
+ * Wraps the pure `getDashboardSections()` builder in `useMemo` so the section
+ * list (and its translated labels) is built once per mount instead of on every
+ * render. The section set is static, so an empty dependency array is correct.
+ *
+ * @return The ordered, memoized list of dashboard sections.
+ */
+export function useDashboardSections(): DashboardSection[] {
+	return useMemo( () => getDashboardSections(), [] );
+}

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -7,6 +7,7 @@
 	},
 	"dependencies": {
 		"@automattic/jetpack-script-data": "workspace:*",
+		"@jetpack-premium-analytics/routing": "workspace:*",
 		"@wordpress/admin-ui": "2.1.0",
 		"@wordpress/api-fetch": "7.46.0",
 		"@wordpress/core-data": "7.46.0",
@@ -15,8 +16,10 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/preferences": "4.46.0",
 		"@wordpress/route": "0.14.1",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/widget-dashboard": "next",
 		"@wordpress/widget-primitives": "next",
-		"fast-deep-equal": "^3.1.3"
+		"fast-deep-equal": "^3.1.3",
+		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -6,5 +6,8 @@
 	flex: 1 1 auto;
 	min-block-size: 0;
 	overflow-y: auto;
+	// Match the horizontal padding of the page header and the section tabs so the
+	// widget grid lines up with them instead of sitting flush to the edge.
 	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -1,0 +1,10 @@
+.dashboard {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+	padding-block-end: 24px;
+}

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,17 +1,20 @@
-/**
- * WordPress dependencies
- */
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Tabs } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
-/**
- * Internal dependencies
- */
-import { DASHBOARD_NAME, useDashboardLayout, useDashboardGridSettings } from './hooks';
+import { DashboardSections } from './components';
+import {
+	DASHBOARD_NAME,
+	useActiveSection,
+	useDashboardGridSettings,
+	useDashboardSectionLayout,
+	useDashboardSections,
+} from './hooks';
+import styles from './stage.module.scss';
 
 /**
  * Premium Analytics dashboard page stage component.
@@ -19,7 +22,12 @@ import { DASHBOARD_NAME, useDashboardLayout, useDashboardGridSettings } from './
  * @return {JSX.Element} The Premium Analytics dashboard.
  */
 function Dashboard(): JSX.Element {
-	const [ layout, setLayout, resetLayout ] = useDashboardLayout( DASHBOARD_NAME );
+	const sections = useDashboardSections();
+	const [ activeSection, setActiveSection ] = useActiveSection();
+	const [ layout, setLayout, resetLayout ] = useDashboardSectionLayout(
+		DASHBOARD_NAME,
+		activeSection
+	);
 	const [ gridSettings, setGridSettings ] = useDashboardGridSettings();
 
 	const widgetModules = useSelect(
@@ -42,19 +50,42 @@ function Dashboard(): JSX.Element {
 			isResolvingWidgetTypes={ isResolvingWidgetTypes }
 			layout={ layout }
 			onLayoutChange={ setLayout }
+			onLayoutReset={ resetLayout }
 			gridSettings={ gridSettings }
 			onGridSettingsChange={ setGridSettings }
 			editMode={ editMode }
 			onEditChange={ setEditMode }
-			onLayoutReset={ resetLayout }
 		>
 			<Page
 				title={ __( 'Analytics', 'jetpack-premium-analytics' ) }
+				subTitle={ __(
+					'Track your site performance and visitor insights.',
+					'jetpack-premium-analytics'
+				) }
 				actions={ <WidgetDashboard.Actions /> }
-				hasPadding
+				className={ styles.dashboard }
 			>
-				<WidgetDashboard.NoWidgetsState />
-				<WidgetDashboard.Widgets />
+				<DashboardSections
+					sections={ sections }
+					value={ activeSection }
+					onChange={ setActiveSection }
+				>
+					{ sections.map( section => (
+						<Tabs.Panel
+							key={ section.id }
+							value={ section.id }
+							focusable={ false }
+							className={ styles.content }
+						>
+							{ activeSection === section.id ? (
+								<>
+									<WidgetDashboard.NoWidgetsState />
+									<WidgetDashboard.Widgets />
+								</>
+							) : null }
+						</Tabs.Panel>
+					) ) }
+				</DashboardSections>
 
 				<WidgetDashboard.Commands />
 			</Page>

--- a/projects/packages/premium-analytics/widgets/hello-world/package.json
+++ b/projects/packages/premium-analytics/widgets/hello-world/package.json
@@ -7,5 +7,10 @@
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
 		"clsx": "^2.1.1"
+	},
+	"devDependencies": {
+		"@wordpress/element": "6.46.0",
+		"@wordpress/widget-dashboard": "next",
+		"@wordpress/widget-primitives": "next"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -1,0 +1,184 @@
+import { useState } from '@wordpress/element';
+import { Tabs } from '@wordpress/ui';
+import { WidgetDashboard, type DashboardWidget } from '@wordpress/widget-dashboard';
+import { DashboardSections } from '../../../routes/dashboard/components';
+import { DEFAULT_SECTION_ID, getDashboardSections } from '../../../routes/dashboard/config';
+import styles from '../../../routes/dashboard/stage.module.scss';
+import type { Meta, StoryObj } from '@storybook/react';
+import type {
+	ResolveWidgetModule,
+	WidgetRenderProps,
+	WidgetType,
+} from '@wordpress/widget-primitives';
+
+type StoryWidgetAttributes = {
+	title: string;
+};
+
+const widgetTypes: WidgetType< StoryWidgetAttributes >[] = [
+	{
+		apiVersion: 1,
+		name: 'jpa/story-widget',
+		title: 'Story widget',
+		renderModule: 'jpa/story-widget',
+	},
+];
+
+const initialLayout: DashboardWidget[] = [
+	{
+		uuid: 'traffic-overview',
+		type: 'jpa/story-widget',
+		attributes: { title: 'Traffic overview' },
+		placement: {
+			width: 2,
+			height: 1,
+			order: 0,
+		},
+	},
+	{
+		uuid: 'visitor-insights',
+		type: 'jpa/story-widget',
+		attributes: { title: 'Visitor insights' },
+		placement: {
+			width: 2,
+			height: 1,
+			order: 1,
+		},
+	},
+	{
+		uuid: 'customizable-widget-grid',
+		type: 'jpa/story-widget',
+		attributes: { title: 'Customizable widget grid' },
+		placement: {
+			width: 'full',
+			height: 1,
+			order: 2,
+		},
+	},
+];
+
+/**
+ * Story-only widget renderer.
+ *
+ * @param props            - Widget render props.
+ * @param props.attributes - Story widget attributes.
+ * @return Rendered story widget.
+ */
+function StoryWidget( { attributes }: WidgetRenderProps< StoryWidgetAttributes > ) {
+	return (
+		<div
+			style={ {
+				alignItems: 'center',
+				background: '#f6f7f7',
+				blockSize: '100%',
+				color: '#1e1e1e',
+				display: 'flex',
+				fontSize: '24px',
+				fontWeight: 600,
+				justifyContent: 'center',
+				minBlockSize: '180px',
+				padding: '24px',
+				textAlign: 'center',
+			} }
+		>
+			{ attributes.title }
+		</div>
+	);
+}
+
+const resolveWidgetModule: ResolveWidgetModule = moduleId =>
+	moduleId === 'jpa/story-widget'
+		? Promise.resolve( { default: StoryWidget } )
+		: Promise.reject( new Error( `Unknown story widget module: ${ moduleId }` ) );
+
+/**
+ * Story showing the dashboard section panel scroll surface around a widget grid.
+ *
+ * @return Story component.
+ */
+function DashboardSectionsGridStory() {
+	const sections = getDashboardSections();
+	const [ activeSection, setActiveSection ] = useState( DEFAULT_SECTION_ID );
+	const [ layout, setLayout ] = useState< DashboardWidget[] >( initialLayout );
+
+	return (
+		<section
+			className={ styles.dashboard }
+			style={ {
+				blockSize: '100%',
+				boxSizing: 'border-box',
+				display: 'flex',
+				flexDirection: 'column',
+				padding: '24px',
+			} }
+		>
+			<header
+				style={ {
+					flex: '0 0 auto',
+					marginBlockEnd: '24px',
+				} }
+			>
+				<h1 style={ { fontSize: '32px', lineHeight: 1.2, margin: 0 } }>Analytics</h1>
+				<p style={ { color: '#50575e', margin: '8px 0 0' } }>
+					Track your site performance and visitor insights.
+				</p>
+			</header>
+
+			<DashboardSections
+				sections={ sections }
+				value={ activeSection }
+				onChange={ setActiveSection }
+			>
+				{ sections.map( section => (
+					<Tabs.Panel
+						key={ section.id }
+						value={ section.id }
+						focusable={ false }
+						className={ styles.content }
+					>
+						{ activeSection === section.id ? (
+							<WidgetDashboard
+								widgetTypes={ widgetTypes }
+								layout={ layout }
+								onLayoutChange={ setLayout }
+								resolveWidgetModule={ resolveWidgetModule }
+								editMode
+							>
+								<WidgetDashboard.NoWidgetsState />
+								<WidgetDashboard.Widgets />
+							</WidgetDashboard>
+						) : null }
+					</Tabs.Panel>
+				) ) }
+			</DashboardSections>
+		</section>
+	);
+}
+
+const meta: Meta< typeof DashboardSectionsGridStory > = {
+	title: 'Packages/Premium Analytics/Routes/Dashboard/SectionsGrid',
+	component: DashboardSectionsGridStory,
+	decorators: [
+		Story => (
+			<div
+				style={ {
+					blockSize: '720px',
+					display: 'flex',
+					flexDirection: 'column',
+					inlineSize: '100%',
+				} }
+			>
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof DashboardSectionsGridStory >;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Proposed changes

Builds out the Premium Analytics dashboard shell (no data wired up yet):

* The tabs are done similar to how Gutenbergs Fonts page works, and I mimicked our tabs component structure based on what we had done in `woocommerce-analytics`.
* Render the dashboard as a full-page SPA inside the `@wordpress/admin-ui` `Page` component (title, subtitle, padding) instead of hand-rolled header markup.
* Add a `DashboardSections` tab bar with four sections — **Traffic, Insights, Subscribers, Store**. Selecting a section updates the `?section=` URL param so sections are deep-linkable (Back/Forward navigates between them). 
* Build the section list through a memoized `useDashboardSections` hook rather than mapping during render.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch and build the package with Node 24 (the repo requires `^24.15.0`):
  ```
  cd projects/packages/premium-analytics && nvm use 24 && pnpm install && pnpm run build
  ```
* Activate the Premium Analytics plugin
* Visit `wp-admin` → `admin.php?page=jetpack-premium-analytics`.
* Confirm the **Analytics** page renders with four tabs: Traffic, Insights, Subscribers, Store.
* Click each tab and confirm the `?section=` URL param updates and survives Back/Forward. Tab content is intentionally empty for now.

### Screenshot

<img width="1427" height="610" alt="Screenshot 2026-06-23 at 14 54 26" src="https://github.com/user-attachments/assets/775196d9-e9e1-48c1-a643-dbb120aa6a05" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
