### PR TITLE
[codex] Add premium analytics owners and reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /projects/github-actions/repo-gardening/ @jeherve
 
 # Packages
+/projects/packages/premium-analytics @Automattic/red @Automattic/ventures
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-vulcan
 /projects/packages/connection/legacy @Automattic/jetpack-vulcan
@@ -62,6 +63,8 @@
 /projects/packages/sync/src/class-package-version.php
 
 # Plugins
+
+/projects/plugins/premium-analytics @Automattic/red @Automattic/ventures
 
 # Functionality that is important to our partners
 /projects/plugins/jetpack/class.jetpack-cli.php @Automattic/jetpack-infinity

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -151,6 +151,7 @@
 			],
 		},
 
+		// Widgets Dashboard packages are still experimental/development-focused, so group them for targeted review.
 		{
 			groupName: 'Widgets Dashboard',
 			matchPackageNames: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -146,6 +146,22 @@
 			// Teams using Build in their projects
 			additionalReviewers: [
 				'team:zap', // Forms
+				'team:red', // Premium Analytics
+				'team:ventures', // Premium Analytics
+			],
+		},
+
+		{
+			groupName: 'Widgets Dashboard',
+			matchPackageNames: [
+				'@wordpress/widget-dashboard',
+				'@wordpress/widget-primitives',
+				'@wordpress/grid',
+			],
+			separateMajorMinor: false,
+			additionalReviewers: [
+				'team:red', // Premium Analytics
+				'team:ventures', // Premium Analytics
 			],
 		},
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,6 +133,8 @@
 				'team:triforce', // Monorepo overall, Publicize, My Jetpack
 				'team:loop', // Newsletter dashboard & subscriber management
 				'team:zap', // Forms, much of the recent componentry work.
+				'team:red', // Premium Analytics
+				'team:ventures', // Premium Analytics
 			],
 		},
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add CODEOWNERS entries for the Premium Analytics package and plugin.
* Assign both `@Automattic/red` and `@Automattic/ventures` as owners for those paths.
* Add `team:red` and `team:ventures` as Premium Analytics reviewers for bundled `@wordpress/*` and `@wordpress/build` Renovate updates.
* Add a `Widgets Dashboard` Renovate group for `@wordpress/widget-dashboard`, `@wordpress/widget-primitives`, and `@wordpress/grid`, with Premium Analytics reviewers.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Review `.github/CODEOWNERS` and confirm the Premium Analytics package and plugin paths list both teams on the same line.
* Review `.github/renovate.json5` and confirm the bundled `@wordpress/*` and `@wordpress/build` `additionalReviewers` lists include `team:red` and `team:ventures` with Premium Analytics comments.
* Review the `Widgets Dashboard` Renovate group and confirm it includes `@wordpress/widget-dashboard`, `@wordpress/widget-primitives`, and `@wordpress/grid`.
* No runtime testing needed; this only updates repository metadata and Renovate configuration.
