### PR TITLE
Podcast Episode block: save a static player so it renders in the Reader

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-reader-render
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-reader-render
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Podcast Episode block: save a real static player (audio/video with cover art and duration) instead of a bare media link, so the episode renders in the Reader, RSS, email, and other non-front-end contexts instead of relying on the dynamic render callback. Existing posts migrate via a block deprecation.

--- a/projects/packages/podcast/changelog/fix-podcast-episode-style-handle
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-style-handle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast Episode block: register the block stylesheet under the conventional jetpack-podcast-episode handle so WPCOM inlines its CSS in the Reader, email, and notification contexts instead of rendering the block unstyled.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -26,8 +26,12 @@ class Podcast_Episode_Block {
 	/**
 	 * Front-end + editor shared style handle. Side-loaded by
 	 * `Assets::register_script` from the sibling `style.css` bundle.
+	 *
+	 * Named `jetpack-<block>` to match the convention WPCOM's block-style
+	 * inliner keys on (`jetpack-%BLOCK_NAME%` / `jetpack-block-%BLOCK_NAME%`),
+	 * so the block is styled in the Reader, email, and notification contexts.
 	 */
-	const STYLE_HANDLE = 'jetpack-podcast-episode-style';
+	const STYLE_HANDLE = 'jetpack-podcast-episode';
 
 	/**
 	 * Front-end view script handle. Enqueued from the render callback

--- a/projects/packages/podcast/src/blocks/podcast-episode/deprecated.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/deprecated.tsx
@@ -1,0 +1,49 @@
+import { useBlockProps } from '@wordpress/block-editor';
+import clsx from 'clsx';
+import metadata from './block.json';
+
+interface DeprecatedSaveProps {
+	attributes: {
+		mediaUrl?: string;
+	};
+}
+
+/**
+ * v1 — original save output.
+ *
+ * The block originally persisted only a bare direct link to the media file and
+ * leaned entirely on the dynamic PHP render callback to build the player on the
+ * front end, which left the Reader, RSS, and email with just a link. The
+ * current `save` emits a full static player, so this deprecation lets posts
+ * saved with the old markup re-parse without tripping block validation. The
+ * attributes are unchanged, so no `migrate` is needed.
+ *
+ * @param props            - Block save props.
+ * @param props.attributes - Block attributes.
+ * @return The original serialized markup, or null when there is no media.
+ */
+function save( { attributes }: DeprecatedSaveProps ) {
+	const { mediaUrl } = attributes;
+	if ( ! mediaUrl ) {
+		return null;
+	}
+
+	const blockProps = useBlockProps.save();
+	return (
+		<a
+			{ ...blockProps }
+			className={ clsx( blockProps.className, 'jetpack-podcast-episode__direct-link' ) }
+			href={ mediaUrl }
+		>
+			{ mediaUrl }
+		</a>
+	);
+}
+
+export default [
+	{
+		attributes: metadata.attributes,
+		supports: metadata.supports,
+		save,
+	},
+];

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.ts
@@ -1,4 +1,5 @@
 import metadata from './block.json';
+import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
 import { registerJetpackBlockFromMetadata } from './util/register-jetpack-block';
@@ -8,4 +9,5 @@ import './editor.scss';
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
 	save,
+	deprecated,
 } );

--- a/projects/packages/podcast/src/blocks/podcast-episode/save.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/save.tsx
@@ -1,26 +1,77 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import clsx from 'clsx';
 
 interface SaveProps {
 	attributes: {
 		mediaUrl?: string;
+		mediaType?: 'audio' | 'video';
+		mediaMimeType?: string;
+		duration?: string;
+		showPoster?: boolean;
+		coverArt?: { url?: string };
 	};
 }
 
+/**
+ * Static save output.
+ *
+ * The dynamic PHP render callback owns the rich front-end render (post title,
+ * author, date, season/episode metadata, cover-art fallback chain, and
+ * schema.org markup). It bails to this saved markup in every other context, so
+ * we persist a real, self-contained player built from the block's own
+ * attributes. That makes the episode render natively in the Reader, RSS, email,
+ * and AMP instead of collapsing to a bare link.
+ *
+ * Only locale-independent attribute values are emitted here. Translated labels
+ * (Season / Episode / Trailer …) are deliberately left to the dynamic render:
+ * baking translated strings into saved markup freezes them to the author's
+ * editor locale and breaks block validation when the post is later edited in a
+ * different locale. Post-derived fields (title, author, date) aren't block
+ * attributes, and the surrounding context (Reader card, feed item, post header)
+ * already presents them.
+ *
+ * @param props            - Block save props.
+ * @param props.attributes - Block attributes.
+ * @return The serialized block markup, or null when there is no media to play.
+ */
 export default function save( { attributes }: SaveProps ) {
-	const { mediaUrl } = attributes;
+	const { mediaUrl, mediaType, mediaMimeType, duration, showPoster = true, coverArt } = attributes;
+
 	if ( ! mediaUrl ) {
 		return null;
 	}
 
 	const blockProps = useBlockProps.save();
+	const coverUrl = coverArt?.url || '';
+
 	return (
-		<a
-			{ ...blockProps }
-			className={ clsx( blockProps.className, 'jetpack-podcast-episode__direct-link' ) }
-			href={ mediaUrl }
-		>
-			{ mediaUrl }
-		</a>
+		<div { ...blockProps }>
+			<article className="jetpack-podcast-episode">
+				{ showPoster && coverUrl && (
+					<figure className="jetpack-podcast-episode__poster">
+						<img src={ coverUrl } alt="" />
+					</figure>
+				) }
+				<div className="jetpack-podcast-episode__body">
+					{ !! duration && (
+						<p className="jetpack-podcast-episode__byline">
+							<span className="jetpack-podcast-episode__duration">{ duration }</span>
+						</p>
+					) }
+					<div className="jetpack-podcast-episode__player">
+						{ mediaType === 'video' ? (
+							<video
+								src={ mediaUrl }
+								controls
+								preload="none"
+								poster={ showPoster && coverUrl ? coverUrl : undefined }
+								data-mime={ mediaMimeType || undefined }
+							/>
+						) : (
+							<audio src={ mediaUrl } controls preload="none" />
+						) }
+					</div>
+				</div>
+			</article>
+		</div>
 	);
 }


### PR DESCRIPTION
Proposed changes
----------------
The Podcast Episode block is dynamic: it only built its player on the web front end and fell back to a bare media link in every other context (Reader, RSS, email, AMP). This changes save() to persist a real static audio/video player from the block attributes, so the episode renders natively in those contexts.

- save.tsx now emits a player (cover art + duration + audio/video) instead of a bare link.
- Only locale-independent attribute values are saved; translated season/episode/badge labels stay in the dynamic render so block validation stays stable across locales.
- A deprecation migrates posts saved with the old link markup (attributes unchanged, no migrate needed).
- The dynamic PHP render callback is unchanged and still owns the rich front-end markup and schema.

Testing instructions
--------------------
1. Add a Podcast Episode block to a post, upload audio, publish.
2. View the post in the Reader and the RSS feed: the player renders instead of a bare link.
3. Open an existing episode saved before this change: it migrates without a block-validation warning.
4. Confirm the front-end post render is unchanged.