### PR TITLE
Top Posts: render live permalink instead of stored Stats URL

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -112,7 +112,8 @@ class Jetpack_Top_Posts_Helper {
 					'id'        => $post_id,
 					'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
 					'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
-					'href'      => $post['href'],
+					// Use the local permalink to avoid stale values from the Stats API.
+					'href'      => get_permalink( $post_id ),
 					'date'      => get_the_date( '', $post_id ),
 					'title'     => $post['title'],
 					'type'      => $post['type'],

--- a/projects/plugins/jetpack/changelog/fix-top-posts-stale-permalink
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-stale-permalink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Top Posts & Pages: Use the live post permalink so links reflect the current site URL instead of a stale stored URL.


### PR DESCRIPTION
## Proposed changes

The Top Posts & Pages block rendered each post link from the `href` stored in the Stats data. That stored `href` reflects the permalink as it was when the views were recorded, so it can hold a stale hostname or structure — most visibly after a staging → production migration, where older posts keep the old staging hostname in their links (a dead-link/SEO problem for crawlers and link-preview tools).

* `Jetpack_Top_Posts_Helper::get_top_posts()` now derives each link with `get_permalink( $post_id )` instead of trusting the stored `$post['href']`.
* This mirrors what the existing fallback-random-posts branch already does (`'href' => get_permalink( $post->ID )`), and the post ID is already validated as a locally-published post earlier in the method, so the value is always safe to resolve.
* The result is self-healing for any permalink change (migrations, permalink-structure changes), not just this one report.

## Related product discussion/links

* Linear: JETPACK-1723
* Same shape as the Reader permalink staleness fixed by `bin/feedbag-update-historic-permalinks.php` on wpcom (stored permalink data going stale after a staging → prod migration).

## Does this pull request change what data or activity we track or use?

No. It only changes how an already-available value (the post permalink) is computed at render time.

## Testing instructions

* On a test site, add the **Top Posts & Pages** block to a page and ensure it has at least one post with recorded Stats views.
* Simulate a stale stored URL: confirm that before this change the block's rendered `<a href>` came from the Stats `href`, and that a post whose stored Stats permalink differs from its current `get_permalink()` (e.g. after changing the site URL or permalink structure) showed the stale URL.
* With this change, view the page source and confirm every Top Posts link uses the site's current permalink (`get_permalink()` output) — no stale hostname.
* Verify both the front-end render and the block editor preview (`/wpcom/v2/top-posts`) show the current permalinks.
* Confirm pages and custom post types still link correctly.
