### PR TITLE
Revert "Notifications: make the v3 panel the default (#49577)"

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notifications-v3-default
+++ b/projects/plugins/jetpack/changelog/update-notifications-v3-default
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Notifications: use the v3 notifications panel by default.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -195,7 +195,9 @@ class Jetpack_Notifications {
 
 		$third_party_cookie_check_iframe = '<span style="display:none;"><iframe class="jetpack-notes-cookie-check" src="https://widgets.wp.com/3rd-party-cookie-check/index.html"></iframe></span>';
 
-		$panel_id = 'wpnt-notes-panel3';
+		// Opt into the v3 notifications panel/iframe via the `notifications=v3` query parameter.
+		$notifications_version = sanitize_key( wp_unslash( $_GET['notifications'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$panel_id              = 'v3' === $notifications_version ? 'wpnt-notes-panel3' : 'wpnt-notes-panel2';
 
 		$title = self::get_notes_markup();
 


### PR DESCRIPTION
## Proposed changes

Reverts #49577 

## Related product discussion/links

Some users reported issues loading the new notifications. See: p1781840448929099-slack-CRWCHQGUB

## Testing instructions

Use Jetpack Beta Tester to test this in your site, go to wp-admin, click the notification bell in your admin bar, verify the old notification is shown.

## Does this pull request change what data or activity we track or use?

No