### PR TITLE
Publicize: honor disabled connection when creating a published post

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-publicize-create-skip-connection
+++ b/projects/packages/publicize/changelog/fix-social-publicize-create-skip-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Honor a disabled connection when publishing a brand new post via the REST API, not only when updating an existing post.

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -38,6 +38,22 @@ class Connections_Post_Field {
 	public $memoized_updates = array();
 
 	/**
+	 * Requested connections for a new post being created, kept until the post
+	 * ID is known so the skip meta can be persisted before Publicize runs.
+	 *
+	 * @var array
+	 */
+	private $new_post_connections = array();
+
+	/**
+	 * The request that is creating a new post, kept alongside
+	 * $new_post_connections so per-connection overrides can be saved.
+	 *
+	 * @var WP_REST_Request|null
+	 */
+	private $new_post_request = null;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -299,9 +315,48 @@ class Connections_Post_Field {
 			// Set the meta before we mark the post as published so that publicize works as expected.
 			// If this is not the case post end up on social media when they are marked as skipped.
 			$this->update( $request_connections, $post, $request );
+		} else {
+			/*
+			 * A brand new post has no ID yet, so we can't persist the skip meta here.
+			 * Persist it as soon as the post is inserted, before Publicize processes
+			 * the publish transition (priority 10). Otherwise a new published post is
+			 * shared to every connection regardless of the requested `enabled` state.
+			 */
+			$this->new_post_connections = $request_connections;
+			$this->new_post_request     = $request;
+			add_action( 'transition_post_status', array( $this, 'set_meta_for_new_post' ), 1, 3 );
 		}
 
 		return $post;
+	}
+
+	/**
+	 * Persist the Publicize skip meta for a newly created post.
+	 *
+	 * Runs on `transition_post_status` before Publicize flags the post for
+	 * sharing, using the memoized data calculated in rest_pre_insert(). This is
+	 * the create-time counterpart to the in-place update() done for existing posts.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public function set_meta_for_new_post( $new_status, $old_status, $post ) {
+		if ( ! isset( $this->memoized_updates[0] ) || wp_is_post_revision( $post->ID ) ) {
+			return;
+		}
+
+		// One-shot: the first non-revision transition is the post we created.
+		remove_action( 'transition_post_status', array( $this, 'set_meta_for_new_post' ), 1 );
+
+		// Move the memoized data to the real post ID now that we know it.
+		$this->memoized_updates[ $post->ID ] = $this->memoized_updates[0];
+		unset( $this->memoized_updates[0] );
+
+		$this->update( $this->new_post_connections, $post, $this->new_post_request );
+
+		$this->new_post_connections = array();
+		$this->new_post_request     = null;
 	}
 
 	/**
@@ -342,13 +397,15 @@ class Connections_Post_Field {
 			return array();
 		}
 
+		// Return memoized data first: a new post is already 'publish' by the time
+		// we persist its skip meta, so the publish check below must not discard it.
+		if ( isset( $this->memoized_updates[ $post_id ] ) ) {
+			return $this->memoized_updates[ $post_id ];
+		}
+
 		$post = get_post( $post_id );
 		if ( isset( $post->post_status ) && 'publish' === $post->post_status ) {
 			return array();
-		}
-
-		if ( isset( $this->memoized_updates[ $post_id ] ) ) {
-			return $this->memoized_updates[ $post_id ];
 		}
 
 		$available_connections = $publicize->get_filtered_connection_data( $post_id );

--- a/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
@@ -523,6 +523,124 @@ class Connections_Post_Field_Test extends TestCase {
 	}
 
 	/**
+	 * A brand new published post must honor `enabled: false` and skip the
+	 * disabled connection. Regression test for the create-time drop where the
+	 * skip meta was only memoized, never persisted, for new posts.
+	 */
+	public function test_create_published_post_skips_disabled_connection() {
+		// get_filtered_connection_data() reads connections from the transient.
+		set_transient(
+			Connections::CONNECTIONS_TRANSIENT,
+			array(
+				array(
+					'service_name'  => 'facebook',
+					'id'            => '456',
+					'connection_id' => '4560',
+					'external_id'   => 'external-456',
+					'shared'        => true,
+					'wpcom_user_id' => 0,
+					'status'        => 'ok',
+				),
+				array(
+					'service_name'  => 'tumblr',
+					'id'            => '123',
+					'connection_id' => '1230',
+					'external_id'   => 'external-123',
+					'shared'        => true,
+					'wpcom_user_id' => 0,
+					'status'        => 'ok',
+				),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$request->set_body_params(
+			array(
+				'title'                         => 'publicize create-drop repro',
+				'status'                        => 'publish',
+				'jetpack_publicize_connections' => array(
+					array(
+						'connection_id' => '4560',
+						'enabled'       => false,
+					),
+				),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$post_id  = $response->get_data()['id'];
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+
+		// The disabled connection must be flagged to skip.
+		$this->assertNotEmpty(
+			get_post_meta( $post_id, $this->publicize->POST_SKIP_PUBLICIZE . '4560', true )
+		);
+
+		// The connection left enabled must not be skipped.
+		$this->assertEmpty(
+			get_post_meta( $post_id, $this->publicize->POST_SKIP_PUBLICIZE . '1230', true )
+		);
+	}
+
+	/**
+	 * A brand new published post with no disabled connections must share to all
+	 * of them (no skip meta written).
+	 *
+	 * Guards against resolving the connection defaults against the already
+	 * published post: the built-in `publicize_checkbox_default` filter returns
+	 * false for published posts, which would mark every connection to skip and
+	 * stop new posts from sharing at all.
+	 */
+	public function test_create_published_post_shares_to_all_connections_by_default() {
+		set_transient(
+			Connections::CONNECTIONS_TRANSIENT,
+			array(
+				array(
+					'service_name'  => 'facebook',
+					'id'            => '456',
+					'connection_id' => '4560',
+					'external_id'   => 'external-456',
+					'shared'        => true,
+					'wpcom_user_id' => 0,
+					'status'        => 'ok',
+				),
+				array(
+					'service_name'  => 'tumblr',
+					'id'            => '123',
+					'connection_id' => '1230',
+					'external_id'   => 'external-123',
+					'shared'        => true,
+					'wpcom_user_id' => 0,
+					'status'        => 'ok',
+				),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$request->set_body_params(
+			array(
+				'title'  => 'publicize create shares all',
+				'status' => 'publish',
+			)
+		);
+
+		$post_id = $this->server->dispatch( $request )->get_data()['id'];
+
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+
+		// Nothing was disabled, so neither connection may be skipped.
+		$this->assertEmpty(
+			get_post_meta( $post_id, $this->publicize->POST_SKIP_PUBLICIZE . '4560', true )
+		);
+		$this->assertEmpty(
+			get_post_meta( $post_id, $this->publicize->POST_SKIP_PUBLICIZE . '1230', true )
+		);
+	}
+
+	/**
 	 * Test that connections are enabled when the publicize_checkbox_default filter isn't used.
 	 */
 	public function test_default_checkbox_filter() {


### PR DESCRIPTION
Fixes SOCIAL-513

## Proposed changes

A new post published via the REST API (`POST /wp/v2/posts`, WP.com and self-hosted) with a Publicize connection set to `enabled: false` was still shared to that connection. The disable flag worked on **update** (publishing a draft) but was dropped on **create** (publishing a brand new post).

Root cause: for a brand new post, `Connections_Post_Field::rest_pre_insert()` could not persist the skip meta because the post ID did not exist yet — it only memoized the computed state. `rest_insert()` runs *after* Publicize has already processed the publish transition, and it merely re-keyed the memoized array without ever writing the meta, so `_wpas_skip_publicize_{id}` was never saved and the post shared everywhere.

* Persist the skip meta on `transition_post_status` (priority 1, before Publicize's `flag_post_for_publicize` at priority 10) once the new post ID is known.
* Look up the memoized data before the published-status early return in `get_meta_to_update()` so it isn't discarded for the freshly created (already `publish`) post.
* The defaults are intentionally computed in `rest_pre_insert()` while the post is not yet `publish` — the same context the update path uses — because the built-in `publicize_checkbox_default` filter returns `false` for published posts. Recomputing against the published post would mark every connection to skip and stop new posts from sharing at all; a regression test guards this.

## Related product discussion/links

* https://linear.app/a8c/issue/SOCIAL-513/jetpack-social-publicize-new-post-is-shared-even-when-connection-is

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with at least two Publicize connections, create a brand new post via the REST API with one connection disabled:

```
POST /wp/v2/posts
{
  "title": "publicize create-drop repro",
  "status": "publish",
  "jetpack_publicize_connections": [
    { "connection_id": "<id>", "enabled": false }
  ]
}
```

* Confirm the post is **not** shared to the disabled connection, and **is** shared to the others.
* Publish a brand new post with no connections disabled and confirm it still shares to all connections.
* PHP tests: `jetpack test php packages/publicize` (see `Connections_Post_Field_Test`).
