### PR TITLE
Premium Analytics: add Stats proxy foundation

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-proxy-foundation
+++ b/projects/packages/premium-analytics/changelog/add-stats-proxy-foundation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Data: Add Jetpack Stats proxy fetch utilities.

--- a/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { getStatsProxyPath } from '../stats-proxy-fetch';
+
+describe( 'getStatsProxyPath', () => {
+	it( 'builds a v1.1 stats proxy path', () => {
+		expect(
+			getStatsProxyPath( {
+				version: '1.1',
+				endpoint: 'stats/top-posts',
+				params: { period: 'day', date: '2026-06-16' },
+			} )
+		).toBe( '/jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?period=day&date=2026-06-16' );
+	} );
+
+	it( 'preserves comma-separated UTM endpoint segments', () => {
+		expect(
+			getStatsProxyPath( {
+				version: '1.1',
+				endpoint: 'stats/utm/utm_source,utm_medium',
+				params: { period: 'month' },
+			} )
+		).toBe(
+			'/jetpack-premium-analytics/v1/proxy/v1.1/stats/utm/utm_source,utm_medium?period=month'
+		);
+	} );
+
+	it( 'builds site-less upgrades proxy path', () => {
+		expect( getStatsProxyPath( { version: '1.2', endpoint: '/upgrades' } ) ).toBe(
+			'/jetpack-premium-analytics/v1/proxy/v1.2/upgrades'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/__tests__/stats-proxy-fetch.test.ts
@@ -1,7 +1,23 @@
 /**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
  * Internal dependencies
  */
-import { getStatsProxyPath } from '../stats-proxy-fetch';
+import { fetchStatsProxy, getStatsProxyPath } from '../stats-proxy-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+beforeEach( () => {
+	mockApiFetch.mockResolvedValue( {} );
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
 
 describe( 'getStatsProxyPath', () => {
 	it( 'builds a v1.1 stats proxy path', () => {
@@ -30,5 +46,51 @@ describe( 'getStatsProxyPath', () => {
 		expect( getStatsProxyPath( { version: '1.2', endpoint: '/upgrades' } ) ).toBe(
 			'/jetpack-premium-analytics/v1/proxy/v1.2/upgrades'
 		);
+	} );
+
+	it( 'omits nullish query params', () => {
+		expect(
+			getStatsProxyPath( {
+				version: '1.1',
+				endpoint: 'stats/visits',
+				params: {
+					period: 'day',
+					date: undefined,
+					start_date: null,
+				} as never,
+			} )
+		).toBe( '/jetpack-premium-analytics/v1/proxy/v1.1/stats/visits?period=day' );
+	} );
+} );
+
+describe( 'fetchStatsProxy', () => {
+	it( 'uses GET by default and omits request data', async () => {
+		await fetchStatsProxy( {
+			version: '1.1',
+			endpoint: 'stats/top-posts',
+			params: { period: 'day' },
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?period=day',
+			method: 'GET',
+		} );
+	} );
+
+	it( 'sends POST bodies as apiFetch data', async () => {
+		const body = { modules: [ 'visits' ] };
+
+		await fetchStatsProxy( {
+			version: '2',
+			endpoint: 'jetpack-stats-dashboard/modules',
+			method: 'POST',
+			body,
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats-dashboard/modules',
+			method: 'POST',
+			data: body,
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/api/constants.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/constants.ts
@@ -2,4 +2,4 @@
  * Constants for API endpoints
  */
 export const statsProxyPath = '/jetpack-premium-analytics/v1/proxy';
-export const reportsPath = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
+export const reportsPath = `${ statsProxyPath }/v2/analytics/reports`;

--- a/projects/packages/premium-analytics/packages/data/src/api/constants.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/constants.ts
@@ -1,4 +1,5 @@
 /**
  * Constants for API endpoints
  */
+export const statsProxyPath = '/jetpack-premium-analytics/v1/proxy';
 export const reportsPath = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';

--- a/projects/packages/premium-analytics/packages/data/src/api/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/index.ts
@@ -43,3 +43,12 @@ export { fetchReportBookings } from './report-bookings-fetch';
 export { fetchReportSessionsByDevice } from './report-sessions-by-device-fetch';
 export { exportReport } from './report-export-fetch';
 export type { ExportReportParams, ExportReportResponse } from './report-export-fetch';
+export {
+	fetchStatsProxy,
+	getStatsProxyPath,
+	type StatsProxyFetchParams,
+	type StatsProxyMethod,
+	type StatsProxyParams,
+	type StatsProxyQueryParams,
+	type StatsProxyVersion,
+} from './stats-proxy-fetch';

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
@@ -14,7 +14,7 @@ export type StatsProxyMethod = 'GET' | 'POST';
 
 export type StatsProxyParams = Record<
 	string,
-	string | number | boolean | null | undefined | Array< string | number | boolean >
+	string | number | boolean | undefined | Array< string | number | boolean >
 >;
 
 export type StatsProxyFetchParams< TBody = unknown > = {
@@ -29,14 +29,27 @@ function normalizeEndpoint( endpoint: string ) {
 	return endpoint.replace( /^\/+/, '' );
 }
 
+function cleanQueryParams( params?: StatsProxyParams ) {
+	if ( ! params ) {
+		return undefined;
+	}
+
+	const cleaned = Object.fromEntries(
+		Object.entries( params ).filter( ( [ , value ] ) => value !== undefined && value !== null )
+	) as StatsProxyParams;
+
+	return Object.keys( cleaned ).length ? cleaned : undefined;
+}
+
 export function getStatsProxyPath( {
 	version,
 	endpoint,
 	params,
 }: Pick< StatsProxyFetchParams, 'version' | 'endpoint' | 'params' > ) {
 	const path = `${ statsProxyPath }/v${ version }/${ normalizeEndpoint( endpoint ) }`;
+	const queryParams = cleanQueryParams( params );
 
-	return params ? addQueryArgs( path, params ) : path;
+	return queryParams ? addQueryArgs( path, queryParams ) : path;
 }
 
 export async function fetchStatsProxy< TResponse = unknown, TBody = unknown >( {
@@ -55,4 +68,4 @@ export async function fetchStatsProxy< TResponse = unknown, TBody = unknown >( {
 	} );
 }
 
-export type StatsProxyQueryParams = StatsProxyFetchParams;
+export type StatsProxyQueryParams = StatsProxyParams;

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-proxy-fetch.ts
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+/**
+ * Internal dependencies
+ */
+import { statsProxyPath } from './constants';
+
+export type StatsProxyVersion = '1.1' | '1.2' | '2';
+
+export type StatsProxyMethod = 'GET' | 'POST';
+
+export type StatsProxyParams = Record<
+	string,
+	string | number | boolean | null | undefined | Array< string | number | boolean >
+>;
+
+export type StatsProxyFetchParams< TBody = unknown > = {
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsProxyParams;
+	method?: StatsProxyMethod;
+	body?: TBody;
+};
+
+function normalizeEndpoint( endpoint: string ) {
+	return endpoint.replace( /^\/+/, '' );
+}
+
+export function getStatsProxyPath( {
+	version,
+	endpoint,
+	params,
+}: Pick< StatsProxyFetchParams, 'version' | 'endpoint' | 'params' > ) {
+	const path = `${ statsProxyPath }/v${ version }/${ normalizeEndpoint( endpoint ) }`;
+
+	return params ? addQueryArgs( path, params ) : path;
+}
+
+export async function fetchStatsProxy< TResponse = unknown, TBody = unknown >( {
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+}: StatsProxyFetchParams< TBody > ): Promise< TResponse > {
+	const path = getStatsProxyPath( { version, endpoint, params } );
+
+	return apiFetch< TResponse >( {
+		path,
+		method,
+		...( method === 'POST' ? { data: body } : {} ),
+	} );
+}
+
+export type StatsProxyQueryParams = StatsProxyFetchParams;

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider, type UseQueryOptions } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { useReport } from '../use-report';
+import type { ReportParams } from '../../utils/search';
+import type { ReactNode } from 'react';
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	} );
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+describe( 'useReport', () => {
+	it( 'keeps endpoint-specific params and overrides only comparison dates', () => {
+		const calls: Array< { params: ReportParams; queryType: string } > = [];
+		const queryFactory = (
+			params: ReportParams,
+			queryType: string
+		): UseQueryOptions< { summary: Record< string, unknown >; data: unknown[] } > => {
+			calls.push( { params, queryType } );
+
+			return {
+				queryKey: [ 'test-report', queryType, params.from, params.to, params.period ],
+				queryFn: async () => ( { summary: {}, data: [] } ),
+				enabled: false,
+			};
+		};
+
+		renderHook(
+			() =>
+				useReport(
+					queryFactory,
+					{
+						from: '2026-06-01',
+						to: '2026-06-07',
+						compare_from: '2026-05-01',
+						compare_to: '2026-05-07',
+						compare_preset: 'previous-period',
+						comp: '1',
+						interval: 'day',
+						period: 'day',
+						section: 'stats',
+					},
+					{
+						enabled: false,
+					}
+				),
+			{ wrapper }
+		);
+
+		expect( calls ).toEqual( [
+			{
+				queryType: 'primary',
+				params: expect.objectContaining( {
+					from: '2026-06-01',
+					to: '2026-06-07',
+					interval: 'day',
+					period: 'day',
+					section: 'stats',
+				} ),
+			},
+			{
+				queryType: 'comparison',
+				params: expect.objectContaining( {
+					from: '2026-05-01',
+					to: '2026-05-07',
+					interval: 'day',
+					period: 'day',
+					section: 'stats',
+				} ),
+			},
+		] );
+		expect( calls[ 0 ].params ).not.toHaveProperty( 'compare_from' );
+		expect( calls[ 1 ].params ).not.toHaveProperty( 'compare_from' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -47,35 +47,29 @@ type QueryFactory< TData > = (
  * );
  * ```
  */
-export function useReport< TData >(
+export function useReport< TData, TParams extends ReportParams = ReportParams >(
 	queryFactory: QueryFactory< TData >,
-	params: ReportParams,
+	params: TParams,
 	options?: UseReportOptions
 ) {
 	const queryEnabled = options?.enabled ?? true;
 	const comparisonEnabled = hasComparisonEnabled( params );
+	const primaryParams = { ...params };
+	delete primaryParams.compare_from;
+	delete primaryParams.compare_to;
+	delete primaryParams.compare_preset;
+	delete primaryParams.comp;
 
 	// Create primary query
-	const primaryQueryOptions = queryFactory(
-		{
-			from: params.from,
-			to: params.to,
-			interval: params.interval,
-			filters: params.filters,
-			date_type: params.date_type,
-		},
-		'primary'
-	);
+	const primaryQueryOptions = queryFactory( primaryParams, 'primary' );
 
 	// Create comparison query if comparison is enabled
 	const comparisonQueryOptions = comparisonEnabled
 		? queryFactory(
 				{
+					...primaryParams,
 					from: params.compare_from,
 					to: params.compare_to,
-					interval: params.interval,
-					filters: params.filters,
-					date_type: params.date_type,
 				},
 				'comparison'
 		  )

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -50,7 +50,6 @@ export type {
 export {
 	getStatsPeriodFromInterval,
 	reportParamsToStatsQueryParams,
-	statsQueryKeyPart,
 	type StatsPeriod,
 	type StatsQueryParams,
 } from './utils/stats-params';

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -37,5 +37,20 @@ export type { ProductType } from './types/product-type';
 export { ORDER_ATTRIBUTION_VIEWS } from './api/report-order-attribution-summary-fetch';
 export { getDefaultIntervalForPeriod, getDateFormatFromInterval } from './utils/interval';
 export { getDefaultPreset, getDefaultQueryParams } from './defaults';
-export { exportReport } from './api';
-export type { ExportReportParams, ExportReportResponse } from './api';
+export { exportReport, fetchStatsProxy, getStatsProxyPath } from './api';
+export type {
+	ExportReportParams,
+	ExportReportResponse,
+	StatsProxyFetchParams,
+	StatsProxyMethod,
+	StatsProxyParams,
+	StatsProxyQueryParams,
+	StatsProxyVersion,
+} from './api';
+export {
+	getStatsPeriodFromInterval,
+	reportParamsToStatsQueryParams,
+	statsQueryKeyPart,
+	type StatsPeriod,
+	type StatsQueryParams,
+} from './utils/stats-params';

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getStatsPeriodFromInterval,
+	reportParamsToStatsQueryParams,
+	statsQueryKeyPart,
+} from '../stats-params';
+
+describe( 'getStatsPeriodFromInterval', () => {
+	it.each( [
+		[ 'hour', 'hour' ],
+		[ 'day', 'day' ],
+		[ 'week', 'week' ],
+		[ 'month', 'month' ],
+		[ 'quarter', 'month' ],
+		[ 'year', 'year' ],
+		[ undefined, 'day' ],
+	] )( 'maps %s to %s', ( interval, period ) => {
+		expect( getStatsPeriodFromInterval( interval ) ).toBe( period );
+	} );
+} );
+
+describe( 'reportParamsToStatsQueryParams', () => {
+	it( 'converts report dates into stats date range params', () => {
+		expect(
+			reportParamsToStatsQueryParams( {
+				from: '2026-06-01T00:00:00',
+				to: '2026-06-07T23:59:59',
+				interval: 'day',
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				period: 'day',
+				date: '2026-06-07',
+				start_date: '2026-06-01',
+				days: 7,
+			} )
+		);
+	} );
+
+	it( 'preserves explicit Stats result limit params', () => {
+		expect(
+			reportParamsToStatsQueryParams( {
+				num: 3,
+				max: 25,
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				num: 3,
+				max: 25,
+			} )
+		);
+	} );
+
+	it( 'does not forward Woo report-only params to Stats endpoints', () => {
+		const params = reportParamsToStatsQueryParams( {
+			from: '2026-06-01',
+			to: '2026-06-01',
+			interval: 'day',
+			comp: '1',
+			compare_from: '2026-05-01',
+			compare_to: '2026-05-01',
+			filters: [ { key: 'product_type', value: [ 'simple' ], compare: 'IN' } ],
+			date_type: 'created',
+		} );
+
+		expect( params ).not.toHaveProperty( 'filters' );
+		expect( params ).not.toHaveProperty( 'comp' );
+		expect( params ).not.toHaveProperty( 'compare_from' );
+		expect( params ).not.toHaveProperty( 'date_type' );
+	} );
+
+	it( 'does not forward path-only Stats options to endpoint query params', () => {
+		const params = reportParamsToStatsQueryParams( {
+			from: '2026-06-01',
+			to: '2026-06-01',
+			geoMode: 'city',
+			utmParams: 'utm_source,utm_campaign',
+			deviceProperty: 'browser',
+		} );
+
+		expect( params ).not.toHaveProperty( 'geoMode' );
+		expect( params ).not.toHaveProperty( 'utmParams' );
+		expect( params ).not.toHaveProperty( 'deviceProperty' );
+	} );
+
+	it( 'omits empty date params when no dates are provided', () => {
+		const params = reportParamsToStatsQueryParams();
+
+		expect( params ).not.toHaveProperty( 'date' );
+		expect( params ).not.toHaveProperty( 'start_date' );
+	} );
+} );
+
+describe( 'statsQueryKeyPart', () => {
+	it( 'serializes object keys in a stable order', () => {
+		expect(
+			statsQueryKeyPart( {
+				b: 2,
+				a: {
+					d: 4,
+					c: 3,
+				},
+			} )
+		).toBe(
+			statsQueryKeyPart( {
+				a: {
+					c: 3,
+					d: 4,
+				},
+				b: 2,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -1,11 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	getStatsPeriodFromInterval,
-	reportParamsToStatsQueryParams,
-	statsQueryKeyPart,
-} from '../stats-params';
+import { getStatsPeriodFromInterval, reportParamsToStatsQueryParams } from '../stats-params';
 
 describe( 'getStatsPeriodFromInterval', () => {
 	it.each( [
@@ -103,27 +99,5 @@ describe( 'reportParamsToStatsQueryParams', () => {
 
 		expect( params ).not.toHaveProperty( 'date' );
 		expect( params ).not.toHaveProperty( 'start_date' );
-	} );
-} );
-
-describe( 'statsQueryKeyPart', () => {
-	it( 'serializes object keys in a stable order', () => {
-		expect(
-			statsQueryKeyPart( {
-				b: 2,
-				a: {
-					d: 4,
-					c: 3,
-				},
-			} )
-		).toBe(
-			statsQueryKeyPart( {
-				a: {
-					c: 3,
-					d: 4,
-				},
-				b: 2,
-			} )
-		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -39,6 +39,19 @@ describe( 'reportParamsToStatsQueryParams', () => {
 		);
 	} );
 
+	it( 'falls back to one day for invalid date ranges', () => {
+		expect(
+			reportParamsToStatsQueryParams( {
+				from: '2026-06-07',
+				to: '2026-06-01',
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				days: 1,
+			} )
+		);
+	} );
+
 	it( 'preserves explicit Stats result limit params', () => {
 		expect(
 			reportParamsToStatsQueryParams( {

--- a/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
@@ -1,12 +1,25 @@
 /**
  * External dependencies
  */
-import { differenceInHours } from 'date-fns';
+import { differenceInCalendarDays, differenceInHours } from 'date-fns';
 /**
  * Internal dependencies
  */
 import { localTZDate } from './date';
 import type { IntervalType } from './search';
+
+export function getDaysBetweenInclusive( from: string, to: string ): number {
+	const fromDate = new Date( `${ from }T00:00:00Z` );
+	const toDate = new Date( `${ to }T00:00:00Z` );
+	const days = differenceInCalendarDays( toDate, fromDate );
+
+	if ( Number.isNaN( days ) || days < 0 ) {
+		// Keep range-based requests bounded even when callers pass an invalid range.
+		return 1;
+	}
+
+	return days + 1;
+}
 
 function getAllowedIntervalsByRange( from: string, to: string ): IntervalType[] {
 	// Use hours instead of days to handle ranges that are 1 second short of a full day.

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -37,6 +37,7 @@ function daysBetweenInclusive( from: string, to: string ) {
 	const diff = toDate.getTime() - fromDate.getTime();
 
 	if ( Number.isNaN( diff ) || diff < 0 ) {
+		// Keep the Stats API request bounded even when callers pass an invalid range.
 		return 1;
 	}
 
@@ -64,21 +65,27 @@ export function reportParamsToStatsQueryParams(
 	params: StatsQueryParamInput = {}
 ): StatsQueryParams {
 	const statsParams = { ...params };
-	delete statsParams.from;
-	delete statsParams.to;
-	delete statsParams.interval;
-	delete statsParams.preset;
-	delete statsParams.compare_from;
-	delete statsParams.compare_to;
-	delete statsParams.compare_preset;
-	delete statsParams.comp;
-	delete statsParams.filters;
-	delete statsParams.section;
-	delete statsParams.date_type;
-	delete statsParams.view;
-	delete statsParams.geoMode;
-	delete statsParams.utmParams;
-	delete statsParams.deviceProperty;
+	const reportOnlyKeys = [
+		'from',
+		'to',
+		'interval',
+		'preset',
+		'compare_from',
+		'compare_to',
+		'compare_preset',
+		'comp',
+		'filters',
+		'section',
+		'date_type',
+		'view',
+		'geoMode',
+		'utmParams',
+		'deviceProperty',
+	] as const;
+
+	reportOnlyKeys.forEach( key => {
+		delete statsParams[ key ];
+	} );
 
 	const from = datePart( params.from );
 	const to = datePart( params.to );
@@ -94,8 +101,6 @@ export function reportParamsToStatsQueryParams(
 		...( date ? { date } : {} ),
 		...( startDate ? { start_date: startDate } : {} ),
 		...( days ? { days } : {} ),
-		...( params.num !== undefined ? { num: params.num } : {} ),
-		...( params.max !== undefined ? { max: params.max } : {} ),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -1,0 +1,125 @@
+/**
+ * Internal dependencies
+ */
+import type { ReportParams } from './search';
+import type { StatsProxyParams } from '../api/stats-proxy-fetch';
+
+export type StatsPeriod = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export type StatsQueryParams = StatsProxyParams & {
+	period?: StatsPeriod | string;
+	date?: string;
+	start_date?: string;
+	days?: number;
+	num?: number;
+	max?: number;
+	summarize?: number | boolean;
+};
+
+type StatsQueryParamInput = Partial< ReportParams > & {
+	period?: StatsPeriod | string;
+	date?: string;
+	start_date?: string;
+	days?: number;
+	num?: number;
+	max?: number;
+	summarize?: number | boolean;
+	[ key: string ]: unknown;
+};
+
+function datePart( value?: string ) {
+	return value?.split( 'T' )[ 0 ];
+}
+
+function daysBetweenInclusive( from: string, to: string ) {
+	const fromDate = new Date( `${ from }T00:00:00Z` );
+	const toDate = new Date( `${ to }T00:00:00Z` );
+	const diff = toDate.getTime() - fromDate.getTime();
+
+	if ( Number.isNaN( diff ) || diff < 0 ) {
+		return 1;
+	}
+
+	return Math.floor( diff / 86400000 ) + 1;
+}
+
+export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
+	switch ( interval ) {
+		case 'hour':
+			return 'hour';
+		case 'week':
+			return 'week';
+		case 'month':
+		case 'quarter':
+			return 'month';
+		case 'year':
+			return 'year';
+		case 'day':
+		default:
+			return 'day';
+	}
+}
+
+export function reportParamsToStatsQueryParams(
+	params: StatsQueryParamInput = {}
+): StatsQueryParams {
+	const statsParams = { ...params };
+	delete statsParams.from;
+	delete statsParams.to;
+	delete statsParams.interval;
+	delete statsParams.preset;
+	delete statsParams.compare_from;
+	delete statsParams.compare_to;
+	delete statsParams.compare_preset;
+	delete statsParams.comp;
+	delete statsParams.filters;
+	delete statsParams.section;
+	delete statsParams.date_type;
+	delete statsParams.view;
+	delete statsParams.geoMode;
+	delete statsParams.utmParams;
+	delete statsParams.deviceProperty;
+
+	const from = datePart( params.from );
+	const to = datePart( params.to );
+	const period = params.period ?? getStatsPeriodFromInterval( params.interval );
+	const date = params.date ?? to;
+	const startDate = params.start_date ?? from;
+	const days =
+		params.days ?? ( startDate && date ? daysBetweenInclusive( startDate, date ) : undefined );
+
+	return {
+		...( statsParams as StatsQueryParams ),
+		period,
+		...( date ? { date } : {} ),
+		...( startDate ? { start_date: startDate } : {} ),
+		...( days ? { days } : {} ),
+		...( params.num !== undefined ? { num: params.num } : {} ),
+		...( params.max !== undefined ? { max: params.max } : {} ),
+	};
+}
+
+function normalizeQueryKeyValue( value: unknown ): unknown {
+	if ( Array.isArray( value ) ) {
+		return value.map( normalizeQueryKeyValue );
+	}
+
+	if ( value && typeof value === 'object' ) {
+		return Object.fromEntries(
+			Object.entries( value )
+				.filter( ( [ , item ] ) => item !== undefined && item !== null )
+				.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+				.map( ( [ key, item ] ) => [ key, normalizeQueryKeyValue( item ) ] )
+		);
+	}
+
+	return value;
+}
+
+export function statsQueryKeyPart( params?: unknown ) {
+	if ( params === undefined || params === null ) {
+		return '';
+	}
+
+	return JSON.stringify( normalizeQueryKeyValue( params ) );
+}

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -1,12 +1,13 @@
 /**
  * Internal dependencies
  */
+import { getDaysBetweenInclusive } from './interval';
 import type { ReportParams } from './search';
 import type { StatsProxyParams } from '../api/stats-proxy-fetch';
 
 export type StatsPeriod = 'hour' | 'day' | 'week' | 'month' | 'year';
 
-export type StatsQueryParams = StatsProxyParams & {
+type StatsQueryParamFields = {
 	period?: StatsPeriod | string;
 	date?: string;
 	start_date?: string;
@@ -16,32 +17,34 @@ export type StatsQueryParams = StatsProxyParams & {
 	summarize?: number | boolean;
 };
 
+export type StatsQueryParams = StatsProxyParams & StatsQueryParamFields;
+
 type StatsQueryParamInput = Partial< ReportParams > & {
-	period?: StatsPeriod | string;
-	date?: string;
-	start_date?: string;
-	days?: number;
-	num?: number;
-	max?: number;
-	summarize?: number | boolean;
 	[ key: string ]: unknown;
-};
+} & Partial< StatsQueryParamFields >;
+
+type ReportOnlyParam = keyof ReportParams | 'geoMode' | 'utmParams' | 'deviceProperty';
+
+const reportOnlyKeys: ReportOnlyParam[] = [
+	'from',
+	'to',
+	'interval',
+	'preset',
+	'compare_from',
+	'compare_to',
+	'compare_preset',
+	'comp',
+	'filters',
+	'section',
+	'date_type',
+	'view',
+	'geoMode',
+	'utmParams',
+	'deviceProperty',
+];
 
 function datePart( value?: string ) {
 	return value?.split( 'T' )[ 0 ];
-}
-
-function daysBetweenInclusive( from: string, to: string ) {
-	const fromDate = new Date( `${ from }T00:00:00Z` );
-	const toDate = new Date( `${ to }T00:00:00Z` );
-	const diff = toDate.getTime() - fromDate.getTime();
-
-	if ( Number.isNaN( diff ) || diff < 0 ) {
-		// Keep the Stats API request bounded even when callers pass an invalid range.
-		return 1;
-	}
-
-	return Math.floor( diff / 86400000 ) + 1;
 }
 
 export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
@@ -65,23 +68,6 @@ export function reportParamsToStatsQueryParams(
 	params: StatsQueryParamInput = {}
 ): StatsQueryParams {
 	const statsParams = { ...params };
-	const reportOnlyKeys = [
-		'from',
-		'to',
-		'interval',
-		'preset',
-		'compare_from',
-		'compare_to',
-		'compare_preset',
-		'comp',
-		'filters',
-		'section',
-		'date_type',
-		'view',
-		'geoMode',
-		'utmParams',
-		'deviceProperty',
-	] as const;
 
 	reportOnlyKeys.forEach( key => {
 		delete statsParams[ key ];
@@ -93,7 +79,7 @@ export function reportParamsToStatsQueryParams(
 	const date = params.date ?? to;
 	const startDate = params.start_date ?? from;
 	const days =
-		params.days ?? ( startDate && date ? daysBetweenInclusive( startDate, date ) : undefined );
+		params.days ?? ( startDate && date ? getDaysBetweenInclusive( startDate, date ) : undefined );
 
 	return {
 		...( statsParams as StatsQueryParams ),

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -89,28 +89,3 @@ export function reportParamsToStatsQueryParams(
 		...( days ? { days } : {} ),
 	};
 }
-
-function normalizeQueryKeyValue( value: unknown ): unknown {
-	if ( Array.isArray( value ) ) {
-		return value.map( normalizeQueryKeyValue );
-	}
-
-	if ( value && typeof value === 'object' ) {
-		return Object.fromEntries(
-			Object.entries( value )
-				.filter( ( [ , item ] ) => item !== undefined && item !== null )
-				.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
-				.map( ( [ key, item ] ) => [ key, normalizeQueryKeyValue( item ) ] )
-		);
-	}
-
-	return value;
-}
-
-export function statsQueryKeyPart( params?: unknown ) {
-	if ( params === undefined || params === null ) {
-		return '';
-	}
-
-	return JSON.stringify( normalizeQueryKeyValue( params ) );
-}


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add the Premium Analytics data package foundation for Jetpack Stats proxy requests.
* Add `fetchStatsProxy()` and `getStatsProxyPath()` for the `/jetpack-premium-analytics/v1/proxy/v*/...` route.
* Add Stats query-param helpers that convert report dates/intervals into Stats-compatible params and stable React Query key parts.
* Update `useReport()` so future Stats report hooks can forward endpoint-specific params without dropping them.
* Export the proxy and Stats param utilities from the data package.

### What changed and why
* This is part 1 of the split from #49773.
* The frontend data layer needs a small shared foundation before endpoint-specific hooks can be added.
* Keeping this PR limited to proxy/param plumbing makes the later hook and normalizer PRs smaller and easier to review.

### PR split and merge plan
This stack breaks the Jetpack Stats data-layer work into reviewable chunks. Each PR is based on the previous branch so reviewers can inspect only the logical delta for that layer.

Merge plan:
* Review the stack from #49775 upward, but land it from the bottom of the dependency graph upward.
* Merge #49775 into `trunk` first.
* After each lower PR lands, rebase the next branch onto `trunk`, retarget that PR to `trunk`, rerun checks, and merge it.
* Repeat until #49782 is merged. If any lower PR changes during review, rebase the dependent PRs on top of the updated branch before continuing.

Breakdown:
* #49775: Shared proxy foundation, Stats path helpers, query-param conversion, and `useReport()` plumbing for endpoint-specific params.
* #49776: Core traffic/report normalizers for the first Stats endpoint group, with fixture-backed coverage.
* #49777: Query factories for the core Stats report endpoints.
* #49778: Public hook exports for the core Stats report widgets.
* #49779: Shared time-series normalization so Stats series use the same normalized keys as Premium Analytics consumers.
* #49780: Secondary report normalizers for the remaining non-time-series Stats payload shapes.
* #49781: Remaining report hooks for the rest of the Stats widgets.
* #49782: Stats app/admin hooks for settings-like resources, kept separate from report hooks.

Dependency graph: each arrow points from a PR to the branch/PR it is based on.

```mermaid
graph TD
    PR49782["#49782 Stats app hooks<br/>head: split/stats-app-hooks"] --> PR49781["#49781 Remaining Stats hooks<br/>base: split/stats-secondary-normalizers"]
    PR49781 --> PR49780["#49780 Secondary Stats normalizers<br/>base: split/stats-time-series-normalizers"]
    PR49780 --> PR49779["#49779 Stats time-series normalizers<br/>base: split/stats-core-hooks"]
    PR49779 --> PR49778["#49778 Stats traffic hooks<br/>base: split/stats-core-queries"]
    PR49778 --> PR49777["#49777 Stats traffic queries<br/>base: split/stats-core-normalizers"]
    PR49777 --> PR49776["#49776 Stats traffic normalizers<br/>base: split/stats-proxy-foundation"]
    PR49776 --> PR49775["#49775 Stats proxy foundation<br/>base: trunk"]
    PR49775 --> TRUNK["trunk"]
```

* #49775
* #49776
* #49777
* #49778
* #49779
* #49780
* #49781
* #49782

## Related product discussion/links
* Part of WOOA7S-1571.
* Linear: https://linear.app/a8c/issue/WOOA7S-1571/premium-analytics-add-stats-proxy-data-hooks.
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Supports the proxied endpoints added in #49571.
* Split from #49773.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No. This adds client-side fetch/param utilities only and does not introduce new tracking.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `pnpm --dir projects/packages/premium-analytics test`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
* Confirm the new `stats-proxy-fetch` and `stats-params` tests pass.
