### PR TITLE
Social previews: Remove the misleading URL from captions when it is not a part of it.

### DIFF
--- a/projects/js-packages/social-previews/changelog/fix-social-preview-url-display-mismatch
+++ b/projects/js-packages/social-previews/changelog/fix-social-preview-url-display-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use the caption/custom text as the source of truth for Bluesky, Facebook, Instagram, Mastodon and Nextdoor previews instead of appending the post URL, so they match what is actually shared

--- a/projects/js-packages/social-previews/changelog/fix-social-preview-url-display-mismatch
+++ b/projects/js-packages/social-previews/changelog/fix-social-preview-url-display-mismatch
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Use the caption/custom text as the source of truth for Bluesky, Facebook, Instagram, Mastodon and Nextdoor previews instead of appending the post URL, so they match what is actually shared
+Use the caption/custom text as the source of truth for Bluesky, Facebook, Instagram, Mastodon and Nextdoor previews instead of appending the post URL.

--- a/projects/js-packages/social-previews/src/bluesky-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/bluesky-preview/post-preview.tsx
@@ -9,14 +9,14 @@ import type { BlueskyPreviewProps } from './types';
 import './styles.scss';
 
 export const BlueskyPostPreview: React.FC< BlueskyPreviewProps > = props => {
-	const { user, media, appendUrl } = props;
+	const { user, media } = props;
 
 	return (
 		<div className="bluesky-preview__post">
 			<BlueskyPostSidebar user={ user } />
 			<div>
 				<BlueskyPostHeader user={ user } />
-				<BlueskyPostBody { ...props } appendUrl={ appendUrl ?? Boolean( media?.length ) }>
+				<BlueskyPostBody { ...props }>
 					{ media?.length ? (
 						<div className={ clsx( 'bluesky-preview__media', { 'as-grid': media.length > 1 } ) }>
 							{ media.map( ( mediaItem, index ) => (

--- a/projects/js-packages/social-previews/src/facebook-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/facebook-preview/post-preview.tsx
@@ -21,7 +21,7 @@ export const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
 		<div className="facebook-preview__post">
 			<FacebookPostHeader user={ user } />
 			<div className="facebook-preview__content">
-				{ customText && <CustomText text={ customText } url={ url } forceUrlDisplay /> }
+				{ customText && <CustomText text={ customText } url={ url } /> }
 				<div className="facebook-preview__body">
 					{ media ? (
 						<div className={ `facebook-preview__media ${ modeClass }` }>

--- a/projects/js-packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -24,7 +24,6 @@ export function InstagramPostPreview( {
 	name,
 	profileImage,
 	caption,
-	url,
 }: InstagramPreviewProps ) {
 	const username = name || 'username';
 
@@ -83,13 +82,6 @@ export function InstagramPostPreview( {
 										} )
 									}
 								</ExpandableText>
-								{ media && url && ! caption.includes( url ) && (
-									<>
-										<br />
-										<br />
-										{ url }
-									</>
-								) }
 							</div>
 						) : null }
 					</div>

--- a/projects/js-packages/social-previews/src/mastodon-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post-preview.tsx
@@ -33,7 +33,9 @@ export const MastodonPostPreview: React.FC< MastodonPreviewProps > = props => {
 					</div>
 				) : null }
 			</MastonPostBody>
-			{ ! media?.length ? <MastodonPostCard { ...props } /> : null }
+			{ ! media?.length && props.customText?.includes( props.url ) ? (
+				<MastodonPostCard { ...props } />
+			) : null }
 			<MastodonPostActions />
 		</div>
 	);

--- a/projects/js-packages/social-previews/src/nextdoor-preview/post-preview.tsx
+++ b/projects/js-packages/social-previews/src/nextdoor-preview/post-preview.tsx
@@ -69,15 +69,6 @@ export function NextdoorPostPreview( {
 										}
 									</ExpandableText>
 								</span>
-								{ ! hasMedia && url && ! description.includes( url ) && (
-									<>
-										<br />
-										<br />
-										<a href={ url } rel="nofollow noopener noreferrer" target="_blank">
-											{ url }
-										</a>
-									</>
-								) }
 							</div>
 						) : null }
 						{ hasMedia ? (

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/post-preview.tsx
@@ -232,10 +232,6 @@ export function PostPreview( { connection, previewData }: PostPreviewProps ) {
 				caption = getCombinedText( title, excerpt );
 			}
 
-			if ( url && ! caption.includes( url ) ) {
-				caption += `\n\n${ url }`;
-			}
-
 			return (
 				<ThreadsPostPreview
 					{ ...commonProps }

--- a/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
+++ b/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Threads preview: stop appending the post URL to the caption so the preview matches what is actually shared

--- a/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
+++ b/projects/packages/publicize/changelog/fix-social-501-threads-preview-url-mismatch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Threads preview: stop appending the post URL to the caption so the preview matches what is actually shared

--- a/projects/packages/publicize/changelog/fix-social-preview-url-display-mismatch
+++ b/projects/packages/publicize/changelog/fix-social-preview-url-display-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social previews: use the caption/custom text as the source of truth instead of appending the post URL, so the preview matches what is actually shared

--- a/projects/packages/publicize/changelog/fix-social-preview-url-display-mismatch
+++ b/projects/packages/publicize/changelog/fix-social-preview-url-display-mismatch
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Social previews: use the caption/custom text as the source of truth instead of appending the post URL, so the preview matches what is actually shared
+Social previews: Remove the misleading URL from captions when it is not a part of it.


### PR DESCRIPTION
Related to SOCIAL-501

## Proposed changes

The social previews synthesized a post URL and appended it to the caption when it wasn't already present. URL placement in the actual share is driven by the message template, so the previews displayed a URL that never appeared in the published post — misleading users about what would be shared.

This makes the caption/custom text the source of truth for the preview across networks, dropping the forced URL append/display:

* **Threads** (publicize preview) — remove the forced URL append from the caption.
* **Bluesky** — stop defaulting `appendUrl` based on media.
* **Facebook** — drop `forceUrlDisplay` on the custom text.
* **Instagram** — remove the appended URL block.
* **Nextdoor** — remove the appended URL link.
* **Mastodon** — only render the link-preview card when the URL is present in the custom text.

A related wpcom change adds support to Threads link preview card - 223942-ghe-Automattic/wpcom

## Related product discussion/links

* SOCIAL-501
* SOCIAL-512

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect one or more social accounts (Threads, Bluesky, Facebook, Instagram, Mastodon, Nextdoor) in Jetpack Social.
* Open the post editor and the Social preview, using the default template (or no custom message) so the URL is not part of the caption/custom text.
* Confirm the preview no longer shows a trailing URL that the published share doesn't include — the preview now matches the actual post.
* Add the URL to the custom message and confirm it still renders in the preview.

| Before | After |
| --- | --- |
|<img width="594" height="545" alt="Screenshot 2026-06-18 at 4 11 10 PM" src="https://github.com/user-attachments/assets/f6495e50-258e-472f-9f0a-b947a84ccc0a" />|<img width="592" height="502" alt="Screenshot 2026-06-18 at 4 10 49 PM" src="https://github.com/user-attachments/assets/28966f1d-64ea-44b4-833f-00602e572c3d" />|