### PR TITLE
Social: fix @wordpress/ui 0.15 type errors in publicize UI

### DIFF
--- a/projects/packages/publicize/_inc/components/services/service-item-modern.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item-modern.tsx
@@ -37,7 +37,9 @@ export function ModernServiceItem( {
 
 	const [ isPanelOpen, setIsPanelOpen ] = useState( Boolean( isPanelDefaultOpen ) );
 	const togglePanel = useCallback( () => setIsPanelOpen( open => ! open ), [] );
-	const rowRef = useRef< HTMLDivElement >( null );
+	// `Collapsible.Trigger` types its ref as `HTMLButtonElement` even when
+	// rendered as a `<div>` (via `render`), so match that to satisfy the ref type.
+	const rowRef = useRef< HTMLButtonElement >( null );
 
 	useEffect( () => {
 		if ( isPanelDefaultOpen ) {

--- a/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
+++ b/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
@@ -68,12 +68,17 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 					label
 				);
 
-				const linkProps = {
-					href,
-					target: '_blank',
-					rel: 'noopener noreferrer',
-					onClick: getOnClick( href, { network: networkName } ),
-				};
+				// `@wordpress/ui`'s Button is not a link, so render it as an anchor and
+				// keep the anchor-specific props (incl. the `HTMLAnchorElement` onClick)
+				// on the rendered `<a>`.
+				const renderLink = (
+					<a
+						href={ href }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ getOnClick( href, { network: networkName } ) }
+					/>
+				);
 
 				return (
 					<div className={ styles.container } key={ networkName }>
@@ -81,12 +86,12 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 							<Button
 								aria-label={ text }
 								className={ clsx( styles[ 'icon-button' ], styles[ networkName ] ) }
-								{ ...linkProps }
+								render={ renderLink }
 							>
 								<SocialServiceIcon serviceName={ networkName } />
 							</Button>
 						) : (
-							<Button aria-label={ text } className="has-text" { ...linkProps }>
+							<Button aria-label={ text } className="has-text" render={ renderLink }>
 								{ 'icon-text' === buttonStyle && (
 									<SocialServiceIcon
 										className={ styles[ networkName ] }

--- a/projects/packages/publicize/changelog/fix-wp-ui-015-type-errors
+++ b/projects/packages/publicize/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Align share-button, service-row and dashboard tab-panel props with the `@wordpress/ui` 0.15 API: render the share `Button` as an anchor (it is a link), match the `Collapsible.Trigger` ref type, and drop the unsupported `focusable` prop on `Tabs.Panel`.

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -87,10 +87,10 @@ const Stage = () => {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<SocialPage activeTab={ activeTab } actions={ actions }>
-				<Tabs.Panel value="overview" focusable={ false }>
+				<Tabs.Panel value="overview">
 					{ activeTab === 'overview' ? <OverviewTab /> : null }
 				</Tabs.Panel>
-				<Tabs.Panel value="settings" focusable={ false }>
+				<Tabs.Panel value="settings">
 					{ activeTab === 'settings' ? <SettingsTab /> : null }
 				</Tabs.Panel>
 			</SocialPage>


### PR DESCRIPTION
## Proposed changes

Part of the bundled `@wordpress/*` monorepo bump (#49272) cleanup, companion to #49795. The `@wordpress/ui` 0.13 → 0.15 upgrade enforces real prop types (0.13 typed these components as `any`), unmasking pre-existing misuses in the Social/publicize UI. These are valid on both versions (verified locally).

### Changes (`packages/publicize`)

* **share-buttons:** the social share buttons passed `href`/`target`/`rel`/`onClick` to `@wordpress/ui`'s `Button`, which is not a link. Render the Button as an anchor via `render={ <a … /> }` (the existing pattern in this package, e.g. `content-creation-card.tsx`) and keep the anchor props — including the `HTMLAnchorElement` `onClick` — on the rendered `<a>`.
* **service-item-modern:** `Collapsible.Trigger` types its ref as `HTMLButtonElement` even when rendered as a `<div>` (via `render`); type `rowRef` to match.
* **dashboard `stage.tsx`:** drop the unsupported `focusable` prop on `Tabs.Panel` (a no-op; the panels already gate content on the active tab, per #49629).

No visual or behavioral change — the share buttons already rendered as anchors at runtime; this aligns the types.

## Related product discussion/links

* Companion to #49795 and the bundled monorepo bump #49272
* Follows the `Tabs.Panel` pattern from #49629

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run typecheck` in `projects/packages/publicize` is clean (verified against both `@wordpress/ui@0.13` and `0.15`).
* Note: the repo-wide "Type checking" CI job covers every package, so it stays red until the remaining bump fixes land; this PR's own files are verified independently.
* Smoke-test the Social block-editor sidebar share buttons (icon / icon-text / text styles) — clicking still opens the share URL in a new tab — and the connection-management "Fix connection" service row still expands/scrolls into view.
