### PR TITLE
AI Launchpad: relevance-tailored tasks + wizard site-identity prefill/persist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-site-identity-prefill
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-site-identity-prefill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Launchpad: pre-fill the wizard Name and Brief description from the site's title and tagline, and save them back to the site on completion.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-tailoring-relevance
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-ai-launchpad-tailoring-relevance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Launchpad: rework the tailoring prompt to rank tasks by relevance to the user's site intent and write site-specific task subtitles, and retry once on a transient AI failure.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -181,16 +181,24 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'is_eligible'        => true,
 			// Site context the client needs: the front-end URL drives the launch-task
 			// CTA (its host is the launch-flow site slug) and the tailored-list
-			// preview thumbnail; the title labels that preview.
+			// preview thumbnail; the title labels that preview. Title and
+			// description also pre-fill the wizard's Name and Brief description
+			// fields so they reflect the site's current identity.
 			'site'               => array(
-				'url'   => home_url(),
-				'title' => get_bloginfo( 'name' ),
+				'url'         => home_url(),
+				'title'       => get_bloginfo( 'name' ),
+				'description' => get_bloginfo( 'description' ),
 			),
 		);
 	}
 
 	/**
-	 * Persists the wizard input to the wizard option.
+	 * Persists the wizard input to the wizard option and, on completion, writes
+	 * the entered Name and Brief description back to the site's identity options
+	 * (blogname / blogdescription) so the wizard reflects and updates the real
+	 * site title and tagline. Empty values are skipped so the wizard never blanks
+	 * an existing title or tagline. Values are already sanitized by the route's
+	 * sanitize_callbacks; update_option re-runs core's option sanitizers too.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
@@ -206,6 +214,15 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		);
 
 		update_option( self::OPTION_WIZARD, $wizard, false );
+
+		if ( '' !== trim( (string) $request['site_name'] ) ) {
+			update_option( 'blogname', $request['site_name'] );
+		}
+		if ( '' !== trim( (string) $request['description'] ) ) {
+			// The tagline is rendered inline by themes, so collapse the textarea
+			// brief's newlines to keep blogdescription single-line.
+			update_option( 'blogdescription', sanitize_text_field( $request['description'] ) );
+		}
 
 		return array( 'wizard' => $wizard );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -50,6 +50,8 @@ export function App() {
 	if ( view === 'wizard' ) {
 		return (
 			<Wizard
+				initialSiteName={ initialData?.site?.title }
+				initialIntent={ initialData?.site?.description }
 				onComplete={ ( _input, tailoring ) => {
 					setPendingTailor( () => tailoring );
 					setView( 'list' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -63,10 +63,17 @@ export const TASK_MENU: readonly string[] = [
 ];
 
 /**
- * Build the single combined prompt sent to jetpack-ai-query. Ported from the
- * wp-calypso PoC's buildCombinedPromptFromIntent, adapted to the snake_case
- * catalog menu and the agent-output-schema shape ({ tasks, inferred,
- * first_post_draft }). English only (v1).
+ * Build the single combined prompt sent to jetpack-ai-query. Produces three
+ * parts in one JSON response, in inference-first order: an inferred-context
+ * blob, a relevance-ranked task list, and a starter blog post draft.
+ *
+ * The model infers the site's niche/audience FIRST, then selects the 6 most
+ * relevant tasks from the menu (ranked against the user's own words rather than
+ * a fixed per-goal template) and writes a specific subtitle for each. Emitting
+ * `inferred` before `tasks` grounds selection in the niche without a second
+ * call. English only (v1; i18n tracked in DOTOBRD-474). Hard rules mirror the
+ * server-side validation in class-ai-launchpad-rest.php (launch task last,
+ * woo/newsletter gating, subtitle sanitization) so valid output is not rejected.
  *
  * @param input - The collected wizard input.
  * @return The prompt string.
@@ -74,43 +81,47 @@ export const TASK_MENU: readonly string[] = [
 export function buildTailorPrompt( input: WizardInput ): string {
 	const { goal, site_name, description } = input;
 
-	return `You are helping a new WordPress.com user onboard. They have described their site in their own words. Produce THREE things in a single JSON response: a tailored task list, an inferred-context blob, and a starter blog post draft.
+	return `You are helping a new WordPress.com user onboard. They have described their site in their own words. Your job is to make their onboarding checklist feel hand-picked for THIS site, not generic.
+
+Produce a single JSON object with THREE parts, in this order: an inferred-context blob, a tailored task list, and a starter blog post draft.
 
 Site name: ${ site_name }
 Goal: ${ goal }
 User description: ${ description }
 
-============ tasks ============
-- Pick exactly 6 tasks from the menu below. The "id" of every task MUST come from the menu verbatim (never invent IDs). Write a short English "subtitle" (max 200 characters) for each task explaining what it does for this specific site.
-- Build the list in this order:
-  STEP 1 - Pick exactly ONE first-creation task that matches the goal:
-    - write / blog / articles -> "first_post_published"
-    - newsletter / email digest -> "first_post_published_newsletter" or "first_post_published"
-    - sell / store / products -> "woo_products"
-    - build / portfolio / showcase -> "first_post_published" or "add_about_page"
-  STEP 2 - Pick 2-3 niche-specific tasks that match the user's description and goal (e.g. "add_about_page", "woo_customize_store", "set_up_payments", "add_10_email_subscribers", "connect_social_media", "site_theme_selected").
-  STEP 3 - Fill the remaining slots with foundation tasks: "site_theme_selected", "complete_profile", "verify_email", "design_edited", "drive_traffic".
-  STEP 4 - The 6th and final task MUST be a launch task. Use "site_launched" (canonical) unless a flow-specific launch task fits better: "blog_launched", "woo_launch_site", or "link_in_bio_launched".
-
-  HARD RULES (do not break):
-    - Never include "woo_products", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" UNLESS the goal is sell or the user explicitly mentions selling, products, store, shop, or commerce.
-    - Never include "add_10_email_subscribers", "subscribers_added", or "newsletter_plan_created" UNLESS the goal is newsletter or the user explicitly mentions email subscribers or a newsletter.
-    - Every "id" must appear in the menu. Drop any task you cannot map to a menu ID.
-
-============ inferred ============
-Extract these fields from the user's description. Reused downstream by the theme picker and post draft.
+============ STEP 1 - inferred ============
+First, read the description closely and infer the site's context. You will use this to choose and describe the tasks, so do it before anything else.
 - "goal": echo the goal value above verbatim. One of: write, build, sell, newsletter, educate, portfolio. Required.
 - "brand_name": the site name. Per the name-resolution rule below.
-- "niche": subject area in a few words (e.g. "long-distance hiking", "handmade ceramics").
+- "niche": the specific subject area in a few words (e.g. "long-distance hiking", "handmade ceramics", "indie game reviews").
 - "vibe": aesthetic hint if implied (e.g. "minimal and editorial", "warm and personal"). Omit if neutral.
-- "audience": who the site is for, if implied.
+- "audience": who the site is for, if implied (e.g. "home cooks", "small-business owners").
 - "tagline": a polished site tagline drafted from the description. Max 200 characters. Noun phrase or third person, not first-person.
 
-============ first_post_draft ============
+============ STEP 2 - tasks ============
+Now choose the 6 tasks from the menu below that are MOST RELEVANT to this site, judged against the site name, goal, description, and the niche/audience you just inferred. Rank the whole menu by how useful each task is for this specific user and keep the top 6. Do not follow a fixed template - two different sites should get noticeably different lists.
+
+For each chosen task write a "subtitle" (max 200 characters) that is specific and engaging: reference the user's niche, audience, or what they will actually publish or sell, so the checklist reads as written for them. Avoid generic, interchangeable phrasing.
+
+GOOD vs BAD subtitles (illustrations - adapt to the user's own niche, do not copy):
+- For a handmade-ceramics studio, "add_about_page" -> GOOD: "Share the story behind your studio and what makes each handmade piece one of a kind." BAD: "Tell visitors who you are."
+- For a handmade-ceramics studio, "site_theme_selected" -> GOOD: "Pick a clean, gallery-style theme that lets your ceramics photos take center stage." BAD: "Choose a theme."
+- For a weekly cycling newsletter, "first_post_published_newsletter" -> GOOD: "Send your first issue with this week's route, ride notes, and gear picks." BAD: "Send your first newsletter."
+
+HARD RULES (do not break - the server rejects output that violates these):
+- Every "id" MUST come from the menu below, verbatim. Never invent IDs. Drop any task you cannot map to a menu ID.
+- Return exactly 6 tasks.
+- At least one task must create content (e.g. "first_post_published", "first_post_published_newsletter", "woo_products", or "add_about_page").
+- The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", "woo_launch_site", or "link_in_bio_launched".
+- Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
+- Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
+- Subtitles must be plain text: no URLs, no HTML, and no template syntax such as {{ }} or [[ ]].
+
+============ STEP 3 - first_post_draft ============
 Write a friendly starter blog post the user can edit and publish.
 - "title": clear and evocative, max 8 words.
 - "subtitle": ONE line, verb-led, max 10 words, describing what publishing this post does for them. Optional.
-- "paragraphs": exactly 2 short paragraphs of opening body text. First introduces the topic in a warm, personal voice; second invites the reader in. Plain English, no jargon. Avoid "Welcome to my blog" and "Hello world" cliches.
+- "paragraphs": exactly 2 short paragraphs of opening body text. First introduces the topic in a warm, personal voice grounded in the user's niche; second invites the reader in. Plain English, no jargon. Avoid "Welcome to my blog" and "Hello world" cliches.
 
 ============ name resolution ============
 Treat the "Site name:" value above as THE ONLY brand/name to use anywhere - in the title, subtitle, paragraphs, and inferred.brand_name. It overrides any name mentioned inside the user description. If the description names a different brand, ignore it and use the "Site name:" value.
@@ -122,8 +133,8 @@ ${ TASK_MENU.map( id => '- ' + id ).join( '\n' ) }
 Return only a JSON object matching this schema. Do not include prose, code fences, or commentary. The first character MUST be "{".
 
 {
-  "tasks": [ { "id": "...", "subtitle": "..." }, ... 6 total ],
   "inferred": { "goal": "...", "brand_name": "...", "niche": "...", "vibe": "...", "audience": "...", "tagline": "..." },
+  "tasks": [ { "id": "...", "subtitle": "..." }, ... 6 total ],
   "first_post_draft": { "title": "...", "subtitle": "...", "paragraphs": [ "...", "..." ] }
 }`;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -15,14 +15,22 @@ interface AiQueryResponse {
 }
 
 /**
- * Call jetpack-ai-query with the combined prompt and return validated output,
- * or null on any failure (network, timeout, auth, quota, malformed or
- * schema-invalid response).
+ * Outcome of a single jetpack-ai-query attempt. `retryable` distinguishes
+ * transient failures worth a second attempt (5xx/429, empty content, or
+ * malformed/schema-invalid JSON that a re-roll often fixes) from failures where
+ * a retry would not help or would only add latency (auth/quota 4xx, network
+ * errors, and timeouts).
+ */
+type FetchOutcome = { ok: true; output: TailoredOutput } | { ok: false; retryable: boolean };
+
+/**
+ * Call jetpack-ai-query once with the combined prompt and return the validated
+ * output, or a failure outcome tagging whether the failure is worth retrying.
  *
  * @param input - The collected wizard input.
- * @return The validated output, or null.
+ * @return The attempt outcome.
  */
-async function fetchAiOutput( input: WizardInput ): Promise< TailoredOutput | null > {
+async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
 	const controller = new AbortController();
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- the timeout must arm before the awaited request and is cleared in finally.
 	const timeout = setTimeout( () => controller.abort(), AI_QUERY_TIMEOUT_MS );
@@ -39,7 +47,7 @@ async function fetchAiOutput( input: WizardInput ): Promise< TailoredOutput | nu
 				messages: [ { role: 'user', content: buildTailorPrompt( input ) } ],
 				feature: 'ai-launchpad',
 				model: 'gpt-4o',
-				max_tokens: 1500,
+				max_tokens: 1800,
 				response_format: 'json_object',
 				stream: false,
 			} ),
@@ -47,23 +55,48 @@ async function fetchAiOutput( input: WizardInput ): Promise< TailoredOutput | nu
 		} );
 
 		if ( ! response.ok ) {
-			return null;
+			// 5xx and 429 are transient; 4xx (auth/quota) will not change on retry.
+			return { ok: false, retryable: response.status === 429 || response.status >= 500 };
 		}
 
 		const body = ( await response.json() ) as AiQueryResponse;
 		const content = body.choices?.[ 0 ]?.message?.content;
 		if ( ! content ) {
-			return null;
+			return { ok: false, retryable: true };
 		}
 
-		return parseAgentResponse( content );
+		const output = parseAgentResponse( content );
+		if ( ! output ) {
+			// Malformed or schema-invalid JSON: a re-roll often returns valid output.
+			return { ok: false, retryable: true };
+		}
+
+		return { ok: true, output };
 	} catch {
-		// Network, timeout, auth, or quota failure: fall back to the deterministic
-		// picker. The AI call itself is logged server-side by the AI Proxy.
-		return null;
+		// Network error or timeout (abort): fall back to the deterministic picker.
+		// Not retried - a timeout retry only doubles the wait before the fallback.
+		// The AI call itself is logged server-side by the AI Proxy.
+		return { ok: false, retryable: false };
 	} finally {
 		clearTimeout( timeout );
 	}
+}
+
+/**
+ * Call jetpack-ai-query, retrying once on a transient/validation failure, and
+ * return the validated output or null. The retry hardens the happy path against
+ * the occasional malformed JSON or transient proxy error without unbounded
+ * latency: timeouts and auth/quota failures are not retried.
+ *
+ * @param input - The collected wizard input.
+ * @return The validated output, or null.
+ */
+async function fetchAiOutputWithRetry( input: WizardInput ): Promise< TailoredOutput | null > {
+	let outcome = await fetchAiOutput( input );
+	if ( ! outcome.ok && outcome.retryable ) {
+		outcome = await fetchAiOutput( input );
+	}
+	return outcome.ok ? outcome.output : null;
 }
 
 /**
@@ -83,9 +116,10 @@ async function persist( output: TailoredOutput, source: TailorSource ): Promise<
 
 /**
  * Tailor the launchpad from the wizard input: call jetpack-ai-query with the
- * combined prompt, validate the response against the agent output schema, and
- * fall back to the deterministic picker on any failure (network, auth, quota,
- * malformed or schema-invalid output). The result is persisted via Stream B's
+ * combined prompt (retrying once on a transient/validation failure), validate
+ * the response against the agent output schema, and fall back to the
+ * deterministic picker on any failure (network, timeout, auth, quota, malformed
+ * or schema-invalid output). The result is persisted via Stream B's
  * PUT /tailored, tagged with its source. If the AI output is rejected by the
  * server (422), retry the persist with the deterministic fallback.
  *
@@ -94,7 +128,7 @@ async function persist( output: TailoredOutput, source: TailorSource ): Promise<
  */
 export async function tailor( input: WizardInput ): Promise< TailorResult > {
 	const start = performance.now();
-	const aiOutput = await fetchAiOutput( input );
+	const aiOutput = await fetchAiOutputWithRetry( input );
 
 	if ( aiOutput ) {
 		try {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -18,8 +18,10 @@ export interface SiteData {
 	// Optional: the fields come from an un-validated REST response, so consumers
 	// must tolerate them being absent (coalesce to null) rather than trust the type.
 	url?: string;
-	// The site name, used to label the preview card.
+	// The site name, used to label the preview card and pre-fill the wizard Name.
 	title?: string;
+	// The site tagline (blogdescription), used to pre-fill the wizard description.
+	description?: string;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -22,6 +22,8 @@ import './style.scss';
 interface Props {
 	// Existing site title. Pre-fills the Name input so users don't retype it.
 	initialSiteName?: string;
+	// Existing site tagline (blogdescription). Pre-fills the Brief description.
+	initialIntent?: string;
 	// User locale, forwarded to the wizard payload and the AI call.
 	locale?: string;
 	// Fired once Finish completes, so the host can swap the wizard for the
@@ -37,15 +39,21 @@ interface Props {
  *
  * @param props                 - Component props.
  * @param props.initialSiteName - Existing site title used to pre-fill Name.
+ * @param props.initialIntent   - Existing site tagline used to pre-fill the description.
  * @param props.locale          - User locale forwarded to the payload.
  * @param props.onComplete      - Called with the input and tailor promise on Finish.
  * @return The wizard element.
  */
-export function Wizard( { initialSiteName = '', locale = 'en', onComplete }: Props ) {
+export function Wizard( {
+	initialSiteName = '',
+	initialIntent = '',
+	locale = 'en',
+	onComplete,
+}: Props ) {
 	const [ step, setStep ] = useState< WizardStep >( 0 );
 	const [ goal, setGoal ] = useState< GoalSlug | null >( null );
 	const [ siteName, setSiteName ] = useState< string >( initialSiteName );
-	const [ intent, setIntent ] = useState< string >( '' );
+	const [ intent, setIntent ] = useState< string >( initialIntent );
 
 	const state: WizardState = { goal, siteName, intent, locale };
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -175,9 +175,11 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( array( 'first_post_published' => true ), $data['checklist_statuses'] );
 		$this->assertFalse( $data['dismissed'] );
 		$this->assertTrue( $data['is_eligible'] );
-		// Site context for the client (launch CTA slug + preview thumbnail/label).
+		// Site context for the client (launch CTA slug + preview thumbnail/label
+		// + wizard Name/Brief-description pre-fill).
 		$this->assertSame( home_url(), $data['site']['url'] );
 		$this->assertSame( get_bloginfo( 'name' ), $data['site']['title'] );
+		$this->assertSame( get_bloginfo( 'description' ), $data['site']['description'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 
@@ -244,6 +246,58 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'Personal blog about long-distance hiking in the Alps.', $option['description'] );
 		$this->assertSame( 'en', $option['locale'] );
 		$this->assertIsInt( $option['generated_at'] );
+
+		// The entered Name and Brief description are written back to the site's
+		// identity options so the wizard reflects and updates the real site.
+		$this->assertSame( 'Alpine Notes', get_option( 'blogname' ) );
+		$this->assertSame( 'Personal blog about long-distance hiking in the Alps.', get_option( 'blogdescription' ) );
+	}
+
+	/**
+	 * Test that PUT /wizard does not blank an existing site title/tagline when the
+	 * Name and Brief description come through empty.
+	 */
+	public function test_put_wizard_keeps_site_identity_when_fields_empty() {
+		wp_set_current_user( $this->admin_id );
+
+		update_option( 'blogname', 'Existing Title' );
+		update_option( 'blogdescription', 'Existing Tagline' );
+
+		$result = $this->call_api(
+			'PUT',
+			'/wizard',
+			array(
+				'goal'        => 'write',
+				'site_name'   => '',
+				'description' => '',
+				'locale'      => 'en',
+			)
+		);
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'Existing Title', get_option( 'blogname' ) );
+		$this->assertSame( 'Existing Tagline', get_option( 'blogdescription' ) );
+	}
+
+	/**
+	 * Test that a multi-line Brief description is collapsed to a single-line tagline.
+	 */
+	public function test_put_wizard_collapses_multiline_description_for_tagline() {
+		wp_set_current_user( $this->admin_id );
+
+		$result = $this->call_api(
+			'PUT',
+			'/wizard',
+			array(
+				'goal'        => 'write',
+				'site_name'   => 'Alpine Notes',
+				'description' => "Line one.\nLine two.",
+				'locale'      => 'en',
+			)
+		);
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'Line one. Line two.', get_option( 'blogdescription' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Two related AI Launchpad improvements.

**Tailoring quality — make the checklist actually feel tailored to the site:**
* Reworked the tailoring prompt (`js/lib/prompts.ts`): the model now infers the site's niche/audience first, then ranks the full task menu by relevance to the user's goal/title/description and keeps the 6 most relevant (replacing the fixed goal-keyed STEP 1→4 skeleton), and writes site-specific task subtitles (few-shot guided). Hard constraints (launch task last, woo/newsletter gating, menu-only IDs, no URLs/template syntax in subtitles) are kept so output still passes server validation.
* `tailor.ts` now retries the AI call once on a transient/validation failure (5xx/429, empty content, malformed/schema-invalid JSON) but not on timeouts (keeps latency bounded), and bumps `max_tokens` 1500→1800. Model stays `gpt-4o`.

**Wizard site-identity prefill/persist:**
* The wizard's Name and Brief description now pre-fill from the site's title (`blogname`) and tagline (`blogdescription`). The existing `initialSiteName` prop was never wired up; this adds `initialIntent` and passes both from the initial `GET /ai-launchpad` read.
* On Finish, the entered Name and Brief description are saved back to `blogname` / `blogdescription` (non-empty values only; the tagline is collapsed to a single line). `GET /ai-launchpad` now returns `site.description`.

## Related product discussion/links
* Related to: DOTOBRD-475

## Does this pull request change what data or activity we track or use?

No new tracking. On wizard completion the feature now writes the site title and tagline (`blogname` / `blogdescription`) — standard site-settings options the user is entering themselves, gated behind `manage_options`. No new data is collected or sent externally beyond the existing `jetpack-ai-query` call.

## Testing instructions

* On an AI-Launchpad-eligible site, set a known Site Title and Tagline under Settings → General.
* Open AI Launchpad (`wp-admin/admin.php?page=ai-launchpad-wp-admin`) with no prior AI output (reset the launchpad state if needed). Pick a goal and click Continue.
* Verify the **Name** field is pre-filled with the site title and **Brief description** with the tagline.
* Change both fields, enter a specific description (e.g. "Handmade ceramic homewares from a one-person studio"), and click Finish.
* Verify the tailored list's selected tasks and subtitles reference the site's niche rather than a generic per-goal list.
* Verify Settings → General now shows the Title and Tagline you entered in the wizard.
