### PR TITLE
Sync: Exclude Beaver Builder history postmeta

### DIFF
--- a/projects/packages/sync/changelog/prevent-beaver-builder-history-postmeta-sync
+++ b/projects/packages/sync/changelog/prevent-beaver-builder-history-postmeta-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Prevent Beaver Builder undo history post meta from syncing.

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules\Search;
 use Automattic\Jetpack\Sync\Queue\Queue_Storage_Table;
 
 /**
@@ -186,6 +187,10 @@ class Settings {
 			} else {
 				$value = $default_array_value;
 			}
+		}
+
+		if ( 'post_meta_whitelist' === $setting ) {
+			$value = Search::remove_postmeta_denylist( $value );
 		}
 
 		return $value;

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -49,6 +49,7 @@ class Search extends Module {
 	public function __construct() {
 		// Post meta whitelists.
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_search_post_meta_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_post_meta_whitelist', array( __CLASS__, 'remove_postmeta_denylist' ), PHP_INT_MAX );
 		// Add options
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_search_options_whitelist' ), 10 );
 		// AI Answers CPTs and post meta (gated by feature flag).
@@ -450,6 +451,17 @@ class Search extends Module {
 		'wccom_product_compatibility'                => array( 'searchable_in_all_content' => true ),
 
 	); // end indexed post meta.
+
+	/**
+	 * Postmeta that should never be synced.
+	 *
+	 * @static
+	 * @access private
+	 * @var array
+	 */
+	private static $postmeta_denylist = array(
+		'_fl_builder_history_state_0', // Beaver Builder undo history.
+	);
 
 	/**
 	 * Postmeta being considered for indexing
@@ -1804,6 +1816,20 @@ class Search extends Module {
 	 */
 	public function add_search_post_meta_whitelist( $list ) {
 		return array_merge( $list, static::get_all_postmeta_keys() );
+	}
+
+	/**
+	 * Remove denied post meta from the post meta whitelist.
+	 *
+	 * @param array|mixed $list Existing post meta whitelist.
+	 * @return array|mixed Updated post meta whitelist.
+	 */
+	public static function remove_postmeta_denylist( $list ) {
+		if ( ! is_array( $list ) ) {
+			return $list;
+		}
+
+		return array_values( array_diff( $list, self::$postmeta_denylist ) );
 	}
 
 	/**

--- a/projects/packages/sync/tests/php/Settings_Test.php
+++ b/projects/packages/sync/tests/php/Settings_Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Test file for Automattic\Jetpack\Sync\Settings
+ *
+ * @package automattic/jetpack-sync
+ */
+
+namespace Automattic\Jetpack\Sync;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Settings_Test
+ *
+ * @covers Automattic\Jetpack\Sync\Settings
+ */
+#[CoversClass( Settings::class )]
+class Settings_Test extends BaseTestCase {
+
+	/**
+	 * Runs after every test in this class.
+	 */
+	protected function tearDown(): void {
+		delete_option( 'jetpack_sync_settings_post_meta_whitelist' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Denied post meta should be excluded from the sync post meta whitelist setting.
+	 */
+	public function test_denied_post_meta_removed_from_post_meta_whitelist_setting() {
+		update_option( 'jetpack_sync_settings_post_meta_whitelist', array( '_fl_builder_history_state_0', 'allowed_custom_meta' ), true );
+
+		$list = Settings::get_setting( 'post_meta_whitelist' );
+
+		$this->assertNotContains( '_fl_builder_history_state_0', $list );
+		$this->assertContains( 'allowed_custom_meta', $list );
+	}
+}

--- a/projects/packages/sync/tests/php/modules/Search_Module_Test.php
+++ b/projects/packages/sync/tests/php/modules/Search_Module_Test.php
@@ -38,7 +38,23 @@ class Search_Module_Test extends BaseTestCase {
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+		remove_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_denied_post_meta' ), 20 );
+		remove_filter( 'jetpack_sync_post_meta_whitelist', array( $this->search_module, 'add_search_post_meta_whitelist' ), 10 );
+		remove_filter( 'jetpack_sync_post_meta_whitelist', array( Modules\Search::class, 'remove_postmeta_denylist' ), PHP_INT_MAX );
+		remove_filter( 'jetpack_sync_options_whitelist', array( $this->search_module, 'add_search_options_whitelist' ), 10 );
+		remove_filter( 'jetpack_sync_post_types_whitelist', array( $this->search_module, 'add_ai_answer_post_types' ), 10 );
 		parent::tearDown();
+	}
+
+	/**
+	 * Denied post meta should be removed from filtered whitelist values.
+	 */
+	public function test_denied_search_post_meta_removed_from_whitelist() {
+		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_denied_post_meta' ), 20 );
+
+		$list = apply_filters( 'jetpack_sync_post_meta_whitelist', array() );
+
+		$this->assertNotContains( '_fl_builder_history_state_0', $list );
 	}
 
 	/**
@@ -70,5 +86,16 @@ class Search_Module_Test extends BaseTestCase {
 		delete_option( 'jetpack_search_ai_answers_enabled' );
 		$this->assertContains( 'wp_guideline', $list );
 		$this->assertNotContains( 'jetpack_search_topic', $list );
+	}
+
+	/**
+	 * Adds denied post meta to the post meta whitelist.
+	 *
+	 * @param array $list Post meta whitelist.
+	 * @return array Updated post meta whitelist.
+	 */
+	public function add_denied_post_meta( $list ) {
+		$list[] = '_fl_builder_history_state_0';
+		return $list;
 	}
 }


### PR DESCRIPTION
In debugging failed Elasticsearch indexing jobs for Jetpack Search, I ran into out of memory issues. In the case of one site, there was a single post with over 300MB of post meta. I traced this down to several hundred rows of `_fl_builder_history_state_0`, which is used by the beaverbuilder page maker plugin as an undo history. Each row stores the entire page builder information, so it can easily become quite large. I can think of no reason why we would actually need to sync this. It is not in the standard allowlist, but it can be overridden in the whitelist by the site. It seems that the beaverbuilder plugin is probably doing this. 

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add `_fl_builder_history_state_0` to a Sync postmeta denylist.
* Strip denylisted postmeta from the authoritative Sync `post_meta_whitelist` setting so it is excluded from both incremental postmeta sync and full-sync metadata queries, even if a remote whitelist setting includes it.
* Keep the Search postmeta whitelist filter from re-adding denylisted postmeta.
* Add regressions for stored Sync settings and filtered Search postmeta whitelist values.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. This intentionally stops syncing Beaver Builder undo-history postmeta (`_fl_builder_history_state_0`).

The field stores page-builder history state, not content needed by Jetpack Sync or Search. On some posts this meta value can grow to 100MB+, which makes Sync payloads much larger than necessary and can contribute to memory pressure, including OOMs during Elasticsearch indexing after the data reaches WordPress.com.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 jetpack test php packages/sync -v`.
* Confirm the package PHP test suite passes.
* Review `Settings_Test::test_denied_post_meta_removed_from_post_meta_whitelist_setting` to confirm `_fl_builder_history_state_0` is removed from the Sync postmeta whitelist setting while other custom whitelist values remain.
