### PR TITLE
Podcast: gate self-hosted loading behind jetpack_podcast_for_the_world filter

### DIFF
--- a/projects/packages/podcast/changelog/podcast-self-hosted-feature-filter
+++ b/projects/packages/podcast/changelog/podcast-self-hosted-feature-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Podcast: allow the package to load on self-hosted Jetpack sites behind the default-off `jetpack_podcast_for_the_world` filter.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -29,7 +29,8 @@ class Podcast {
 	/**
 	 * Initialize the package.
 	 *
-	 * Bails on hosts other than Simple and Atomic.
+	 * Always loads on Simple and WoA. On self-hosted Jetpack it stays dormant
+	 * unless opted in via the `jetpack_podcast_for_the_world` filter.
 	 */
 	public static function init() {
 		if ( self::$initialized ) {
@@ -38,7 +39,17 @@ class Podcast {
 		self::$initialized = true;
 
 		$host = new Host();
-		if ( ! $host->is_wpcom_simple() && ! $host->is_woa_site() ) {
+
+		/**
+		 * Allow the Podcast package to load on self-hosted Jetpack sites.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $enabled Whether to load the package on self-hosted. Default false.
+		 */
+		$for_the_world = (bool) apply_filters( 'jetpack_podcast_for_the_world', false );
+
+		if ( ! $host->is_wpcom_simple() && ! $host->is_woa_site() && ! $for_the_world ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes PODS-167

## Proposed changes

Lets the Podcast package load on self-hosted Jetpack sites, gated behind the new default-off `jetpack_podcast_for_the_world` filter. No behavior change on WordPress.com Simple/WoA.

_This filter is not active anywhere yet AND the package is not loading in Jetpack plugin yet._

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

Smoke check and look at the code.