### PR TITLE
Forms: warn admins and editors when a form isn't collecting responses

### DIFF
--- a/projects/packages/forms/changelog/add-forms-not-collecting-warning
+++ b/projects/packages/forms/changelog/add-forms-not-collecting-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration) in the editor, on the live form, and in the dashboard

--- a/projects/packages/forms/changelog/add-forms-not-collecting-warning
+++ b/projects/packages/forms/changelog/add-forms-not-collecting-warning
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration) in the editor, on the live form, and in the dashboard
+Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration) in the editor, on the live form, and in the dashboard.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -7,12 +7,15 @@ import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Icon,
+	Tooltip,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
 import { useSearch, useNavigate } from '@wordpress/route';
 import { Badge, EmptyState } from '@wordpress/ui';
 /**
@@ -205,8 +208,31 @@ function StageInner() {
 				id: 'title',
 				label: __( 'Form name', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.title,
-				render: ( { item }: { item: FormListItem } ) =>
-					item.title || __( '(no title)', 'jetpack-forms' ),
+				render: ( { item }: { item: FormListItem } ) => {
+					const title = item.title || __( '(no title)', 'jetpack-forms' );
+					if ( item.isCollectingResponses ) {
+						return title;
+					}
+					return (
+						<HStack spacing={ 1 } justify="flex-start" expanded={ false }>
+							<span>{ title }</span>
+							<Tooltip
+								delay={ 0 }
+								text={ __(
+									'This form isn’t collecting responses. Turn on email or saving to start.',
+									'jetpack-forms'
+								) }
+							>
+								<span
+									className="jetpack-forms__not-collecting-icon"
+									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+								>
+									<Icon icon={ caution } size={ 20 } />
+								</span>
+							</Tooltip>
+						</HStack>
+					);
+				},
 				enableSorting: false,
 				enableHiding: false,
 			},

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -7,8 +7,6 @@ import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Icon,
-	Tooltip,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -17,7 +15,7 @@ import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
 import { useSearch, useNavigate } from '@wordpress/route';
-import { Badge, EmptyState } from '@wordpress/ui';
+import { Badge, EmptyState, Icon, Stack, Tooltip } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -214,23 +212,26 @@ function StageInner() {
 						return title;
 					}
 					return (
-						<HStack spacing={ 1 } justify="flex-start" expanded={ false }>
+						<Stack direction="row" gap="xs" align="center" justify="flex-start">
 							<span>{ title }</span>
-							<Tooltip
-								delay={ 0 }
-								text={ __(
-									'This form isn’t collecting responses. Turn on email or saving to start.',
-									'jetpack-forms'
-								) }
-							>
-								<span
-									className="jetpack-forms__not-collecting-icon"
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									className="jetpack-forms__not-collecting-badge"
 									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
 								>
-									<Icon icon={ caution } size={ 20 } />
-								</span>
-							</Tooltip>
-						</HStack>
+									<Badge intent="high">
+										<Icon icon={ caution } size={ 16 } />
+										{ __( 'Not collecting', 'jetpack-forms' ) }
+									</Badge>
+								</Tooltip.Trigger>
+								<Tooltip.Popup>
+									{ __(
+										'This form isn’t collecting responses. Turn on email notifications or response storage in form settings.',
+										'jetpack-forms'
+									) }
+								</Tooltip.Popup>
+							</Tooltip.Root>
+						</Stack>
 					);
 				},
 				enableSorting: false,

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -13,9 +13,8 @@ import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { caution } from '@wordpress/icons';
 import { useSearch, useNavigate } from '@wordpress/route';
-import { Badge, EmptyState, Icon, Stack, Tooltip } from '@wordpress/ui';
+import { Badge, EmptyState, Stack, Tooltip } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -212,21 +211,18 @@ function StageInner() {
 						return title;
 					}
 					return (
-						<Stack direction="row" gap="xs" align="center" justify="flex-start">
+						<Stack direction="row" gap="sm" align="center" justify="flex-start">
 							<span>{ title }</span>
 							<Tooltip.Root>
 								<Tooltip.Trigger
 									className="jetpack-forms__not-collecting-badge"
 									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
 								>
-									<Badge intent="high">
-										<Icon icon={ caution } size={ 16 } />
-										{ __( 'Not collecting', 'jetpack-forms' ) }
-									</Badge>
+									<Badge intent="high">{ __( 'Not collecting', 'jetpack-forms' ) }</Badge>
 								</Tooltip.Trigger>
 								<Tooltip.Popup>
 									{ __(
-										'This form isn’t collecting responses. Turn on email notifications or response storage in form settings.',
+										'Turn on email notifications or response storage in form settings.',
 										'jetpack-forms'
 									) }
 								</Tooltip.Popup>

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,12 +1,18 @@
 @use "../shared";
 
-// Warning icon next to a form that isn't collecting responses.
-.jetpack-forms__not-collecting-icon {
+// Tooltip trigger (button) wrapping the "not collecting" badge in the list.
+// The Badge carries its own intent colour; the button only needs a reset so
+// it sits inline with the form title.
+.jetpack-forms__not-collecting-badge {
 	display: inline-flex;
 	align-items: center;
-	color: #b32d2e;
+	padding: 0;
+	border: 0;
+	background: none;
+	cursor: help;
 
 	svg {
 		fill: currentColor;
+		margin-inline-end: 2px;
 	}
 }

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,18 +1,11 @@
 @use "../shared";
 
-// Tooltip trigger (button) wrapping the "not collecting" badge in the list.
-// The Badge carries its own intent colour; the button only needs a reset so
-// it sits inline with the form title.
+// The "not collecting" badge is wrapped in a Tooltip trigger, which renders a
+// native <button>; strip its default chrome so only the Badge shows.
 .jetpack-forms__not-collecting-badge {
 	display: inline-flex;
-	align-items: center;
 	padding: 0;
 	border: 0;
 	background: none;
 	cursor: help;
-
-	svg {
-		fill: currentColor;
-		margin-inline-end: 2px;
-	}
 }

--- a/projects/packages/forms/routes/forms/style.scss
+++ b/projects/packages/forms/routes/forms/style.scss
@@ -1,1 +1,12 @@
 @use "../shared";
+
+// Warning icon next to a form that isn't collecting responses.
+.jetpack-forms__not-collecting-icon {
+	display: inline-flex;
+	align-items: center;
+	color: #b32d2e;
+
+	svg {
+		fill: currentColor;
+	}
+}

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -7,8 +7,10 @@ import { formatNumber } from '@automattic/number-formatters';
  * WordPress dependencies
  */
 import {
+	Notice,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -669,6 +671,24 @@ function StageInner() {
 		onOpenIntegrations: handleIntegrations,
 	} );
 
+	// On a single-form view, surface a persistent warning when the form isn't
+	// collecting its responses anywhere (email + saving off, no integration).
+	const isFormNotCollecting = useSelect(
+		select => {
+			if ( ! isSingleFormView ) {
+				return false;
+			}
+			const form = select( coreStore ).getEntityRecord(
+				'postType',
+				'jetpack_form',
+				sourceIdNumber,
+				{ context: 'edit' }
+			) as { is_collecting_responses?: boolean } | undefined;
+			return form ? form.is_collecting_responses === false : false;
+		},
+		[ isSingleFormView, sourceIdNumber ]
+	);
+
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
@@ -691,6 +711,18 @@ function StageInner() {
 			hasPadding={ false }
 			showFooter={ false }
 		>
+			{ isFormNotCollecting && (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="jetpack-forms__not-collecting-banner"
+				>
+					{ __(
+						'This form isn’t collecting responses. Turn on email or saving in the form’s settings to start.',
+						'jetpack-forms'
+					) }
+				</Notice>
+			) }
 			<DataViews
 				empty={
 					<EmptyResponses

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -6,19 +6,23 @@ import { formatNumber } from '@automattic/number-formatters';
 /**
  * WordPress dependencies
  */
-import {
-	Notice,
-	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
+import { __experimentalText as Text } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import {
+	useMemo,
+	useState,
+	useCallback,
+	useEffect,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
-import { Badge, Link, Stack } from '@wordpress/ui';
+import { Badge, Link, Notice, Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -28,6 +32,7 @@ import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
+import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsPage from '../../src/dashboard/wp-build/components/page';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
@@ -171,6 +176,7 @@ function StageInner() {
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
+	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 
 	const [ view, setView ] = useState< View >( () => ( {
 		...DEFAULT_VIEW,
@@ -689,6 +695,26 @@ function StageInner() {
 		[ isSingleFormView, sourceIdNumber ]
 	);
 
+	// Deep link to the form editor with a specific settings panel pre-opened, so the
+	// "email notifications" / "response storage" links lead users straight to the fix.
+	const buildPanelEditUrl = useCallback(
+		( panel: 'form-notifications' | 'responses-storage' ) =>
+			`${ getFormEditUrl( sourceIdNumber, adminUrl ) }&jetpack-form-panel=${ panel }`,
+		[ adminUrl, sourceIdNumber ]
+	);
+
+	// Whether the form has any stored responses at all — across inbox, spam and
+	// trash, not just the current view — so a form with responses only in spam or
+	// trash still keeps the table (and its status tabs) and gets a banner above it.
+	// A form with no responses anywhere replaces the table entirely with a
+	// prominent, front-and-center warning so the problem is impossible to miss.
+	const totalResponseCount =
+		( totalItemsInbox ?? 0 ) + ( totalItemsSpam ?? 0 ) + ( totalItemsTrash ?? 0 );
+	const countsReady = ! isLoadingData && ! isQueryStale;
+	const hasAnyResponses = countsReady && totalResponseCount > 0;
+	const showNotCollectingCallout =
+		isFormNotCollecting && isSingleFormView && countsReady && totalResponseCount === 0;
+
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
 
@@ -711,54 +737,89 @@ function StageInner() {
 			hasPadding={ false }
 			showFooter={ false }
 		>
-			{ isFormNotCollecting && (
-				<Notice
-					status="warning"
-					isDismissible={ false }
+			{ isFormNotCollecting && hasAnyResponses && (
+				<Notice.Root
+					intent="error"
+					icon={ caution }
 					className="jetpack-forms__not-collecting-banner"
 				>
-					{ __(
-						'This form isn’t collecting responses. Turn on email or saving in the form’s settings to start.',
-						'jetpack-forms'
-					) }
-				</Notice>
+					<Notice.Title>
+						{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ createInterpolateElement(
+							__(
+								'New submissions are being dropped. Turn on <email>email notifications</email> or <storage>response storage</storage> in form settings.',
+								'jetpack-forms'
+							),
+							{
+								email: (
+									<Link href={ buildPanelEditUrl( 'form-notifications' ) } children={ null } />
+								),
+								storage: (
+									<Link href={ buildPanelEditUrl( 'responses-storage' ) } children={ null } />
+								),
+							}
+						) }
+					</Notice.Description>
+				</Notice.Root>
 			) }
-			<DataViews
-				empty={
+			{ showNotCollectingCallout ? (
+				<div className="jetpack-forms__not-collecting-callout">
 					<EmptyResponses
-						isSearch={ !! view.search }
+						isSearch={ false }
 						isSingleFormView={ isSingleFormView }
-						readStatusFilter={ readStatusFilter }
 						status={ statusView }
+						isNotCollecting
+						notCollectingLinks={ {
+							email: buildPanelEditUrl( 'form-notifications' ),
+							storage: buildPanelEditUrl( 'responses-storage' ),
+						} }
 					/>
-				}
-				data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
-				fields={ fields as Field< unknown >[] }
-				view={ view }
-				onChangeView={ onChangeView }
-				paginationInfo={ paginationInfo }
-				isLoading={ isLoadingData || isQueryStale }
-				getItemId={ getItemId }
-				defaultLayouts={ defaultLayouts }
-				selection={ selection }
-				onChangeSelection={ onChangeSelection }
-				onClickItem={ onClickItem }
-				actions={ actions as Action< unknown >[] }
-			>
-				<DataViewsHeaderRow
-					activeTab="responses"
-					isSingleFormView={ isSingleFormView }
-					activeStatus={ statusView }
-					statusCounts={ {
-						inbox: totalItemsInbox ?? 0,
-						spam: totalItemsSpam ?? 0,
-						trash: totalItemsTrash ?? 0,
-					} }
-					onStatusChange={ onStatusChange }
-				/>
-				<DataViews.Layout />
-				<DataViews.Footer />
-			</DataViews>
+				</div>
+			) : (
+				<DataViews
+					empty={
+						<EmptyResponses
+							isSearch={ !! view.search }
+							isSingleFormView={ isSingleFormView }
+							readStatusFilter={ readStatusFilter }
+							status={ statusView }
+							isNotCollecting={ isFormNotCollecting }
+							notCollectingLinks={ {
+								email: buildPanelEditUrl( 'form-notifications' ),
+								storage: buildPanelEditUrl( 'responses-storage' ),
+							} }
+						/>
+					}
+					data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
+					fields={ fields as Field< unknown >[] }
+					view={ view }
+					onChangeView={ onChangeView }
+					paginationInfo={ paginationInfo }
+					isLoading={ isLoadingData || isQueryStale }
+					getItemId={ getItemId }
+					defaultLayouts={ defaultLayouts }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					onClickItem={ onClickItem }
+					actions={ actions as Action< unknown >[] }
+				>
+					<DataViewsHeaderRow
+						activeTab="responses"
+						isSingleFormView={ isSingleFormView }
+						activeStatus={ statusView }
+						statusCounts={ {
+							inbox: totalItemsInbox ?? 0,
+							spam: totalItemsSpam ?? 0,
+							trash: totalItemsTrash ?? 0,
+						} }
+						onStatusChange={ onStatusChange }
+					/>
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</DataViews>
+			) }
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }
 				onClose={ closeIntegrationsModal }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -11,13 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import {
-	useMemo,
-	useState,
-	useCallback,
-	useEffect,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
@@ -695,25 +689,32 @@ function StageInner() {
 		[ isSingleFormView, sourceIdNumber ]
 	);
 
-	// Deep link to the form editor with a specific settings panel pre-opened, so the
-	// "email notifications" / "response storage" links lead users straight to the fix.
-	const buildPanelEditUrl = useCallback(
-		( panel: 'form-notifications' | 'responses-storage' ) =>
-			`${ getFormEditUrl( sourceIdNumber, adminUrl ) }&jetpack-form-panel=${ panel }`,
+	// Link to the form editor, where the author can set up a response destination.
+	const formEditUrl = useMemo(
+		() => getFormEditUrl( sourceIdNumber, adminUrl ),
 		[ adminUrl, sourceIdNumber ]
 	);
 
-	// Whether the form has any stored responses at all — across inbox, spam and
-	// trash, not just the current view — so a form with responses only in spam or
+	// Whether the form has any stored responses — summed across inbox, spam and
+	// trash, not just the current view, so a form with responses only in spam or
 	// trash still keeps the table (and its status tabs) and gets a banner above it.
-	// A form with no responses anywhere replaces the table entirely with a
-	// prominent, front-and-center warning so the problem is impossible to miss.
+	// These counts carry the active search / read-status filters, so they're only
+	// a reliable "has anything at all" signal when no search or filter is applied —
+	// otherwise a search that matches nothing would read as an empty form.
 	const totalResponseCount =
 		( totalItemsInbox ?? 0 ) + ( totalItemsSpam ?? 0 ) + ( totalItemsTrash ?? 0 );
+	const hasActiveSearchOrFilter = !! view.search || ( view.filters?.length ?? 0 ) > 0;
 	const countsReady = ! isLoadingData && ! isQueryStale;
 	const hasAnyResponses = countsReady && totalResponseCount > 0;
+	// Replace the table with the front-and-center warning only when the form truly
+	// has no responses anywhere — never while a search/filter is narrowing the list,
+	// so real data is never hidden behind the callout.
 	const showNotCollectingCallout =
-		isFormNotCollecting && isSingleFormView && countsReady && totalResponseCount === 0;
+		isFormNotCollecting &&
+		isSingleFormView &&
+		countsReady &&
+		! hasActiveSearchOrFilter &&
+		totalResponseCount === 0;
 
 	// Check if read_status filter is applied
 	const readStatusFilter = view.filters?.find( filter => filter.field === 'read_status' )?.value;
@@ -747,36 +748,28 @@ function StageInner() {
 						{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
 					</Notice.Title>
 					<Notice.Description>
-						{ createInterpolateElement(
-							__(
-								'New submissions are being dropped. Turn on <email>email notifications</email> or <storage>response storage</storage> in form settings.',
-								'jetpack-forms'
-							),
-							{
-								email: (
-									<Link href={ buildPanelEditUrl( 'form-notifications' ) } children={ null } />
-								),
-								storage: (
-									<Link href={ buildPanelEditUrl( 'responses-storage' ) } children={ null } />
-								),
-							}
+						{ __(
+							'New submissions are being dropped because this form has nowhere to send them.',
+							'jetpack-forms'
 						) }
 					</Notice.Description>
+					<Notice.Actions>
+						<Notice.ActionLink href={ formEditUrl }>
+							{ __( 'Choose where responses go', 'jetpack-forms' ) }
+						</Notice.ActionLink>
+					</Notice.Actions>
 				</Notice.Root>
 			) }
 			{ showNotCollectingCallout ? (
-				<div className="jetpack-forms__not-collecting-callout">
+				<Stack className="jetpack-forms__not-collecting-callout" align="center" justify="center">
 					<EmptyResponses
 						isSearch={ false }
 						isSingleFormView={ isSingleFormView }
 						status={ statusView }
 						isNotCollecting
-						notCollectingLinks={ {
-							email: buildPanelEditUrl( 'form-notifications' ),
-							storage: buildPanelEditUrl( 'responses-storage' ),
-						} }
+						notCollectingEditUrl={ formEditUrl }
 					/>
-				</div>
+				</Stack>
 			) : (
 				<DataViews
 					empty={
@@ -786,10 +779,7 @@ function StageInner() {
 							readStatusFilter={ readStatusFilter }
 							status={ statusView }
 							isNotCollecting={ isFormNotCollecting }
-							notCollectingLinks={ {
-								email: buildPanelEditUrl( 'form-notifications' ),
-								storage: buildPanelEditUrl( 'responses-storage' ),
-							} }
+							notCollectingEditUrl={ formEditUrl }
 						/>
 					}
 					data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -13,7 +13,35 @@
 }
 
 // Persistent warning shown on a single form's responses view when the form
-// isn't collecting responses anywhere.
-.jetpack-forms__not-collecting-banner.components-notice {
+// isn't collecting responses anywhere (and the form already has responses).
+.jetpack-forms__not-collecting-banner {
 	margin: 16px;
+}
+
+// Front-and-center warning that replaces the responses table when a single form
+// isn't collecting responses and has none stored. The wrapper centers the state
+// horizontally without letting the surrounding flex column stretch it (which
+// otherwise distorts the icon and balloons the spacing).
+.jetpack-forms__not-collecting-callout {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 320px;
+	padding: 64px 32px;
+	box-sizing: border-box;
+	text-align: center;
+}
+
+.jetpack-forms__not-collecting-empty {
+	max-width: 420px;
+
+	// Keep the warning icon at its intended size; an unconstrained SVG in a tall
+	// flex parent stretches into an ellipse.
+	svg {
+		width: 48px;
+		height: 48px;
+		fill: var(--wpds-color-fg-content-error, #b32d2e);
+	}
 }

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -11,3 +11,9 @@
 	padding-inline: variables.$grid-unit * 2.5;
 	padding-block: variables.$grid-unit * 1.5;
 }
+
+// Persistent warning shown on a single form's responses view when the form
+// isn't collecting responses anywhere.
+.jetpack-forms__not-collecting-banner.components-notice {
+	margin: 16px;
+}

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -19,29 +19,10 @@
 }
 
 // Front-and-center warning that replaces the responses table when a single form
-// isn't collecting responses and has none stored. The wrapper centers the state
-// horizontally without letting the surrounding flex column stretch it (which
-// otherwise distorts the icon and balloons the spacing).
+// isn't collecting responses and has none stored. Centering/layout comes from
+// the <Stack> wrapper and the EmptyState's own styles; this just gives it
+// vertical presence and breathing room.
 .jetpack-forms__not-collecting-callout {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
 	min-height: 320px;
 	padding: 64px 32px;
-	box-sizing: border-box;
-	text-align: center;
-}
-
-.jetpack-forms__not-collecting-empty {
-	max-width: 420px;
-
-	// Keep the warning icon at its intended size; an unconstrained SVG in a tall
-	// flex parent stretches into an ellipse.
-	svg {
-		width: 48px;
-		height: 48px;
-		fill: var(--wpds-color-fg-content-error, #b32d2e);
-	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -343,7 +343,7 @@ function JetpackContactFormEdit( {
 		},
 		[ isJetpackFormEditor ]
 	);
-	const { closePanel, openPanel } = useDispatch( PANEL_STATE_STORE );
+	const { closePanel } = useDispatch( PANEL_STATE_STORE );
 
 	// Track open state for each panel - panels open when activePanel matches, then stay open
 	const [ openPanels, setOpenPanels ] = useState< Record< string, boolean > >( {} );
@@ -356,24 +356,6 @@ function JetpackContactFormEdit( {
 			closePanel();
 		}
 	}, [ activePanel, closePanel ] );
-
-	// Open a specific settings panel when the editor is opened from a dashboard
-	// "email notifications" / "response storage" deep link (?jetpack-form-panel=…).
-	useEffect( () => {
-		if ( ! isJetpackFormEditor ) {
-			return;
-		}
-		const panel = new URLSearchParams( window.location.search ).get( 'jetpack-form-panel' );
-		if (
-			panel === 'form-notifications' ||
-			panel === 'responses-storage' ||
-			panel === 'action-after-submit'
-		) {
-			openPanel( panel );
-		}
-		// Only run once on mount, when arriving from a deep link.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	const { isSingleStep, isFirstStep, isLastStep, currentStepClientId } = useSelect(
 		select => {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -62,6 +62,7 @@ import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults.js';
 import { getEditorContext } from './util/get-editor-context.ts';
+import { isCollectingResponses } from './util/is-collecting-responses.ts';
 import VariationPicker from './variation-picker.js';
 
 import './util/form-styles.js';
@@ -1097,6 +1098,20 @@ function JetpackContactFormEdit( {
 					{ variationName === 'multistep' && <StepControls formClientId={ clientId } /> }
 				</BlockControls>
 				<InspectorControls>
+					{ ! isCollectingResponses( attributes ) && (
+						<Notice
+							status="warning"
+							isDismissible={ false }
+							className="jetpack-contact-form__not-collecting-notice"
+						>
+							<strong>{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }</strong>
+							<br />
+							{ __(
+								'With email and saving both off, nothing is stored. Turn on either one to start collecting.',
+								'jetpack-forms'
+							) }
+						</Notice>
+					) }
 					<PanelBody
 						title={ __( 'Action after submit', 'jetpack-forms' ) }
 						initialOpen={ false }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -16,7 +16,8 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
-	Notice,
+	Button,
+	Notice as CoreNotice,
 	PanelBody,
 	TextareaControl,
 	TextControl,
@@ -27,9 +28,17 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
+import {
+	useRef,
+	useEffect,
+	useCallback,
+	lazy,
+	Suspense,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Notice } from '@wordpress/ui';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -334,7 +343,7 @@ function JetpackContactFormEdit( {
 		},
 		[ isJetpackFormEditor ]
 	);
-	const { closePanel } = useDispatch( PANEL_STATE_STORE );
+	const { closePanel, openPanel } = useDispatch( PANEL_STATE_STORE );
 
 	// Track open state for each panel - panels open when activePanel matches, then stay open
 	const [ openPanels, setOpenPanels ] = useState< Record< string, boolean > >( {} );
@@ -347,6 +356,24 @@ function JetpackContactFormEdit( {
 			closePanel();
 		}
 	}, [ activePanel, closePanel ] );
+
+	// Open a specific settings panel when the editor is opened from a dashboard
+	// "email notifications" / "response storage" deep link (?jetpack-form-panel=…).
+	useEffect( () => {
+		if ( ! isJetpackFormEditor ) {
+			return;
+		}
+		const panel = new URLSearchParams( window.location.search ).get( 'jetpack-form-panel' );
+		if (
+			panel === 'form-notifications' ||
+			panel === 'responses-storage' ||
+			panel === 'action-after-submit'
+		) {
+			openPanel( panel );
+		}
+		// Only run once on mount, when arriving from a deep link.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const { isSingleStep, isFirstStep, isLastStep, currentStepClientId } = useSelect(
 		select => {
@@ -1035,9 +1062,9 @@ function JetpackContactFormEdit( {
 				? __( "You don't have permission to edit this form.", 'jetpack-forms' )
 				: _x( 'The referenced form could not be found.', 'synced form error', 'jetpack-forms' );
 		elt = (
-			<Notice status="warning" isDismissible={ false }>
+			<CoreNotice status="warning" isDismissible={ false }>
 				{ errorMessage }
-			</Notice>
+			</CoreNotice>
 		);
 	}
 	// In widget editor, synced forms (with ref) are not editable
@@ -1099,18 +1126,39 @@ function JetpackContactFormEdit( {
 				</BlockControls>
 				<InspectorControls>
 					{ ! isCollectingResponses( attributes ) && (
-						<Notice
-							status="warning"
-							isDismissible={ false }
-							className="jetpack-contact-form__not-collecting-notice"
-						>
-							<strong>{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }</strong>
-							<br />
-							{ __(
-								'With email and saving both off, nothing is stored. Turn on either one to start collecting.',
-								'jetpack-forms'
-							) }
-						</Notice>
+						<Notice.Root intent="warning" className="jetpack-contact-form__not-collecting-notice">
+							<Notice.Title>
+								{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+							</Notice.Title>
+							<Notice.Description>
+								{ createInterpolateElement(
+									__(
+										'Turn on <email>email notifications</email> or <storage>response storage</storage> settings to start collecting.',
+										'jetpack-forms'
+									),
+									{
+										email: (
+											<Button
+												variant="link"
+												onClick={ () =>
+													setOpenPanels( prev => ( { ...prev, 'form-notifications': true } ) )
+												}
+												children={ null }
+											/>
+										),
+										storage: (
+											<Button
+												variant="link"
+												onClick={ () =>
+													setOpenPanels( prev => ( { ...prev, 'responses-storage': true } ) )
+												}
+												children={ null }
+											/>
+										),
+									}
+								) }
+							</Notice.Description>
+						</Notice.Root>
 					) }
 					<PanelBody
 						title={ __( 'Action after submit', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1254,6 +1254,13 @@
 	margin-bottom: 16px;
 }
 
+/* Inline warning shown in the form settings sidebar when the form isn't
+   collecting responses. It renders outside a panel body, so give it the same
+   16px spacing a panel body would have. */
+.jetpack-contact-form__not-collecting-notice {
+	margin: 16px;
+}
+
 /* "Other" option text input styles */
 .jetpack-other-text-input-wrapper {
 	margin-left: 1.5em;

--- a/projects/packages/forms/src/blocks/contact-form/util/is-collecting-responses.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/is-collecting-responses.ts
@@ -43,16 +43,19 @@ function isTruthy( value: boolean | string | undefined | null, fallback: boolean
  * @return True when the form has at least one response destination.
  */
 export function isCollectingResponses( attributes: FormAttributes = {} ): boolean {
-	// Email destination: on by default, and needs a recipient to be a real sink.
-	const emailOn = isTruthy( attributes.emailNotifications, true );
-	const hasRecipient = attributes.to === undefined || String( attributes.to ).trim() !== '';
-	const emailActive = emailOn && hasRecipient;
+	// Email destination: on by default. A blank or invalid recipient is not a dead
+	// end — submissions fall back to the site admin email at send time — so email
+	// being on always counts as a real destination.
+	const emailActive = isTruthy( attributes.emailNotifications, true );
 
 	// Saving to the responses dashboard: on by default.
 	const savingActive = isTruthy( attributes.saveResponses, true );
 
 	// Integrations that actually persist or route the submission. Akismet (spam
 	// filtering) and Google Drive (exports already-saved responses) are excluded.
+	// Webhooks are excluded too: they only fire for forms whose author can
+	// manage_options, so counting them from attributes alone (with no author
+	// context here) would wrongly silence the warning for editor-authored forms.
 	const integrationActive =
 		isTruthy( attributes.jetpackCRM, false ) ||
 		!! attributes.mailpoet?.enabledForForm ||

--- a/projects/packages/forms/src/blocks/contact-form/util/is-collecting-responses.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/is-collecting-responses.ts
@@ -1,0 +1,64 @@
+type FormAttributes = {
+	emailNotifications?: boolean | string;
+	to?: string;
+	saveResponses?: boolean | string;
+	jetpackCRM?: boolean | string;
+	mailpoet?: { enabledForForm?: boolean } | null;
+	hostingerReach?: { enabledForForm?: boolean } | null;
+	salesforceData?: { sendToSalesforce?: boolean; organizationId?: string } | null;
+	[ key: string ]: unknown;
+};
+
+/**
+ * Normalize a possibly-boolean-or-string toggle attribute to a boolean.
+ *
+ * Toggle attributes are booleans in the editor but persist as 'yes'/'no'
+ * strings in some contexts, so both forms must be handled.
+ *
+ * @param value    - The attribute value.
+ * @param fallback - Value to use when the attribute is undefined/null.
+ * @return The normalized boolean.
+ */
+function isTruthy( value: boolean | string | undefined | null, fallback: boolean ): boolean {
+	if ( value === undefined || value === null ) {
+		return fallback;
+	}
+	if ( typeof value === 'string' ) {
+		return ! [ '', 'no', 'false', '0' ].includes( value.trim().toLowerCase() );
+	}
+	return !! value;
+}
+
+/**
+ * Determine whether a form is configured to collect its responses anywhere.
+ *
+ * A form "collects responses" when submissions are delivered to at least one
+ * destination: emailed to a recipient, saved to the responses dashboard, or
+ * routed to an active data integration. When all are off, submissions are
+ * silently dropped.
+ *
+ * Keep this in sync with the PHP helper `Contact_Form::is_collecting_responses()`.
+ *
+ * @param attributes - The contact-form block attributes.
+ * @return True when the form has at least one response destination.
+ */
+export function isCollectingResponses( attributes: FormAttributes = {} ): boolean {
+	// Email destination: on by default, and needs a recipient to be a real sink.
+	const emailOn = isTruthy( attributes.emailNotifications, true );
+	const hasRecipient = attributes.to === undefined || String( attributes.to ).trim() !== '';
+	const emailActive = emailOn && hasRecipient;
+
+	// Saving to the responses dashboard: on by default.
+	const savingActive = isTruthy( attributes.saveResponses, true );
+
+	// Integrations that actually persist or route the submission. Akismet (spam
+	// filtering) and Google Drive (exports already-saved responses) are excluded.
+	const integrationActive =
+		isTruthy( attributes.jetpackCRM, false ) ||
+		!! attributes.mailpoet?.enabledForForm ||
+		!! attributes.hostingerReach?.enabledForForm ||
+		( !! attributes.salesforceData?.sendToSalesforce &&
+			!! attributes.salesforceData?.organizationId );
+
+	return emailActive || savingActive || integrationActive;
+}

--- a/projects/packages/forms/src/blocks/contact-form/util/test/is-collecting-responses.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/test/is-collecting-responses.test.js
@@ -30,10 +30,10 @@ describe( 'isCollectingResponses', () => {
 		).toBe( true );
 	} );
 
-	it( 'is not collecting when email is on but the recipient is empty', () => {
+	it( 'is collecting when email is on even with an empty recipient (admin email fallback)', () => {
 		expect(
 			isCollectingResponses( { emailNotifications: true, to: '  ', saveResponses: false } )
-		).toBe( false );
+		).toBe( true );
 	} );
 
 	it( 'handles yes/no string toggles', () => {

--- a/projects/packages/forms/src/blocks/contact-form/util/test/is-collecting-responses.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/test/is-collecting-responses.test.js
@@ -1,0 +1,78 @@
+import { isCollectingResponses } from '../is-collecting-responses';
+
+describe( 'isCollectingResponses', () => {
+	it( 'treats default attributes (email + saving on) as collecting', () => {
+		expect( isCollectingResponses( {} ) ).toBe( true );
+		expect( isCollectingResponses( { emailNotifications: true, saveResponses: true } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'flags a form with email off, saving off and no integrations', () => {
+		expect( isCollectingResponses( { emailNotifications: false, saveResponses: false } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'is collecting when only saving is on', () => {
+		expect( isCollectingResponses( { emailNotifications: false, saveResponses: true } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'is collecting when only email is on with a recipient', () => {
+		expect(
+			isCollectingResponses( {
+				emailNotifications: true,
+				to: 'admin@example.com',
+				saveResponses: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'is not collecting when email is on but the recipient is empty', () => {
+		expect(
+			isCollectingResponses( { emailNotifications: true, to: '  ', saveResponses: false } )
+		).toBe( false );
+	} );
+
+	it( 'handles yes/no string toggles', () => {
+		expect( isCollectingResponses( { emailNotifications: 'no', saveResponses: 'no' } ) ).toBe(
+			false
+		);
+		expect( isCollectingResponses( { emailNotifications: 'no', saveResponses: 'yes' } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'is collecting when a data integration is active', () => {
+		const base = { emailNotifications: false, saveResponses: false };
+		expect( isCollectingResponses( { ...base, jetpackCRM: true } ) ).toBe( true );
+		expect( isCollectingResponses( { ...base, mailpoet: { enabledForForm: true } } ) ).toBe( true );
+		expect( isCollectingResponses( { ...base, hostingerReach: { enabledForForm: true } } ) ).toBe(
+			true
+		);
+		expect(
+			isCollectingResponses( {
+				...base,
+				salesforceData: { sendToSalesforce: true, organizationId: '00D5g000000abcd' },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'ignores Salesforce without an organization id', () => {
+		expect(
+			isCollectingResponses( {
+				emailNotifications: false,
+				saveResponses: false,
+				salesforceData: { sendToSalesforce: true, organizationId: '' },
+			} )
+		).toBe( false );
+	} );
+
+	it( 'does not count jetpackCRM unless explicitly enabled', () => {
+		expect( isCollectingResponses( { emailNotifications: false, saveResponses: false } ) ).toBe(
+			false
+		);
+	} );
+} );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -346,6 +346,106 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Determine whether a form is configured to collect its responses anywhere.
+	 *
+	 * A form "collects responses" when submissions are delivered to at least one
+	 * destination: emailed to a recipient, saved to the responses dashboard, or
+	 * routed to an active data integration. When all three are off, submissions
+	 * are silently dropped.
+	 *
+	 * This must run on the RAW block attributes (as authored), not the values
+	 * merged with Contact_Form's runtime defaults — e.g. `jetpackCRM` defaults to
+	 * `true` at render time but is only "on" when explicitly enabled on the form.
+	 *
+	 * Keep this in sync with the JS helper `isCollectingResponses()` in
+	 * blocks/contact-form/util/is-collecting-responses.ts.
+	 *
+	 * @param array $attributes Raw contact-form block attributes.
+	 * @return bool True when the form has at least one response destination.
+	 */
+	public static function is_collecting_responses( $attributes ) {
+		if ( ! is_array( $attributes ) ) {
+			return true;
+		}
+
+		// Email destination: on by default, and needs a recipient to be a real sink.
+		$email_on      = self::attribute_is_truthy( $attributes, 'emailNotifications', true );
+		$has_recipient = ! array_key_exists( 'to', $attributes ) || '' !== trim( (string) $attributes['to'] );
+		$email_active  = $email_on && $has_recipient;
+
+		// Saving to the responses dashboard: on by default.
+		$saving_active = self::attribute_is_truthy( $attributes, 'saveResponses', true );
+
+		// Integrations that actually persist or route the submission. Akismet
+		// (spam filtering) and Google Drive (exports already-saved responses) are
+		// intentionally excluded — neither is an independent destination.
+		$integration_active = self::attribute_is_truthy( $attributes, 'jetpackCRM', false )
+			|| ! empty( $attributes['mailpoet']['enabledForForm'] )
+			|| ! empty( $attributes['hostingerReach']['enabledForForm'] )
+			|| (
+				! empty( $attributes['salesforceData']['sendToSalesforce'] )
+				&& ! empty( $attributes['salesforceData']['organizationId'] )
+			);
+
+		return $email_active || $saving_active || $integration_active;
+	}
+
+	/**
+	 * Normalize a possibly-boolean-or-string block attribute to a boolean.
+	 *
+	 * Toggle attributes arrive as JS booleans from the editor but are persisted
+	 * as `'yes'`/`'no'` strings in some contexts, so both forms must be handled.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $key        Attribute name.
+	 * @param bool   $default    Value to use when the attribute is absent.
+	 * @return bool
+	 */
+	private static function attribute_is_truthy( $attributes, $key, $default ) {
+		if ( ! array_key_exists( $key, $attributes ) ) {
+			return $default;
+		}
+
+		$value = $attributes[ $key ];
+
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+
+		if ( is_string( $value ) ) {
+			return ! in_array( strtolower( trim( $value ) ), array( '', 'no', 'false', '0' ), true );
+		}
+
+		return (bool) $value;
+	}
+
+	/**
+	 * Render an admin-only notice when a form isn't collecting responses.
+	 *
+	 * Shown on the live front-end form and in form previews, but only to users
+	 * who can manage forms (`edit_pages`) — never to visitors.
+	 *
+	 * @param array $attributes Raw contact-form block attributes.
+	 * @return string Notice HTML, or an empty string.
+	 */
+	private static function render_not_collecting_notice( $attributes ) {
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return '';
+		}
+
+		if ( self::is_collecting_responses( $attributes ) ) {
+			return '';
+		}
+
+		wp_enqueue_style( 'jetpack-form-status-notice' );
+
+		return sprintf(
+			'<div class="jetpack-form-status-notice jetpack-form-status-notice--warning jetpack-form-not-collecting-notice"><p>%s</p></div>',
+			esc_html__( 'Only you can see this. This form isn’t collecting responses. Turn on email or saving to start.', 'jetpack-forms' )
+		);
+	}
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
@@ -1561,6 +1661,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$r .= '</div>';
+
+		// Surface an admin-only warning above the form when nothing will capture its responses.
+		$r = self::render_not_collecting_notice( $attributes ) . $r;
 
 		/**
 		 * Filter the contact form, allowing plugins to modify the HTML.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -442,7 +442,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		return sprintf(
 			'<div class="jetpack-form-status-notice jetpack-form-status-notice--warning jetpack-form-not-collecting-notice"><p>%s</p></div>',
-			esc_html__( 'Only you can see this. This form isn’t collecting responses. Turn on email or saving to start.', 'jetpack-forms' )
+			esc_html__( 'Only you can see this. This form isn’t collecting responses. Turn on email notifications or response storage in form settings.', 'jetpack-forms' )
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -360,7 +360,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Keep this in sync with the JS helper `isCollectingResponses()` in
 	 * blocks/contact-form/util/is-collecting-responses.ts.
 	 *
-	 * @param array $attributes Raw contact-form block attributes.
+	 * @param mixed $attributes Raw contact-form block attributes. Non-arrays are
+	 *                          treated as collecting (no warning).
 	 * @return bool True when the form has at least one response destination.
 	 */
 	public static function is_collecting_responses( $attributes ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -360,6 +360,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Keep this in sync with the JS helper `isCollectingResponses()` in
 	 * blocks/contact-form/util/is-collecting-responses.ts.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param mixed $attributes Raw contact-form block attributes. Non-arrays are
 	 *                          treated as collecting (no warning).
 	 * @return bool True when the form has at least one response destination.
@@ -369,10 +371,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return true;
 		}
 
-		// Email destination: on by default, and needs a recipient to be a real sink.
-		$email_on      = self::attribute_is_truthy( $attributes, 'emailNotifications', true );
-		$has_recipient = ! array_key_exists( 'to', $attributes ) || '' !== trim( (string) $attributes['to'] );
-		$email_active  = $email_on && $has_recipient;
+		// Email destination: on by default. A blank or invalid recipient is not a
+		// dead end — submissions fall back to the site admin email at send time —
+		// so email being on always counts as a real destination.
+		$email_active = self::attribute_is_truthy( $attributes, 'emailNotifications', true );
 
 		// Saving to the responses dashboard: on by default.
 		$saving_active = self::attribute_is_truthy( $attributes, 'saveResponses', true );
@@ -380,6 +382,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Integrations that actually persist or route the submission. Akismet
 		// (spam filtering) and Google Drive (exports already-saved responses) are
 		// intentionally excluded — neither is an independent destination.
+		//
+		// Webhooks (`postToUrl`/`webhooks`) are also excluded: they only fire when
+		// the form author has `manage_options` (see
+		// Jetpack_Forms::should_honor_content_destinations()), so whether they're a
+		// real destination depends on author capability, not the attributes alone.
+		// This shared helper is intentionally context-free so PHP and JS agree, so
+		// counting them here would wrongly silence the warning for editor-authored
+		// forms whose webhook never runs.
 		$integration_active = self::attribute_is_truthy( $attributes, 'jetpackCRM', false )
 			|| ! empty( $attributes['mailpoet']['enabledForForm'] )
 			|| ! empty( $attributes['hostingerReach']['enabledForForm'] )
@@ -396,6 +406,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * Toggle attributes arrive as JS booleans from the editor but are persisted
 	 * as `'yes'`/`'no'` strings in some contexts, so both forms must be handled.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array  $attributes Block attributes.
 	 * @param string $key        Attribute name.
@@ -425,6 +437,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * Shown on the live front-end form and in form previews, but only to users
 	 * who can manage forms (`edit_pages`) — never to visitors.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $attributes Raw contact-form block attributes.
 	 * @return string Notice HTML, or an empty string.

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -263,6 +263,8 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * warn about forms that drop their submissions. Only added for the `edit`
 	 * context, which is permission-gated to users who can manage forms.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param \WP_Post         $item    Post object.
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
@@ -285,6 +287,8 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * Parses the form's block content and applies the shared detection rule.
 	 * Returns true (no warning) when the form has no contact-form block to read.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param int $form_id Form (jetpack_form) post ID.
 	 * @return bool
 	 */
@@ -306,6 +310,8 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 	/**
 	 * Recursively locate the first jetpack/contact-form block's attributes.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $block A parsed block.
 	 * @return array|null The block attributes, or null when not found.

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -257,6 +257,77 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Attach the `is_collecting_responses` flag to admin (edit-context) responses.
+	 *
+	 * Exposed on both the forms list and single-form fetches so the dashboard can
+	 * warn about forms that drop their submissions. Only added for the `edit`
+	 * context, which is permission-gated to users who can manage forms.
+	 *
+	 * @param \WP_Post         $item    Post object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		if ( 'edit' === $request->get_param( 'context' ) && isset( $item->ID ) ) {
+			$data                            = $response->get_data();
+			$data['is_collecting_responses'] = $this->is_form_collecting_responses( (int) $item->ID );
+			$response->set_data( $data );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Whether a stored form is configured to collect its responses anywhere.
+	 *
+	 * Parses the form's block content and applies the shared detection rule.
+	 * Returns true (no warning) when the form has no contact-form block to read.
+	 *
+	 * @param int $form_id Form (jetpack_form) post ID.
+	 * @return bool
+	 */
+	private function is_form_collecting_responses( int $form_id ): bool {
+		$post = get_post( $form_id );
+		if ( ! $post instanceof \WP_Post || '' === $post->post_content ) {
+			return true;
+		}
+
+		foreach ( parse_blocks( $post->post_content ) as $block ) {
+			$attributes = $this->find_contact_form_attributes( $block );
+			if ( null !== $attributes ) {
+				return Contact_Form::is_collecting_responses( $attributes );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Recursively locate the first jetpack/contact-form block's attributes.
+	 *
+	 * @param array $block A parsed block.
+	 * @return array|null The block attributes, or null when not found.
+	 */
+	private function find_contact_form_attributes( array $block ): ?array {
+		if ( isset( $block['blockName'] ) && 'jetpack/contact-form' === $block['blockName'] ) {
+			return isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			foreach ( $block['innerBlocks'] as $inner_block ) {
+				$attributes = $this->find_contact_form_attributes( $inner_block );
+				if ( null !== $attributes ) {
+					return $attributes;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Batch compute feedback counts for a list of form IDs.
 	 *
 	 * @param int[] $form_ids Form IDs to count entries for.

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -5,7 +5,7 @@ import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useCallback, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { page, search, shield, trash } from '@wordpress/icons';
+import { caution, page, search, shield, trash } from '@wordpress/icons';
 import { Button, EmptyState, Link } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -38,6 +38,10 @@ type EmptyResponsesProps = {
 	isSingleFormView?: boolean;
 	readStatusFilter?: 'unread' | 'read';
 	status: string;
+	/** Whether the form isn't collecting responses anywhere (email + saving off). */
+	isNotCollecting?: boolean;
+	/** Editor deep links used by the not-collecting empty state. */
+	notCollectingLinks?: { email: string; storage: string };
 };
 
 /**
@@ -160,6 +164,8 @@ const EmptyResponses = ( {
 	isSingleFormView = false,
 	readStatusFilter,
 	status,
+	isNotCollecting = false,
+	notCollectingLinks,
 }: EmptyResponsesProps ) => {
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 	const {
@@ -232,6 +238,37 @@ const EmptyResponses = ( {
 				<EmptyState.Icon icon={ shield } />
 				<EmptyState.Title>{ noSpamHeading }</EmptyState.Title>
 				<EmptyState.Description>{ noSpamMessage }</EmptyState.Description>
+			</EmptyState.Root>
+		);
+	}
+
+	// A single form that isn't collecting responses anywhere: surface the warning
+	// front and center (large warning icon + action buttons) in place of the
+	// responses table, rather than the generic "no responses yet" message, so the
+	// problem is impossible to miss and the messaging doesn't contradict itself.
+	if ( isSingleFormView && isNotCollecting ) {
+		return (
+			<EmptyState.Root className="jetpack-forms__not-collecting-empty">
+				<EmptyState.Icon icon={ caution } />
+				<EmptyState.Title>
+					{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+				</EmptyState.Title>
+				<EmptyState.Description>
+					{ __(
+						'Submissions are silently dropped because this form has nowhere to send them.',
+						'jetpack-forms'
+					) }
+				</EmptyState.Description>
+				{ notCollectingLinks && (
+					<EmptyState.Actions>
+						<Link href={ notCollectingLinks.email }>
+							{ __( 'Turn on email notifications', 'jetpack-forms' ) }
+						</Link>
+						<Link href={ notCollectingLinks.storage }>
+							{ __( 'Turn on response storage', 'jetpack-forms' ) }
+						</Link>
+					</EmptyState.Actions>
+				) }
 			</EmptyState.Root>
 		);
 	}

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -40,8 +40,8 @@ type EmptyResponsesProps = {
 	status: string;
 	/** Whether the form isn't collecting responses anywhere (email + saving off). */
 	isNotCollecting?: boolean;
-	/** Editor deep links used by the not-collecting empty state. */
-	notCollectingLinks?: { email: string; storage: string };
+	/** Editor URL the not-collecting empty state's "set up" button links to. */
+	notCollectingEditUrl?: string;
 };
 
 /**
@@ -165,7 +165,7 @@ const EmptyResponses = ( {
 	readStatusFilter,
 	status,
 	isNotCollecting = false,
-	notCollectingLinks,
+	notCollectingEditUrl,
 }: EmptyResponsesProps ) => {
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 	const {
@@ -243,12 +243,12 @@ const EmptyResponses = ( {
 	}
 
 	// A single form that isn't collecting responses anywhere: surface the warning
-	// front and center (large warning icon + action buttons) in place of the
-	// responses table, rather than the generic "no responses yet" message, so the
-	// problem is impossible to miss and the messaging doesn't contradict itself.
+	// front and center in place of the responses table, rather than the generic
+	// "no responses yet" message, so the problem is impossible to miss and the
+	// messaging doesn't contradict itself.
 	if ( isSingleFormView && isNotCollecting ) {
 		return (
-			<EmptyState.Root className="jetpack-forms__not-collecting-empty">
+			<EmptyState.Root>
 				<EmptyState.Icon icon={ caution } />
 				<EmptyState.Title>
 					{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
@@ -259,14 +259,11 @@ const EmptyResponses = ( {
 						'jetpack-forms'
 					) }
 				</EmptyState.Description>
-				{ notCollectingLinks && (
+				{ notCollectingEditUrl && (
 					<EmptyState.Actions>
-						<Link href={ notCollectingLinks.email }>
-							{ __( 'Turn on email notifications', 'jetpack-forms' ) }
-						</Link>
-						<Link href={ notCollectingLinks.storage }>
-							{ __( 'Turn on response storage', 'jetpack-forms' ) }
-						</Link>
+						<Button variant="outline" render={ <a href={ notCollectingEditUrl } /> }>
+							{ __( 'Choose where responses go', 'jetpack-forms' ) }
+						</Button>
 					</EmptyState.Actions>
 				) }
 			</EmptyState.Root>

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -7,8 +7,6 @@ import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Icon,
-	Tooltip,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
@@ -17,7 +15,7 @@ import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { EmptyState } from '@wordpress/ui';
+import { Badge, EmptyState, Icon, Stack, Tooltip } from '@wordpress/ui';
 import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -176,23 +174,26 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						return title;
 					}
 					return (
-						<HStack spacing={ 1 } justify="flex-start" expanded={ false }>
+						<Stack direction="row" gap="xs" align="center" justify="flex-start">
 							<span>{ title }</span>
-							<Tooltip
-								delay={ 0 }
-								text={ __(
-									'This form isn’t collecting responses. Turn on email or saving to start.',
-									'jetpack-forms'
-								) }
-							>
-								<span
-									className="jetpack-forms__not-collecting-icon"
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									className="jetpack-forms__not-collecting-badge"
 									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
 								>
-									<Icon icon={ caution } size={ 20 } />
-								</span>
-							</Tooltip>
-						</HStack>
+									<Badge intent="high">
+										<Icon icon={ caution } size={ 16 } />
+										{ __( 'Not collecting', 'jetpack-forms' ) }
+									</Badge>
+								</Tooltip.Trigger>
+								<Tooltip.Popup>
+									{ __(
+										'This form isn’t collecting responses. Turn on email notifications or response storage in form settings.',
+										'jetpack-forms'
+									) }
+								</Tooltip.Popup>
+							</Tooltip.Root>
+						</Stack>
 					);
 				},
 				enableSorting: false,

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -13,9 +13,8 @@ import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { caution } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { Badge, EmptyState, Icon, Stack, Tooltip } from '@wordpress/ui';
+import { Badge, EmptyState, Stack, Tooltip } from '@wordpress/ui';
 import { useNavigate } from 'react-router';
 /**
  * Internal dependencies
@@ -174,21 +173,18 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						return title;
 					}
 					return (
-						<Stack direction="row" gap="xs" align="center" justify="flex-start">
+						<Stack direction="row" gap="sm" align="center" justify="flex-start">
 							<span>{ title }</span>
 							<Tooltip.Root>
 								<Tooltip.Trigger
 									className="jetpack-forms__not-collecting-badge"
 									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
 								>
-									<Badge intent="high">
-										<Icon icon={ caution } size={ 16 } />
-										{ __( 'Not collecting', 'jetpack-forms' ) }
-									</Badge>
+									<Badge intent="high">{ __( 'Not collecting', 'jetpack-forms' ) }</Badge>
 								</Tooltip.Trigger>
 								<Tooltip.Popup>
 									{ __(
-										'This form isn’t collecting responses. Turn on email notifications or response storage in form settings.',
+										'Turn on email notifications or response storage in form settings.',
 										'jetpack-forms'
 									) }
 								</Tooltip.Popup>

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -7,12 +7,15 @@ import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Icon,
+	Tooltip,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { EmptyState } from '@wordpress/ui';
 import { useNavigate } from 'react-router';
@@ -167,8 +170,31 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				id: 'title',
 				label: __( 'Form name', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.title,
-				render: ( { item }: { item: FormListItem } ) =>
-					item.title || __( '(no title)', 'jetpack-forms' ),
+				render: ( { item }: { item: FormListItem } ) => {
+					const title = item.title || __( '(no title)', 'jetpack-forms' );
+					if ( item.isCollectingResponses ) {
+						return title;
+					}
+					return (
+						<HStack spacing={ 1 } justify="flex-start" expanded={ false }>
+							<span>{ title }</span>
+							<Tooltip
+								delay={ 0 }
+								text={ __(
+									'This form isn’t collecting responses. Turn on email or saving to start.',
+									'jetpack-forms'
+								) }
+							>
+								<span
+									className="jetpack-forms__not-collecting-icon"
+									aria-label={ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+								>
+									<Icon icon={ caution } size={ 20 } />
+								</span>
+							</Tooltip>
+						</HStack>
+					);
+				},
 				enableSorting: false,
 				enableHiding: false,
 			},

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -9,6 +9,7 @@ export type FormListItem = {
 	modified: string;
 	entriesCount: number;
 	editUrl?: string;
+	isCollectingResponses: boolean;
 };
 
 /**
@@ -57,6 +58,7 @@ type JetpackFormRestItem = {
 	modified: string;
 	entries_count?: number;
 	edit_url?: string;
+	is_collecting_responses?: boolean;
 };
 
 type UseFormsDataReturn = {
@@ -113,6 +115,8 @@ export default function useFormsData(
 				modified: typedItem.modified,
 				entriesCount: typedItem.entries_count ?? 0,
 				editUrl: typedItem.edit_url,
+				// Default to true so we never warn on a form whose status we couldn't determine.
+				isCollectingResponses: typedItem.is_collecting_responses ?? true,
 			} );
 		}
 		return items;

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -43,13 +43,19 @@ body.jetpack_page_jetpack-forms-admin {
 	padding-right: 24px;
 }
 
-// Warning icon next to a form that isn't collecting responses.
-.jetpack-forms__not-collecting-icon {
+// Tooltip trigger (button) wrapping the "not collecting" badge in the list.
+// The Badge carries its own intent colour; the button only needs a reset so
+// it sits inline with the form title.
+.jetpack-forms__not-collecting-badge {
 	display: inline-flex;
 	align-items: center;
-	color: #b32d2e;
+	padding: 0;
+	border: 0;
+	background: none;
+	cursor: help;
 
 	svg {
 		fill: currentColor;
+		margin-inline-end: 2px;
 	}
 }

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -42,3 +42,14 @@ body.jetpack_page_jetpack-forms-admin {
 	padding-left: 24px;
 	padding-right: 24px;
 }
+
+// Warning icon next to a form that isn't collecting responses.
+.jetpack-forms__not-collecting-icon {
+	display: inline-flex;
+	align-items: center;
+	color: #b32d2e;
+
+	svg {
+		fill: currentColor;
+	}
+}

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -43,19 +43,12 @@ body.jetpack_page_jetpack-forms-admin {
 	padding-right: 24px;
 }
 
-// Tooltip trigger (button) wrapping the "not collecting" badge in the list.
-// The Badge carries its own intent colour; the button only needs a reset so
-// it sits inline with the form title.
+// The "not collecting" badge is wrapped in a Tooltip trigger, which renders a
+// native <button>; strip its default chrome so only the Badge shows.
 .jetpack-forms__not-collecting-badge {
 	display: inline-flex;
-	align-items: center;
 	padding: 0;
 	border: 0;
 	background: none;
 	cursor: help;
-
-	svg {
-		fill: currentColor;
-		margin-inline-end: 2px;
-	}
 }

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.scss
@@ -35,6 +35,11 @@
 			border-top: none;
 		}
 
+		// Warning shown when the form has no response destination.
+		.jetpack-form-pre-publish__not-collecting-notice {
+			margin-bottom: 16px;
+		}
+
 		// Form identity card
 		.jetpack-form-pre-publish__form-card {
 			display: flex;

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	Button,
-	Notice,
+	Notice as CoreNotice,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -14,12 +14,14 @@ import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, _nx, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { Notice } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import ConsentToggle from '../../blocks/contact-form/components/jetpack-integrations-modal/components/consent-toggle.tsx';
 import IntegrationsModal from '../../blocks/contact-form/components/jetpack-integrations-modal/index.tsx';
 import { settings as formBlockSettings } from '../../blocks/contact-form/index.js';
+import { isCollectingResponses } from '../../blocks/contact-form/util/is-collecting-responses.ts';
 import { FORM_POST_TYPE, FORM_BLOCK_NAME } from '../../blocks/shared/util/constants.js';
 import { INTEGRATIONS_STORE } from '../../store/integrations/index.ts';
 import { PANEL_STATE_STORE } from '../store/panel-state.ts';
@@ -264,18 +266,31 @@ export const FormPrePublishPanel = () => {
 	if ( ! hasFields ) {
 		return (
 			<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
-				<Notice status="error" isDismissible={ false }>
+				<CoreNotice status="error" isDismissible={ false }>
 					{ __(
 						'This form has no fields. Add at least one field before publishing.',
 						'jetpack-forms'
 					) }
-				</Notice>
+				</CoreNotice>
 			</PluginPrePublishPanel>
 		);
 	}
 
 	return (
 		<PluginPrePublishPanel className="jetpack-form-pre-publish-panel" initialOpen>
+			{ ! isCollectingResponses( attributes ) && (
+				<Notice.Root intent="warning" className="jetpack-form-pre-publish__not-collecting-notice">
+					<Notice.Title>
+						{ __( 'This form isn’t collecting responses', 'jetpack-forms' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ __(
+							'Turn on email notifications or response storage below, or submissions will be silently dropped.',
+							'jetpack-forms'
+						) }
+					</Notice.Description>
+				</Notice.Root>
+			) }
 			<div className="jetpack-form-pre-publish__form-card">
 				<span className="jetpack-form-pre-publish__form-icon">{ formBlockSettings.icon.src }</span>
 				<span className="jetpack-form-pre-publish__form-title">

--- a/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
@@ -1,7 +1,7 @@
 /**
  * Header Actions Plugin
  *
- * Adds "View Responses" button to the form editor header.
+ * Adds "View responses" button to the form editor header.
  */
 
 import { Button, Fill } from '@wordpress/components';
@@ -38,7 +38,7 @@ export const HeaderActions = () => {
 	return (
 		<Fill name="PinnedItems/core">
 			<Button variant="secondary" size="compact" onClick={ handleViewResponses }>
-				{ __( 'View Responses', 'jetpack-forms' ) }
+				{ __( 'View responses', 'jetpack-forms' ) }
 			</Button>
 		</Fill>
 	);

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
@@ -57,13 +57,13 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'email on but empty recipient'             => array(
+			'email on with empty recipient still collects (admin email fallback)' => array(
 				array(
 					'emailNotifications' => true,
 					'to'                 => '  ',
 					'saveResponses'      => false,
 				),
-				false,
+				true,
 			),
 			'email on with recipient'                  => array(
 				array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
@@ -28,36 +28,36 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 	 */
 	public static function provide_attributes() {
 		return array(
-			'empty attributes default to collecting'      => array( array(), true ),
-			'email and saving both on'                    => array(
+			'empty attributes default to collecting'   => array( array(), true ),
+			'email and saving both on'                 => array(
 				array(
 					'emailNotifications' => true,
 					'saveResponses'      => true,
 				),
 				true,
 			),
-			'email off and saving off, no integration'    => array(
+			'email off and saving off, no integration' => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
 				),
 				false,
 			),
-			'yes/no strings, both off'                     => array(
+			'yes/no strings, both off'                 => array(
 				array(
 					'emailNotifications' => 'no',
 					'saveResponses'      => 'no',
 				),
 				false,
 			),
-			'only saving on (string yes)'                  => array(
+			'only saving on (string yes)'              => array(
 				array(
 					'emailNotifications' => 'no',
 					'saveResponses'      => 'yes',
 				),
 				true,
 			),
-			'email on but empty recipient'                 => array(
+			'email on but empty recipient'             => array(
 				array(
 					'emailNotifications' => true,
 					'to'                 => '  ',
@@ -65,7 +65,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				false,
 			),
-			'email on with recipient'                      => array(
+			'email on with recipient'                  => array(
 				array(
 					'emailNotifications' => true,
 					'to'                 => 'admin@example.com',
@@ -73,7 +73,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'jetpackCRM explicitly enabled'                => array(
+			'jetpackCRM explicitly enabled'            => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
@@ -81,7 +81,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'mailpoet enabled for form'                    => array(
+			'mailpoet enabled for form'                => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
@@ -89,7 +89,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'hostinger reach enabled for form'             => array(
+			'hostinger reach enabled for form'         => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
@@ -97,7 +97,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'salesforce with org id'                       => array(
+			'salesforce with org id'                   => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
@@ -108,7 +108,7 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 				),
 				true,
 			),
-			'salesforce without org id is not a sink'      => array(
+			'salesforce without org id is not a sink'  => array(
 				array(
 					'emailNotifications' => false,
 					'saveResponses'      => false,
@@ -123,6 +123,8 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 	}
 
 	/**
+	 * @dataProvider provide_attributes
+	 *
 	 * @param array<string,mixed> $attributes Raw block attributes.
 	 * @param bool                $expected   Expected collecting state.
 	 */
@@ -136,5 +138,58 @@ class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
 	 */
 	public function test_non_array_attributes_are_collecting() {
 		$this->assertTrue( Contact_Form::is_collecting_responses( null ) );
+	}
+
+	/**
+	 * The rendered form shows the admin-only notice to users who can manage forms.
+	 */
+	public function test_front_end_notice_visible_to_editors() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'cf_notice_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'cf_notice_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$content = '[contact-field type="name" label="Name" required="1" /]';
+
+		$broken = Contact_Form::parse(
+			array(
+				'emailNotifications' => false,
+				'saveResponses'      => false,
+			),
+			$content
+		);
+		$this->assertStringContainsString( 'jetpack-form-not-collecting-notice', $broken, 'Editors should see the not-collecting notice.' );
+
+		$healthy = Contact_Form::parse(
+			array(
+				'emailNotifications' => true,
+				'saveResponses'      => true,
+			),
+			$content
+		);
+		$this->assertStringNotContainsString( 'jetpack-form-not-collecting-notice', $healthy, 'A collecting form should not show the notice.' );
+	}
+
+	/**
+	 * The rendered form never shows the notice to logged-out visitors.
+	 */
+	public function test_front_end_notice_hidden_from_visitors() {
+		wp_set_current_user( 0 );
+
+		$content = '[contact-field type="name" label="Name" required="1" /]';
+		$broken  = Contact_Form::parse(
+			array(
+				'emailNotifications' => false,
+				'saveResponses'      => false,
+			),
+			$content
+		);
+
+		$this->assertStringNotContainsString( 'jetpack-form-not-collecting-notice', $broken, 'Visitors should never see the notice.' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Is_Collecting_Responses_Test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Unit tests for Contact_Form::is_collecting_responses().
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form::is_collecting_responses().
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ */
+#[CoversClass( Contact_Form::class )]
+class Contact_Form_Is_Collecting_Responses_Test extends BaseTestCase {
+
+	/**
+	 * Data provider for is_collecting_responses().
+	 *
+	 * @return array<string,array{0:array<string,mixed>,1:bool}>
+	 */
+	public static function provide_attributes() {
+		return array(
+			'empty attributes default to collecting'      => array( array(), true ),
+			'email and saving both on'                    => array(
+				array(
+					'emailNotifications' => true,
+					'saveResponses'      => true,
+				),
+				true,
+			),
+			'email off and saving off, no integration'    => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+				),
+				false,
+			),
+			'yes/no strings, both off'                     => array(
+				array(
+					'emailNotifications' => 'no',
+					'saveResponses'      => 'no',
+				),
+				false,
+			),
+			'only saving on (string yes)'                  => array(
+				array(
+					'emailNotifications' => 'no',
+					'saveResponses'      => 'yes',
+				),
+				true,
+			),
+			'email on but empty recipient'                 => array(
+				array(
+					'emailNotifications' => true,
+					'to'                 => '  ',
+					'saveResponses'      => false,
+				),
+				false,
+			),
+			'email on with recipient'                      => array(
+				array(
+					'emailNotifications' => true,
+					'to'                 => 'admin@example.com',
+					'saveResponses'      => false,
+				),
+				true,
+			),
+			'jetpackCRM explicitly enabled'                => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+					'jetpackCRM'         => true,
+				),
+				true,
+			),
+			'mailpoet enabled for form'                    => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+					'mailpoet'           => array( 'enabledForForm' => true ),
+				),
+				true,
+			),
+			'hostinger reach enabled for form'             => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+					'hostingerReach'     => array( 'enabledForForm' => true ),
+				),
+				true,
+			),
+			'salesforce with org id'                       => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+					'salesforceData'     => array(
+						'sendToSalesforce' => true,
+						'organizationId'   => '00D5g000000abcd',
+					),
+				),
+				true,
+			),
+			'salesforce without org id is not a sink'      => array(
+				array(
+					'emailNotifications' => false,
+					'saveResponses'      => false,
+					'salesforceData'     => array(
+						'sendToSalesforce' => true,
+						'organizationId'   => '',
+					),
+				),
+				false,
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $attributes Raw block attributes.
+	 * @param bool                $expected   Expected collecting state.
+	 */
+	#[DataProvider( 'provide_attributes' )]
+	public function test_is_collecting_responses( array $attributes, bool $expected ) {
+		$this->assertSame( $expected, Contact_Form::is_collecting_responses( $attributes ) );
+	}
+
+	/**
+	 * Non-array input should never be treated as a broken form.
+	 */
+	public function test_non_array_attributes_are_collecting() {
+		$this->assertTrue( Contact_Form::is_collecting_responses( null ) );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -283,6 +283,47 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	}
 
 	/**
+	 * A contact-form block nested inside another block is still detected.
+	 *
+	 * Covers the recursive innerBlocks branch of find_contact_form_attributes().
+	 */
+	public function test_nested_broken_form_is_not_collecting() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		$nested = $this->insert_form(
+			'Nested Broken',
+			'<!-- wp:group --><div class="wp-block-group">' . self::BROKEN_FORM_CONTENT . '</div><!-- /wp:group -->'
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $nested );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertFalse( $response->get_data()['is_collecting_responses'] );
+	}
+
+	/**
+	 * A form post with no contact-form block defaults to collecting (no warning).
+	 *
+	 * Covers the "no block found" and empty-content fall-throughs.
+	 */
+	public function test_form_without_contact_block_defaults_to_collecting() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		$no_block = $this->insert_form( 'No Block', '<!-- wp:paragraph --><p>Just text.</p><!-- /wp:paragraph -->' );
+		$empty    = $this->insert_form( 'Empty', '' );
+
+		foreach ( array( $no_block, $empty ) as $id ) {
+			$request = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $id );
+			$request->set_param( 'context', 'edit' );
+			$response = $this->server->dispatch( $request );
+			$this->assertTrue( $response->get_data()['is_collecting_responses'], "Form $id should default to collecting" );
+		}
+	}
+
+	/**
 	 * A healthy single (edit-context) form fetch reports is_collecting_responses=true.
 	 */
 	public function test_single_healthy_form_is_collecting() {

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -233,6 +233,91 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	}
 
 	/**
+	 * A form block with no destination configured.
+	 */
+	private const BROKEN_FORM_CONTENT = '<!-- wp:jetpack/contact-form {"emailNotifications":false,"saveResponses":false} --><!-- /wp:jetpack/contact-form -->';
+
+	/**
+	 * A form block left at its (collecting) defaults.
+	 */
+	private const HEALTHY_FORM_CONTENT = '<!-- wp:jetpack/contact-form --><!-- /wp:jetpack/contact-form -->';
+
+	/**
+	 * Helper to insert a jetpack_form with the given block content.
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Block content.
+	 * @return int Post ID.
+	 */
+	private function insert_form( string $title, string $content ): int {
+		return wp_insert_post(
+			array(
+				'post_type'    => 'jetpack_form',
+				'post_title'   => $title,
+				'post_status'  => 'publish',
+				'post_content' => $content,
+			)
+		);
+	}
+
+	/**
+	 * A broken single (edit-context) form fetch reports is_collecting_responses=false.
+	 *
+	 * Covers prepare_item_for_response() -> is_form_collecting_responses() ->
+	 * find_contact_form_attributes() for a form that drops its submissions.
+	 */
+	public function test_single_broken_form_is_not_collecting() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		$broken = $this->insert_form( 'Broken Single', self::BROKEN_FORM_CONTENT );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $broken );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'is_collecting_responses', $data );
+		$this->assertFalse( $data['is_collecting_responses'] );
+	}
+
+	/**
+	 * A healthy single (edit-context) form fetch reports is_collecting_responses=true.
+	 */
+	public function test_single_healthy_form_is_collecting() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		$healthy = $this->insert_form( 'Healthy Single', self::HEALTHY_FORM_CONTENT );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $healthy );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'is_collecting_responses', $data );
+		$this->assertTrue( $data['is_collecting_responses'] );
+	}
+
+	/**
+	 * The flag is omitted from non-edit (view) context responses.
+	 */
+	public function test_is_collecting_responses_absent_in_view_context() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		$broken = $this->insert_form( 'Broken View', self::BROKEN_FORM_CONTENT );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/' . $broken );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayNotHasKey( 'is_collecting_responses', $response->get_data() );
+	}
+
+	/**
 	 * Test updating a jetpack-form via REST API.
 	 */
 	public function test_update_jetpack_form_via_rest() {

--- a/projects/plugins/jetpack/changelog/add-forms-not-collecting-warning
+++ b/projects/plugins/jetpack/changelog/add-forms-not-collecting-warning
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration)
+Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration).

--- a/projects/plugins/jetpack/changelog/add-forms-not-collecting-warning
+++ b/projects/plugins/jetpack/changelog/add-forms-not-collecting-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: warn admins and editors when a form isn't collecting responses (email and saving both off, no integration)


### PR DESCRIPTION
Fixes FORMS-695

## Proposed changes

When a form has **no response destination** — email notifications off, "Save responses" off, and no active integration (CRM / MailPoet / Hostinger Reach / Salesforce) — submissions are silently dropped and nothing tells the site owner.

This adds a single detection rule and surfaces a warning to logged-in admins and editors (`edit_pages`), never to visitors, everywhere a form shows up:

* **Editor — settings sidebar** — an inline notice at the top of the form's settings, reactive to the email / saving / integration toggles.
* **Editor — pre-publish panel** — a warning above the form's destination summary when you go to publish, so it's caught before the form goes live.
* **Live form & preview** — an admin-only notice above the rendered form on the front end (hidden from logged-out visitors and other roles).
* **Dashboard — Forms list** — a "Not collecting" badge with a tooltip on the form's row.
* **Dashboard — single form** — when the form has no responses, a front-and-center callout replaces the table with a **Choose where responses go** action; when it already has responses, a persistent banner sits above them.

Detection runs on the form's **raw block attributes**, shared between PHP (`Contact_Form::is_collecting_responses()`) and JS (`isCollectingResponses()`) so every surface always agrees. Email counts as a destination whenever it's on — a blank/invalid recipient still falls back to the site admin email at send time. Akismet (spam filtering) and Google Drive (exports already-saved responses) are intentionally excluded — neither is an independent destination. Webhooks are excluded too: they only fire for forms whose author can `manage_options`, so counting them from attributes alone (with no author context in the shared helper) would wrongly silence the warning for editor-authored forms whose webhook never runs.

## Related product discussion/links

* [FORMS-695](https://linear.app/a8c/issue/FORMS-695)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Create or edit a form. Under **Form notifications** turn off "Send responses to email", and under **Responses storage** turn off "Save responses". Leave all integrations off.
2. **Editor — sidebar:** the inline notice appears at the top of the form settings; toggle email or saving back on and it disappears.
3. **Editor — pre-publish:** click **Publish** — the pre-publish panel shows the warning above the destination summary rows. The **Email notifications** / **Save responses** rows beneath it open the matching settings.
4. **Front end:** view the page with the form while logged in as an admin/editor — the notice shows above the form. Reload logged out (or as a subscriber) — no notice.
5. **Dashboard → Jetpack → Forms:** the form's row shows a **Not collecting** badge; hover it for the tooltip.
6. Click the form → its responses page. With no responses, the table is replaced by a centered warning with a **Choose where responses go** button; with existing responses, a banner appears above the table. (Searching/filtering never replaces real data with the callout.)
7. Repeat with a "healthy" form (email or saving on, or an active integration) and confirm none of the warnings appear.

### Screenshots

**Editor — inline notice in form settings**

![Editor notice](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/editor-note.png)

**Editor — pre-publish panel**

![Pre-publish notice](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/pre-publish-panel.png)

**Live form — visible to admins/editors only, never to visitors**

| Admin / editor | Logged-out visitor |
| --- | --- |
| ![Admin sees notice](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/frontend-admin.png) | ![Visitor sees nothing](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/frontend-visitor.png) |

**Dashboard — Forms list badge + tooltip**

![Dashboard list](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/dashboard-list-tooltip.png)

**Dashboard — single form's responses page**

![Single form callout](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-not-collecting-warning/single-form-notice.png)
