### PR TITLE
Sync: Add Jetpack Social image focal point to post meta whitelist

### DIFF
--- a/projects/packages/sync/changelog/add-social-image-focal-point-sync-whitelist
+++ b/projects/packages/sync/changelog/add-social-image-focal-point-sync-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: Add the Jetpack Social image focal point to the post meta sync whitelist.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -781,6 +781,7 @@ class Defaults {
 		'_wpas_customize_per_network',
 		'_wpas_mess',
 		'_wpas_options',
+		'_jetpack_social_image_focal_point', // Publicize_Base::ATTACHMENT_IMAGE_FOCAL_POINT.
 		'advanced_seo_description', // Jetpack_SEO_Posts::DESCRIPTION_META_KEY.
 		'content_width',
 		'custom_css_add',


### PR DESCRIPTION
Related to SOCIAL-506 and SOCIAL-507.

## Proposed changes
* Add the Jetpack Social image focal point attachment meta (`_jetpack_social_image_focal_point`) to the Sync post meta whitelist so it syncs to WordPress.com.
* This is the send-side half of the focal-point sync coordination described in SOCIAL-506: the WordPress.com shadow replicastore needs a matching post-meta allowlist entry to store it (handled WPcom-side for SOCIAL-507). Without this entry the focal point is never sent for Jetpack/Atomic sites, so the server-side focal crop can't run there. WordPress.com Simple sites read the attachment meta directly and are unaffected.

## Related product discussion/links
* SOCIAL-506
* SOCIAL-507
* og:image crop that consumes this point: #49746

## Does this pull request change what data or activity we track or use?
Yes — it adds one attachment post-meta key (`_jetpack_social_image_focal_point`, an `{ x, y }` image focal point the author sets in the editor) to the data synced to WordPress.com, so the focal-point crop can be applied server-side. These are image-crop coordinates, not personal data.

## Testing instructions
* On a Jetpack-connected (or Atomic) test site, set a focal point on an image via the Jetpack Social media section so `_jetpack_social_image_focal_point` is stored on the attachment.
* Trigger a sync (or let incremental sync run) and confirm the meta reaches WordPress.com — e.g. via the Sync Validator on the Jetpack Debug page, or check that `Automattic\Jetpack\Sync\Defaults::get_post_meta_whitelist()` includes the key.
* `jetpack test php plugins/jetpack --testsuite=sync` — `test_sync_whitelisted_post_meta` iterates the whitelist and now covers the new key.
