### PR TITLE
Jetpack AI Sidebar: Specify an agentId only when one is not already set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-agent-claim-if-unclaimed
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-agent-claim-if-unclaimed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Agents Manager: let the host that mounts the Agents Manager own the agent, so a host provider's agent and tools (e.g. Big Sky) are no longer overridden or stripped

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -19,16 +19,15 @@ use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 require_once __DIR__ . '/../../../shared/cdn-locale.php';
 
-const AM_ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
-const AM_ASSET_TRANSIENT          = 'jetpack_am_gutenberg_asset';
-const AM_ASSET_DC_TRANSIENT       = 'jetpack_am_gutenberg_dc_asset';
-const AI_SIDEBAR_ASSET_TRANSIENT  = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL           = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL      = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID         = 'wp-orchestrator';
-const BIG_SKY_AGENT_PROVIDER_PATH = '/big-sky-plugin/build/calypso-agent-provider/';
+const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
+const AM_ASSET_TRANSIENT         = 'jetpack_am_gutenberg_asset';
+const AM_ASSET_DC_TRANSIENT      = 'jetpack_am_gutenberg_dc_asset';
+const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -585,32 +584,16 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
-		// intentional overrides should use the AI Editorial Review and preview filters.
-		if ( isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] ) ) {
-			$data['agentProviders'] = self::filter_agent_providers_for_jetpack_ai_sidebar( $data['agentProviders'] );
+		// Inject Jetpack's additive preview fields. Claim the agent only when no
+		// host or other provider has already set one, so the plugin that mounts
+		// the Agents Manager owns the agent: Big Sky keeps its agent on Big Sky
+		// surfaces, while Jetpack-only surfaces still resolve to wp-orchestrator.
+		if ( empty( $data['agentId'] ) ) {
+			$data['agentId'] = AI_SIDEBAR_AGENT_ID;
 		}
-		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
-	}
-
-	/**
-	 * Remove providers that should not participate in the Jetpack AI Sidebar surface.
-	 *
-	 * @param array $providers Provider URLs.
-	 * @return array Filtered provider URLs.
-	 */
-	private static function filter_agent_providers_for_jetpack_ai_sidebar( array $providers ): array {
-		return array_values(
-			array_filter(
-				$providers,
-				static function ( $provider ): bool {
-					return ! is_string( $provider ) || ! str_contains( $provider, BIG_SKY_AGENT_PROVIDER_PATH );
-				}
-			)
-		);
 	}
 
 	/**
@@ -671,16 +654,14 @@ class Jetpack_AI_Sidebar {
 			AI_SIDEBAR_AGENT_ID,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
-		$big_sky_provider_payload    = wp_json_encode(
-			BIG_SKY_AGENT_PROVIDER_PATH,
-			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
-		);
 
+		// Claim the agent only when nothing else has, so the host that enqueued
+		// the Agents Manager keeps ownership (e.g. Big Sky's agent survives on
+		// Big Sky surfaces). The preview fields are additive and always applied.
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
-				. ' if ( Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter( function( provider ) { return typeof provider !== "string" || provider.indexOf( ' . $big_sky_provider_payload . ' ) === -1; } ); }'
-				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
+				. ' if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = ' . $agent_id_payload . '; }'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'
 				. ' }',

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -627,29 +627,42 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Big Sky's provider should not participate in the Jetpack AI Sidebar surface.
+	 * The host that mounts the Agents Manager owns the agent. When another
+	 * provider has already claimed an agent, Jetpack must not override it, and it
+	 * must leave the provider list untouched so the host's tools (e.g. Big Sky's)
+	 * survive the merge.
 	 */
-	public function test_add_agents_manager_data_filters_big_sky_provider() {
+	public function test_add_agents_manager_data_preserves_claimed_agent_and_providers() {
 		$this->set_block_editor_screen();
+
+		$providers = array(
+			'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+			'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+			array( 'provider' => 'metadata' ),
+		);
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
 				'sectionName'    => 'gutenberg',
-				'agentProviders' => array(
-					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
-					'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
-					array( 'provider' => 'metadata' ),
-				),
+				'agentId'        => 'dolly',
+				'agentProviders' => $providers,
 			)
 		);
 
-		$this->assertSame(
-			array(
-				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
-				array( 'provider' => 'metadata' ),
-			),
-			$data['agentProviders']
-		);
+		$this->assertSame( 'dolly', $data['agentId'], 'A host-claimed agent must not be overridden.' );
+		$this->assertSame( $providers, $data['agentProviders'], 'Provider list must pass through untouched.' );
+	}
+
+	/**
+	 * When no provider has claimed an agent, Jetpack fills in its default so a
+	 * Jetpack-only surface still resolves to wp-orchestrator.
+	 */
+	public function test_add_agents_manager_data_claims_agent_when_unclaimed() {
+		$this->set_block_editor_screen();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 	}
 
 	/**
@@ -827,16 +840,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
-		$this->assertStringContainsString(
+		// The host that enqueued AM owns the agent and the provider list, so the
+		// patch must not strip providers (Big Sky's tools must survive the merge).
+		$this->assertStringNotContainsString(
 			'agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter',
 			$this->get_agents_manager_inline_script()
 		);
+		// The agent is claimed only when nothing else has set one.
 		$this->assertStringContainsString(
-			'/big-sky-plugin/build/calypso-agent-provider/',
-			$this->get_agents_manager_inline_script()
-		);
-		$this->assertStringContainsString(
-			'agentsManagerData.agentId = "wp-orchestrator"',
+			'if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(


### PR DESCRIPTION
Fixes FORNO-377

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* When Jetpack AI provider is registered in a surface where another AM is already running, we currently overwrite the agentId. This can cause problems if Jetpack AI Sidebar loads in a surface where Agents Manager is already mounted. To avoid inadvertently overwriting the agent, this PR allows the plugin that mounts Agents Manager to own the agent. 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Observed while testing with Dolly in the site editor. peGwbA-5iF-p2#comment-8190

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Checkout this branch locally
* Apply this diff to run Jetpack AI Sidebar in the page editor

```PHP
diff --git a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
index 3c4d69e6d2..b3a644cd9b 100644
--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -693,10 +693,7 @@ class Jetpack_AI_Sidebar {
                        return false;
                }
 
-               $screen = get_current_screen();
-               return $screen instanceof \WP_Screen
-                       && 'post' === $screen->base
-                       && 'post' === $screen->post_type;
+               return true;
        }
```

* Sync it to your sandbox `jetpack rsync jetpack user@your.server.example.com:/home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/dev`
* Sandbox your test site and load the page editor
* Send a request to the agent, check your network requests and make sure it goes to dolly agent.
* Open the post editor and send a request in the agent, check the request goes to orchestrator agent.
