### PR TITLE
Newsletter: allow Contributors to submit for review with Subscriptions active

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-contributor-submit-for-review
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-contributor-submit-for-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: fix "Sorry, you are not allowed to do this" error for Contributors on the first Submit for Review when the Subscriptions module is active.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -977,21 +977,21 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Checks if the current user can publish posts.
+	 * Checks if the current user can edit posts.
 	 *
 	 * @return bool
 	 */
 	public function first_published_status_meta_auth_callback() {
 		/**
-		 * Filter the capability to view if a post was ever published in the Subscription Module.
+		 * Filter the capability required to edit the "was ever published" post meta.
 		 *
 		 * @module subscriptions
 		 *
 		 * @since 13.4
 		 *
-		 * @param string $capability User capability needed to view if a post was ever published. Default to publish_posts.
+		 * @param string $capability User capability needed to edit the "was ever published" meta. Default to edit_posts.
 		 */
-		$capability = apply_filters( 'jetpack_subscriptions_post_was_ever_published_capability', 'publish_posts' );
+		$capability = apply_filters( 'jetpack_subscriptions_post_was_ever_published_capability', 'edit_posts' );
 		if ( current_user_can( $capability ) ) {
 			return true;
 		}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -192,6 +192,51 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Contributors can submit a post for review without the "was ever published" meta
+	 * blocking the save. Regression test for NL-706 / CM-232: the meta is included in
+	 * the editor save payload, and its auth_callback previously required publish_posts,
+	 * which Contributors lack — failing the first "Submit for Review" save.
+	 */
+	public function test_first_published_status_meta_auth_callback_allows_contributor() {
+		$subscriptions  = Jetpack_Subscriptions::init();
+		$contributor_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
+
+		wp_set_current_user( $contributor_id );
+		$this->assertFalse(
+			current_user_can( 'publish_posts' ),
+			'Contributors should not be able to publish posts (test precondition).'
+		);
+		$this->assertTrue(
+			$subscriptions->first_published_status_meta_auth_callback(),
+			'Contributors must be authorized to save the "was ever published" meta.'
+		);
+	}
+
+	/**
+	 * A logged-out visitor cannot edit the "was ever published" meta, and the
+	 * jetpack_subscriptions_post_was_ever_published_capability filter is still honored.
+	 */
+	public function test_first_published_status_meta_auth_callback_respects_filter_and_denies_anonymous() {
+		$subscriptions = Jetpack_Subscriptions::init();
+
+		wp_set_current_user( 0 );
+		$this->assertFalse(
+			$subscriptions->first_published_status_meta_auth_callback(),
+			'Logged-out users must not be authorized to edit the meta.'
+		);
+
+		$contributor_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
+		wp_set_current_user( $contributor_id );
+
+		add_filter( 'jetpack_subscriptions_post_was_ever_published_capability', fn() => 'publish_posts' );
+		$this->assertFalse(
+			$subscriptions->first_published_status_meta_auth_callback(),
+			'The capability filter should still be able to restrict access.'
+		);
+		remove_all_filters( 'jetpack_subscriptions_post_was_ever_published_capability' );
+	}
+
+	/**
 	 * Test that wpcom_newsletter_send_default option defaults to true.
 	 */
 	public function test_newsletter_send_default_option_defaults_to_true() {

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -228,7 +228,12 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		$contributor_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
 		wp_set_current_user( $contributor_id );
 
-		add_filter( 'jetpack_subscriptions_post_was_ever_published_capability', fn() => 'publish_posts' );
+		add_filter(
+			'jetpack_subscriptions_post_was_ever_published_capability',
+			function () {
+				return 'publish_posts';
+			}
+		);
 		$this->assertFalse(
 			$subscriptions->first_published_status_meta_auth_callback(),
 			'The capability filter should still be able to restrict access.'


### PR DESCRIPTION
Fixes NL-706

## Proposed changes
Contributors hit a "Sorry, you are not allowed to do this" error on their first Submit for Review with the Newsletter module active, because the _jetpack_post_was_ever_published meta's auth_callback required publish_posts, which Contributors don't have — so WordPress rejected the meta in the save payload. Changed the default capability to edit_posts (matching the sibling newsletter metas); the flag is system-managed, so letting lower roles send the unchanged default is harmless, and the existing filter is preserved.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with Jetpack connected, go to Jetpack → Settings → Newsletter and enable "Let visitors subscribe to this site and receive emails when you publish a post".
* Log in as a **Contributor**-role user.
* Create a new post in the block editor and add some content.
* Click **Submit for Review**.
* Confirm the post is submitted successfully on the **first** click, with no "Sorry, you are not allowed to do this" error.
* Disable the Newsletter toggle and repeat — behavior should be unchanged (still succeeds).
