### PR TITLE
Podcast: bump version to 1.1.0 and consolidate changelog

### DIFF
--- a/projects/packages/podcast/CHANGELOG.md
+++ b/projects/packages/podcast/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-18
+### Added
+- Add a persistent "Create episode" button to the /podcast page header and a server-side prefill that assigns the configured category (and, on Premium, inserts the Podcast Episode block) when `post-new.php?podcast_episode=1` is opened.
+- Create AI Podcast: Limit the "from specific posts" selection to 25 posts and surface a hint indicating the cap.
+- Podcast: allow the package to load on self-hosted Jetpack sites behind the default-off `jetpack_podcast_for_the_world` filter.
+- Podcast: ignore a deleted podcast category and add a raw show image URL accessor
+- Podcast Episode block: add email renderer for the WooCommerce Email Editor.
+
+### Changed
+- Podcast: add a dedicated wpcom/v2 REST endpoint for site settings and load/save them through it from the dashboard, reachable on Simple, WoA, and self-hosted from a single definition.
+- Podcast: align the distribution readiness notices with their settings field labels so it's clear which field each one refers to.
+- Podcast: drop stale references to the removed jetpack_podcast_untangle gate and at-pressable-podcasting bridge from package docs.
+- Podcast: gate the Posts to Podcast sub-feature to WordPress.com Simple and WoA hosts so it does not load on self-hosted Jetpack once the rest of the package becomes available there.
+- Podcast: simplify REST endpoint and settings internals by dropping singleton init guards and single-use constants. No functional change.
+- Posts to Podcast: Make the Create AI Podcast page available to connected users.
+- Update package dependencies.
+
+### Removed
+- Podcast: remove the jetpack_podcast_untangle gate now that the legacy podcasting stack and at-pressable-podcasting bridge are gone; the package owns the experience unconditionally.
+
+### Fixed
+- Add a TypeScript config so dashboard route files type-check correctly.
+- Create AI Podcast: Register the Media submenu without an is_admin() guard so it appears in the Calypso nav, not just wp-admin.
+- Create AI Podcast: Require a connected WordPress.com account.
+- Fix the "Create episode" button hover state to match standard Jetpack primary buttons.
+- Podcast: a podcast app visiting your feed only confirms a listing you already started, instead of creating one on its own.
+- Podcast: fix empty episode descriptions in the feed when no excerpt is set.
+- Podcast: resolve the blog ID via Connection_Manager::get_site_id() for feed enclosure URLs and tracks events so Atomic sites use the correct WPCOM site ID instead of 1.
+
 ## [1.0.2] - 2026-05-20
 ### Changed
 - Podcast: default jetpack_podcast_untangle to true. The new package now owns the experience on every Simple and Atomic site by default; the filter stays as an escape hatch for forcing the legacy stack back on.
@@ -95,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard: Replace the wp-build placeholder with page chrome and tab navigation. [#48559]
 - Dashboard: Slim down wp-build wiring to the Backup pattern. [#48600]
 
+[1.1.0]: https://github.com/Automattic/jetpack-podcast/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Automattic/jetpack-podcast/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Automattic/jetpack-podcast/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Automattic/jetpack-podcast/compare/v0.1.0...v1.0.0

--- a/projects/packages/podcast/changelog/add-create-ai-podcast-post-limit
+++ b/projects/packages/podcast/changelog/add-create-ai-podcast-post-limit
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Create AI Podcast: Limit the "from specific posts" selection to 25 posts and surface a hint indicating the cap.

--- a/projects/packages/podcast/changelog/add-podcast-episode-email-renderer
+++ b/projects/packages/podcast/changelog/add-podcast-episode-email-renderer
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Podcast Episode block: add email renderer for the WooCommerce Email Editor.

--- a/projects/packages/podcast/changelog/automattic-podcasting-rem
+++ b/projects/packages/podcast/changelog/automattic-podcasting-rem
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Podcast: ignore a deleted podcast category and add a raw show image URL accessor

--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-calypso-menu
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-calypso-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create AI Podcast: Register the Media submenu without an is_admin() guard so it appears in the Calypso nav, not just wp-admin.

--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-user-connection
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-user-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create AI Podcast: Require a connected WordPress.com account.

--- a/projects/packages/podcast/changelog/fix-invalid-text-domain
+++ b/projects/packages/podcast/changelog/fix-invalid-text-domain
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add a TypeScript config so dashboard route files type-check correctly.

--- a/projects/packages/podcast/changelog/fix-podcast-create-episode-button-hover
+++ b/projects/packages/podcast/changelog/fix-podcast-create-episode-button-hover
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix the "Create episode" button hover state to match standard Jetpack primary buttons.

--- a/projects/packages/podcast/changelog/fix-podcast-enclosure-url
+++ b/projects/packages/podcast/changelog/fix-podcast-enclosure-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: resolve the blog ID via Connection_Manager::get_site_id() for feed enclosure URLs and tracks events so Atomic sites use the correct WPCOM site ID instead of 1.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-detection-state
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-detection-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: a podcast app visiting your feed only confirms a listing you already started, instead of creating one on its own.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-empty-descriptions
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-empty-descriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: fix empty episode descriptions in the feed when no excerpt is set.

--- a/projects/packages/podcast/changelog/fix-podcast-owner-email-copy
+++ b/projects/packages/podcast/changelog/fix-podcast-owner-email-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: align the distribution readiness notices with their settings field labels so it's clear which field each one refers to.

--- a/projects/packages/podcast/changelog/launch-posts-to-podcast-public
+++ b/projects/packages/podcast/changelog/launch-posts-to-podcast-public
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Posts to Podcast: Make the Create AI Podcast page available to connected users.

--- a/projects/packages/podcast/changelog/podcast-self-hosted-feature-filter
+++ b/projects/packages/podcast/changelog/podcast-self-hosted-feature-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Podcast: allow the package to load on self-hosted Jetpack sites behind the default-off `jetpack_podcast_for_the_world` filter.

--- a/projects/packages/podcast/changelog/pods-create-episode-button
+++ b/projects/packages/podcast/changelog/pods-create-episode-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a persistent "Create episode" button to the /podcast page header and a server-side prefill that assigns the configured category (and, on Premium, inserts the Podcast Episode block) when `post-new.php?podcast_episode=1` is opened.

--- a/projects/packages/podcast/changelog/post-to-podcast-only-for-wpcom
+++ b/projects/packages/podcast/changelog/post-to-podcast-only-for-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: gate the Posts to Podcast sub-feature to WordPress.com Simple and WoA hosts so it does not load on self-hosted Jetpack once the rest of the package becomes available there.

--- a/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
-

--- a/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
+++ b/projects/packages/podcast/changelog/remove-at-pressable-podcasting-bridge
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Podcast: remove the jetpack_podcast_untangle gate now that the legacy podcasting stack and at-pressable-podcasting bridge are gone; the package owns the experience unconditionally.

--- a/projects/packages/podcast/changelog/remove-untangle-doc-references
+++ b/projects/packages/podcast/changelog/remove-untangle-doc-references
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: drop stale references to the removed jetpack_podcast_untangle gate and at-pressable-podcasting bridge from package docs.

--- a/projects/packages/podcast/changelog/renovate-@wordpressbuild
+++ b/projects/packages/podcast/changelog/renovate-@wordpressbuild
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-babel-monorepo
+++ b/projects/packages/podcast/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-bundled-@wordpress-monorepo
+++ b/projects/packages/podcast/changelog/renovate-bundled-@wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-concurrently-10.x
+++ b/projects/packages/podcast/changelog/renovate-concurrently-10.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-npm-babel-core-vulnerability
+++ b/projects/packages/podcast/changelog/renovate-npm-babel-core-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/podcast/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/podcast/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/renovate-wordpress-monorepo#3
+++ b/projects/packages/podcast/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/changelog/simplify-rest-and-settings-internals
+++ b/projects/packages/podcast/changelog/simplify-rest-and-settings-internals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: simplify REST endpoint and settings internals by dropping singleton init guards and single-use constants. No functional change.

--- a/projects/packages/podcast/changelog/update-add_code_coverage_scripts_to_various_packages
+++ b/projects/packages/podcast/changelog/update-add_code_coverage_scripts_to_various_packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: CI: Enable tests or test coverage.
-
-

--- a/projects/packages/podcast/changelog/update-min-wp-to-6.9#2
+++ b/projects/packages/podcast/changelog/update-min-wp-to-6.9#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Exclude wp-build "build" dir from Phan. It's confusing when running CI (where it doesn't exist) versus locally (where it might).
-
-

--- a/projects/packages/podcast/changelog/update-phpcs-remove_unused_suppressions
+++ b/projects/packages/podcast/changelog/update-phpcs-remove_unused_suppressions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: PHPCS: Remove unneeded suppressions.
-
-

--- a/projects/packages/podcast/changelog/update-pnpm-11-wont-allow-underscores-anymore
+++ b/projects/packages/podcast/changelog/update-pnpm-11-wont-allow-underscores-anymore
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Rename internal JS packages to no longer prefix with underscore, pnpm 11 won't allow it. Sigh.
-
-

--- a/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
+++ b/projects/packages/podcast/changelog/update-podcast-settings-jetpack-v4-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Podcast: add a dedicated wpcom/v2 REST endpoint for site settings and load/save them through it from the dashboard, reachable on Simple, WoA, and self-hosted from a single definition.

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -58,7 +58,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-podcast",
 		"branch-alias": {
-			"dev-trunk": "1.0.x-dev"
+			"dev-trunk": "1.1.x-dev"
 		},
 		"textdomain": "jetpack-podcast",
 		"version-constants": {

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-podcast",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"private": true,
 	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/podcast/#readme",

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Podcast {
 
-	const PACKAGE_VERSION = '1.0.2';
+	const PACKAGE_VERSION = '1.1.0';
 
 	/**
 	 * Whether the class has been initialized.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-podcast-1-1-0
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-podcast-1-1-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1520,7 +1520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "d4a89b99f139d8d4f746af1d512d064c48eb7560"
+                "reference": "7ece8afde05a2c7aee25181ce7c7a8045565039c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1545,7 +1545,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "1.0.x-dev"
+                    "dev-trunk": "1.1.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/update-podcast-1-1-0
+++ b/projects/plugins/wpcomsh/changelog/update-podcast-1-1-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1707,7 +1707,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "d4a89b99f139d8d4f746af1d512d064c48eb7560"
+                "reference": "7ece8afde05a2c7aee25181ce7c7a8045565039c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1732,7 +1732,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "1.0.x-dev"
+                    "dev-trunk": "1.1.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes
* Bump the Podcast package version from `1.0.2` to `1.1.0` (minor).
* Consolidate the accumulated `changelog/` entries into `CHANGELOG.md` under the new `1.1.0` heading.
* Update version in `package.json`, the `composer.json` branch-alias (`1.1.x-dev`), and the `PACKAGE_VERSION` constant in `src/class-podcast.php`.

This is a routine release housekeeping change — no functional code changes.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Confirm `projects/packages/podcast/CHANGELOG.md` has a `## [1.1.0]` section listing the previously pending changelog entries, and that `projects/packages/podcast/changelog/` no longer contains those individual files.
* Confirm the version is `1.1.0` in `package.json`, `PACKAGE_VERSION` in `src/class-podcast.php`, and the branch-alias is `1.1.x-dev` in `composer.json`.
