### PR TITLE
Newsletter: fix @wordpress/dataviews 16 + @wordpress/ui 0.15 type errors

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -215,7 +215,6 @@ function ImportStatusNotice( { jobs }: { jobs: ImportJob[] } ): JSX.Element | nu
 					<Notice.ActionLink
 						href="https://jetpack.com/support/newsletter/import-subscribers/"
 						openInNewTab
-						rel="noreferrer"
 					>
 						{ __( 'Learn more', 'jetpack-newsletter' ) }
 					</Notice.ActionLink>

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -214,7 +214,7 @@ function ImportStatusNotice( { jobs }: { jobs: ImportJob[] } ): JSX.Element | nu
 				<Notice.Actions>
 					<Notice.ActionLink
 						href="https://jetpack.com/support/newsletter/import-subscribers/"
-						target="_blank"
+						openInNewTab
 						rel="noreferrer"
 					>
 						{ __( 'Learn more', 'jetpack-newsletter' ) }

--- a/projects/packages/newsletter/changelog/fix-wp-ui-015-type-errors
+++ b/projects/packages/newsletter/changelog/fix-wp-ui-015-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Align the settings DataForm field `Edit` controls, the import-subscribers notice `ActionLink`, and the dashboard tab panels with the `@wordpress/dataviews` 16 and `@wordpress/ui` 0.15 type APIs.

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -136,10 +136,10 @@ const Stage = () => {
 						>
 							{ subscribersEnabled ? (
 								<>
-									<Tabs.Panel value="subscribers" focusable={ false }>
+									<Tabs.Panel value="subscribers">
 										{ activeTab === 'subscribers' ? subscribersPanel : null }
 									</Tabs.Panel>
-									<Tabs.Panel value="settings" focusable={ false }>
+									<Tabs.Panel value="settings">
 										{ activeTab === 'settings' ? <NewsletterSettingsBody isModernized /> : null }
 									</Tabs.Panel>
 								</>

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -4,16 +4,17 @@
 import analytics from '@automattic/jetpack-analytics';
 import { getAdminUrl, type SiteType } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
-import { type Field } from '@wordpress/dataviews';
+import { type NormalizedField, type DeepPartial } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
+import type { NewsletterSettings } from '../types';
 
 interface ToggleWithLinkProps {
-	data: Record< string, unknown >;
-	field: Field< Record< string, unknown > >;
-	onChange: ( updates: Record< string, unknown > ) => void;
+	data: NewsletterSettings;
+	field: NormalizedField< NewsletterSettings >;
+	onChange: ( value: DeepPartial< NewsletterSettings > ) => void;
 	url: string;
 	linkText: string;
 	isExternal?: boolean;
@@ -43,13 +44,15 @@ export function ToggleWithLink( {
 	onLinkClick,
 }: ToggleWithLinkProps ): JSX.Element {
 	const handleChange = useCallback( () => {
-		onChange( { [ field.id ]: ! data[ field.id ] } );
+		onChange( {
+			[ field.id ]: ! ( data as Record< string, unknown > )[ field.id ],
+		} as DeepPartial< NewsletterSettings > );
 	}, [ data, field.id, onChange ] );
 
 	return (
 		<ToggleControl
 			__nextHasNoMarginBottom
-			checked={ !! data[ field.id ] }
+			checked={ !! ( data as Record< string, unknown > )[ field.id ] }
 			onChange={ handleChange }
 			label={
 				<span>
@@ -71,9 +74,9 @@ export function ToggleWithLink( {
 }
 
 interface ToggleWithEditorLinkProps {
-	data: Record< string, unknown >;
-	field: Field< Record< string, unknown > >;
-	onChange: ( updates: Record< string, unknown > ) => void;
+	data: NewsletterSettings;
+	field: NormalizedField< NewsletterSettings >;
+	onChange: ( value: DeepPartial< NewsletterSettings > ) => void;
 	themeStylesheet: string;
 	postType: 'wp_template' | 'wp_template_part';
 	templateId: string;

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -41,8 +41,8 @@ export function EmailBylineSection( {
 			Edit: newsletterScriptData?.email
 				? ( { data: fieldData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithLink
-							data={ fieldData as Record< string, unknown > }
-							field={ field as Field< Record< string, unknown > > }
+							data={ fieldData }
+							field={ field }
 							onChange={ fieldOnChange }
 							url="https://gravatar.com/profile/avatars"
 							linkText={ __( 'Update your Gravatar', 'jetpack-newsletter' ) }
@@ -66,8 +66,8 @@ export function EmailBylineSection( {
 			type: 'boolean' as const,
 			Edit: ( { data: fieldData, field, onChange: fieldOnChange } ) => (
 				<ToggleWithLink
-					data={ fieldData as Record< string, unknown > }
-					field={ field as Field< Record< string, unknown > > }
+					data={ fieldData }
+					field={ field }
 					onChange={ fieldOnChange }
 					url={ getAdminUrl( 'options-general.php' ) }
 					linkText={ __( 'Customize date format', 'jetpack-newsletter' ) }

--- a/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
@@ -15,12 +15,6 @@ import { ToggleWithEditorLink } from '../components/toggle-with-link';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
-interface FieldRenderProps {
-	data: NewsletterSettings;
-	field: Field< Record< string, unknown > >;
-	onChange: ( updates: Partial< NewsletterSettings > ) => void;
-}
-
 interface LegacySubscriptionsSectionProps {
 	data: NewsletterSettings;
 	onChange: ( updates: Partial< NewsletterSettings > ) => void;
@@ -75,7 +69,7 @@ export function LegacySubscriptionsSection( {
 			label: __( 'Add the Subscribe Block at the end of each post', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -93,7 +87,7 @@ export function LegacySubscriptionsSection( {
 			label: __( 'Show subscription pop-up when scrolling a post', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -111,7 +105,7 @@ export function LegacySubscriptionsSection( {
 			label: __( 'Subscription overlay on homepage', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -129,7 +123,7 @@ export function LegacySubscriptionsSection( {
 			label: __( "Floating subscribe button on site's bottom corner", 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -147,7 +141,7 @@ export function LegacySubscriptionsSection( {
 			label: __( 'Add the Subscribe Block to the navigation', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }
@@ -165,7 +159,7 @@ export function LegacySubscriptionsSection( {
 			label: __( 'Add the Subscriber Login Block to the navigation', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
-				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
+				? ( { data: formData, field, onChange: fieldOnChange } ) => (
 						<ToggleWithEditorLink
 							data={ formData }
 							field={ field }


### PR DESCRIPTION
## Proposed changes

Final package in the bundled `@wordpress/*` monorepo bump (#49272) cleanup, companion to #49795. This one spans the `@wordpress/dataviews` 14→16 **and** `@wordpress/ui` 0.13→0.15 API changes that the bump unmasks in the Newsletter settings + dashboard.

Verified to type-check against **both** trunk's current deps (dataviews `14.3.0` + `@wordpress/ui@0.13`) and the bump's (dataviews `16.0.1` + `@wordpress/ui@0.15`), so it can land on trunk independently.

### Changes (`packages/newsletter`)

* **`toggle-with-link` helpers:** typed with `Record<string, unknown>` / `Field<Record>` and bridged via casts at every call site. Retype them with the dataviews control shape (`data: NewsletterSettings`, `field: NormalizedField<NewsletterSettings>`, `onChange: (value: DeepPartial<NewsletterSettings>)`), so the `Field.Edit` callbacks pass through cleanly; the one unavoidable dynamic `field.id` access is cast once internally.
* **`email-byline-section` / `legacy-subscriptions-section`:** drop the now-unnecessary `data as Record` / `field as Field<Record>` casts and the stale local `FieldRenderProps` interface. The `Edit` callbacks infer `DataFormControlProps<NewsletterSettings>` from the already-typed `Field<NewsletterSettings>[]` array.
* **add-subscribers modal:** `Notice.ActionLink` (like `Link`) omits `target`; use `openInNewTab` instead of `target="_blank"`.
* **dashboard `stage.tsx`:** drop the unsupported `focusable` prop on `Tabs.Panel` (content already gated on the active tab, per #49629).

No behavior change — these align types with the runtime the components already had.

## Related product discussion/links

* Companion to #49795 and the bundled monorepo bump #49272

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run typecheck` in `projects/packages/newsletter` is clean — verified against both dataviews `14.3.0`+ui`0.13` and dataviews `16.0.1`+ui`0.15`.
* Note: the repo-wide "Type checking" CI job covers every package; with this PR, `newsletter` is the last of the bump's type errors — once all these companion PRs land, the bundled bump (#49272) type-check goes green.
* Smoke-test the Newsletter settings (email byline toggles with their "Update your Gravatar" / "Customize date format" / "Preview and edit" links, and the legacy subscriptions toggles) and the "Add subscribers" modal's import-support notice link, plus the dashboard Subscribers/Settings tabs.
