### PR TITLE
My Jetpack: relevance-ranked Products search with category search and uniform results

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/styles.module.scss
@@ -64,4 +64,6 @@
 
 	@include gb.body-small;
 	color: #{gb.$gray-700};
+	// Avoid a single word wrapping alone onto the last line (typographic orphan).
+	text-wrap: pretty;
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-products.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-products.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { Flex, __experimentalText as Text } from '@wordpress/components';
+import { Flex } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { ProductSection } from './product-section';
 import { useProductFiltersContext } from './products-tracking-context';
+import { SearchResultsList } from './search-results-list';
 import { Skeleton } from './skeleton';
+import styles from './styles.module.scss';
 import { useFilteredProducts, UseFilteredProductsOptions } from './use-filtered-products';
 
 export type FilteredProductsProps = UseFilteredProductsOptions;
@@ -17,11 +18,14 @@ export type FilteredProductsProps = UseFilteredProductsOptions;
  * @return The rendered component.
  */
 export function FilteredProducts( { search, selectedFilter }: FilteredProductsProps ) {
-	const { sections, isLoading } = useFilteredProducts( { search, selectedFilter } );
+	const { sections, searchResults, isLoading } = useFilteredProducts( { search, selectedFilter } );
 	const { trackEmptyResults } = useProductFiltersContext();
 
+	const isSearching = Boolean( search?.trim() );
+	const hasResults = isSearching ? searchResults.length > 0 : sections.length > 0;
+
 	useEffect( () => {
-		if ( ! sections.length && ! isLoading ) {
+		if ( ! hasResults && ! isLoading ) {
 			let emptyStateType: 'search' | 'filter' | 'combined';
 
 			if ( search && selectedFilter && selectedFilter !== 'all' ) {
@@ -38,14 +42,47 @@ export function FilteredProducts( { search, selectedFilter }: FilteredProductsPr
 				activeFilter: selectedFilter || 'all',
 			} );
 		}
-	}, [ sections.length, isLoading, search, selectedFilter, trackEmptyResults ] );
+	}, [ hasResults, isLoading, search, selectedFilter, trackEmptyResults ] );
 
 	if ( isLoading ) {
 		return <Skeleton />;
 	}
 
-	if ( ! sections.length ) {
-		return <Text size={ 20 }>{ __( 'No results found.', 'jetpack-my-jetpack' ) }</Text>;
+	// The `.product-section` class is what scopes the `.section-heading` style, so the
+	// empty-state and search-results headings are wrapped in it to match the category headings.
+	if ( ! hasResults ) {
+		return (
+			<Flex
+				as="section"
+				className={ styles[ 'product-section' ] }
+				direction="column"
+				expanded={ false }
+			>
+				<h2 className={ styles[ 'section-heading' ] } role="status">
+					{ __( 'No results found.', 'jetpack-my-jetpack' ) }
+				</h2>
+			</Flex>
+		);
+	}
+
+	// When searching, show a single relevance-ranked list of uniform rows instead of the
+	// category-grouped product cards.
+	if ( isSearching ) {
+		return (
+			<Flex
+				as="section"
+				className={ styles[ 'product-section' ] }
+				direction="column"
+				justify="start"
+				gap={ 6 }
+				expanded={ false }
+			>
+				<h2 className={ styles[ 'section-heading' ] } role="status">
+					{ __( 'Search results', 'jetpack-my-jetpack' ) }
+				</h2>
+				<SearchResultsList items={ searchResults } />
+			</Flex>
+		);
 	}
 
 	return (

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/search-results-list.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/search-results-list.tsx
@@ -1,0 +1,115 @@
+import { Flex } from '@wordpress/components';
+import { DataViews, Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
+import { useId, useMemo } from 'react';
+import { ModuleStatus } from '../../module-status';
+import { ModuleToggle } from '../../module-toggle';
+import modulesStyles from '../../modules-list/styles.module.scss';
+import { getModuleStatus } from '../../modules-list/utils';
+import { ProductCardAction } from './product-card-action';
+import { SearchResultItem } from './types';
+import { getProductStatus } from './utils';
+
+import '../../modules-list/style.scss';
+
+export type SearchResultsListProps = {
+	items: Array< SearchResultItem >;
+};
+
+const noop = () => {};
+
+const getItemId = ( item: SearchResultItem ) =>
+	item.kind === 'card' ? `card:${ item.card.product.slug }` : `module:${ item.module.module }`;
+
+const getName = ( item: SearchResultItem ) =>
+	item.kind === 'card' ? item.card.product.name : item.module.name;
+
+const getDescription = ( item: SearchResultItem ) =>
+	item.kind === 'card' ? item.card.product.description : item.module.description;
+
+/**
+ * Renders relevance-ranked search results as a single uniform list of compact rows, mixing
+ * product cards and modules so the best match leads regardless of its type.
+ *
+ * @param {SearchResultsListProps} props - The component props.
+ *
+ * @return The rendered component.
+ */
+export function SearchResultsList( { items }: SearchResultsListProps ) {
+	const baseId = useId();
+
+	const fields = useMemo< Array< Field< SearchResultItem > > >( () => {
+		return [
+			{
+				id: 'title',
+				label: __( 'Title', 'jetpack-my-jetpack' ),
+				getValue( { item } ) {
+					return getName( item );
+				},
+				render( { item } ) {
+					return (
+						<div className={ modulesStyles[ 'module-title-wrapper' ] }>
+							<span className={ modulesStyles[ 'module-name' ] }>{ getName( item ) }</span>
+							<span
+								id={ `${ baseId }-description-${ getItemId( item ) }` }
+								className={ modulesStyles[ 'module-description' ] }
+							>
+								{ getDescription( item ) }
+							</span>
+						</div>
+					);
+				},
+			},
+			{
+				id: 'action',
+				label: __( 'Action', 'jetpack-my-jetpack' ),
+				render: ( { item } ) => {
+					const { isAvailable, reason } =
+						item.kind === 'card'
+							? getProductStatus( item.card.product )
+							: getModuleStatus( item.module );
+
+					if ( ! isAvailable ) {
+						return <Badge intent="medium">{ reason }</Badge>;
+					}
+
+					return item.kind === 'card' ? (
+						<Flex justify="end" className={ modulesStyles[ 'toggle-wrap' ] }>
+							<ProductCardAction product={ item.card.product } module={ item.card.module } />
+						</Flex>
+					) : (
+						<Flex gap={ 4 } className={ modulesStyles[ 'toggle-wrap' ] }>
+							<ModuleStatus module={ item.module } />
+							<ModuleToggle
+								module={ item.module }
+								describedby={ `${ baseId }-description-${ getItemId( item ) }` }
+							/>
+						</Flex>
+					);
+				},
+			},
+		];
+	}, [ baseId ] );
+
+	return (
+		<div className={ modulesStyles.wrapper }>
+			<DataViews
+				data={ items }
+				fields={ fields }
+				view={ {
+					type: 'table',
+					titleField: 'title',
+					fields: [ 'action' ],
+				} }
+				getItemId={ getItemId }
+				paginationInfo={ {
+					totalItems: items.length,
+					totalPages: 1,
+				} }
+				onChangeView={ noop }
+				defaultLayouts={ { table: {} } }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -145,6 +145,8 @@
 	.card-description {
 
 		@include gb.body-medium;
+		// Avoid a single word wrapping alone onto the last line (typographic orphan).
+		text-wrap: pretty;
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment node
+ */
+import { buildCards, filterSections, searchAndRankItems } from '../utils';
+import type { ProductCamelCase } from '../../../../data/types';
+import type { MyJetpackModule } from '../../../../types';
+import type { CardItem, ProductSection } from '../types';
+
+/**
+ * Build a minimal card fixture with only the fields the search ranks against.
+ *
+ * @param {object} fields                 - Partial product fields.
+ * @param          fields.slug            - The product slug.
+ * @param          fields.name            - The product name.
+ * @param          fields.title           - The product title (defaults to the name).
+ * @param          fields.description     - The short description.
+ * @param          fields.longDescription - The long description.
+ * @return A CardItem suitable for the ranking helpers.
+ */
+function makeCard( fields: {
+	slug: string;
+	name: string;
+	title?: string;
+	description?: string;
+	longDescription?: string;
+} ): CardItem {
+	return {
+		product: {
+			slug: fields.slug,
+			name: fields.name,
+			title: fields.title ?? fields.name,
+			description: fields.description ?? '',
+			longDescription: fields.longDescription ?? '',
+		} as unknown as ProductCamelCase,
+	};
+}
+
+/**
+ * Build a minimal module fixture.
+ *
+ * @param {object} fields                  - Partial module fields.
+ * @param          fields.module           - The module slug.
+ * @param          fields.name             - The module name.
+ * @param          fields.description      - The short description.
+ * @param          fields.long_description - The long description.
+ * @param          fields.search_terms     - The curated search terms.
+ * @return A MyJetpackModule suitable for the ranking helpers.
+ */
+function makeModule( fields: {
+	module: string;
+	name: string;
+	description?: string;
+	long_description?: string;
+	search_terms?: string;
+} ): MyJetpackModule {
+	return {
+		module: fields.module,
+		name: fields.name,
+		description: fields.description ?? '',
+		long_description: fields.long_description ?? '',
+		search_terms: fields.search_terms ?? '',
+		available: true,
+		activated: false,
+	};
+}
+
+const forms = makeCard( {
+	slug: 'jetpack-forms',
+	name: 'Forms',
+	description: 'Build and share forms to collect leads, feedback, and payments.',
+} );
+const akismet = makeCard( {
+	slug: 'akismet',
+	name: 'Akismet Anti-spam',
+	description: 'Automatically clear spam from comments and forms.',
+} );
+const stats = makeCard( {
+	slug: 'stats',
+	name: 'Stats',
+	description: 'Clear, concise, and actionable analysis of your site performance.',
+} );
+
+describe( 'buildCards', () => {
+	const productA = makeCard( { slug: 'a', name: 'A' } ).product;
+
+	it( 'skips slugs whose product is unavailable (regression: undefined-product crash)', () => {
+		const result = buildCards( [ 'a', 'missing' ], { a: productA }, {}, {} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].product.slug ).toBe( 'a' );
+	} );
+
+	it( 'pairs a card with its module via the productModules override', () => {
+		const vaultpress = makeModule( { module: 'vaultpress', name: 'Backup' } );
+		const result = buildCards( [ 'a' ], { a: productA }, { vaultpress }, { a: 'vaultpress' } );
+
+		expect( result[ 0 ].module?.module ).toBe( 'vaultpress' );
+	} );
+
+	it( 'returns an empty array when no products are loaded', () => {
+		expect( buildCards( [ 'a', 'b' ], {}, {}, {} ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'filterSections', () => {
+	const sections: Array< ProductSection > = [
+		{ id: 'security', title: 'Security', cards: [ akismet ], modules: [] },
+		{ id: 'growth', title: 'Growth', cards: [ stats, forms ], modules: [] },
+	];
+
+	it( 'floats the section holding the strongest match to the top', () => {
+		const result = filterSections( sections, { search: 'form' } );
+
+		expect( result[ 0 ].id ).toBe( 'growth' );
+		expect( result[ 0 ].cards?.[ 0 ].product.slug ).toBe( 'jetpack-forms' );
+	} );
+
+	it( 'drops sections with no matches', () => {
+		const result = filterSections( sections, { search: 'stats' } );
+
+		expect( result.every( section => section.id !== 'security' ) ).toBe( true );
+	} );
+
+	it( 'returns the sections untouched when there is no search term', () => {
+		expect( filterSections( sections, { search: '' } ) ).toBe( sections );
+		expect( filterSections( sections, { search: undefined } ) ).toBe( sections );
+	} );
+} );
+
+describe( 'searchAndRankItems', () => {
+	const formsModule = makeModule( {
+		module: 'contact-form',
+		name: 'Forms',
+		description: 'Add contact, registration, and feedback forms directly from the block editor.',
+	} );
+
+	it( 'ranks the best match first regardless of whether it is a card or a module', () => {
+		// The Forms module (exact name match) must lead the Akismet card (description-only match).
+		const result = searchAndRankItems( [ akismet ], [ formsModule ], 'forms' );
+
+		expect( result[ 0 ] ).toMatchObject( { kind: 'module' } );
+		expect( result[ 0 ].kind === 'module' && result[ 0 ].module.module ).toBe( 'contact-form' );
+	} );
+
+	it( 'returns a flat mix of cards and modules', () => {
+		const result = searchAndRankItems( [ akismet, forms ], [ formsModule ], 'forms' );
+		const kinds = result.map( item => item.kind );
+
+		expect( kinds ).toContain( 'card' );
+		expect( kinds ).toContain( 'module' );
+	} );
+
+	it( 'does not surface unrelated products via fuzzy description matches', () => {
+		// "Stats"/"Boost" only relate to "forms" through "performance" — must not appear.
+		const result = searchAndRankItems( [ stats ], [], 'forms' );
+
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'de-duplicates a product that appears more than once', () => {
+		const result = searchAndRankItems( [ forms, forms ], [], 'forms' );
+
+		expect( result ).toHaveLength( 1 );
+	} );
+
+	it( 'returns an empty array when nothing matches', () => {
+		expect( searchAndRankItems( [ forms ], [ formsModule ], 'zzzznotathing' ) ).toEqual( [] );
+	} );
+
+	it( 'returns an empty array when there is no search term', () => {
+		expect( searchAndRankItems( [ forms ], [ formsModule ], '' ) ).toEqual( [] );
+		expect( searchAndRankItems( [ forms ], [ formsModule ], undefined ) ).toEqual( [] );
+	} );
+
+	it( 'returns every item in a category when searching the category name', () => {
+		// Neither item mentions "security" in its name/description — only the category does.
+		const monitor = makeModule( {
+			module: 'monitor',
+			name: 'Monitor',
+			description: 'Downtime alerts.',
+		} );
+		const result = searchAndRankItems( [ akismet ], [ monitor ], 'security', {
+			cardCategories: new Map( [ [ akismet.product.slug, [ 'Security' ] ] ] ),
+			moduleCategories: new Map( [ [ 'monitor', [ 'Security' ] ] ] ),
+		} );
+
+		expect( result ).toHaveLength( 2 );
+	} );
+
+	it( 'does not match a category an item does not belong to', () => {
+		const result = searchAndRankItems( [ akismet ], [], 'performance', {
+			cardCategories: new Map( [ [ akismet.product.slug, [ 'Security' ] ] ] ),
+		} );
+
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'is case-insensitive', () => {
+		const lower = searchAndRankItems( [ akismet, forms ], [], 'forms' );
+		const upper = searchAndRankItems( [ akismet, forms ], [], 'FORMS' );
+
+		expect( upper[ 0 ] ).toEqual( lower[ 0 ] );
+		expect( upper[ 0 ].kind === 'card' && upper[ 0 ].card.product.slug ).toBe( 'jetpack-forms' );
+	} );
+
+	it( 'does not match on the slug (regression for the old JSON.stringify search)', () => {
+		// "jetpack-forms" only appears as a slug here; the product name is "Stats".
+		const onlySlug = makeCard( { slug: 'jetpack-forms', name: 'Stats' } );
+
+		expect( searchAndRankItems( [ onlySlug ], [], 'jetpack-forms' ) ).toEqual( [] );
+	} );
+
+	it( 'matches a module via its curated search terms', () => {
+		const newsletter = makeModule( {
+			module: 'subscriptions',
+			name: 'Newsletter',
+			description: 'Grow your subscriber list and deliver your content to their inbox.',
+			search_terms: 'subscriptions, subscribers, email',
+		} );
+		const result = searchAndRankItems( [], [ newsletter ], 'subscribers' );
+
+		expect( result[ 0 ].kind === 'module' && result[ 0 ].module.module ).toBe( 'subscriptions' );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/types.ts
@@ -5,12 +5,22 @@ export type ProductCategory = 'recommended' | 'security' | 'growth' | 'performan
 
 export type ProductFilter = ProductCategory | 'all' | 'included';
 
+export type CardItem = {
+	product: ProductCamelCase;
+	module?: MyJetpackModule;
+};
+
 export type ProductSection = {
 	id: string;
 	title: string;
-	cards?: Array< {
-		product: ProductCamelCase;
-		module?: MyJetpackModule;
-	} >;
+	cards?: Array< CardItem >;
 	modules?: Array< MyJetpackModule >;
 };
+
+/**
+ * A single relevance-ranked search result, which can be either a product card or a module.
+ * Rendered as a uniform compact row in the search results list.
+ */
+export type SearchResultItem =
+	| { kind: 'card'; card: CardItem }
+	| { kind: 'module'; module: MyJetpackModule };

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
@@ -1,15 +1,34 @@
 import { useMemo } from 'react';
-import useProducts from '../../../data/products/use-products';
-import { JetpackProductWithCard } from '../../../types';
+import { useAllProducts } from '../../../data/products/use-all-products';
 import { CATEGORY_CARDS_AND_MODULES, PRODUCT_MODULES } from './mappings';
 import { ProductFilter } from './types';
 import { useAllJetpackModules } from './use-all-jetpack-modules';
-import { filterAndSortModules, filterSections, getSectionTitle } from './utils';
+import { buildCards, filterAndSortModules, getSectionTitle, searchAndRankItems } from './utils';
+
+const ALL_CATEGORIES = Object.entries( CATEGORY_CARDS_AND_MODULES );
 
 export type UseFilteredProductsOptions = {
 	selectedFilter: ProductFilter | undefined;
 	search: string | undefined;
 };
+
+/**
+ * Record that an item (by slug) belongs to a category label.
+ *
+ * @param {Map<string, string[]>} map   - The slug-to-category-labels map to update.
+ * @param {string}                slug  - The item slug.
+ * @param {string | undefined}    label - The category label.
+ */
+function addCategory( map: Map< string, string[] >, slug: string, label: string | undefined ) {
+	if ( ! label ) {
+		return;
+	}
+	const labels = map.get( slug ) ?? [];
+	if ( ! labels.includes( label ) ) {
+		labels.push( label );
+		map.set( slug, labels );
+	}
+}
 
 /**
  * Custom hook to filter products based on search term and selected filter.
@@ -19,67 +38,63 @@ export type UseFilteredProductsOptions = {
  * @return An array of sections and the corresponding cards and modules
  */
 export function useFilteredProducts( { search, selectedFilter }: UseFilteredProductsOptions ) {
-	// Let us default to all the sections by default.
-	let sections = Object.entries( CATEGORY_CARDS_AND_MODULES );
-
-	// If a known filter is selected, we filter the sections accordingly, which means that we show the section/products based on the selected filter/category.
-	if ( CATEGORY_CARDS_AND_MODULES[ selectedFilter ] ) {
-		sections = sections.filter( ( [ category ] ) => category === selectedFilter );
-	} else {
-		// Since were defaulting to all categories, we can filter out the 'recommended' category.
-		sections = sections.filter( ( [ category ] ) => category !== 'recommended' );
-	}
-
-	// Let us extract the product slugs from the sections, based on the cards in the section, because we want to display product cards accordingly.
-	const productSlugs = sections.reduce< Array< JetpackProductWithCard > >(
-		( acc, [ , { cards } ] ) => {
-			return [ ...acc, ...cards ];
-		},
-		[]
-	);
-
-	const { products } = useProducts( productSlugs );
+	const { data: allProducts } = useAllProducts();
 	const { modules: allModules, isLoading: isLoadingModules } = useAllJetpackModules();
 
-	// Let us create a mapping of products by their slug for easy access.
-	const productsBySlug = products.reduce(
-		( acc, product ) => {
-			return {
-				...acc,
-				[ product.slug ]: product,
-			};
-		},
-		{} as Record< JetpackProductWithCard, ( typeof products )[ number ] >
+	// Build every category's cards and modules up front so search can always scan every
+	// product/module regardless of the selected category filter.
+	const allSections = useMemo(
+		() =>
+			ALL_CATEGORIES.map( ( [ category, { cards, modules } ] ) => ( {
+				id: category,
+				title: getSectionTitle( category ),
+				cards: buildCards( cards, allProducts, allModules, PRODUCT_MODULES ),
+				modules: filterAndSortModules( modules.map( slug => allModules[ slug ] ) ),
+			} ) ),
+		[ allProducts, allModules ]
 	);
 
-	const $sections = filterSections(
-		sections.map( ( [ category, { cards, modules } ] ) => ( {
-			id: category,
-			title: getSectionTitle( category ),
-			cards: cards
-				.map( slug => {
-					const product = productsBySlug[ slug ];
-					if ( ! product ) {
-						return null;
-					}
-					const moduleSlug = PRODUCT_MODULES[ slug ] || slug;
+	// The browse view honors the selected category filter; the default 'all' view hides the
+	// 'recommended' category (it is reachable via its own filter and would duplicate cards).
+	const sections = useMemo(
+		() =>
+			allSections.filter( ( { id } ) =>
+				CATEGORY_CARDS_AND_MODULES[ selectedFilter ] ? id === selectedFilter : id !== 'recommended'
+			),
+		[ allSections, selectedFilter ]
+	);
 
-					return {
-						product,
-						module: allModules[ moduleSlug ],
-					};
-				} )
-				.filter( Boolean ),
-			modules: filterAndSortModules( modules.map( slug => allModules[ slug ] ) ),
-		} ) ),
-		{ search }
+	// Map each card/module to the category labels it belongs to, so searching a category name
+	// (e.g. "security", "growth", "performance") surfaces every item in that category.
+	const { cardCategories, moduleCategories } = useMemo( () => {
+		const cards = new Map< string, string[] >();
+		const modules = new Map< string, string[] >();
+		allSections.forEach( section => {
+			section.cards.forEach( ( { product } ) => addCategory( cards, product.slug, section.title ) );
+			section.modules.forEach( module => addCategory( modules, module.module, section.title ) );
+		} );
+		return { cardCategories: cards, moduleCategories: modules };
+	}, [ allSections ] );
+
+	// Search always scans every category and ranks results into a single uniform list; browse
+	// (no search term) keeps the category grouping above.
+	const searchResults = useMemo(
+		() =>
+			searchAndRankItems(
+				allSections.flatMap( section => section.cards ),
+				allSections.flatMap( section => section.modules ),
+				search,
+				{ cardCategories, moduleCategories }
+			),
+		[ allSections, cardCategories, moduleCategories, search ]
 	);
 
 	return useMemo(
 		() => ( {
-			sections: $sections,
+			sections,
+			searchResults,
 			isLoading: isLoadingModules,
 		} ),
-		[ $sections, isLoadingModules ]
+		[ sections, searchResults, isLoadingModules ]
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { JETPACK_PRODUCTS_NOT_FOR_MULTISITE } from '../../../constants';
 import { ProductCamelCase } from '../../../data/types';
 import { JetpackModuleSlug, MyJetpackModule } from '../../../types';
-import { ProductFilter, ProductSection } from './types';
+import { CardItem, ProductFilter, ProductSection, SearchResultItem } from './types';
 
 /**
  * Legacy modules that should only appear in the module list when they are already active.
@@ -78,44 +78,301 @@ export function isValidFilter( value: string | null ): value is ProductFilter {
 }
 
 /**
- * Filter sections based on the search term by matching the card and module data with the search term.
+ * A field to match against, with a relevance weight. Name/title dominate, then the curated
+ * search terms, then the description. Noisy fields (slugs, URLs, pricing) are intentionally
+ * excluded so a direct title match always outranks an incidental mention.
+ */
+type ScoredField = { value: string | undefined; weight: number };
+
+/**
+ * A parsed search term: the lowercased text plus a precompiled word-boundary matcher, so the
+ * RegExp is built once per search rather than once per field/item in the scoring loop.
+ */
+type SearchTerm = { text: string; wordRe: RegExp };
+
+/**
+ * Whether a search term is meaningful (non-empty after trimming).
  *
- * @param {Array<ProductSection>} sections - The sections to filter.
- * @param {FilterSectionsOptions} options  - The options for filtering sections.
- * @return  The filtered sections.
+ * @param {string | undefined} search - The raw search term.
+ * @return True when the term should trigger ranking/filtering.
+ */
+function hasSearch( search: string | undefined ): search is string {
+	return Boolean( search?.trim() );
+}
+
+/**
+ * Escape a string for safe use inside a RegExp.
+ *
+ * @param {string} value - The string to escape.
+ * @return The escaped string.
+ */
+function escapeRegExp( value: string ): string {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}
+
+/**
+ * Parse a search string into lowercased terms, each with a precompiled word-boundary matcher.
+ *
+ * @param {string} search - The search term.
+ * @return The individual parsed terms.
+ */
+function searchTerms( search: string ): Array< SearchTerm > {
+	return search
+		.toLowerCase()
+		.split( /\s+/ )
+		.filter( Boolean )
+		.map( text => ( { text, wordRe: new RegExp( `\\b${ escapeRegExp( text ) }` ) } ) );
+}
+
+/**
+ * Score a single term against a field value. Higher is a better match, 0 means no match.
+ * Tiers: exact > prefix > word-start > substring.
+ *
+ * @param {SearchTerm}         term  - The parsed search term.
+ * @param {string | undefined} value - The field value to test.
+ * @return The match score for this field.
+ */
+function scoreTerm( term: SearchTerm, value: string | undefined ): number {
+	if ( ! value ) {
+		return 0;
+	}
+
+	const haystack = value.toLowerCase();
+
+	if ( haystack === term.text ) {
+		return 100;
+	}
+	if ( haystack.startsWith( term.text ) ) {
+		return 75;
+	}
+	if ( term.wordRe.test( haystack ) ) {
+		return 50;
+	}
+	if ( haystack.includes( term.text ) ) {
+		return 25;
+	}
+
+	return 0;
+}
+
+/**
+ * Score an item (described by its weighted fields) against the search. Every term must match
+ * at least one field (AND semantics); the item's score is the sum of each term's best weighted
+ * field score. Returns 0 when any term is unmatched, so the item is filtered out.
+ *
+ * @param {Array<SearchTerm>}  terms  - The parsed search terms.
+ * @param {Array<ScoredField>} fields - The weighted fields to match against.
+ * @return The item's total relevance score, or 0 when it does not match.
+ */
+function scoreFields( terms: Array< SearchTerm >, fields: Array< ScoredField > ): number {
+	let total = 0;
+
+	for ( const term of terms ) {
+		let best = 0;
+		for ( const field of fields ) {
+			best = Math.max( best, scoreTerm( term, field.value ) * field.weight );
+		}
+		if ( best === 0 ) {
+			return 0;
+		}
+		total += best;
+	}
+
+	return total;
+}
+
+/**
+ * Score, filter, and sort a list of items by relevance — the shared map → score → filter (>0)
+ * → sort (best first) pipeline used by every ranking helper.
+ *
+ * @param {Array<T>}          items     - The items to rank.
+ * @param {Array<SearchTerm>} terms     - The parsed search terms.
+ * @param {Function}          fieldsFor - Maps an item to its weighted fields.
+ * @return The matching items with their scores, best match first.
+ */
+function rankBy< T >(
+	items: Array< T >,
+	terms: Array< SearchTerm >,
+	fieldsFor: ( item: T ) => Array< ScoredField >
+): Array< { item: T; score: number } > {
+	return items
+		.map( item => ( { item, score: scoreFields( terms, fieldsFor( item ) ) } ) )
+		.filter( ( { score } ) => score > 0 )
+		.sort( ( a, b ) => b.score - a.score );
+}
+
+/**
+ * The weighted fields for a product card. When provided, the categories the card belongs to
+ * are matchable too, so searching a category name surfaces every item in that category.
+ *
+ * @param {CardItem}           card       - The card.
+ * @param {string | undefined} categories - The card's category labels, space-joined.
+ * @return The weighted fields to match against.
+ */
+function cardFields( card: CardItem, categories?: string ): Array< ScoredField > {
+	return [
+		{ value: card.product.name, weight: 3 },
+		{ value: card.product.title, weight: 3 },
+		{ value: card.module?.name, weight: 3 },
+		{ value: card.module?.search_terms, weight: 2 },
+		{ value: categories, weight: 2 },
+		{ value: card.product.description, weight: 1 },
+		{ value: card.module?.description, weight: 1 },
+	];
+}
+
+/**
+ * The weighted fields for a standalone module. When provided, the categories the module
+ * belongs to are matchable too.
+ *
+ * @param {MyJetpackModule}    module     - The module.
+ * @param {string | undefined} categories - The module's category labels, space-joined.
+ * @return The weighted fields to match against.
+ */
+function moduleFields( module: MyJetpackModule, categories?: string ): Array< ScoredField > {
+	return [
+		{ value: module.name, weight: 3 },
+		{ value: module.search_terms, weight: 2 },
+		{ value: categories, weight: 2 },
+		{ value: module.description, weight: 1 },
+	];
+}
+
+/**
+ * Filter sections based on the search term, ranking the cards and modules within each section
+ * by relevance and floating the section that holds the strongest match to the top.
+ * Used by the "Included in plan" view, which keeps its per-plan grouping.
+ *
+ * @param {Array<ProductSection>} sections       - The sections to filter.
+ * @param {object}                options        - The options for filtering sections.
+ * @param {string | undefined}    options.search - The search term.
+ * @return  The filtered, ranked sections.
  */
 export function filterSections(
 	sections: Array< ProductSection >,
 	{ search }: { search: string | undefined }
 ): Array< ProductSection > {
-	if ( ! search ) {
+	if ( ! hasSearch( search ) ) {
 		return sections;
 	}
 
-	// TODO Improve search
+	const terms = searchTerms( search );
+
 	return sections
-		.map( section => ( {
-			...section,
-			cards: section.cards?.filter( item => {
-				// Search only the values, not the keys
-				const str = JSON.stringify(
-					Object.values( {
-						...item.product,
-						...item.module,
-					} )
-				);
+		.map( section => {
+			const cards = rankBy( section.cards ?? [], terms, card => cardFields( card ) );
+			const modules = rankBy( section.modules ?? [], terms, module => moduleFields( module ) );
+			const bestScore = Math.max(
+				0,
+				...cards.map( ( { score } ) => score ),
+				...modules.map( ( { score } ) => score )
+			);
 
-				return str.toLowerCase().includes( search.toLowerCase() );
-			} ),
-			modules: section.modules?.filter( item => {
-				const str = JSON.stringify( Object.values( item ) );
+			return {
+				section: {
+					...section,
+					cards: cards.map( ( { item } ) => item ),
+					modules: modules.map( ( { item } ) => item ),
+				},
+				bestScore,
+			};
+		} )
+		.filter( ( { section } ) => section.cards.length || section.modules.length )
+		.sort( ( a, b ) => b.bestScore - a.bestScore )
+		.map( ( { section } ) => section );
+}
 
-				return str.toLowerCase().includes( search.toLowerCase() );
-			} ),
-		} ) )
-		.filter( section => {
-			return section.cards?.length || section.modules?.length;
-		} );
+/**
+ * Search across all cards and modules and return a single relevance-ranked list of items.
+ * Cards and modules are de-duplicated (some products appear in more than one category) and
+ * ranked on one scale, so the strongest match leads regardless of its type. Returns an empty
+ * array when there is no search term — the caller falls back to the category browse view.
+ *
+ * Category matching is intentionally a capability of this unified search view only: callers
+ * pass `categories` so typing a category name surfaces its items. The browse/per-section paths
+ * (`filterSections`) omit it because category context there is already provided by grouping.
+ *
+ * @param {Array<CardItem>}        cards                         - All cards in scope.
+ * @param {Array<MyJetpackModule>} modules                       - All modules in scope.
+ * @param {string | undefined}     search                        - The search term.
+ * @param {object}                 [categories]                  - Per-item category labels for category search.
+ * @param {Map<string, string[]>}  [categories.cardCategories]   - Card slug to category labels.
+ * @param {Map<string, string[]>}  [categories.moduleCategories] - Module slug to category labels.
+ * @return  The matching items ordered best match first.
+ */
+export function searchAndRankItems(
+	cards: Array< CardItem >,
+	modules: Array< MyJetpackModule >,
+	search: string | undefined,
+	categories?: {
+		cardCategories?: Map< string, string[] >;
+		moduleCategories?: Map< string, string[] >;
+	}
+): Array< SearchResultItem > {
+	if ( ! hasSearch( search ) ) {
+		return [];
+	}
+
+	const terms = searchTerms( search );
+
+	const cardsBySlug = new Map< string, CardItem >();
+	const modulesBySlug = new Map< string, MyJetpackModule >();
+
+	cards.forEach( card => {
+		if ( card?.product?.slug && ! cardsBySlug.has( card.product.slug ) ) {
+			cardsBySlug.set( card.product.slug, card );
+		}
+	} );
+	modules.forEach( module => {
+		if ( module?.module && ! modulesBySlug.has( module.module ) ) {
+			modulesBySlug.set( module.module, module );
+		}
+	} );
+
+	const items: Array< SearchResultItem > = [
+		...[ ...cardsBySlug.values() ].map( card => ( { kind: 'card' as const, card } ) ),
+		...[ ...modulesBySlug.values() ].map( module => ( { kind: 'module' as const, module } ) ),
+	];
+
+	return rankBy( items, terms, item =>
+		item.kind === 'card'
+			? cardFields(
+					item.card,
+					categories?.cardCategories?.get( item.card.product.slug )?.join( ' ' )
+			  )
+			: moduleFields(
+					item.module,
+					categories?.moduleCategories?.get( item.module.module )?.join( ' ' )
+			  )
+	).map( ( { item } ) => item );
+}
+
+/**
+ * Build the product cards for a set of card slugs, pairing each product with its module.
+ * Slugs whose product is not loaded (unavailable on this site, or still loading) are skipped
+ * so callers never dereference an undefined product.
+ *
+ * @param {Array<string>}                    slugs          - The product card slugs.
+ * @param {Record<string, ProductCamelCase>} products       - Products keyed by slug.
+ * @param {Record<string, MyJetpackModule>}  modules        - Modules keyed by slug.
+ * @param {Record<string, string>}           productModules - Card slug to module slug overrides.
+ * @return The resolved cards, with unavailable products skipped.
+ */
+export function buildCards(
+	slugs: Array< string >,
+	products: Record< string, ProductCamelCase >,
+	modules: Record< string, MyJetpackModule >,
+	productModules: Record< string, string >
+): Array< CardItem > {
+	return slugs
+		.map< CardItem | null >( slug => {
+			const product = products[ slug ];
+			if ( ! product ) {
+				return null;
+			}
+			return { product, module: modules[ productModules[ slug ] || slug ] };
+		} )
+		.filter( ( card ): card is CardItem => card !== null );
 }
 
 /**

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -27,6 +27,16 @@
 	body.jetpack_page_my-jetpack:not(.jetpack-admin-full-screen) {
 
 		@include jetpack-admin-page-layout;
+
+		// Reserve space for the scrollable middle's vertical scrollbar so toggling
+		// between search results and category browse — which changes the content
+		// height, and thus whether the scrollbar is present — doesn't shift the
+		// layout sideways. Most noticeable on Firefox / platforms with classic
+		// (space-consuming) scrollbars; a no-op where unsupported. The selector
+		// mirrors the "scrollable middle" defined by jetpack-admin-page-layout.
+		.jp-admin-page__page > :not(:first-child):not(.jetpack-footer) {
+			scrollbar-gutter: stable;
+		}
 	}
 
 	// Defend @wordpress/ui Button against wp-admin's unlayered anchor styles

--- a/projects/packages/my-jetpack/changelog/2026-06-18-23-07-20-689362
+++ b/projects/packages/my-jetpack/changelog/2026-06-18-23-07-20-689362
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-My Jetpack: rank product search results by relevance so direct title matches appear first
+My Jetpack: Rank product search results by relevance so direct title matches appear first.

--- a/projects/packages/my-jetpack/changelog/2026-06-18-23-07-20-689362
+++ b/projects/packages/my-jetpack/changelog/2026-06-18-23-07-20-689362
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: rank product search results by relevance so direct title matches appear first


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/a332d708-c272-41ca-876d-8768733e368d

After:

https://github.com/user-attachments/assets/f0e6befe-bae8-436a-bcc8-dd23b9c2e754


## Proposed changes
* Rework the My Jetpack **Products** search so results are ranked by relevance instead of unordered substring matches — a direct title match (e.g. "Forms") now leads.
* When a search is active, collapse the category sections into a single **"Search results"** list of uniform compact rows (product cards and modules ranked together on one scale), instead of the grouped promotional card boxes.
* Replace the previous `JSON.stringify`-everything matching with a small, dependency-free weighted substring scorer: name/title (×3) > curated search terms (×2) > description (×1); noisy fields like slugs/URLs/pricing are excluded. Match tiers are exact > prefix > word-start > substring, and multi-word queries require every word to match.
* Search now always scans **every** product/module regardless of the category selected in the sidebar.
* **Category search:** typing a category name — `security`, `growth`, `performance`, `other`, `recommended` — returns every item in that category (each item carries its category labels as a matchable field).
* Guard the `productsBySlug` lookup against `undefined` products, so the page no longer crashes when a requested card's product is unavailable on the site (surfaced by the newly added Jetpack Forms card in the Growth category).
* Add `scrollbar-gutter: stable` to the My Jetpack scrollable area so the layout no longer shifts sideways on Firefox when the inner scrollbar appears/disappears. Scoped to the My Jetpack page only.
* Add unit tests covering the ranking, category search, de-duplication, and no-match behavior.

No new dependencies; the lockfile is unchanged.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with Jetpack connected, go to **Jetpack → My Jetpack → Products**.
* In the search box, type `forms` → **Forms** appears at the top of a single "Search results" list of compact rows (no large card boxes).
* Type `search`, `stats`, `backup` → the product whose title matches leads in each case.
* Type a category name — `security`, `growth`, `performance`, `other` — and confirm all items in that category are returned.
* Select a category in the left sidebar, then type a query → results still come from every category (search ignores the selected filter).
* Clear the search box → the normal category-grouped browse view returns unchanged.
* In **Firefox**, toggle between a short and a tall result set (e.g. search then clear) and confirm the layout no longer jumps sideways as the scrollbar appears/disappears.
