### PR TITLE
Premium Analytics: add Stats proxy data hooks

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-proxy-data-hooks
+++ b/projects/packages/premium-analytics/changelog/add-stats-proxy-data-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Data: Add Jetpack Stats proxy data hooks.

--- a/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { getStatsProxyPath } from '../stats-proxy-fetch';
+
+describe( 'getStatsProxyPath', () => {
+	it( 'builds a v1.1 stats proxy path', () => {
+		expect(
+			getStatsProxyPath( {
+				version: '1.1',
+				endpoint: 'stats/top-posts',
+				params: { period: 'day', date: '2026-06-16' },
+			} )
+		).toBe( '/jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?period=day&date=2026-06-16' );
+	} );
+
+	it( 'preserves comma-separated UTM endpoint segments', () => {
+		expect(
+			getStatsProxyPath( {
+				version: '1.1',
+				endpoint: 'stats/utm/utm_source,utm_medium',
+				params: { period: 'month' },
+			} )
+		).toBe(
+			'/jetpack-premium-analytics/v1/proxy/v1.1/stats/utm/utm_source,utm_medium?period=month'
+		);
+	} );
+
+	it( 'builds site-less upgrades proxy path', () => {
+		expect( getStatsProxyPath( { version: '1.2', endpoint: '/upgrades' } ) ).toBe(
+			'/jetpack-premium-analytics/v1/proxy/v1.2/upgrades'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/api/constants.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/constants.ts
@@ -1,4 +1,5 @@
 /**
  * Constants for API endpoints
  */
+export const statsProxyPath = '/jetpack-premium-analytics/v1/proxy';
 export const reportsPath = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';

--- a/projects/packages/premium-analytics/packages/data/src/api/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/index.ts
@@ -43,3 +43,12 @@ export { fetchReportBookings } from './report-bookings-fetch';
 export { fetchReportSessionsByDevice } from './report-sessions-by-device-fetch';
 export { exportReport } from './report-export-fetch';
 export type { ExportReportParams, ExportReportResponse } from './report-export-fetch';
+export {
+	fetchStatsProxy,
+	getStatsProxyPath,
+	type StatsProxyFetchParams,
+	type StatsProxyMethod,
+	type StatsProxyParams,
+	type StatsProxyQueryParams,
+	type StatsProxyVersion,
+} from './stats-proxy-fetch';

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+/**
+ * Internal dependencies
+ */
+import { statsProxyPath } from './constants';
+
+export type StatsProxyVersion = '1.1' | '1.2' | '2' | ( string & {} );
+
+export type StatsProxyMethod = 'GET' | 'POST';
+
+export type StatsProxyParams = Record<
+	string,
+	string | number | boolean | null | undefined | Array< string | number | boolean >
+>;
+
+export type StatsProxyFetchParams< TBody = unknown > = {
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsProxyParams;
+	method?: StatsProxyMethod;
+	body?: TBody;
+};
+
+function normalizeEndpoint( endpoint: string ) {
+	return endpoint.replace( /^\/+/, '' );
+}
+
+export function getStatsProxyPath( {
+	version,
+	endpoint,
+	params,
+}: Pick< StatsProxyFetchParams, 'version' | 'endpoint' | 'params' > ) {
+	const path = `${ statsProxyPath }/v${ version }/${ normalizeEndpoint( endpoint ) }`;
+
+	return params ? addQueryArgs( path, params ) : path;
+}
+
+export async function fetchStatsProxy< TResponse = unknown, TBody = unknown >( {
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+}: StatsProxyFetchParams< TBody > ): Promise< TResponse > {
+	const path = getStatsProxyPath( { version, endpoint, params } );
+
+	return apiFetch< TResponse >( {
+		path,
+		method,
+		...( method === 'POST' ? { data: body } : {} ),
+	} );
+}
+
+export type StatsProxyQueryParams = StatsProxyFetchParams;

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { statsProxyPath } from './constants';
 
-export type StatsProxyVersion = '1.1' | '1.2' | '2' | ( string & {} );
+export type StatsProxyVersion = '1.1' | '1.2' | '2';
 
 export type StatsProxyMethod = 'GET' | 'POST';
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -8,6 +8,8 @@ describe( 'Stats public hook names', () => {
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailSummary' );
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailOpensBreakdown' );
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailClicksBreakdown' );
+		expect( dataPackage ).toHaveProperty( 'useStatsSubscribersCounts' );
+		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsEarnings' );
 		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsStats' );
 		expect( dataPackage ).toHaveProperty( 'useStatsUtm' );
 	} );
@@ -22,7 +24,6 @@ describe( 'Stats public hook names', () => {
 		expect( dataPackage ).toHaveProperty( 'useStatsAppPurchases' );
 		expect( dataPackage ).toHaveProperty( 'useStatsAppNotices' );
 		expect( dataPackage ).toHaveProperty( 'useStatsAppNoticeMutation' );
-		expect( dataPackage ).toHaveProperty( 'useStatsAppWordAdsEarnings' );
 		expect( dataPackage ).toHaveProperty( 'useStatsAppCommercialClassificationMutation' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -8,12 +8,21 @@ describe( 'Stats public hook names', () => {
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailSummary' );
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailOpensBreakdown' );
 		expect( dataPackage ).toHaveProperty( 'useStatsEmailClicksBreakdown' );
-		expect( dataPackage ).toHaveProperty( 'useStatsReferrersSpam' );
-		expect( dataPackage ).toHaveProperty( 'useStatsReferrersMarkSpamMutation' );
-		expect( dataPackage ).toHaveProperty( 'useStatsDashboardModules' );
-		expect( dataPackage ).toHaveProperty( 'useStatsDashboardModulesMutation' );
-		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsEarnings' );
 		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsStats' );
 		expect( dataPackage ).toHaveProperty( 'useStatsUtm' );
+	} );
+
+	it( 'exports Stats app/admin resource hooks separately from report hooks', () => {
+		expect( dataPackage ).toHaveProperty( 'useStatsAppReferrersSpam' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppReferrersMarkSpamMutation' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppDashboardModules' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppDashboardModulesMutation' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppDashboardModuleSettings' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppPlanUsage' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppPurchases' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppNotices' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppNoticeMutation' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppWordAdsEarnings' );
+		expect( dataPackage ).toHaveProperty( 'useStatsAppCommercialClassificationMutation' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import * as dataPackage from '../../index';
+
+describe( 'Stats public hook names', () => {
+	it( 'exports discoverable family-prefixed Stats hooks', () => {
+		expect( dataPackage ).toHaveProperty( 'useStatsEmailSummary' );
+		expect( dataPackage ).toHaveProperty( 'useStatsEmailOpensBreakdown' );
+		expect( dataPackage ).toHaveProperty( 'useStatsEmailClicksBreakdown' );
+		expect( dataPackage ).toHaveProperty( 'useStatsReferrersSpam' );
+		expect( dataPackage ).toHaveProperty( 'useStatsReferrersMarkSpamMutation' );
+		expect( dataPackage ).toHaveProperty( 'useStatsDashboardModules' );
+		expect( dataPackage ).toHaveProperty( 'useStatsDashboardModulesMutation' );
+		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsEarnings' );
+		expect( dataPackage ).toHaveProperty( 'useStatsWordAdsStats' );
+		expect( dataPackage ).toHaveProperty( 'useStatsUtm' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -6,6 +6,7 @@ export { useReportCustomers } from './use-report-customers';
 export { useReportConversionRate } from './use-report-conversion-rate';
 export { useReportBookings } from './use-report-bookings';
 export * from './use-stats';
+export * from './use-stats-app';
 
 /**
  * @deprecated Use individual hooks instead: useReportOrders, useReportOrderAttribution, useReportCoupons

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { useReportCouponsByDate } from './use-report-coupons-by-date';
 export { useReportCustomers } from './use-report-customers';
 export { useReportConversionRate } from './use-report-conversion-rate';
 export { useReportBookings } from './use-report-bookings';
+export * from './use-stats';
 
 /**
  * @deprecated Use individual hooks instead: useReportOrders, useReportOrderAttribution, useReportCoupons

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -47,35 +47,29 @@ type QueryFactory< TData > = (
  * );
  * ```
  */
-export function useReport< TData >(
+export function useReport< TData, TParams extends ReportParams = ReportParams >(
 	queryFactory: QueryFactory< TData >,
-	params: ReportParams,
+	params: TParams,
 	options?: UseReportOptions
 ) {
 	const queryEnabled = options?.enabled ?? true;
 	const comparisonEnabled = hasComparisonEnabled( params );
+	const primaryParams = { ...params };
+	delete primaryParams.compare_from;
+	delete primaryParams.compare_to;
+	delete primaryParams.compare_preset;
+	delete primaryParams.comp;
 
 	// Create primary query
-	const primaryQueryOptions = queryFactory(
-		{
-			from: params.from,
-			to: params.to,
-			interval: params.interval,
-			filters: params.filters,
-			date_type: params.date_type,
-		},
-		'primary'
-	);
+	const primaryQueryOptions = queryFactory( primaryParams, 'primary' );
 
 	// Create comparison query if comparison is enabled
 	const comparisonQueryOptions = comparisonEnabled
 		? queryFactory(
 				{
+					...primaryParams,
 					from: params.compare_from,
 					to: params.compare_to,
-					interval: params.interval,
-					filters: params.filters,
-					date_type: params.date_type,
 				},
 				'comparison'
 		  )

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
@@ -15,8 +15,6 @@ import {
 	statsAppPurchasesQuery,
 	statsAppReferrersSpamQuery,
 	statsAppSiteHasNeverPublishedPostQuery,
-	statsAppSubscribersCountsQuery,
-	statsAppWordAdsEarningsQuery,
 	updateStatsAppNotice,
 	type StatsAppNoticeMutationParams,
 } from '../queries/stats-app-queries';
@@ -29,16 +27,6 @@ type UseStatsAppOptions = {
 export function useStatsAppReferrersSpam( options?: UseStatsAppOptions ) {
 	return useQuery( {
 		...statsAppReferrersSpamQuery(),
-		enabled: options?.enabled ?? true,
-	} );
-}
-
-export function useStatsAppSubscribersCounts(
-	params?: StatsQueryParams,
-	options?: UseStatsAppOptions
-) {
-	return useQuery( {
-		...statsAppSubscribersCountsQuery( params ),
 		enabled: options?.enabled ?? true,
 	} );
 }
@@ -76,16 +64,6 @@ export function useStatsAppDashboardModuleSettings(
 ) {
 	return useQuery( {
 		...statsAppDashboardModuleSettingsQuery( params ),
-		enabled: options?.enabled ?? true,
-	} );
-}
-
-export function useStatsAppWordAdsEarnings(
-	params?: StatsQueryParams,
-	options?: UseStatsAppOptions
-) {
-	return useQuery( {
-		...statsAppWordAdsEarningsQuery( params ),
 		enabled: options?.enabled ?? true,
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
@@ -1,0 +1,202 @@
+/**
+ * External dependencies
+ */
+import { useMutation, useQuery } from '@tanstack/react-query';
+/**
+ * Internal dependencies
+ */
+import { fetchStatsProxy } from '../api/stats-proxy-fetch';
+import { queryClient } from '../providers';
+import {
+	statsAppDashboardModulesQuery,
+	statsAppDashboardModuleSettingsQuery,
+	statsAppNoticesQuery,
+	statsAppPlanUsageQuery,
+	statsAppPurchasesQuery,
+	statsAppReferrersSpamQuery,
+	statsAppSiteHasNeverPublishedPostQuery,
+	statsAppSubscribersCountsQuery,
+	statsAppWordAdsEarningsQuery,
+	updateStatsAppNotice,
+	type StatsAppNoticeMutationParams,
+} from '../queries/stats-app-queries';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+type UseStatsAppOptions = {
+	enabled?: boolean;
+};
+
+export function useStatsAppReferrersSpam( options?: UseStatsAppOptions ) {
+	return useQuery( {
+		...statsAppReferrersSpamQuery(),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppSubscribersCounts(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...statsAppSubscribersCountsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppSiteHasNeverPublishedPost(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...statsAppSiteHasNeverPublishedPostQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppPlanUsage( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useQuery( {
+		...statsAppPlanUsageQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppDashboardModules(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...statsAppDashboardModulesQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppDashboardModuleSettings(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...statsAppDashboardModuleSettingsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppWordAdsEarnings(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...statsAppWordAdsEarningsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppPurchases( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useQuery( {
+		...statsAppPurchasesQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppNotices( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useQuery( {
+		...statsAppNoticesQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsAppReferrersMarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/new',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'referrers-spam' ] } );
+		},
+	} );
+}
+
+export function useStatsAppReferrersUnmarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/delete',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'referrers-spam' ] } );
+		},
+	} );
+}
+
+export function useStatsAppDashboardModulesMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/modules',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'dashboard-modules' ] } );
+		},
+	} );
+}
+
+export function useStatsAppDashboardModuleSettingsMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/module-settings',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'stats-app', 'dashboard-module-settings' ],
+			} );
+		},
+	} );
+}
+
+export function useStatsAppNoticeMutation() {
+	return useMutation( {
+		mutationFn: ( data: StatsAppNoticeMutationParams ) => updateStatsAppNotice( data ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'notices' ] } );
+		},
+	} );
+}
+
+export function useStatsAppUserFeedbackMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats/user-feedback',
+				method: 'POST',
+				body,
+			} ),
+	} );
+}
+
+export function useStatsAppCommercialClassificationMutation() {
+	return useMutation( {
+		mutationFn: ( params?: StatsQueryParams ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'commercial-classification',
+				method: 'POST',
+				params,
+			} ),
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app.ts
@@ -177,18 +177,6 @@ export function useStatsAppNoticeMutation() {
 	} );
 }
 
-export function useStatsAppUserFeedbackMutation() {
-	return useMutation( {
-		mutationFn: ( body: unknown ) =>
-			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'jetpack-stats/user-feedback',
-				method: 'POST',
-				body,
-			} ),
-	} );
-}
-
 export function useStatsAppCommercialClassificationMutation() {
 	return useMutation( {
 		mutationFn: ( params?: StatsQueryParams ) =>

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
@@ -29,12 +29,14 @@ import {
 	statsSingleVideoQuery,
 	statsSiteQuery,
 	statsStreakQuery,
+	statsSubscribersCountsQuery,
 	statsSubscribersQuery,
 	statsTagsQuery,
 	statsTopAuthorsQuery,
 	statsTopPostsQuery,
 	statsUtmQuery,
 	statsVideoPlaysQuery,
+	statsWordAdsEarningsQuery,
 	statsVisitsQuery,
 	statsWordAdsStatsQuery,
 	type StatsReportParams,
@@ -253,6 +255,13 @@ export function useStatsSubscribers( params?: StatsQueryParams, options?: UseSta
 	return useQuery( { ...statsSubscribersQuery( params ), enabled: options?.enabled ?? true } );
 }
 
+export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( {
+		...statsSubscribersCountsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
 export function useStatsSinglePost(
 	postId: number,
 	params?: StatsQueryParams,
@@ -327,4 +336,8 @@ export function useStatsEmailClicksTimeSeries(
 
 export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
 	return useQuery( { ...statsWordAdsStatsQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsWordAdsEarningsQuery( params ), enabled: options?.enabled ?? true } );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
@@ -1,0 +1,461 @@
+/**
+ * External dependencies
+ */
+import { useMutation, useQuery } from '@tanstack/react-query';
+/**
+ * Internal dependencies
+ */
+import { fetchStatsProxy } from '../api/stats-proxy-fetch';
+import { queryClient } from '../providers';
+import {
+	statsArchivesQuery,
+	statsClicksQuery,
+	statsCommentFollowersQuery,
+	statsCommentsQuery,
+	statsCountryViewsQuery,
+	statsDashboardModulesQuery,
+	statsDashboardModuleSettingsQuery,
+	statsDevicesQuery,
+	statsEmailClicksBreakdownQuery,
+	statsEmailClicksTimeSeriesQuery,
+	statsEmailOpensBreakdownQuery,
+	statsEmailOpensTimeSeriesQuery,
+	statsEmailSummaryQuery,
+	statsFileDownloadsQuery,
+	statsFollowersQuery,
+	statsHighlightsQuery,
+	statsInsightsQuery,
+	statsLocationsQuery,
+	statsPlanUsageQuery,
+	statsPublicizeQuery,
+	statsPurchasesQuery,
+	statsReferrersQuery,
+	statsReferrersSpamQuery,
+	statsSearchTermsQuery,
+	statsSinglePostQuery,
+	statsSingleVideoQuery,
+	statsSiteHasNeverPublishedPostQuery,
+	statsSiteQuery,
+	statsStreakQuery,
+	statsSubscribersCountsQuery,
+	statsSubscribersQuery,
+	statsTagsQuery,
+	statsTopAuthorsQuery,
+	statsTopPostsQuery,
+	statsUtmQuery,
+	statsVideoPlaysQuery,
+	statsVisitsQuery,
+	statsWordAdsEarningsQuery,
+	statsWordAdsStatsQuery,
+	type StatsReportParams,
+} from '../queries/stats-queries';
+import { useReport } from './use-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+type UseStatsOptions = {
+	enabled?: boolean;
+};
+
+type StatsReportQueryFactory< TParams extends StatsReportParams = StatsReportParams > = (
+	params: TParams
+) => ReturnType< typeof statsTopPostsQuery >;
+
+function useStatsReport(
+	queryFactory: StatsReportQueryFactory,
+	params: StatsReportParams,
+	disabledComparisonKey: string[],
+	options?: UseStatsOptions
+) {
+	return useReport( p => queryFactory( p as StatsReportParams ), params, {
+		enabled: options?.enabled,
+		disabledComparisonKey,
+	} );
+}
+
+export function useStatsSite( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsSiteQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsTopPosts( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTopPostsQuery,
+		params,
+		[ 'stats', 'top-posts', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsReferrers( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsReferrersQuery,
+		params,
+		[ 'stats', 'referrers', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsClicks( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsClicksQuery,
+		params,
+		[ 'stats', 'clicks', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsSearchTerms( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsSearchTermsQuery,
+		params,
+		[ 'stats', 'search-terms', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsFileDownloads( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsFileDownloadsQuery,
+		params,
+		[ 'stats', 'file-downloads', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsTopAuthors( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTopAuthorsQuery,
+		params,
+		[ 'stats', 'top-authors', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsLocations(
+	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
+	options?: UseStatsOptions
+) {
+	return useStatsReport(
+		statsLocationsQuery,
+		params,
+		[ 'stats', 'locations', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsCountryViews( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsCountryViewsQuery,
+		params,
+		[ 'stats', 'country-views', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsVideoPlays( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsVideoPlaysQuery,
+		params,
+		[ 'stats', 'video-plays', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsVisits( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsVisitsQuery,
+		params,
+		[ 'stats', 'visits', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsUtm(
+	params: StatsReportParams & { utmParams?: string },
+	options?: UseStatsOptions
+) {
+	return useStatsReport(
+		statsUtmQuery,
+		params,
+		[ 'stats', 'utm', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsDevices(
+	params: StatsReportParams & { deviceProperty?: string },
+	options?: UseStatsOptions
+) {
+	return useStatsReport(
+		statsDevicesQuery,
+		params,
+		[ 'stats', 'devices', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsArchives( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsArchivesQuery,
+		params,
+		[ 'stats', 'archives', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsPublicize( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsPublicizeQuery,
+		params,
+		[ 'stats', 'publicize', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsFollowers( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsFollowersQuery,
+		params,
+		[ 'stats', 'followers', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsTags( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTagsQuery,
+		params,
+		[ 'stats', 'tags', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsComments( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsCommentsQuery,
+		params,
+		[ 'stats', 'comments', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsCommentFollowers( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsCommentFollowersQuery,
+		params,
+		[ 'stats', 'comment-followers', '__comparison__', 'disabled' ],
+		options
+	);
+}
+
+export function useStatsStreak( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsStreakQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsInsights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsInsightsQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsHighlights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsHighlightsQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsSubscribers( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsSubscribersQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsSinglePost(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsSinglePostQuery( postId, params ),
+		enabled: ( options?.enabled ?? true ) && !! postId,
+	} );
+}
+
+export function useStatsSingleVideo(
+	videoId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsSingleVideoQuery( videoId, params ),
+		enabled: ( options?.enabled ?? true ) && !! videoId,
+	} );
+}
+
+export function useStatsEmailSummary( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsEmailSummaryQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsEmailOpensBreakdown(
+	postId: number,
+	breakdown: 'client' | 'device' | 'country' | 'rate',
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsEmailOpensBreakdownQuery( postId, breakdown, params ),
+		enabled: ( options?.enabled ?? true ) && !! postId,
+	} );
+}
+
+export function useStatsEmailClicksBreakdown(
+	postId: number,
+	breakdown: 'client' | 'device' | 'country' | 'rate' | 'link' | 'user-content-link',
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsEmailClicksBreakdownQuery( postId, breakdown, params ),
+		enabled: ( options?.enabled ?? true ) && !! postId,
+	} );
+}
+
+export function useStatsEmailOpensTimeSeries(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsEmailOpensTimeSeriesQuery( postId, params ),
+		enabled: ( options?.enabled ?? true ) && !! postId,
+	} );
+}
+
+export function useStatsEmailClicksTimeSeries(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsEmailClicksTimeSeriesQuery( postId, params ),
+		enabled: ( options?.enabled ?? true ) && !! postId,
+	} );
+}
+
+export function useStatsReferrersSpam( options?: UseStatsOptions ) {
+	return useQuery( { ...statsReferrersSpamQuery(), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( {
+		...statsSubscribersCountsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsSiteHasNeverPublishedPost(
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsSiteHasNeverPublishedPostQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsPlanUsage( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsPlanUsageQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsDashboardModules( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsDashboardModulesQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsDashboardModuleSettings(
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useQuery( {
+		...statsDashboardModuleSettingsQuery( params ),
+		enabled: options?.enabled ?? true,
+	} );
+}
+
+export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsWordAdsEarningsQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsWordAdsStatsQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsPurchases( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsPurchasesQuery( params ), enabled: options?.enabled ?? true } );
+}
+
+export function useStatsReferrersMarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/new',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers-spam' ] } );
+		},
+	} );
+}
+
+export function useStatsReferrersUnmarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/delete',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers-spam' ] } );
+		},
+	} );
+}
+
+export function useStatsDashboardModulesMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/modules',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'dashboard-modules' ] } );
+		},
+	} );
+}
+
+export function useStatsDashboardModuleSettingsMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/module-settings',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats', 'dashboard-module-settings' ] } );
+		},
+	} );
+}
+
+export function useStatsCommercialClassificationMutation() {
+	return useMutation( {
+		mutationFn: ( params?: StatsQueryParams ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'commercial-classification',
+				method: 'POST',
+				params,
+			} ),
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats.ts
@@ -1,20 +1,16 @@
 /**
  * External dependencies
  */
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 /**
  * Internal dependencies
  */
-import { fetchStatsProxy } from '../api/stats-proxy-fetch';
-import { queryClient } from '../providers';
 import {
 	statsArchivesQuery,
 	statsClicksQuery,
 	statsCommentFollowersQuery,
 	statsCommentsQuery,
 	statsCountryViewsQuery,
-	statsDashboardModulesQuery,
-	statsDashboardModuleSettingsQuery,
 	statsDevicesQuery,
 	statsEmailClicksBreakdownQuery,
 	statsEmailClicksTimeSeriesQuery,
@@ -26,18 +22,13 @@ import {
 	statsHighlightsQuery,
 	statsInsightsQuery,
 	statsLocationsQuery,
-	statsPlanUsageQuery,
 	statsPublicizeQuery,
-	statsPurchasesQuery,
 	statsReferrersQuery,
-	statsReferrersSpamQuery,
 	statsSearchTermsQuery,
 	statsSinglePostQuery,
 	statsSingleVideoQuery,
-	statsSiteHasNeverPublishedPostQuery,
 	statsSiteQuery,
 	statsStreakQuery,
-	statsSubscribersCountsQuery,
 	statsSubscribersQuery,
 	statsTagsQuery,
 	statsTopAuthorsQuery,
@@ -45,7 +36,6 @@ import {
 	statsUtmQuery,
 	statsVideoPlaysQuery,
 	statsVisitsQuery,
-	statsWordAdsEarningsQuery,
 	statsWordAdsStatsQuery,
 	type StatsReportParams,
 } from '../queries/stats-queries';
@@ -335,127 +325,6 @@ export function useStatsEmailClicksTimeSeries(
 	} );
 }
 
-export function useStatsReferrersSpam( options?: UseStatsOptions ) {
-	return useQuery( { ...statsReferrersSpamQuery(), enabled: options?.enabled ?? true } );
-}
-
-export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useQuery( {
-		...statsSubscribersCountsQuery( params ),
-		enabled: options?.enabled ?? true,
-	} );
-}
-
-export function useStatsSiteHasNeverPublishedPost(
-	params?: StatsQueryParams,
-	options?: UseStatsOptions
-) {
-	return useQuery( {
-		...statsSiteHasNeverPublishedPostQuery( params ),
-		enabled: options?.enabled ?? true,
-	} );
-}
-
-export function useStatsPlanUsage( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useQuery( { ...statsPlanUsageQuery( params ), enabled: options?.enabled ?? true } );
-}
-
-export function useStatsDashboardModules( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useQuery( { ...statsDashboardModulesQuery( params ), enabled: options?.enabled ?? true } );
-}
-
-export function useStatsDashboardModuleSettings(
-	params?: StatsQueryParams,
-	options?: UseStatsOptions
-) {
-	return useQuery( {
-		...statsDashboardModuleSettingsQuery( params ),
-		enabled: options?.enabled ?? true,
-	} );
-}
-
-export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useQuery( { ...statsWordAdsEarningsQuery( params ), enabled: options?.enabled ?? true } );
-}
-
 export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
 	return useQuery( { ...statsWordAdsStatsQuery( params ), enabled: options?.enabled ?? true } );
-}
-
-export function useStatsPurchases( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useQuery( { ...statsPurchasesQuery( params ), enabled: options?.enabled ?? true } );
-}
-
-export function useStatsReferrersMarkSpamMutation() {
-	return useMutation( {
-		mutationFn: ( domain: string ) =>
-			fetchStatsProxy( {
-				version: '1.1',
-				endpoint: 'stats/referrers/spam/new',
-				method: 'POST',
-				params: { domain },
-			} ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers-spam' ] } );
-		},
-	} );
-}
-
-export function useStatsReferrersUnmarkSpamMutation() {
-	return useMutation( {
-		mutationFn: ( domain: string ) =>
-			fetchStatsProxy( {
-				version: '1.1',
-				endpoint: 'stats/referrers/spam/delete',
-				method: 'POST',
-				params: { domain },
-			} ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers-spam' ] } );
-		},
-	} );
-}
-
-export function useStatsDashboardModulesMutation() {
-	return useMutation( {
-		mutationFn: ( body: unknown ) =>
-			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'jetpack-stats-dashboard/modules',
-				method: 'POST',
-				body,
-			} ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'dashboard-modules' ] } );
-		},
-	} );
-}
-
-export function useStatsDashboardModuleSettingsMutation() {
-	return useMutation( {
-		mutationFn: ( body: unknown ) =>
-			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'jetpack-stats-dashboard/module-settings',
-				method: 'POST',
-				body,
-			} ),
-		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'stats', 'dashboard-module-settings' ] } );
-		},
-	} );
-}
-
-export function useStatsCommercialClassificationMutation() {
-	return useMutation( {
-		mutationFn: ( params?: StatsQueryParams ) =>
-			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'commercial-classification',
-				method: 'POST',
-				params,
-			} ),
-	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -15,6 +15,7 @@ export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-loca
 export { useReportBookings } from './hooks/use-report-bookings';
 export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
 export * from './hooks/use-stats';
+export * from './hooks/use-stats-app';
 export { prefetchReport } from './prefetch';
 export {
 	normalizeReportParams,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -14,6 +14,7 @@ export { useReportVisitors } from './hooks/use-report-visitors';
 export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-location';
 export { useReportBookings } from './hooks/use-report-bookings';
 export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
+export * from './hooks/use-stats';
 export { prefetchReport } from './prefetch';
 export {
 	normalizeReportParams,
@@ -37,5 +38,22 @@ export type { ProductType } from './types/product-type';
 export { ORDER_ATTRIBUTION_VIEWS } from './api/report-order-attribution-summary-fetch';
 export { getDefaultIntervalForPeriod, getDateFormatFromInterval } from './utils/interval';
 export { getDefaultPreset, getDefaultQueryParams } from './defaults';
-export { exportReport } from './api';
-export type { ExportReportParams, ExportReportResponse } from './api';
+export { exportReport, fetchStatsProxy, getStatsProxyPath } from './api';
+export type {
+	ExportReportParams,
+	ExportReportResponse,
+	StatsProxyFetchParams,
+	StatsProxyMethod,
+	StatsProxyParams,
+	StatsProxyQueryParams,
+	StatsProxyVersion,
+} from './api';
+export type { StatsNormalizedItem, StatsNormalizedReport } from './processing/stats';
+export {
+	getStatsPeriodFromInterval,
+	reportParamsToStatsQueryParams,
+	statsQueryKeyPart,
+	type StatsPeriod,
+	type StatsQueryParams,
+} from './utils/stats-params';
+export type { StatsReportParams } from './queries/stats-queries';

--- a/projects/packages/premium-analytics/packages/data/src/processing/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/index.ts
@@ -4,6 +4,7 @@ export * from './customers';
 export * from './products';
 export * from './visitors';
 export * from './visitors-by-location';
+export * from './stats';
 
 // TODO: Add coupons processing functions
 // export * from './coupons';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
@@ -1,0 +1,53 @@
+export const topPostsFixture = {
+	days: {
+		'2026-06-16': {
+			total_views: 184,
+			postviews: [
+				{
+					id: 41,
+					href: 'https://example.com/hello/',
+					title: 'Hello world',
+					type: 'post',
+					views: 64,
+				},
+			],
+		},
+	},
+};
+
+export const referrersFixture = {
+	days: {
+		'2026-06-16': {
+			groups: [
+				{
+					name: 'example.com',
+					total: 12,
+					results: [ { name: 'example.com/path', views: 12, url: 'https://example.com/path' } ],
+				},
+			],
+		},
+	},
+};
+
+export const fileDownloadsFixture = {
+	days: {
+		'2026-06-16': {
+			files: [
+				{
+					relative_url: '/download.pdf',
+					filename: 'download.pdf',
+					downloads: '5',
+					download_url: 'https://example.com/download.pdf',
+				},
+			],
+		},
+	},
+};
+
+export const utmFixture = [
+	{
+		label: 'google',
+		value: 10,
+		children: [ { label: 'cpc', value: 6 } ],
+	},
+];

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
@@ -66,3 +66,212 @@ export const genericListFixture = [
 		value: 'raw-value',
 	},
 ];
+
+export const visitsFixture = {
+	unit: 'day',
+	fields: [ 'period', 'views', 'visitors', 'likes' ],
+	data: [
+		[ '2026-06-16', '12', '5', 1 ],
+		[ '2026-06-17', '8', '3', 0 ],
+	],
+};
+
+export const weeklyVisitsFixture = {
+	unit: 'week',
+	fields: [ 'period', 'views', 'visitors' ],
+	data: [ [ '2026-W25', '20', '9' ] ],
+};
+
+export const emailOpensTimeSeriesFixture = {
+	timeline: {
+		fields: [ 'date', 'opens_count' ],
+		data: [
+			[ '2026-06-16', '7' ],
+			[ '2026-06-17', '3' ],
+		],
+		unit: 'day',
+	},
+	opens_rate: {
+		total_sends: 2,
+		unique_opens: 2,
+		total_opens: 3,
+		opens_rate: 1,
+	},
+};
+
+export const emailClicksTimeSeriesFixture = {
+	timeline: {
+		fields: [ 'date', 'clicks_count' ],
+		data: [
+			[ '2026-06-16', '5' ],
+			[ '2026-06-17', '2' ],
+		],
+		unit: 'day',
+	},
+};
+
+export const subscribersFixture = {
+	unit: 'day',
+	fields: [ 'period', 'subscribers', 'subscribers_change' ],
+	data: [
+		[ '2026-06-16', '14', '2' ],
+		[ '2026-06-17', '15', '1' ],
+	],
+};
+
+export const publicizeFixture = {
+	services: [
+		{
+			service: 'mastodon',
+			followers: '12',
+		},
+	],
+};
+
+export const followersFixture = {
+	page: 1,
+	pages: 1,
+	total: 125,
+	total_email: 5,
+	total_wpcom: 120,
+	subscribers: [
+		{
+			ID: 111,
+			label: 'reader@example.com',
+			url: null,
+			date_subscribed: '2026-06-16T18:53:05+00:00',
+		},
+	],
+};
+
+export const tagsFixture = {
+	tags: [
+		{
+			tags: [
+				{
+					type: 'category',
+					name: 'News',
+					link: 'https://example.com/category/news/',
+				},
+			],
+			views: '18',
+		},
+	],
+};
+
+export const commentsFixture = {
+	total_comments: 22,
+	authors: [
+		{
+			name: 'Jane',
+			comments: '12',
+			gravatar: 'https://example.com/avatar.jpg',
+		},
+	],
+	posts: [
+		{
+			id: 41,
+			name: 'Hello world',
+			comments: '10',
+			link: 'https://example.com/hello/',
+		},
+	],
+};
+
+export const commentFollowersFixture = {
+	page: 1,
+	pages: 1,
+	total: 2,
+	posts: [
+		{
+			id: 0,
+			followers: 20,
+		},
+		{
+			id: 41,
+			title: 'Hello world',
+			followers: '10',
+			url: 'https://example.com/hello/',
+		},
+	],
+};
+
+export const emailSummaryFixture = {
+	posts: [
+		{
+			id: 41,
+			href: 'https://example.com/hello/',
+			date: '2026-06-16',
+			title: 'Hello world',
+			type: 'post',
+			opens: '7',
+			clicks: '3',
+			opens_rate: '0.7',
+			clicks_rate: '0.3',
+			unique_opens: '5',
+			unique_clicks: '2',
+			total_sends: '10',
+		},
+	],
+};
+
+export const emailOpensBreakdownFixture = {
+	clients: {
+		fields: [ 'client', 'opens_count' ],
+		data: [ [ 'Other', '3' ] ],
+	},
+};
+
+export const emailClicksCountryBreakdownFixture = {
+	countries: {
+		fields: [ 'country', 'clicks_count' ],
+		data: [ [ 'NZ', '4' ] ],
+	},
+	'countries-info': {
+		NZ: {
+			country_full: 'New Zealand',
+		},
+	},
+};
+
+export const singlePostFixture = {
+	unit: 'day',
+	fields: [ 'period', 'views', 'visitors' ],
+	data: [ [ '2026-06-16', '19', '11' ] ],
+	post: {
+		id: 41,
+		title: 'Hello world',
+	},
+};
+
+export const utmTopValuesFixture = {
+	top_utm_values: {
+		'["google","cpc"]': 11,
+	},
+	top_posts: {
+		'["google","cpc"]': [
+			{
+				id: 41,
+				title: 'Hello world',
+				views: 6,
+				href: 'https://example.com/hello/',
+			},
+		],
+	},
+};
+
+export const devicesTopValuesFixture = {
+	top_values: {
+		mobile: 9,
+		desktop: 4,
+	},
+};
+
+export const wordAdsStatsFixture = {
+	unit: 'day',
+	fields: [ 'period', 'impressions', 'revenue', 'cpm' ],
+	data: [
+		[ '2026-06-16', '1200', '4.20', '3.50' ],
+		[ '2026-06-17', '800', '2.40', '3.00' ],
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
@@ -244,6 +244,13 @@ export const singlePostFixture = {
 	},
 };
 
+export const scalarDaysTimeSeriesFixture = {
+	days: {
+		'2026-06-16': '7',
+		'2026-06-17': 3,
+	},
+};
+
 export const utmTopValuesFixture = {
 	top_utm_values: {
 		'["google","cpc"]': 11,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/stats.ts
@@ -51,3 +51,18 @@ export const utmFixture = [
 		children: [ { label: 'cpc', value: 6 } ],
 	},
 ];
+
+export const devicesFixture = [
+	{
+		label: 'Desktop',
+		value: '42',
+	},
+];
+
+export const genericListFixture = [
+	{
+		name: 'Example tag',
+		views: '18',
+		value: 'raw-value',
+	},
+];

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Internal dependencies
+ */
+import {
+	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsReferrersResponse,
+	sanitizeStatsTopPostsResponse,
+	sanitizeStatsUtmResponse,
+} from '..';
+import {
+	fileDownloadsFixture,
+	referrersFixture,
+	topPostsFixture,
+	utmFixture,
+} from '../__fixtures__/stats';
+
+describe( 'Stats normalizers', () => {
+	it( 'normalizes top posts into report data', () => {
+		expect(
+			sanitizeStatsTopPostsResponse( topPostsFixture, { period: 'day', date: '2026-06-16' } ).data
+		).toEqual( [
+			expect.objectContaining( {
+				id: 41,
+				label: 'Hello world',
+				value: 64,
+				link: 'https://example.com/hello/',
+			} ),
+		] );
+	} );
+
+	it( 'normalizes nested referrers', () => {
+		const result = sanitizeStatsReferrersResponse( referrersFixture, {
+			period: 'day',
+			date: '2026-06-16',
+		} );
+
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'example.com/path',
+				value: 12,
+				actionMenu: 1,
+			} )
+		);
+	} );
+
+	it( 'normalizes file downloads with numeric values', () => {
+		expect(
+			sanitizeStatsFileDownloadsResponse( fileDownloadsFixture, {
+				period: 'day',
+				date: '2026-06-16',
+			} ).data[ 0 ]
+		).toEqual(
+			expect.objectContaining( {
+				label: '/download.pdf',
+				shortLabel: 'download.pdf',
+				value: 5,
+			} )
+		);
+	} );
+
+	it( 'flattens UTM children with parent context', () => {
+		expect( sanitizeStatsUtmResponse( utmFixture ).data ).toEqual( [
+			expect.objectContaining( { label: 'google', value: 10 } ),
+			expect.objectContaining( { label: 'google > cpc', value: 6 } ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
@@ -2,20 +2,46 @@
  * Internal dependencies
  */
 import {
+	sanitizeStatsCommentFollowersResponse,
+	sanitizeStatsCommentsResponse,
 	sanitizeStatsDevicesResponse,
+	sanitizeStatsEmailBreakdownResponse,
+	sanitizeStatsEmailSummaryResponse,
 	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsFollowersResponse,
 	sanitizeStatsGenericListResponse,
+	sanitizeStatsPublicizeResponse,
 	sanitizeStatsReferrersResponse,
+	sanitizeStatsTagsResponse,
+	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsTopPostsResponse,
 	sanitizeStatsUtmResponse,
+	sanitizeStatsVisitsResponse,
 } from '..';
 import {
 	devicesFixture,
+	devicesTopValuesFixture,
+	commentFollowersFixture,
+	commentsFixture,
+	emailClicksCountryBreakdownFixture,
+	emailClicksTimeSeriesFixture,
+	emailOpensBreakdownFixture,
+	emailOpensTimeSeriesFixture,
+	emailSummaryFixture,
 	fileDownloadsFixture,
+	followersFixture,
 	genericListFixture,
+	publicizeFixture,
 	referrersFixture,
+	singlePostFixture,
+	subscribersFixture,
+	tagsFixture,
 	topPostsFixture,
 	utmFixture,
+	utmTopValuesFixture,
+	visitsFixture,
+	weeklyVisitsFixture,
+	wordAdsStatsFixture,
 } from '../__fixtures__/stats';
 
 describe( 'Stats normalizers', () => {
@@ -85,6 +111,315 @@ describe( 'Stats normalizers', () => {
 			expect.objectContaining( {
 				label: 'Example tag',
 				value: 18,
+			} )
+		);
+	} );
+
+	it( 'normalizes visits chart data to the Premium Analytics time-series shape', () => {
+		const result = sanitizeStatsVisitsResponse( visitsFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				views: 20,
+				visitors: 8,
+				likes: 1,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				views: 12,
+				visitors: 5,
+				likes: 1,
+				value: 12,
+			} )
+		);
+	} );
+
+	it( 'normalizes subscribers chart data to the Premium Analytics time-series shape', () => {
+		const result = sanitizeStatsTimeSeriesResponse( subscribersFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				subscribers: 29,
+				subscribers_change: 3,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				subscribers: 14,
+				subscribers_change: 2,
+				value: 14,
+			} )
+		);
+	} );
+
+	it( 'expands weekly visits chart periods to date_start and date_end', () => {
+		expect( sanitizeStatsVisitsResponse( weeklyVisitsFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				date_start: '2026-06-15',
+				date_end: '2026-06-21',
+				views: 20,
+				visitors: 9,
+			} )
+		);
+	} );
+
+	it( 'normalizes email opens object-row time series to the Premium Analytics shape', () => {
+		const result = sanitizeStatsTimeSeriesResponse( emailOpensTimeSeriesFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				opens_count: 10,
+				total_sends: 2,
+				total_opens: 3,
+				opens_rate: 1,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				opens_count: 7,
+				value: 7,
+			} )
+		);
+	} );
+
+	it( 'normalizes email clicks time series to the Premium Analytics shape', () => {
+		const result = sanitizeStatsTimeSeriesResponse( emailClicksTimeSeriesFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				clicks_count: 7,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				clicks_count: 5,
+				value: 5,
+			} )
+		);
+	} );
+
+	it( 'normalizes single post chart data to the Premium Analytics time-series shape', () => {
+		const result = sanitizeStatsTimeSeriesResponse( singlePostFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				views: 19,
+				visitors: 11,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				views: 19,
+				visitors: 11,
+				value: 19,
+			} )
+		);
+	} );
+
+	it( 'normalizes email summary rows', () => {
+		const result = sanitizeStatsEmailSummaryResponse( emailSummaryFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				total_sends: 10,
+				opens: 7,
+				clicks: 3,
+				unique_opens: 5,
+				unique_clicks: 2,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 41,
+				label: 'Hello world',
+				value: 7,
+				clicks: 3,
+			} )
+		);
+	} );
+
+	it( 'normalizes email opens breakdown matrices', () => {
+		const result = sanitizeStatsEmailBreakdownResponse( emailOpensBreakdownFixture );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { opens_count: 3 } ) );
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				client: 'Other',
+				label: 'Other',
+				opens_count: 3,
+				value: 3,
+			} )
+		);
+	} );
+
+	it( 'normalizes email clicks country breakdown matrices', () => {
+		const result = sanitizeStatsEmailBreakdownResponse( emailClicksCountryBreakdownFixture );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { clicks_count: 4 } ) );
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				country: 'NZ',
+				countryCode: 'NZ',
+				countryFull: 'New Zealand',
+				label: 'New Zealand',
+				clicks_count: 4,
+				value: 4,
+			} )
+		);
+	} );
+
+	it( 'normalizes publicize service rows', () => {
+		expect( sanitizeStatsPublicizeResponse( publicizeFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'mastodon',
+				value: 12,
+			} )
+		);
+	} );
+
+	it( 'normalizes followers subscriber rows', () => {
+		const result = sanitizeStatsFollowersResponse( followersFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				total: 125,
+				total_email: 5,
+				total_wpcom: 120,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 111,
+				label: 'reader@example.com',
+				value: 0,
+				date_subscribed: '2026-06-16T18:53:05+00:00',
+			} )
+		);
+	} );
+
+	it( 'normalizes tag rows', () => {
+		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'News',
+				value: 18,
+				link: 'https://example.com/category/news/',
+			} )
+		);
+	} );
+
+	it( 'normalizes comments into author and post groups', () => {
+		const result = sanitizeStatsCommentsResponse( commentsFixture );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { total_comments: 22 } ) );
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				label: 'authors',
+				value: 12,
+			} ),
+			expect.objectContaining( {
+				label: 'posts',
+				value: 10,
+			} ),
+		] );
+	} );
+
+	it( 'normalizes comment follower post rows', () => {
+		const result = sanitizeStatsCommentFollowersResponse( commentFollowersFixture );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { total: 2 } ) );
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				label: 'All Posts',
+				value: 20,
+			} ),
+			expect.objectContaining( {
+				id: 41,
+				label: 'Hello world',
+				value: 10,
+				labelIcon: 'external',
+			} ),
+		] );
+	} );
+
+	it( 'keeps UTM top-value payloads as leaderboard rows', () => {
+		expect( sanitizeStatsUtmResponse( utmTopValuesFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'google / cpc',
+				value: 11,
+				children: [
+					expect.objectContaining( {
+						id: 41,
+						label: 'Hello world',
+						value: 6,
+					} ),
+				],
+			} )
+		);
+	} );
+
+	it( 'keeps devices top-value payloads as leaderboard rows', () => {
+		expect( sanitizeStatsDevicesResponse( devicesTopValuesFixture ).data ).toEqual( [
+			expect.objectContaining( {
+				key: 'mobile',
+				label: 'mobile',
+				value: 9,
+			} ),
+			expect.objectContaining( {
+				key: 'desktop',
+				label: 'desktop',
+				value: 4,
+			} ),
+		] );
+	} );
+
+	it( 'normalizes WordAds stats chart data to the Premium Analytics time-series shape', () => {
+		const result = sanitizeStatsTimeSeriesResponse( wordAdsStatsFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				impressions: 2000,
+				revenue: 6.6,
+				cpm: 6.5,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				impressions: 1200,
+				revenue: 4.2,
+				cpm: 3.5,
+				value: 1200,
 			} )
 		);
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
@@ -2,13 +2,17 @@
  * Internal dependencies
  */
 import {
+	sanitizeStatsDevicesResponse,
 	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsGenericListResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsTopPostsResponse,
 	sanitizeStatsUtmResponse,
 } from '..';
 import {
+	devicesFixture,
 	fileDownloadsFixture,
+	genericListFixture,
 	referrersFixture,
 	topPostsFixture,
 	utmFixture,
@@ -63,5 +67,25 @@ describe( 'Stats normalizers', () => {
 			expect.objectContaining( { label: 'google', value: 10 } ),
 			expect.objectContaining( { label: 'google > cpc', value: 6 } ),
 		] );
+	} );
+
+	it( 'keeps parsed device values when the raw payload value is a string', () => {
+		expect( sanitizeStatsDevicesResponse( devicesFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'Desktop',
+				value: 42,
+			} )
+		);
+	} );
+
+	it( 'keeps parsed generic list values when the raw payload has a value field', () => {
+		expect(
+			sanitizeStatsGenericListResponse( genericListFixture, 'views', 'name' ).data[ 0 ]
+		).toEqual(
+			expect.objectContaining( {
+				label: 'Example tag',
+				value: 18,
+			} )
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/stats.test.ts
@@ -33,6 +33,7 @@ import {
 	genericListFixture,
 	publicizeFixture,
 	referrersFixture,
+	scalarDaysTimeSeriesFixture,
 	singlePostFixture,
 	subscribersFixture,
 	tagsFixture,
@@ -241,6 +242,32 @@ describe( 'Stats normalizers', () => {
 				value: 19,
 			} )
 		);
+	} );
+
+	it( 'normalizes scalar days maps as time-series values', () => {
+		const result = sanitizeStatsTimeSeriesResponse( scalarDaysTimeSeriesFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-16',
+				date_end: '2026-06-17',
+				value: 10,
+			} )
+		);
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16',
+				date_end: '2026-06-16',
+				value: 7,
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-17',
+				date_start: '2026-06-17',
+				date_end: '2026-06-17',
+				value: 3,
+			} ),
+		] );
 	} );
 
 	it( 'normalizes email summary rows', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -255,9 +255,13 @@ function parseTimeSeriesRows( payload: unknown ) {
 		return data.map( numericTimeSeriesRow );
 	}
 
-	return Object.entries( asRecord( response.days ) ).map( ( [ period, value ] ) =>
-		numericTimeSeriesRow( { period, ...asRecord( value ) } )
-	);
+	return Object.entries( asRecord( response.days ) ).map( ( [ period, value ] ) => {
+		if ( typeof value === 'number' || typeof value === 'string' ) {
+			return numericTimeSeriesRow( { period, value } );
+		}
+
+		return numericTimeSeriesRow( { period, ...asRecord( value ) } );
+	} );
 }
 
 function isTimeSeriesPayload( payload: unknown ) {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -1,0 +1,455 @@
+/**
+ * Internal dependencies
+ */
+import { safeParseFloat } from '../../utils/parsing';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsItemAction = {
+	type: string;
+	data: unknown;
+};
+
+export type StatsNormalizedItem = {
+	id?: string | number;
+	label: unknown;
+	value: number;
+	children?: StatsNormalizedItem[] | null;
+	link?: string | null;
+	page?: string | null;
+	shortLabel?: string;
+	labelIcon?: string | null;
+	icon?: string | null;
+	iconClassName?: string;
+	className?: string | null;
+	countryCode?: string;
+	countryFull?: string;
+	region?: string;
+	coordinates?: unknown;
+	actions?: StatsItemAction[];
+	actionMenu?: number;
+	[ key: string ]: unknown;
+};
+
+export type StatsNormalizedReport = {
+	summary: Record< string, unknown >;
+	data: StatsNormalizedItem[];
+};
+
+type AnyRecord = Record< string, any >;
+
+const EMPTY_REPORT: StatsNormalizedReport = {
+	summary: {},
+	data: [],
+};
+
+function asRecord( value: unknown ): AnyRecord {
+	return value && typeof value === 'object' && ! Array.isArray( value )
+		? ( value as AnyRecord )
+		: {};
+}
+
+function asArray< T = AnyRecord >( value: unknown ): T[] {
+	return Array.isArray( value ) ? ( value as T[] ) : [];
+}
+
+function numericSummary( value: unknown ): Record< string, unknown > {
+	return Object.fromEntries(
+		Object.entries( asRecord( value ) ).map( ( [ key, item ] ) => [
+			key,
+			typeof item === 'number' || typeof item === 'string' ? safeParseFloat( item ) : item,
+		] )
+	);
+}
+
+function getFirstDayBucket( response: AnyRecord ) {
+	const days = asRecord( response.days );
+	const firstKey = Object.keys( days )[ 0 ];
+
+	return firstKey ? asRecord( days[ firstKey ] ) : {};
+}
+
+function getStatsBucket( response: unknown, query: StatsQueryParams = {} ) {
+	const payload = asRecord( response );
+	const summary = asRecord( payload.summary );
+
+	if ( query.summarize && Object.keys( summary ).length ) {
+		return summary;
+	}
+
+	const days = asRecord( payload.days );
+	const requested = query.start_date ?? query.date;
+
+	if ( requested && days[ requested ] ) {
+		return asRecord( days[ requested ] );
+	}
+
+	return getFirstDayBucket( payload );
+}
+
+function mapNestedItems( items: AnyRecord[], mapper: ( item: AnyRecord ) => StatsNormalizedItem ) {
+	return items.map( item => mapper( item ) );
+}
+
+function parseChartData( payload: unknown ) {
+	const response = asRecord( payload );
+	const fields = asArray< string >( response.fields );
+
+	return asArray< unknown[] >( response.data ).map( record => {
+		const parsed: Record< string, unknown > = {};
+		record.forEach( ( value, index ) => {
+			const field = fields[ index ];
+			if ( field ) {
+				parsed[ field ] =
+					field === 'period' && typeof value === 'string' ? value.replace( /W/g, '-' ) : value;
+			}
+		} );
+		return parsed;
+	} );
+}
+
+function normalizeChartResponse( payload: unknown ): StatsNormalizedReport {
+	const rows = parseChartData( payload );
+	const summary = rows.reduce< Record< string, number > >( ( totals, row ) => {
+		Object.entries( row ).forEach( ( [ key, value ] ) => {
+			if ( key !== 'period' && ( typeof value === 'number' || typeof value === 'string' ) ) {
+				totals[ key ] = ( totals[ key ] ?? 0 ) + safeParseFloat( value );
+			}
+		} );
+		return totals;
+	}, {} );
+
+	return {
+		summary,
+		data: rows.map( row => ( {
+			label: row.period ?? '',
+			value: safeParseFloat( row.views ?? row.visits ?? row.value ?? 0 ),
+			...row,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsSiteResponse( response: unknown ) {
+	const payload = asRecord( response );
+
+	return {
+		...payload,
+		stats: numericSummary( payload.stats ),
+	};
+}
+
+export function sanitizeStatsTopPostsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const items = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.postviews )
+		: asArray< AnyRecord >( bucket.postviews );
+
+	return {
+		summary: numericSummary( {
+			total_views: bucket.total_views ?? asRecord( response ).summary?.total_views,
+		} ),
+		data: items.map( item => ( {
+			id: item.id,
+			label: item.title,
+			value: safeParseFloat( item.views ),
+			link: item.href ?? null,
+			page: item.id ? `/stats/post/${ item.id }` : null,
+			public: item.public,
+			type: item.type,
+			actions: item.href ? [ { type: 'link', data: item.href } ] : [],
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsReferrersResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const groups = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.groups )
+		: asArray< AnyRecord >( bucket.groups );
+
+	const parse = ( item: AnyRecord ): StatsNormalizedItem => ( {
+		label: item.name ?? item.group ?? '',
+		value: safeParseFloat( item.views ?? item.total ),
+		link: item.url ?? null,
+		icon: item.icon,
+		labelIcon: item.results || item.children ? null : 'external',
+		children: mapNestedItems( asArray( item.results ?? item.children ), parse ),
+	} );
+
+	return {
+		summary: numericSummary( {
+			total:
+				bucket.total ??
+				groups.reduce( ( total, item ) => total + safeParseFloat( item.total ?? item.views ), 0 ),
+		} ),
+		data: groups.map( item => {
+			const normalized = parse( item.results?.length === 1 ? item.results[ 0 ] : item );
+			const domain = item.name ?? item.group;
+			const canSpam = typeof domain === 'string' && domain.includes( '.' );
+
+			return {
+				...normalized,
+				actions: canSpam ? [ { type: 'spam', data: { domain } } ] : [],
+				actionMenu: canSpam ? 1 : 0,
+			};
+		} ),
+	};
+}
+
+export function sanitizeStatsClicksResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const clicks = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.clicks )
+		: asArray< AnyRecord >( bucket.clicks );
+
+	const parse = ( item: AnyRecord ): StatsNormalizedItem => ( {
+		label: item.name ?? '',
+		value: safeParseFloat( item.views ),
+		link: item.url ?? null,
+		icon: item.icon,
+		labelIcon: item.children?.length ? null : 'external',
+		children: mapNestedItems( asArray( item.children ), child => ( {
+			label: child.name?.replace?.( item.name, '' ) || '/',
+			value: safeParseFloat( child.views ),
+			link: child.url ?? null,
+			labelIcon: 'external',
+			children: null,
+		} ) ),
+	} );
+
+	return {
+		summary: numericSummary( {
+			total: clicks.reduce( ( total, item ) => total + safeParseFloat( item.views ), 0 ),
+		} ),
+		data: clicks.map( parse ),
+	};
+}
+
+export function sanitizeStatsSearchTermsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const terms = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.search_terms )
+		: asArray< AnyRecord >( bucket.search_terms );
+
+	return {
+		summary: numericSummary( {
+			total: terms.reduce( ( total, item ) => total + safeParseFloat( item.views ), 0 ),
+		} ),
+		data: terms.map( item => ( {
+			label: item.term,
+			value: safeParseFloat( item.views ),
+			className: 'user-selectable',
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsFileDownloadsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const files = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.files )
+		: asArray< AnyRecord >( bucket.files );
+
+	return {
+		summary: numericSummary( {
+			total: files.reduce( ( total, item ) => total + safeParseFloat( item.downloads ), 0 ),
+		} ),
+		data: files.map( item => ( {
+			label: item.relative_url,
+			shortLabel: item.filename,
+			value: safeParseFloat( item.downloads ),
+			link: item.download_url,
+			linkTitle: item.relative_url,
+			labelIcon: 'external',
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsTopAuthorsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const authors = query?.summarize
+		? asArray< AnyRecord >( asRecord( response ).summary?.authors )
+		: asArray< AnyRecord >( bucket.authors );
+
+	return {
+		summary: numericSummary( {
+			total: authors.reduce( ( total, item ) => total + safeParseFloat( item.views ), 0 ),
+		} ),
+		data: authors.map( item => ( {
+			label: item.name || 'Untracked Authors',
+			value: safeParseFloat( item.views ),
+			icon: item.avatar,
+			iconClassName: 'avatar-user',
+			className: 'module-content-list-item-large',
+			children: asArray< AnyRecord >( item.posts ).map( post => ( {
+				id: post.id,
+				label: post.title,
+				value: safeParseFloat( post.views ),
+				link: post.url ?? null,
+				page: post.id ? `/stats/post/${ post.id }` : null,
+				children: null,
+			} ) ),
+		} ) ),
+	};
+}
+
+export function sanitizeStatsLocationsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const bucket = getStatsBucket( response, query );
+	const views = query?.summarize
+		? asArray< AnyRecord >( payload.summary?.views )
+		: asArray< AnyRecord >( bucket.views );
+	const countryInfo = asRecord( payload[ 'country-info' ] ?? payload.countryInfo );
+
+	return {
+		summary: numericSummary( {
+			total: views.reduce( ( total, item ) => total + safeParseFloat( item.views ), 0 ),
+		} ),
+		data: views
+			.filter( item => ! [ 'A1', 'A2', 'ZZ' ].includes( item.country_code ) )
+			.map( item => {
+				const country = asRecord( countryInfo[ item.country_code ] );
+				const label = item.location ?? country.country_full ?? item.country_code ?? '';
+
+				return {
+					label: typeof label === 'string' ? label.replace( /’/, "'" ) : label,
+					value: safeParseFloat( item.views ),
+					countryCode: item.country_code,
+					countryFull: country.country_full,
+					region: country.map_region,
+					coordinates: item.coordinates,
+					children: null,
+				};
+			} ),
+	};
+}
+
+export function sanitizeStatsVideoPlaysResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+	const payload = asRecord( response );
+	const videoData = query?.complete_stats
+		? asArray< AnyRecord >( bucket.data ?? payload.days?.summary?.data )
+		: asArray< AnyRecord >( bucket.plays ?? payload.days?.summary?.plays );
+
+	return {
+		summary: numericSummary( {
+			total: videoData.reduce(
+				( total, item ) => total + safeParseFloat( item.views ?? item.plays ),
+				0
+			),
+		} ),
+		data: videoData.map( item => ( {
+			id: item.post_id,
+			label: item.title,
+			value: safeParseFloat( item.views ?? item.plays ),
+			link: item.url ?? null,
+			impressions: safeParseFloat( item.impressions ),
+			watch_time: safeParseFloat( item.watch_time ),
+			retention_rate: safeParseFloat( item.retention_rate ),
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsUtmResponse( response: unknown ): StatsNormalizedReport {
+	const rows: AnyRecord[] = [];
+
+	asArray< AnyRecord >( response ).forEach( row => {
+		rows.push( row );
+		asArray< AnyRecord >( row.children ).forEach( child =>
+			rows.push( { ...child, context: row.label } )
+		);
+	} );
+
+	return {
+		summary: numericSummary( {
+			total: rows.reduce( ( total, item ) => total + safeParseFloat( item.value ), 0 ),
+		} ),
+		data: rows.map( row => ( {
+			label: row.context ? `${ row.context } > ${ row.label }` : row.label,
+			value: safeParseFloat( row.value ),
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsDevicesResponse( response: unknown ): StatsNormalizedReport {
+	if ( Array.isArray( response ) ) {
+		return {
+			summary: numericSummary( {
+				total: response.reduce(
+					( total, item ) => total + safeParseFloat( asRecord( item ).value ),
+					0
+				),
+			} ),
+			data: response.map( item => ( {
+				label: asRecord( item ).label ?? asRecord( item ).name ?? '',
+				value: safeParseFloat( asRecord( item ).value ?? asRecord( item ).views ),
+				...asRecord( item ),
+			} ) ),
+		};
+	}
+
+	return normalizeChartResponse( response );
+}
+
+export function sanitizeStatsVisitsResponse( response: unknown ): StatsNormalizedReport {
+	return normalizeChartResponse( response );
+}
+
+export function sanitizeStatsGenericListResponse(
+	response: unknown,
+	valueKey = 'views',
+	labelKey = 'label'
+): StatsNormalizedReport {
+	const items = Array.isArray( response )
+		? asArray< AnyRecord >( response )
+		: asArray< AnyRecord >( asRecord( response ).data ?? asRecord( response ).items );
+
+	if ( items.length ) {
+		return {
+			summary: numericSummary( {
+				total: items.reduce(
+					( total, item ) => total + safeParseFloat( item[ valueKey ] ?? item.value ),
+					0
+				),
+			} ),
+			data: items.map( item => ( {
+				label: item[ labelKey ] ?? item.name ?? item.title ?? item.term ?? '',
+				value: safeParseFloat( item[ valueKey ] ?? item.value ),
+				...item,
+			} ) ),
+		};
+	}
+
+	return EMPTY_REPORT;
+}
+
+export function sanitizeStatsPassthroughResponse< T >( response: T ): T {
+	return response;
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -37,15 +37,17 @@ export type StatsNormalizedReport = {
 
 type AnyRecord = Record< string, any >;
 
-const EMPTY_REPORT: StatsNormalizedReport = {
-	summary: {},
-	data: [],
-};
-
 function asRecord( value: unknown ): AnyRecord {
 	return value && typeof value === 'object' && ! Array.isArray( value )
 		? ( value as AnyRecord )
 		: {};
+}
+
+function emptyReport(): StatsNormalizedReport {
+	return {
+		summary: {},
+		data: [],
+	};
 }
 
 function asArray< T = AnyRecord >( value: unknown ): T[] {
@@ -77,7 +79,7 @@ function getStatsBucket( response: unknown, query: StatsQueryParams = {} ) {
 	}
 
 	const days = asRecord( payload.days );
-	const requested = query.start_date ?? query.date;
+	const requested = query.date ?? query.start_date;
 
 	if ( requested && days[ requested ] ) {
 		return asRecord( days[ requested ] );
@@ -407,11 +409,15 @@ export function sanitizeStatsDevicesResponse( response: unknown ): StatsNormaliz
 					0
 				),
 			} ),
-			data: response.map( item => ( {
-				label: asRecord( item ).label ?? asRecord( item ).name ?? '',
-				value: safeParseFloat( asRecord( item ).value ?? asRecord( item ).views ),
-				...asRecord( item ),
-			} ) ),
+			data: response.map( item => {
+				const record = asRecord( item );
+
+				return {
+					...record,
+					label: record.label ?? record.name ?? '',
+					value: safeParseFloat( record.value ?? record.views ),
+				};
+			} ),
 		};
 	}
 
@@ -440,14 +446,14 @@ export function sanitizeStatsGenericListResponse(
 				),
 			} ),
 			data: items.map( item => ( {
+				...item,
 				label: item[ labelKey ] ?? item.name ?? item.title ?? item.term ?? '',
 				value: safeParseFloat( item[ valueKey ] ?? item.value ),
-				...item,
 			} ) ),
 		};
 	}
 
-	return EMPTY_REPORT;
+	return emptyReport();
 }
 
 export function sanitizeStatsPassthroughResponse< T >( response: T ): T {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -13,6 +13,9 @@ export type StatsNormalizedItem = {
 	id?: string | number;
 	label: unknown;
 	value: number;
+	time_interval?: string;
+	date_start?: string;
+	date_end?: string;
 	children?: StatsNormalizedItem[] | null;
 	link?: string | null;
 	page?: string | null;
@@ -34,6 +37,7 @@ export type StatsNormalizedReport = {
 	summary: Record< string, unknown >;
 	data: StatsNormalizedItem[];
 };
+export type StatsTimeSeriesReport = StatsNormalizedReport;
 
 type AnyRecord = Record< string, any >;
 
@@ -54,6 +58,18 @@ function asArray< T = AnyRecord >( value: unknown ): T[] {
 	return Array.isArray( value ) ? ( value as T[] ) : [];
 }
 
+function decodeLabel( value: unknown ) {
+	if ( typeof value !== 'string' ) {
+		return value ?? '';
+	}
+
+	try {
+		return decodeURIComponent( value );
+	} catch {
+		return value;
+	}
+}
+
 function numericSummary( value: unknown ): Record< string, unknown > {
 	return Object.fromEntries(
 		Object.entries( asRecord( value ) ).map( ( [ key, item ] ) => [
@@ -61,6 +77,98 @@ function numericSummary( value: unknown ): Record< string, unknown > {
 			typeof item === 'number' || typeof item === 'string' ? safeParseFloat( item ) : item,
 		] )
 	);
+}
+
+function formatDatePart( date: Date ) {
+	return date.toISOString().split( 'T' )[ 0 ];
+}
+
+function addDays( date: Date, days: number ) {
+	const result = new Date( date );
+	result.setUTCDate( result.getUTCDate() + days );
+	return result;
+}
+
+function isoWeekRange( period: string ) {
+	const match = period.match( /^(\d{4})-?W?(\d{1,2})$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const year = Number( match[ 1 ] );
+	const week = Number( match[ 2 ] );
+	const fourthOfJanuary = new Date( Date.UTC( year, 0, 4 ) );
+	const day = fourthOfJanuary.getUTCDay() || 7;
+	const firstWeekStart = addDays( fourthOfJanuary, 1 - day );
+	const start = addDays( firstWeekStart, ( week - 1 ) * 7 );
+	const end = addDays( start, 6 );
+
+	return {
+		date_start: formatDatePart( start ),
+		date_end: formatDatePart( end ),
+	};
+}
+
+function monthRange( period: string ) {
+	const match = period.match( /^(\d{4})-(\d{2})$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const year = Number( match[ 1 ] );
+	const month = Number( match[ 2 ] );
+	const start = new Date( Date.UTC( year, month - 1, 1 ) );
+	const end = new Date( Date.UTC( year, month, 0 ) );
+
+	return {
+		date_start: formatDatePart( start ),
+		date_end: formatDatePart( end ),
+	};
+}
+
+function yearRange( period: string ) {
+	const match = period.match( /^(\d{4})$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const year = Number( match[ 1 ] );
+
+	return {
+		date_start: `${ year }-01-01`,
+		date_end: `${ year }-12-31`,
+	};
+}
+
+function getChartPeriodRange( unit: string, period: unknown ) {
+	const periodString = typeof period === 'string' ? period : '';
+
+	if ( ! periodString ) {
+		return {
+			date_start: '',
+			date_end: '',
+		};
+	}
+
+	if ( unit === 'week' ) {
+		return isoWeekRange( periodString ) ?? { date_start: periodString, date_end: periodString };
+	}
+
+	if ( unit === 'month' ) {
+		return monthRange( periodString ) ?? { date_start: periodString, date_end: periodString };
+	}
+
+	if ( unit === 'year' ) {
+		return yearRange( periodString ) ?? { date_start: periodString, date_end: periodString };
+	}
+
+	return {
+		date_start: periodString,
+		date_end: periodString,
+	};
 }
 
 function getFirstDayBucket( response: AnyRecord ) {
@@ -96,37 +204,471 @@ function parseChartData( payload: unknown ) {
 	const response = asRecord( payload );
 	const fields = asArray< string >( response.fields );
 
+	if ( ! fields.length ) {
+		return [];
+	}
+
 	return asArray< unknown[] >( response.data ).map( record => {
 		const parsed: Record< string, unknown > = {};
 		record.forEach( ( value, index ) => {
 			const field = fields[ index ];
 			if ( field ) {
 				parsed[ field ] =
-					field === 'period' && typeof value === 'string' ? value.replace( /W/g, '-' ) : value;
+					[ 'period', 'time_interval', 'date', 'date_start', 'date_end' ].includes( field ) ||
+					! ( typeof value === 'number' || typeof value === 'string' )
+						? value
+						: safeParseFloat( value );
 			}
 		} );
 		return parsed;
 	} );
 }
 
-function normalizeChartResponse( payload: unknown ): StatsNormalizedReport {
-	const rows = parseChartData( payload );
+function numericTimeSeriesRow( row: AnyRecord ) {
+	return Object.fromEntries(
+		Object.entries( row ).map( ( [ key, value ] ) => [
+			key,
+			key === 'period' ||
+			key === 'time_interval' ||
+			key === 'date' ||
+			key === 'date_start' ||
+			key === 'date_end' ||
+			! ( typeof value === 'number' || typeof value === 'string' )
+				? value
+				: safeParseFloat( value ),
+		] )
+	);
+}
+
+function parseTimeSeriesRows( payload: unknown ) {
+	const response = asRecord( payload );
+	const timeline = asRecord( response.timeline );
+	const chartRows = parseChartData( Object.keys( timeline ).length ? timeline : response );
+
+	if ( chartRows.length ) {
+		return chartRows;
+	}
+
+	const data = asArray< AnyRecord >( response.data );
+
+	if ( data.length ) {
+		return data.map( numericTimeSeriesRow );
+	}
+
+	return Object.entries( asRecord( response.days ) ).map( ( [ period, value ] ) =>
+		numericTimeSeriesRow( { period, ...asRecord( value ) } )
+	);
+}
+
+function isTimeSeriesPayload( payload: unknown ) {
+	const response = asRecord( payload );
+
+	if ( asArray( response.fields ).length || Object.keys( asRecord( response.days ) ).length ) {
+		return true;
+	}
+
+	const firstRow = asRecord( asArray< AnyRecord >( response.data )[ 0 ] );
+
+	return Boolean(
+		firstRow.period || firstRow.time_interval || firstRow.date || firstRow.date_start
+	);
+}
+
+function parseUtmLabelParts( key: string ) {
+	if ( ! key.startsWith( '[' ) ) {
+		return [ key ];
+	}
+
+	try {
+		const parsed = JSON.parse( key );
+		return asArray< string >( parsed );
+	} catch {
+		return [ key ];
+	}
+}
+
+function getPrimaryMetricValue( row: AnyRecord ) {
+	const primaryMetric = Object.entries( row ).find(
+		( [ key, value ] ) =>
+			! [ 'period', 'time_interval', 'date', 'date_start', 'date_end' ].includes( key ) &&
+			typeof value === 'number'
+	);
+
+	return primaryMetric?.[ 1 ] ?? 0;
+}
+
+function getTimeSeriesSummarySidecars( response: AnyRecord ) {
+	return {
+		...numericSummary( response.summary ),
+		...numericSummary( response.opens_rate ),
+		...numericSummary( response.clicks_rate ),
+		...numericSummary( response.rate ),
+	};
+}
+
+export function sanitizeStatsTimeSeriesResponse(
+	payload: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const response = asRecord( payload );
+	const timeline = asRecord( response.timeline );
+	const unit = String( timeline.unit ?? response.unit ?? query?.unit ?? query?.period ?? 'day' );
+	const rows = parseTimeSeriesRows( payload );
 	const summary = rows.reduce< Record< string, number > >( ( totals, row ) => {
 		Object.entries( row ).forEach( ( [ key, value ] ) => {
-			if ( key !== 'period' && ( typeof value === 'number' || typeof value === 'string' ) ) {
+			if (
+				! [ 'period', 'time_interval', 'date', 'date_start', 'date_end' ].includes( key ) &&
+				typeof value === 'number'
+			) {
 				totals[ key ] = ( totals[ key ] ?? 0 ) + safeParseFloat( value );
 			}
 		} );
 		return totals;
 	}, {} );
+	const normalizedRows = rows.map( row => {
+		const period = row.period ?? row.time_interval ?? row.date_start ?? row.date;
+		const range =
+			row.date_start && row.date_end
+				? { date_start: String( row.date_start ), date_end: String( row.date_end ) }
+				: getChartPeriodRange( unit, period );
+		const value = safeParseFloat( getPrimaryMetricValue( row ) );
+
+		return {
+			...row,
+			time_interval: range.date_start,
+			date_start: range.date_start,
+			date_end: range.date_end,
+			label: range.date_start,
+			value,
+		};
+	} );
+	const firstRow = normalizedRows[ 0 ];
+	const lastRow = normalizedRows[ normalizedRows.length - 1 ];
 
 	return {
-		summary,
-		data: rows.map( row => ( {
-			label: row.period ?? '',
-			value: safeParseFloat( row.views ?? row.visits ?? row.value ?? 0 ),
-			...row,
+		summary: {
+			...getTimeSeriesSummarySidecars( response ),
+			...summary,
+			date_start: firstRow?.date_start ?? query?.start_date ?? '',
+			date_end: lastRow?.date_end ?? query?.date ?? '',
+		},
+		data: normalizedRows as StatsNormalizedItem[],
+	};
+}
+
+export function sanitizeStatsArchivesResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const bucket = getStatsBucket( response, query );
+
+	if ( Array.isArray( bucket ) ) {
+		return emptyReport();
+	}
+
+	const rows = Object.entries( bucket ).reduce< StatsNormalizedItem[] >(
+		( normalizedRows, [ archiveType, archiveItems ] ) => {
+			if ( archiveType === 'tax' ) {
+				const children = Object.entries( asRecord( archiveItems ) )
+					.map( ( [ taxonomy, terms ] ) => {
+						const termRows = asArray< AnyRecord >( terms ).map( term => ( {
+							label: decodeLabel( term.value ),
+							value: safeParseFloat( term.views ),
+							link: term.href,
+							children: null,
+						} ) );
+						const value = termRows.reduce( ( total, term ) => total + term.value, 0 );
+
+						return {
+							label: taxonomy,
+							value,
+							children: termRows,
+						};
+					} )
+					.filter( item => item.value > 0 );
+				const value = children.reduce( ( total, item ) => total + item.value, 0 );
+
+				if ( children.length ) {
+					normalizedRows.push( {
+						label: archiveType,
+						value,
+						children,
+					} );
+				}
+
+				return normalizedRows;
+			}
+
+			const children = asArray< AnyRecord >( archiveItems )
+				.filter( item => item.value )
+				.map( item => ( {
+					label: archiveType === 'home' ? item.href : decodeLabel( item.value ),
+					value: safeParseFloat( item.views ),
+					link: item.href,
+					children: null,
+				} ) );
+			const value = children.reduce( ( total, item ) => total + item.value, 0 );
+
+			if ( children.length ) {
+				normalizedRows.push( {
+					label: archiveType,
+					value,
+					children: archiveType === 'home' && children.length < 2 ? null : children,
+				} );
+			}
+
+			return normalizedRows;
+		},
+		[]
+	);
+
+	return {
+		summary: numericSummary( {
+			total: rows.reduce( ( total, row ) => total + row.value, 0 ),
+		} ),
+		data: rows.sort( ( a, b ) => b.value - a.value ),
+	};
+}
+
+export function sanitizeStatsPublicizeResponse( response: unknown ): StatsNormalizedReport {
+	const services = asArray< AnyRecord >( asRecord( response ).services );
+
+	return {
+		summary: numericSummary( {
+			total: services.reduce(
+				( total, service ) => total + safeParseFloat( service.followers ),
+				0
+			),
+		} ),
+		data: services.map( service => ( {
+			...service,
+			label: service.label ?? service.name ?? service.service ?? '',
+			value: safeParseFloat( service.followers ),
 		} ) ),
+	};
+}
+
+export function sanitizeStatsFollowersResponse( response: unknown ): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const subscribers = asArray< AnyRecord >( payload.subscribers );
+
+	return {
+		summary: numericSummary( {
+			page: payload.page,
+			pages: payload.pages,
+			total: payload.total,
+			total_email: payload.total_email,
+			total_wpcom: payload.total_wpcom,
+		} ),
+		data: subscribers.map( item => ( {
+			id: item.ID ?? item.id ?? item.subscription_id,
+			label: item.label ?? item.name ?? item.email ?? '',
+			value: 0,
+			iconClassName: 'avatar-user',
+			icon: item.avatar ?? null,
+			link: item.url ?? null,
+			date_subscribed: item.date_subscribed,
+			subscription_id: item.subscription_id,
+			actions: [
+				{
+					type: 'follow',
+					data: item.follow_data?.params ?? false,
+				},
+			],
+		} ) ),
+	};
+}
+
+export function sanitizeStatsTagsResponse( response: unknown ): StatsNormalizedReport {
+	const tags = asArray< AnyRecord >( asRecord( response ).tags );
+	const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
+
+	return {
+		summary: numericSummary( {
+			total: tags.reduce( ( total, item ) => total + safeParseFloat( item.views ), 0 ),
+		} ),
+		data: tags.map( item => {
+			const tagItems = asArray< AnyRecord >( item.tags );
+			const hasChildren = tagItems.length > 1;
+			const labels = tagItems.map( tag => ( {
+				label: tag.name,
+				labelIcon: tagIcon( tag.type ),
+				link: hasChildren ? null : tag.link,
+			} ) );
+
+			return {
+				...item,
+				label: labels.map( label => label.label ).join( ', ' ),
+				labels,
+				link: hasChildren ? null : labels[ 0 ]?.link,
+				value: safeParseFloat( item.views ),
+				children: hasChildren
+					? tagItems.map( tag => ( {
+							label: tag.name,
+							labelIcon: tagIcon( tag.type ),
+							value: 0,
+							link: tag.link,
+							children: null,
+					  } ) )
+					: null,
+			};
+		} ),
+	};
+}
+
+export function sanitizeStatsCommentsResponse( response: unknown ): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const authors = asArray< AnyRecord >( payload.authors ).map( author => ( {
+		label: author.name,
+		value: safeParseFloat( author.comments ),
+		iconClassName: 'avatar-user',
+		icon: author.gravatar ?? null,
+		link: author.link ?? null,
+		className: 'module-content-list-item-large',
+		actions: [
+			{
+				type: 'follow',
+				data: author.follow_data?.params ?? false,
+			},
+		],
+	} ) );
+	const posts = asArray< AnyRecord >( payload.posts ).map( post => ( {
+		id: post.id,
+		label: post.name ?? post.title ?? '',
+		value: safeParseFloat( post.comments ),
+		link: post.link ?? null,
+		page: post.id ? `/stats/post/${ post.id }` : null,
+		actions: post.link ? [ { type: 'link', data: post.link } ] : [],
+	} ) );
+
+	return {
+		summary: numericSummary( {
+			total_comments: payload.total_comments,
+			most_active_day: payload.most_active_day,
+			most_active_time: payload.most_active_time,
+			monthly_comments: payload.monthly_comments,
+		} ),
+		data: [
+			{
+				label: 'authors',
+				value: authors.reduce( ( total, author ) => total + author.value, 0 ),
+				children: authors,
+			},
+			{
+				label: 'posts',
+				value: posts.reduce( ( total, post ) => total + post.value, 0 ),
+				children: posts,
+			},
+		].filter( item => item.children.length ),
+	};
+}
+
+export function sanitizeStatsCommentFollowersResponse( response: unknown ): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const posts = asArray< AnyRecord >( payload.posts );
+
+	return {
+		summary: numericSummary( {
+			page: payload.page,
+			pages: payload.pages,
+			total: payload.total,
+		} ),
+		data: posts.map( item => ( {
+			id: item.id,
+			label: item.id === 0 ? 'All Posts' : item.title,
+			value: safeParseFloat( item.followers ),
+			link: item.id === 0 ? null : item.url,
+			labelIcon: item.id === 0 ? undefined : 'external',
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsEmailSummaryResponse( response: unknown ): StatsNormalizedReport {
+	const posts = asArray< AnyRecord >( asRecord( response ).posts );
+
+	return {
+		summary: numericSummary( {
+			total_sends: posts.reduce( ( total, post ) => total + safeParseFloat( post.total_sends ), 0 ),
+			opens: posts.reduce( ( total, post ) => total + safeParseFloat( post.opens ), 0 ),
+			clicks: posts.reduce( ( total, post ) => total + safeParseFloat( post.clicks ), 0 ),
+			unique_opens: posts.reduce(
+				( total, post ) => total + safeParseFloat( post.unique_opens ),
+				0
+			),
+			unique_clicks: posts.reduce(
+				( total, post ) => total + safeParseFloat( post.unique_clicks ),
+				0
+			),
+		} ),
+		data: posts.map( post => ( {
+			id: post.id,
+			label: post.title,
+			value: safeParseFloat( post.opens ),
+			link: post.href,
+			date: post.date,
+			type: post.type,
+			opens: safeParseFloat( post.opens ),
+			clicks: safeParseFloat( post.clicks ),
+			opens_rate: safeParseFloat( post.opens_rate ),
+			clicks_rate: safeParseFloat( post.clicks_rate ),
+			unique_opens: safeParseFloat( post.unique_opens ),
+			unique_clicks: safeParseFloat( post.unique_clicks ),
+			total_sends: safeParseFloat( post.total_sends ),
+			children: null,
+		} ) ),
+	};
+}
+
+export function sanitizeStatsEmailBreakdownResponse( response: unknown ): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const matrixKey = [ 'clients', 'devices', 'countries', 'links', 'user-content-links' ].find(
+		key => asArray( asRecord( payload[ key ] ).fields ).length
+	);
+
+	if ( ! matrixKey ) {
+		return {
+			summary: numericSummary( payload ),
+			data: [],
+		};
+	}
+
+	const matrix = asRecord( payload[ matrixKey ] );
+	const fields = asArray< string >( matrix.fields );
+	const labelKey = fields[ 0 ] ?? 'label';
+	const metricKey = fields.find( field => field.endsWith( '_count' ) ) ?? fields[ 1 ] ?? 'value';
+	const countryInfo = asRecord( payload[ 'countries-info' ] );
+	const rows = asArray< unknown[] >( matrix.data ).map( record => {
+		const parsed: AnyRecord = {};
+		record.forEach( ( value, index ) => {
+			const field = fields[ index ];
+			if ( field ) {
+				parsed[ field ] =
+					field === labelKey || ! ( typeof value === 'number' || typeof value === 'string' )
+						? value
+						: safeParseFloat( value );
+			}
+		} );
+
+		const country = asRecord( countryInfo[ parsed[ labelKey ] ] );
+		const label =
+			matrixKey === 'countries' ? country.country_full ?? parsed[ labelKey ] : parsed[ labelKey ];
+
+		return {
+			...parsed,
+			label,
+			value: safeParseFloat( parsed[ metricKey ] ),
+			countryCode: matrixKey === 'countries' ? String( parsed[ labelKey ] ) : undefined,
+			countryFull: country.country_full,
+			children: null,
+		};
+	} );
+
+	return {
+		summary: numericSummary( {
+			[ metricKey ]: rows.reduce( ( total, row ) => total + row.value, 0 ),
+		} ),
+		data: rows,
 	};
 }
 
@@ -378,7 +920,44 @@ export function sanitizeStatsVideoPlaysResponse(
 	};
 }
 
-export function sanitizeStatsUtmResponse( response: unknown ): StatsNormalizedReport {
+export function sanitizeStatsUtmResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	if ( isTimeSeriesPayload( response ) ) {
+		return sanitizeStatsTimeSeriesResponse( response, query );
+	}
+
+	const payload = asRecord( response );
+	const topUtmValues = asRecord( payload.top_utm_values );
+
+	if ( Object.keys( topUtmValues ).length ) {
+		const topPosts = asRecord( payload.top_posts );
+		const rows = Object.entries( topUtmValues ).map( ( [ key, value ] ) => {
+			const parsedKey = parseUtmLabelParts( key );
+
+			return {
+				label: parsedKey.join( ' / ' ),
+				value: safeParseFloat( value ),
+				children: asArray< AnyRecord >( topPosts[ key ] ).map( post => ( {
+					id: post.id,
+					label: post.title,
+					value: safeParseFloat( post.views ),
+					link: post.href,
+					page: post.id ? `/stats/post/${ post.id }` : null,
+					children: null,
+				} ) ),
+			};
+		} );
+
+		return {
+			summary: numericSummary( {
+				total: rows.reduce( ( total, item ) => total + item.value, 0 ),
+			} ),
+			data: rows,
+		};
+	}
+
 	const rows: AnyRecord[] = [];
 
 	asArray< AnyRecord >( response ).forEach( row => {
@@ -400,7 +979,28 @@ export function sanitizeStatsUtmResponse( response: unknown ): StatsNormalizedRe
 	};
 }
 
-export function sanitizeStatsDevicesResponse( response: unknown ): StatsNormalizedReport {
+export function sanitizeStatsDevicesResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const payload = asRecord( response );
+	const topValues = asRecord( payload.top_values );
+
+	if ( Object.keys( topValues ).length ) {
+		const rows = Object.entries( topValues ).map( ( [ key, value ] ) => ( {
+			key,
+			label: key,
+			value: safeParseFloat( value ),
+		} ) );
+
+		return {
+			summary: numericSummary( {
+				total: rows.reduce( ( total, item ) => total + item.value, 0 ),
+			} ),
+			data: rows,
+		};
+	}
+
 	if ( Array.isArray( response ) ) {
 		return {
 			summary: numericSummary( {
@@ -421,11 +1021,14 @@ export function sanitizeStatsDevicesResponse( response: unknown ): StatsNormaliz
 		};
 	}
 
-	return normalizeChartResponse( response );
+	return sanitizeStatsTimeSeriesResponse( response, query );
 }
 
-export function sanitizeStatsVisitsResponse( response: unknown ): StatsNormalizedReport {
-	return normalizeChartResponse( response );
+export function sanitizeStatsVisitsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	return sanitizeStatsTimeSeriesResponse( response, query );
 }
 
 export function sanitizeStatsGenericListResponse(
@@ -433,9 +1036,19 @@ export function sanitizeStatsGenericListResponse(
 	valueKey = 'views',
 	labelKey = 'label'
 ): StatsNormalizedReport {
+	const payload = asRecord( response );
 	const items = Array.isArray( response )
 		? asArray< AnyRecord >( response )
-		: asArray< AnyRecord >( asRecord( response ).data ?? asRecord( response ).items );
+		: [
+				payload.data,
+				payload.items,
+				payload.summary,
+				payload.services,
+				payload.subscribers,
+				payload.posts,
+		  ]
+				.map( asArray< AnyRecord > )
+				.find( candidates => candidates.length ) ?? [];
 
 	if ( items.length ) {
 		return {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -10,3 +10,4 @@ export { reportVisitorsQuery } from './report-visitors-query';
 export { reportVisitorsByLocationQuery } from './report-visitors-by-location-query';
 export { reportSessionsByDeviceQuery } from './report-sessions-by-device-query';
 export { reportBookingsQuery } from './report-bookings-query';
+export * from './stats-queries';

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -11,3 +11,4 @@ export { reportVisitorsByLocationQuery } from './report-visitors-by-location-que
 export { reportSessionsByDeviceQuery } from './report-sessions-by-device-query';
 export { reportBookingsQuery } from './report-bookings-query';
 export * from './stats-queries';
+export * from './stats-app-queries';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-queries.ts
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+/**
+ * Internal dependencies
+ */
+import {
+	fetchStatsProxy,
+	type StatsProxyMethod,
+	type StatsProxyVersion,
+} from '../api/stats-proxy-fetch';
+import { statsQueryKeyPart, type StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+const noticesPath = '/jetpack-premium-analytics/v1/notices';
+
+type StatsAppQueryConfig = {
+	name: string;
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsQueryParams;
+	method?: StatsProxyMethod;
+	body?: unknown;
+	enabled?: boolean;
+};
+
+export function statsAppProxyQuery< TData = unknown >( {
+	name,
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+	enabled = true,
+}: StatsAppQueryConfig ): UseQueryOptions< TData > {
+	return {
+		queryKey: [
+			'stats-app',
+			name,
+			version,
+			endpoint,
+			method,
+			statsQueryKeyPart( params ),
+			statsQueryKeyPart( body ),
+		],
+		queryFn: () => fetchStatsProxy< TData >( { version, endpoint, params, method, body } ),
+		enabled,
+		placeholderData: previousData => previousData,
+	};
+}
+
+export const statsAppReferrersSpamQuery = () =>
+	statsAppProxyQuery( {
+		name: 'referrers-spam',
+		version: '1.1',
+		endpoint: 'stats/referrers/spam',
+	} );
+
+export const statsAppSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'subscribers-counts',
+		version: '2',
+		endpoint: 'subscribers/counts',
+		params,
+	} );
+
+export const statsAppSiteHasNeverPublishedPostQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'site-has-never-published-post',
+		version: '2',
+		endpoint: 'site-has-never-published-post',
+		params,
+	} );
+
+export const statsAppPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'plan-usage',
+		version: '2',
+		endpoint: 'jetpack-stats/usage',
+		params,
+	} );
+
+export const statsAppDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-modules',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/modules',
+		params,
+	} );
+
+export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-module-settings',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/module-settings',
+		params,
+	} );
+
+export const statsAppWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'wordads-earnings',
+		version: '1.1',
+		endpoint: 'wordads/earnings',
+		params,
+	} );
+
+export const statsAppPurchasesQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'purchases',
+		version: '1.2',
+		endpoint: 'upgrades',
+		params,
+	} );
+
+export const statsAppNoticesQuery = (
+	params: StatsQueryParams = {}
+): UseQueryOptions< unknown > => ( {
+	queryKey: [ 'stats-app', 'notices', statsQueryKeyPart( params ) ],
+	queryFn: () =>
+		apiFetch( {
+			path: addQueryArgs( noticesPath, params ),
+		} ),
+	placeholderData: previousData => previousData,
+} );
+
+export type StatsAppNoticeMutationParams = {
+	id: string;
+	status: string;
+	postponed_for?: number;
+};
+
+export const updateStatsAppNotice = ( data: StatsAppNoticeMutationParams ) =>
+	apiFetch( {
+		path: noticesPath,
+		method: 'POST',
+		data,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-queries.ts
@@ -58,14 +58,6 @@ export const statsAppReferrersSpamQuery = () =>
 		endpoint: 'stats/referrers/spam',
 	} );
 
-export const statsAppSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
-	statsAppProxyQuery( {
-		name: 'subscribers-counts',
-		version: '2',
-		endpoint: 'subscribers/counts',
-		params,
-	} );
-
 export const statsAppSiteHasNeverPublishedPostQuery = ( params: StatsQueryParams = {} ) =>
 	statsAppProxyQuery( {
 		name: 'site-has-never-published-post',
@@ -95,14 +87,6 @@ export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams =
 		name: 'dashboard-module-settings',
 		version: '2',
 		endpoint: 'jetpack-stats-dashboard/module-settings',
-		params,
-	} );
-
-export const statsAppWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
-	statsAppProxyQuery( {
-		name: 'wordads-earnings',
-		version: '1.1',
-		endpoint: 'wordads/earnings',
 		params,
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
@@ -234,6 +234,14 @@ export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
 		sanitizer: 'timeSeries',
 	} );
 
+export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers-counts',
+		version: '2',
+		endpoint: 'subscribers/counts',
+		params,
+	} );
+
 export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
 	statsProxyQuery( {
 		name: 'single-post',
@@ -311,4 +319,12 @@ export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
 		endpoint: 'wordads/stats',
 		params,
 		sanitizer: 'timeSeries',
+	} );
+
+export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-earnings',
+		version: '1.1',
+		endpoint: 'wordads/earnings',
+		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
@@ -11,16 +11,25 @@ import {
 } from '../api/stats-proxy-fetch';
 import {
 	sanitizeStatsClicksResponse,
+	sanitizeStatsArchivesResponse,
+	sanitizeStatsCommentFollowersResponse,
+	sanitizeStatsCommentsResponse,
 	sanitizeStatsDevicesResponse,
+	sanitizeStatsEmailBreakdownResponse,
+	sanitizeStatsEmailSummaryResponse,
 	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsFollowersResponse,
 	sanitizeStatsGenericListResponse,
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsPassthroughResponse,
+	sanitizeStatsPublicizeResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
 	sanitizeStatsSiteResponse,
+	sanitizeStatsTagsResponse,
 	sanitizeStatsTopAuthorsResponse,
 	sanitizeStatsTopPostsResponse,
+	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsUtmResponse,
 	sanitizeStatsVideoPlaysResponse,
 	sanitizeStatsVisitsResponse,
@@ -49,14 +58,18 @@ const statsSanitizers = {
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
 	visits: sanitizeStatsVisitsResponse,
+	timeSeries: sanitizeStatsTimeSeriesResponse,
 	utm: sanitizeStatsUtmResponse,
 	devices: sanitizeStatsDevicesResponse,
-	archives: response => sanitizeStatsGenericListResponse( response ),
-	publicize: response => sanitizeStatsGenericListResponse( response, 'followers', 'label' ),
-	followers: response => sanitizeStatsGenericListResponse( response, 'total', 'label' ),
-	tags: response => sanitizeStatsGenericListResponse( response, 'views', 'name' ),
-	comments: response => sanitizeStatsGenericListResponse( response, 'comments', 'name' ),
-	commentFollowers: response => sanitizeStatsGenericListResponse( response, 'followers', 'title' ),
+	archives: sanitizeStatsArchivesResponse,
+	publicize: sanitizeStatsPublicizeResponse,
+	followers: sanitizeStatsFollowersResponse,
+	tags: sanitizeStatsTagsResponse,
+	comments: sanitizeStatsCommentsResponse,
+	commentFollowers: sanitizeStatsCommentFollowersResponse,
+	emailSummary: sanitizeStatsEmailSummaryResponse,
+	emailBreakdown: sanitizeStatsEmailBreakdownResponse,
+	genericList: response => sanitizeStatsGenericListResponse( response ),
 } satisfies Record< string, StatsSanitizer >;
 
 type StatsSanitizerKey = keyof typeof statsSanitizers;
@@ -90,7 +103,7 @@ export function statsProxyQuery< TData = unknown >( {
 			endpoint,
 			method,
 			statsQueryKeyPart( params ),
-			body ?? null,
+			statsQueryKeyPart( body ),
 			sanitizer,
 		],
 		queryFn: async () => {
@@ -213,7 +226,13 @@ export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
 	statsProxyQuery( { name: 'highlights', version: '1.1', endpoint: 'stats/highlights', params } );
 
 export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'subscribers', version: '1.1', endpoint: 'stats/subscribers', params } );
+	statsProxyQuery( {
+		name: 'subscribers',
+		version: '1.1',
+		endpoint: 'stats/subscribers',
+		params,
+		sanitizer: 'timeSeries',
+	} );
 
 export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
 	statsProxyQuery( {
@@ -221,6 +240,7 @@ export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams =
 		version: '1.1',
 		endpoint: `stats/post/${ postId }`,
 		params,
+		sanitizer: 'timeSeries',
 	} );
 
 export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams = {} ) =>
@@ -237,6 +257,7 @@ export const statsEmailSummaryQuery = ( params: StatsQueryParams = {} ) =>
 		version: '1.1',
 		endpoint: 'stats/emails/summary',
 		params,
+		sanitizer: 'emailSummary',
 	} );
 
 export const statsEmailOpensBreakdownQuery = (
@@ -249,6 +270,7 @@ export const statsEmailOpensBreakdownQuery = (
 		version: '1.1',
 		endpoint: `stats/opens/emails/${ postId }/${ breakdown }`,
 		params,
+		sanitizer: 'emailBreakdown',
 	} );
 
 export const statsEmailClicksBreakdownQuery = (
@@ -261,6 +283,7 @@ export const statsEmailClicksBreakdownQuery = (
 		version: '1.1',
 		endpoint: `stats/clicks/emails/${ postId }/${ breakdown }`,
 		params,
+		sanitizer: 'emailBreakdown',
 	} );
 
 export const statsEmailOpensTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
@@ -269,6 +292,7 @@ export const statsEmailOpensTimeSeriesQuery = ( postId: number, params: StatsQue
 		version: '1.1',
 		endpoint: `stats/opens/emails/${ postId }`,
 		params,
+		sanitizer: 'timeSeries',
 	} );
 
 export const statsEmailClicksTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
@@ -277,60 +301,14 @@ export const statsEmailClicksTimeSeriesQuery = ( postId: number, params: StatsQu
 		version: '1.1',
 		endpoint: `stats/clicks/emails/${ postId }`,
 		params,
-	} );
-
-export const statsReferrersSpamQuery = () =>
-	statsProxyQuery( {
-		name: 'referrers-spam',
-		version: '1.1',
-		endpoint: 'stats/referrers/spam',
-	} );
-
-export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
-		name: 'subscribers-counts',
-		version: '2',
-		endpoint: 'subscribers/counts',
-		params,
-	} );
-
-export const statsSiteHasNeverPublishedPostQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
-		name: 'site-has-never-published-post',
-		version: '2',
-		endpoint: 'site-has-never-published-post',
-		params,
-	} );
-
-export const statsPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'plan-usage', version: '2', endpoint: 'jetpack-stats/usage', params } );
-
-export const statsDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
-		name: 'dashboard-modules',
-		version: '2',
-		endpoint: 'jetpack-stats-dashboard/modules',
-		params,
-	} );
-
-export const statsDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
-		name: 'dashboard-module-settings',
-		version: '2',
-		endpoint: 'jetpack-stats-dashboard/module-settings',
-		params,
-	} );
-
-export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
-		name: 'wordads-earnings',
-		version: '1.1',
-		endpoint: 'wordads/earnings',
-		params,
+		sanitizer: 'timeSeries',
 	} );
 
 export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'wordads-stats', version: '1.1', endpoint: 'wordads/stats', params } );
-
-export const statsPurchasesQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'purchases', version: '1.2', endpoint: 'upgrades', params } );
+	statsProxyQuery( {
+		name: 'wordads-stats',
+		version: '1.1',
+		endpoint: 'wordads/stats',
+		params,
+		sanitizer: 'timeSeries',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
@@ -35,15 +35,40 @@ import type { ReportParams } from '../utils/search';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
 export type StatsReportParams = ReportParams & StatsQueryParams;
+type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQueryParams ) => TData;
 
-export type StatsQueryConfig< TData = unknown > = {
+const statsSanitizers = {
+	passthrough: sanitizeStatsPassthroughResponse,
+	site: sanitizeStatsSiteResponse,
+	topPosts: sanitizeStatsTopPostsResponse,
+	referrers: sanitizeStatsReferrersResponse,
+	clicks: sanitizeStatsClicksResponse,
+	searchTerms: sanitizeStatsSearchTermsResponse,
+	fileDownloads: sanitizeStatsFileDownloadsResponse,
+	topAuthors: sanitizeStatsTopAuthorsResponse,
+	locations: sanitizeStatsLocationsResponse,
+	videoPlays: sanitizeStatsVideoPlaysResponse,
+	visits: sanitizeStatsVisitsResponse,
+	utm: sanitizeStatsUtmResponse,
+	devices: sanitizeStatsDevicesResponse,
+	archives: response => sanitizeStatsGenericListResponse( response ),
+	publicize: response => sanitizeStatsGenericListResponse( response, 'followers', 'label' ),
+	followers: response => sanitizeStatsGenericListResponse( response, 'total', 'label' ),
+	tags: response => sanitizeStatsGenericListResponse( response, 'views', 'name' ),
+	comments: response => sanitizeStatsGenericListResponse( response, 'comments', 'name' ),
+	commentFollowers: response => sanitizeStatsGenericListResponse( response, 'followers', 'title' ),
+} satisfies Record< string, StatsSanitizer >;
+
+type StatsSanitizerKey = keyof typeof statsSanitizers;
+
+export type StatsQueryConfig = {
 	name: string;
 	version: StatsProxyVersion;
 	endpoint: string;
 	params?: StatsQueryParams;
 	method?: StatsProxyMethod;
 	body?: unknown;
-	sanitize?: ( response: unknown, params?: StatsQueryParams ) => TData;
+	sanitizer?: StatsSanitizerKey;
 	enabled?: boolean;
 };
 
@@ -54,9 +79,9 @@ export function statsProxyQuery< TData = unknown >( {
 	params,
 	method = 'GET',
 	body,
-	sanitize = sanitizeStatsPassthroughResponse as ( response: unknown ) => TData,
+	sanitizer = 'passthrough',
 	enabled = true,
-}: StatsQueryConfig< TData > ): UseQueryOptions< TData > {
+}: StatsQueryConfig ): UseQueryOptions< TData > {
 	return {
 		queryKey: [
 			'stats',
@@ -66,11 +91,11 @@ export function statsProxyQuery< TData = unknown >( {
 			method,
 			statsQueryKeyPart( params ),
 			body ?? null,
-			sanitize,
+			sanitizer,
 		],
 		queryFn: async () => {
 			const response = await fetchStatsProxy( { version, endpoint, params, method, body } );
-			return sanitize( response, params );
+			return statsSanitizers[ sanitizer ]( response, params ) as TData;
 		},
 		enabled,
 		placeholderData: previousData => previousData,
@@ -81,7 +106,7 @@ function statsReportQuery< TData = StatsNormalizedReport >(
 	name: string,
 	endpoint: string,
 	params: StatsReportParams,
-	sanitize: ( response: unknown, params?: StatsQueryParams ) => TData,
+	sanitizer: StatsSanitizerKey,
 	version: StatsProxyVersion = '1.1'
 ): UseQueryOptions< TData > {
 	const statsParams = reportParamsToStatsQueryParams( params );
@@ -91,7 +116,7 @@ function statsReportQuery< TData = StatsNormalizedReport >(
 		version,
 		endpoint,
 		params: statsParams,
-		sanitize,
+		sanitizer,
 		enabled: !! ( statsParams.date || statsParams.start_date || params.from || params.to ),
 	} );
 }
@@ -102,36 +127,26 @@ export const statsSiteQuery = ( params: StatsQueryParams = {} ) =>
 		version: '1.1',
 		endpoint: 'stats',
 		params,
-		sanitize: sanitizeStatsSiteResponse,
+		sanitizer: 'site',
 	} );
 
 export const statsTopPostsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'top-posts', 'stats/top-posts', params, sanitizeStatsTopPostsResponse );
+	statsReportQuery( 'top-posts', 'stats/top-posts', params, 'topPosts' );
 
 export const statsReferrersQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'referrers', 'stats/referrers', params, sanitizeStatsReferrersResponse );
+	statsReportQuery( 'referrers', 'stats/referrers', params, 'referrers' );
 
 export const statsClicksQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'clicks', 'stats/clicks', params, sanitizeStatsClicksResponse );
+	statsReportQuery( 'clicks', 'stats/clicks', params, 'clicks' );
 
 export const statsSearchTermsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery(
-		'search-terms',
-		'stats/search-terms',
-		params,
-		sanitizeStatsSearchTermsResponse
-	);
+	statsReportQuery( 'search-terms', 'stats/search-terms', params, 'searchTerms' );
 
 export const statsFileDownloadsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery(
-		'file-downloads',
-		'stats/file-downloads',
-		params,
-		sanitizeStatsFileDownloadsResponse
-	);
+	statsReportQuery( 'file-downloads', 'stats/file-downloads', params, 'fileDownloads' );
 
 export const statsTopAuthorsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'top-authors', 'stats/top-authors', params, sanitizeStatsTopAuthorsResponse );
+	statsReportQuery( 'top-authors', 'stats/top-authors', params, 'topAuthors' );
 
 export const statsLocationsQuery = (
 	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' }
@@ -141,30 +156,25 @@ export const statsLocationsQuery = (
 		`locations-${ geoMode }`,
 		`stats/location-views/${ geoMode }`,
 		params,
-		sanitizeStatsLocationsResponse
+		'locations'
 	);
 };
 
 export const statsCountryViewsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery(
-		'country-views',
-		'stats/country-views',
-		params,
-		sanitizeStatsLocationsResponse
-	);
+	statsReportQuery( 'country-views', 'stats/country-views', params, 'locations' );
 
 export const statsVideoPlaysQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'video-plays', 'stats/video-plays', params, sanitizeStatsVideoPlaysResponse );
+	statsReportQuery( 'video-plays', 'stats/video-plays', params, 'videoPlays' );
 
 export const statsVisitsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'visits', 'stats/visits', params, sanitizeStatsVisitsResponse );
+	statsReportQuery( 'visits', 'stats/visits', params, 'visits' );
 
 export const statsUtmQuery = ( params: StatsReportParams & { utmParams?: string } ) =>
 	statsReportQuery(
 		'utm',
 		`stats/utm/${ params.utmParams ?? 'utm_source,utm_medium' }`,
 		params,
-		sanitizeStatsUtmResponse
+		'utm'
 	);
 
 export const statsDevicesQuery = ( params: StatsReportParams & { deviceProperty?: string } ) =>
@@ -172,38 +182,26 @@ export const statsDevicesQuery = ( params: StatsReportParams & { deviceProperty?
 		'devices',
 		`stats/devices/${ params.deviceProperty ?? 'screensize' }`,
 		params,
-		sanitizeStatsDevicesResponse
+		'devices'
 	);
 
 export const statsArchivesQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'archives', 'stats/archives', params, response =>
-		sanitizeStatsGenericListResponse( response )
-	);
+	statsReportQuery( 'archives', 'stats/archives', params, 'archives' );
 
 export const statsPublicizeQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'publicize', 'stats/publicize', params, response =>
-		sanitizeStatsGenericListResponse( response, 'followers', 'label' )
-	);
+	statsReportQuery( 'publicize', 'stats/publicize', params, 'publicize' );
 
 export const statsFollowersQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'followers', 'stats/followers', params, response =>
-		sanitizeStatsGenericListResponse( response, 'total', 'label' )
-	);
+	statsReportQuery( 'followers', 'stats/followers', params, 'followers' );
 
 export const statsTagsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'tags', 'stats/tags', params, response =>
-		sanitizeStatsGenericListResponse( response, 'views', 'name' )
-	);
+	statsReportQuery( 'tags', 'stats/tags', params, 'tags' );
 
 export const statsCommentsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'comments', 'stats/comments', params, response =>
-		sanitizeStatsGenericListResponse( response, 'comments', 'name' )
-	);
+	statsReportQuery( 'comments', 'stats/comments', params, 'comments' );
 
 export const statsCommentFollowersQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'comment-followers', 'stats/comment-followers', params, response =>
-		sanitizeStatsGenericListResponse( response, 'followers', 'title' )
-	);
+	statsReportQuery( 'comment-followers', 'stats/comment-followers', params, 'commentFollowers' );
 
 export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
 	statsProxyQuery( { name: 'streak', version: '1.1', endpoint: 'stats/streak', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-queries.ts
@@ -1,0 +1,338 @@
+/**
+ * External dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import {
+	fetchStatsProxy,
+	type StatsProxyMethod,
+	type StatsProxyVersion,
+} from '../api/stats-proxy-fetch';
+import {
+	sanitizeStatsClicksResponse,
+	sanitizeStatsDevicesResponse,
+	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsGenericListResponse,
+	sanitizeStatsLocationsResponse,
+	sanitizeStatsPassthroughResponse,
+	sanitizeStatsReferrersResponse,
+	sanitizeStatsSearchTermsResponse,
+	sanitizeStatsSiteResponse,
+	sanitizeStatsTopAuthorsResponse,
+	sanitizeStatsTopPostsResponse,
+	sanitizeStatsUtmResponse,
+	sanitizeStatsVideoPlaysResponse,
+	sanitizeStatsVisitsResponse,
+	type StatsNormalizedReport,
+} from '../processing/stats';
+import {
+	reportParamsToStatsQueryParams,
+	statsQueryKeyPart,
+	type StatsQueryParams,
+} from '../utils/stats-params';
+import type { ReportParams } from '../utils/search';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+export type StatsReportParams = ReportParams & StatsQueryParams;
+
+export type StatsQueryConfig< TData = unknown > = {
+	name: string;
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsQueryParams;
+	method?: StatsProxyMethod;
+	body?: unknown;
+	sanitize?: ( response: unknown, params?: StatsQueryParams ) => TData;
+	enabled?: boolean;
+};
+
+export function statsProxyQuery< TData = unknown >( {
+	name,
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+	sanitize = sanitizeStatsPassthroughResponse as ( response: unknown ) => TData,
+	enabled = true,
+}: StatsQueryConfig< TData > ): UseQueryOptions< TData > {
+	return {
+		queryKey: [
+			'stats',
+			name,
+			version,
+			endpoint,
+			method,
+			statsQueryKeyPart( params ),
+			body ?? null,
+			sanitize,
+		],
+		queryFn: async () => {
+			const response = await fetchStatsProxy( { version, endpoint, params, method, body } );
+			return sanitize( response, params );
+		},
+		enabled,
+		placeholderData: previousData => previousData,
+	};
+}
+
+function statsReportQuery< TData = StatsNormalizedReport >(
+	name: string,
+	endpoint: string,
+	params: StatsReportParams,
+	sanitize: ( response: unknown, params?: StatsQueryParams ) => TData,
+	version: StatsProxyVersion = '1.1'
+): UseQueryOptions< TData > {
+	const statsParams = reportParamsToStatsQueryParams( params );
+
+	return statsProxyQuery( {
+		name,
+		version,
+		endpoint,
+		params: statsParams,
+		sanitize,
+		enabled: !! ( statsParams.date || statsParams.start_date || params.from || params.to ),
+	} );
+}
+
+export const statsSiteQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'site',
+		version: '1.1',
+		endpoint: 'stats',
+		params,
+		sanitize: sanitizeStatsSiteResponse,
+	} );
+
+export const statsTopPostsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'top-posts', 'stats/top-posts', params, sanitizeStatsTopPostsResponse );
+
+export const statsReferrersQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'referrers', 'stats/referrers', params, sanitizeStatsReferrersResponse );
+
+export const statsClicksQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'clicks', 'stats/clicks', params, sanitizeStatsClicksResponse );
+
+export const statsSearchTermsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery(
+		'search-terms',
+		'stats/search-terms',
+		params,
+		sanitizeStatsSearchTermsResponse
+	);
+
+export const statsFileDownloadsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery(
+		'file-downloads',
+		'stats/file-downloads',
+		params,
+		sanitizeStatsFileDownloadsResponse
+	);
+
+export const statsTopAuthorsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'top-authors', 'stats/top-authors', params, sanitizeStatsTopAuthorsResponse );
+
+export const statsLocationsQuery = (
+	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' }
+) => {
+	const geoMode = params.geoMode ?? 'country';
+	return statsReportQuery(
+		`locations-${ geoMode }`,
+		`stats/location-views/${ geoMode }`,
+		params,
+		sanitizeStatsLocationsResponse
+	);
+};
+
+export const statsCountryViewsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery(
+		'country-views',
+		'stats/country-views',
+		params,
+		sanitizeStatsLocationsResponse
+	);
+
+export const statsVideoPlaysQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'video-plays', 'stats/video-plays', params, sanitizeStatsVideoPlaysResponse );
+
+export const statsVisitsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'visits', 'stats/visits', params, sanitizeStatsVisitsResponse );
+
+export const statsUtmQuery = ( params: StatsReportParams & { utmParams?: string } ) =>
+	statsReportQuery(
+		'utm',
+		`stats/utm/${ params.utmParams ?? 'utm_source,utm_medium' }`,
+		params,
+		sanitizeStatsUtmResponse
+	);
+
+export const statsDevicesQuery = ( params: StatsReportParams & { deviceProperty?: string } ) =>
+	statsReportQuery(
+		'devices',
+		`stats/devices/${ params.deviceProperty ?? 'screensize' }`,
+		params,
+		sanitizeStatsDevicesResponse
+	);
+
+export const statsArchivesQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'archives', 'stats/archives', params, response =>
+		sanitizeStatsGenericListResponse( response )
+	);
+
+export const statsPublicizeQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'publicize', 'stats/publicize', params, response =>
+		sanitizeStatsGenericListResponse( response, 'followers', 'label' )
+	);
+
+export const statsFollowersQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'followers', 'stats/followers', params, response =>
+		sanitizeStatsGenericListResponse( response, 'total', 'label' )
+	);
+
+export const statsTagsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'tags', 'stats/tags', params, response =>
+		sanitizeStatsGenericListResponse( response, 'views', 'name' )
+	);
+
+export const statsCommentsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'comments', 'stats/comments', params, response =>
+		sanitizeStatsGenericListResponse( response, 'comments', 'name' )
+	);
+
+export const statsCommentFollowersQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'comment-followers', 'stats/comment-followers', params, response =>
+		sanitizeStatsGenericListResponse( response, 'followers', 'title' )
+	);
+
+export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'streak', version: '1.1', endpoint: 'stats/streak', params } );
+
+export const statsInsightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'insights', version: '1.1', endpoint: 'stats/insights', params } );
+
+export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'highlights', version: '1.1', endpoint: 'stats/highlights', params } );
+
+export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'subscribers', version: '1.1', endpoint: 'stats/subscribers', params } );
+
+export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-post',
+		version: '1.1',
+		endpoint: `stats/post/${ postId }`,
+		params,
+	} );
+
+export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-video',
+		version: '1.1',
+		endpoint: `stats/video/${ videoId }`,
+		params,
+	} );
+
+export const statsEmailSummaryQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-summary',
+		version: '1.1',
+		endpoint: 'stats/emails/summary',
+		params,
+	} );
+
+export const statsEmailOpensBreakdownQuery = (
+	postId: number,
+	breakdown: 'client' | 'device' | 'country' | 'rate',
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-opens-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/opens/emails/${ postId }/${ breakdown }`,
+		params,
+	} );
+
+export const statsEmailClicksBreakdownQuery = (
+	postId: number,
+	breakdown: 'client' | 'device' | 'country' | 'rate' | 'link' | 'user-content-link',
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-clicks-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/clicks/emails/${ postId }/${ breakdown }`,
+		params,
+	} );
+
+export const statsEmailOpensTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-opens-time-series',
+		version: '1.1',
+		endpoint: `stats/opens/emails/${ postId }`,
+		params,
+	} );
+
+export const statsEmailClicksTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-clicks-time-series',
+		version: '1.1',
+		endpoint: `stats/clicks/emails/${ postId }`,
+		params,
+	} );
+
+export const statsReferrersSpamQuery = () =>
+	statsProxyQuery( {
+		name: 'referrers-spam',
+		version: '1.1',
+		endpoint: 'stats/referrers/spam',
+	} );
+
+export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers-counts',
+		version: '2',
+		endpoint: 'subscribers/counts',
+		params,
+	} );
+
+export const statsSiteHasNeverPublishedPostQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'site-has-never-published-post',
+		version: '2',
+		endpoint: 'site-has-never-published-post',
+		params,
+	} );
+
+export const statsPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'plan-usage', version: '2', endpoint: 'jetpack-stats/usage', params } );
+
+export const statsDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'dashboard-modules',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/modules',
+		params,
+	} );
+
+export const statsDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'dashboard-module-settings',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/module-settings',
+		params,
+	} );
+
+export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-earnings',
+		version: '1.1',
+		endpoint: 'wordads/earnings',
+		params,
+	} );
+
+export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'wordads-stats', version: '1.1', endpoint: 'wordads/stats', params } );
+
+export const statsPurchasesQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'purchases', version: '1.2', endpoint: 'upgrades', params } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -54,4 +54,18 @@ describe( 'reportParamsToStatsQueryParams', () => {
 		expect( params ).not.toHaveProperty( 'compare_from' );
 		expect( params ).not.toHaveProperty( 'date_type' );
 	} );
+
+	it( 'does not forward path-only Stats options to endpoint query params', () => {
+		const params = reportParamsToStatsQueryParams( {
+			from: '2026-06-01',
+			to: '2026-06-01',
+			geoMode: 'city',
+			utmParams: 'utm_source,utm_campaign',
+			deviceProperty: 'browser',
+		} );
+
+		expect( params ).not.toHaveProperty( 'geoMode' );
+		expect( params ).not.toHaveProperty( 'utmParams' );
+		expect( params ).not.toHaveProperty( 'deviceProperty' );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { getStatsPeriodFromInterval, reportParamsToStatsQueryParams } from '../stats-params';
+import {
+	getStatsPeriodFromInterval,
+	reportParamsToStatsQueryParams,
+	statsQueryKeyPart,
+} from '../stats-params';
 
 describe( 'getStatsPeriodFromInterval', () => {
 	it.each( [
@@ -67,5 +71,34 @@ describe( 'reportParamsToStatsQueryParams', () => {
 		expect( params ).not.toHaveProperty( 'geoMode' );
 		expect( params ).not.toHaveProperty( 'utmParams' );
 		expect( params ).not.toHaveProperty( 'deviceProperty' );
+	} );
+
+	it( 'omits empty date params when no dates are provided', () => {
+		const params = reportParamsToStatsQueryParams();
+
+		expect( params ).not.toHaveProperty( 'date' );
+		expect( params ).not.toHaveProperty( 'start_date' );
+	} );
+} );
+
+describe( 'statsQueryKeyPart', () => {
+	it( 'serializes object keys in a stable order', () => {
+		expect(
+			statsQueryKeyPart( {
+				b: 2,
+				a: {
+					d: 4,
+					c: 3,
+				},
+			} )
+		).toBe(
+			statsQueryKeyPart( {
+				a: {
+					c: 3,
+					d: 4,
+				},
+				b: 2,
+			} )
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import { getStatsPeriodFromInterval, reportParamsToStatsQueryParams } from '../stats-params';
+
+describe( 'getStatsPeriodFromInterval', () => {
+	it.each( [
+		[ 'hour', 'hour' ],
+		[ 'day', 'day' ],
+		[ 'week', 'week' ],
+		[ 'month', 'month' ],
+		[ 'quarter', 'month' ],
+		[ 'year', 'year' ],
+		[ undefined, 'day' ],
+	] )( 'maps %s to %s', ( interval, period ) => {
+		expect( getStatsPeriodFromInterval( interval ) ).toBe( period );
+	} );
+} );
+
+describe( 'reportParamsToStatsQueryParams', () => {
+	it( 'converts report dates into stats date range params', () => {
+		expect(
+			reportParamsToStatsQueryParams( {
+				from: '2026-06-01T00:00:00',
+				to: '2026-06-07T23:59:59',
+				interval: 'day',
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				period: 'day',
+				date: '2026-06-07',
+				start_date: '2026-06-01',
+				days: 7,
+				num: 1,
+				max: 10,
+			} )
+		);
+	} );
+
+	it( 'does not forward Woo report-only params to Stats endpoints', () => {
+		const params = reportParamsToStatsQueryParams( {
+			from: '2026-06-01',
+			to: '2026-06-01',
+			interval: 'day',
+			comp: '1',
+			compare_from: '2026-05-01',
+			compare_to: '2026-05-01',
+			filters: [ { key: 'product_type', value: [ 'simple' ], compare: 'IN' } ],
+			date_type: 'created',
+		} );
+
+		expect( params ).not.toHaveProperty( 'filters' );
+		expect( params ).not.toHaveProperty( 'comp' );
+		expect( params ).not.toHaveProperty( 'compare_from' );
+		expect( params ).not.toHaveProperty( 'date_type' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -35,8 +35,20 @@ describe( 'reportParamsToStatsQueryParams', () => {
 				date: '2026-06-07',
 				start_date: '2026-06-01',
 				days: 7,
-				num: 1,
-				max: 10,
+			} )
+		);
+	} );
+
+	it( 'preserves explicit Stats result limit params', () => {
+		expect(
+			reportParamsToStatsQueryParams( {
+				num: 3,
+				max: 25,
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				num: 3,
+				max: 25,
 			} )
 		);
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -76,6 +76,9 @@ export function reportParamsToStatsQueryParams(
 	delete statsParams.section;
 	delete statsParams.date_type;
 	delete statsParams.view;
+	delete statsParams.geoMode;
+	delete statsParams.utmParams;
+	delete statsParams.deviceProperty;
 
 	const from = datePart( params.from );
 	const to = datePart( params.to );

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -28,7 +28,7 @@ type StatsQueryParamInput = Partial< ReportParams > & {
 };
 
 function datePart( value?: string ) {
-	return value?.split( 'T' )[ 0 ] ?? '';
+	return value?.split( 'T' )[ 0 ];
 }
 
 function daysBetweenInclusive( from: string, to: string ) {
@@ -91,22 +91,35 @@ export function reportParamsToStatsQueryParams(
 	return {
 		...( statsParams as StatsQueryParams ),
 		period,
-		date,
-		start_date: startDate,
+		...( date ? { date } : {} ),
+		...( startDate ? { start_date: startDate } : {} ),
 		...( days ? { days } : {} ),
 		num: params.num ?? 1,
 		max: params.max ?? 10,
 	};
 }
 
-export function statsQueryKeyPart( params?: StatsProxyParams ) {
-	if ( ! params ) {
+function normalizeQueryKeyValue( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( normalizeQueryKeyValue );
+	}
+
+	if ( value && typeof value === 'object' ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ , item ] ) => item !== undefined && item !== null )
+				.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+				.map( ( [ key, item ] ) => [ key, normalizeQueryKeyValue( item ) ] )
+		);
+	}
+
+	return value;
+}
+
+export function statsQueryKeyPart( params?: unknown ) {
+	if ( params === undefined || params === null ) {
 		return '';
 	}
 
-	const normalized = Object.entries( params )
-		.filter( ( [ , value ] ) => value !== undefined && value !== null )
-		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) );
-
-	return JSON.stringify( normalized );
+	return JSON.stringify( normalizeQueryKeyValue( params ) );
 }

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -94,8 +94,8 @@ export function reportParamsToStatsQueryParams(
 		...( date ? { date } : {} ),
 		...( startDate ? { start_date: startDate } : {} ),
 		...( days ? { days } : {} ),
-		num: params.num ?? 1,
-		max: params.max ?? 10,
+		...( params.num !== undefined ? { num: params.num } : {} ),
+		...( params.max !== undefined ? { max: params.max } : {} ),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal dependencies
+ */
+import type { ReportParams } from './search';
+import type { StatsProxyParams } from '../api/stats-proxy-fetch';
+
+export type StatsPeriod = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export type StatsQueryParams = StatsProxyParams & {
+	period?: StatsPeriod | string;
+	date?: string;
+	start_date?: string;
+	days?: number;
+	num?: number;
+	max?: number;
+	summarize?: number | boolean;
+};
+
+type StatsQueryParamInput = Partial< ReportParams > & {
+	period?: StatsPeriod | string;
+	date?: string;
+	start_date?: string;
+	days?: number;
+	num?: number;
+	max?: number;
+	summarize?: number | boolean;
+	[ key: string ]: unknown;
+};
+
+function datePart( value?: string ) {
+	return value?.split( 'T' )[ 0 ] ?? '';
+}
+
+function daysBetweenInclusive( from: string, to: string ) {
+	const fromDate = new Date( `${ from }T00:00:00Z` );
+	const toDate = new Date( `${ to }T00:00:00Z` );
+	const diff = toDate.getTime() - fromDate.getTime();
+
+	if ( Number.isNaN( diff ) || diff < 0 ) {
+		return 1;
+	}
+
+	return Math.floor( diff / 86400000 ) + 1;
+}
+
+export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
+	switch ( interval ) {
+		case 'hour':
+			return 'hour';
+		case 'week':
+			return 'week';
+		case 'month':
+		case 'quarter':
+			return 'month';
+		case 'year':
+			return 'year';
+		case 'day':
+		default:
+			return 'day';
+	}
+}
+
+export function reportParamsToStatsQueryParams(
+	params: StatsQueryParamInput = {}
+): StatsQueryParams {
+	const statsParams = { ...params };
+	delete statsParams.from;
+	delete statsParams.to;
+	delete statsParams.interval;
+	delete statsParams.preset;
+	delete statsParams.compare_from;
+	delete statsParams.compare_to;
+	delete statsParams.compare_preset;
+	delete statsParams.comp;
+	delete statsParams.filters;
+	delete statsParams.section;
+	delete statsParams.date_type;
+	delete statsParams.view;
+
+	const from = datePart( params.from );
+	const to = datePart( params.to );
+	const period = params.period ?? getStatsPeriodFromInterval( params.interval );
+	const date = params.date ?? to;
+	const startDate = params.start_date ?? from;
+	const days =
+		params.days ?? ( startDate && date ? daysBetweenInclusive( startDate, date ) : undefined );
+
+	return {
+		...( statsParams as StatsQueryParams ),
+		period,
+		date,
+		start_date: startDate,
+		...( days ? { days } : {} ),
+		num: params.num ?? 1,
+		max: params.max ?? 10,
+	};
+}
+
+export function statsQueryKeyPart( params?: StatsProxyParams ) {
+	if ( ! params ) {
+		return '';
+	}
+
+	const normalized = Object.entries( params )
+		.filter( ( [ , value ] ) => value !== undefined && value !== null )
+		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) );
+
+	return JSON.stringify( normalized );
+}


### PR DESCRIPTION
## Proposed changes
* Add a shared Premium Analytics data fetcher for the unified Stats proxy route.
* Add consistently named `useStats...` hooks and mutations for the WPCOM-proxied Stats endpoint families from #49571.
* Add lightweight Stats response normalization for widget/report-style data, including fixture-backed normalizer tests.
* Export Stats proxy helpers, query utilities, normalized types, and hook APIs from the data package.

## Related product discussion/links
* Follow-up to #49571.

## Does this pull request change what data or activity we track or use?
No. This adds frontend data-layer access to existing proxied Stats endpoints and does not add or change tracking.

## Testing instructions
* `pnpm --dir projects/packages/premium-analytics test`
* `pnpm --dir projects/packages/premium-analytics typecheck`
* `pnpm --dir projects/packages/premium-analytics build`
