### PR TITLE
AI Launchpad: polish the tailored list to match the design PoC (DOTOBRD-476)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-design-polish
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-design-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: polish the tailored list to match the design prototype — centered layout with a heading, progress, and site preview; action-specific task CTAs; and a "Tailoring your checklist…" loading state.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -180,9 +180,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
 			// Site context the client needs: the front-end URL drives the launch-task
-			// CTA (its host is the launch-flow site slug) and the tailored-list preview.
+			// CTA (its host is the launch-flow site slug) and the tailored-list
+			// preview thumbnail; the title labels that preview.
 			'site'               => array(
-				'url' => home_url(),
+				'url'   => home_url(),
+				'title' => get_bloginfo( 'name' ),
 			),
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -59,11 +59,14 @@ export function App() {
 	}
 
 	// After the wizard, the list runs the fresh tailor flow (initialData would be
-	// the pre-wizard read); returning users render straight from initialData.
+	// the pre-wizard read); returning users render straight from initialData. The
+	// site context is path-independent, so it's passed either way — that lets the
+	// loading skeleton show the site preview before the tailored read lands.
 	return (
 		<TailoredList
 			pendingTailor={ pendingTailor }
 			initialData={ pendingTailor ? undefined : initialData }
+			site={ initialData?.site }
 		/>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
@@ -1,0 +1,55 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { SitePreview } from './site-preview.tsx';
+import type { ReactNode } from 'react';
+
+interface Props {
+	// The line under the heading: the "X of N completed" progress for the loaded
+	// list, or the "Tailoring your checklist…" copy while the AI call is in flight.
+	progressLabel: string;
+	// Site context for the preview card; omitted when unknown (dev fixtures).
+	siteUrl: string | null;
+	siteTitle?: string | null;
+	// The left column: the task cards, or the loading skeleton.
+	children: ReactNode;
+}
+
+/**
+ * The shared chrome for the tailored list and its loading state: a centered
+ * content column with a heading and a progress/status line, the supplied
+ * content (task cards or skeleton) on the left, and the site preview on the
+ * right. Sharing this between the loaded and loading states keeps the
+ * wizard→tailoring→list transition seamless — only the left column and the
+ * status line change.
+ *
+ * @param props               - Component props.
+ * @param props.progressLabel - The status line under the heading.
+ * @param props.siteUrl       - The site's front-end URL (for the preview).
+ * @param props.siteTitle     - The site name (for the preview).
+ * @param props.children      - The left column content.
+ * @return The layout element.
+ */
+export function Layout( { progressLabel, siteUrl, siteTitle, children }: Props ) {
+	// Without a site URL there's no preview, so collapse to a single column —
+	// otherwise the grid reserves an empty preview track and squeezes the tasks.
+	const hasPreview = !! siteUrl;
+
+	return (
+		<div className="ai-launchpad-tailored-list__layout">
+			<header className="ai-launchpad-tailored-list__heading">
+				<h1 className="ai-launchpad-tailored-list__title-heading">
+					{ __( 'Get the most out of WordPress', 'jetpack-mu-wpcom' ) }
+				</h1>
+				<p className="ai-launchpad-tailored-list__progress">{ progressLabel }</p>
+			</header>
+			<div
+				className={ clsx( 'ai-launchpad-tailored-list__columns', {
+					'has-preview': hasPreview,
+				} ) }
+			>
+				{ children }
+				<SitePreview siteUrl={ siteUrl } siteTitle={ siteTitle } />
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -15,9 +15,11 @@ export interface EnrichedTask {
 
 /** The site context the list needs (front-end URL for the launch CTA + preview). */
 export interface SiteData {
-	// Optional: the field comes from an un-validated REST response, so consumers
-	// must tolerate it being absent (coalesce to null) rather than trust the type.
+	// Optional: the fields come from an un-validated REST response, so consumers
+	// must tolerate them being absent (coalesce to null) rather than trust the type.
 	url?: string;
+	// The site name, used to label the preview card.
+	title?: string;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -1,0 +1,64 @@
+import { ExternalLink } from '@wordpress/components';
+
+interface Props {
+	// The site's front-end URL, from the composite read. When absent (older
+	// reads, dev fixtures) the preview is omitted entirely.
+	siteUrl: string | null;
+	// The site name; falls back to the domain when absent.
+	siteTitle?: string | null;
+}
+
+/**
+ * Build the mShots thumbnail URL for a site's front end. mShots renders the
+ * live page server-side and caches it; the first hit may return a "generating"
+ * placeholder that resolves on a later load — acceptable for this preview (the
+ * legacy launchpad widget relies on the same endpoint).
+ *
+ * @param siteUrl - The site's front-end URL.
+ * @return The mShots image URL (rendered at 2x the displayed width for retina).
+ */
+function mshotsUrl( siteUrl: string ): string {
+	return `https://s0.wp.com/mshots/v1/${ encodeURIComponent( siteUrl ) }?w=700`;
+}
+
+/**
+ * The site-preview card shown to the right of the tailored list: an mShots
+ * thumbnail of the site's front end, the site name, and a link to the site.
+ * Rendered in both the loading and loaded states so the layout is stable across
+ * the wizard→tailoring→list transition. Returns nothing when the site URL is
+ * unknown (e.g. dev fixtures), so the list still renders without it.
+ *
+ * @param props           - Component props.
+ * @param props.siteUrl   - The site's front-end URL.
+ * @param props.siteTitle - The site name (falls back to the domain).
+ * @return The preview element, or null when there's no site URL.
+ */
+export function SitePreview( { siteUrl, siteTitle }: Props ) {
+	if ( ! siteUrl ) {
+		return null;
+	}
+
+	let domain = siteUrl;
+	try {
+		domain = new URL( siteUrl ).host;
+	} catch {
+		// A malformed home URL still renders: fall back to the raw string.
+	}
+
+	return (
+		<aside className="ai-launchpad-tailored-list__preview">
+			<div className="ai-launchpad-tailored-list__preview-frame">
+				<img
+					className="ai-launchpad-tailored-list__preview-image"
+					src={ mshotsUrl( siteUrl ) }
+					alt=""
+					loading="lazy"
+				/>
+			</div>
+			<p className="ai-launchpad-tailored-list__preview-title">{ siteTitle || domain }</p>
+			<ExternalLink className="ai-launchpad-tailored-list__preview-link" href={ siteUrl }>
+				{ domain }
+			</ExternalLink>
+		</aside>
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -9,21 +9,11 @@ interface Props {
 }
 
 /**
- * Build the mShots thumbnail URL for a site's front end. mShots renders the
- * live page server-side and caches it; the first hit may return a "generating"
- * placeholder that resolves on a later load — acceptable for this preview (the
- * legacy launchpad widget relies on the same endpoint).
- *
- * @param siteUrl - The site's front-end URL.
- * @return The mShots image URL (rendered at 2x the displayed width for retina).
- */
-function mshotsUrl( siteUrl: string ): string {
-	return `https://s0.wp.com/mshots/v1/${ encodeURIComponent( siteUrl ) }?w=700`;
-}
-
-/**
- * The site-preview card shown to the right of the tailored list: an mShots
- * thumbnail of the site's front end, the site name, and a link to the site.
+ * The site-preview card shown to the right of the tailored list: a live,
+ * scaled-down preview of the site's front end, the site name, and a link to the
+ * site. The preview is a non-interactive iframe of the front end with the
+ * banners/overlay hidden, mirroring the wp-admin dashboard's site-management
+ * widget — it renders immediately rather than waiting on an mShots screenshot.
  * Rendered in both the loading and loaded states so the layout is stable across
  * the wizard→tailoring→list transition. Returns nothing when the site URL is
  * unknown (e.g. dev fixtures), so the list still renders without it.
@@ -48,11 +38,12 @@ export function SitePreview( { siteUrl, siteTitle }: Props ) {
 	return (
 		<aside className="ai-launchpad-tailored-list__preview">
 			<div className="ai-launchpad-tailored-list__preview-frame">
-				<img
-					className="ai-launchpad-tailored-list__preview-image"
-					src={ mshotsUrl( siteUrl ) }
-					alt=""
-					loading="lazy"
+				<iframe
+					className="ai-launchpad-tailored-list__preview-iframe"
+					title={ siteTitle || domain }
+					src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
+					inert="true"
+					tabIndex={ -1 }
 				/>
 			</div>
 			<p className="ai-launchpad-tailored-list__preview-title">{ siteTitle || domain }</p>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
@@ -1,11 +1,10 @@
-import { Card, CardBody } from '@wordpress/components';
-
-const PLACEHOLDER_COUNT = 6;
+const PLACEHOLDER_COUNT = 5;
 
 /**
- * Loading placeholder for the tailored list, shown while the AI call is in
- * flight. Renders six shimmering cards so the layout doesn't jump when the
- * real task cards arrive.
+ * Loading placeholder for the tailored list's task column, shown while the AI
+ * call is in flight. Rendered inside {@link Layout} so the heading and site
+ * preview stay put; only these shimmering bars stand in for the task cards
+ * until the real ones arrive.
  *
  * @return The skeleton element.
  */
@@ -13,11 +12,11 @@ export function TailoredListSkeleton() {
 	return (
 		<div className="ai-launchpad-tailored-list">
 			{ Array.from( { length: PLACEHOLDER_COUNT } ).map( ( _, index ) => (
-				<Card key={ index } className="ai-launchpad-tailored-list__card is-skeleton">
-					<CardBody>
-						<span className="ai-launchpad-tailored-list__skeleton-line is-title" />
-					</CardBody>
-				</Card>
+				<span
+					key={ index }
+					className="ai-launchpad-tailored-list__skeleton-bar"
+					aria-hidden="true"
+				/>
 			) ) }
 		</div>
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -2,10 +2,19 @@
 
 	// The centered content column shared by the loaded list and its loading
 	// state: heading + progress line, then a two-column grid (tasks | preview).
+	// A responsive, generous top pad pushes the content off the admin chrome
+	// without relying on a fixed-height container to vertically center.
 	&__layout {
 		max-width: 960px;
 		margin: 0 auto;
-		padding-block-start: 16px;
+		padding: clamp(24px, 8vh, 96px) 24px 48px;
+	}
+
+	@media (max-width: 782px) {
+
+		&__layout {
+			padding: 24px 16px 32px;
+		}
 	}
 
 	&__heading {
@@ -34,7 +43,7 @@
 		// Reserve the preview track only when there's a preview to show, so a
 		// missing site URL doesn't leave an empty gutter squeezing the tasks.
 		&.has-preview {
-			grid-template-columns: minmax(0, 1fr) 320px;
+			grid-template-columns: minmax(0, 1fr) 300px;
 		}
 	}
 
@@ -47,10 +56,15 @@
 		}
 	}
 
-	// The task column itself: a vertical stack of cards (and skeleton bars).
+	// The task column itself: a vertical stack of cards (and skeleton bars),
+	// wrapped in a padded grey container so the white cards read as a grouped
+	// checklist. The padding matches the inter-card gap.
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
+	padding: 8px;
+	background: #f6f7f7;
+	border-radius: 8px;
 
 	&__card {
 
@@ -136,32 +150,48 @@
 		gap: 8px;
 	}
 
-	// The site-preview card in the right column: mShots thumbnail + name + link.
+	// The site-preview card in the right column: a live scaled site preview +
+	// name + link.
 	&__preview {
 		display: flex;
 		flex-direction: column;
 	}
 
+	// A square frame holding a desktop-width iframe scaled down to fit, mirroring
+	// the wp-admin dashboard site-management widget (renders immediately, no
+	// mShots wait). The iframe is 4× the frame and scaled 0.25, so the frame
+	// shows a ~1200px-wide front-end view regardless of the frame's actual size.
 	&__preview-frame {
+		position: relative;
+		width: 100%;
+		max-width: 300px;
+		aspect-ratio: 1 / 1;
 		overflow: hidden;
 		border: 1px solid #e0e0e0;
 		border-radius: 8px;
 		background: #f6f7f7;
-		aspect-ratio: 4 / 5;
 	}
 
-	&__preview-image {
-		display: block;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		object-position: top;
+	&__preview-iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 400%;
+		min-height: 440%;
+		border: 0;
+		transform: scale(0.25);
+		transform-origin: top left;
+		// Nudge the scaled view up to crop the logged-in admin bar (~32px at the
+		// 1200px render width → ~8px at scale 0.25), mirroring the dashboard widget.
+		translate: 0 -8px;
+		// Purely a thumbnail — the link below is the interactive affordance.
+		pointer-events: none;
 	}
 
 	&__preview-title {
 		margin: 12px 0 2px;
 		font-weight: 600;
-		font-size: 14px;
+		font-size: 15px;
 	}
 
 	&__preview-link {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -1,4 +1,53 @@
 .ai-launchpad-tailored-list {
+
+	// The centered content column shared by the loaded list and its loading
+	// state: heading + progress line, then a two-column grid (tasks | preview).
+	&__layout {
+		max-width: 960px;
+		margin: 0 auto;
+		padding-block-start: 16px;
+	}
+
+	&__heading {
+		margin-bottom: 24px;
+	}
+
+	&__title-heading {
+		margin: 0;
+		font-size: 32px;
+		line-height: 1.2;
+		font-weight: 500;
+	}
+
+	&__progress {
+		margin: 8px 0 0;
+		color: #757575;
+		font-size: 14px;
+	}
+
+	&__columns {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		gap: 32px;
+		align-items: start;
+
+		// Reserve the preview track only when there's a preview to show, so a
+		// missing site URL doesn't leave an empty gutter squeezing the tasks.
+		&.has-preview {
+			grid-template-columns: minmax(0, 1fr) 320px;
+		}
+	}
+
+	// Stack the preview under the tasks on narrow screens (WP admin's mobile
+	// breakpoint), so neither column gets squeezed.
+	@media (max-width: 782px) {
+
+		&__columns.has-preview {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	// The task column itself: a vertical stack of cards (and skeleton bars).
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
@@ -17,7 +66,6 @@
 	&__header {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		gap: 8px;
 		width: 100%;
 		height: auto;
@@ -35,6 +83,7 @@
 	}
 
 	&__title {
+		flex: 1;
 		font-weight: 500;
 		font-size: 14px;
 
@@ -46,11 +95,27 @@
 
 	&__icon {
 		flex-shrink: 0;
-		margin-inline-end: 8px;
 
+		// Incomplete tasks: a dashed ring (no equivalent in @wordpress/icons), sized
+		// to match the 24px completed-state icon so titles align across rows.
+		&.is-todo {
+			width: 24px;
+			height: 24px;
+			border: 1.5px dashed #c3c4c7;
+			border-radius: 50%;
+			box-sizing: border-box;
+		}
+
+		// Completed tasks: the @wordpress/icons "published" check-in-circle, greyed
+		// to sit alongside the struck-through title.
 		&.is-done {
 			fill: #757575;
 		}
+	}
+
+	&__chevron {
+		flex-shrink: 0;
+		fill: #757575;
 	}
 
 	&__body {
@@ -71,11 +136,43 @@
 		gap: 8px;
 	}
 
-	&__skeleton-line {
+	// The site-preview card in the right column: mShots thumbnail + name + link.
+	&__preview {
+		display: flex;
+		flex-direction: column;
+	}
+
+	&__preview-frame {
+		overflow: hidden;
+		border: 1px solid #e0e0e0;
+		border-radius: 8px;
+		background: #f6f7f7;
+		aspect-ratio: 4 / 5;
+	}
+
+	&__preview-image {
 		display: block;
-		height: 16px;
-		width: 60%;
-		border-radius: 2px;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		object-position: top;
+	}
+
+	&__preview-title {
+		margin: 12px 0 2px;
+		font-weight: 600;
+		font-size: 14px;
+	}
+
+	&__preview-link {
+		font-size: 13px;
+	}
+
+	// Loading placeholders: solid shimmering bars standing in for the task cards.
+	&__skeleton-bar {
+		display: block;
+		height: 56px;
+		border-radius: 4px;
 		background: linear-gradient(90deg, #f0f0f0 25%, #e6e6e6 37%, #f0f0f0 63%);
 		background-size: 400% 100%;
 		animation: ai-launchpad-shimmer 1.4s ease infinite;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -66,38 +66,25 @@
 	background: #f6f7f7;
 	border-radius: 8px;
 
+	// Tighten the @wordpress/ui Card padding so the cards read as compact
+	// checklist rows rather than full content cards. Zero the header→content
+	// margin (it otherwise leaves a gap below the header even when collapsed);
+	// the expanded gap is re-added on the subtitle, inside the clipped panel.
 	&__card {
-
-		.components-card__body {
-			padding: 16px 20px;
-		}
-
-		&.is-expanded .components-card__body {
-			padding-bottom: 20px;
-		}
+		--wp-ui-card-padding: 16px;
+		--wp-ui-card-header-content-margin: 0;
 	}
 
-	&__header {
+	// The icon + title row placed inside the (clickable) card header. The
+	// CollapsibleCard supplies the chevron trigger beside it.
+	&__header-inner {
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		width: 100%;
-		height: auto;
-		text-align: start;
-
-		// The collapsed header is a Button; strip its chrome so it reads as a row.
-		&.components-button {
-			padding: 0;
-			color: inherit;
-
-			&:hover:not(:disabled) {
-				color: inherit;
-			}
-		}
+		min-width: 0;
 	}
 
 	&__title {
-		flex: 1;
 		font-weight: 500;
 		font-size: 14px;
 
@@ -107,40 +94,26 @@
 		}
 	}
 
+	// The inline SVG task icons use `currentColor`, so tone them via `color`.
 	&__icon {
 		flex-shrink: 0;
 
-		// Incomplete tasks: a dashed ring (no equivalent in @wordpress/icons), sized
-		// to match the 24px completed-state icon so titles align across rows.
+		// Incomplete tasks: a light dashed ring.
 		&.is-todo {
-			width: 24px;
-			height: 24px;
-			border: 1.5px dashed #c3c4c7;
-			border-radius: 50%;
-			box-sizing: border-box;
+			color: #c3c4c7;
 		}
 
-		// Completed tasks: the @wordpress/icons "published" check-in-circle, greyed
-		// to sit alongside the struck-through title.
+		// Completed tasks: a check-in-circle, greyed to sit alongside the
+		// struck-through title.
 		&.is-done {
-			fill: #757575;
+			color: #757575;
 		}
 	}
 
-	&__chevron {
-		flex-shrink: 0;
-		fill: #757575;
-	}
-
-	&__body {
-		margin-top: 12px;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
+	// 8px top re-creates the header→content gap (the card's own margin is zeroed
+	// above); being inside the panel, it's clipped when the card is collapsed.
 	&__subtitle {
-		margin: 0;
+		margin: 8px 0 16px;
 		color: #757575;
 	}
 
@@ -165,7 +138,7 @@
 		position: relative;
 		width: 100%;
 		max-width: 300px;
-		aspect-ratio: 1 / 1;
+		aspect-ratio: 4 / 3;
 		overflow: hidden;
 		border: 1px solid #e0e0e0;
 		border-radius: 8px;
@@ -196,6 +169,15 @@
 
 	&__preview-link {
 		font-size: 13px;
+	}
+
+	// Stacked under the tasks on mobile, the preview spans the full column width.
+	// Declared after the base rule above so it wins at the mobile breakpoint.
+	@media (max-width: 782px) {
+
+		&__preview-frame {
+			max-width: none;
+		}
 	}
 
 	// Loading placeholders: solid shimmering bars standing in for the task cards.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -1,8 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { createFirstPostDraft } from '../lib/first-post.ts';
 import { createPatternPage } from '../lib/pattern-page.ts';
 import { trackTaskClicked } from '../lib/tracks.ts';
+import { Layout } from './layout.tsx';
 import {
 	firstIncompleteIndex,
 	isTaskActionable,
@@ -10,6 +12,7 @@ import {
 	tasksFromFixture,
 	type EnrichedTask,
 	type LaunchpadData,
+	type SiteData,
 } from './model.ts';
 import { TailoredListSkeleton } from './skeleton.tsx';
 import { TaskCard } from './task-card.tsx';
@@ -40,12 +43,20 @@ interface Props {
 	// view, so it hands the data down here to avoid fetching the same expensive
 	// endpoint a second time. Omitted on the wizard→list path.
 	initialData?: LaunchpadData;
+
+	// Site context (URL + title) for the preview card. The host always has this
+	// from its initial composite read, so it's passed on the wizard→list path too
+	// — that lets the loading skeleton show the preview before the tailored read
+	// lands. The fetched/initialData site (when present) takes precedence.
+	site?: SiteData;
 }
 
 /**
- * The tailored launchpad list: six task cards rendered from the AI output. The
- * first incomplete task auto-expands; each task offers "Get started" and "Skip"
- * actions. While the AI output is loading, a six-card skeleton is shown.
+ * The tailored launchpad list: task cards rendered from the AI output inside a
+ * centered layout with a heading, "X of N completed" progress, and a site
+ * preview. The first incomplete task auto-expands; each task offers an
+ * action-specific CTA and "Skip". While the AI output is loading, the same
+ * layout is shown with a shimmering skeleton and "Tailoring your checklist…".
  *
  * Titles, completion state, and deeplink paths come from Stream B's
  * `GET /ai-launchpad/`; subtitles come from the AI. In dev mode the list
@@ -55,16 +66,30 @@ interface Props {
  * @param props               - Component props.
  * @param props.pendingTailor - In-flight tailor call to await before fetching.
  * @param props.initialData   - Composite read supplied by the host (returning users).
+ * @param props.site          - Site context for the preview (always supplied by the host).
  * @return The tailored-list element.
  */
-export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
-	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( null );
-	const [ output, setOutput ] = useState< TailoredOutput | null >( null );
+export function TailoredList( { pendingTailor, initialData, site }: Props = {} ) {
+	// Returning users arrive with the composite read already done, so seed straight
+	// from it — otherwise the first frame shows the "Tailoring…" loading copy before
+	// the effect runs. The wizard→list path has no initialData and starts as loading.
+	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( () => initialData?.tasks ?? null );
+	const [ output, setOutput ] = useState< TailoredOutput | null >(
+		() => initialData?.ai_output?.payload ?? null
+	);
 	const [ expandedId, setExpandedId ] = useState< string | null >( null );
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
-	// The site's front-end URL, used to build the launch CTA. From the composite read.
-	const [ siteUrl, setSiteUrl ] = useState< string | null >( null );
+	// The site's front-end URL, used to build the launch CTA and the preview
+	// thumbnail; the title labels the preview. Seeded from the read (returning users)
+	// or the host's `site` prop (wizard path, so the skeleton shows the preview),
+	// then overridden once the read lands.
+	const [ siteUrl, setSiteUrl ] = useState< string | null >(
+		() => initialData?.site?.url ?? site?.url ?? null
+	);
+	const [ siteTitle, setSiteTitle ] = useState< string | null >(
+		() => initialData?.site?.title ?? site?.title ?? null
+	);
 
 	useEffect( () => {
 		// Returning users: render from the data the host already fetched, so the
@@ -72,7 +97,10 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 		if ( initialData ) {
 			setTasks( initialData.tasks );
 			setOutput( initialData.ai_output?.payload ?? null );
-			setSiteUrl( initialData.site?.url ?? null );
+			if ( initialData.site ) {
+				setSiteUrl( initialData.site.url ?? null );
+				setSiteTitle( initialData.site.title ?? null );
+			}
 			return;
 		}
 
@@ -95,6 +123,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 
 			if ( data?.site ) {
 				setSiteUrl( data.site.url ?? null );
+				setSiteTitle( data.site.title ?? null );
 			}
 
 			if ( data && data.tasks.length > 0 ) {
@@ -136,8 +165,24 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	}, [ tasks, visibleTasks, expandedId ] );
 
 	if ( ! tasks ) {
-		return <TailoredListSkeleton />;
+		return (
+			<Layout
+				progressLabel={ __( 'Tailoring your checklist…', 'jetpack-mu-wpcom' ) }
+				siteUrl={ siteUrl }
+				siteTitle={ siteTitle }
+			>
+				<TailoredListSkeleton />
+			</Layout>
+		);
 	}
+
+	const completedCount = visibleTasks.filter( task => task.completed ).length;
+	const progressLabel = sprintf(
+		/* translators: 1: number of completed tasks, 2: total number of tasks. */
+		__( '%1$d of %2$d completed', 'jetpack-mu-wpcom' ),
+		completedCount,
+		visibleTasks.length
+	);
 
 	const handleGetStarted = async ( task: EnrichedTask ) => {
 		setBusyId( task.id );
@@ -174,19 +219,21 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	};
 
 	return (
-		<div className="ai-launchpad-tailored-list">
-			{ visibleTasks.map( task => (
-				<TaskCard
-					key={ task.id }
-					task={ task }
-					isExpanded={ expandedId === task.id }
-					isBusy={ busyId === task.id }
-					canStart={ isTaskActionable( task, output, siteUrl ) }
-					onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
-					onGetStarted={ () => handleGetStarted( task ) }
-					onSkip={ () => handleSkip( task ) }
-				/>
-			) ) }
-		</div>
+		<Layout progressLabel={ progressLabel } siteUrl={ siteUrl } siteTitle={ siteTitle }>
+			<div className="ai-launchpad-tailored-list">
+				{ visibleTasks.map( task => (
+					<TaskCard
+						key={ task.id }
+						task={ task }
+						isExpanded={ expandedId === task.id }
+						isBusy={ busyId === task.id }
+						canStart={ isTaskActionable( task, output, siteUrl ) }
+						onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
+						onGetStarted={ () => handleGetStarted( task ) }
+						onSkip={ () => handleSkip( task ) }
+					/>
+				) ) }
+			</div>
+		</Layout>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -77,7 +77,6 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	const [ output, setOutput ] = useState< TailoredOutput | null >(
 		() => initialData?.ai_output?.payload ?? null
 	);
-	const [ expandedId, setExpandedId ] = useState< string | null >( null );
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
 	// The site's front-end URL, used to build the launch CTA and the preview
@@ -151,19 +150,6 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		[ tasks, skippedIds ]
 	);
 
-	useEffect( () => {
-		if ( ! tasks || expandedId !== null ) {
-			return;
-		}
-		// Scan visibleTasks (skipped→completed) so skipping the last actionable
-		// task doesn't re-select it and bounce the just-dismissed card open.
-		const index = firstIncompleteIndex( visibleTasks );
-		const first = index === -1 ? undefined : visibleTasks[ index ];
-		if ( first ) {
-			setExpandedId( first.id );
-		}
-	}, [ tasks, visibleTasks, expandedId ] );
-
 	if ( ! tasks ) {
 		return (
 			<Layout
@@ -210,25 +196,23 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 
 	const handleSkip = ( task: EnrichedTask ) => {
 		setSkippedIds( prev => new Set( prev ).add( task.id ) );
-		if ( expandedId === task.id ) {
-			const next = visibleTasks.find(
-				candidate => candidate.id !== task.id && ! candidate.completed
-			);
-			setExpandedId( next ? next.id : null );
-		}
 	};
+
+	// The first incomplete task opens on mount; because the cards are uncontrolled
+	// (defaultOpen), the user can then collapse it — or all of them — without it
+	// reopening. Computed from the initial render (skippedIds is empty then).
+	const firstOpenIndex = firstIncompleteIndex( visibleTasks );
 
 	return (
 		<Layout progressLabel={ progressLabel } siteUrl={ siteUrl } siteTitle={ siteTitle }>
 			<div className="ai-launchpad-tailored-list">
-				{ visibleTasks.map( task => (
+				{ visibleTasks.map( ( task, index ) => (
 					<TaskCard
 						key={ task.id }
 						task={ task }
-						isExpanded={ expandedId === task.id }
 						isBusy={ busyId === task.id }
 						canStart={ isTaskActionable( task, output, siteUrl ) }
-						onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
+						defaultOpen={ index === firstOpenIndex }
 						onGetStarted={ () => handleGetStarted( task ) }
 						onSkip={ () => handleSkip( task ) }
 					/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,8 +1,8 @@
 import { Card, CardBody, Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check, chevronDown, chevronUp } from '@wordpress/icons';
+import { chevronDown, chevronUp, published } from '@wordpress/icons';
 import clsx from 'clsx';
-import type { EnrichedTask } from './model.ts';
+import { ctaKind, type EnrichedTask } from './model.ts';
 
 interface Props {
 	task: EnrichedTask;
@@ -15,18 +15,64 @@ interface Props {
 }
 
 /**
+ * Resolve the action-specific label for a task's primary CTA. A static,
+ * translatable map keyed first by task id (the most specific) then by
+ * {@link ctaKind} (the behavioral class), falling back to a generic
+ * "Get started" so a task with no entry still gets a sensible button.
+ *
+ * The map lives here rather than in `model.ts` because the labels must be
+ * `__()` literals (so they're extracted for translation) and `model.ts` is
+ * intentionally free of `@wordpress/*` imports so its node:test suite runs.
+ * Labels are AI-independent on purpose — AI output is English-only today
+ * (DOTOBRD-474), so deriving labels from it would regress i18n.
+ *
+ * @param taskId - The catalog task id.
+ * @return The translated CTA label.
+ */
+function getCtaLabel( taskId: string ): string {
+	switch ( taskId ) {
+		case 'site_theme_selected':
+			return __( 'Browse themes', 'jetpack-mu-wpcom' );
+		case 'woo_products':
+			return __( 'Add products', 'jetpack-mu-wpcom' );
+		case 'woo_customize_store':
+			return __( 'Customize store', 'jetpack-mu-wpcom' );
+		case 'set_up_payments':
+			return __( 'Set up payments', 'jetpack-mu-wpcom' );
+		case 'connect_social_media':
+			return __( 'Connect socials', 'jetpack-mu-wpcom' );
+		// Both the AI-selectable catalog id and the deterministic fallback id for
+		// growing a subscriber list, so the label holds on the fallback path too.
+		case 'subscribers_added':
+		case 'add_10_email_subscribers':
+			return __( 'Add subscribers', 'jetpack-mu-wpcom' );
+	}
+
+	switch ( ctaKind( taskId ) ) {
+		case 'first_post':
+			return __( 'Write post', 'jetpack-mu-wpcom' );
+		case 'pattern_page':
+			return __( 'Add page', 'jetpack-mu-wpcom' );
+		case 'launch':
+			return __( 'Launch site', 'jetpack-mu-wpcom' );
+		default:
+			return __( 'Get started', 'jetpack-mu-wpcom' );
+	}
+}
+
+/**
  * A single task in the tailored list, rendered as a card. Completed tasks show
- * a struck-through title with a check icon and aren't expandable. Incomplete
- * tasks show a title + chevron when collapsed; expanding reveals the AI
- * subtitle and the "Get started" / "Skip" actions.
+ * a struck-through title with a check-in-circle icon and aren't expandable.
+ * Incomplete tasks show a dashed-circle icon, title, and chevron when collapsed;
+ * expanding reveals the AI subtitle and the action-specific CTA / "Skip" actions.
  *
  * @param props              - The component props.
  * @param props.task         - The enriched task to render.
  * @param props.isExpanded   - Whether this card is expanded.
- * @param props.isBusy       - Whether the "Get started" action is in flight.
+ * @param props.isBusy       - Whether the primary action is in flight.
  * @param props.canStart     - Whether the task has an actionable CTA destination.
  * @param props.onToggle     - Called when the collapsed header is clicked.
- * @param props.onGetStarted - Called when "Get started" is clicked.
+ * @param props.onGetStarted - Called when the primary CTA is clicked.
  * @param props.onSkip       - Called when "Skip" is clicked.
  * @return The task card element.
  */
@@ -44,7 +90,7 @@ export function TaskCard( {
 			<Card className="ai-launchpad-tailored-list__card is-completed">
 				<CardBody>
 					<div className="ai-launchpad-tailored-list__header">
-						<Icon icon={ check } className="ai-launchpad-tailored-list__icon is-done" />
+						<Icon icon={ published } className="ai-launchpad-tailored-list__icon is-done" />
 						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
 					</div>
 				</CardBody>
@@ -60,8 +106,12 @@ export function TaskCard( {
 					onClick={ onToggle }
 					aria-expanded={ isExpanded }
 				>
+					<span className="ai-launchpad-tailored-list__icon is-todo" aria-hidden="true" />
 					<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
-					<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+					<Icon
+						className="ai-launchpad-tailored-list__chevron"
+						icon={ isExpanded ? chevronUp : chevronDown }
+					/>
 				</Button>
 				{ isExpanded && (
 					<div className="ai-launchpad-tailored-list__body">
@@ -74,7 +124,7 @@ export function TaskCard( {
 									isBusy={ isBusy }
 									disabled={ isBusy }
 								>
-									{ __( 'Get started', 'jetpack-mu-wpcom' ) }
+									{ getCtaLabel( task.id ) }
 								</Button>
 							) }
 							<Button variant="tertiary" onClick={ onSkip }>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,15 +1,50 @@
-import { Card, CardBody, Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronUp, published } from '@wordpress/icons';
-import clsx from 'clsx';
+import { Button, Card, CollapsibleCard } from '@wordpress/ui';
 import { ctaKind, type EnrichedTask } from './model.ts';
+
+// WPDS doesn't ship a "todo / dashed-circle" or "check-in-circle" icon yet (only
+// `check`), so we inline both. Sized at 24px to line up with each other;
+// `currentColor` lets us tone them via CSS.
+const taskActiveIcon = (
+	<svg
+		className="ai-launchpad-tailored-list__icon is-todo"
+		width={ 24 }
+		height={ 24 }
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" strokeDasharray="3 2.5" />
+	</svg>
+);
+
+const taskDoneIcon = (
+	<svg
+		className="ai-launchpad-tailored-list__icon is-done"
+		width={ 24 }
+		height={ 24 }
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+		<path
+			d="M8 12.5L11 15.5L16 9.5"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
 
 interface Props {
 	task: EnrichedTask;
-	isExpanded: boolean;
 	isBusy: boolean;
 	canStart: boolean;
-	onToggle: () => void;
+	defaultOpen: boolean;
 	onGetStarted: () => void;
 	onSkip: () => void;
 }
@@ -61,79 +96,57 @@ function getCtaLabel( taskId: string ): string {
 }
 
 /**
- * A single task in the tailored list, rendered as a card. Completed tasks show
- * a struck-through title with a check-in-circle icon and aren't expandable.
- * Incomplete tasks show a dashed-circle icon, title, and chevron when collapsed;
- * expanding reveals the AI subtitle and the action-specific CTA / "Skip" actions.
+ * A single task in the tailored list. Completed tasks render as a plain card
+ * with a struck-through title and a check-in-circle icon, and aren't expandable.
+ * Incomplete tasks render as a `CollapsibleCard` (dashed-circle icon + title in
+ * the always-visible header, which is the toggle trigger); expanding reveals the
+ * AI subtitle and the action-specific CTA / "Skip" actions.
  *
  * @param props              - The component props.
  * @param props.task         - The enriched task to render.
- * @param props.isExpanded   - Whether this card is expanded.
  * @param props.isBusy       - Whether the primary action is in flight.
  * @param props.canStart     - Whether the task has an actionable CTA destination.
- * @param props.onToggle     - Called when the collapsed header is clicked.
+ * @param props.defaultOpen  - Whether the card starts expanded (uncontrolled, so
+ *                           the user can then collapse it without it reopening).
  * @param props.onGetStarted - Called when the primary CTA is clicked.
  * @param props.onSkip       - Called when "Skip" is clicked.
  * @return The task card element.
  */
-export function TaskCard( {
-	task,
-	isExpanded,
-	isBusy,
-	canStart,
-	onToggle,
-	onGetStarted,
-	onSkip,
-}: Props ) {
+export function TaskCard( { task, isBusy, canStart, defaultOpen, onGetStarted, onSkip }: Props ) {
 	if ( task.completed ) {
 		return (
-			<Card className="ai-launchpad-tailored-list__card is-completed">
-				<CardBody>
-					<div className="ai-launchpad-tailored-list__header">
-						<Icon icon={ published } className="ai-launchpad-tailored-list__icon is-done" />
+			<Card.Root className="ai-launchpad-tailored-list__card is-completed">
+				<Card.Header>
+					<span className="ai-launchpad-tailored-list__header-inner">
+						{ taskDoneIcon }
 						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
-					</div>
-				</CardBody>
-			</Card>
+					</span>
+				</Card.Header>
+			</Card.Root>
 		);
 	}
 
 	return (
-		<Card className={ clsx( 'ai-launchpad-tailored-list__card', { 'is-expanded': isExpanded } ) }>
-			<CardBody>
-				<Button
-					className="ai-launchpad-tailored-list__header"
-					onClick={ onToggle }
-					aria-expanded={ isExpanded }
-				>
-					<span className="ai-launchpad-tailored-list__icon is-todo" aria-hidden="true" />
+		<CollapsibleCard.Root className="ai-launchpad-tailored-list__card" defaultOpen={ defaultOpen }>
+			<CollapsibleCard.Header>
+				<span className="ai-launchpad-tailored-list__header-inner">
+					{ taskActiveIcon }
 					<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
-					<Icon
-						className="ai-launchpad-tailored-list__chevron"
-						icon={ isExpanded ? chevronUp : chevronDown }
-					/>
-				</Button>
-				{ isExpanded && (
-					<div className="ai-launchpad-tailored-list__body">
-						<p className="ai-launchpad-tailored-list__subtitle">{ task.subtitle }</p>
-						<div className="ai-launchpad-tailored-list__actions">
-							{ canStart && (
-								<Button
-									variant="primary"
-									onClick={ onGetStarted }
-									isBusy={ isBusy }
-									disabled={ isBusy }
-								>
-									{ getCtaLabel( task.id ) }
-								</Button>
-							) }
-							<Button variant="tertiary" onClick={ onSkip }>
-								{ __( 'Skip', 'jetpack-mu-wpcom' ) }
-							</Button>
-						</div>
-					</div>
-				) }
-			</CardBody>
-		</Card>
+				</span>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<p className="ai-launchpad-tailored-list__subtitle">{ task.subtitle }</p>
+				<div className="ai-launchpad-tailored-list__actions">
+					{ canStart && (
+						<Button variant="solid" onClick={ onGetStarted } loading={ isBusy } disabled={ isBusy }>
+							{ getCtaLabel( task.id ) }
+						</Button>
+					) }
+					<Button variant="minimal" tone="neutral" onClick={ onSkip }>
+						{ __( 'Skip', 'jetpack-mu-wpcom' ) }
+					</Button>
+				</div>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -175,8 +175,9 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( array( 'first_post_published' => true ), $data['checklist_statuses'] );
 		$this->assertFalse( $data['dismissed'] );
 		$this->assertTrue( $data['is_eligible'] );
-		// Site context for the client (launch CTA slug + preview).
+		// Site context for the client (launch CTA slug + preview thumbnail/label).
 		$this->assertSame( home_url(), $data['site']['url'] );
+		$this->assertSame( get_bloginfo( 'name' ), $data['site']['title'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 


### PR DESCRIPTION
## Proposed changes

Pre-design-review polish so [DOTOBRD-455](https://linear.app/a8c/issue/DOTOBRD-455) (Nuria's feedback round) starts from a baseline that already matches the PoC ([Automattic/wp-calypso#110642](https://github.com/Automattic/wp-calypso/pull/110642)) rather than the flush full-width list. All work is in `js/tailored-list/` plus one additive REST field.

* **Centered two-column layout** — a new `Layout` wrapper, shared by the list and its loading state: a `Get the most out of WordPress` heading, an `X of N completed` progress line, task cards on the left, and an mShots **site preview** (thumbnail + name + domain link) on the right. Collapses to a single column when there's no site URL (dev fixtures / older reads).
* **Per-task CTA labels** — a static, translatable map (id override → `ctaKind` → `Get started` fallback) replaces the blanket `Get started`: Write post, Add page, Launch site, Browse themes, Add products, Customize store, Set up payments, Connect socials, Add subscribers. The map lives in `task-card.tsx` (not `model.ts`) because the labels must be `__()` literals for string extraction and `model.ts` stays free of `@wordpress/*` imports so its `node:test` suite runs.
* **Loading state** — reuses the same layout with a `Tailoring your checklist…` status and shimmer bars, so wizard → tailoring → list is seamless (tailoring is ~12s worst-case, so the screen is on-view).
* **Task icons** — dashed-circle (incomplete) / `published` check-in-circle, greyed (completed).
* **REST** — `get_data()` returns `site.title` (`get_bloginfo('name')`) alongside the existing `site.url`, to label the preview.

Deferred per MVP_PLAN §7 / DOTOBRD-455: composite/disclosure UI, full interstitial choreography, modal wizard entry.

Known follow-ups already queued for the next iteration (not in this PR): square 300×300 preview, reuse the wp-admin dashboard site-preview widget's load logic, preview title/url type scale, page paddings, gray checklist container, and vertical centering / generous top margin.

## Related product discussion/links

* DOTOBRD-476
* PoC: Automattic/wp-calypso#110642

## Does this pull request change what data or activity we track or use?

No. No new tracking. The added `site.title` is the site's own name (`get_bloginfo('name')`), returned on the existing eligibility-gated composite read and rendered as escaped React text.

## Testing instructions

* On a site with the AI Launchpad enabled (`wp option update wpcom_ai_launchpad_enabled 1`), open **AI Launchpad** in wp-admin.
* New user (no AI output): complete the wizard → confirm the **Tailoring your checklist…** loading screen shows the heading + skeleton bars + site preview, then transitions seamlessly to the list.
* Returning user (AI output present): confirm the centered layout — heading, `X of N completed`, task cards left, site preview right (thumbnail + name + domain link).
* Confirm CTAs are action-specific (e.g. theme → **Browse themes**, first post → **Write post**, launch → **Launch site**), completed tasks are struck-through with a check-in-circle icon, and incomplete tasks show a dashed-circle icon.
* Verified locally: 72 JS `node:test` + 33 PHP tests green; ESLint/stylelint/phpcs clean; build green; Playwright self-smoke of both list and loading states (zero console errors).
