### PR TITLE
Blocks: Fix Google Docs embed icon colors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-JETPACK-1738-block-icon-color-inconsistencies
+++ b/projects/plugins/jetpack/changelog/fix-JETPACK-1738-block-icon-color-inconsistencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blocks: Fix Google Docs embed icon colors in the editor.

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -8,7 +8,7 @@
 	"version": "12.5.0",
 	"textdomain": "jetpack",
 	"category": "embed",
-	"icon": "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
+	"icon": "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z M42,0l22,22H42V0z M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"anchor": true

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/variations.js
@@ -7,7 +7,7 @@ const variations = [
 		isDefault: true,
 		title: __( 'Google Docs', 'jetpack' ),
 		description: __( 'Embed a Google Document.', 'jetpack' ),
-		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z M42,0l22,22H42V0z M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
 		keywords: [ __( 'document', 'jetpack' ), __( 'gsuite', 'jetpack' ), __( 'doc', 'jetpack' ) ],
 		attributes: { variation: 'jetpack/google-docs' },
 		isActive: [ 'variation' ],
@@ -17,7 +17,7 @@ const variations = [
 		isDefault: true,
 		title: __( 'Google Sheets', 'jetpack' ),
 		description: __( 'Embed a Google Sheet.', 'jetpack' ),
-		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M17,39.5h12.5V46H17V39.5z M17,51h12.5v6.5H17V51z M47,57.5H34.5V51H47V57.5z M47,46 H34.5v-6.5H47V46z' /></svg>",
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z M42,0l22,22H42V0z M12,34.5v28h40v-28H12z M17,39.5h12.5V46H17V39.5z M17,51h12.5v6.5H17V51z M47,57.5H34.5V51H47V57.5z M47,46 H34.5v-6.5H47V46z' /></svg>",
 		keywords: [ __( 'sheet', 'jetpack' ), __( 'spreadsheet', 'jetpack' ) ],
 		attributes: { variation: 'jetpack/google-sheets' },
 		isActive: [ 'variation' ],
@@ -27,7 +27,7 @@ const variations = [
 		isDefault: true,
 		title: __( 'Google Slides', 'jetpack' ),
 		description: __( 'Embed a Google Slides presentation.', 'jetpack' ),
-		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M47,57.5H17v-18h30V57.5z' /></svg>",
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z M42,0l22,22H42V0z M12,34.5v28h40v-28H12z M47,57.5H17v-18h30V57.5z' /></svg>",
 
 		keywords: [
 			__( 'slide', 'jetpack' ),


### PR DESCRIPTION
Fixes JETPACK-1738

## Proposed changes
* Preserve the original Google Docs embed block and variation icon geometry.
* Convert the hard-coded white detail fills into SVG cutouts so the Google Docs, Sheets, and Slides inserter icons inherit the editor default icon color.
* Add a Jetpack changelog entry.

## Related product discussion/links
* JETPACK-1738

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Confirm the Google Docs embed block icon and its Google Docs, Google Sheets, and Google Slides variations preserve their original glyph shape while rendering with the default editor icon color.
* Confirm no hard-coded block icon fill/stroke colors remain in the Google Docs embed metadata.
* Confirm `git diff --check` passes.
* Screenshot below was captured from the local WordPress block editor with Jetpack Blocks active and beta blocks enabled. It includes the selected Google Docs block UI and the Docs/Sheets/Slides inserter variations; before panels use the old SVGs, after panels use this branch.

![Before and after for the Google Docs embed block icon and variation icons in the WordPress block editor](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/fix/JETPACK-1738-block-icon-color-inconsistencies/JETPACK-1738-google-docs-icons-editor-before-after.png?v=editor-before-after)
