### PR TITLE
Threads preview: don't append post URL to caption

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
@@ -232,10 +232,6 @@ export function PostPreview( { connection, previewData }: PostPreviewProps ) {
 				caption = getCombinedText( title, excerpt );
 			}
 
-			if ( url && ! caption.includes( url ) ) {
-				caption += `\n\n${ url }`;
-			}
-
 			return (
 				<ThreadsPostPreview
 					{ ...commonProps }

--- a/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
+++ b/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Threads preview: stop appending the post URL to the caption so the preview matches what is actually shared


### PR DESCRIPTION
Related to SOCIAL-501

## Proposed changes

* The Threads preview force-appended the post URL to the caption whenever it wasn't already present. URL placement in the actual share is driven by the message template, so the preview displayed a URL that never appeared in the published Threads post.
* Remove the forced URL append from the Threads case so the preview reflects what is actually shared.

A related wpcom change adds support to link preview card - 223942-ghe-Automattic/wpcom

## Related product discussion/links

* SOCIAL-501
* SOCIAL-512

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a Threads account in Jetpack Social.
* Open the post editor and the Social preview for Threads, using the default template (or no custom message).
* Confirm the preview caption no longer shows a trailing URL that the published share doesn't include — the preview now matches the actual Threads post.

| Before | After |
| --- | --- |
|<img width="594" height="545" alt="Screenshot 2026-06-18 at 4 11 10 PM" src="https://github.com/user-attachments/assets/f6495e50-258e-472f-9f0a-b947a84ccc0a" />|<img width="592" height="502" alt="Screenshot 2026-06-18 at 4 10 49 PM" src="https://github.com/user-attachments/assets/28966f1d-64ea-44b4-833f-00602e572c3d" />|