### PR TITLE
Search: Use default editor color for block icons

### DIFF
--- a/projects/packages/search/changelog/fix-JETPACK-1738-search-block-icon-colors
+++ b/projects/packages/search/changelog/fix-JETPACK-1738-search-block-icon-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search blocks: Use the default editor color for block icons.

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -64,12 +64,9 @@ const BLOCK_ICONS = {
 	'jetpack-search/filters-product': store,
 	'jetpack-search/active-filters': pin,
 	'jetpack-search/clear-filters': reset,
-	// The "Powered by Jetpack Search" block advertises Jetpack ownership in
-	// the post footer — the Jetpack logo is the right glyph here, even
-	// though every other Search block uses a neutral @wordpress/icons glyph.
-	// The logo SVG has hardcoded brand colours and is included verbatim so
-	// the glyph keeps its native green / white treatment.
-	'jetpack-search/powered-by': <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
+	'jetpack-search/powered-by': (
+		<JetpackLogo showText={ false } height={ 24 } width={ 24 } logoColor="currentColor" />
+	),
 };
 
 /**

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -1,14 +1,10 @@
 /**
  * Single source of truth for Jetpack Search block icons.
  *
- * Each block uses a distinct glyph from `@wordpress/icons`, painted in the
- * Jetpack brand green via the `foreground` field of Gutenberg's documented
- * icon-object shape. The `background` field is intentionally omitted — the
- * inserter / breadcrumb / toolbar all render the icon container without a
- * filled pill, so the glyph reads as a coloured mark rather than a heavy
- * badge. The Jetpack-logo brand mark on the inserter's "Search" category
- * heading (see `setCategories` in `register-blocks.js`) carries the family
- * identity for the whole group.
+ * Each block uses a distinct glyph from `@wordpress/icons` and lets the
+ * editor paint it with the current icon color. The Jetpack-logo brand mark
+ * on the inserter's "Search" category heading (see `setCategories` in
+ * `register-blocks.js`) carries the family identity for the whole group.
  *
  * Glyphs come from `@wordpress/icons` (Core's modern icon library, already
  * a direct dep at 12.2.0). Adding a new Search block: append one entry
@@ -49,35 +45,30 @@ import {
 	tool,
 } from '@wordpress/icons';
 
-const BRAND_FOREGROUND = '#069e08';
-
-const greened = src => ( { src, foreground: BRAND_FOREGROUND } );
-
 const BLOCK_ICONS = {
-	'jetpack-search/ai-answer': greened( commentContent ),
-	'jetpack-search/search-input': greened( search ),
-	'jetpack-search/search-results': greened( listView ),
-	'jetpack-search/results-list': greened( grid ),
-	'jetpack-search/results-count': greened( info ),
-	'jetpack-search/results-sort': greened( chevronUpDown ),
-	'jetpack-search/results-load-more': greened( plus ),
-	'jetpack-search/filter-checkbox': greened( formatListBullets ),
-	'jetpack-search/filter-date': greened( calendar ),
-	'jetpack-search/filter-wc-attribute': greened( tag ),
-	'jetpack-search/filter-wc-price': greened( currencyDollar ),
-	'jetpack-search/filter-wc-rating': greened( starFilled ),
-	'jetpack-search/filter-wc-stock-status': greened( box ),
-	'jetpack-search/filters': greened( filter ),
-	'jetpack-search/filters-popover': greened( funnel ),
-	'jetpack-search/filters-product': greened( store ),
-	'jetpack-search/active-filters': greened( pin ),
-	'jetpack-search/clear-filters': greened( reset ),
+	'jetpack-search/ai-answer': commentContent,
+	'jetpack-search/search-input': search,
+	'jetpack-search/search-results': listView,
+	'jetpack-search/results-list': grid,
+	'jetpack-search/results-count': info,
+	'jetpack-search/results-sort': chevronUpDown,
+	'jetpack-search/results-load-more': plus,
+	'jetpack-search/filter-checkbox': formatListBullets,
+	'jetpack-search/filter-date': calendar,
+	'jetpack-search/filter-wc-attribute': tag,
+	'jetpack-search/filter-wc-price': currencyDollar,
+	'jetpack-search/filter-wc-rating': starFilled,
+	'jetpack-search/filter-wc-stock-status': box,
+	'jetpack-search/filters': filter,
+	'jetpack-search/filters-popover': funnel,
+	'jetpack-search/filters-product': store,
+	'jetpack-search/active-filters': pin,
+	'jetpack-search/clear-filters': reset,
 	// The "Powered by Jetpack Search" block advertises Jetpack ownership in
 	// the post footer — the Jetpack logo is the right glyph here, even
 	// though every other Search block uses a neutral @wordpress/icons glyph.
-	// The logo SVG has hardcoded brand colours, so the `foreground` override
-	// is a no-op (and intentionally omitted) — included verbatim so the
-	// glyph keeps its native green / white treatment.
+	// The logo SVG has hardcoded brand colours and is included verbatim so
+	// the glyph keeps its native green / white treatment.
 	'jetpack-search/powered-by': <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
 };
 
@@ -94,21 +85,21 @@ const BLOCK_ICONS = {
  * merchant scanning the inserter.
  *
  * Applied via a `blocks.registerBlockType` filter in `register-blocks.js`
- * (the only practical way to brand variation icons when the variations
+ * (the only practical way to set variation icons when the variations
  * themselves are PHP-registered). Glyphs are picked from `@wordpress/icons`
  * and intentionally avoid every name already used in `BLOCK_ICONS` so the
  * full 19 + 8 set has no duplicates.
  */
 const FILTER_CHECKBOX_VARIATION_ICONS = {
-	category: greened( category ),
-	post_tag: greened( postTerms ),
-	post_type: greened( postList ),
-	author: greened( postAuthor ),
-	product_cat: greened( cart ),
-	product_tag: greened( published ),
-	product_brand: greened( swatch ),
-	custom_taxonomy: greened( tool ),
+	category,
+	post_tag: postTerms,
+	post_type: postList,
+	author: postAuthor,
+	product_cat: cart,
+	product_tag: published,
+	product_brand: swatch,
+	custom_taxonomy: tool,
 };
 
 export default BLOCK_ICONS;
-export { BRAND_FOREGROUND, FILTER_CHECKBOX_VARIATION_ICONS };
+export { FILTER_CHECKBOX_VARIATION_ICONS };

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -114,7 +114,7 @@ const wcOnlyBlocks = new Set(
 // already carries them — but with no `icon` field. Hooking
 // `blocks.registerBlockType` is the documented place to mutate block
 // settings before they land in the registry; we walk the variations
-// array and stamp the matching branded glyph from
+// array and stamp the matching glyph from
 // `FILTER_CHECKBOX_VARIATION_ICONS`. Variations without a mapped icon
 // (e.g. a forward-compat one added later) fall through and inherit the
 // parent block's `formatListBullets` glyph — the same fallback Gutenberg

--- a/projects/packages/search/tests/js/search-blocks/icons.test.js
+++ b/projects/packages/search/tests/js/search-blocks/icons.test.js
@@ -1,3 +1,4 @@
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import BLOCK_ICONS, {
 	FILTER_CHECKBOX_VARIATION_ICONS,
 } from '../../../src/search-blocks/editor/icons';
@@ -14,13 +15,17 @@ describe( 'Search block editor icons', () => {
 			),
 		};
 
-		for ( const [ name, icon ] of Object.entries( icons ) ) {
-			if ( name === 'jetpack-search/powered-by' ) {
-				continue;
-			}
-
+		for ( const icon of Object.values( icons ) ) {
 			expect( icon ).not.toHaveProperty( 'foreground' );
 			expect( icon ).not.toHaveProperty( 'background' );
 		}
+	} );
+
+	it( 'keeps the Powered by Jetpack logo shape while using the current icon color', () => {
+		const icon = BLOCK_ICONS[ 'jetpack-search/powered-by' ];
+
+		expect( icon.type ).toBe( JetpackLogo );
+		expect( icon ).toHaveProperty( 'props.logoColor', 'currentColor' );
+		expect( icon ).toHaveProperty( 'props.showText', false );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/icons.test.js
+++ b/projects/packages/search/tests/js/search-blocks/icons.test.js
@@ -1,0 +1,26 @@
+import BLOCK_ICONS, {
+	FILTER_CHECKBOX_VARIATION_ICONS,
+} from '../../../src/search-blocks/editor/icons';
+
+describe( 'Search block editor icons', () => {
+	it( 'lets the editor paint Search block icons with the default icon color', () => {
+		const icons = {
+			...BLOCK_ICONS,
+			...Object.fromEntries(
+				Object.entries( FILTER_CHECKBOX_VARIATION_ICONS ).map( ( [ name, icon ] ) => [
+					`jetpack-search/filter-checkbox:${ name }`,
+					icon,
+				] )
+			),
+		};
+
+		for ( const [ name, icon ] of Object.entries( icons ) ) {
+			if ( name === 'jetpack-search/powered-by' ) {
+				continue;
+			}
+
+			expect( icon ).not.toHaveProperty( 'foreground' );
+			expect( icon ).not.toHaveProperty( 'background' );
+		}
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-1738

## Proposed changes
* Update Jetpack Search block icons to use the editor's default icon color instead of forcing Jetpack green.
* Keep the original block icon shapes, including the Jetpack logo shape for the `jetpack-search/powered-by` block.
* Add a focused JS test to guard against reintroducing `foreground` / `background` color overrides and against changing the Powered by Jetpack block away from the Jetpack logo.

## Screenshot
Actual block editor inserter, filtered to the affected Jetpack Search blocks:

![Jetpack Search block icons using neutral editor icon color](https://honestly-probable-kiwi.jurassic.ninja/wp-content/uploads/jetpack-1738/powered-by-block-after.png)

## Related product discussion/links
* JETPACK-1738

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `CI=true PATH=/Users/dethier/Library/pnpm:$PATH /Users/dethier/Library/pnpm/pnpm --dir projects/packages/search test-scripts tests/js/search-blocks/icons.test.js`.
* Run `git diff --check`.
* Build the Search package with `CI=true NODE_ENV=production BABEL_ENV=production PATH=/Users/dethier/Library/pnpm:$PATH /Users/dethier/Library/pnpm/pnpm --dir projects/packages/search run build`.
* In the block editor, open the block inserter and search for `Powered`.
* Confirm Jetpack Search block icons use the default editor icon color instead of Jetpack green, while keeping their original icon shapes.
