### PR TITLE
AI Launchpad: MVP design-polish batch (DOTOBRD-476/477/478)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-calypso-cta-host
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-calypso-cta-host
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: navigate Calypso-relative task CTAs to wordpress.com instead of the site host.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-launch-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: give the launch task a working CTA to the WordPress.com launch flow.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-design-polish
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-design-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: polish the tailored list to match the design prototype — centered layout with a heading, progress, and site preview; action-specific task CTAs; and a "Tailoring your checklist…" loading state.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -180,9 +180,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
 			// Site context the client needs: the front-end URL drives the launch-task
-			// CTA (its host is the launch-flow site slug) and the tailored-list preview.
+			// CTA (its host is the launch-flow site slug) and the tailored-list
+			// preview thumbnail; the title labels that preview.
 			'site'               => array(
-				'url' => home_url(),
+				'url'   => home_url(),
+				'title' => get_bloginfo( 'name' ),
 			),
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -179,6 +179,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'checklist_statuses' => (array) get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
+			// Site context the client needs: the front-end URL drives the launch-task
+			// CTA (its host is the launch-flow site slug) and the tailored-list preview.
+			'site'               => array(
+				'url' => home_url(),
+			),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -59,11 +59,14 @@ export function App() {
 	}
 
 	// After the wizard, the list runs the fresh tailor flow (initialData would be
-	// the pre-wizard read); returning users render straight from initialData.
+	// the pre-wizard read); returning users render straight from initialData. The
+	// site context is path-independent, so it's passed either way — that lets the
+	// loading skeleton show the site preview before the tailored read lands.
 	return (
 		<TailoredList
 			pendingTailor={ pendingTailor }
 			initialData={ pendingTailor ? undefined : initialData }
+			site={ initialData?.site }
 		/>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
@@ -1,0 +1,55 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { SitePreview } from './site-preview.tsx';
+import type { ReactNode } from 'react';
+
+interface Props {
+	// The line under the heading: the "X of N completed" progress for the loaded
+	// list, or the "Tailoring your checklist…" copy while the AI call is in flight.
+	progressLabel: string;
+	// Site context for the preview card; omitted when unknown (dev fixtures).
+	siteUrl: string | null;
+	siteTitle?: string | null;
+	// The left column: the task cards, or the loading skeleton.
+	children: ReactNode;
+}
+
+/**
+ * The shared chrome for the tailored list and its loading state: a centered
+ * content column with a heading and a progress/status line, the supplied
+ * content (task cards or skeleton) on the left, and the site preview on the
+ * right. Sharing this between the loaded and loading states keeps the
+ * wizard→tailoring→list transition seamless — only the left column and the
+ * status line change.
+ *
+ * @param props               - Component props.
+ * @param props.progressLabel - The status line under the heading.
+ * @param props.siteUrl       - The site's front-end URL (for the preview).
+ * @param props.siteTitle     - The site name (for the preview).
+ * @param props.children      - The left column content.
+ * @return The layout element.
+ */
+export function Layout( { progressLabel, siteUrl, siteTitle, children }: Props ) {
+	// Without a site URL there's no preview, so collapse to a single column —
+	// otherwise the grid reserves an empty preview track and squeezes the tasks.
+	const hasPreview = !! siteUrl;
+
+	return (
+		<div className="ai-launchpad-tailored-list__layout">
+			<header className="ai-launchpad-tailored-list__heading">
+				<h1 className="ai-launchpad-tailored-list__title-heading">
+					{ __( 'Get the most out of WordPress', 'jetpack-mu-wpcom' ) }
+				</h1>
+				<p className="ai-launchpad-tailored-list__progress">{ progressLabel }</p>
+			</header>
+			<div
+				className={ clsx( 'ai-launchpad-tailored-list__columns', {
+					'has-preview': hasPreview,
+				} ) }
+			>
+				{ children }
+				<SitePreview siteUrl={ siteUrl } siteTitle={ siteTitle } />
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -4,7 +4,13 @@ import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { validateAgainstSchema } from '../lib/schema-validator.ts';
-import { ctaKind, firstIncompleteIndex, resolveCtaUrl, tasksFromFixture } from './model.ts';
+import {
+	ctaKind,
+	firstIncompleteIndex,
+	resolveCtaUrl,
+	tasksFromFixture,
+	toNavigableUrl,
+} from './model.ts';
 import type { EnrichedTask } from './model.ts';
 import type { TailoredOutput } from '../lib/types.ts';
 
@@ -83,6 +89,38 @@ describe( 'ctaKind', () => {
 	} );
 } );
 
+describe( 'toNavigableUrl', () => {
+	it( 'pins Calypso router paths to wordpress.com', () => {
+		assert.equal(
+			toNavigableUrl( '/me#complete-your-profile' ),
+			'https://wordpress.com/me#complete-your-profile'
+		);
+		assert.equal(
+			toNavigableUrl( '/marketing/connections/example.com' ),
+			'https://wordpress.com/marketing/connections/example.com'
+		);
+	} );
+
+	it( 'leaves site-relative wp-admin paths untouched', () => {
+		assert.equal( toNavigableUrl( '/wp-admin/post.php?post=1' ), '/wp-admin/post.php?post=1' );
+		// The root wp-admin path, with or without a query/hash, is still site-relative.
+		assert.equal( toNavigableUrl( '/wp-admin' ), '/wp-admin' );
+		assert.equal( toNavigableUrl( '/wp-admin/' ), '/wp-admin/' );
+		assert.equal( toNavigableUrl( '/wp-admin?foo=bar' ), '/wp-admin?foo=bar' );
+	} );
+
+	it( 'leaves absolute URLs untouched', () => {
+		assert.equal(
+			toNavigableUrl( 'https://example.com/wp-admin/admin.php?page=wc-admin' ),
+			'https://example.com/wp-admin/admin.php?page=wc-admin'
+		);
+		assert.equal(
+			toNavigableUrl( 'https://connect.stripe.com/x' ),
+			'https://connect.stripe.com/x'
+		);
+	} );
+} );
+
 describe( 'resolveCtaUrl', () => {
 	/**
 	 * Build CtaHandlers that record the clicked task IDs and return marker URLs.
@@ -108,8 +146,34 @@ describe( 'resolveCtaUrl', () => {
 			null,
 			handlers
 		);
-		assert.equal( url, '/themes/x' );
+		// A Calypso router path is pinned to wordpress.com (it must not resolve
+		// against the site host where the launchpad runs).
+		assert.equal( url, 'https://wordpress.com/themes/x' );
 		assert.deepEqual( clicked, [ 'site_theme_selected' ] );
+	} );
+
+	it( 'passes absolute deeplinks (admin_url / Stripe / launch) through unchanged', async () => {
+		const { handlers } = stubHandlers();
+		const stripe = await resolveCtaUrl(
+			task( { id: 'stripe_connected', calypso_path: 'https://connect.stripe.com/setup/x' } ),
+			null,
+			handlers
+		);
+		assert.equal( stripe, 'https://connect.stripe.com/setup/x' );
+
+		const launch = await resolveCtaUrl(
+			task( {
+				id: 'site_launched',
+				calypso_path:
+					'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin',
+			} ),
+			null,
+			handlers
+		);
+		assert.equal(
+			launch,
+			'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin'
+		);
 	} );
 
 	it( 'drafts a post and returns its editor URL for first-creation tasks', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -7,6 +7,8 @@ import { validateAgainstSchema } from '../lib/schema-validator.ts';
 import {
 	ctaKind,
 	firstIncompleteIndex,
+	isTaskActionable,
+	launchSiteUrl,
 	resolveCtaUrl,
 	tasksFromFixture,
 	toNavigableUrl,
@@ -83,8 +85,15 @@ describe( 'ctaKind', () => {
 		assert.equal( ctaKind( 'add_about_page' ), 'pattern_page' );
 	} );
 
+	it( 'routes pathless launch tasks to the launch handler', () => {
+		assert.equal( ctaKind( 'site_launched' ), 'launch' );
+		assert.equal( ctaKind( 'blog_launched' ), 'launch' );
+		assert.equal( ctaKind( 'link_in_bio_launched' ), 'launch' );
+	} );
+
 	it( 'routes everything else to a deeplink', () => {
 		assert.equal( ctaKind( 'site_theme_selected' ), 'deeplink' );
+		// woo_launch_site has its own wc-admin deeplink, so it is not a launch kind.
 		assert.equal( ctaKind( 'woo_launch_site' ), 'deeplink' );
 	} );
 } );
@@ -121,6 +130,32 @@ describe( 'toNavigableUrl', () => {
 	} );
 } );
 
+describe( 'launchSiteUrl', () => {
+	it( 'builds the wordpress.com launch-flow URL from the site URL', () => {
+		assert.equal(
+			launchSiteUrl( 'https://example.wpcomstaging.com' ),
+			'https://wordpress.com/start/launch-site?siteSlug=example.wpcomstaging.com&ref=wp-admin'
+		);
+	} );
+
+	it( 'returns null for a malformed site URL instead of throwing', () => {
+		assert.equal( launchSiteUrl( 'not-a-url' ), null );
+		assert.equal( launchSiteUrl( '' ), null );
+	} );
+} );
+
+describe( 'isTaskActionable', () => {
+	it( 'treats a launch task as actionable only when the site URL is known', () => {
+		const launch = task( { id: 'site_launched', calypso_path: null } );
+		assert.equal( isTaskActionable( launch, null, 'https://example.com' ), true );
+		assert.equal( isTaskActionable( launch, null, null ), false );
+		// An empty or malformed URL can't build a launch URL, so it must not be
+		// actionable (stays in lockstep with resolveCtaUrl).
+		assert.equal( isTaskActionable( launch, null, '' ), false );
+		assert.equal( isTaskActionable( launch, null, 'not-a-url' ), false );
+	} );
+} );
+
 describe( 'resolveCtaUrl', () => {
 	/**
 	 * Build CtaHandlers that record the clicked task IDs and return marker URLs.
@@ -152,7 +187,7 @@ describe( 'resolveCtaUrl', () => {
 		assert.deepEqual( clicked, [ 'site_theme_selected' ] );
 	} );
 
-	it( 'passes absolute deeplinks (admin_url / Stripe / launch) through unchanged', async () => {
+	it( 'passes absolute deeplinks (admin_url / Stripe) through unchanged', async () => {
 		const { handlers } = stubHandlers();
 		const stripe = await resolveCtaUrl(
 			task( { id: 'stripe_connected', calypso_path: 'https://connect.stripe.com/setup/x' } ),
@@ -161,19 +196,15 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( stripe, 'https://connect.stripe.com/setup/x' );
 
-		const launch = await resolveCtaUrl(
+		const admin = await resolveCtaUrl(
 			task( {
-				id: 'site_launched',
-				calypso_path:
-					'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin',
+				id: 'woo_products',
+				calypso_path: 'https://example.com/wp-admin/admin.php?page=wc-admin&task=products',
 			} ),
 			null,
 			handlers
 		);
-		assert.equal(
-			launch,
-			'https://wordpress.com/start/launch-site?siteSlug=x.wordpress.com&ref=wp-admin'
-		);
+		assert.equal( admin, 'https://example.com/wp-admin/admin.php?page=wc-admin&task=products' );
 	} );
 
 	it( 'drafts a post and returns its editor URL for first-creation tasks', async () => {
@@ -196,6 +227,32 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( url, '/wp-admin/post.php?post=2' );
 		assert.deepEqual( clicked, [ 'add_about_page' ] );
+	} );
+
+	it( 'sends launch tasks to the wordpress.com launch flow built from the site URL', async () => {
+		const { clicked, handlers } = stubHandlers();
+		const url = await resolveCtaUrl(
+			task( { id: 'site_launched', calypso_path: null } ),
+			null,
+			handlers,
+			'https://example.wpcomstaging.com'
+		);
+		assert.equal(
+			url,
+			'https://wordpress.com/start/launch-site?siteSlug=example.wpcomstaging.com&ref=wp-admin'
+		);
+		assert.deepEqual( clicked, [ 'site_launched' ] );
+	} );
+
+	it( 'returns null for a launch task when the site URL is unavailable', async () => {
+		const { handlers } = stubHandlers();
+		const url = await resolveCtaUrl(
+			task( { id: 'site_launched', calypso_path: null } ),
+			null,
+			handlers,
+			null
+		);
+		assert.equal( url, null );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -13,6 +13,13 @@ export interface EnrichedTask {
 	calypso_path: string | null;
 }
 
+/** The site context the list needs (front-end URL for the launch CTA + preview). */
+export interface SiteData {
+	// Optional: the field comes from an un-validated REST response, so consumers
+	// must tolerate it being absent (coalesce to null) rather than trust the type.
+	url?: string;
+}
+
 /**
  * The relevant slice of Stream B's `GET /ai-launchpad/` response. Only the
  * fields the tailored list renders from are typed here.
@@ -22,19 +29,29 @@ export interface LaunchpadData {
 	ai_output: {
 		payload: TailoredOutput;
 	} | null;
+	site?: SiteData;
 }
 
 /** How a task's "Get started" CTA behaves when clicked. */
-export type CtaKind = 'first_post' | 'pattern_page' | 'deeplink';
+export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
 const PATTERN_PAGE_TASK_IDS = [ 'add_about_page' ];
+// Launch tasks that have no catalog deeplink: they send the user to the
+// wordpress.com launch flow. woo_launch_site is excluded — it has its own
+// wc-admin deeplink and is handled as a plain deeplink.
+const LAUNCH_TASK_IDS = [
+	'site_launched',
+	'blog_launched',
+	'link_in_bio_launched',
+	'videopress_launched',
+];
 
 /**
  * Resolve how a task's "Get started" CTA behaves. First-creation tasks draft a
  * real post via Stream F's `createFirstPostDraft`; page-creating tasks build a
- * pattern page via `createPatternPage`; everything else deeplinks to the
- * catalog's `calypso_path`.
+ * pattern page via `createPatternPage`; launch tasks open the wordpress.com
+ * launch flow; everything else deeplinks to the catalog's `calypso_path`.
  *
  * @param taskId - The catalog task ID.
  * @return The CTA kind.
@@ -46,7 +63,33 @@ export function ctaKind( taskId: string ): CtaKind {
 	if ( PATTERN_PAGE_TASK_IDS.includes( taskId ) ) {
 		return 'pattern_page';
 	}
+	if ( LAUNCH_TASK_IDS.includes( taskId ) ) {
+		return 'launch';
+	}
 	return 'deeplink';
+}
+
+/**
+ * Build the wordpress.com launch-flow URL for a launch task. Launch tasks have
+ * no catalog deeplink; the legacy launchpad widget routes them to
+ * `/start/launch-site` keyed by the site slug (the host of the site's home URL).
+ *
+ * @param siteUrl - The site's front-end URL (from the composite read).
+ * @return The launch-flow URL, or null if the site URL can't be parsed.
+ */
+export function launchSiteUrl( siteUrl: string ): string | null {
+	let slug: string;
+	try {
+		slug = new URL( siteUrl ).host;
+	} catch {
+		// A malformed/relative home URL (e.g. a broken `home_url` filter) can't
+		// produce a launch slug; return null so the CTA is hidden rather than
+		// throwing on click.
+		return null;
+	}
+	return `https://wordpress.com/start/launch-site?siteSlug=${ encodeURIComponent(
+		slug
+	) }&ref=wp-admin`;
 }
 
 /**
@@ -110,12 +153,14 @@ export function toNavigableUrl( url: string ): string {
  * @param task     - The clicked task.
  * @param output   - The AI output (post draft + inferred details), or null.
  * @param handlers - The CTA side effects.
+ * @param siteUrl  - The site's front-end URL, used to build the launch CTA.
  * @return The destination URL, or null.
  */
 export async function resolveCtaUrl(
 	task: EnrichedTask,
 	output: TailoredOutput | null,
-	handlers: CtaHandlers
+	handlers: CtaHandlers,
+	siteUrl: string | null = null
 ): Promise< string | null > {
 	handlers.trackTaskClicked( { task_id: task.id } );
 
@@ -125,6 +170,8 @@ export async function resolveCtaUrl(
 		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
 	} else if ( kind === 'pattern_page' && output ) {
 		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
+	} else if ( kind === 'launch' ) {
+		url = siteUrl ? launchSiteUrl( siteUrl ) : null;
 	} else {
 		url = task.calypso_path;
 	}
@@ -139,14 +186,24 @@ export async function resolveCtaUrl(
  * every other task is actionable only when it has a deeplink path. Used to hide
  * the CTA for tasks that would otherwise be a silent no-op.
  *
- * @param task   - The task.
- * @param output - The AI output, or null.
+ * @param task    - The task.
+ * @param output  - The AI output, or null.
+ * @param siteUrl - The site's front-end URL, used to build the launch CTA.
  * @return True when "Get started" would navigate somewhere.
  */
-export function isTaskActionable( task: EnrichedTask, output: TailoredOutput | null ): boolean {
+export function isTaskActionable(
+	task: EnrichedTask,
+	output: TailoredOutput | null,
+	siteUrl: string | null = null
+): boolean {
 	const kind = ctaKind( task.id );
 	if ( ( kind === 'first_post' || kind === 'pattern_page' ) && output ) {
 		return true;
+	}
+	if ( kind === 'launch' ) {
+		// Only actionable when a launch URL can actually be built — keeps this in
+		// lockstep with resolveCtaUrl (no CTA shown for a missing/malformed URL).
+		return !! siteUrl && launchSiteUrl( siteUrl ) !== null;
 	}
 	return task.calypso_path !== null;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -15,9 +15,11 @@ export interface EnrichedTask {
 
 /** The site context the list needs (front-end URL for the launch CTA + preview). */
 export interface SiteData {
-	// Optional: the field comes from an un-validated REST response, so consumers
-	// must tolerate it being absent (coalesce to null) rather than trust the type.
+	// Optional: the fields come from an un-validated REST response, so consumers
+	// must tolerate them being absent (coalesce to null) rather than trust the type.
 	url?: string;
+	// The site name, used to label the preview card.
+	title?: string;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -65,10 +65,47 @@ export interface CtaHandlers {
 }
 
 /**
+ * Make a resolved CTA destination safe to navigate to from wp-admin.
+ *
+ * Catalog deeplinks arrive in three shapes: absolute URLs (`admin_url()`-based
+ * wp-admin links, Stripe connect URLs, the synthesized launch URL), site-relative
+ * wp-admin paths (e.g. the editor URL of a freshly created draft), and Calypso
+ * router paths (e.g. `/me`, `/marketing/connections/{slug}`) that are relative
+ * to wordpress.com. The launchpad runs in wp-admin, so a Calypso path navigated
+ * via `window.location` would resolve against the *site* host and 404; only those
+ * must be pinned to wordpress.com.
+ *
+ * This mirrors the legacy launchpad dashboard widget, which rebases relative task
+ * links with `new URL( href, 'https://wordpress.com' )` (see
+ * `wpcom-dashboard-widgets/wpcom-launchpad-widget`). The one difference: that
+ * widget's task admin links are already absolute, whereas our created-content
+ * CTAs return site-relative `/wp-admin/…` editor URLs, so those are excluded from
+ * the rebase. Absolute URLs don't start with `/` and pass through unchanged.
+ *
+ * @param url - The resolved destination URL or path.
+ * @return The navigable URL.
+ */
+export function toNavigableUrl( url: string ): string {
+	// Site-relative wp-admin paths must resolve against the current site. Match the
+	// root path too (`/wp-admin`, `/wp-admin?…`, `/wp-admin#…`), not just `/wp-admin/`.
+	if ( /^\/wp-admin(\/|\?|#|$)/.test( url ) ) {
+		return url;
+	}
+	// Calypso router paths are relative to wordpress.com; absolute URLs (Stripe,
+	// admin_url(), the launch URL) don't start with `/` and fall through unchanged.
+	if ( url.startsWith( '/' ) ) {
+		return new URL( url, 'https://wordpress.com' ).href;
+	}
+	return url;
+}
+
+/**
  * Fire the Tracks event and resolve the destination URL for a "Get started"
  * click. First-creation tasks draft a post; page-creating tasks build a pattern
- * page; everything else uses the catalog deeplink. Returns the URL to navigate
- * to, or null when the task has no actionable destination.
+ * page; everything else uses the catalog deeplink. The resolved URL is run
+ * through {@link toNavigableUrl} so Calypso paths point at wordpress.com rather
+ * than the site host. Returns the URL to navigate to, or null when the task has
+ * no actionable destination.
  *
  * @param task     - The clicked task.
  * @param output   - The AI output (post draft + inferred details), or null.
@@ -83,15 +120,16 @@ export async function resolveCtaUrl(
 	handlers.trackTaskClicked( { task_id: task.id } );
 
 	const kind = ctaKind( task.id );
+	let url: string | null;
 	if ( kind === 'first_post' && output ) {
-		const { edit_url } = await handlers.createFirstPostDraft( output.first_post_draft );
-		return edit_url;
+		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
+	} else if ( kind === 'pattern_page' && output ) {
+		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
+	} else {
+		url = task.calypso_path;
 	}
-	if ( kind === 'pattern_page' && output ) {
-		const { edit_url } = await handlers.createPatternPage( output.inferred );
-		return edit_url;
-	}
-	return task.calypso_path;
+
+	return url === null ? null : toNavigableUrl( url );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -1,0 +1,55 @@
+import { ExternalLink } from '@wordpress/components';
+
+interface Props {
+	// The site's front-end URL, from the composite read. When absent (older
+	// reads, dev fixtures) the preview is omitted entirely.
+	siteUrl: string | null;
+	// The site name; falls back to the domain when absent.
+	siteTitle?: string | null;
+}
+
+/**
+ * The site-preview card shown to the right of the tailored list: a live,
+ * scaled-down preview of the site's front end, the site name, and a link to the
+ * site. The preview is a non-interactive iframe of the front end with the
+ * banners/overlay hidden, mirroring the wp-admin dashboard's site-management
+ * widget — it renders immediately rather than waiting on an mShots screenshot.
+ * Rendered in both the loading and loaded states so the layout is stable across
+ * the wizard→tailoring→list transition. Returns nothing when the site URL is
+ * unknown (e.g. dev fixtures), so the list still renders without it.
+ *
+ * @param props           - Component props.
+ * @param props.siteUrl   - The site's front-end URL.
+ * @param props.siteTitle - The site name (falls back to the domain).
+ * @return The preview element, or null when there's no site URL.
+ */
+export function SitePreview( { siteUrl, siteTitle }: Props ) {
+	if ( ! siteUrl ) {
+		return null;
+	}
+
+	let domain = siteUrl;
+	try {
+		domain = new URL( siteUrl ).host;
+	} catch {
+		// A malformed home URL still renders: fall back to the raw string.
+	}
+
+	return (
+		<aside className="ai-launchpad-tailored-list__preview">
+			<div className="ai-launchpad-tailored-list__preview-frame">
+				<iframe
+					className="ai-launchpad-tailored-list__preview-iframe"
+					title={ siteTitle || domain }
+					src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
+					inert="true"
+					tabIndex={ -1 }
+				/>
+			</div>
+			<p className="ai-launchpad-tailored-list__preview-title">{ siteTitle || domain }</p>
+			<ExternalLink className="ai-launchpad-tailored-list__preview-link" href={ siteUrl }>
+				{ domain }
+			</ExternalLink>
+		</aside>
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
@@ -1,11 +1,10 @@
-import { Card, CardBody } from '@wordpress/components';
-
-const PLACEHOLDER_COUNT = 6;
+const PLACEHOLDER_COUNT = 5;
 
 /**
- * Loading placeholder for the tailored list, shown while the AI call is in
- * flight. Renders six shimmering cards so the layout doesn't jump when the
- * real task cards arrive.
+ * Loading placeholder for the tailored list's task column, shown while the AI
+ * call is in flight. Rendered inside {@link Layout} so the heading and site
+ * preview stay put; only these shimmering bars stand in for the task cards
+ * until the real ones arrive.
  *
  * @return The skeleton element.
  */
@@ -13,11 +12,11 @@ export function TailoredListSkeleton() {
 	return (
 		<div className="ai-launchpad-tailored-list">
 			{ Array.from( { length: PLACEHOLDER_COUNT } ).map( ( _, index ) => (
-				<Card key={ index } className="ai-launchpad-tailored-list__card is-skeleton">
-					<CardBody>
-						<span className="ai-launchpad-tailored-list__skeleton-line is-title" />
-					</CardBody>
-				</Card>
+				<span
+					key={ index }
+					className="ai-launchpad-tailored-list__skeleton-bar"
+					aria-hidden="true"
+				/>
 			) ) }
 		</div>
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -1,37 +1,87 @@
 .ai-launchpad-tailored-list {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
 
-	&__card {
+	// The centered content column shared by the loaded list and its loading
+	// state: heading + progress line, then a two-column grid (tasks | preview).
+	// A responsive, generous top pad pushes the content off the admin chrome
+	// without relying on a fixed-height container to vertically center.
+	&__layout {
+		max-width: 960px;
+		margin: 0 auto;
+		padding: clamp(24px, 8vh, 96px) 24px 48px;
+	}
 
-		.components-card__body {
-			padding: 16px 20px;
-		}
+	@media (max-width: 782px) {
 
-		&.is-expanded .components-card__body {
-			padding-bottom: 20px;
+		&__layout {
+			padding: 24px 16px 32px;
 		}
 	}
 
-	&__header {
+	&__heading {
+		margin-bottom: 24px;
+	}
+
+	&__title-heading {
+		margin: 0;
+		font-size: 32px;
+		line-height: 1.2;
+		font-weight: 500;
+	}
+
+	&__progress {
+		margin: 8px 0 0;
+		color: #757575;
+		font-size: 14px;
+	}
+
+	&__columns {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		gap: 32px;
+		align-items: start;
+
+		// Reserve the preview track only when there's a preview to show, so a
+		// missing site URL doesn't leave an empty gutter squeezing the tasks.
+		&.has-preview {
+			grid-template-columns: minmax(0, 1fr) 300px;
+		}
+	}
+
+	// Stack the preview under the tasks on narrow screens (WP admin's mobile
+	// breakpoint), so neither column gets squeezed.
+	@media (max-width: 782px) {
+
+		&__columns.has-preview {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	// The task column itself: a vertical stack of cards (and skeleton bars),
+	// wrapped in a padded grey container so the white cards read as a grouped
+	// checklist. The padding matches the inter-card gap.
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 8px;
+	background: #f6f7f7;
+	border-radius: 8px;
+
+	// Tighten the @wordpress/ui Card padding so the cards read as compact
+	// checklist rows rather than full content cards. Zero the header→content
+	// margin (it otherwise leaves a gap below the header even when collapsed);
+	// the expanded gap is re-added on the subtitle, inside the clipped panel.
+	&__card {
+		--wp-ui-card-padding: 16px;
+		--wp-ui-card-header-content-margin: 0;
+	}
+
+	// The icon + title row placed inside the (clickable) card header. The
+	// CollapsibleCard supplies the chevron trigger beside it.
+	&__header-inner {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		gap: 8px;
-		width: 100%;
-		height: auto;
-		text-align: start;
-
-		// The collapsed header is a Button; strip its chrome so it reads as a row.
-		&.components-button {
-			padding: 0;
-			color: inherit;
-
-			&:hover:not(:disabled) {
-				color: inherit;
-			}
-		}
+		min-width: 0;
 	}
 
 	&__title {
@@ -44,24 +94,26 @@
 		}
 	}
 
+	// The inline SVG task icons use `currentColor`, so tone them via `color`.
 	&__icon {
 		flex-shrink: 0;
-		margin-inline-end: 8px;
 
+		// Incomplete tasks: a light dashed ring.
+		&.is-todo {
+			color: #c3c4c7;
+		}
+
+		// Completed tasks: a check-in-circle, greyed to sit alongside the
+		// struck-through title.
 		&.is-done {
-			fill: #757575;
+			color: #757575;
 		}
 	}
 
-	&__body {
-		margin-top: 12px;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
+	// 8px top re-creates the header→content gap (the card's own margin is zeroed
+	// above); being inside the panel, it's clipped when the card is collapsed.
 	&__subtitle {
-		margin: 0;
+		margin: 8px 0 16px;
 		color: #757575;
 	}
 
@@ -71,11 +123,68 @@
 		gap: 8px;
 	}
 
-	&__skeleton-line {
+	// The site-preview card in the right column: a live scaled site preview +
+	// name + link.
+	&__preview {
+		display: flex;
+		flex-direction: column;
+	}
+
+	// A square frame holding a desktop-width iframe scaled down to fit, mirroring
+	// the wp-admin dashboard site-management widget (renders immediately, no
+	// mShots wait). The iframe is 4× the frame and scaled 0.25, so the frame
+	// shows a ~1200px-wide front-end view regardless of the frame's actual size.
+	&__preview-frame {
+		position: relative;
+		width: 100%;
+		max-width: 300px;
+		aspect-ratio: 4 / 3;
+		overflow: hidden;
+		border: 1px solid #e0e0e0;
+		border-radius: 8px;
+		background: #f6f7f7;
+	}
+
+	&__preview-iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 400%;
+		min-height: 440%;
+		border: 0;
+		transform: scale(0.25);
+		transform-origin: top left;
+		// Nudge the scaled view up to crop the logged-in admin bar (~32px at the
+		// 1200px render width → ~8px at scale 0.25), mirroring the dashboard widget.
+		translate: 0 -8px;
+		// Purely a thumbnail — the link below is the interactive affordance.
+		pointer-events: none;
+	}
+
+	&__preview-title {
+		margin: 12px 0 2px;
+		font-weight: 600;
+		font-size: 15px;
+	}
+
+	&__preview-link {
+		font-size: 13px;
+	}
+
+	// Stacked under the tasks on mobile, the preview spans the full column width.
+	// Declared after the base rule above so it wins at the mobile breakpoint.
+	@media (max-width: 782px) {
+
+		&__preview-frame {
+			max-width: none;
+		}
+	}
+
+	// Loading placeholders: solid shimmering bars standing in for the task cards.
+	&__skeleton-bar {
 		display: block;
-		height: 16px;
-		width: 60%;
-		border-radius: 2px;
+		height: 56px;
+		border-radius: 4px;
 		background: linear-gradient(90deg, #f0f0f0 25%, #e6e6e6 37%, #f0f0f0 63%);
 		background-size: 400% 100%;
 		animation: ai-launchpad-shimmer 1.4s ease infinite;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -1,8 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { createFirstPostDraft } from '../lib/first-post.ts';
 import { createPatternPage } from '../lib/pattern-page.ts';
 import { trackTaskClicked } from '../lib/tracks.ts';
+import { Layout } from './layout.tsx';
 import {
 	firstIncompleteIndex,
 	isTaskActionable,
@@ -10,6 +12,7 @@ import {
 	tasksFromFixture,
 	type EnrichedTask,
 	type LaunchpadData,
+	type SiteData,
 } from './model.ts';
 import { TailoredListSkeleton } from './skeleton.tsx';
 import { TaskCard } from './task-card.tsx';
@@ -40,12 +43,20 @@ interface Props {
 	// view, so it hands the data down here to avoid fetching the same expensive
 	// endpoint a second time. Omitted on the wizard→list path.
 	initialData?: LaunchpadData;
+
+	// Site context (URL + title) for the preview card. The host always has this
+	// from its initial composite read, so it's passed on the wizard→list path too
+	// — that lets the loading skeleton show the preview before the tailored read
+	// lands. The fetched/initialData site (when present) takes precedence.
+	site?: SiteData;
 }
 
 /**
- * The tailored launchpad list: six task cards rendered from the AI output. The
- * first incomplete task auto-expands; each task offers "Get started" and "Skip"
- * actions. While the AI output is loading, a six-card skeleton is shown.
+ * The tailored launchpad list: task cards rendered from the AI output inside a
+ * centered layout with a heading, "X of N completed" progress, and a site
+ * preview. The first incomplete task auto-expands; each task offers an
+ * action-specific CTA and "Skip". While the AI output is loading, the same
+ * layout is shown with a shimmering skeleton and "Tailoring your checklist…".
  *
  * Titles, completion state, and deeplink paths come from Stream B's
  * `GET /ai-launchpad/`; subtitles come from the AI. In dev mode the list
@@ -55,16 +66,29 @@ interface Props {
  * @param props               - Component props.
  * @param props.pendingTailor - In-flight tailor call to await before fetching.
  * @param props.initialData   - Composite read supplied by the host (returning users).
+ * @param props.site          - Site context for the preview (always supplied by the host).
  * @return The tailored-list element.
  */
-export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
-	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( null );
-	const [ output, setOutput ] = useState< TailoredOutput | null >( null );
-	const [ expandedId, setExpandedId ] = useState< string | null >( null );
+export function TailoredList( { pendingTailor, initialData, site }: Props = {} ) {
+	// Returning users arrive with the composite read already done, so seed straight
+	// from it — otherwise the first frame shows the "Tailoring…" loading copy before
+	// the effect runs. The wizard→list path has no initialData and starts as loading.
+	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( () => initialData?.tasks ?? null );
+	const [ output, setOutput ] = useState< TailoredOutput | null >(
+		() => initialData?.ai_output?.payload ?? null
+	);
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
-	// The site's front-end URL, used to build the launch CTA. From the composite read.
-	const [ siteUrl, setSiteUrl ] = useState< string | null >( null );
+	// The site's front-end URL, used to build the launch CTA and the preview
+	// thumbnail; the title labels the preview. Seeded from the read (returning users)
+	// or the host's `site` prop (wizard path, so the skeleton shows the preview),
+	// then overridden once the read lands.
+	const [ siteUrl, setSiteUrl ] = useState< string | null >(
+		() => initialData?.site?.url ?? site?.url ?? null
+	);
+	const [ siteTitle, setSiteTitle ] = useState< string | null >(
+		() => initialData?.site?.title ?? site?.title ?? null
+	);
 
 	useEffect( () => {
 		// Returning users: render from the data the host already fetched, so the
@@ -72,7 +96,10 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 		if ( initialData ) {
 			setTasks( initialData.tasks );
 			setOutput( initialData.ai_output?.payload ?? null );
-			setSiteUrl( initialData.site?.url ?? null );
+			if ( initialData.site ) {
+				setSiteUrl( initialData.site.url ?? null );
+				setSiteTitle( initialData.site.title ?? null );
+			}
 			return;
 		}
 
@@ -95,6 +122,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 
 			if ( data?.site ) {
 				setSiteUrl( data.site.url ?? null );
+				setSiteTitle( data.site.title ?? null );
 			}
 
 			if ( data && data.tasks.length > 0 ) {
@@ -122,22 +150,25 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 		[ tasks, skippedIds ]
 	);
 
-	useEffect( () => {
-		if ( ! tasks || expandedId !== null ) {
-			return;
-		}
-		// Scan visibleTasks (skipped→completed) so skipping the last actionable
-		// task doesn't re-select it and bounce the just-dismissed card open.
-		const index = firstIncompleteIndex( visibleTasks );
-		const first = index === -1 ? undefined : visibleTasks[ index ];
-		if ( first ) {
-			setExpandedId( first.id );
-		}
-	}, [ tasks, visibleTasks, expandedId ] );
-
 	if ( ! tasks ) {
-		return <TailoredListSkeleton />;
+		return (
+			<Layout
+				progressLabel={ __( 'Tailoring your checklist…', 'jetpack-mu-wpcom' ) }
+				siteUrl={ siteUrl }
+				siteTitle={ siteTitle }
+			>
+				<TailoredListSkeleton />
+			</Layout>
+		);
 	}
+
+	const completedCount = visibleTasks.filter( task => task.completed ).length;
+	const progressLabel = sprintf(
+		/* translators: 1: number of completed tasks, 2: total number of tasks. */
+		__( '%1$d of %2$d completed', 'jetpack-mu-wpcom' ),
+		completedCount,
+		visibleTasks.length
+	);
 
 	const handleGetStarted = async ( task: EnrichedTask ) => {
 		setBusyId( task.id );
@@ -165,28 +196,28 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 
 	const handleSkip = ( task: EnrichedTask ) => {
 		setSkippedIds( prev => new Set( prev ).add( task.id ) );
-		if ( expandedId === task.id ) {
-			const next = visibleTasks.find(
-				candidate => candidate.id !== task.id && ! candidate.completed
-			);
-			setExpandedId( next ? next.id : null );
-		}
 	};
 
+	// The first incomplete task opens on mount; because the cards are uncontrolled
+	// (defaultOpen), the user can then collapse it — or all of them — without it
+	// reopening. Computed from the initial render (skippedIds is empty then).
+	const firstOpenIndex = firstIncompleteIndex( visibleTasks );
+
 	return (
-		<div className="ai-launchpad-tailored-list">
-			{ visibleTasks.map( task => (
-				<TaskCard
-					key={ task.id }
-					task={ task }
-					isExpanded={ expandedId === task.id }
-					isBusy={ busyId === task.id }
-					canStart={ isTaskActionable( task, output, siteUrl ) }
-					onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
-					onGetStarted={ () => handleGetStarted( task ) }
-					onSkip={ () => handleSkip( task ) }
-				/>
-			) ) }
-		</div>
+		<Layout progressLabel={ progressLabel } siteUrl={ siteUrl } siteTitle={ siteTitle }>
+			<div className="ai-launchpad-tailored-list">
+				{ visibleTasks.map( ( task, index ) => (
+					<TaskCard
+						key={ task.id }
+						task={ task }
+						isBusy={ busyId === task.id }
+						canStart={ isTaskActionable( task, output, siteUrl ) }
+						defaultOpen={ index === firstOpenIndex }
+						onGetStarted={ () => handleGetStarted( task ) }
+						onSkip={ () => handleSkip( task ) }
+					/>
+				) ) }
+			</div>
+		</Layout>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -63,6 +63,8 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	const [ expandedId, setExpandedId ] = useState< string | null >( null );
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
+	// The site's front-end URL, used to build the launch CTA. From the composite read.
+	const [ siteUrl, setSiteUrl ] = useState< string | null >( null );
 
 	useEffect( () => {
 		// Returning users: render from the data the host already fetched, so the
@@ -70,6 +72,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 		if ( initialData ) {
 			setTasks( initialData.tasks );
 			setOutput( initialData.ai_output?.payload ?? null );
+			setSiteUrl( initialData.site?.url ?? null );
 			return;
 		}
 
@@ -88,6 +91,10 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 			}
 			if ( cancelled ) {
 				return;
+			}
+
+			if ( data?.site ) {
+				setSiteUrl( data.site.url ?? null );
 			}
 
 			if ( data && data.tasks.length > 0 ) {
@@ -135,11 +142,16 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 	const handleGetStarted = async ( task: EnrichedTask ) => {
 		setBusyId( task.id );
 		try {
-			const url = await resolveCtaUrl( task, output, {
-				trackTaskClicked,
-				createFirstPostDraft,
-				createPatternPage,
-			} );
+			const url = await resolveCtaUrl(
+				task,
+				output,
+				{
+					trackTaskClicked,
+					createFirstPostDraft,
+					createPatternPage,
+				},
+				siteUrl
+			);
 			if ( url ) {
 				navigate( url );
 			}
@@ -169,7 +181,7 @@ export function TailoredList( { pendingTailor, initialData }: Props = {} ) {
 					task={ task }
 					isExpanded={ expandedId === task.id }
 					isBusy={ busyId === task.id }
-					canStart={ isTaskActionable( task, output ) }
+					canStart={ isTaskActionable( task, output, siteUrl ) }
 					onToggle={ () => setExpandedId( expandedId === task.id ? null : task.id ) }
 					onGetStarted={ () => handleGetStarted( task ) }
 					onSkip={ () => handleSkip( task ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,89 +1,152 @@
-import { Card, CardBody, Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check, chevronDown, chevronUp } from '@wordpress/icons';
-import clsx from 'clsx';
-import type { EnrichedTask } from './model.ts';
+import { Button, Card, CollapsibleCard } from '@wordpress/ui';
+import { ctaKind, type EnrichedTask } from './model.ts';
+
+// WPDS doesn't ship a "todo / dashed-circle" or "check-in-circle" icon yet (only
+// `check`), so we inline both. Sized at 24px to line up with each other;
+// `currentColor` lets us tone them via CSS.
+const taskActiveIcon = (
+	<svg
+		className="ai-launchpad-tailored-list__icon is-todo"
+		width={ 24 }
+		height={ 24 }
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" strokeDasharray="3 2.5" />
+	</svg>
+);
+
+const taskDoneIcon = (
+	<svg
+		className="ai-launchpad-tailored-list__icon is-done"
+		width={ 24 }
+		height={ 24 }
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+		<path
+			d="M8 12.5L11 15.5L16 9.5"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
 
 interface Props {
 	task: EnrichedTask;
-	isExpanded: boolean;
 	isBusy: boolean;
 	canStart: boolean;
-	onToggle: () => void;
+	defaultOpen: boolean;
 	onGetStarted: () => void;
 	onSkip: () => void;
 }
 
 /**
- * A single task in the tailored list, rendered as a card. Completed tasks show
- * a struck-through title with a check icon and aren't expandable. Incomplete
- * tasks show a title + chevron when collapsed; expanding reveals the AI
- * subtitle and the "Get started" / "Skip" actions.
+ * Resolve the action-specific label for a task's primary CTA. A static,
+ * translatable map keyed first by task id (the most specific) then by
+ * {@link ctaKind} (the behavioral class), falling back to a generic
+ * "Get started" so a task with no entry still gets a sensible button.
+ *
+ * The map lives here rather than in `model.ts` because the labels must be
+ * `__()` literals (so they're extracted for translation) and `model.ts` is
+ * intentionally free of `@wordpress/*` imports so its node:test suite runs.
+ * Labels are AI-independent on purpose — AI output is English-only today
+ * (DOTOBRD-474), so deriving labels from it would regress i18n.
+ *
+ * @param taskId - The catalog task id.
+ * @return The translated CTA label.
+ */
+function getCtaLabel( taskId: string ): string {
+	switch ( taskId ) {
+		case 'site_theme_selected':
+			return __( 'Browse themes', 'jetpack-mu-wpcom' );
+		case 'woo_products':
+			return __( 'Add products', 'jetpack-mu-wpcom' );
+		case 'woo_customize_store':
+			return __( 'Customize store', 'jetpack-mu-wpcom' );
+		case 'set_up_payments':
+			return __( 'Set up payments', 'jetpack-mu-wpcom' );
+		case 'connect_social_media':
+			return __( 'Connect socials', 'jetpack-mu-wpcom' );
+		// Both the AI-selectable catalog id and the deterministic fallback id for
+		// growing a subscriber list, so the label holds on the fallback path too.
+		case 'subscribers_added':
+		case 'add_10_email_subscribers':
+			return __( 'Add subscribers', 'jetpack-mu-wpcom' );
+	}
+
+	switch ( ctaKind( taskId ) ) {
+		case 'first_post':
+			return __( 'Write post', 'jetpack-mu-wpcom' );
+		case 'pattern_page':
+			return __( 'Add page', 'jetpack-mu-wpcom' );
+		case 'launch':
+			return __( 'Launch site', 'jetpack-mu-wpcom' );
+		default:
+			return __( 'Get started', 'jetpack-mu-wpcom' );
+	}
+}
+
+/**
+ * A single task in the tailored list. Completed tasks render as a plain card
+ * with a struck-through title and a check-in-circle icon, and aren't expandable.
+ * Incomplete tasks render as a `CollapsibleCard` (dashed-circle icon + title in
+ * the always-visible header, which is the toggle trigger); expanding reveals the
+ * AI subtitle and the action-specific CTA / "Skip" actions.
  *
  * @param props              - The component props.
  * @param props.task         - The enriched task to render.
- * @param props.isExpanded   - Whether this card is expanded.
- * @param props.isBusy       - Whether the "Get started" action is in flight.
+ * @param props.isBusy       - Whether the primary action is in flight.
  * @param props.canStart     - Whether the task has an actionable CTA destination.
- * @param props.onToggle     - Called when the collapsed header is clicked.
- * @param props.onGetStarted - Called when "Get started" is clicked.
+ * @param props.defaultOpen  - Whether the card starts expanded (uncontrolled, so
+ *                           the user can then collapse it without it reopening).
+ * @param props.onGetStarted - Called when the primary CTA is clicked.
  * @param props.onSkip       - Called when "Skip" is clicked.
  * @return The task card element.
  */
-export function TaskCard( {
-	task,
-	isExpanded,
-	isBusy,
-	canStart,
-	onToggle,
-	onGetStarted,
-	onSkip,
-}: Props ) {
+export function TaskCard( { task, isBusy, canStart, defaultOpen, onGetStarted, onSkip }: Props ) {
 	if ( task.completed ) {
 		return (
-			<Card className="ai-launchpad-tailored-list__card is-completed">
-				<CardBody>
-					<div className="ai-launchpad-tailored-list__header">
-						<Icon icon={ check } className="ai-launchpad-tailored-list__icon is-done" />
+			<Card.Root className="ai-launchpad-tailored-list__card is-completed">
+				<Card.Header>
+					<span className="ai-launchpad-tailored-list__header-inner">
+						{ taskDoneIcon }
 						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
-					</div>
-				</CardBody>
-			</Card>
+					</span>
+				</Card.Header>
+			</Card.Root>
 		);
 	}
 
 	return (
-		<Card className={ clsx( 'ai-launchpad-tailored-list__card', { 'is-expanded': isExpanded } ) }>
-			<CardBody>
-				<Button
-					className="ai-launchpad-tailored-list__header"
-					onClick={ onToggle }
-					aria-expanded={ isExpanded }
-				>
+		<CollapsibleCard.Root className="ai-launchpad-tailored-list__card" defaultOpen={ defaultOpen }>
+			<CollapsibleCard.Header>
+				<span className="ai-launchpad-tailored-list__header-inner">
+					{ taskActiveIcon }
 					<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
-					<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-				</Button>
-				{ isExpanded && (
-					<div className="ai-launchpad-tailored-list__body">
-						<p className="ai-launchpad-tailored-list__subtitle">{ task.subtitle }</p>
-						<div className="ai-launchpad-tailored-list__actions">
-							{ canStart && (
-								<Button
-									variant="primary"
-									onClick={ onGetStarted }
-									isBusy={ isBusy }
-									disabled={ isBusy }
-								>
-									{ __( 'Get started', 'jetpack-mu-wpcom' ) }
-								</Button>
-							) }
-							<Button variant="tertiary" onClick={ onSkip }>
-								{ __( 'Skip', 'jetpack-mu-wpcom' ) }
-							</Button>
-						</div>
-					</div>
-				) }
-			</CardBody>
-		</Card>
+				</span>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
+				<p className="ai-launchpad-tailored-list__subtitle">{ task.subtitle }</p>
+				<div className="ai-launchpad-tailored-list__actions">
+					{ canStart && (
+						<Button variant="solid" onClick={ onGetStarted } loading={ isBusy } disabled={ isBusy }>
+							{ getCtaLabel( task.id ) }
+						</Button>
+					) }
+					<Button variant="minimal" tone="neutral" onClick={ onSkip }>
+						{ __( 'Skip', 'jetpack-mu-wpcom' ) }
+					</Button>
+				</div>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -175,6 +175,8 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( array( 'first_post_published' => true ), $data['checklist_statuses'] );
 		$this->assertFalse( $data['dismissed'] );
 		$this->assertTrue( $data['is_eligible'] );
+		// Site context for the client (launch CTA slug + preview).
+		$this->assertSame( home_url(), $data['site']['url'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -175,8 +175,9 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( array( 'first_post_published' => true ), $data['checklist_statuses'] );
 		$this->assertFalse( $data['dismissed'] );
 		$this->assertTrue( $data['is_eligible'] );
-		// Site context for the client (launch CTA slug + preview).
+		// Site context for the client (launch CTA slug + preview thumbnail/label).
 		$this->assertSame( home_url(), $data['site']['url'] );
+		$this->assertSame( get_bloginfo( 'name' ), $data['site']['title'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 


### PR DESCRIPTION
## Proposed changes

Ships the AI Launchpad **MVP design-polish batch** to trunk. This is the dev branch `add/ai-launchpad-design-polish` (three feature PRs already reviewed and merged into it), bringing the tailored launchpad up to the design prototype and giving every task an actionable, correctly-routed CTA — ahead of the design-review round (DOTOBRD-455).

All changes are scoped to the `jetpack-mu-wpcom` AI Launchpad feature (`src/features/ai-launchpad/`); the feature stays gated by the per-site `wpcom_ai_launchpad_enabled` option (off by default in production).

**DOTOBRD-478 — Calypso-relative CTA host (#49758)**
* `resolveCtaUrl` runs results through a new `toNavigableUrl()` that rebases single-leading-slash, non-`/wp-admin` paths onto `https://wordpress.com` (mirroring the legacy launchpad dashboard widget), so Calypso router paths (`/me`, `/marketing/connections/{slug}`) no longer resolve against the site host and 404. Absolute URLs and site-relative `/wp-admin/` editor URLs pass through unchanged.

**DOTOBRD-477 — launch task CTA (#49761)**
* Adds a `launch` `CtaKind` that opens the wordpress.com launch flow (`/start/launch-site`) for the pathless launch tasks (`site_launched`, `blog_launched`, `link_in_bio_launched`, `videopress_launched`); `woo_launch_site` keeps its own wc-admin deeplink. The site slug comes from `home_url()`, exposed via a new `site.url` field on the composite read.

**DOTOBRD-476 — MVP design polish (#49764)**
* Centered layout with a "Get the most out of WordPress" heading, an "X of N completed" progress line, the task cards on the left, and a live site preview on the right (a scaled, `inert` front-end iframe reusing the wp-admin dashboard site-management widget's approach). The same layout backs the "Tailoring your checklist…" loading state.
* Per-task CTA labels (a static, translatable id/kind → label map; "Get started" fallback) instead of every card reading "Get started".
* Task cards now use `@wordpress/ui` `CollapsibleCard` / `Card` / `Button`. Expansion is uncontrolled — the first incomplete task opens on load, but the user can collapse it (or all of them) without it reopening.
* Inline 24px dashed-circle (todo) and check-in-circle (done) SVG icons; the REST read also returns `site.title` to label the preview.

## Related product discussion/links

* Project: Replace Launchpad with AI Tasks
* DOTOBRD-478, DOTOBRD-477, DOTOBRD-476 (this batch); unblocks DOTOBRD-455 (design-review round)
* Follow-up filed: DOTOBRD-482 (trim the bundle — `@wordpress/ui` adds ~70KB)

## Does this pull request change what data or activity we track or use?

No new tracking. The composite read now returns `site.url` and `site.title` (the site's own `home_url()` / `get_bloginfo('name')`), on the existing eligibility-gated `GET /wpcom/v2/ai-launchpad` endpoint, rendered as escaped React text. No new Tracks events.

## Testing instructions

* Enable the feature on a paid, not-yet-onboarded site: `wp option update wpcom_ai_launchpad_enabled 1`. Open **AI Launchpad** in wp-admin.
* New user: complete the wizard → confirm the "Tailoring your checklist…" loading screen (heading + skeleton + site preview) transitions seamlessly into the centered list.
* Confirm: action-specific CTAs (theme → "Browse themes", first post → "Write post", launch → "Launch site"); the first incomplete task auto-expands and can be collapsed without reopening; completed tasks are struck-through with a check-in-circle; the site preview shows the live front end and is full-width on mobile.
* Click a Calypso-routed CTA (e.g. "Complete your profile") → confirm it navigates to `wordpress.com/...`, not the site host. Click a launch task → confirm `wordpress.com/start/launch-site?siteSlug=...`.
* Verified locally: ai-launchpad JS `node:test` + PHP suites green; ESLint/stylelint/phpcs clean; build green; Playwright self-smoke of the list + loading states on desktop and mobile, zero console errors.
