### PR TITLE
AI Sidebar: rename jetpackAiSidebarPreview AM key to jetpackAiSidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-sidebar-rename-preview-key
+++ b/projects/plugins/jetpack/changelog/update-ai-sidebar-rename-preview-key
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: AI Sidebar: rename the emitted agentsManagerData key from jetpackAiSidebarPreview to jetpackAiSidebar; the old key becomes a legacy marker for the paired Calypso reader/gate update.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -385,7 +385,7 @@ class Jetpack_AI_Sidebar {
 		return array(
 			'agentId'                  => AI_SIDEBAR_AGENT_ID,
 			'aiEditorialReviewEnabled' => self::is_ai_editorial_review_enabled(),
-			'jetpackAiSidebarPreview'  => self::get_sidebar_config(),
+			'jetpackAiSidebar'         => self::get_sidebar_config(),
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -539,12 +539,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['chatHistory'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['supportGuides'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['chatHistory'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['supportGuides'] );
 	}
 
 	/**
@@ -559,9 +559,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
-		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 	}
 
 	/**
@@ -592,8 +592,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 	}
 
 	/**
@@ -607,7 +607,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}
 
 	/**
@@ -629,7 +629,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -679,7 +679,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			$inline_script
 		);
 		$this->assertStringContainsString(
-			'agentsManagerData.jetpackAiSidebarPreview = {"enabled":true',
+			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
 			$inline_script
 		);
 	}
@@ -718,7 +718,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringNotContainsString(
-			'agentsManagerData.jetpackAiSidebarPreview',
+			'agentsManagerData.jetpackAiSidebar',
 			$this->get_agents_manager_inline_script()
 		);
 	}
@@ -744,7 +744,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'agentsManagerData.jetpackAiSidebarPreview = {"enabled":true',
+			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(


### PR DESCRIPTION
## Proposed changes

Pure rename of one emitted Agents Manager wire key: `agentsManagerData.jetpackAiSidebarPreview` → `agentsManagerData.jetpackAiSidebar`, from the single source `get_sidebar_am_fields()`. The old key becomes a legacy marker only older Jetpack releases emit.

* Emit the sidebar config under `jetpackAiSidebar`.
* Update PHPUnit assertions to the new key.

**Coordination / deploy order:** the client reader (`@automattic/jetpack-ai-sidebar` in wp-calypso) still reads the old key today. A paired Calypso PR will switch the reader to `jetpackAiSidebar` and flip the provider-suppression gate to key on it. **This rename must not reach WordPress.com Simple before that Calypso reader is live** — otherwise the client finds no config and falls back to defaults (e.g. internal-only Optimize-Title would show for everyone).

## Related product discussion/links

* Stacked on #49489.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack docker phpunit jetpack -- tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php` passes.
* Open the post editor on a site with the AI Assistant setting enabled and confirm `agentsManagerData.jetpackAiSidebar` is emitted (and `jetpackAiSidebarPreview` is gone).
