### PR TITLE
AI Launchpad: add an internal no-CLI test-enable handler

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-dev-enable
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-dev-enable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Launchpad: add an internal helper for enabling and resetting the feature during testing.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/eligibility.php';
 require_once __DIR__ . '/class-ai-launchpad-rest.php';
 require_once __DIR__ . '/class-ai-launchpad-listeners.php';
 require_once __DIR__ . '/class-ai-launchpad-theme-listener.php';
+require_once __DIR__ . '/class-ai-launchpad-dev-enable.php';
 
 /**
  * Registers the AI Launchpad admin page and its wp-build assets.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * AI Launchpad no-CLI test-enable handler.
+ *
+ * Lets a tester turn the AI Launchpad on (and reset its state) for a site
+ * straight from the browser, removing the `wp option update
+ * wpcom_ai_launchpad_enabled 1` / reset-script SSH steps that testing otherwise
+ * requires. Modeled on the existing wpcom query-param overrides
+ * (wpcom-dashboard-redesign-override.php `?enable-dashboard-redesign=1`,
+ * jetpack stats `?enable_new_stats=1`), which likewise flip a feature straight
+ * from a `$_GET` flag.
+ *
+ * Recognized query args (on any admin page, for a `manage_options` user):
+ *   ?enable-ai-launchpad=1  Set wpcom_ai_launchpad_enabled to 1.
+ *   ?enable-ai-launchpad=0  Delete wpcom_ai_launchpad_enabled (turn back off).
+ *   ?reset-ai-launchpad=1   Clear the wizard / AI-output / dismissed / task-status
+ *                           options so the wizard runs fresh.
+ *
+ * Each action redirects to the clean AI Launchpad page URL so a refresh does not
+ * re-fire it.
+ *
+ * Hooked on `admin_menu`, not `admin_init`: when the feature is OFF its admin
+ * page is unregistered, and WordPress runs the `user_can_access_admin_page()`
+ * check (and dies with "you are not allowed to access this page") in
+ * wp-admin/menu.php — which loads *before* `admin_init`. `admin_menu` fires
+ * inside that same file but before the access check, so handling it there lets
+ * the launchpad page's own URL self-enable instead of dying first.
+ *
+ * Gate: `current_user_can( 'manage_options' )` only — no nonce, matching the
+ * wpcom precedents, so the URL stays bookmarkable/shareable. NOTE: this ships to
+ * production on real sites, where it lets any paid-site admin self-enable the
+ * (otherwise OFF) feature on their own site. That exposure was reviewed and
+ * accepted as an interim testing affordance; tighten the gate before the
+ * controlled rollout (DOTOBRD-456) if the feature must stay invisible to
+ * customers.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Handles the AI Launchpad test-enable / reset query params.
+ */
+class AI_Launchpad_Dev_Enable {
+
+	/**
+	 * The per-site enablement option, mirrored from AI_Launchpad::is_enabled_for_site().
+	 */
+	const OPTION_ENABLED = 'wpcom_ai_launchpad_enabled';
+
+	/**
+	 * Options cleared by a reset, matching docs/bin/reset-ai-launchpad-test-site.sh.
+	 * The first three reference the REST controller's canonical constants so a
+	 * rename there can't silently leave the reset clearing a stale option name.
+	 */
+	const RESET_OPTIONS = array(
+		AI_Launchpad_REST::OPTION_WIZARD,
+		AI_Launchpad_REST::OPTION_AI_OUTPUT,
+		AI_Launchpad_REST::OPTION_DISMISSED,
+		'launchpad_checklist_tasks_statuses', // Shared completion option; no dedicated constant.
+	);
+
+	/**
+	 * Register the admin-request handler.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'admin_menu', array( __CLASS__, 'maybe_handle_request' ) );
+	}
+
+	/**
+	 * Acts on the test-enable / reset query params, then redirects to the clean
+	 * AI Launchpad page URL so a refresh does not re-fire the action.
+	 *
+	 * @return void
+	 */
+	public static function maybe_handle_request() {
+		$redirect = self::handle();
+
+		if ( '' === $redirect ) {
+			return;
+		}
+
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Applies the requested option changes and returns where to send the user.
+	 * Split from the redirect/exit so it can be unit-tested. No-op (and cheap) on
+	 * the overwhelming majority of admin requests, which carry neither param.
+	 *
+	 * @return string The URL to redirect to, or '' when there is nothing to do
+	 *                (no recognized param, or the user lacks the capability).
+	 */
+	public static function handle() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Intentional no-nonce toggle, see file docblock; cap-gated below.
+		$enable = isset( $_GET['enable-ai-launchpad'] );
+		$reset  = isset( $_GET['reset-ai-launchpad'] );
+
+		if ( ! $enable && ! $reset ) {
+			return '';
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return '';
+		}
+
+		$disabling = false;
+
+		if ( $enable ) {
+			$value = sanitize_text_field( wp_unslash( $_GET['enable-ai-launchpad'] ) );
+			if ( '0' === $value ) {
+				delete_option( self::OPTION_ENABLED );
+				$disabling = true;
+			} else {
+				update_option( self::OPTION_ENABLED, 1 );
+			}
+		}
+
+		if ( $reset ) {
+			foreach ( self::RESET_OPTIONS as $option ) {
+				delete_option( $option );
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		// Disabling removes the (eligibility-gated) launchpad page, so land on the
+		// dashboard rather than the now-inaccessible page. Otherwise go to the
+		// launchpad: the redirect starts a fresh request where the menu
+		// re-registers. (On a site without a paid plan the page stays gated, but
+		// that is out of scope — the feature requires a paid plan.)
+		if ( $disabling ) {
+			return admin_url();
+		}
+
+		return admin_url( 'admin.php?page=' . \Automattic\Jetpack\Jetpack_Mu_Wpcom\AI_Launchpad::MENU_SLUG );
+	}
+}
+
+AI_Launchpad_Dev_Enable::register();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
@@ -60,6 +60,15 @@ class AI_Launchpad_Dev_Enable {
 	);
 
 	/**
+	 * Redirect targets returned by handle(): nothing to do, the AI Launchpad page,
+	 * or the wp-admin dashboard. Kept as abstract tokens (not URLs) so handle() can
+	 * be unit-tested without loading the AI Launchpad page bootstrap.
+	 */
+	const REDIRECT_NONE      = '';
+	const REDIRECT_PAGE      = 'page';
+	const REDIRECT_DASHBOARD = 'dashboard';
+
+	/**
 	 * Register the admin-request handler.
 	 *
 	 * @return void
@@ -69,29 +78,37 @@ class AI_Launchpad_Dev_Enable {
 	}
 
 	/**
-	 * Acts on the test-enable / reset query params, then redirects to the clean
-	 * AI Launchpad page URL so a refresh does not re-fire the action.
+	 * Acts on the test-enable / reset query params, then redirects so a refresh
+	 * does not re-fire the action. Disabling lands on the dashboard (the gated
+	 * page is gone); everything else lands on the AI Launchpad page, where the
+	 * fresh request re-registers the now-eligible menu.
 	 *
 	 * @return void
 	 */
 	public static function maybe_handle_request() {
-		$redirect = self::handle();
+		$target = self::handle();
 
-		if ( '' === $redirect ) {
+		if ( self::REDIRECT_NONE === $target ) {
 			return;
 		}
 
-		wp_safe_redirect( $redirect );
+		$url = self::REDIRECT_DASHBOARD === $target
+			? admin_url()
+			: admin_url( 'admin.php?page=' . \Automattic\Jetpack\Jetpack_Mu_Wpcom\AI_Launchpad::MENU_SLUG );
+
+		wp_safe_redirect( $url );
 		exit;
 	}
 
 	/**
-	 * Applies the requested option changes and returns where to send the user.
-	 * Split from the redirect/exit so it can be unit-tested. No-op (and cheap) on
-	 * the overwhelming majority of admin requests, which carry neither param.
+	 * Applies the requested option changes and returns where to send the user, as
+	 * one of the REDIRECT_* tokens. Split from the redirect/exit — and kept free of
+	 * the AI Launchpad page bootstrap — so it can be unit-tested in isolation. No-op
+	 * (and cheap) on the overwhelming majority of admin requests, which carry
+	 * neither param.
 	 *
-	 * @return string The URL to redirect to, or '' when there is nothing to do
-	 *                (no recognized param, or the user lacks the capability).
+	 * @return string One of the REDIRECT_* constants (REDIRECT_NONE when there is
+	 *                nothing to do: no recognized param, or no capability).
 	 */
 	public static function handle() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Intentional no-nonce toggle, see file docblock; cap-gated below.
@@ -99,11 +116,11 @@ class AI_Launchpad_Dev_Enable {
 		$reset  = isset( $_GET['reset-ai-launchpad'] );
 
 		if ( ! $enable && ! $reset ) {
-			return '';
+			return self::REDIRECT_NONE;
 		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return '';
+			return self::REDIRECT_NONE;
 		}
 
 		$disabling = false;
@@ -130,11 +147,7 @@ class AI_Launchpad_Dev_Enable {
 		// launchpad: the redirect starts a fresh request where the menu
 		// re-registers. (On a site without a paid plan the page stays gated, but
 		// that is out of scope — the feature requires a paid plan.)
-		if ( $disabling ) {
-			return admin_url();
-		}
-
-		return admin_url( 'admin.php?page=' . \Automattic\Jetpack\Jetpack_Mu_Wpcom\AI_Launchpad::MENU_SLUG );
+		return $disabling ? self::REDIRECT_DASHBOARD : self::REDIRECT_PAGE;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Dev_Enable_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Dev_Enable_Test.php
@@ -7,6 +7,12 @@
 
 use PHPUnit\Framework\Attributes\CoversClass;
 
+// class-ai-launchpad-rest.php defines the OPTION_* constants referenced by
+// AI_Launchpad_Dev_Enable::RESET_OPTIONS; load it first so the handler file is
+// self-contained. Neither file pulls in eligibility.php, so this does not leak
+// wpcom_ai_launchpad_is_eligible() into the shared process (which would break
+// the REST test's Brain Monkey mock).
+require_once __DIR__ . '/../../../../src/features/ai-launchpad/class-ai-launchpad-rest.php';
 require_once __DIR__ . '/../../../../src/features/ai-launchpad/class-ai-launchpad-dev-enable.php';
 
 /**
@@ -48,7 +54,7 @@ class AI_Launchpad_Dev_Enable_Test extends \WorDBless\BaseTestCase {
 	public function test_no_params_is_a_noop() {
 		$this->login_as( 'administrator' );
 
-		$this->assertSame( '', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertSame( AI_Launchpad_Dev_Enable::REDIRECT_NONE, AI_Launchpad_Dev_Enable::handle() );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
 	}
 
@@ -59,23 +65,23 @@ class AI_Launchpad_Dev_Enable_Test extends \WorDBless\BaseTestCase {
 		$this->login_as( 'subscriber' );
 		$_GET['enable-ai-launchpad'] = '1';
 
-		$this->assertSame( '', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertSame( AI_Launchpad_Dev_Enable::REDIRECT_NONE, AI_Launchpad_Dev_Enable::handle() );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
 	}
 
 	/**
-	 * `?enable-ai-launchpad=1` sets the per-site option and redirects to the page.
+	 * `?enable-ai-launchpad=1` sets the per-site option and routes to the page.
 	 */
 	public function test_enable_sets_the_option() {
 		$this->login_as( 'administrator' );
 		$_GET['enable-ai-launchpad'] = '1';
 
-		$this->assertStringContainsString( 'page=ai-launchpad-wp-admin', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertSame( AI_Launchpad_Dev_Enable::REDIRECT_PAGE, AI_Launchpad_Dev_Enable::handle() );
 		$this->assertSame( 1, get_option( 'wpcom_ai_launchpad_enabled' ) );
 	}
 
 	/**
-	 * `?enable-ai-launchpad=0` removes the option and redirects to the dashboard
+	 * `?enable-ai-launchpad=0` removes the option and routes to the dashboard
 	 * (not the now-inaccessible launchpad page).
 	 */
 	public function test_enable_zero_deletes_the_option() {
@@ -83,9 +89,7 @@ class AI_Launchpad_Dev_Enable_Test extends \WorDBless\BaseTestCase {
 		update_option( 'wpcom_ai_launchpad_enabled', 1 );
 		$_GET['enable-ai-launchpad'] = '0';
 
-		$redirect = AI_Launchpad_Dev_Enable::handle();
-		$this->assertStringNotContainsString( 'page=ai-launchpad-wp-admin', $redirect );
-		$this->assertNotSame( '', $redirect );
+		$this->assertSame( AI_Launchpad_Dev_Enable::REDIRECT_DASHBOARD, AI_Launchpad_Dev_Enable::handle() );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
 	}
 
@@ -102,7 +106,7 @@ class AI_Launchpad_Dev_Enable_Test extends \WorDBless\BaseTestCase {
 		update_option( 'launchpad_checklist_tasks_statuses', array( 'x' => true ) );
 		$_GET['reset-ai-launchpad'] = '1';
 
-		$this->assertStringContainsString( 'page=ai-launchpad-wp-admin', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertSame( AI_Launchpad_Dev_Enable::REDIRECT_PAGE, AI_Launchpad_Dev_Enable::handle() );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_wizard' ) );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_ai_output' ) );
 		$this->assertFalse( get_option( 'wpcom_ai_launchpad_dismissed' ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Dev_Enable_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Dev_Enable_Test.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for the AI Launchpad no-CLI test-enable handler.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once __DIR__ . '/../../../../src/features/ai-launchpad/class-ai-launchpad-dev-enable.php';
+
+/**
+ * Test class for AI_Launchpad_Dev_Enable.
+ *
+ * @covers \AI_Launchpad_Dev_Enable
+ */
+#[CoversClass( AI_Launchpad_Dev_Enable::class )]
+class AI_Launchpad_Dev_Enable_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		unset( $_GET['enable-ai-launchpad'], $_GET['reset-ai-launchpad'] );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Sets the current user to one with or without `manage_options`.
+	 *
+	 * @param string $role A role granting manage_options ('administrator') or not ('subscriber').
+	 */
+	private function login_as( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test_' . wp_rand() . '@example.com',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * With neither param present the handler does nothing and returns no redirect.
+	 */
+	public function test_no_params_is_a_noop() {
+		$this->login_as( 'administrator' );
+
+		$this->assertSame( '', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
+	}
+
+	/**
+	 * A non-admin cannot enable the feature even with the param present.
+	 */
+	public function test_non_admin_cannot_enable() {
+		$this->login_as( 'subscriber' );
+		$_GET['enable-ai-launchpad'] = '1';
+
+		$this->assertSame( '', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
+	}
+
+	/**
+	 * `?enable-ai-launchpad=1` sets the per-site option and redirects to the page.
+	 */
+	public function test_enable_sets_the_option() {
+		$this->login_as( 'administrator' );
+		$_GET['enable-ai-launchpad'] = '1';
+
+		$this->assertStringContainsString( 'page=ai-launchpad-wp-admin', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertSame( 1, get_option( 'wpcom_ai_launchpad_enabled' ) );
+	}
+
+	/**
+	 * `?enable-ai-launchpad=0` removes the option and redirects to the dashboard
+	 * (not the now-inaccessible launchpad page).
+	 */
+	public function test_enable_zero_deletes_the_option() {
+		$this->login_as( 'administrator' );
+		update_option( 'wpcom_ai_launchpad_enabled', 1 );
+		$_GET['enable-ai-launchpad'] = '0';
+
+		$redirect = AI_Launchpad_Dev_Enable::handle();
+		$this->assertStringNotContainsString( 'page=ai-launchpad-wp-admin', $redirect );
+		$this->assertNotSame( '', $redirect );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_enabled' ) );
+	}
+
+	/**
+	 * `?reset-ai-launchpad=1` clears the wizard / AI-output / dismissed / status
+	 * options while leaving the enablement option untouched.
+	 */
+	public function test_reset_clears_state_options() {
+		$this->login_as( 'administrator' );
+		update_option( 'wpcom_ai_launchpad_enabled', 1 );
+		update_option( 'wpcom_ai_launchpad_wizard', array( 'foo' => 'bar' ) );
+		update_option( 'wpcom_ai_launchpad_ai_output', array( 'source' => 'ai' ) );
+		update_option( 'wpcom_ai_launchpad_dismissed', 1 );
+		update_option( 'launchpad_checklist_tasks_statuses', array( 'x' => true ) );
+		$_GET['reset-ai-launchpad'] = '1';
+
+		$this->assertStringContainsString( 'page=ai-launchpad-wp-admin', AI_Launchpad_Dev_Enable::handle() );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_wizard' ) );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_ai_output' ) );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_dismissed' ) );
+		$this->assertFalse( get_option( 'launchpad_checklist_tasks_statuses' ) );
+		// Reset leaves enablement alone.
+		$this->assertSame( 1, get_option( 'wpcom_ai_launchpad_enabled' ) );
+	}
+}


### PR DESCRIPTION
Fixes DOTOBRD-485

## Proposed changes
* Adds `AI_Launchpad_Dev_Enable`, a small `admin_menu` handler that lets a `manage_options` user enable, disable, and reset the AI Launchpad for a site from the browser, instead of running wp-cli on the site. It only writes the existing per-site enablement option and the wizard/state options — the eligibility gates (paid plan, not AI-onboarded) are unchanged, so it cannot surface the feature on an ineligible site.
* Hooked on `admin_menu` (not `admin_init`) so the eligibility-gated AI Launchpad page's own URL can self-enable before WordPress's page-access check runs (which otherwise `wp_die`s first).

⚠️ This is a `manage_options`-gated, no-nonce affordance that ships to production. It lets an admin of an otherwise-eligible site self-enable the (currently OFF) feature on their own site. This was an accepted interim testing tradeoff; the gate should be tightened before the broader rollout.

## Related product discussion/links
* Part of the AI Launchpad MVP testing workflow. Related: DOTOBRD-456.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an eligible site (paid plan, not AI-onboarded) where the AI Launchpad is not yet enabled, as an admin visit `…/wp-admin/admin.php?page=ai-launchpad-wp-admin&enable-ai-launchpad=1` → you should be redirected to the AI Launchpad page and see the wizard.
* Visit the same page with `&reset-ai-launchpad=1` → wizard/AI-output state is cleared and the wizard runs fresh.
* Visit it with `&enable-ai-launchpad=0` → the feature turns off and you land on the dashboard (not an error page).
* Confirm a non-admin (e.g. subscriber) cannot trigger any of these.
* Unit tests: from `projects/packages/jetpack-mu-wpcom`, run `composer phpunit -- --filter AI_Launchpad_Dev_Enable_Test`.