### PR TITLE
Donations: skip editor side effects when the block is rendered as an inserter preview

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-block-flickering
+++ b/projects/plugins/jetpack/changelog/fix-donations-block-flickering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Donations Form: don't render the first-time modal, lock post saving, or fetch Stripe status when the block is shown as an inserter preview, which caused the editor to flicker on hover.

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -1,5 +1,5 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useBlockProps } from '@wordpress/block-editor';
+import { store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
 import { Icon, Spinner } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -74,6 +74,17 @@ const Edit = props => {
 	const [ showFirstTimeModal, setShowFirstTimeModal ] = useState( false );
 	const isUserConnected = useIsUserConnected();
 
+	// When the inserter renders this block as an example/preview (it declares
+	// `"example": {}` in block.json), Gutenberg mounts this Edit component inside
+	// a BlockPreview with `isPreviewMode` set. We use this flag to skip all editor
+	// side effects (Stripe status fetch, post-saving lock, first-time modal,
+	// analytics) so hovering the block in the inserter doesn't flicker the screen,
+	// lock post saving, or fire tracking events. Mirrors the `map` block.
+	const isPreviewMode = useSelect(
+		select => select( blockEditorStore ).getSettings().isPreviewMode,
+		[]
+	);
+
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const { getEntityRecord, getCurrentUser } = useSelect( 'core' );
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
@@ -101,7 +112,7 @@ const Edit = props => {
 	// stripeDefaultCurrency populated) or the user is not Jetpack-connected,
 	// so the stripe_connected snapshot is accurate.
 	useEffect( () => {
-		if ( ! clientId || blockLoadedFiredClientIds.has( clientId ) ) {
+		if ( isPreviewMode || ! clientId || blockLoadedFiredClientIds.has( clientId ) ) {
 			return;
 		}
 		const stripeStateResolved = !! stripeConnectUrl || !! stripeDefaultCurrency;
@@ -115,7 +126,14 @@ const Edit = props => {
 			is_user_connected: !! isUserConnected,
 			stripe_connected: isUserConnected ? ! stripeConnectUrl : null,
 		} );
-	}, [ clientId, isUserConnected, stripeConnectUrl, stripeDefaultCurrency, tracks ] );
+	}, [
+		clientId,
+		isUserConnected,
+		stripeConnectUrl,
+		stripeDefaultCurrency,
+		tracks,
+		isPreviewMode,
+	] );
 
 	useEffect( () => {
 		if ( ! currency && stripeDefaultCurrency && ! isPostSavingLocked ) {
@@ -163,12 +181,19 @@ const Edit = props => {
 
 	// Show the modal if the user has not dismissed the warning
 	useEffect( () => {
+		if ( isPreviewMode ) {
+			return;
+		}
 		if ( currentUser?.id && hasDismissedDonationWarning === false ) {
 			setShowFirstTimeModal( true );
 		}
-	}, [ currentUser, hasDismissedDonationWarning ] );
+	}, [ currentUser, hasDismissedDonationWarning, isPreviewMode ] );
 
 	useEffect( () => {
+		if ( isPreviewMode ) {
+			return;
+		}
+
 		lockPostSaving( 'donations' );
 
 		const filterProducts = productList =>
@@ -229,23 +254,34 @@ const Edit = props => {
 		setConnectUrl,
 		setConnectedAccountDefaultCurrency,
 		unlockPostSaving,
+		isPreviewMode,
 	] );
+
+	// In preview/example mode the Stripe status fetch is skipped, so fall back to
+	// placeholder products and a valid currency to render a representative form
+	// rather than a perpetual spinner or a "connect Stripe" nudge.
+	const previewProducts = { 'one-time': -1, '1 month': -1, '1 year': -1 };
+	const effectiveProducts = isPreviewMode ? previewProducts : products;
+	const effectiveProps =
+		isPreviewMode && ! currency
+			? { ...props, attributes: { ...attributes, currency: 'USD' } }
+			: props;
 
 	let content;
 
-	if ( ! isUserConnected ) {
+	if ( ! isPreviewMode && ! isUserConnected ) {
 		content = (
 			<ConnectBanner
 				block="Donations Form"
 				explanation={ __( 'Connect your WordPress.com account to enable donations.', 'jetpack' ) }
 			/>
 		);
-	} else if ( loadingError ) {
+	} else if ( ! isPreviewMode && loadingError ) {
 		content = <LoadingError error={ loadingError } />;
-	} else if ( stripeConnectUrl ) {
+	} else if ( ! isPreviewMode && stripeConnectUrl ) {
 		// Need to connect Stripe first
 		content = <StripeNudge blockName="donations" />;
-	} else if ( ! currency ) {
+	} else if ( ! isPreviewMode && ! currency ) {
 		// Memberships settings are still loading
 		content = <Spinner />;
 	} else if ( displayMode === 'modal' ) {
@@ -267,7 +303,7 @@ const Edit = props => {
 			</>
 		);
 	} else {
-		content = <Tabs { ...props } products={ products } />;
+		content = <Tabs { ...effectiveProps } products={ effectiveProducts } />;
 	}
 
 	// When the first time modal is closed, update the user meta to mark the donation warning as dismissed


### PR DESCRIPTION
Fixes JETPACK-1737

## Proposed changes

The Donations Form block and its **Tips** variation declare `"example": {}` in `block.json`, so the inserter renders their live `Edit` component as a hover preview (inside a `BlockPreview`, with `settings.isPreviewMode === true`). That fired all of `Edit`'s side effects on every hover. This PR gates those editor-only behaviors on `isPreviewMode` — the same signal the `map` block already uses:

* The first-time **"Accept Donations with Stripe"** modal (a full-viewport `Modal`) no longer renders during previews — this was the reported screen flicker.
* `lockPostSaving( 'donations' )` is no longer called on the **global** `core/editor` store, so hovering the block no longer flickers/locks the post's Save button (`BlockPreview` only sandboxes `core/block-editor`, not `core/editor`).
* The Stripe `memberships/status` fetch and the `jetpack_donations_block_loaded` analytics event no longer fire on every hover preview.
* Because skipping the fetch leaves `currency` empty — which would crash the form at `amount.js`'s `CURRENCIES[ currency ].symbol` — the preview now renders a representative donation form using placeholder products and a `USD` fallback currency, instead of a perpetual spinner. The override is applied to a cloned attributes object, so it never leaks into a real inserted block.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?

It does not add or change any collected data. It stops the existing `jetpack_donations_block_loaded` Tracks event from firing when the block is merely rendered as an inserter hover preview (it still fires when the block is actually present in the editor), removing spurious preview events.

## Testing instructions

* Create a new post or page.
* Open the block inserter and search for `donations`.
* Hover the **Donations Form** and **Tips** results to surface the preview popover.
  * **Before:** the screen flickers and the "Accept Donations with Stripe" modal flashes on/off until you move the mouse away; the Save button may flicker disabled.
  * **After:** hovering shows a clean preview — a full donation form (Donations Form) / a "Buy me a coffee" button (Tips) — with no flicker, no modal, and the Save button stays enabled.
* Now actually insert the **Donations Form** block into the post.
  * The first-time "Accept Donations with Stripe" modal should still appear (unless you've previously dismissed it), and the block should load and behave exactly as before — confirming the non-preview path is unchanged.
