### PR TITLE
Social previews: fix Mastodon focal-point test render condition

### DIFF
--- a/projects/js-packages/social-previews/changelog/fix-mastodon-focal-point-test
+++ b/projects/js-packages/social-previews/changelog/fix-mastodon-focal-point-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update the Mastodon focal-point test to match the card's render condition.

--- a/projects/js-packages/social-previews/changelog/fix-mastodon-focal-point-test
+++ b/projects/js-packages/social-previews/changelog/fix-mastodon-focal-point-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update the Mastodon focal-point test to match the card's render condition.

--- a/projects/js-packages/social-previews/changelog/fix-social-previews-mastodon-focal-point-test
+++ b/projects/js-packages/social-previews/changelog/fix-social-previews-mastodon-focal-point-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update the Mastodon focal-point test to match the card's render condition.
+
+

--- a/projects/js-packages/social-previews/tests/focal-point.test.tsx
+++ b/projects/js-packages/social-previews/tests/focal-point.test.tsx
@@ -218,10 +218,12 @@ const platforms: PlatformCase[] = [
 	},
 	{
 		name: 'mastodon',
+		// The card renders only when the custom text contains the post URL.
 		render: imageFocalPoint => (
 			<MastodonPostPreview
 				url={ POST_URL }
 				title={ POST_TITLE }
+				customText={ POST_URL }
 				image={ IMAGE_SRC }
 				imageFocalPoint={ imageFocalPoint }
 			/>


### PR DESCRIPTION
## Proposed changes

The `social-previews` focal-point test suite started failing on `trunk` for the Mastodon case after two PRs landed against different base commits — a semantic merge conflict:

* [#49687](https://github.com/Automattic/jetpack/pull/49687) added the focal-point integration test while the Mastodon card still rendered unconditionally (`! media?.length`), so its selector matched.
* [#49745](https://github.com/Automattic/jetpack/pull/49745) gated the Mastodon card behind `customText?.includes( props.url )` while the test for it didn't yet exist.

Both PRs were green in isolation and merged cleanly (different files), so neither CI run exercised the other's code. Once both landed on `trunk`, the Mastodon card no longer rendered without `customText`, so the test's `<img>` selector matched `null`.

This updates the Mastodon test case to pass `customText` containing the post URL, matching the condition under which the card actually renders. No production code changes.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/js-packages/social-previews`
* Run `pnpm test`
* Confirm all suites pass (70 tests), including `tests/focal-point.test.tsx`.
