### PR TITLE
JSON API: Gate REST dispatch on Jetpack 15.9 for fields parity

### DIFF
--- a/projects/plugins/jetpack/changelog/update-json-api-rest-min-jp-version-parity
+++ b/projects/plugins/jetpack/changelog/update-json-api-rest-min-jp-version-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+JSON API: Require Jetpack 15.9 or later to dispatch the posts, users, site, and plugins endpoints over REST.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -18,7 +18,7 @@ new WPCOM_JSON_API_GET_Site_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'                           => '/site',
-		'rest_min_jp_version'                  => '14.5-a.2',
+		'rest_min_jp_version'                  => '15.9',
 		'allow_jetpack_site_auth'              => true,
 
 		'allow_fallback_to_jetpack_blog_token' => true,

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -17,7 +17,7 @@ new WPCOM_JSON_API_GET_Site_V1_2_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'                           => '/site',
-		'rest_min_jp_version'                  => '14.5-a.2',
+		'rest_min_jp_version'                  => '15.9',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -21,7 +21,7 @@ new WPCOM_JSON_API_List_Posts_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'                           => '/posts',
-		'rest_min_jp_version'                  => '14.5-a.2',
+		'rest_min_jp_version'                  => '15.9',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -22,7 +22,7 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'                           => '/posts',
-		'rest_min_jp_version'                  => '14.5-a.2',
+		'rest_min_jp_version'                  => '15.9',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -22,7 +22,7 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'                           => '/posts',
-		'rest_min_jp_version'                  => '14.5-a.2',
+		'rest_min_jp_version'                  => '15.9',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -19,7 +19,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			'$site' => '(int|string) Site ID or domain',
 		),
 		'rest_route'           => '/users',
-		'rest_min_jp_version'  => '14.5-a.2',
+		'rest_min_jp_version'  => '15.9',
 
 		'query_parameters'     => array(
 			'number'          => '(int=20) Limit the total number of authors returned.',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
@@ -10,7 +10,7 @@ new Jetpack_JSON_API_Plugins_List_Endpoint(
 		'method'                  => 'GET',
 		'path'                    => '/sites/%s/plugins',
 		'rest_route'              => '/plugins',
-		'rest_min_jp_version'     => '14.4',
+		'rest_min_jp_version'     => '15.9',
 		'stat'                    => 'plugins',
 		'min_version'             => '1',
 		'max_version'             => '1.1',


### PR DESCRIPTION
## Proposed changes
* Raise `rest_min_jp_version` to `15.9` for the JSON API endpoints dispatched over REST — posts (v1 / v1.1 / v1.2), users, site (v1 / v1.2), and plugins. Previously `14.5-a.2` (posts/users/site) and `14.4` (plugins).
* `15.9` is the release that shipped `fields`-parameter parity for REST dispatch (#49396): `WPCOM_JSON_API_Endpoint::rest_callback()` now runs `filter_fields()` so REST responses return the same keys as the XML-RPC transport. Because that fix lives in the shared `rest_callback`, every REST-dispatched endpoint inherits the dependency, hence the uniform floor.
* Below 15.9 a site's REST responses can diverge from XML-RPC, so those sites should stay on XML-RPC, the WPCOM proxy falls back automatically when `get_rest_min_jp_version()` isn't met.

## Related product discussion/links
* P2: pf5801-24W-p2
* Fields parity fix this gates on: #49396

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Code Review