### PR TITLE
Charts: fix @wordpress/ui 0.15 type error in leaderboard chart

### DIFF
--- a/projects/js-packages/charts/changelog/fix-wp-ui-015-type-errors
+++ b/projects/js-packages/charts/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: type `leaderboardChart.labelSpacing` as a WPDS `GapSize` token instead of `number` (the numeric value was silently ignored by `@wordpress/ui`'s Stack) to fix `@wordpress/ui` 0.15 type errors.

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -53,7 +53,7 @@ const defaultTheme: CompleteChartTheme = {
 	leaderboardChart: {
 		rowGap: 12,
 		columnGap: 4,
-		labelSpacing: 1.5,
+		labelSpacing: 'xs',
 		deltaColors: [ '#FF8C8F', '#757575', '#1F9828' ], // [negative, neutral, positive]
 	},
 	conversionFunnelChart: {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -259,7 +259,7 @@ export type ChartTheme = {
 		/** Gap between columns in the leaderboard grid */
 		columnGap?: number;
 		/** Spacing between label and progress bars */
-		labelSpacing?: number;
+		labelSpacing?: GapSize;
 		/** Primary color for current period bars */
 		primaryColor?: string;
 		/** Secondary color for comparison period bars */


### PR DESCRIPTION
## Proposed changes

Part of the bundled `@wordpress/*` monorepo bump (#49272) cleanup, companion to #49795. The `@wordpress/ui` 0.13 → 0.15 upgrade unmasks a pre-existing type misuse in the leaderboard chart.

`leaderboardChart.labelSpacing` was typed `number` (default `1.5`) and passed straight to a `@wordpress/ui` `Stack`'s `gap`, which expects a WPDS `GapSize` token. The numeric value was silently ignored at runtime (0.13 typed `Stack` as `any`; 0.15 enforces `GapSize`). This change types `labelSpacing` as `GapSize` and defaults it to `'xs'`.

Because the leaderboard chart is a shared import, this also clears the same error in **my-jetpack**, **premium-analytics** and **publicize** (premium-analytics has no other bump errors).

### ⚠️ Minor API note
`leaderboardChart.labelSpacing` changes from `number` to a `GapSize` string token. The numeric form never produced spacing, so no working behavior changes — but it is a type-signature change to a public theme option. Happy to bump the changelog to `minor` if the Charts team prefers.

### Note on visuals
With `labelSpacing` previously ignored, there is currently no gap between a leaderboard row's label and its bars. `'xs'` introduces a small gap (the originally-intended spacing). Worth a quick visual check.

## Related product discussion/links

* Companion to #49795 and the bundled monorepo bump #49272

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run typecheck` in `projects/js-packages/charts` is clean (the `GapSize` type is identical across `@wordpress/ui` 0.13/0.15, so this is version-agnostic).
* Note: the repo-wide "Type checking" CI job covers every package, so it stays red until the remaining bump fixes land; this PR's own change is verified independently.
* Visual: render a Leaderboard chart (e.g. in My Jetpack / Stats) and confirm the row label sits slightly above its bars with a small gap.
