### PR TITLE
Premium Analytics: normalize Stats time-series reports

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-time-series-normalizers
+++ b/projects/packages/premium-analytics/changelog/add-stats-time-series-normalizers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add time-series response normalizers.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
@@ -1,0 +1,58 @@
+export const emailCountriesFixture = {
+	countries: {
+		fields: [ 'country_code', 'opens_count' ],
+		data: [ [ 'NZ', '12' ] ],
+	},
+	'countries-info': {
+		NZ: {
+			country_full: 'New Zealand',
+		},
+	},
+};
+
+export const emailFieldlessCountriesFixture = {
+	countries: {
+		data: [
+			[ 'US', '18' ],
+			[ 'NZ', '12' ],
+			[ 'XX', '2' ],
+		],
+	},
+	'countries-info': {
+		NZ: {
+			country_full: 'New Zealand',
+			map_region: '009',
+		},
+		US: {
+			country_full: 'United States',
+			map_region: '019',
+		},
+	},
+};
+
+export const emailFieldlessClientsFixture = {
+	clients: {
+		data: [
+			[ 'Other', '1' ],
+			[ 'Apple Mail', '10' ],
+			[ 'Gmail', '8' ],
+		],
+	},
+};
+
+export const emailFieldlessLinksFixture = {
+	links: {
+		data: [
+			[ 'post-url', '7' ],
+			[ 'custom-action', '3' ],
+			[ 'user_link', '2' ],
+			[ 'like-post', '1' ],
+		],
+	},
+	'user-content-links': {
+		data: [
+			[ 'https://example.com/a', '4' ],
+			[ 'https://example.com/b', '2' ],
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-summary.ts
@@ -1,0 +1,18 @@
+export const emailSummaryFixture = {
+	posts: [
+		{
+			id: 71,
+			title: 'Newsletter',
+			href: 'https://example.com/newsletter/',
+			type: 'post',
+			date: '2026-06-16',
+			total_sends: '100',
+			opens: '30',
+			clicks: '4',
+			opens_rate: '30',
+			clicks_rate: '4',
+			unique_opens: '24',
+			unique_clicks: '3',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
@@ -1,0 +1,55 @@
+export const visitsFixture = {
+	fields: [ 'period', 'views', 'visitors', 'likes', 'comments' ],
+	data: [
+		[ '2026-06-15', '8', '3', 1, 0 ],
+		[ '2026-06-16', '13', '5', 2, 1 ],
+	],
+};
+
+export const objectRowsTimeSeriesFixture = {
+	unit: 'day',
+	data: [
+		{
+			period: '2026-06-15',
+			subscribers: '7',
+			unsubscribers: '2',
+		},
+	],
+};
+
+export const weeklySubscribersFixture = {
+	unit: 'week',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2026-W25', '9' ] ],
+};
+
+export const invalidWeekSubscribersFixture = {
+	unit: 'week',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2026-W54', '9' ] ],
+};
+
+export const invalidIsoWeekYearSubscribersFixture = {
+	unit: 'week',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2025-W53', '9' ] ],
+};
+
+export const monthlySubscribersFixture = {
+	unit: 'month',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2024-02', '29' ] ],
+};
+
+export const yearlySubscribersFixture = {
+	unit: 'year',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2024', '366' ] ],
+};
+
+export const scalarDaysTimeSeriesFixture = {
+	days: {
+		'2026-06-15': '7',
+		'2026-06-16': 3,
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
@@ -1,0 +1,92 @@
+import { sanitizeStatsEmailBreakdownResponse } from '..';
+import {
+	emailCountriesFixture,
+	emailFieldlessClientsFixture,
+	emailFieldlessCountriesFixture,
+	emailFieldlessLinksFixture,
+} from '../__fixtures__/email-breakdown';
+
+describe( 'Stats email breakdown normalizer', () => {
+	it( 'normalizes email breakdown matrices', () => {
+		expect(
+			sanitizeStatsEmailBreakdownResponse( emailCountriesFixture, {
+				period: 'day',
+				date: '2026-06-16',
+			} ).data[ 0 ].items[ 0 ]
+		).toEqual(
+			expect.objectContaining( {
+				label: 'New Zealand',
+				value: 12,
+				countryCode: 'NZ',
+				countryFull: 'New Zealand',
+			} )
+		);
+	} );
+
+	it( 'returns summary-only data when no matrix metric is present', () => {
+		expect(
+			sanitizeStatsEmailBreakdownResponse( {
+				total_opens: '12',
+				countries: { data: [] },
+				'countries-info': { NZ: { country_full: 'New Zealand' } },
+			} )
+		).toEqual( {
+			summary: {
+				total_opens: 12,
+			},
+			data: [],
+		} );
+	} );
+
+	it( 'normalizes fieldless email country breakdowns', () => {
+		const result = sanitizeStatsEmailBreakdownResponse( emailFieldlessCountriesFixture );
+
+		expect( result.summary ).toEqual( { value: 32 } );
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'United States',
+				value: 18,
+				countryCode: 'US',
+				countryFull: 'United States',
+				region: '019',
+			} ),
+			expect.objectContaining( {
+				label: 'New Zealand',
+				value: 12,
+				countryCode: 'NZ',
+				countryFull: 'New Zealand',
+				region: '009',
+			} ),
+			expect.objectContaining( {
+				label: 'Unknown',
+				value: 2,
+			} ),
+		] );
+	} );
+
+	it( 'normalizes fieldless email clients and keeps Other last', () => {
+		expect(
+			sanitizeStatsEmailBreakdownResponse( emailFieldlessClientsFixture ).data[ 0 ].items
+		).toEqual( [
+			expect.objectContaining( { label: 'Apple Mail', value: 10 } ),
+			expect.objectContaining( { label: 'Gmail', value: 8 } ),
+			expect.objectContaining( { label: 'Other', value: 1 } ),
+		] );
+	} );
+
+	it( 'normalizes fieldless email link breakdowns', () => {
+		expect(
+			sanitizeStatsEmailBreakdownResponse( emailFieldlessLinksFixture ).data[ 0 ].items
+		).toEqual( [
+			expect.objectContaining( { label: 'Post URL', value: 7 } ),
+			expect.objectContaining( {
+				label: 'https://example.com/a',
+				link: 'https://example.com/a',
+				value: 4,
+			} ),
+			expect.objectContaining( { label: 'https://example.com/b', value: 2 } ),
+			expect.objectContaining( { label: 'Like', value: 1 } ),
+			expect.objectContaining( { label: 'Other', value: 3 } ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
@@ -1,0 +1,52 @@
+import { sanitizeStatsEmailSummaryResponse } from '..';
+import { emailSummaryFixture } from '../__fixtures__/email-summary';
+
+describe( 'Stats email summary normalizer', () => {
+	it( 'normalizes email summary metrics', () => {
+		expect(
+			sanitizeStatsEmailSummaryResponse( emailSummaryFixture, {
+				period: 'day',
+				date: '2026-06-16',
+			} )
+		).toEqual(
+			expect.objectContaining( {
+				summary: expect.objectContaining( {
+					total_sends: 100,
+					opens: 30,
+					clicks: 4,
+				} ),
+				data: [
+					expect.objectContaining( {
+						time_interval: '2026-06-16',
+						items: [
+							expect.objectContaining( {
+								id: 71,
+								label: 'Newsletter',
+								value: 4,
+								link: 'https://example.com/newsletter/',
+								actions: [ { type: 'link', data: 'https://example.com/newsletter/' } ],
+								unique_opens: 24,
+								unique_clicks: 3,
+							} ),
+						],
+					} ),
+				],
+			} )
+		);
+	} );
+
+	it( 'returns empty data for empty email summaries', () => {
+		expect(
+			sanitizeStatsEmailSummaryResponse( {}, { period: 'day', date: '2026-06-16' } )
+		).toEqual( {
+			summary: {
+				total_sends: 0,
+				opens: 0,
+				clicks: 0,
+				unique_opens: 0,
+				unique_clicks: 0,
+			},
+			data: [],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -1,0 +1,142 @@
+import { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from '..';
+import {
+	invalidIsoWeekYearSubscribersFixture,
+	invalidWeekSubscribersFixture,
+	monthlySubscribersFixture,
+	objectRowsTimeSeriesFixture,
+	scalarDaysTimeSeriesFixture,
+	visitsFixture,
+	weeklySubscribersFixture,
+	yearlySubscribersFixture,
+} from '../__fixtures__/time-series';
+
+describe( 'Stats time-series normalizer', () => {
+	it( 'normalizes visits rows with Premium Analytics date keys', () => {
+		const result = sanitizeStatsTimeSeriesResponse( visitsFixture, { period: 'day' } );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				views: 21,
+				visitors: 8,
+				date_start: '2026-06-15T00:00:00+00:00',
+				date_end: '2026-06-16T23:59:59+00:00',
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				date_start: '2026-06-15T00:00:00+00:00',
+				date_end: '2026-06-15T23:59:59+00:00',
+				label: '2026-06-15',
+				value: 8,
+				views: 8,
+				visitors: 3,
+				items: [],
+			} )
+		);
+	} );
+
+	it( 'normalizes object rows from top-level data arrays', () => {
+		const result = sanitizeStatsTimeSeriesResponse( objectRowsTimeSeriesFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				subscribers: 7,
+				unsubscribers: 2,
+			} )
+		);
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				value: 7,
+				subscribers: 7,
+				unsubscribers: 2,
+			} )
+		);
+	} );
+
+	it( 'normalizes ISO week rows with date ranges', () => {
+		expect( sanitizeStatsTimeSeriesResponse( weeklySubscribersFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				date_start: '2026-06-15T00:00:00+00:00',
+				date_end: '2026-06-21T23:59:59+00:00',
+				value: 9,
+				subscribers: 9,
+			} )
+		);
+	} );
+
+	it( 'falls back to raw period strings for invalid ISO weeks', () => {
+		expect( sanitizeStatsTimeSeriesResponse( invalidWeekSubscribersFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-W54',
+				date_start: '2026-W54T00:00:00+00:00',
+				date_end: '2026-W54T23:59:59+00:00',
+				value: 9,
+				subscribers: 9,
+			} )
+		);
+		expect(
+			sanitizeStatsTimeSeriesResponse( invalidIsoWeekYearSubscribersFixture ).data[ 0 ]
+		).toEqual(
+			expect.objectContaining( {
+				time_interval: '2025-W53',
+				date_start: '2025-W53T00:00:00+00:00',
+				date_end: '2025-W53T23:59:59+00:00',
+				value: 9,
+				subscribers: 9,
+			} )
+		);
+	} );
+
+	it( 'normalizes month and year rows with date-fns boundaries', () => {
+		expect( sanitizeStatsTimeSeriesResponse( monthlySubscribersFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2024-02-01',
+				date_start: '2024-02-01T00:00:00+00:00',
+				date_end: '2024-02-29T23:59:59+00:00',
+				value: 29,
+				subscribers: 29,
+			} )
+		);
+		expect( sanitizeStatsTimeSeriesResponse( yearlySubscribersFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2024-01-01',
+				date_start: '2024-01-01T00:00:00+00:00',
+				date_end: '2024-12-31T23:59:59+00:00',
+				value: 366,
+				subscribers: 366,
+			} )
+		);
+	} );
+
+	it( 'normalizes scalar days maps into numeric value rows', () => {
+		const result = sanitizeStatsTimeSeriesResponse( scalarDaysTimeSeriesFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				value: 10,
+			} )
+		);
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				value: 7,
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				value: 3,
+			} ),
+		] );
+	} );
+
+	it( 'detects supported time-series payload shapes', () => {
+		expect( isStatsTimeSeriesPayload( visitsFixture ) ).toBe( true );
+		expect( isStatsTimeSeriesPayload( scalarDaysTimeSeriesFixture ) ).toBe( true );
+		expect( isStatsTimeSeriesPayload( objectRowsTimeSeriesFixture ) ).toBe( true );
+		expect( isStatsTimeSeriesPayload( { data: [ { title: 'Not a time series' } ] } ) ).toBe(
+			false
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/visits.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/visits.test.ts
@@ -1,0 +1,14 @@
+import { sanitizeStatsVisitsResponse } from '..';
+import { visitsFixture } from '../__fixtures__/time-series';
+
+describe( 'Stats visits normalizer', () => {
+	it( 'normalizes visits through the time-series processor', () => {
+		expect( sanitizeStatsVisitsResponse( visitsFixture, { period: 'day' } ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15',
+				views: 8,
+				visitors: 3,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
@@ -1,0 +1,223 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsEmailBreakdownItem extends StatsNormalizedItemBase< null > {
+	value: number;
+	countryCode?: string;
+	countryFull?: unknown;
+	link?: string;
+	[ key: string ]: unknown;
+}
+
+const emailLinkLabels: Record< string, string > = {
+	'post-url': 'Post URL',
+	'like-post': 'Like',
+	'comment-post': 'Comment',
+	'remove-subscription': 'Unsubscribe',
+};
+
+function isEmailBreakdownSummaryValue( value: unknown ): boolean {
+	return (
+		typeof value === 'number' ||
+		( typeof value === 'string' && value.trim() !== '' && ! Number.isNaN( Number( value ) ) )
+	);
+}
+
+function normalizeEmailBreakdownScalarSummary( response: StatsRecord ) {
+	return Object.fromEntries(
+		Object.entries( response )
+			.filter( ( [ , value ] ) => isEmailBreakdownSummaryValue( value ) )
+			.map( ( [ key, value ] ) => [ key, safeParseFloat( value ) ] )
+	);
+}
+
+function sortEmailBreakdownItems( items: StatsEmailBreakdownItem[] ): StatsEmailBreakdownItem[] {
+	return [ ...items ].sort( ( a, b ) => {
+		if ( a.label === 'Other' ) {
+			return 1;
+		}
+
+		if ( b.label === 'Other' ) {
+			return -1;
+		}
+
+		return b.value - a.value;
+	} );
+}
+
+function parseFieldlessEmailCountryRows( response: StatsRecord ): StatsEmailBreakdownItem[] {
+	const countries = coerceStatsArray< unknown[] >( coerceStatsRecord( response.countries ).data );
+	const countryInfo = coerceStatsRecord( response[ 'countries-info' ] );
+
+	return sortEmailBreakdownItems(
+		countries.map( row => {
+			const countryCode = String( row[ 0 ] ?? '' );
+			const country = coerceStatsRecord( countryInfo[ countryCode ] );
+			const countryFull = country.country_full;
+
+			return {
+				label: countryFull ?? 'Unknown',
+				value: safeParseFloat( row[ 1 ] ),
+				countryCode: countryFull ? countryCode : undefined,
+				countryFull,
+				region: country.map_region,
+				children: null,
+			};
+		} )
+	);
+}
+
+function parseFieldlessEmailListRows(
+	response: StatsRecord,
+	key: 'clients' | 'devices'
+): StatsEmailBreakdownItem[] {
+	const rows = coerceStatsArray< unknown[] >( coerceStatsRecord( response[ key ] ).data );
+
+	return sortEmailBreakdownItems(
+		rows.map( row => ( {
+			label: row[ 0 ],
+			value: safeParseFloat( row[ 1 ] ),
+			children: null,
+		} ) )
+	);
+}
+
+function parseFieldlessEmailLinkRows( response: StatsRecord ): StatsEmailBreakdownItem[] {
+	const internalLinks = coerceStatsArray< unknown[] >( coerceStatsRecord( response.links ).data );
+	const userContentLinks = coerceStatsArray< unknown[] >(
+		coerceStatsRecord( response[ 'user-content-links' ] ).data
+	);
+	const items: StatsEmailBreakdownItem[] = internalLinks
+		.filter( row => typeof row[ 0 ] === 'string' && emailLinkLabels[ row[ 0 ] ] )
+		.map( row => ( {
+			label: emailLinkLabels[ String( row[ 0 ] ) ],
+			value: safeParseFloat( row[ 1 ] ),
+			children: null,
+		} ) );
+	const otherInternalLinks = internalLinks.reduce( ( total, row ) => {
+		const linkType = String( row[ 0 ] ?? '' );
+
+		return emailLinkLabels[ linkType ] || linkType === 'user_link'
+			? total
+			: total + safeParseFloat( row[ 1 ] );
+	}, 0 );
+
+	if ( otherInternalLinks ) {
+		items.push( {
+			label: 'Other',
+			value: otherInternalLinks,
+			children: null,
+		} );
+	}
+
+	userContentLinks.forEach( row => {
+		const link = typeof row[ 0 ] === 'string' ? row[ 0 ] : undefined;
+
+		items.push( {
+			label: link ?? '',
+			link,
+			value: safeParseFloat( row[ 1 ] ),
+			children: null,
+		} );
+	} );
+
+	return sortEmailBreakdownItems( items );
+}
+
+function parseFieldlessEmailBreakdownRows( response: StatsRecord ): StatsEmailBreakdownItem[] {
+	if ( coerceStatsArray( coerceStatsRecord( response.countries ).data ).length ) {
+		return parseFieldlessEmailCountryRows( response );
+	}
+
+	if ( coerceStatsArray( coerceStatsRecord( response.devices ).data ).length ) {
+		return parseFieldlessEmailListRows( response, 'devices' );
+	}
+
+	if ( coerceStatsArray( coerceStatsRecord( response.clients ).data ).length ) {
+		return parseFieldlessEmailListRows( response, 'clients' );
+	}
+
+	if (
+		coerceStatsArray( coerceStatsRecord( response.links ).data ).length ||
+		coerceStatsArray( coerceStatsRecord( response[ 'user-content-links' ] ).data ).length
+	) {
+		return parseFieldlessEmailLinkRows( response );
+	}
+
+	return [];
+}
+
+function parseStatsEmailBreakdownRows( response: unknown ): {
+	items: StatsEmailBreakdownItem[];
+	metricKey?: string;
+} {
+	const payload = coerceStatsRecord( response );
+	const matrixKey = [ 'clients', 'devices', 'countries', 'links', 'user-content-links' ].find(
+		key => coerceStatsArray( coerceStatsRecord( payload[ key ] ).fields ).length
+	);
+
+	if ( ! matrixKey ) {
+		const items = parseFieldlessEmailBreakdownRows( payload );
+
+		return { items, metricKey: items.length ? 'value' : undefined };
+	}
+
+	const matrix = coerceStatsRecord( payload[ matrixKey ] );
+	const fields = coerceStatsArray< string >( matrix.fields );
+	const labelKey = fields[ 0 ] ?? 'label';
+	const metricKey = fields.find( field => field.endsWith( '_count' ) ) ?? fields[ 1 ] ?? 'value';
+	const countryInfo = coerceStatsRecord( payload[ 'countries-info' ] );
+	const items = coerceStatsArray< unknown[] >( matrix.data ).map( record => {
+		const parsed: StatsRecord = {};
+		record.forEach( ( value, index ) => {
+			const field = fields[ index ];
+
+			if ( field ) {
+				parsed[ field ] =
+					field === labelKey || ! ( typeof value === 'number' || typeof value === 'string' )
+						? value
+						: safeParseFloat( value );
+			}
+		} );
+
+		const country = coerceStatsRecord( countryInfo[ String( parsed[ labelKey ] ) ] );
+		// Matrix link payloads keep their API labels; fieldless all-time link payloads map known
+		// link types to display labels to match the legacy email stats parser.
+		const label =
+			matrixKey === 'countries' ? country.country_full ?? parsed[ labelKey ] : parsed[ labelKey ];
+
+		return {
+			...parsed,
+			label,
+			value: safeParseFloat( parsed[ metricKey ] ),
+			countryCode: matrixKey === 'countries' ? String( parsed[ labelKey ] ) : undefined,
+			countryFull: country.country_full,
+			children: null,
+		};
+	} );
+
+	return { items, metricKey };
+}
+
+export function sanitizeStatsEmailBreakdownResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsEmailBreakdownItem > {
+	const { items, metricKey } = parseStatsEmailBreakdownRows( response );
+
+	if ( ! items.length || ! metricKey ) {
+		return {
+			summary: normalizeEmailBreakdownScalarSummary( coerceStatsRecord( response ) ),
+			data: [],
+		};
+	}
+
+	return {
+		summary: {
+			[ metricKey ]: items.reduce( ( total, item ) => total + item.value, 0 ),
+		},
+		data: [ createStatsListDataPoint( response, query, items ) ],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
@@ -1,0 +1,67 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import type {
+	StatsItemAction,
+	StatsNormalizedItemBase,
+	StatsNormalizedReport,
+	StatsRecord,
+} from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsEmailSummaryItem extends StatsNormalizedItemBase< null > {
+	id?: string | number;
+	value: number;
+	link?: unknown;
+	actions?: StatsItemAction[];
+	date?: unknown;
+	type?: unknown;
+	opens: number;
+	clicks: number;
+	opens_rate: number;
+	clicks_rate: number;
+	unique_opens: number;
+	unique_clicks: number;
+	total_sends: number;
+}
+
+function normalizeStatsEmailSummaryItem( post: StatsRecord ): StatsEmailSummaryItem {
+	const link = post.href;
+
+	return {
+		id: post.id as string | number | undefined,
+		label: post.title,
+		value: safeParseFloat( post.clicks_rate ),
+		link,
+		actions: typeof link === 'string' ? [ { type: 'link', data: link } ] : [],
+		date: post.date,
+		type: post.type,
+		opens: safeParseFloat( post.opens ),
+		clicks: safeParseFloat( post.clicks ),
+		opens_rate: safeParseFloat( post.opens_rate ),
+		clicks_rate: safeParseFloat( post.clicks_rate ),
+		unique_opens: safeParseFloat( post.unique_opens ),
+		unique_clicks: safeParseFloat( post.unique_clicks ),
+		total_sends: safeParseFloat( post.total_sends ),
+		children: null,
+	};
+}
+
+export function sanitizeStatsEmailSummaryResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsEmailSummaryItem > {
+	const items = coerceStatsArray< StatsRecord >( coerceStatsRecord( response ).posts ).map(
+		normalizeStatsEmailSummaryItem
+	);
+
+	return {
+		summary: {
+			total_sends: items.reduce( ( total, item ) => total + item.total_sends, 0 ),
+			opens: items.reduce( ( total, item ) => total + item.opens, 0 ),
+			clicks: items.reduce( ( total, item ) => total + item.clicks, 0 ),
+			unique_opens: items.reduce( ( total, item ) => total + item.unique_opens, 0 ),
+			unique_clicks: items.reduce( ( total, item ) => total + item.unique_clicks, 0 ),
+		},
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -11,6 +11,10 @@ export { sanitizeStatsFileDownloadsResponse } from './file-downloads';
 export { sanitizeStatsTopAuthorsResponse } from './top-authors';
 export { sanitizeStatsLocationsResponse } from './locations';
 export { sanitizeStatsVideoPlaysResponse } from './video-plays';
+export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './time-series';
+export { sanitizeStatsVisitsResponse } from './visits';
+export { sanitizeStatsEmailSummaryResponse } from './email-summary';
+export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export type { StatsTopPostsItem } from './top-posts';
 export type { StatsReferrersItem } from './referrers';
 export type { StatsClicksItem } from './clicks';
@@ -19,6 +23,8 @@ export type { StatsFileDownloadsItem } from './file-downloads';
 export type { StatsTopAuthorsItem } from './top-authors';
 export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
+export type { StatsEmailSummaryItem } from './email-summary';
+export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -1,0 +1,231 @@
+import {
+	endOfISOWeek,
+	endOfMonth,
+	endOfYear,
+	format,
+	isValid,
+	parse,
+	startOfISOWeek,
+	startOfMonth,
+	startOfYear,
+} from 'date-fns';
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	getStatsIntervalFields,
+	normalizeStatsSummary,
+} from './utils';
+import type { StatsNormalizedDataPoint, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+const nonMetricFields = [ 'period', 'time_interval', 'date', 'date_start', 'date_end' ];
+const dateFormat = 'yyyy-MM-dd';
+const referenceDate = new Date( 2001, 0, 1 );
+
+function numericTimeSeriesRow( row: StatsRecord ) {
+	return Object.fromEntries(
+		Object.entries( row ).map( ( [ key, value ] ) => [
+			key,
+			nonMetricFields.includes( key ) ||
+			! ( typeof value === 'number' || typeof value === 'string' )
+				? value
+				: safeParseFloat( value ),
+		] )
+	);
+}
+
+function parseMatrixRows( payload: unknown ) {
+	const response = coerceStatsRecord( payload );
+	const fields = coerceStatsArray< string >( response.fields );
+
+	if ( ! fields.length ) {
+		return [];
+	}
+
+	return coerceStatsArray< unknown[] >( response.data ).map( record => {
+		const parsed: StatsRecord = {};
+		record.forEach( ( value, index ) => {
+			const field = fields[ index ];
+
+			if ( field ) {
+				parsed[ field ] = value;
+			}
+		} );
+
+		return numericTimeSeriesRow( parsed );
+	} );
+}
+
+function parseTimeSeriesRows( payload: unknown ) {
+	const response = coerceStatsRecord( payload );
+	const matrixRows = parseMatrixRows( response );
+
+	if ( matrixRows.length ) {
+		return matrixRows;
+	}
+
+	const dataRows = coerceStatsArray< StatsRecord >( response.data );
+
+	if ( dataRows.length ) {
+		return dataRows.map( numericTimeSeriesRow );
+	}
+
+	return Object.entries( coerceStatsRecord( response.days ) ).map( ( [ period, value ] ) => {
+		if ( typeof value === 'number' || typeof value === 'string' ) {
+			return numericTimeSeriesRow( { period, value } );
+		}
+
+		return numericTimeSeriesRow( { period, ...coerceStatsRecord( value ) } );
+	} );
+}
+
+function getPrimaryMetricValue( row: StatsRecord ) {
+	// The first numeric metric is the headline value; matrix payloads preserve API field order.
+	const primaryMetric = Object.entries( row ).find(
+		( [ key, value ] ) => ! nonMetricFields.includes( key ) && typeof value === 'number'
+	);
+
+	return primaryMetric?.[ 1 ] ?? 0;
+}
+
+function getDateFnsIntervalFields( startDate: Date, endDate: Date ) {
+	// Stats interval fields are normalized calendar bucket labels, matching getStatsIntervalFields.
+	// They are not intended to be reinterpreted as site-timezone instants downstream.
+	return {
+		time_interval: format( startDate, dateFormat ),
+		date_start: `${ format( startDate, dateFormat ) }T00:00:00+00:00`,
+		date_end: `${ format( endDate, dateFormat ) }T23:59:59+00:00`,
+	};
+}
+
+function getWeekIntervalFields( period: string ) {
+	const match = period.match( /^(\d{4})-?W?(\d{1,2})$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const normalizedPeriod = `${ match[ 1 ] }-W${ match[ 2 ].padStart( 2, '0' ) }`;
+	const parsed = parse( normalizedPeriod, "RRRR-'W'II", referenceDate );
+
+	if ( ! isValid( parsed ) || format( parsed, "RRRR-'W'II" ) !== normalizedPeriod ) {
+		return null;
+	}
+
+	return getDateFnsIntervalFields( startOfISOWeek( parsed ), endOfISOWeek( parsed ) );
+}
+
+function getMonthIntervalFields( period: string ) {
+	const parsed = parse( period, 'yyyy-MM', referenceDate );
+
+	if ( ! isValid( parsed ) || format( parsed, 'yyyy-MM' ) !== period ) {
+		return null;
+	}
+
+	return getDateFnsIntervalFields( startOfMonth( parsed ), endOfMonth( parsed ) );
+}
+
+function getYearIntervalFields( period: string ) {
+	const parsed = parse( period, 'yyyy', referenceDate );
+
+	if ( ! isValid( parsed ) || format( parsed, 'yyyy' ) !== period ) {
+		return null;
+	}
+
+	return getDateFnsIntervalFields( startOfYear( parsed ), endOfYear( parsed ) );
+}
+
+function getTimeSeriesIntervalFields( period: unknown, unit?: string ) {
+	const periodString = typeof period === 'string' ? period : '';
+
+	if ( unit === 'week' ) {
+		return getWeekIntervalFields( periodString ) ?? getStatsIntervalFields( periodString, unit );
+	}
+
+	if ( unit === 'month' ) {
+		return getMonthIntervalFields( periodString ) ?? getStatsIntervalFields( periodString, unit );
+	}
+
+	if ( unit === 'year' ) {
+		return getYearIntervalFields( periodString ) ?? getStatsIntervalFields( periodString, unit );
+	}
+
+	return getStatsIntervalFields( periodString, unit );
+}
+
+function getTimeSeriesSummarySidecars( response: StatsRecord ) {
+	return {
+		...normalizeStatsSummary( coerceStatsRecord( response.summary ) ),
+		...normalizeStatsSummary( coerceStatsRecord( response.opens_rate ) ),
+		...normalizeStatsSummary( coerceStatsRecord( response.clicks_rate ) ),
+		...normalizeStatsSummary( coerceStatsRecord( response.rate ) ),
+	};
+}
+
+export function isStatsTimeSeriesPayload( payload: unknown ) {
+	const response = coerceStatsRecord( payload );
+
+	if (
+		coerceStatsArray( response.fields ).length ||
+		Object.keys( coerceStatsRecord( response.days ) ).length
+	) {
+		return true;
+	}
+
+	const firstRow = coerceStatsRecord( coerceStatsArray< StatsRecord >( response.data )[ 0 ] );
+
+	return Boolean(
+		firstRow.period || firstRow.time_interval || firstRow.date || firstRow.date_start
+	);
+}
+
+export function sanitizeStatsTimeSeriesResponse(
+	payload: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const response = coerceStatsRecord( payload );
+	const unit = String( response.unit ?? query?.period ?? 'day' );
+	const rows = parseTimeSeriesRows( payload );
+	const summary = rows.reduce< Record< string, number > >( ( totals, row ) => {
+		Object.entries( row ).forEach( ( [ key, value ] ) => {
+			if ( ! nonMetricFields.includes( key ) && typeof value === 'number' ) {
+				totals[ key ] = ( totals[ key ] ?? 0 ) + value;
+			}
+		} );
+
+		return totals;
+	}, {} );
+	const data = rows.map< StatsNormalizedDataPoint >( row => {
+		const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
+		const range =
+			typeof row.date_start === 'string' && typeof row.date_end === 'string'
+				? {
+						time_interval: row.date_start,
+						date_start: row.date_start,
+						date_end: row.date_end,
+				  }
+				: getTimeSeriesIntervalFields( rawPeriod, unit );
+		const value = safeParseFloat( getPrimaryMetricValue( row ) );
+
+		return {
+			...row,
+			...range,
+			label: range.time_interval,
+			value,
+			items: [],
+		};
+	} );
+	const firstRow = data[ 0 ];
+	const lastRow = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...getTimeSeriesSummarySidecars( response ),
+			...summary,
+			date_start: firstRow?.date_start ?? query?.start_date ?? '',
+			date_end: lastRow?.date_end ?? query?.end_date ?? query?.date ?? '',
+		},
+		data,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
@@ -1,4 +1,6 @@
 import type { StatsClicksItem } from './clicks';
+import type { StatsEmailBreakdownItem } from './email-breakdown';
+import type { StatsEmailSummaryItem } from './email-summary';
 import type { StatsFileDownloadsItem } from './file-downloads';
 import type { StatsLocationsItem } from './locations';
 import type { StatsReferrersItem } from './referrers';
@@ -25,7 +27,9 @@ export type StatsNormalizedItem =
 	| StatsFileDownloadsItem
 	| StatsTopAuthorsItem
 	| StatsLocationsItem
-	| StatsVideoPlaysItem;
+	| StatsVideoPlaysItem
+	| StatsEmailSummaryItem
+	| StatsEmailBreakdownItem;
 
 export type StatsNormalizedDataPoint< TItem extends StatsNormalizedItem = StatsNormalizedItem > = {
 	time_interval: string;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -179,6 +179,26 @@ export function createStatsSummaryDataPoint< TItem extends StatsNormalizedItem >
 	};
 }
 
+export function createStatsListDataPoint< TItem extends StatsNormalizedItem >(
+	response: unknown,
+	query: StatsQueryParams | undefined,
+	items: TItem[]
+): StatsNormalizedDataPoint< TItem > {
+	const date = getStatsTopLevelDataDate( response, query ) ?? '';
+
+	return {
+		...( date
+			? getStatsIntervalFields( date, getStatsTopLevelPeriod( response, query ) )
+			: {
+					time_interval: '',
+					date_start: '',
+					date_end: '',
+			  } ),
+		...getStatsSummaryIntervalFields( query, response ),
+		items,
+	};
+}
+
 export function mapStatsDataPoints< TItem extends StatsNormalizedItem >(
 	response: unknown,
 	query: StatsQueryParams | undefined,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/visits.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { sanitizeStatsTimeSeriesResponse } from './time-series';
+import type { StatsNormalizedReport } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export function sanitizeStatsVisitsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	return sanitizeStatsTimeSeriesResponse( response, query );
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add split Stats normalizers for generic time-series reports, visits, email summary, and email breakdowns.
* Keep endpoint-specific normalizers separate; this PR does not change the existing traffic endpoint normalizers from the earlier stack.
* Normalize generic time-series payloads from matrix `fields`/`data`, object `data`, and scalar/object `days` shapes.
* Normalize email summary and email breakdown payloads, including fieldless email all-time breakdown arrays for countries, clients/devices, and links.
* Use `date-fns` helpers for week/month/year interval boundaries and validate ISO week labels before normalizing them.
* Add focused fixtures and tests for visits/time-series payloads, email payloads, scalar `days` maps, month/year/leap-year boundaries, and invalid ISO week fallback.

## Related product discussion/links
* Stacked on #49778.
* Stack continues in #49780.
* Top Posts row `value` contract follow-up: WOOA7S-1585.

## Does this pull request change what data or activity we track or use?
No. This only normalizes existing Stats API response shapes.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand projects/packages/premium-analytics/packages/data/src/processing/stats`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Browser verification for the stack: the live Stats dashboard request capture confirmed the visits/time-series request pattern, and raw authenticated replays confirmed the non-summarized `date`, `period`, and `days` response shape expected by the normalizers.

## Out of scope
* This PR does not add a generic `value` field to existing endpoint normalizers. Consumers should choose the primary row metric in a follow-up adapter/row-contract change, tracked in WOOA7S-1585.
