### PR TITLE
Agents Manager: only dequeue Help Center in block editor when unified experience is active

### DIFF
--- a/projects/packages/agents-manager/AGENTS.md
+++ b/projects/packages/agents-manager/AGENTS.md
@@ -4,6 +4,13 @@ Backend for the Agents Manager. Handles script enqueueing, feature gating, and U
 
 The frontend code lives in the Calypso repo (`packages/agents-manager/` and `apps/agents-manager/`). This feature only handles loading those bundles and backend concerns.
 
+## Concepts
+
+- **Unified experience** = the **Help Center takeover**. When active, Agents Manager replaces the Help Center UI, unifying Odie and Dolly (the orchestrator) into a single chat experience. Gated by `agents_manager_use_unified_experience`; read everywhere via the `is_unified_experience()` helper. This is the *only* mode in which Help Center is dequeued.
+- **Block-editor-only mode** = Agents Manager replaces Big Sky's *native* block-editor UI, but does **not** take over the Help Center. Gated by `agents_manager_enabled_in_block_editor` (hooked by Big Sky, e.g. via `?flags=unified-big-sky`). Help Center must stay available here — do not dequeue it.
+
+These two are independent: block-editor enablement does not imply the unified experience. They were briefly conflated (the dequeue keyed on "are we in Gutenberg?") until the block-editor filter was split out in #47277; see AI-1013.
+
 ## Cross-Repo Relationship
 
 - All JS/CSS bundles are fetched from `widgets.wp.com/agents-manager/`, built by the Calypso `apps/agents-manager/` app.
@@ -17,13 +24,13 @@ These filters control behavior and are used by other plugins (like Big Sky) to i
 | Filter | Purpose | Default |
 |--------|---------|---------|
 | `agents_manager_agent_providers` | Register extension provider module URLs | `[]` |
-| `agents_manager_use_unified_experience` | Enable unified experience UI | `false` |
+| `agents_manager_use_unified_experience` | Enable the unified experience (Help Center takeover; see Concepts). Read via `is_unified_experience()` | `false` |
 | `agents_manager_enabled_in_ciab` | Enable/disable in CIAB | `true` |
-| `agents_manager_enabled_in_block_editor` | Enable/disable in block editor | `false` |
+| `agents_manager_enabled_in_block_editor` | Enable in the block editor without the Help Center takeover (block-editor-only mode; see Concepts) | `false` |
 | `jetpack_ai_sidebar_agents_manager_data` | Add host-specific data to `agentsManagerData` | `current inline data` |
 
 ## Pitfalls
 
-- **Enqueue priority matters**: Scripts enqueue at priority 101 (after Help Center at 100) so the Agents Manager can dequeue Help Center. Changing priority breaks this.
+- **Enqueue priority matters**: Scripts enqueue at priority 101 (after Help Center at 100) so the Agents Manager can dequeue Help Center. Changing priority breaks this. Note the dequeue only runs in the unified experience (see Concepts) — block-editor-only mode leaves Help Center alone.
 - **Feature gating is multi-layered**: `is_enabled()` checks CIAB, unified experience, and block editor filters in order. The first match wins. This is not a simple on/off.
 - **Router history cleanup**: The `calypso_preferences_update` filter silently limits history to 50 entries. If debugging missing history state, check this.

--- a/projects/packages/agents-manager/changelog/fix-help-center-dequeue-block-editor-only
+++ b/projects/packages/agents-manager/changelog/fix-help-center-dequeue-block-editor-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only dequeue Help Center in the block editor when the full unified experience is active, so Help Center stays available in block-editor-only mode (e.g. ?flags=unified-big-sky)

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -56,7 +56,7 @@ class Agents_Manager {
 	 * @return bool True if the menu panel should be displayed.
 	 */
 	public function should_display_menu_panel() {
-		return apply_filters( 'agents_manager_use_unified_experience', false );
+		return self::is_unified_experience();
 	}
 
 	/**
@@ -203,7 +203,7 @@ class Agents_Manager {
 		// In block-editor-only mode (e.g. ?flags=unified-big-sky) Agents Manager replaces
 		// Big Sky's native UI and Help Center should remain available.
 		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
-		if ( $is_gutenberg && apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+		if ( $is_gutenberg && self::is_unified_experience() ) {
 			wp_dequeue_script( 'help-center' );
 			wp_dequeue_style( 'help-center-style' );
 		}
@@ -257,7 +257,7 @@ class Agents_Manager {
 			}
 
 			// Standalone AI chat button, shown only in the unified experience.
-			if ( ! $use_disconnected && apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+			if ( ! $use_disconnected && self::is_unified_experience() ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}
@@ -273,15 +273,7 @@ class Agents_Manager {
 		 */
 		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
 
-		/**
-		 * Filter to determine if user should see the unified chat experience.
-		 *
-		 * When true, Help Center will render UnifiedAIAgent instead of traditional UI.
-		 * The filter is hooked by should_use_unified_experience() in this class.
-		 *
-		 * @param bool $use_unified_experience Whether to use unified experience. Default false.
-		 */
-		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
+		$use_unified_experience = self::is_unified_experience();
 
 		/**
 		 * Filter the default agent ID for the Agents Manager.
@@ -390,6 +382,28 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Whether the unified experience — the Help Center takeover — is active.
+	 *
+	 * "Unified" here means Agents Manager takes over the Help Center, unifying Odie and
+	 * Dolly (the orchestrator) into a single chat experience. This is distinct from
+	 * block-editor-only enablement, which replaces Big Sky's native UI without taking
+	 * over the Help Center.
+	 *
+	 * @return bool
+	 */
+	public static function is_unified_experience() {
+		/**
+		 * Filter to determine if the user should see the unified chat experience.
+		 *
+		 * When true, Help Center will render UnifiedAIAgent instead of traditional UI.
+		 * The filter is hooked by should_use_unified_experience() in this class.
+		 *
+		 * @param bool $use_unified_experience Whether to use unified experience. Default false.
+		 */
+		return (bool) apply_filters( 'agents_manager_use_unified_experience', false );
+	}
+
+	/**
 	 * Returns true if the Agents Manager should be loaded in the current context.
 	 *
 	 * @return bool
@@ -407,7 +421,7 @@ class Agents_Manager {
 		}
 
 		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
-		if ( apply_filters( 'agents_manager_use_unified_experience', false ) ) {
+		if ( self::is_unified_experience() ) {
 			return true;
 		}
 

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -198,9 +198,12 @@ class Agents_Manager {
 		$use_disconnected = str_contains( $variant, 'disconnected' );
 		$is_gutenberg     = $this->is_block_editor();
 
-		// In Gutenberg, dequeue Help Center so we don't end up with two buttons.
+		// In Gutenberg, dequeue Help Center so we don't end up with two buttons — but only
+		// in the full unified experience, where Agents Manager takes over the Help Center.
+		// In block-editor-only mode (e.g. ?flags=unified-big-sky) Agents Manager replaces
+		// Big Sky's native UI and Help Center should remain available.
 		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
-		if ( $is_gutenberg ) {
+		if ( $is_gutenberg && apply_filters( 'agents_manager_use_unified_experience', false ) ) {
 			wp_dequeue_script( 'help-center' );
 			wp_dequeue_style( 'help-center-style' );
 		}

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -520,6 +520,79 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that Help Center is dequeued in the block editor when the unified experience
+	 * (Help Center takeover) is active — Agents Manager becomes the single help affordance.
+	 */
+	public function test_help_center_dequeued_in_block_editor_when_unified() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'post' );
+		$screen     = get_current_screen();
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		// Reset registries for isolation.
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = null;
+		$wp_styles  = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Help Center enqueues before Agents Manager (priority 100 vs 101), so it is already queued.
+		wp_enqueue_script( 'help-center', 'https://example.com/help-center.js', array(), '1.0', true );
+		wp_enqueue_style( 'help-center-style', 'https://example.com/help-center.css', array(), '1.0' );
+
+		// Full unified experience: Agents Manager takes over the Help Center.
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse( wp_script_is( 'help-center', 'enqueued' ), 'Help Center script should be dequeued in the unified experience.' );
+		$this->assertFalse( wp_style_is( 'help-center-style', 'enqueued' ), 'Help Center style should be dequeued in the unified experience.' );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+	}
+
+	/**
+	 * Tests that Help Center remains enqueued in block-editor-only mode, where Agents Manager
+	 * replaces Big Sky's native UI but does not take over the Help Center. Regression test for AI-1013.
+	 */
+	public function test_help_center_not_dequeued_in_block_editor_only_mode() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'post' );
+		$screen     = get_current_screen();
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		// Reset registries for isolation.
+		global $wp_scripts, $wp_styles;
+		$wp_scripts = null;
+		$wp_styles  = null;
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		wp_enqueue_script( 'help-center', 'https://example.com/help-center.js', array(), '1.0', true );
+		wp_enqueue_style( 'help-center-style', 'https://example.com/help-center.css', array(), '1.0' );
+
+		// Block-editor-only enablement, without the unified (Help Center takeover) experience.
+		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertTrue( wp_script_is( 'help-center', 'enqueued' ), 'Help Center script should remain enqueued in block-editor-only mode.' );
+		$this->assertTrue( wp_style_is( 'help-center-style', 'enqueued' ), 'Help Center style should remain enqueued in block-editor-only mode.' );
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
 	 * Tests that the standalone AI chat button is added to the admin bar when the
 	 * unified experience is enabled.
 	 */


### PR DESCRIPTION
Fixes AI-1013

## Proposed changes

* In the block editor, Help Center was being dequeued for **any** Gutenberg context. After [#47277](https://github.com/Automattic/jetpack/pull/47277) introduced the `agents_manager_enabled_in_block_editor` filter — decoupling block-editor enablement from the unified experience — this wrongly removed Help Center in block-editor-only mode (e.g. `?flags=unified-big-sky`), where Agents Manager replaces Big Sky's native UI rather than taking over Help Center.
* The dequeue is now gated on `agents_manager_use_unified_experience`, so Help Center is only removed when the unified experience is active. In block-editor-only mode, Help Center stays available.
* Extracted a single `is_unified_experience()` helper to replace five duplicated `apply_filters( 'agents_manager_use_unified_experience', false )` reads, and made it the canonical doc site for the filter.
* Added regression tests, and documented the unified experience in the package `AGENTS.md`.

### A note on "unified"

"Unified" means the **Help Center takeover** — Agents Manager unifying Odie and Dolly (the orchestrator) into a single chat experience. It is distinct from block-editor-only enablement, which only replaces Big Sky's native UI and must leave Help Center intact.

### Background

The `wp_dequeue_script( 'help-center' )` call was added in [#47088](https://github.com/Automattic/jetpack/pull/47088). At that time, the only way Agents Manager could enqueue in Gutenberg was via the unified experience, so keying the dequeue on `$is_gutenberg` was a safe proxy for "unified is active." [#47277](https://github.com/Automattic/jetpack/pull/47277) (merged the same day) split block-editor enablement into its own filter, explicitly *separate* from the Help Center takeover — but the dequeue guard was never updated to match, so it kept firing for the block-editor-only path.

## Related product discussion/links

* AI-1013

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

In a sandbox with the Agents Manager + Big Sky plugins set up:

- Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin ai-1013-help-center-is-dequeued-in-gutenberg-with-unified-big-sky`
- Sandbox a paid *.wordpress.com site with AI Assistant enabled (default for Big Sky sites)

**Block-editor-only mode (the fix):**
* Edit a post in the block editor with `?flags=unified-big-sky` (so `agents_manager_enabled_in_block_editor` is true but `agents_manager_use_unified_experience` is false).
* Confirm Agents Manager loads **and** Help Center is still available (the `?`/Help Center button still works). Before this change, Help Center was missing.

**Unified experience (unchanged):**
* With `agents_manager_use_unified_experience` returning true, edit a post in the block editor.
* Confirm Help Center is dequeued and Agents Manager takes over — no double buttons. This behaviour is unchanged.

**Disconnected variants (unchanged):**
* Verify both unified-disconnected (Help Center still dequeued, Agents Manager disconnected variant shows the help link) and block-editor-only-disconnected (Help Center remains) behave as expected.

Automated: `composer phpunit -- --filter Agents_Manager_Test` (82 tests pass, including the two new dequeue regression tests).