### PR TITLE
Charts: Leaderboard interactive-row refinements (CHARTS-219 follow-up)

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-219-leaderboard-interactive-refinements
+++ b/projects/js-packages/charts/changelog/add-charts-219-leaderboard-interactive-refinements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: Leaderboard interactive rows gain an opt-in `ariaLabel` for image-only labels, and the hover affordance now shrinks each bar in proportion to its length so small-share rows stay consistent.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -103,14 +103,15 @@
 	text-align: inherit;
 	cursor: pointer;
 
-	// On hover/focus the bar dims and its inline-end edge pulls back by a fixed
-	// amount while the value/delta slides toward the inline start by the same
-	// amount, clearing room for the chevron revealed at the inline-end edge.
-	// Because both move by the same fixed pixels (not a percentage scale), the
-	// bar↔value gap stays identical at rest and on hover for every row. The bar
-	// width (set in leaderboard-chart.tsx) is a grid item aligned to the inline
-	// start, so its inset mirrors automatically in RTL; the value slide is given
-	// an RTL override below. No row background — the bar carries the state.
+	// On hover/focus the bar dims and its inline-end edge pulls back while the
+	// value/delta slides toward the inline start to clear room for the chevron
+	// revealed at the inline-end edge. The value always slides the full inset
+	// (it must clear the chevron), but the bar pulls back in proportion to its
+	// length (see getBarWidth in leaderboard-chart.tsx): the full-length bar —
+	// the one that reaches the value — pulls back the whole inset to keep its
+	// gap, while shorter bars move proportionally less, down to ~0. The bar is
+	// a grid item aligned to the inline start, so its inset mirrors in RTL; the
+	// value slide is given an RTL override below. No row background.
 	.bar {
 		transition: opacity 0.15s ease, width 0.15s ease;
 	}
@@ -122,8 +123,8 @@
 	&:hover,
 	&:focus-visible {
 
-		// Fixed reserve for the chevron — shared by the bar width inset
-		// (see leaderboard-chart.tsx) and the value slide so their gap is constant.
+		// Fixed reserve for the chevron — the value slides by it in full, and the
+		// bar width inset (see leaderboard-chart.tsx) scales it by the bar's share.
 		--a8c--charts--leaderboard--bar--hover-inset: var(--wpds-dimension-gap-2xl, 32px);
 
 		.bar {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -31,7 +31,7 @@
 	&.is-overlay {
 		grid-template: "overlap" 1fr / 1fr;
 
-		/* contains a single cell callded 'overlap' */
+		/* contains a single cell called 'overlap' */
 
 		>* {
 			grid-area: overlap;

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -85,6 +85,8 @@
 }
 
 .interactiveRow {
+	--focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
+
 	display: grid;
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
@@ -92,10 +94,13 @@
 	position: relative;
 
 	// Native button reset.
+	box-sizing: border-box;
 	appearance: none;
 	width: 100%;
 	margin: 0;
-	padding: 0;
+	// Reserve a ring's worth of space on every edge so the inset focus outline
+	// hugs the row without the bar painting over it (see :focus-visible below).
+	padding: var(--focus-ring-width);
 	border: 0;
 	background: none;
 	color: inherit;
@@ -147,8 +152,15 @@
 	}
 
 	&:focus-visible {
-		outline: 2px solid var(--wpds-color-fg-interactive-brand, var(--wp-admin-theme-color, #3858e9));
-		outline-offset: -2px;
+		border-radius: var(--wpds-border-radius-sm, 2px);
+		outline:
+			var(--focus-ring-width) solid
+			var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
+		// Inset by its own width so the outer edge hugs the row boundary: the
+		// outline then sits in the row's padding (also a ring width), clear of the
+		// bar, and stays inside the overflow:auto container that would clip an
+		// outset ring.
+		outline-offset: calc(-1 * var(--focus-ring-width));
 	}
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -378,6 +378,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 											type="button"
 											className={ styles.interactiveRow }
 											onClick={ entry.onClick }
+											aria-label={ entry.ariaLabel }
 										>
 											{ rowCells }
 											<Icon className={ styles.chevron } icon={ chevronRight } size={ 24 } />

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -54,14 +54,16 @@ const defaultDeltaFormatter = ( value: number ): string => {
 
 /**
  * Build a bar's width. A hover-inset CSS variable (0 by default) is subtracted
- * so interactive rows can pull the bar's right edge back by a fixed pixel amount
- * on hover — instead of a percentage scale — keeping the bar↔value gap constant.
+ * on hover, scaled by the bar's share so the pull-back is proportional to its
+ * length: the full-length (100%) bar — the one that reaches the value — pulls
+ * back the whole inset to keep its gap with the value, while shorter bars pull
+ * back proportionally less, down to ~0 for a very short bar.
  *
  * @param share - The bar's share of the row width, as a percentage.
  * @return A CSS width value.
  */
 const getBarWidth = ( share: number ): string =>
-	`calc(${ share }% - var(--a8c--charts--leaderboard--bar--hover-inset, 0px))`;
+	`calc(${ share }% - var(--a8c--charts--leaderboard--bar--hover-inset, 0px) * ${ share } / 100)`;
 
 const BarLabel = ( { label }: { label: LeaderboardEntry[ 'label' ] } ) => (
 	<>{ typeof label === 'string' ? <Text className={ styles.label }>{ label }</Text> : label }</>

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -46,6 +46,7 @@ interface LeaderboardEntry {
 	delta: number;               // Percentage change
 	imageColor?: string;         // Optional color for the entry's image/icon
 	onClick?: ( event: MouseEvent ) => void; // Optional. Makes the whole row an interactive button (click + keyboard); the consumer supplies the action.
+	ariaLabel?: string;          // Optional. Accessible name for the row button when onClick is set; use for image-only JSX labels.
 }
 ```
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -208,6 +208,8 @@ Handle different value ranges with conditional formatting:
 
 Any entry with an `onClick` field becomes a clickable, keyboard-accessible row. The row renders as a `<button>` (activatable with Enter or Space) and reveals a chevron on hover or focus. Rows without `onClick` remain inert.
 
+By default the button's accessible name is derived from its rendered content (the label plus the formatted value). For an image-only JSX label whose text content doesn't yield a clean name, set the optional `ariaLabel` field on the entry to give assistive tech a deterministic name.
+
 Configuring what happens on click — for example, drilling down into a sub-view — is the consumer's responsibility, not the chart's:
 
 <Canvas of={ LeaderboardChartStories.Interactive } />
@@ -563,6 +565,7 @@ The Leaderboard Chart component supports an optional entry animation that create
 - Interactive legends are keyboard accessible when `legend.interactive` is enabled.
 - Legend items can be toggled via keyboard using standard button interaction.
 - Rows with `onClick` render as native `<button>` elements and are activatable with Enter or Space.
+- An interactive row's accessible name comes from its content (label + value); set the entry's `ariaLabel` to override it for image-only labels.
 
 ### Screen Reader Support
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -403,6 +403,39 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getByRole( 'button' ) ).toHaveAccessibleName( /Direct.*12\.5K/ );
 		} );
 
+		it( 'derives the accessible name from an image label via its alt text', () => {
+			render(
+				<LeaderboardChart
+					data={ [
+						{
+							...mockData[ 0 ],
+							label: <img src="https://example.com/flag.svg" alt="United States" />,
+							onClick: jest.fn(),
+						},
+					] }
+				/>
+			);
+			expect( screen.getByRole( 'button' ) ).toHaveAccessibleName( /United States.*12\.5K/ );
+		} );
+
+		it( 'uses ariaLabel as the accessible name when provided', () => {
+			render(
+				<LeaderboardChart
+					data={ [
+						{
+							...mockData[ 0 ],
+							label: <img src="https://example.com/flag.svg" alt="" />,
+							ariaLabel: 'United States: 12.5K visitors',
+							onClick: jest.fn(),
+						},
+					] }
+				/>
+			);
+			expect( screen.getByRole( 'button' ) ).toHaveAccessibleName(
+				'United States: 12.5K visitors'
+			);
+		} );
+
 		it( 'does not render a button for entries without onClick', () => {
 			render( <LeaderboardChart data={ [ mockData[ 0 ] ] } /> );
 			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -393,7 +393,7 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getByRole( 'button' ) ).toHaveFocus();
 
 			await user.keyboard( '{Enter}' );
-			await user.keyboard( '{Space}' );
+			await user.keyboard( '[Space]' );
 			expect( onClick ).toHaveBeenCalledTimes( 2 );
 		} );
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import LeaderboardChart from '../leaderboard-chart';
 import type { LeaderboardEntry } from '../../../types';
 
@@ -375,12 +376,25 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getByRole( 'button' ).tagName ).toBe( 'BUTTON' );
 		} );
 
-		it( 'calls onClick when the row is clicked', () => {
+		it( 'calls onClick when the row is clicked', async () => {
+			const user = userEvent.setup();
 			const onClick = jest.fn();
 			render( <LeaderboardChart data={ [ { ...mockData[ 0 ], onClick } ] } /> );
-			// eslint-disable-next-line testing-library/prefer-user-event
-			fireEvent.click( screen.getByRole( 'button' ) );
+			await user.click( screen.getByRole( 'button' ) );
 			expect( onClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'activates onClick via the keyboard (Enter and Space)', async () => {
+			const user = userEvent.setup();
+			const onClick = jest.fn();
+			render( <LeaderboardChart data={ [ { ...mockData[ 0 ], onClick } ] } /> );
+
+			await user.tab();
+			expect( screen.getByRole( 'button' ) ).toHaveFocus();
+
+			await user.keyboard( '{Enter}' );
+			await user.keyboard( '{ }' );
+			expect( onClick ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'gives the interactive row an accessible name from the label and value', () => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -393,7 +393,7 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getByRole( 'button' ) ).toHaveFocus();
 
 			await user.keyboard( '{Enter}' );
-			await user.keyboard( '{ }' );
+			await user.keyboard( '{Space}' );
 			expect( onClick ).toHaveBeenCalledTimes( 2 );
 		} );
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -392,7 +392,7 @@ describe( 'LeaderboardChart', () => {
 			await user.tab();
 			expect( screen.getByRole( 'button' ) ).toHaveFocus();
 
-			await user.keyboard( '{Enter}' );
+			await user.keyboard( '[Enter]' );
 			await user.keyboard( '[Space]' );
 			expect( onClick ).toHaveBeenCalledTimes( 2 );
 		} );

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -231,11 +231,12 @@ export type LeaderboardEntry = {
 
 	/**
 	 * Optional accessible name for the interactive row's `<button>`. Only applies
-	 * when `onClick` is set. By default the button derives its name from its
-	 * rendered content (label text plus the formatted value), which is the right
-	 * outcome for plain-text labels. Set this when the `label` is JSX whose text
-	 * content does not yield a clean name on its own — e.g. an image-only label —
-	 * to give assistive tech a deterministic, human-readable name.
+	 * when `onClick` is set — without it the row renders as a Fragment with no
+	 * element to receive `aria-label`. By default the button derives its name from
+	 * its rendered content (label text plus the formatted value), which is the
+	 * right outcome for plain-text labels. Set this when the `label` is JSX whose
+	 * text content does not yield a clean name on its own — e.g. an image-only
+	 * label — to give assistive tech a deterministic, human-readable name.
 	 */
 	ariaLabel?: string;
 };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -228,6 +228,16 @@ export type LeaderboardEntry = {
 	 * never both, since interactive elements cannot be nested in HTML.
 	 */
 	onClick?: ( event: MouseEvent< HTMLButtonElement > ) => void;
+
+	/**
+	 * Optional accessible name for the interactive row's `<button>`. Only applies
+	 * when `onClick` is set. By default the button derives its name from its
+	 * rendered content (label text plus the formatted value), which is the right
+	 * outcome for plain-text labels. Set this when the `label` is JSX whose text
+	 * content does not yield a clean name on its own — e.g. an image-only label —
+	 * to give assistive tech a deterministic, human-readable name.
+	 */
+	ariaLabel?: string;
 };
 
 export type GradientStop = {


### PR DESCRIPTION
## Why

Follow-up to #49733 (CHARTS-219), addressing the post-merge review on that PR. Four refinements to the Leaderboard's interactive rows: the fixed hover inset made small-share bars look unresponsive, the promised keyboard activation wasn't tested, image-only labels had no way to guarantee a clean accessible name, and the focus ring didn't follow WPDS conventions.

## Proposed changes

* **Proportional bar shrink on hover.** The hover affordance pulled every bar's inline-end edge back by the same fixed inset while the value slid by that amount — which only kept the bar↔value gap right for a full-length bar. A short bar couldn't recede the full inset (it hit `min-width`), so its gap grew and the hover looked unresponsive. The bar's pull-back is now scaled by its share (`inset * share / 100`): the full-length bar still recedes the whole inset to keep its gap, shorter bars recede proportionally less (down to ~0), and the value still slides the full inset to clear the chevron.
* **Keyboard-activation test.** The original PR described Enter/Space activation but only the click path was tested. Switched the click test to `@testing-library/user-event` (available here — dropped the `prefer-user-event` eslint-disable) and added a test that tabs to the row and fires both Enter and Space.
* **Opt-in `ariaLabel` on `LeaderboardEntry`.** An interactive row's accessible name is derived from its rendered content (label + value), which is right for plain-text labels but can be unclear for an image-only label. Added an opt-in `ariaLabel?` that names the row's `<button>` directly when set — it only overrides when a consumer asks for it, unlike the auto aria-label removed during the original review. Added tests for the image-label (alt-derived) case and the `ariaLabel` override, and documented the field.
* **WPDS-aligned focus ring.** The focus-visible indicator was an ad-hoc square 2px inset outline in `fg-interactive-brand`. It now uses the WPDS focus tokens (`border-width-focus`, `stroke-focus-brand`) with `border-radius-sm` rounded corners, matching `@wordpress/ui` Button. The row is full-bleed inside an `overflow: auto` scroll container, so an outset ring would clip on the sides; instead the outline is inset by its own width to hug the row edge, and the row reserves a matching ring-width of padding so the bar no longer paints over the outline.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* In Storybook, open **JS Packages / Charts Library → Charts → Leaderboard Chart → Interactive**.
* **Hover** the longest row (Direct): the bar recedes ~32px and the value/chevron reveal with a tight gap.
* **Hover** the short row (Referral, 4%): the bar barely moves (it no longer slams into `min-width`); the value still slides to reveal the chevron.
* **Keyboard**: Tab to a row, press **Enter** and **Space** — each fires the action.
* **Focus ring**: the focus ring is rounded and brand-colored, hugs the row edge, and the bar color does not bleed over it.
* Run `pnpm --filter @automattic/charts test` (890 pass), plus `typecheck` (clean).
