### PR TITLE
Premium Analytics: normalize secondary Stats reports

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-secondary-normalizers
+++ b/projects/packages/premium-analytics/changelog/add-stats-secondary-normalizers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add secondary response normalizers.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
@@ -1,0 +1,34 @@
+export const archivesFixture = {
+	days: {
+		'2026-06-16': {
+			home: [
+				{
+					value: 'home',
+					href: 'https://example.com/',
+					views: '3',
+				},
+			],
+			post_type: [
+				{
+					value: 'post',
+					href: 'https://example.com/type/post/',
+					views: '4',
+				},
+				{
+					value: 'page',
+					href: 'https://example.com/type/page/',
+					views: '0',
+				},
+			],
+			tax: {
+				category: [
+					{
+						value: 'News%20%26%20Updates',
+						href: 'https://example.com/category/news/',
+						views: '8',
+					},
+				],
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/comment-followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/comment-followers.ts
@@ -1,0 +1,18 @@
+export const commentFollowersFixture = {
+	page: 1,
+	pages: 1,
+	total: 2,
+	posts: [
+		{
+			id: 0,
+			title: 'All Posts',
+			followers: 20,
+		},
+		{
+			id: 41,
+			title: 'Hello world',
+			followers: '10',
+			url: 'https://example.com/hello/',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/comments.ts
@@ -1,0 +1,20 @@
+export const commentsFixture = {
+	total_comments: 22,
+	most_active_day: 'Monday',
+	most_active_time: '17:00',
+	authors: [
+		{
+			name: 'Jane',
+			comments: '12',
+			gravatar: 'https://example.com/avatar.jpg',
+		},
+	],
+	posts: [
+		{
+			id: 41,
+			name: 'Hello world',
+			comments: '10',
+			link: 'https://example.com/hello/',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/devices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/devices.ts
@@ -1,0 +1,6 @@
+export const devicesFixture = {
+	top_values: {
+		mobile: '9',
+		desktop: '4',
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/followers.ts
@@ -1,0 +1,15 @@
+export const followersFixture = {
+	page: 1,
+	pages: 1,
+	total: 125,
+	total_email: 5,
+	total_wpcom: 120,
+	subscribers: [
+		{
+			ID: 111,
+			label: 'reader@example.com',
+			url: null,
+			date_subscribed: '2026-06-16T18:53:05+00:00',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/generic-list.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/generic-list.ts
@@ -1,0 +1,7 @@
+export const genericListFixture = [
+	{
+		name: 'Example tag',
+		views: '18',
+		value: 'raw-value',
+	},
+];

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/publicize.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/publicize.ts
@@ -1,0 +1,8 @@
+export const publicizeFixture = {
+	services: [
+		{
+			service: 'mastodon',
+			followers: '12',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
@@ -1,0 +1,14 @@
+export const tagsFixture = {
+	tags: [
+		{
+			tags: [
+				{
+					type: 'category',
+					name: 'News',
+					link: 'https://example.com/category/news/',
+				},
+			],
+			views: '18',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/video-plays.ts
@@ -22,6 +22,25 @@ export const videoPlaysSummaryFixture = {
 	period: 'day',
 	days: {
 		summary: {
+			plays: [
+				{
+					post_id: 12,
+					title: 'Launch video',
+					url: 'https://example.com/video/',
+					plays: 11,
+				},
+			],
+			total_plays: 11,
+			other_plays: 0,
+		},
+	},
+};
+
+export const videoPlaysCompleteStatsSummaryFixture = {
+	date: '2026-06-22',
+	period: 'day',
+	days: {
+		summary: {
 			data: [
 				{
 					post_id: 12,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
@@ -1,0 +1,28 @@
+import { sanitizeStatsArchivesResponse } from '..';
+import { archivesFixture } from '../__fixtures__/archives';
+
+describe( 'Stats archives normalizer', () => {
+	it( 'normalizes archives into sorted grouped rows', () => {
+		const result = sanitizeStatsArchivesResponse( archivesFixture, {
+			period: 'day',
+			end_date: '2026-06-16',
+		} );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { views: 15 } ) );
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'tax',
+				views: 8,
+			} ),
+			expect.objectContaining( {
+				label: 'post_type',
+				views: 4,
+			} ),
+			expect.objectContaining( {
+				label: 'home',
+				views: 3,
+				children: null,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comment-followers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comment-followers.test.ts
@@ -1,0 +1,22 @@
+import { sanitizeStatsCommentFollowersResponse } from '..';
+import { commentFollowersFixture } from '../__fixtures__/comment-followers';
+
+describe( 'Stats comment followers normalizer', () => {
+	it( 'normalizes comment follower post rows', () => {
+		const result = sanitizeStatsCommentFollowersResponse( commentFollowersFixture );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { total: 2 } ) );
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'All Posts',
+				followers: 20,
+			} ),
+			expect.objectContaining( {
+				id: 41,
+				label: 'Hello world',
+				followers: 10,
+				labelIcon: 'external',
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
@@ -1,0 +1,26 @@
+import { sanitizeStatsCommentsResponse } from '..';
+import { commentsFixture } from '../__fixtures__/comments';
+
+describe( 'Stats comments normalizer', () => {
+	it( 'normalizes comments into author and post groups', () => {
+		const result = sanitizeStatsCommentsResponse( commentsFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				total_comments: 22,
+				most_active_day: 'Monday',
+				most_active_time: '17:00',
+			} )
+		);
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'authors',
+				comments: 12,
+			} ),
+			expect.objectContaining( {
+				label: 'posts',
+				comments: 10,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/devices.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/devices.test.ts
@@ -1,0 +1,19 @@
+import { sanitizeStatsDevicesResponse } from '..';
+import { devicesFixture } from '../__fixtures__/devices';
+
+describe( 'Stats devices normalizer', () => {
+	it( 'normalizes summarized device top-value payloads as leaderboard rows', () => {
+		expect( sanitizeStatsDevicesResponse( devicesFixture ).data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				key: 'mobile',
+				label: 'mobile',
+				views: 9,
+			} ),
+			expect.objectContaining( {
+				key: 'desktop',
+				label: 'desktop',
+				views: 4,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
@@ -1,0 +1,24 @@
+import { sanitizeStatsFollowersResponse } from '..';
+import { followersFixture } from '../__fixtures__/followers';
+
+describe( 'Stats followers normalizer', () => {
+	it( 'normalizes followers subscriber rows', () => {
+		const result = sanitizeStatsFollowersResponse( followersFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				total: 125,
+				total_email: 5,
+				total_wpcom: 120,
+			} )
+		);
+		expect( result.data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 111,
+				label: 'reader@example.com',
+				date_subscribed: '2026-06-16T18:53:05+00:00',
+			} )
+		);
+		expect( result.data[ 0 ].items[ 0 ] ).not.toHaveProperty( 'value' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/generic-list.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/generic-list.test.ts
@@ -1,0 +1,15 @@
+import { sanitizeStatsGenericListResponse } from '..';
+import { genericListFixture } from '../__fixtures__/generic-list';
+
+describe( 'Stats generic list normalizer', () => {
+	it( 'keeps parsed generic list metrics when the raw payload has a value field', () => {
+		expect(
+			sanitizeStatsGenericListResponse( genericListFixture, 'views', 'name' ).data[ 0 ].items[ 0 ]
+		).toEqual(
+			expect.objectContaining( {
+				label: 'Example tag',
+				views: 18,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/publicize.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/publicize.test.ts
@@ -1,0 +1,13 @@
+import { sanitizeStatsPublicizeResponse } from '..';
+import { publicizeFixture } from '../__fixtures__/publicize';
+
+describe( 'Stats publicize normalizer', () => {
+	it( 'normalizes publicize service rows', () => {
+		expect( sanitizeStatsPublicizeResponse( publicizeFixture ).data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'mastodon',
+				followers: 12,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -1,0 +1,14 @@
+import { sanitizeStatsTagsResponse } from '..';
+import { tagsFixture } from '../__fixtures__/tags';
+
+describe( 'Stats tags normalizer', () => {
+	it( 'normalizes tag rows', () => {
+		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'News',
+				views: 18,
+				link: 'https://example.com/category/news/',
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
@@ -1,5 +1,9 @@
 import { sanitizeStatsVideoPlaysResponse } from '..';
-import { videoPlaysFixture, videoPlaysSummaryFixture } from '../__fixtures__/video-plays';
+import {
+	videoPlaysCompleteStatsSummaryFixture,
+	videoPlaysFixture,
+	videoPlaysSummaryFixture,
+} from '../__fixtures__/video-plays';
 
 describe( 'Stats video plays normalizer', () => {
 	it( 'normalizes video plays with the default plays shape', () => {
@@ -20,6 +24,30 @@ describe( 'Stats video plays normalizer', () => {
 
 	it( 'normalizes summarized video plays into range data', () => {
 		const result = sanitizeStatsVideoPlaysResponse( videoPlaysSummaryFixture, {
+			period: 'day',
+			start_date: '2026-06-16',
+			end_date: '2026-06-22',
+			summarize: true,
+		} );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				total_plays: 11,
+				other_plays: 0,
+			} )
+		);
+		expect( result.data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 12,
+				label: 'Launch video',
+				plays: 11,
+				link: 'https://example.com/video/',
+			} )
+		);
+	} );
+
+	it( 'normalizes complete summarized video plays into range data', () => {
+		const result = sanitizeStatsVideoPlaysResponse( videoPlaysCompleteStatsSummaryFixture, {
 			period: 'day',
 			start_date: '2026-06-16',
 			end_date: '2026-06-22',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -1,0 +1,128 @@
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	createStatsSummaryDataPoint,
+	emptyStatsReport,
+	getStatsBuckets,
+	getStatsLabel,
+	getStatsTopLevelDataDate,
+} from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsArchivesItem extends StatsNormalizedItemBase< StatsArchivesItem > {
+	views: number;
+	link?: unknown;
+}
+
+function normalizeArchiveChildren(
+	archiveType: string,
+	archiveItems: unknown
+): StatsArchivesItem[] {
+	if ( archiveType === 'tax' ) {
+		return Object.entries( coerceStatsRecord( archiveItems ) )
+			.map( ( [ taxonomy, terms ] ) => {
+				const children = coerceStatsArray< StatsRecord >( terms )
+					.map( term => ( {
+						label: getStatsLabel( term.value ),
+						views: safeParseFloat( term.views ),
+						link: term.href,
+						children: null,
+					} ) )
+					.filter( item => item.views > 0 );
+				const views = children.reduce( ( total, term ) => total + term.views, 0 );
+
+				return {
+					label: taxonomy,
+					views,
+					children,
+				};
+			} )
+			.filter( item => item.views > 0 );
+	}
+
+	return coerceStatsArray< StatsRecord >( archiveItems )
+		.map( item => ( {
+			label: archiveType === 'home' ? getStatsLabel( item.href ) : getStatsLabel( item.value ),
+			views: safeParseFloat( item.views ),
+			link: item.href,
+			children: null,
+		} ) )
+		.filter( item => item.views > 0 );
+}
+
+export function sanitizeStatsArchivesResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsArchivesItem > {
+	const payload = coerceStatsRecord( response );
+	const summary = coerceStatsRecord( payload.summary );
+
+	if ( query?.summarize && Object.keys( summary ).length ) {
+		const items = Object.entries( summary )
+			.map( ( [ archiveType, archiveItems ] ) => {
+				const children = normalizeArchiveChildren( archiveType, archiveItems );
+				const views = children.reduce( ( total, item ) => total + item.views, 0 );
+
+				return {
+					label: archiveType,
+					views,
+					children: archiveType === 'home' && children.length < 2 ? null : children,
+				};
+			} )
+			.filter( item => item.views > 0 )
+			.sort( ( a, b ) => b.views - a.views );
+		const summaryDate = getStatsTopLevelDataDate( response, query );
+
+		return {
+			summary: {
+				views: items.reduce( ( total, item ) => total + item.views, 0 ),
+			},
+			data: summaryDate
+				? [ createStatsSummaryDataPoint( summaryDate, response, query, items ) ]
+				: [],
+		};
+	}
+
+	const buckets = getStatsBuckets( response, query );
+
+	if ( ! buckets.length ) {
+		return emptyStatsReport();
+	}
+
+	const data = buckets
+		.map( ( [ date, bucket ] ) => {
+			const items = Object.entries( bucket )
+				.map( ( [ archiveType, archiveItems ] ) => {
+					const children = normalizeArchiveChildren( archiveType, archiveItems );
+					const views = children.reduce( ( total, item ) => total + item.views, 0 );
+
+					return {
+						label: archiveType,
+						views,
+						children: archiveType === 'home' && children.length < 2 ? null : children,
+					};
+				} )
+				.filter( item => item.views > 0 )
+				.sort( ( a, b ) => b.views - a.views );
+
+			return {
+				...createStatsListDataPoint( { date }, query, items ),
+				time_interval: date,
+			};
+		} )
+		.filter( point => point.items.length );
+
+	return {
+		summary: {
+			views: data.reduce(
+				( total, point ) =>
+					total + point.items.reduce( ( itemTotal, item ) => itemTotal + item.views, 0 ),
+				0
+			),
+		},
+		data,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comment-followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comment-followers.ts
@@ -1,0 +1,40 @@
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	normalizeStatsSummary,
+} from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsCommentFollowersItem extends StatsNormalizedItemBase< null > {
+	id?: unknown;
+	followers: number;
+	link?: unknown;
+	labelIcon?: string;
+}
+
+export function sanitizeStatsCommentFollowersResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsCommentFollowersItem > {
+	const payload = coerceStatsRecord( response );
+	const items = coerceStatsArray< StatsRecord >( payload.posts ).map( item => ( {
+		id: item.id,
+		label: item.title ?? item.label ?? '',
+		followers: safeParseFloat( item.followers ),
+		link: item.id === 0 ? null : item.url,
+		labelIcon: item.id === 0 ? undefined : 'external',
+		children: null,
+	} ) );
+
+	return {
+		summary: normalizeStatsSummary( {
+			page: payload.page,
+			pages: payload.pages,
+			total: payload.total,
+		} ),
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
@@ -1,0 +1,80 @@
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	normalizeStatsSummary,
+} from './utils';
+import type {
+	StatsItemAction,
+	StatsNormalizedItemBase,
+	StatsNormalizedReport,
+	StatsRecord,
+} from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsCommentsItem extends StatsNormalizedItemBase< StatsCommentsItem > {
+	comments: number;
+	id?: unknown;
+	link?: unknown;
+	page?: string | null;
+	iconClassName?: string;
+	icon?: unknown;
+	className?: string;
+	actions?: StatsItemAction[];
+}
+
+export function sanitizeStatsCommentsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsCommentsItem > {
+	const payload = coerceStatsRecord( response );
+	const authors = coerceStatsArray< StatsRecord >( payload.authors ).map( author => ( {
+		label: author.name,
+		comments: safeParseFloat( author.comments ),
+		iconClassName: 'avatar-user',
+		icon: author.gravatar ?? null,
+		link: author.link ?? null,
+		className: 'module-content-list-item-large',
+		actions: [
+			{
+				type: 'follow',
+				data: coerceStatsRecord( author.follow_data ).params ?? false,
+			},
+		],
+		children: null,
+	} ) );
+	const posts = coerceStatsArray< StatsRecord >( payload.posts ).map( post => ( {
+		id: post.id,
+		label: post.name ?? post.title ?? '',
+		comments: safeParseFloat( post.comments ),
+		link: post.link ?? null,
+		page: post.id ? `/stats/post/${ post.id }` : null,
+		actions: post.link ? [ { type: 'link', data: post.link } ] : [],
+		children: null,
+	} ) );
+	const items = [
+		{
+			label: 'authors',
+			comments: authors.reduce( ( total, author ) => total + author.comments, 0 ),
+			children: authors,
+		},
+		{
+			label: 'posts',
+			comments: posts.reduce( ( total, post ) => total + post.comments, 0 ),
+			children: posts,
+		},
+	].filter( item => item.children.length );
+
+	return {
+		summary: {
+			...normalizeStatsSummary( {
+				total_comments: payload.total_comments,
+			} ),
+			most_active_day: payload.most_active_day,
+			most_active_time: payload.most_active_time,
+			monthly_comments: payload.monthly_comments,
+		},
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/devices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/devices.ts
@@ -1,0 +1,43 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './time-series';
+import {
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	emptyStatsReport,
+} from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsDevicesItem extends StatsNormalizedItemBase< null > {
+	views: number;
+	key?: string;
+	[ key: string ]: unknown;
+}
+
+export function sanitizeStatsDevicesResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport {
+	const payload = coerceStatsRecord( response );
+	const topValues = coerceStatsRecord( payload.top_values );
+
+	if ( Object.keys( topValues ).length ) {
+		const items = Object.entries( topValues ).map( ( [ key, value ] ) => ( {
+			key,
+			label: key,
+			views: safeParseFloat( value ),
+			children: null,
+		} ) );
+
+		return {
+			summary: {
+				views: items.reduce( ( total, item ) => total + item.views, 0 ),
+			},
+			data: [ createStatsListDataPoint( response, query, items ) ],
+		};
+	}
+
+	return isStatsTimeSeriesPayload( response )
+		? sanitizeStatsTimeSeriesResponse( response, query )
+		: emptyStatsReport();
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
@@ -1,0 +1,58 @@
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	normalizeStatsSummary,
+} from './utils';
+import type {
+	StatsItemAction,
+	StatsNormalizedItemBase,
+	StatsNormalizedReport,
+	StatsRecord,
+} from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsFollowersItem extends StatsNormalizedItemBase< null > {
+	id?: unknown;
+	iconClassName: string;
+	icon?: unknown;
+	link?: unknown;
+	date_subscribed?: unknown;
+	subscription_id?: unknown;
+	actions: StatsItemAction[];
+}
+
+export function sanitizeStatsFollowersResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsFollowersItem > {
+	const payload = coerceStatsRecord( response );
+	const subscribers = coerceStatsArray< StatsRecord >( payload.subscribers );
+	const items = subscribers.map( item => ( {
+		id: item.ID ?? item.id ?? item.subscription_id,
+		label: item.label ?? item.name ?? item.email ?? '',
+		iconClassName: 'avatar-user',
+		icon: item.avatar ?? null,
+		link: item.url ?? null,
+		date_subscribed: item.date_subscribed,
+		subscription_id: item.subscription_id,
+		actions: [
+			{
+				type: 'follow',
+				data: coerceStatsRecord( item.follow_data ).params ?? false,
+			},
+		],
+		children: null,
+	} ) );
+
+	return {
+		summary: normalizeStatsSummary( {
+			page: payload.page,
+			pages: payload.pages,
+			total: payload.total,
+			total_email: payload.total_email,
+			total_wpcom: payload.total_wpcom,
+		} ),
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/generic-list.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/generic-list.ts
@@ -1,0 +1,60 @@
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	emptyStatsReport,
+	getStatsLabel,
+} from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsGenericListItem extends StatsNormalizedItemBase< null > {
+	[ key: string ]: unknown;
+}
+
+export function sanitizeStatsGenericListResponse(
+	response: unknown,
+	valueKey = 'views',
+	labelKey = 'label',
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsGenericListItem > {
+	const payload = coerceStatsRecord( response );
+	const items = Array.isArray( response )
+		? coerceStatsArray< StatsRecord >( response )
+		: [
+				payload.data,
+				payload.items,
+				payload.summary,
+				payload.services,
+				payload.subscribers,
+				payload.posts,
+		  ]
+				.map( coerceStatsArray< StatsRecord > )
+				.find( candidates => candidates.length ) ?? [];
+
+	if ( ! items.length ) {
+		return emptyStatsReport();
+	}
+
+	const normalizedItems = items.map( item => {
+		const metric = safeParseFloat( item[ valueKey ] ?? item.value );
+
+		return {
+			...item,
+			label: getStatsLabel( item[ labelKey ] ?? item.name ?? item.title ?? item.term ),
+			[ valueKey ]: metric,
+			children: null,
+		};
+	} );
+
+	return {
+		summary: {
+			[ valueKey ]: normalizedItems.reduce(
+				( total, item ) => total + safeParseFloat( item[ valueKey ] ),
+				0
+			),
+		},
+		data: [ createStatsListDataPoint( response, query, normalizedItems ) ],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -15,6 +15,14 @@ export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './tim
 export { sanitizeStatsVisitsResponse } from './visits';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
+export { sanitizeStatsDevicesResponse } from './devices';
+export { sanitizeStatsArchivesResponse } from './archives';
+export { sanitizeStatsPublicizeResponse } from './publicize';
+export { sanitizeStatsFollowersResponse } from './followers';
+export { sanitizeStatsTagsResponse } from './tags';
+export { sanitizeStatsCommentsResponse } from './comments';
+export { sanitizeStatsCommentFollowersResponse } from './comment-followers';
+export { sanitizeStatsGenericListResponse } from './generic-list';
 export type { StatsTopPostsItem } from './top-posts';
 export type { StatsReferrersItem } from './referrers';
 export type { StatsClicksItem } from './clicks';
@@ -25,6 +33,14 @@ export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
+export type { StatsDevicesItem } from './devices';
+export type { StatsArchivesItem } from './archives';
+export type { StatsPublicizeItem } from './publicize';
+export type { StatsFollowersItem } from './followers';
+export type { StatsTagsItem } from './tags';
+export type { StatsCommentsItem } from './comments';
+export type { StatsCommentFollowersItem } from './comment-followers';
+export type { StatsGenericListItem } from './generic-list';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/publicize.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/publicize.ts
@@ -1,0 +1,13 @@
+import { sanitizeStatsGenericListResponse } from './generic-list';
+import type { StatsGenericListItem } from './generic-list';
+import type { StatsNormalizedReport } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsPublicizeItem = StatsGenericListItem;
+
+export function sanitizeStatsPublicizeResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsPublicizeItem > {
+	return sanitizeStatsGenericListResponse( response, 'followers', 'service', query );
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,0 +1,52 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsItem > {
+	views: number;
+	link?: unknown;
+	labels?: Array< { label: unknown; labelIcon: string; link: unknown } >;
+	labelIcon?: string;
+}
+
+const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
+
+export function sanitizeStatsTagsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsTagsItem > {
+	const tags = coerceStatsArray< StatsRecord >( coerceStatsRecord( response ).tags );
+	const items = tags.map( item => {
+		const tagItems = coerceStatsArray< StatsRecord >( item.tags );
+		const hasChildren = tagItems.length > 1;
+		const labels = tagItems.map( tag => ( {
+			label: tag.name,
+			labelIcon: tagIcon( tag.type ),
+			link: hasChildren ? null : tag.link,
+		} ) );
+
+		return {
+			label: labels.map( label => label.label ).join( ', ' ),
+			labels,
+			link: hasChildren ? null : labels[ 0 ]?.link,
+			views: safeParseFloat( item.views ),
+			children: hasChildren
+				? tagItems.map( tag => ( {
+						label: tag.name,
+						labelIcon: tagIcon( tag.type ),
+						views: 0,
+						link: tag.link,
+						children: null,
+				  } ) )
+				: null,
+		};
+	} );
+
+	return {
+		summary: {
+			views: items.reduce( ( total, item ) => total + item.views, 0 ),
+		},
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
@@ -1,10 +1,18 @@
+import type { StatsArchivesItem } from './archives';
 import type { StatsClicksItem } from './clicks';
+import type { StatsCommentFollowersItem } from './comment-followers';
+import type { StatsCommentsItem } from './comments';
+import type { StatsDevicesItem } from './devices';
 import type { StatsEmailBreakdownItem } from './email-breakdown';
 import type { StatsEmailSummaryItem } from './email-summary';
 import type { StatsFileDownloadsItem } from './file-downloads';
+import type { StatsFollowersItem } from './followers';
+import type { StatsGenericListItem } from './generic-list';
 import type { StatsLocationsItem } from './locations';
+import type { StatsPublicizeItem } from './publicize';
 import type { StatsReferrersItem } from './referrers';
 import type { StatsSearchTermsItem } from './search-terms';
+import type { StatsTagsItem } from './tags';
 import type { StatsTopAuthorsItem } from './top-authors';
 import type { StatsTopPostsItem } from './top-posts';
 import type { StatsVideoPlaysItem } from './video-plays';
@@ -29,7 +37,15 @@ export type StatsNormalizedItem =
 	| StatsLocationsItem
 	| StatsVideoPlaysItem
 	| StatsEmailSummaryItem
-	| StatsEmailBreakdownItem;
+	| StatsEmailBreakdownItem
+	| StatsDevicesItem
+	| StatsArchivesItem
+	| StatsPublicizeItem
+	| StatsFollowersItem
+	| StatsTagsItem
+	| StatsCommentsItem
+	| StatsCommentFollowersItem
+	| StatsGenericListItem;
 
 export type StatsNormalizedDataPoint< TItem extends StatsNormalizedItem = StatsNormalizedItem > = {
 	time_interval: string;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -26,6 +26,31 @@ export function coerceStatsArray< T = StatsRecord >( value: unknown ): T[] {
 	return Array.isArray( value ) ? ( value as T[] ) : [];
 }
 
+export function emptyStatsReport<
+	TItem extends StatsNormalizedItem,
+>(): StatsNormalizedReport< TItem > {
+	return {
+		summary: {},
+		data: [],
+	};
+}
+
+export function getStatsLabel( value: unknown ): string {
+	if ( typeof value === 'string' ) {
+		try {
+			return decodeURIComponent( value );
+		} catch {
+			return value;
+		}
+	}
+
+	if ( typeof value === 'number' || typeof value === 'boolean' ) {
+		return String( value );
+	}
+
+	return '';
+}
+
 function isStatsNumericSummaryValue( value: unknown ): boolean {
 	return (
 		typeof value === 'number' ||


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add split secondary Stats normalizers for devices, archives, publicize, followers, tags, comments, and comment followers.
* Add shared generic-list helpers and endpoint-specific fixture coverage for summarized and raw response shapes.
* Incorporate review/browser feedback: support summarized archives, align video-play summary fixtures with the live `plays` shape, avoid stringifying object labels as `[object Object]`, and leave UTM unnormalized because it was inspected only for request behavior in this stack.

## Related product discussion/links
* Stacked on #49779.
* Stack continues in #49781.

## Does this pull request change what data or activity we track or use?
No. This only normalizes existing Stats API response shapes.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
* Browser verification for the stack: dashboard and detail-page requests were inspected while logged in. Summarized secondary endpoints use `summarize=1`; detail and period shortcut requests also continue to use `summarize=1`, usually with `max=0`. Authenticated raw replays without `summarize=1` confirmed endpoint-specific `days` buckets such as `files`, `plays`, `search_terms`, `clicks`, `groups`, `postviews`, and `authors`, plus scalar totals where present.
* UTM was inspected for request behavior only and is intentionally not normalized by this PR.
