### PR TITLE
AI Launchpad: pin Calypso-relative task CTAs to wordpress.com (DOTOBRD-478)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-calypso-cta-host
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-calypso-cta-host
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: navigate Calypso-relative task CTAs to wordpress.com instead of the site host.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -103,6 +103,10 @@ describe( 'toNavigableUrl', () => {
 
 	it( 'leaves site-relative wp-admin paths untouched', () => {
 		assert.equal( toNavigableUrl( '/wp-admin/post.php?post=1' ), '/wp-admin/post.php?post=1' );
+		// The root wp-admin path, with or without a query/hash, is still site-relative.
+		assert.equal( toNavigableUrl( '/wp-admin' ), '/wp-admin' );
+		assert.equal( toNavigableUrl( '/wp-admin/' ), '/wp-admin/' );
+		assert.equal( toNavigableUrl( '/wp-admin?foo=bar' ), '/wp-admin?foo=bar' );
 	} );
 
 	it( 'leaves absolute URLs untouched', () => {
@@ -146,16 +150,6 @@ describe( 'resolveCtaUrl', () => {
 		// against the site host where the launchpad runs).
 		assert.equal( url, 'https://wordpress.com/themes/x' );
 		assert.deepEqual( clicked, [ 'site_theme_selected' ] );
-	} );
-
-	it( 'leaves wp-admin editor URLs from created content site-relative', async () => {
-		const { handlers } = stubHandlers();
-		const url = await resolveCtaUrl(
-			task( { id: 'first_post_published', calypso_path: null } ),
-			fixture,
-			handlers
-		);
-		assert.equal( url, '/wp-admin/post.php?post=1' );
 	} );
 
 	it( 'passes absolute deeplinks (admin_url / Stripe / launch) through unchanged', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -4,7 +4,13 @@ import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { validateAgainstSchema } from '../lib/schema-validator.ts';
-import { ctaKind, firstIncompleteIndex, resolveCtaUrl, tasksFromFixture } from './model.ts';
+import {
+	ctaKind,
+	firstIncompleteIndex,
+	resolveCtaUrl,
+	tasksFromFixture,
+	toNavigableUrl,
+} from './model.ts';
 import type { EnrichedTask } from './model.ts';
 import type { TailoredOutput } from '../lib/types.ts';
 
@@ -83,6 +89,34 @@ describe( 'ctaKind', () => {
 	} );
 } );
 
+describe( 'toNavigableUrl', () => {
+	it( 'pins Calypso router paths to wordpress.com', () => {
+		assert.equal(
+			toNavigableUrl( '/me#complete-your-profile' ),
+			'https://wordpress.com/me#complete-your-profile'
+		);
+		assert.equal(
+			toNavigableUrl( '/marketing/connections/example.com' ),
+			'https://wordpress.com/marketing/connections/example.com'
+		);
+	} );
+
+	it( 'leaves site-relative wp-admin paths untouched', () => {
+		assert.equal( toNavigableUrl( '/wp-admin/post.php?post=1' ), '/wp-admin/post.php?post=1' );
+	} );
+
+	it( 'leaves absolute URLs untouched', () => {
+		assert.equal(
+			toNavigableUrl( 'https://example.com/wp-admin/admin.php?page=wc-admin' ),
+			'https://example.com/wp-admin/admin.php?page=wc-admin'
+		);
+		assert.equal(
+			toNavigableUrl( 'https://connect.stripe.com/x' ),
+			'https://connect.stripe.com/x'
+		);
+	} );
+} );
+
 describe( 'resolveCtaUrl', () => {
 	/**
 	 * Build CtaHandlers that record the clicked task IDs and return marker URLs.
@@ -108,8 +142,44 @@ describe( 'resolveCtaUrl', () => {
 			null,
 			handlers
 		);
-		assert.equal( url, '/themes/x' );
+		// A Calypso router path is pinned to wordpress.com (it must not resolve
+		// against the site host where the launchpad runs).
+		assert.equal( url, 'https://wordpress.com/themes/x' );
 		assert.deepEqual( clicked, [ 'site_theme_selected' ] );
+	} );
+
+	it( 'leaves wp-admin editor URLs from created content site-relative', async () => {
+		const { handlers } = stubHandlers();
+		const url = await resolveCtaUrl(
+			task( { id: 'first_post_published', calypso_path: null } ),
+			fixture,
+			handlers
+		);
+		assert.equal( url, '/wp-admin/post.php?post=1' );
+	} );
+
+	it( 'passes absolute deeplinks (admin_url / Stripe / launch) through unchanged', async () => {
+		const { handlers } = stubHandlers();
+		const stripe = await resolveCtaUrl(
+			task( { id: 'stripe_connected', calypso_path: 'https://connect.stripe.com/setup/x' } ),
+			null,
+			handlers
+		);
+		assert.equal( stripe, 'https://connect.stripe.com/setup/x' );
+
+		const launch = await resolveCtaUrl(
+			task( {
+				id: 'site_launched',
+				calypso_path:
+					'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin',
+			} ),
+			null,
+			handlers
+		);
+		assert.equal(
+			launch,
+			'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin'
+		);
 	} );
 
 	it( 'drafts a post and returns its editor URL for first-creation tasks', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -86,8 +86,9 @@ export interface CtaHandlers {
  * @return The navigable URL.
  */
 export function toNavigableUrl( url: string ): string {
-	// Site-relative wp-admin paths must resolve against the current site.
-	if ( url.startsWith( '/wp-admin/' ) ) {
+	// Site-relative wp-admin paths must resolve against the current site. Match the
+	// root path too (`/wp-admin`, `/wp-admin?…`, `/wp-admin#…`), not just `/wp-admin/`.
+	if ( /^\/wp-admin(\/|\?|#|$)/.test( url ) ) {
 		return url;
 	}
 	// Calypso router paths are relative to wordpress.com; absolute URLs (Stripe,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -65,10 +65,46 @@ export interface CtaHandlers {
 }
 
 /**
+ * Make a resolved CTA destination safe to navigate to from wp-admin.
+ *
+ * Catalog deeplinks arrive in three shapes: absolute URLs (`admin_url()`-based
+ * wp-admin links, Stripe connect URLs, the synthesized launch URL), site-relative
+ * wp-admin paths (e.g. the editor URL of a freshly created draft), and Calypso
+ * router paths (e.g. `/me`, `/marketing/connections/{slug}`) that are relative
+ * to wordpress.com. The launchpad runs in wp-admin, so a Calypso path navigated
+ * via `window.location` would resolve against the *site* host and 404; only those
+ * must be pinned to wordpress.com.
+ *
+ * This mirrors the legacy launchpad dashboard widget, which rebases relative task
+ * links with `new URL( href, 'https://wordpress.com' )` (see
+ * `wpcom-dashboard-widgets/wpcom-launchpad-widget`). The one difference: that
+ * widget's task admin links are already absolute, whereas our created-content
+ * CTAs return site-relative `/wp-admin/…` editor URLs, so those are excluded from
+ * the rebase. Absolute URLs don't start with `/` and pass through unchanged.
+ *
+ * @param url - The resolved destination URL or path.
+ * @return The navigable URL.
+ */
+export function toNavigableUrl( url: string ): string {
+	// Site-relative wp-admin paths must resolve against the current site.
+	if ( url.startsWith( '/wp-admin/' ) ) {
+		return url;
+	}
+	// Calypso router paths are relative to wordpress.com; absolute URLs (Stripe,
+	// admin_url(), the launch URL) don't start with `/` and fall through unchanged.
+	if ( url.startsWith( '/' ) ) {
+		return new URL( url, 'https://wordpress.com' ).href;
+	}
+	return url;
+}
+
+/**
  * Fire the Tracks event and resolve the destination URL for a "Get started"
  * click. First-creation tasks draft a post; page-creating tasks build a pattern
- * page; everything else uses the catalog deeplink. Returns the URL to navigate
- * to, or null when the task has no actionable destination.
+ * page; everything else uses the catalog deeplink. The resolved URL is run
+ * through {@link toNavigableUrl} so Calypso paths point at wordpress.com rather
+ * than the site host. Returns the URL to navigate to, or null when the task has
+ * no actionable destination.
  *
  * @param task     - The clicked task.
  * @param output   - The AI output (post draft + inferred details), or null.
@@ -83,15 +119,16 @@ export async function resolveCtaUrl(
 	handlers.trackTaskClicked( { task_id: task.id } );
 
 	const kind = ctaKind( task.id );
+	let url: string | null;
 	if ( kind === 'first_post' && output ) {
-		const { edit_url } = await handlers.createFirstPostDraft( output.first_post_draft );
-		return edit_url;
+		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
+	} else if ( kind === 'pattern_page' && output ) {
+		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
+	} else {
+		url = task.calypso_path;
 	}
-	if ( kind === 'pattern_page' && output ) {
-		const { edit_url } = await handlers.createPatternPage( output.inferred );
-		return edit_url;
-	}
-	return task.calypso_path;
+
+	return url === null ? null : toNavigableUrl( url );
 }
 
 /**


### PR DESCRIPTION
Part of the AI Launchpad MVP design-polish / CTA-fix batch (merges into `add/ai-launchpad-design-polish`, not trunk). Ref: DOTOBRD-478.

## Proposed changes
* The AI Launchpad renders in wp-admin, but several task CTAs are **Calypso router paths** (e.g. `complete_profile` → `/me`, `connect_social_media` → `/marketing/connections/{slug}`). The client navigated with `window.location.href = path`, so a single-leading-slash path resolved against the **site host** (`{site}.wpcomstaging.com/me`) and 404'd instead of `wordpress.com/me`.
* `resolveCtaUrl()` now runs its resolved destination through a new `toNavigableUrl()` helper that rebases single-leading-slash, non-`/wp-admin/` paths onto `https://wordpress.com` using `new URL( path, 'https://wordpress.com' )` — the same idiom the legacy launchpad dashboard widget already uses.
* Absolute URLs (`admin_url()`-based wp-admin links, Stripe connect URLs, the synthesized launch URL) and site-relative `/wp-admin/…` editor URLs (from created posts/pages) pass through unchanged.

## Related product discussion/links
* DOTOBRD-478

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the AI Launchpad enabled (`wp option update wpcom_ai_launchpad_enabled 1`), open **AI Launchpad** in wp-admin and get a tailored list that includes a Calypso-path task (e.g. "Complete your profile" or "Connect your social media accounts").
* Click **Get started** on that task and confirm it navigates to `https://wordpress.com/…`, not `https://{your-site-host}/…`.
* Confirm a task whose CTA is a wp-admin screen (e.g. "Choose a theme" → `wp-admin/themes.php`) and the post/page editor CTAs still open on the **site** host.
* Unit: `node --test --experimental-strip-types projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts` (covers `toNavigableUrl` + `resolveCtaUrl`).

Verified live on an Atomic test site via Playwright: Calypso paths → `wordpress.com`; absolute admin URLs unchanged.
