### PR TITLE
Premium Analytics: add Stats traffic hooks

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-core-hooks
+++ b/projects/packages/premium-analytics/changelog/add-stats-core-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add core traffic report hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import * as dataPackage from '../../index';
+
+describe( 'Stats public hook names', () => {
+	it( 'exports discoverable family-prefixed traffic hooks', () => {
+		expect( dataPackage ).toHaveProperty( 'useStatsSite' );
+		expect( dataPackage ).toHaveProperty( 'useStatsTopPosts' );
+		expect( dataPackage ).toHaveProperty( 'useStatsReferrers' );
+		expect( dataPackage ).toHaveProperty( 'useStatsClicks' );
+		expect( dataPackage ).toHaveProperty( 'useStatsSearchTerms' );
+		expect( dataPackage ).toHaveProperty( 'useStatsFileDownloads' );
+		expect( dataPackage ).toHaveProperty( 'useStatsTopAuthors' );
+		expect( dataPackage ).toHaveProperty( 'useStatsLocations' );
+		expect( dataPackage ).toHaveProperty( 'useStatsCountryViews' );
+		expect( dataPackage ).toHaveProperty( 'useStatsVideoPlays' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -3,17 +3,24 @@
  */
 import * as dataPackage from '../../index';
 
+const statsHookNames = [
+	'useStatsSite',
+	'useStatsTopPosts',
+	'useStatsReferrers',
+	'useStatsClicks',
+	'useStatsSearchTerms',
+	'useStatsFileDownloads',
+	'useStatsTopAuthors',
+	'useStatsLocations',
+	'useStatsCountryViews',
+	'useStatsVideoPlays',
+] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
+
 describe( 'Stats public hook names', () => {
-	it( 'exports discoverable family-prefixed traffic hooks', () => {
-		expect( dataPackage ).toHaveProperty( 'useStatsSite' );
-		expect( dataPackage ).toHaveProperty( 'useStatsTopPosts' );
-		expect( dataPackage ).toHaveProperty( 'useStatsReferrers' );
-		expect( dataPackage ).toHaveProperty( 'useStatsClicks' );
-		expect( dataPackage ).toHaveProperty( 'useStatsSearchTerms' );
-		expect( dataPackage ).toHaveProperty( 'useStatsFileDownloads' );
-		expect( dataPackage ).toHaveProperty( 'useStatsTopAuthors' );
-		expect( dataPackage ).toHaveProperty( 'useStatsLocations' );
-		expect( dataPackage ).toHaveProperty( 'useStatsCountryViews' );
-		expect( dataPackage ).toHaveProperty( 'useStatsVideoPlays' );
-	} );
+	it.each( statsHookNames )(
+		'exports %s as a discoverable family-prefixed traffic hook',
+		hookName => {
+			expect( dataPackage[ hookName ] ).toEqual( expect.any( Function ) );
+		}
+	);
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -5,6 +5,17 @@ export { useReportCouponsByDate } from './use-report-coupons-by-date';
 export { useReportCustomers } from './use-report-customers';
 export { useReportConversionRate } from './use-report-conversion-rate';
 export { useReportBookings } from './use-report-bookings';
+export { useStatsSite } from './use-stats-site';
+export { useStatsTopPosts } from './use-stats-top-posts';
+export { useStatsReferrers } from './use-stats-referrers';
+export { useStatsClicks } from './use-stats-clicks';
+export { useStatsSearchTerms } from './use-stats-search-terms';
+export { useStatsFileDownloads } from './use-stats-file-downloads';
+export { useStatsTopAuthors } from './use-stats-top-authors';
+export { useStatsLocations } from './use-stats-locations';
+export { useStatsCountryViews } from './use-stats-country-views';
+export { useStatsVideoPlays } from './use-stats-video-plays';
+export type { UseStatsOptions } from './use-stats-report';
 
 /**
  * @deprecated Use individual hooks instead: useReportOrders, useReportOrderAttribution, useReportCoupons

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsClicksQuery } from '../queries/stats-clicks-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsClicks( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsClicksQuery,
-		params,
-		[ 'stats', 'clicks', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsClicksQuery, params, 'clicks', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsClicksQuery } from '../queries/stats-clicks-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsClicks( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsClicksQuery,
+		params,
+		[ 'stats', 'clicks', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsCountryViewsQuery } from '../queries/stats-country-views-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsCountryViews( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsCountryViewsQuery,
+		params,
+		[ 'stats', 'country-views', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsCountryViewsQuery } from '../queries/stats-country-views-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsCountryViews( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsCountryViewsQuery,
-		params,
-		[ 'stats', 'country-views', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsCountryViewsQuery, params, 'country-views', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsFileDownloadsQuery } from '../queries/stats-file-downloads-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsFileDownloads( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsFileDownloadsQuery,
-		params,
-		[ 'stats', 'file-downloads', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsFileDownloadsQuery, params, 'file-downloads', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsFileDownloadsQuery } from '../queries/stats-file-downloads-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsFileDownloads( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsFileDownloadsQuery,
+		params,
+		[ 'stats', 'file-downloads', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsLocationsQuery } from '../queries/stats-locations-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
@@ -10,10 +10,5 @@ export function useStatsLocations(
 	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
 	options?: UseStatsOptions
 ) {
-	return useStatsReport(
-		statsLocationsQuery,
-		params,
-		[ 'stats', 'locations', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsLocationsQuery, params, 'locations', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsLocationsQuery } from '../queries/stats-locations-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsLocations(
+	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
+	options?: UseStatsOptions
+) {
+	return useStatsReport(
+		statsLocationsQuery,
+		params,
+		[ 'stats', 'locations', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsReferrersQuery } from '../queries/stats-referrers-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsReferrers( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsReferrersQuery,
+		params,
+		[ 'stats', 'referrers', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsReferrersQuery } from '../queries/stats-referrers-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsReferrers( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsReferrersQuery,
-		params,
-		[ 'stats', 'referrers', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsReferrersQuery, params, 'referrers', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { useReport } from './use-report';
+import type { statsTopPostsQuery } from '../queries/stats-top-posts-query';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export type UseStatsOptions = {
+	enabled?: boolean;
+};
+
+type StatsReportQueryFactory = (
+	params: StatsReportParams
+) => ReturnType< typeof statsTopPostsQuery >;
+
+export function useStatsReport(
+	queryFactory: StatsReportQueryFactory,
+	params: StatsReportParams,
+	disabledComparisonKey: string[],
+	options?: UseStatsOptions
+) {
+	return useReport( p => queryFactory( p as StatsReportParams ), params, {
+		enabled: options?.enabled,
+		disabledComparisonKey,
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -2,25 +2,22 @@
  * Internal dependencies
  */
 import { useReport } from './use-report';
-import type { statsTopPostsQuery } from '../queries/stats-top-posts-query';
-import type { StatsReportParams } from '../queries/stats-query';
+import type { StatsReportParams, StatsReportQueryOptions } from '../queries/stats-query';
 
 export type UseStatsOptions = {
 	enabled?: boolean;
 };
 
-type StatsReportQueryFactory = (
-	params: StatsReportParams
-) => ReturnType< typeof statsTopPostsQuery >;
+type StatsReportQueryFactory = ( params: StatsReportParams ) => StatsReportQueryOptions;
 
 export function useStatsReport(
 	queryFactory: StatsReportQueryFactory,
 	params: StatsReportParams,
-	disabledComparisonKey: string[],
+	reportSlug: string,
 	options?: UseStatsOptions
 ) {
 	return useReport( p => queryFactory( p as StatsReportParams ), params, {
 		enabled: options?.enabled,
-		disabledComparisonKey,
+		disabledComparisonKey: [ 'stats', reportSlug, '__comparison__', 'disabled' ],
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsSearchTermsQuery } from '../queries/stats-search-terms-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsSearchTerms( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsSearchTermsQuery,
-		params,
-		[ 'stats', 'search-terms', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsSearchTermsQuery, params, 'search-terms', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsSearchTermsQuery } from '../queries/stats-search-terms-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsSearchTerms( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsSearchTermsQuery,
+		params,
+		[ 'stats', 'search-terms', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-site.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-site.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { useQuery } from '@tanstack/react-query';
+/**
+ * Internal dependencies
+ */
+import { statsSiteQuery } from '../queries/stats-site-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSite( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useQuery( { ...statsSiteQuery( params ), enabled: options?.enabled ?? true } );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsTopAuthorsQuery } from '../queries/stats-top-authors-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsTopAuthors( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsTopAuthorsQuery,
-		params,
-		[ 'stats', 'top-authors', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsTopAuthorsQuery, params, 'top-authors', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsTopAuthorsQuery } from '../queries/stats-top-authors-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsTopAuthors( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTopAuthorsQuery,
+		params,
+		[ 'stats', 'top-authors', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsTopPostsQuery } from '../queries/stats-top-posts-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsTopPosts( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsTopPostsQuery,
-		params,
-		[ 'stats', 'top-posts', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsTopPostsQuery, params, 'top-posts', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsTopPostsQuery } from '../queries/stats-top-posts-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsTopPosts( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTopPostsQuery,
+		params,
+		[ 'stats', 'top-posts', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsReport } from './use-stats-report';
+import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsVideoPlays( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsVideoPlaysQuery,
+		params,
+		[ 'stats', 'video-plays', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -1,16 +1,11 @@
 /**
  * Internal dependencies
  */
-import { useStatsReport } from './use-stats-report';
 import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsVideoPlays( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsVideoPlaysQuery,
-		params,
-		[ 'stats', 'video-plays', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsVideoPlaysQuery, params, 'video-plays', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -14,6 +14,17 @@ export { useReportVisitors } from './hooks/use-report-visitors';
 export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-location';
 export { useReportBookings } from './hooks/use-report-bookings';
 export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
+export { useStatsSite } from './hooks/use-stats-site';
+export { useStatsTopPosts } from './hooks/use-stats-top-posts';
+export { useStatsReferrers } from './hooks/use-stats-referrers';
+export { useStatsClicks } from './hooks/use-stats-clicks';
+export { useStatsSearchTerms } from './hooks/use-stats-search-terms';
+export { useStatsFileDownloads } from './hooks/use-stats-file-downloads';
+export { useStatsTopAuthors } from './hooks/use-stats-top-authors';
+export { useStatsLocations } from './hooks/use-stats-locations';
+export { useStatsCountryViews } from './hooks/use-stats-country-views';
+export { useStatsVideoPlays } from './hooks/use-stats-video-plays';
+export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
 	normalizeReportParams,
@@ -62,6 +73,7 @@ export type {
 	StatsTopPostsItem,
 	StatsVideoPlaysItem,
 } from './processing/stats';
+export type { StatsReportParams } from './queries/stats-query';
 export {
 	getStatsPeriodFromInterval,
 	reportParamsToStatsQueryParams,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -37,6 +37,7 @@ const statsSanitizers = {
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;
 type StatsSanitizerData = ReturnType< ( typeof statsSanitizers )[ StatsSanitizerKey ] >;
+export type StatsReportQueryOptions = UseQueryOptions< StatsSanitizerData >;
 
 export type StatsQueryConfig = {
 	name: string;
@@ -49,7 +50,7 @@ export type StatsQueryConfig = {
 	enabled?: boolean;
 };
 
-export function statsProxyQuery( config: StatsQueryConfig ): UseQueryOptions< StatsSanitizerData > {
+export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions {
 	const { name, version, endpoint, params, method = 'GET', body, enabled = true } = config;
 	const sanitizer = config.sanitizer ?? 'passthrough';
 	const apiParams = statsQueryParamsToApiParams( params );
@@ -77,7 +78,7 @@ export function statsReportQuery(
 	params: StatsReportParams,
 	sanitizer: StatsSanitizerKey,
 	version: StatsProxyVersion = '1.1'
-): UseQueryOptions< StatsSanitizerData > {
+): StatsReportQueryOptions {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const reportParams = {
 		...statsParams,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add split `useStats*` hooks for the core traffic endpoints introduced by #49777.
* Keep comparison handling in the shared `useStatsReport` helper while leaving each endpoint hook in its own file.
* Export the new hooks from the hooks package surface and the package root, with an export-shape test for discoverability.

## Related product discussion/links
* Stacked on #49777.
* Stack continues in #49779.

## Does this pull request change what data or activity we track or use?
No. This exposes React Query hooks for existing Stats query factories.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
* Browser verification for the stack: dashboard and detail-page requests were inspected in a logged-in browser; summarized traffic endpoints continue to use `summarize=1`, while replayed raw requests without `summarize=1` return the expected `date`, `period`, and `days` bucket shapes.
