### PR TITLE
My Jetpack: clip modules list rounded corners so row dividers don't poke out

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
@@ -5,6 +5,9 @@
 	:global(.dataviews-wrapper) {
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		border-radius: 8px;
+		// Clip the inner layout container's square corners and the row
+		// dividers to the rounded border, otherwise they poke out at the corners.
+		overflow: hidden;
 		background-color: #{gb.$white};
 	}
 

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-table-corner
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-table-corner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Modules list: fix rounded corners so row dividers no longer poke past the border


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

The modules list on the My Jetpack **Products** tab is a DataViews table wrapped in a card with `border-radius: 8px`. The wrapper had `overflow: visible`, so the inner square-cornered layout container and the full-width row dividers extended past the rounded corners — producing a small notch/overflow artifact at the card corners.

* Add `overflow: hidden` to the modules list `.dataviews-wrapper` so its rounded border clips the inner layout container and the row dividers. CSS-only; no JS/PHP changes.

### Before / After

Captured on a live Jurassic Ninja site at `/wp-admin/admin.php?page=my-jetpack#/products`. The only change between the two is the `overflow` value on the wrapper.

| Before (`overflow: visible`) | After (`overflow: hidden`) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-table-corner/before.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-table-corner/after.png) |

In the "before" image the row dividers run edge-to-edge and collide with the rounded corners; in the "after" image they are clipped, leaving the corners clean.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect Jetpack on a test site and open **Jetpack → My Jetpack → Products** (`/wp-admin/admin.php?page=my-jetpack#/products`).
* Look at the card around the modules list (e.g. Account Protection, Downtime Monitor, Firewall).
* Confirm the row divider lines stay inside the rounded corners and the card corners render cleanly with no notch/overflow where the dividers meet the border.
