### PR TITLE
Write: support a logged-out variant of the editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-read-558-anon-write-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-read-558-anon-write-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: enable a logged-out variant of the Write editor when the host page sets `window.wpcomWriteIsAnon = true` — drafts persist to localStorage, broken UI is hidden, and Publish hands off to /setup/write-on. No effect on the existing authenticated path.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -2460,7 +2460,31 @@ body.bw-modal-open {
  * JS guards programmatic call paths (e.g. slash menu) and any URL-bar reach.
  */
 html.bw-anon .bw-back,
-html.bw-anon .bw-more-menu .bw-more-menu-item:not(.bw-more-save-draft),
+html.bw-anon .bw-more-wrap,
+html.bw-anon .bw-btn-draft,
+html.bw-anon .bw-toolbar [data-wp-on--click="actions.openImageModal"],
+html.bw-anon #bw-slash-opt-image,
 html.bw-anon .bw-unsupported-open-editor {
 	display: none !important;
+}
+
+/*
+ * Brand text on the left, "Not signed in" indicator before Publish. Both are
+ * injected by view.js when window.wpcomWriteIsAnon is true so they participate
+ * in the same i18n string table the editor already uses.
+ */
+.bw-anon-brand {
+	font-size: 13px;
+	font-weight: 500;
+	color: #1d2327;
+	white-space: nowrap;
+	margin-right: 8px;
+}
+
+.bw-anon-status {
+	font-size: 13px;
+	color: #757575;
+	white-space: nowrap;
+	align-self: center;
+	margin-right: 4px;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -2451,3 +2451,16 @@ body.bw-modal-open {
 		flex: 1;
 	}
 }
+
+/*
+ * Anonymous (logged-out) Write editor: hide UI surfaces that have no working
+ * counterpart for a visitor without an authenticated session. The `bw-anon`
+ * class is added to <html> by view.js when window.wpcomWriteIsAnon is true.
+ * Hides pair with early-returns in view.js actions — CSS hides the affordance,
+ * JS guards programmatic call paths (e.g. slash menu) and any URL-bar reach.
+ */
+html.bw-anon .bw-back,
+html.bw-anon .bw-more-menu .bw-more-menu-item:not(.bw-more-save-draft),
+html.bw-anon .bw-unsupported-open-editor {
+	display: none !important;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -2463,6 +2463,7 @@ html.bw-anon .bw-back,
 html.bw-anon .bw-help-wrap,
 html.bw-anon .bw-more-wrap,
 html.bw-anon .bw-btn-draft,
+html.bw-anon .bw-disclaimer-banner,
 html.bw-anon .bw-toolbar [data-wp-on--click="actions.openImageModal"],
 html.bw-anon #bw-slash-opt-image,
 html.bw-anon .bw-unsupported-open-editor {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -2460,6 +2460,7 @@ body.bw-modal-open {
  * JS guards programmatic call paths (e.g. slash menu) and any URL-bar reach.
  */
 html.bw-anon .bw-back,
+html.bw-anon .bw-help-wrap,
 html.bw-anon .bw-more-wrap,
 html.bw-anon .bw-btn-draft,
 html.bw-anon .bw-toolbar [data-wp-on--click="actions.openImageModal"],

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1158,12 +1158,16 @@
 }
 
 /* Content area */
+.bw-content,
+.bw-content-inner {
+	outline: none;
+}
+
 .bw-content {
 	min-height: 60vh;
 	font-size: 1.125rem;
 	line-height: 1.8;
 	color: #333;
-	outline: none;
 	overflow-wrap: break-word;
 	word-break: normal;
 	text-wrap: stable;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6124,8 +6124,14 @@ const autosaveReady = setInterval( () => {
 		actions.autosave();
 	}, AUTOSAVE_INTERVAL_MS );
 
-	// Show the beta disclaimer unless previously dismissed.
-	if ( ! localStorage.getItem( DISCLAIMER_STORAGE_KEY ) ) {
+	// Show the beta disclaimer unless previously dismissed. Anon visitors
+	// skip this entirely — not just because the banner is irrelevant, but
+	// because the layout's sibling selectors (`.bw-disclaimer-banner:not(
+	// [hidden]) ~ .bw-toolbar`) push the toolbar down based on the `hidden`
+	// attribute, which the Interactivity API only sets when the state is
+	// false. Leaving state true would shift the toolbar down by 44px even
+	// though our anon CSS hides the banner itself.
+	if ( ! isAnon() && ! localStorage.getItem( DISCLAIMER_STORAGE_KEY ) ) {
 		state.showDisclaimer = true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -22,7 +22,94 @@ let activeBlockquote = null;
 const AUTOSAVE_INTERVAL_MS = 30000; // 30 seconds.
 const AUTOSAVE_MESSAGE_DURATION_MS = 2000;
 const AUTOSAVE_STORAGE_KEY = 'wpcom-write-autosave-draft';
+const ANON_DRAFT_STORAGE_KEY = 'wpcom-write-anon-draft';
 const DISCLAIMER_STORAGE_KEY = 'wpcom-write-disclaimer-dismissed';
+
+/**
+ * Whether the editor is running on a logged-out page that opts into the
+ * anonymous flow by setting `window.wpcomWriteIsAnon = true` before the module
+ * loads. All anon branches in this file are gated on this — when the flag is
+ * absent, every code path below behaves exactly as it did before.
+ *
+ * @return {boolean} True if the host page set the anon flag.
+ */
+function isAnon() {
+	return typeof window !== 'undefined' && window.wpcomWriteIsAnon === true;
+}
+
+/**
+ * Persist the current draft snapshot to localStorage under the anon key.
+ *
+ * Failures (quota, blocked storage, undefined `localStorage`) are caught and
+ * surfaced as a Tracks event so silent draft loss doesn't read as abandonment.
+ *
+ * @param {string} title   - Current post title.
+ * @param {string} content - Current post content (raw editable HTML).
+ */
+function saveDraftToLocalStorage( title, content ) {
+	try {
+		window.localStorage.setItem(
+			ANON_DRAFT_STORAGE_KEY,
+			JSON.stringify( { title, content, ts: Date.now() } )
+		);
+	} catch ( err ) {
+		const errorName = ( err && err.name ) || 'UnknownError';
+		try {
+			window._tkq = window._tkq || [];
+			window._tkq.push( [
+				'recordEvent',
+				'wpcom_write_editor_anon_draft_persist_failed',
+				{ error_name: errorName },
+			] );
+		} catch {
+			// Tracks failed too — nothing useful to do here; swallow.
+		}
+	}
+}
+
+/**
+ * Read the persisted anon draft snapshot, or `null` if missing/unreadable.
+ *
+ * @return {{title: string, content: string, ts: number} | null} Snapshot or null.
+ */
+function readAnonDraft() {
+	try {
+		const raw = window.localStorage.getItem( ANON_DRAFT_STORAGE_KEY );
+		if ( ! raw ) {
+			return null;
+		}
+		const parsed = JSON.parse( raw );
+		if ( ! parsed || typeof parsed !== 'object' ) {
+			return null;
+		}
+		return {
+			title: typeof parsed.title === 'string' ? parsed.title : '',
+			content: typeof parsed.content === 'string' ? parsed.content : '',
+			ts: typeof parsed.ts === 'number' ? parsed.ts : 0,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Discard the persisted anon draft snapshot. Safe to call when absent.
+ */
+function clearAnonDraft() {
+	try {
+		window.localStorage.removeItem( ANON_DRAFT_STORAGE_KEY );
+	} catch {
+		// No-op: if we can't clear it, the worst case is a stale recovery banner next visit.
+	}
+}
+
+// Mark the page as anonymous so style.css can hide UI that has no anon
+// equivalent (back button, "Open in block editor", preview, post picker,
+// media upload, media library, featured image). Set as early as the module
+// loads so the initial render doesn't flash the hidden surfaces.
+if ( isAnon() && typeof document !== 'undefined' && document.documentElement ) {
+	document.documentElement.classList.add( 'bw-anon' );
+}
 
 // Autosave state — tracked outside the store to avoid triggering reactivity.
 let lastSavedSnapshot = { title: '', content: '' };
@@ -4509,6 +4596,12 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		openImageModal() {
+			// Image insertion needs an upload endpoint and a media library; neither
+			// is available without auth, and CSS hides the entry point. The guard
+			// here covers programmatic callers (slash menu, etc.).
+			if ( isAnon() ) {
+				return;
+			}
 			// If the edit panel is open for an existing image, end that
 			// session first so the user's changes land as a discrete undo
 			// entry before the insert overlay replaces the panel.
@@ -4535,6 +4628,9 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		toggleLibraryPicker() {
+			if ( isAnon() ) {
+				return;
+			}
 			state.showLibraryPicker = ! state.showLibraryPicker;
 			// Lazy-fetch the library on first expand, and refresh on every
 			// reopen so a just-uploaded image appears at the top.
@@ -4902,6 +4998,10 @@ const { state } = store( 'wpcom-write', {
 			event.preventDefault();
 			clearDropIndicator();
 
+			if ( isAnon() ) {
+				return;
+			}
+
 			const images = Array.from( event.dataTransfer.files || [] ).filter( f =>
 				f.type.startsWith( 'image/' )
 			);
@@ -5197,6 +5297,9 @@ const { state } = store( 'wpcom-write', {
 
 		async openInBlockEditor() {
 			state.showMoreMenu = false;
+			if ( isAnon() ) {
+				return;
+			}
 
 			// New posts need a save to create the underlying post before we
 			// have a URL to navigate to. Surface the same "Please write
@@ -5237,6 +5340,9 @@ const { state } = store( 'wpcom-write', {
 
 		async previewPost() {
 			state.showMoreMenu = false;
+			if ( isAnon() ) {
+				return;
+			}
 
 			if ( ! state.editPostId && ! hasWritableContent() ) {
 				state.message = i18n.pleaseWriteSomething || 'Please write something';
@@ -5268,6 +5374,9 @@ const { state } = store( 'wpcom-write', {
 
 		openPostPicker() {
 			state.showMoreMenu = false;
+			if ( isAnon() ) {
+				return;
+			}
 
 			if ( isDirty() ) {
 				state.pendingOpenPost = true;
@@ -5511,15 +5620,36 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		async publish() {
+			if ( isAnon() ) {
+				// Anon visitors hand off to the signup flow at /setup/write-on,
+				// which reads the draft from localStorage and publishes after
+				// signup completes. The draft persists across the navigation.
+				window.location.assign( '/setup/write-on' );
+				return;
+			}
 			await savePost( 'publish' );
 		},
 
 		async saveDraft() {
+			if ( isAnon() ) {
+				// Anon persists to localStorage on every autosave tick; an
+				// explicit "save draft" maps to the same operation.
+				const contentEl = document.querySelector( '.bw-content' );
+				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				lastSavedSnapshot = getContentSnapshot();
+				return;
+			}
 			await savePost( 'draft' );
 		},
 
 		async saveDraftFromMenu() {
 			state.showMoreMenu = false;
+			if ( isAnon() ) {
+				const contentEl = document.querySelector( '.bw-content' );
+				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				lastSavedSnapshot = getContentSnapshot();
+				return;
+			}
 			await savePost( 'draft' );
 		},
 
@@ -5546,6 +5676,14 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
+			if ( isAnon() ) {
+				// Anon visitors have no server post; snapshot the editable HTML
+				// to localStorage so a refresh can rehydrate via the recovery banner.
+				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				lastSavedSnapshot = getContentSnapshot();
+				return;
+			}
+
 			await savePost( 'draft', true );
 		},
 
@@ -5553,6 +5691,21 @@ const { state } = store( 'wpcom-write', {
 		 * Resume editing an autosaved draft.
 		 */
 		resumeDraft() {
+			if ( isAnon() ) {
+				// Anon snapshot is a JSON blob, not a server post id — hydrate the
+				// editor in place rather than navigating.
+				const snapshot = readAnonDraft();
+				if ( snapshot ) {
+					state.title = snapshot.title;
+					const contentEl = document.querySelector( '.bw-content' );
+					if ( contentEl ) {
+						contentEl.innerHTML = snapshot.content;
+					}
+					lastSavedSnapshot = { title: snapshot.title, content: snapshot.content };
+				}
+				state.showRecoveryBanner = false;
+				return;
+			}
 			const draftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
 			if ( draftId && /^\d+$/.test( draftId ) ) {
 				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
@@ -5564,7 +5717,11 @@ const { state } = store( 'wpcom-write', {
 		 * Dismiss the recovery banner and discard the autosaved draft reference.
 		 */
 		dismissRecovery() {
-			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+			if ( isAnon() ) {
+				clearAnonDraft();
+			} else {
+				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+			}
 			state.showRecoveryBanner = false;
 		},
 
@@ -5903,7 +6060,15 @@ const autosaveReady = setInterval( () => {
 	}
 
 	// Check for a recoverable autosaved draft (only for new posts).
-	if ( ! state.editPostId ) {
+	if ( isAnon() ) {
+		// Anon recovery reads a JSON snapshot rather than a post id. Show the
+		// banner only when the snapshot has any actual content to restore — an
+		// empty record is no better than starting fresh.
+		const snapshot = readAnonDraft();
+		if ( snapshot && ( snapshot.title || snapshot.content ) ) {
+			state.showRecoveryBanner = true;
+		}
+	} else if ( ! state.editPostId ) {
 		const draftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
 		if ( draftId ) {
 			state.showRecoveryBanner = true;
@@ -6019,6 +6184,12 @@ window.addEventListener( 'dragover', event => {
 
 window.addEventListener( 'drop', event => {
 	if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
+	if ( isAnon() ) {
+		// No upload endpoint for anon — prevent the default file-open behavior
+		// (matching the rest of this handler) but skip the upload path.
+		event.preventDefault();
+		return;
+	}
 	// The editor (.bw-content) and the image-modal overlay each have
 	// their own data-wp-on--drop handlers; those fire on the inner
 	// target first and bubble up to here. Check via composedPath rather

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -44,7 +44,7 @@ function isAnon() {
  * surfaced as a Tracks event so silent draft loss doesn't read as abandonment.
  *
  * @param {string} title   - Current post title.
- * @param {string} content - Current post content (raw editable HTML).
+ * @param {string} content - Current post content (block-formatted markup).
  */
 function saveDraftToLocalStorage( title, content ) {
 	try {
@@ -90,6 +90,19 @@ function readAnonDraft() {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Capture the current editor content as a block-formatted snapshot and persist
+ * it to localStorage. Reads from `.bw-content-inner` (the editable wrapper) so
+ * the outer `.bw-content` element's chrome attributes don't leak in, and runs
+ * the inner HTML through `convertToBlocks` so the signup-flow handoff lands a
+ * clean block draft instead of raw contenteditable markup.
+ */
+function captureAnonSnapshot() {
+	const contentEl = getContent();
+	const html = contentEl ? contentEl.innerHTML : '';
+	saveDraftToLocalStorage( state.title, html ? convertToBlocks( html ) : '' );
 }
 
 /**
@@ -5660,8 +5673,7 @@ const { state } = store( 'wpcom-write', {
 				// Flush the latest draft snapshot before navigating — autosave is
 				// on a 30s tick, and a fast typer-then-clicker would otherwise
 				// hand off stale (or no) content to the signup flow.
-				const contentEl = document.querySelector( '.bw-content' );
-				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				captureAnonSnapshot();
 
 				// Suppress the dirty-state leave prompt the way every other
 				// internal navigation in this file does (cf. openInBlockEditor).
@@ -5679,8 +5691,7 @@ const { state } = store( 'wpcom-write', {
 			if ( isAnon() ) {
 				// Anon persists to localStorage on every autosave tick; an
 				// explicit "save draft" maps to the same operation.
-				const contentEl = document.querySelector( '.bw-content' );
-				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				captureAnonSnapshot();
 				lastSavedSnapshot = getContentSnapshot();
 				return;
 			}
@@ -5690,8 +5701,7 @@ const { state } = store( 'wpcom-write', {
 		async saveDraftFromMenu() {
 			state.showMoreMenu = false;
 			if ( isAnon() ) {
-				const contentEl = document.querySelector( '.bw-content' );
-				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				captureAnonSnapshot();
 				lastSavedSnapshot = getContentSnapshot();
 				return;
 			}
@@ -5715,7 +5725,7 @@ const { state } = store( 'wpcom-write', {
 			}
 
 			// Require at least a title or content before autosaving.
-			const contentEl = document.querySelector( '.bw-content' );
+			const contentEl = getContent();
 			const hasContent = state.title.trim() || ( contentEl && contentEl.textContent.trim() );
 			if ( ! hasContent ) {
 				return;
@@ -5724,7 +5734,7 @@ const { state } = store( 'wpcom-write', {
 			if ( isAnon() ) {
 				// Anon visitors have no server post; snapshot the editable HTML
 				// to localStorage so a refresh can rehydrate via the recovery banner.
-				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+				captureAnonSnapshot();
 				lastSavedSnapshot = getContentSnapshot();
 				return;
 			}
@@ -5742,11 +5752,20 @@ const { state } = store( 'wpcom-write', {
 				const snapshot = readAnonDraft();
 				if ( snapshot ) {
 					state.title = snapshot.title;
-					const contentEl = document.querySelector( '.bw-content' );
+					// The title <textarea> binds input → state.title one-way; mutating
+					// state alone does not update the field, so set the DOM value too
+					// (matching applyUndoSnapshot's pattern).
+					const titleEl = document.querySelector( '.bw-title' );
+					if ( titleEl ) {
+						titleEl.value = snapshot.title;
+						titleEl.style.height = 'auto';
+						titleEl.style.height = titleEl.scrollHeight + 'px';
+					}
+					const contentEl = getContent();
 					if ( contentEl ) {
 						contentEl.innerHTML = snapshot.content;
 					}
-					lastSavedSnapshot = { title: snapshot.title, content: snapshot.content };
+					lastSavedSnapshot = getContentSnapshot();
 				}
 				state.showRecoveryBanner = false;
 				return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -104,11 +104,47 @@ function clearAnonDraft() {
 }
 
 // Mark the page as anonymous so style.css can hide UI that has no anon
-// equivalent (back button, "Open in block editor", preview, post picker,
-// media upload, media library, featured image). Set as early as the module
-// loads so the initial render doesn't flash the hidden surfaces.
+// equivalent (back button, more-menu, the standalone Save-draft button,
+// unsupported-content "Open in editor" buttons). Set as early as the
+// module loads so the initial render doesn't flash the hidden surfaces.
 if ( isAnon() && typeof document !== 'undefined' && document.documentElement ) {
 	document.documentElement.classList.add( 'bw-anon' );
+}
+
+/**
+ * Inject the brand label on the left of the top bar and the "Not signed in"
+ * indicator before the Publish button. Both are anon-only; the strings come
+ * from window.wpcomWriteStrings (with English fallbacks) so translations land
+ * via the same path as the rest of the editor UI.
+ */
+function injectAnonTopbarLabels() {
+	const topbar = document.querySelector( '.bw-topbar' );
+	if ( ! topbar || topbar.querySelector( '.bw-anon-brand' ) ) {
+		return;
+	}
+
+	const brand = document.createElement( 'span' );
+	brand.className = 'bw-anon-brand';
+	brand.textContent = i18n.anonBrand || 'WordPress.com · Write';
+	topbar.prepend( brand );
+
+	const status = document.createElement( 'span' );
+	status.className = 'bw-anon-status';
+	status.textContent = i18n.anonStatus || 'Not signed in';
+	const publishBtn = topbar.querySelector( '.bw-btn-publish' );
+	if ( publishBtn && publishBtn.parentNode ) {
+		publishBtn.parentNode.insertBefore( status, publishBtn );
+	} else {
+		topbar.appendChild( status );
+	}
+}
+
+if ( isAnon() && typeof document !== 'undefined' ) {
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', injectAnonTopbarLabels );
+	} else {
+		injectAnonTopbarLabels();
+	}
 }
 
 // Autosave state — tracked outside the store to avoid triggering reactivity.
@@ -5621,10 +5657,10 @@ const { state } = store( 'wpcom-write', {
 
 		async publish() {
 			if ( isAnon() ) {
-				// Anon visitors hand off to the signup flow at /setup/write-on,
-				// which reads the draft from localStorage and publishes after
-				// signup completes. The draft persists across the navigation.
-				window.location.assign( '/setup/write-on' );
+				// Anon visitors hand off to the signup flow, which reads the draft
+				// from localStorage and publishes after signup completes. The
+				// draft persists across the navigation.
+				window.location.assign( 'https://wordpress.com/setup/write-on' );
 				return;
 			}
 			await savePost( 'publish' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5765,6 +5765,12 @@ const { state } = store( 'wpcom-write', {
 					if ( contentEl ) {
 						contentEl.innerHTML = snapshot.content;
 					}
+					// The CSS placeholder is driven by `bw-is-empty` on the outer
+					// `.bw-content`, normally removed by the first input event.
+					// Programmatic hydration fires no input, so clear it directly.
+					if ( snapshot.content ) {
+						document.querySelector( '.bw-content' )?.classList.remove( 'bw-is-empty' );
+					}
 					lastSavedSnapshot = getContentSnapshot();
 				}
 				state.showRecoveryBanner = false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5657,9 +5657,18 @@ const { state } = store( 'wpcom-write', {
 
 		async publish() {
 			if ( isAnon() ) {
+				// Flush the latest draft snapshot before navigating — autosave is
+				// on a 30s tick, and a fast typer-then-clicker would otherwise
+				// hand off stale (or no) content to the signup flow.
+				const contentEl = document.querySelector( '.bw-content' );
+				saveDraftToLocalStorage( state.title, contentEl ? contentEl.innerHTML : '' );
+
+				// Suppress the dirty-state leave prompt the way every other
+				// internal navigation in this file does (cf. openInBlockEditor).
+				allowLeave = true;
+
 				// Anon visitors hand off to the signup flow, which reads the draft
-				// from localStorage and publishes after signup completes. The
-				// draft persists across the navigation.
+				// from localStorage and publishes after signup completes.
 				window.location.assign( 'https://wordpress.com/setup/write-on' );
 				return;
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -97,6 +97,11 @@ function wpcom_write_get_editor_strings() {
 		'citation'             => __( 'Citation', 'jetpack-mu-wpcom' ),
 		'postNotFound'         => __( 'Post not found. Check the URL or ID and try again.', 'jetpack-mu-wpcom' ),
 		'postNoPermission'     => __( 'You don\'t have permission to edit this post.', 'jetpack-mu-wpcom' ),
+		// Labels used only when the editor is rendered for a logged-out
+		// visitor (window.wpcomWriteIsAnon). Brand text is intentionally
+		// rendered as the WordPress.com product mark with the feature name.
+		'anonBrand'            => __( 'WordPress.com · Write', 'jetpack-mu-wpcom' ),
+		'anonStatus'           => __( 'Not signed in', 'jetpack-mu-wpcom' ),
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -98,9 +98,9 @@ function wpcom_write_get_editor_strings() {
 		'postNotFound'         => __( 'Post not found. Check the URL or ID and try again.', 'jetpack-mu-wpcom' ),
 		'postNoPermission'     => __( 'You don\'t have permission to edit this post.', 'jetpack-mu-wpcom' ),
 		// Labels used only when the editor is rendered for a logged-out
-		// visitor (window.wpcomWriteIsAnon). Brand text is intentionally
-		// rendered as the WordPress.com product mark with the feature name.
-		'anonBrand'            => __( 'WordPress.com · Write', 'jetpack-mu-wpcom' ),
+		// visitor (window.wpcomWriteIsAnon). "WordPress.com" is a product
+		// mark and stays untranslated; only the feature name is localised.
+		'anonBrand'            => 'WordPress.com · ' . _x( 'Write', 'editor name in the anonymous brand label', 'jetpack-mu-wpcom' ),
 		'anonStatus'           => __( 'Not signed in', 'jetpack-mu-wpcom' ),
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -53,6 +53,54 @@ function wpcom_write_url() {
 }
 
 /**
+ * Translated UI strings consumed by view.js as `window.wpcomWriteStrings`.
+ *
+ * Exposed as a helper so callers that render the Write editor outside the
+ * wp-admin page lifecycle (and therefore never hit the admin_enqueue_scripts
+ * hook below) can print the same strings without duplicating the list.
+ *
+ * @return array<string, string> Map of i18n key -> translated string.
+ */
+function wpcom_write_get_editor_strings() {
+	return array(
+		'caption'              => __( 'Caption', 'jetpack-mu-wpcom' ),
+		'editImage'            => __( 'Edit image', 'jetpack-mu-wpcom' ),
+		'writeCaption'         => __( 'Write a caption...', 'jetpack-mu-wpcom' ),
+		// translators: %s is the error message from the upload failure.
+		'uploadFailed'         => __( 'Upload failed: %s', 'jetpack-mu-wpcom' ),
+		'libraryLoading'       => __( 'Loading your library…', 'jetpack-mu-wpcom' ),
+		'libraryEmpty'         => __( 'No images in your library yet.', 'jetpack-mu-wpcom' ),
+		'libraryNoResults'     => __( 'No matching images.', 'jetpack-mu-wpcom' ),
+		'libraryLoadFailed'    => __( "Couldn't load your library.", 'jetpack-mu-wpcom' ),
+		// translators: %s is the alt text or filename of the selected library image.
+		'librarySelected'      => __( 'Selected %s', 'jetpack-mu-wpcom' ),
+		'invalidVideoUrl'      => __( 'Please paste a valid YouTube or Vimeo URL', 'jetpack-mu-wpcom' ),
+		'pleaseAddTitle'       => __( 'Please add a title', 'jetpack-mu-wpcom' ),
+		'pleaseWriteSomething' => __( 'Please write something', 'jetpack-mu-wpcom' ),
+		'savingDraft'          => __( 'Saving draft...', 'jetpack-mu-wpcom' ),
+		'updating'             => __( 'Updating...', 'jetpack-mu-wpcom' ),
+		'publishing'           => __( 'Publishing...', 'jetpack-mu-wpcom' ),
+		'updated'              => __( 'Updated!', 'jetpack-mu-wpcom' ),
+		'published'            => __( 'Published!', 'jetpack-mu-wpcom' ),
+		'draftSaved'           => __( 'Draft saved', 'jetpack-mu-wpcom' ),
+		'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
+		// translators: %s is the error message.
+		'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
+		'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
+		'heading2'             => __( 'Heading 2', 'jetpack-mu-wpcom' ),
+		'heading3'             => __( 'Heading 3', 'jetpack-mu-wpcom' ),
+		'preview'              => __( 'Preview', 'jetpack-mu-wpcom' ),
+		// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
+		'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
+		'untitled'             => __( 'Untitled', 'jetpack-mu-wpcom' ),
+		'addCitation'          => __( 'Add citation…', 'jetpack-mu-wpcom' ),
+		'citation'             => __( 'Citation', 'jetpack-mu-wpcom' ),
+		'postNotFound'         => __( 'Post not found. Check the URL or ID and try again.', 'jetpack-mu-wpcom' ),
+		'postNoPermission'     => __( 'You don\'t have permission to edit this post.', 'jetpack-mu-wpcom' ),
+	);
+}
+
+/**
  * Register the script module on init.
  */
 add_action(
@@ -123,44 +171,8 @@ add_action(
 		wp_enqueue_script_module( 'wpcom-write/view' );
 
 		// Pass translated strings to JavaScript for dynamic messages.
-		$write_strings = array(
-			'caption'              => __( 'Caption', 'jetpack-mu-wpcom' ),
-			'editImage'            => __( 'Edit image', 'jetpack-mu-wpcom' ),
-			'writeCaption'         => __( 'Write a caption...', 'jetpack-mu-wpcom' ),
-			// translators: %s is the error message from the upload failure.
-			'uploadFailed'         => __( 'Upload failed: %s', 'jetpack-mu-wpcom' ),
-			'libraryLoading'       => __( 'Loading your library…', 'jetpack-mu-wpcom' ),
-			'libraryEmpty'         => __( 'No images in your library yet.', 'jetpack-mu-wpcom' ),
-			'libraryNoResults'     => __( 'No matching images.', 'jetpack-mu-wpcom' ),
-			'libraryLoadFailed'    => __( "Couldn't load your library.", 'jetpack-mu-wpcom' ),
-			// translators: %s is the alt text or filename of the selected library image.
-			'librarySelected'      => __( 'Selected %s', 'jetpack-mu-wpcom' ),
-			'invalidVideoUrl'      => __( 'Please paste a valid YouTube or Vimeo URL', 'jetpack-mu-wpcom' ),
-			'pleaseAddTitle'       => __( 'Please add a title', 'jetpack-mu-wpcom' ),
-			'pleaseWriteSomething' => __( 'Please write something', 'jetpack-mu-wpcom' ),
-			'savingDraft'          => __( 'Saving draft...', 'jetpack-mu-wpcom' ),
-			'updating'             => __( 'Updating...', 'jetpack-mu-wpcom' ),
-			'publishing'           => __( 'Publishing...', 'jetpack-mu-wpcom' ),
-			'updated'              => __( 'Updated!', 'jetpack-mu-wpcom' ),
-			'published'            => __( 'Published!', 'jetpack-mu-wpcom' ),
-			'draftSaved'           => __( 'Draft saved', 'jetpack-mu-wpcom' ),
-			'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
-			// translators: %s is the error message.
-			'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
-			'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
-			'heading2'             => __( 'Heading 2', 'jetpack-mu-wpcom' ),
-			'heading3'             => __( 'Heading 3', 'jetpack-mu-wpcom' ),
-			'preview'              => __( 'Preview', 'jetpack-mu-wpcom' ),
-			// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
-			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
-			'untitled'             => __( 'Untitled', 'jetpack-mu-wpcom' ),
-			'addCitation'          => __( 'Add citation…', 'jetpack-mu-wpcom' ),
-			'citation'             => __( 'Citation', 'jetpack-mu-wpcom' ),
-			'postNotFound'         => __( 'Post not found. Check the URL or ID and try again.', 'jetpack-mu-wpcom' ),
-			'postNoPermission'     => __( 'You don\'t have permission to edit this post.', 'jetpack-mu-wpcom' ),
-		);
 		wp_print_inline_script_tag(
-			'window.wpcomWriteStrings = ' . wp_json_encode( $write_strings, JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
+			'window.wpcomWriteStrings = ' . wp_json_encode( wpcom_write_get_editor_strings(), JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
 		);
 
 		wp_enqueue_style(
@@ -574,6 +586,12 @@ function wpcom_write_inline_color_marks_to_spans( $html ) {
  * @return array Array of { id: int, title: string, modified: string } objects.
  */
 function wpcom_write_get_recent_drafts( $exclude_post_id = 0 ) {
+	// Drafts always belong to the current user; without one there is nothing to
+	// return, and querying with author=0 would otherwise match orphaned drafts.
+	if ( ! is_user_logged_in() ) {
+		return array();
+	}
+
 	$args = array(
 		'post_type'      => 'post',
 		'post_status'    => 'draft',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1669,6 +1669,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			'draftAutosaved',
 			'error',
 			'untitled',
+			'anonBrand',
+			'anonStatus',
 		);
 		foreach ( $expected as $key ) {
 			$this->assertArrayHasKey( $key, $strings, "Missing editor string: $key" );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1623,6 +1623,60 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Logged-out callers must never receive drafts. The early-return guards
+	 * against a query running with author=0 (which would otherwise match every
+	 * orphaned draft on a multisite blog).
+	 */
+	public function test_recent_drafts_returns_empty_for_logged_out_user() {
+		wp_set_current_user( 0 );
+
+		$drafts = wpcom_write_get_recent_drafts();
+
+		$this->assertSame( array(), $drafts );
+	}
+
+	/**
+	 * Logged-out callers must also get an empty result when passing an exclude
+	 * id — verifies the guard sits in front of the exclude branch.
+	 */
+	public function test_recent_drafts_returns_empty_for_logged_out_user_with_exclude() {
+		wp_set_current_user( 0 );
+
+		$drafts = wpcom_write_get_recent_drafts( 123 );
+
+		$this->assertSame( array(), $drafts );
+	}
+
+	/**
+	 * The editor-strings helper is the contract the inline script tag
+	 * (and any other caller rendering the editor outside the wp-admin page
+	 * lifecycle) relies on. Validate the returned shape so a silently-dropped
+	 * key in a future edit is caught here rather than at runtime in view.js.
+	 */
+	public function test_editor_strings_returns_expected_keys() {
+		$strings = wpcom_write_get_editor_strings();
+
+		$this->assertIsArray( $strings );
+
+		// Spot-check the keys view.js reads as `i18n.<key>`. Not exhaustive —
+		// adding a new string should not require updating this test — but a
+		// removal of any of these keys would break the JS at runtime.
+		$expected = array(
+			'pleaseAddTitle',
+			'pleaseWriteSomething',
+			'savingDraft',
+			'publishing',
+			'draftAutosaved',
+			'error',
+			'untitled',
+		);
+		foreach ( $expected as $key ) {
+			$this->assertArrayHasKey( $key, $strings, "Missing editor string: $key" );
+			$this->assertNotEmpty( $strings[ $key ], "Editor string $key should not be empty" );
+		}
+	}
+
+	/**
 	 * Test that openPostError is seeded as empty string by default.
 	 */
 	public function test_interactivity_state_includes_open_post_error() {


### PR DESCRIPTION
Fixes READ-558.

## Proposed changes
* Add a logged-out variant of the Write editor in `jetpack-mu-wpcom`, gated entirely on `window.wpcomWriteIsAnon`. When the flag is absent every code path behaves as it does today — the authenticated wp-admin Write page is byte-for-byte unchanged.
* When the flag is set, autosave persists `{title, content, ts}` JSON to `localStorage['wpcom-write-anon-draft']` (with try/catch + a `wpcom_write_editor_anon_draft_persist_failed` Tracks event so silent draft loss doesn't read as abandonment), the recovery banner hydrates the snapshot in place rather than navigating to a server post id, and Publish hands off to `/setup/write-on`.
* Hide the surfaces that have no anon equivalent — back button, "Open in block editor", Preview, "Open post", "Open in classic/block editor" buttons in the unsupported-content modal — and early-return on the corresponding actions (`openImageModal`, `toggleLibraryPicker`, `openPostPicker`, `previewPost`, `openInBlockEditor`, drag-and-drop image inserts) so programmatic call paths can't fire either.
* Extract the editor i18n strings into a new `wpcom_write_get_editor_strings()` helper so a caller rendering the editor outside the wp-admin page lifecycle can print the same strings; defense-in-depth `! is_user_logged_in()` guard on `wpcom_write_get_recent_drafts()` (so a future caller can't accidentally run the query with `author = 0`).

<img width="1108" height="363" alt="Screenshot 2026-06-18 at 2 34 40 PM" src="https://github.com/user-attachments/assets/0ac5acc5-4c64-48b4-aedd-f96b6c351344" />



## Related product discussion/links
* READ-558
* The host page that sets `window.wpcomWriteIsAnon = true` (and serves the editor outside wp-admin) ships separately. Until that lands, this change is inert in production.

## Does this pull request change what data or activity we track or use?
Yes — adds one Tracks event, `wpcom_write_editor_anon_draft_persist_failed`, fired client-side when localStorage `setItem` throws (`QuotaExceededError`, `SecurityError`, or no storage at all). Props: `error_name`. No new server-side tracking; existing `wpcom_write_editor_*` events are unchanged.

## Testing instructions

### Authenticated path (must be unchanged)
1. Go to `wp-admin/admin.php?page=write`.
2. Type a title and body, wait ~30s — the existing autosave toast appears and the draft is created via the REST API as before.
3. Click the "⋮" menu — "Save draft", "Open in block editor", "Preview", and "Open post" are all visible and functional.
4. Click Publish — the post publishes normally and you're redirected to its admin URL.
5. Refresh the editor with an outstanding autosave — the existing "You have a recent draft" recovery banner appears and "Resume" navigates to the autosaved post.

### Anonymous path
The full entry point lives outside this package, so to exercise the anon code locally:
1. Open the Write editor while logged in.
2. In devtools, run `window.wpcomWriteIsAnon = true; document.documentElement.classList.add('bw-anon');` — do not reload (the flag would be lost). Type to test autosave + recovery + publish-handoff against the current page.
3. Verify:
    * The back button, "Open in block editor", Preview, "Open post", and unsupported-content "Open in editor" buttons are hidden.
    * Wait ~30s after typing — `localStorage.getItem('wpcom-write-anon-draft')` returns the JSON snapshot. No POST to `/wp/v2/posts` fires in the Network panel.
    * Click Publish — the page navigates to `/setup/write-on` (will 404 on local until that flow ships; expected).
4. Quota failure path: in devtools, override `localStorage.setItem` to throw `new DOMException('quota', 'QuotaExceededError')`, type to trigger an autosave, and confirm the Tracks event fires (`window._tkq` push).

### Tests
* New PHPUnit cases cover the logged-out `wpcom_write_get_recent_drafts()` guard (with and without an `exclude_post_id`) and the shape of `wpcom_write_get_editor_strings()`.
* `pnpm test` (existing undo-history suite) still passes; ESLint, PHPCS, and Stylelint are clean.
* Note: the local PHPUnit bootstrap is currently broken on `trunk` because of an unrelated missing `Shared_Stores_Assets` class (introduced yesterday by the shared-stores externalization). The new tests follow the same patterns as the existing `Write_Test.php` cases; CI will run them.