### PR TITLE
Content Guidelines: align empty-state banner orbs and reduce size

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -93,19 +93,21 @@ $cg-diff-removed: #f8d7da;
 	position: absolute;
 	border-radius: 50%;
 	pointer-events: none;
-	width: 236px;
-	height: 236px;
+	width: 180px;
+	height: 180px;
 	background: linear-gradient(to right, #04c, #48ff50);
 
+	// Both orbs share the same inset-inline-end so the top glow and the
+	// bottom sphere line up on the same vertical axis.
 	&--top {
-		inset-block-start: -134px;
-		inset-inline-end: -30px;
+		inset-block-start: -96px;
+		inset-inline-end: 56px;
 		filter: blur(25px);
 	}
 
 	&--bottom {
-		inset-block-end: -120px;
-		inset-inline-end: 70px;
+		inset-block-end: -96px;
+		inset-inline-end: 56px;
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -96,18 +96,17 @@ $cg-diff-removed: #f8d7da;
 	width: 180px;
 	height: 180px;
 	background: linear-gradient(to right, #04c, #48ff50);
+	// Shared by both orbs so the top glow and the bottom sphere line up
+	// on the same vertical axis.
+	inset-inline-end: 56px;
 
-	// Both orbs share the same inset-inline-end so the top glow and the
-	// bottom sphere line up on the same vertical axis.
 	&--top {
 		inset-block-start: -96px;
-		inset-inline-end: 56px;
 		filter: blur(25px);
 	}
 
 	&--bottom {
 		inset-block-end: -96px;
-		inset-inline-end: 56px;
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-banner-orb
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-banner-orb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Content Guidelines: align the empty-state banner orbs on the same axis and reduce their size.


### PR DESCRIPTION
Fixes # N/A — design feedback follow-up to #47959

## Proposed changes
Adjusts the decorative gradient orbs on the Content Guidelines empty-state banner, per designer feedback:

* Align the top orb (the soft blurred glow) and the bottom orb (the sphere) on the **same vertical axis** — both now use `inset-inline-end: 56px` instead of `-30px` / `70px`, so the glow sits directly above the sphere instead of being diagonally offset.
* **Reduce the orb height/size**: diameter `236px → 180px`, with the `inset-block` offsets retuned (`-96px`) so the sphere is less tall and dominant.

Only `_inc/content-guidelines-ai/style.scss` changes; the orb markup is untouched.

**Before**
<img width="705" height="272" alt="image" src="https://github.com/user-attachments/assets/b7c82b25-7bb4-4b30-85f0-196b365359de" />

**After**
<img width="701" height="270" alt="image" src="https://github.com/user-attachments/assets/6be9d67e-e670-4802-9508-200bfe38d4f9" />

## Related product discussion/links
* Follow-up to #47959 (Content Guidelines AI generate/improve UI).

## Does this pull request change what data or activity we track or use?
No. CSS-only visual change.

## Testing instructions

* Build the Jetpack plugin (`pnpm jetpack build plugins/jetpack`) or run the watcher.
* In wp-admin go to **Settings → Guidelines** on a site that has the Content Guidelines AI feature enabled and **no** guidelines saved yet (so the empty-state banner shows). If guidelines already exist, clear them / reset the banner dismissal.
* Confirm the **"Generate your guidelines in seconds"** banner shows the two orbs:
  * The top glow and the bottom sphere are lined up on the **same vertical line** (one directly above the other), not diagonally offset.
  * The sphere is **smaller / shorter** than before — it no longer rises as high into the banner.
* Check both LTR and RTL (the orbs use logical `inset-inline-end`, so they should mirror correctly).
