### PR TITLE
AI Launchpad: give the launch task a working CTA (DOTOBRD-477)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-AI Launchpad: give the launch task a working CTA to the wordpress.com launch flow.
+AI Launchpad: give the launch task a working CTA to the WordPress.com launch flow.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: give the launch task a working CTA to the wordpress.com launch flow.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -179,6 +179,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'checklist_statuses' => (array) get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
+			// Site context the client needs: the front-end URL drives the launch-task
+			// CTA (its host is the launch-flow site slug) and the tailored-list preview.
+			'site'               => array(
+				'url' => home_url(),
+			),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -7,6 +7,8 @@ import { validateAgainstSchema } from '../lib/schema-validator.ts';
 import {
 	ctaKind,
 	firstIncompleteIndex,
+	isTaskActionable,
+	launchSiteUrl,
 	resolveCtaUrl,
 	tasksFromFixture,
 	toNavigableUrl,
@@ -83,8 +85,15 @@ describe( 'ctaKind', () => {
 		assert.equal( ctaKind( 'add_about_page' ), 'pattern_page' );
 	} );
 
+	it( 'routes pathless launch tasks to the launch handler', () => {
+		assert.equal( ctaKind( 'site_launched' ), 'launch' );
+		assert.equal( ctaKind( 'blog_launched' ), 'launch' );
+		assert.equal( ctaKind( 'link_in_bio_launched' ), 'launch' );
+	} );
+
 	it( 'routes everything else to a deeplink', () => {
 		assert.equal( ctaKind( 'site_theme_selected' ), 'deeplink' );
+		// woo_launch_site has its own wc-admin deeplink, so it is not a launch kind.
 		assert.equal( ctaKind( 'woo_launch_site' ), 'deeplink' );
 	} );
 } );
@@ -121,6 +130,23 @@ describe( 'toNavigableUrl', () => {
 	} );
 } );
 
+describe( 'launchSiteUrl', () => {
+	it( 'builds the wordpress.com launch-flow URL from the site URL', () => {
+		assert.equal(
+			launchSiteUrl( 'https://example.wpcomstaging.com' ),
+			'https://wordpress.com/start/launch-site?siteSlug=example.wpcomstaging.com&ref=wp-admin'
+		);
+	} );
+} );
+
+describe( 'isTaskActionable', () => {
+	it( 'treats a launch task as actionable only when the site URL is known', () => {
+		const launch = task( { id: 'site_launched', calypso_path: null } );
+		assert.equal( isTaskActionable( launch, null, 'https://example.com' ), true );
+		assert.equal( isTaskActionable( launch, null, null ), false );
+	} );
+} );
+
 describe( 'resolveCtaUrl', () => {
 	/**
 	 * Build CtaHandlers that record the clicked task IDs and return marker URLs.
@@ -152,7 +178,7 @@ describe( 'resolveCtaUrl', () => {
 		assert.deepEqual( clicked, [ 'site_theme_selected' ] );
 	} );
 
-	it( 'passes absolute deeplinks (admin_url / Stripe / launch) through unchanged', async () => {
+	it( 'passes absolute deeplinks (admin_url / Stripe) through unchanged', async () => {
 		const { handlers } = stubHandlers();
 		const stripe = await resolveCtaUrl(
 			task( { id: 'stripe_connected', calypso_path: 'https://connect.stripe.com/setup/x' } ),
@@ -161,19 +187,15 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( stripe, 'https://connect.stripe.com/setup/x' );
 
-		const launch = await resolveCtaUrl(
+		const admin = await resolveCtaUrl(
 			task( {
-				id: 'site_launched',
-				calypso_path:
-					'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin',
+				id: 'woo_products',
+				calypso_path: 'https://example.com/wp-admin/admin.php?page=wc-admin&task=products',
 			} ),
 			null,
 			handlers
 		);
-		assert.equal(
-			launch,
-			'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin'
-		);
+		assert.equal( admin, 'https://example.com/wp-admin/admin.php?page=wc-admin&task=products' );
 	} );
 
 	it( 'drafts a post and returns its editor URL for first-creation tasks', async () => {
@@ -196,6 +218,32 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( url, '/wp-admin/post.php?post=2' );
 		assert.deepEqual( clicked, [ 'add_about_page' ] );
+	} );
+
+	it( 'sends launch tasks to the wordpress.com launch flow built from the site URL', async () => {
+		const { clicked, handlers } = stubHandlers();
+		const url = await resolveCtaUrl(
+			task( { id: 'site_launched', calypso_path: null } ),
+			null,
+			handlers,
+			'https://example.wpcomstaging.com'
+		);
+		assert.equal(
+			url,
+			'https://wordpress.com/start/launch-site?siteSlug=example.wpcomstaging.com&ref=wp-admin'
+		);
+		assert.deepEqual( clicked, [ 'site_launched' ] );
+	} );
+
+	it( 'returns null for a launch task when the site URL is unavailable', async () => {
+		const { handlers } = stubHandlers();
+		const url = await resolveCtaUrl(
+			task( { id: 'site_launched', calypso_path: null } ),
+			null,
+			handlers,
+			null
+		);
+		assert.equal( url, null );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -137,6 +137,11 @@ describe( 'launchSiteUrl', () => {
 			'https://wordpress.com/start/launch-site?siteSlug=example.wpcomstaging.com&ref=wp-admin'
 		);
 	} );
+
+	it( 'returns null for a malformed site URL instead of throwing', () => {
+		assert.equal( launchSiteUrl( 'not-a-url' ), null );
+		assert.equal( launchSiteUrl( '' ), null );
+	} );
 } );
 
 describe( 'isTaskActionable', () => {
@@ -144,6 +149,10 @@ describe( 'isTaskActionable', () => {
 		const launch = task( { id: 'site_launched', calypso_path: null } );
 		assert.equal( isTaskActionable( launch, null, 'https://example.com' ), true );
 		assert.equal( isTaskActionable( launch, null, null ), false );
+		// An empty or malformed URL can't build a launch URL, so it must not be
+		// actionable (stays in lockstep with resolveCtaUrl).
+		assert.equal( isTaskActionable( launch, null, '' ), false );
+		assert.equal( isTaskActionable( launch, null, 'not-a-url' ), false );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -13,6 +13,11 @@ export interface EnrichedTask {
 	calypso_path: string | null;
 }
 
+/** The site context the list needs (front-end URL for the launch CTA + preview). */
+export interface SiteData {
+	url: string;
+}
+
 /**
  * The relevant slice of Stream B's `GET /ai-launchpad/` response. Only the
  * fields the tailored list renders from are typed here.
@@ -22,19 +27,29 @@ export interface LaunchpadData {
 	ai_output: {
 		payload: TailoredOutput;
 	} | null;
+	site?: SiteData;
 }
 
 /** How a task's "Get started" CTA behaves when clicked. */
-export type CtaKind = 'first_post' | 'pattern_page' | 'deeplink';
+export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
 const PATTERN_PAGE_TASK_IDS = [ 'add_about_page' ];
+// Launch tasks that have no catalog deeplink: they send the user to the
+// wordpress.com launch flow. woo_launch_site is excluded — it has its own
+// wc-admin deeplink and is handled as a plain deeplink.
+const LAUNCH_TASK_IDS = [
+	'site_launched',
+	'blog_launched',
+	'link_in_bio_launched',
+	'videopress_launched',
+];
 
 /**
  * Resolve how a task's "Get started" CTA behaves. First-creation tasks draft a
  * real post via Stream F's `createFirstPostDraft`; page-creating tasks build a
- * pattern page via `createPatternPage`; everything else deeplinks to the
- * catalog's `calypso_path`.
+ * pattern page via `createPatternPage`; launch tasks open the wordpress.com
+ * launch flow; everything else deeplinks to the catalog's `calypso_path`.
  *
  * @param taskId - The catalog task ID.
  * @return The CTA kind.
@@ -46,7 +61,25 @@ export function ctaKind( taskId: string ): CtaKind {
 	if ( PATTERN_PAGE_TASK_IDS.includes( taskId ) ) {
 		return 'pattern_page';
 	}
+	if ( LAUNCH_TASK_IDS.includes( taskId ) ) {
+		return 'launch';
+	}
 	return 'deeplink';
+}
+
+/**
+ * Build the wordpress.com launch-flow URL for a launch task. Launch tasks have
+ * no catalog deeplink; the legacy launchpad widget routes them to
+ * `/start/launch-site` keyed by the site slug (the host of the site's home URL).
+ *
+ * @param siteUrl - The site's front-end URL (from the composite read).
+ * @return The launch-flow URL.
+ */
+export function launchSiteUrl( siteUrl: string ): string {
+	const slug = new URL( siteUrl ).host;
+	return `https://wordpress.com/start/launch-site?siteSlug=${ encodeURIComponent(
+		slug
+	) }&ref=wp-admin`;
 }
 
 /**
@@ -110,12 +143,14 @@ export function toNavigableUrl( url: string ): string {
  * @param task     - The clicked task.
  * @param output   - The AI output (post draft + inferred details), or null.
  * @param handlers - The CTA side effects.
+ * @param siteUrl  - The site's front-end URL, used to build the launch CTA.
  * @return The destination URL, or null.
  */
 export async function resolveCtaUrl(
 	task: EnrichedTask,
 	output: TailoredOutput | null,
-	handlers: CtaHandlers
+	handlers: CtaHandlers,
+	siteUrl: string | null = null
 ): Promise< string | null > {
 	handlers.trackTaskClicked( { task_id: task.id } );
 
@@ -125,6 +160,8 @@ export async function resolveCtaUrl(
 		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
 	} else if ( kind === 'pattern_page' && output ) {
 		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
+	} else if ( kind === 'launch' ) {
+		url = siteUrl ? launchSiteUrl( siteUrl ) : null;
 	} else {
 		url = task.calypso_path;
 	}
@@ -139,14 +176,22 @@ export async function resolveCtaUrl(
  * every other task is actionable only when it has a deeplink path. Used to hide
  * the CTA for tasks that would otherwise be a silent no-op.
  *
- * @param task   - The task.
- * @param output - The AI output, or null.
+ * @param task    - The task.
+ * @param output  - The AI output, or null.
+ * @param siteUrl - The site's front-end URL, used to build the launch CTA.
  * @return True when "Get started" would navigate somewhere.
  */
-export function isTaskActionable( task: EnrichedTask, output: TailoredOutput | null ): boolean {
+export function isTaskActionable(
+	task: EnrichedTask,
+	output: TailoredOutput | null,
+	siteUrl: string | null = null
+): boolean {
 	const kind = ctaKind( task.id );
 	if ( ( kind === 'first_post' || kind === 'pattern_page' ) && output ) {
 		return true;
+	}
+	if ( kind === 'launch' ) {
+		return siteUrl !== null;
 	}
 	return task.calypso_path !== null;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -15,7 +15,9 @@ export interface EnrichedTask {
 
 /** The site context the list needs (front-end URL for the launch CTA + preview). */
 export interface SiteData {
-	url: string;
+	// Optional: the field comes from an un-validated REST response, so consumers
+	// must tolerate it being absent (coalesce to null) rather than trust the type.
+	url?: string;
 }
 
 /**
@@ -73,10 +75,18 @@ export function ctaKind( taskId: string ): CtaKind {
  * `/start/launch-site` keyed by the site slug (the host of the site's home URL).
  *
  * @param siteUrl - The site's front-end URL (from the composite read).
- * @return The launch-flow URL.
+ * @return The launch-flow URL, or null if the site URL can't be parsed.
  */
-export function launchSiteUrl( siteUrl: string ): string {
-	const slug = new URL( siteUrl ).host;
+export function launchSiteUrl( siteUrl: string ): string | null {
+	let slug: string;
+	try {
+		slug = new URL( siteUrl ).host;
+	} catch {
+		// A malformed/relative home URL (e.g. a broken `home_url` filter) can't
+		// produce a launch slug; return null so the CTA is hidden rather than
+		// throwing on click.
+		return null;
+	}
 	return `https://wordpress.com/start/launch-site?siteSlug=${ encodeURIComponent(
 		slug
 	) }&ref=wp-admin`;
@@ -191,7 +201,9 @@ export function isTaskActionable(
 		return true;
 	}
 	if ( kind === 'launch' ) {
-		return siteUrl !== null;
+		// Only actionable when a launch URL can actually be built — keeps this in
+		// lockstep with resolveCtaUrl (no CTA shown for a missing/malformed URL).
+		return !! siteUrl && launchSiteUrl( siteUrl ) !== null;
 	}
 	return task.calypso_path !== null;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -63,6 +63,8 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	const [ expandedId, setExpandedId ] = useState< string | null >( null );
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
+	// The site's front-end URL, used to build the launch CTA. From the composite read.
+	const [ siteUrl, setSiteUrl ] = useState< string | null >( null );
 
 	useEffect( () => {
 		// Returning users: render from the data the host already fetched, so the
@@ -70,6 +72,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 		if ( initialData ) {
 			setTasks( initialData.tasks );
 			setOutput( initialData.ai_output?.payload ?? null );
+			setSiteUrl( initialData.site?.url ?? null );
 			return;
 		}
 
@@ -88,6 +91,10 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 			}
 			if ( cancelled ) {
 				return;
+			}
+
+			if ( data?.site ) {
+				setSiteUrl( data.site.url );
 			}
 
 			if ( data && data.tasks.length > 0 ) {
@@ -135,11 +142,16 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	const handleGetStarted = async ( task: EnrichedTask ) => {
 		setBusyId( task.id );
 		try {
-			const url = await resolveCtaUrl( task, output, {
-				trackTaskClicked,
-				createFirstPostDraft,
-				createPatternPage,
-			} );
+			const url = await resolveCtaUrl(
+				task,
+				output,
+				{
+					trackTaskClicked,
+					createFirstPostDraft,
+					createPatternPage,
+				},
+				siteUrl
+			);
 			if ( url ) {
 				navigate( url );
 			}
@@ -169,7 +181,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 					task={ task }
 					isExpanded={ expandedId === task.id }
 					isBusy={ busyId === task.id }
-					canStart={ isTaskActionable( task, output ) }
+					canStart={ isTaskActionable( task, output, siteUrl ) }
 					onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
 					onGetStarted={ () => handleGetStarted( task ) }
 					onSkip={ () => handleSkip( task ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -94,7 +94,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 			}
 
 			if ( data?.site ) {
-				setSiteUrl( data.site.url );
+				setSiteUrl( data.site.url ?? null );
 			}
 
 			if ( data && data.tasks.length > 0 ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -175,6 +175,8 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( array( 'first_post_published' => true ), $data['checklist_statuses'] );
 		$this->assertFalse( $data['dismissed'] );
 		$this->assertTrue( $data['is_eligible'] );
+		// Site context for the client (launch CTA slug + preview).
+		$this->assertSame( home_url(), $data['site']['url'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 


### PR DESCRIPTION
Part of the AI Launchpad MVP design-polish / CTA-fix batch (merges into `add/ai-launchpad-design-polish`, not trunk). Ref: DOTOBRD-477.

## Proposed changes
* The mandatory launch task (`site_launched`, `blog_launched`, `link_in_bio_launched`, `videopress_launched`) is **completion-only** in the catalog — no `get_calypso_path` — so after the round-3 "hide CTA when non-actionable" change its card rendered with only "Skip". "% of new users who launch" is the project's headline metric, so this was a real gap.
* Adds a `'launch'` `CtaKind` in `model.ts` that opens the **wordpress.com launch flow** (`/start/launch-site?siteSlug={host}&ref=wp-admin`), mirroring the legacy launchpad dashboard widget (`wpcom-launchpad-widget`'s `isLaunchTask` handler).
* The site slug is the host of the canonical `home_url()`, exposed to the client via a new `site.url` field on the composite read (`GET /ai-launchpad`). This keeps `build_tasks()` a faithful catalog mirror rather than having the REST layer synthesize/override CTA paths.
* `woo_launch_site` is intentionally **not** a launch kind — it has its own `wc-admin` deeplink and stays a plain deeplink.

## Audit (the other half of the issue)
Of the tasks the AI can actually select, the only ones that rendered with no CTA were the launch tasks (fixed here) and **`share_site`** (no catalog destination at all — a separate, lower-priority gap; not expanded here). The completion-tracking gap surfaced while testing (e.g. `complete_profile` can't self-complete on Atomic) is tracked separately in DOTOBRD-480.

## Related product discussion/links
* DOTOBRD-477

## Does this pull request change what data or activity we track or use?
No. (Adds `site.url` = `home_url()` to the authenticated composite read; no new tracking.)

## Testing instructions
* On a site with the AI Launchpad enabled, open the launchpad with a tailored list whose last task is a launch task (`site_launched`). Expand it: the card now shows **"Get started"** (previously only "Skip").
* Click it and confirm it navigates to `https://wordpress.com/start/launch-site?siteSlug={your-site-host}&ref=wp-admin`.
* Unit: `node --test --experimental-strip-types projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts` and `composer phpunit -- tests/php/features/ai-launchpad/` in the package.

Verified live on an Atomic test site via Playwright.
