### PR TITLE
Fix @wordpress/ui 0.15 type errors (my-jetpack, forms, seo, jetpack)

### DIFF
--- a/projects/packages/forms/changelog/fix-wp-ui-015-type-errors
+++ b/projects/packages/forms/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `@wordpress/ui` 0.15 type error: use a valid Stack `gap` token (`xs`) in the responses dashboard.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -490,7 +490,7 @@ function StageInner() {
 								useHovercard={ false }
 							/>
 							{ styleUnreadValue(
-								<Stack direction="column" gap="2xs">
+								<Stack direction="column" gap="xs">
 									<Stack direction="row" align="center" gap="xs">
 										<Text ellipsizeMode="tail" limit={ 50 } truncate>
 											{ displayName }

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -8,7 +8,7 @@ export type SecondaryButtonProps = {
 	variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
 	label?: string;
 	shouldShowButton?: () => boolean;
-	onClick?: ( () => void ) | ( ( e: MouseEvent< HTMLButtonElement > ) => void );
+	onClick?: ( () => void ) | ( ( e: MouseEvent< HTMLElement > ) => void );
 	isExternalLink?: boolean;
 	disabled?: boolean;
 	isLoading?: boolean;

--- a/projects/packages/my-jetpack/changelog/fix-wp-ui-015-type-errors
+++ b/projects/packages/my-jetpack/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `@wordpress/ui` 0.15 type error: accept anchor click events on the secondary action button's `onClick` handler so it works when rendered as a Link.

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -76,7 +76,7 @@ const TitleStructureRow: FC< RowProps > = ( { pageTypeId, label, tokens, onChang
 
 	return (
 		<div className="jetpack-seo-settings__title-row">
-			<Stack direction="row" gap="xs" wrap>
+			<Stack direction="row" gap="xs" wrap="wrap">
 				{ PAGE_TYPE_SUGGESTIONS[ pageTypeId ].map( tokenId => (
 					<Button
 						key={ tokenId }

--- a/projects/packages/seo/changelog/fix-wp-ui-015-type-errors
+++ b/projects/packages/seo/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `@wordpress/ui` 0.15 type error: pass a valid Stack `wrap` value in the SEO title-structure field.

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/index.tsx
@@ -84,7 +84,6 @@ const MobileApp: FC< Props > = ( { slug, underside = false } ) => {
 							<Link
 								openInNewTab
 								href={ getRedirectUrl( 'jetpack-plugin-recommendations-mobile-app-component' ) }
-								rel="noopener noreferrer"
 								onClick={ onJpcomAppClick }
 								children={ null }
 							/>

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/index.tsx
@@ -85,7 +85,6 @@ const MobileApp: FC< Props > = ( { slug, underside = false } ) => {
 								openInNewTab
 								href={ getRedirectUrl( 'jetpack-plugin-recommendations-mobile-app-component' ) }
 								rel="noopener noreferrer"
-								target="_blank"
 								onClick={ onJpcomAppClick }
 								children={ null }
 							/>

--- a/projects/plugins/jetpack/changelog/fix-wp-ui-015-type-errors
+++ b/projects/plugins/jetpack/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix `@wordpress/ui` 0.15 type errors: drop the unsupported `target` prop on Link (it is set via `openInNewTab`) in the mobile-app recommendation, and type the AI Assistant message icon as a `ReactElement`.

--- a/projects/plugins/jetpack/changelog/fix-wp-ui-015-type-errors
+++ b/projects/plugins/jetpack/changelog/fix-wp-ui-015-type-errors
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Fix `@wordpress/ui` 0.15 type errors: drop the unsupported `target` prop on Link (it is set via `openInNewTab`) in the mobile-app recommendation, and type the AI Assistant message icon as a `ReactElement`.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/message/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/message/index.tsx
@@ -53,7 +53,9 @@ export default function Message( {
 }: MessageProps ): ReactElement {
 	return (
 		<div className="jetpack-ai-assistant__message">
-			{ ( severity || icon ) && <Icon icon={ messageIconsMap[ severity ] || icon } /> }
+			{ ( severity || icon ) && (
+				<Icon icon={ ( messageIconsMap[ severity ] || icon ) as ReactElement } />
+			) }
 			<div className="jetpack-ai-assistant__message-content">{ children }</div>
 		</div>
 	);


### PR DESCRIPTION
## Proposed changes

Part of the bundled `@wordpress/*` monorepo bump (#49272) cleanup, companion to #49795. Batched one-line `@wordpress/ui` 0.15 type fixes across four projects. Each was a pre-existing prop misuse masked by 0.13's `any` typings — valid on both versions, no behavior change.

* **my-jetpack** (`secondary-button`): broaden the `onClick` handler param to `MouseEvent<HTMLElement>` so it type-checks for both the Link (anchor) and Button render branches.
* **forms** (`responses/stage`): `Stack gap="2xs"` → `gap="xs"` (`2xs` is not a `GapSize` token).
* **seo** (`title-structure-field`): `Stack ... wrap` (boolean) → `wrap="wrap"` (the prop is a `flexWrap` string).
* **jetpack** (mobile-app recommendation): drop the unsupported `target="_blank"` on `@wordpress/ui` `Link` — `LinkProps` omits `target`, which is set via `openInNewTab`.
* **jetpack** (AI Assistant `message`): type the value passed to `@wordpress/icons` `Icon` as a `ReactElement`.

## Related product discussion/links

* Companion to #49795 and the bundled monorepo bump #49272

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run typecheck` is clean in `projects/packages/my-jetpack`, `projects/packages/forms`, `projects/packages/seo`, and `projects/plugins/jetpack`.
* Note: the repo-wide "Type checking" CI job covers every package, so it stays red until the remaining bump fixes land (only `newsletter` after this); these files are verified independently.
* No visual change expected — smoke-test: My Jetpack product cards' secondary buttons, the Forms responses list, the SEO title-structure token row, the mobile-app recommendation link, and an AI Assistant message with an icon.
