### PR TITLE
Donations: skip first-time modal and editor side effects in inserter preview

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-inserter-preview-modal-strobe
+++ b/projects/plugins/jetpack/changelog/fix-donations-inserter-preview-modal-strobe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Donations: stop the first-time modal and editor-only side effects from running in the block inserter preview, which caused a strobe/flicker when hovering the Donations Form and Tips blocks

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -1,5 +1,5 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { Icon, Spinner } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -57,6 +57,16 @@ const Edit = props => {
 		}
 	}, [ className, setAttributes ] );
 
+	// True when this block is rendered as a static preview (e.g. the live
+	// preview shown when hovering the block in the inserter). In that context
+	// the block must not run editor-only side effects or pop the first-time
+	// modal — doing so causes a strobe/flicker loop as the modal overlay fights
+	// the inserter hover state. See JETPACK-1737.
+	const isPreviewMode = useSelect(
+		select => !! select( blockEditorStore ).getSettings().isPreviewMode,
+		[]
+	);
+
 	const instanceId = useInstanceId( Edit, 'jp-donations' );
 	const customStyles = buildCustomStyles( attributes, `.${ instanceId }` );
 
@@ -101,7 +111,9 @@ const Edit = props => {
 	// stripeDefaultCurrency populated) or the user is not Jetpack-connected,
 	// so the stripe_connected snapshot is accurate.
 	useEffect( () => {
-		if ( ! clientId || blockLoadedFiredClientIds.has( clientId ) ) {
+		// Don't record block_loaded for inserter previews — they would inflate
+		// the funnel with impressions the user never intentionally created.
+		if ( isPreviewMode || ! clientId || blockLoadedFiredClientIds.has( clientId ) ) {
 			return;
 		}
 		const stripeStateResolved = !! stripeConnectUrl || !! stripeDefaultCurrency;
@@ -115,7 +127,14 @@ const Edit = props => {
 			is_user_connected: !! isUserConnected,
 			stripe_connected: isUserConnected ? ! stripeConnectUrl : null,
 		} );
-	}, [ clientId, isUserConnected, stripeConnectUrl, stripeDefaultCurrency, tracks ] );
+	}, [
+		isPreviewMode,
+		clientId,
+		isUserConnected,
+		stripeConnectUrl,
+		stripeDefaultCurrency,
+		tracks,
+	] );
 
 	useEffect( () => {
 		if ( ! currency && stripeDefaultCurrency && ! isPostSavingLocked ) {
@@ -161,14 +180,23 @@ const Edit = props => {
 	const hasDismissedDonationWarning =
 		currentUser?.meta?.jetpack_donation_warning_dismissed || false;
 
-	// Show the modal if the user has not dismissed the warning
+	// Show the modal if the user has not dismissed the warning. Never in preview
+	// mode: the inserter renders a live preview on hover, and popping a full-editor
+	// modal there triggers a strobe/flicker loop (JETPACK-1737).
 	useEffect( () => {
-		if ( currentUser?.id && hasDismissedDonationWarning === false ) {
+		if ( ! isPreviewMode && currentUser?.id && hasDismissedDonationWarning === false ) {
 			setShowFirstTimeModal( true );
 		}
-	}, [ currentUser, hasDismissedDonationWarning ] );
+	}, [ isPreviewMode, currentUser, hasDismissedDonationWarning ] );
 
 	useEffect( () => {
+		// Inserter previews share the real editor's core/editor store, so locking
+		// post saving (and the products fetch) from a hover preview would block the
+		// actual post and fire a network request per hover. Skip in preview mode.
+		if ( isPreviewMode ) {
+			return;
+		}
+
 		lockPostSaving( 'donations' );
 
 		const filterProducts = productList =>
@@ -223,6 +251,7 @@ const Edit = props => {
 			unlockPostSaving( 'donations' );
 		}, apiError );
 	}, [
+		isPreviewMode,
 		lockPostSaving,
 		currency,
 		post.id,
@@ -298,7 +327,7 @@ const Edit = props => {
 			<StyleControls attributes={ attributes } setAttributes={ setAttributes } />
 			{ customStyles && <style>{ customStyles }</style> }
 			{ content }
-			{ showFirstTimeModal && <FirstTimeModal onClose={ handleModalClose } /> }
+			{ ! isPreviewMode && showFirstTimeModal && <FirstTimeModal onClose={ handleModalClose } /> }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes JETPACK-1737

## Proposed changes

The Donations block's `Edit` component runs editor-only logic for **every** instance of the block — including the live preview Gutenberg renders when you hover the block in the block inserter. On a fresh site this causes a visible **strobe/flicker** when hovering the **Donations Form** and **Tips** blocks in the inserter.

Root cause: hovering mounts a `BlockPreview` of the block → `Edit` fires the "first-time" onboarding `Modal`. That modal portals a full-editor overlay, which covers/shifts the inserter and moves the hovered item out from under the cursor → the preview unmounts → the modal unmounts → the item snaps back under the cursor → re-hover → the modal reopens. The loop repeats several times per second (measured ~22 mount/unmount cycles in ~4s), producing the strobe.

This PR detects the inserter-preview context via the block-editor settings' `isPreviewMode` flag (the same pattern the Map block already uses) and skips editor-only side effects when previewing:

* The first-time onboarding modal no longer opens in a preview (this is what stops the strobe).
* `block_loaded` Tracks events are no longer recorded for inserter-hover impressions.
* Post-save locking and the products/status network fetch no longer run from a preview (these previously locked the *real* post's saving and fired a request on every hover, since previews share the global `core/editor` store).

## Related product discussion/links

* JETPACK-1737

## Does this pull request change what data or activity we track or use?

Yes — it **stops** firing the `jetpack_donations_block_loaded` Tracks event for block-inserter previews (impressions the user never intentionally created). No new tracking is added.

## Testing instructions

1. On a site with Jetpack connected (so the block registers), create a new post or page. Use a fresh user / site where the donations first-time warning has **not** been dismissed.
2. Open the block inserter and search for "donation".
3. Hover the **Donations Form** block (and the **Tips** block) in the inserter results.
   * **Before:** the editor strobes/flickers as the onboarding modal repeatedly opens and closes.
   * **After:** the inserter shows a calm static preview; no modal, no flicker.
4. Insert the Donations block into the canvas — the first-time onboarding modal should still appear as expected (only the *preview* suppresses it).
