### PR TITLE
WP.com: allow enabling React 19 GB experiment via sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/enable-gutenberg-react-19-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/enable-gutenberg-react-19-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable the `gutenberg-react-19` Gutenberg experiment for sites with the `gutenberg-react-19` blog sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -105,6 +105,10 @@ class Jetpack_Mu_Wpcom {
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
 
+		// Enable the `gutenberg-react-19` Gutenberg experiment for sites with the `gutenberg-react-19` blog sticker.
+		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
+		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -819,6 +823,26 @@ class Jetpack_Mu_Wpcom {
 		}
 
 		$experiments['gutenberg-classic-block-deprecation'] = true;
+		return $experiments;
+	}
+
+	/**
+	 * Add `gutenberg-react-19` to the list of enabled Gutenberg experiments.
+	 * Only sites with the `gutenberg-react-19` blog sticker are opted in.
+	 *
+	 * @param mixed $experiments The current value of the gutenberg-experiments option.
+	 * @return mixed Original option value or the filtered experiments.
+	 */
+	public static function enable_gutenberg_react_19_experiment( $experiments ) {
+		if ( ! wpcom_has_blog_sticker( 'gutenberg-react-19', get_wpcom_blog_id() ) ) {
+			return $experiments;
+		}
+
+		if ( ! is_array( $experiments ) ) {
+			$experiments = array();
+		}
+
+		$experiments['gutenberg-react-19'] = true;
 		return $experiments;
 	}
 


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Enables the `gutenberg-react-19` Gutenberg experiment ([shipped](https://github.com/WordPress/gutenberg/pull/79077) in GB 23.4.0) for sites with the `gutenberg-react-19` blog sticker.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Have Atomic dev site (internal ref PCYsg-Osp-p2, not a regular Atomic site)
* Enable sticker on Atomic site via CLI or RC using 163051-ghe-Automattic/missioncontrol
* Apply PR e.g. using [Jetpack beta plugin](https://jetpack.com/download-jetpack-beta/)
    <img width="768" height="495" alt="Screenshot 2026-06-22 at 15 15 15" src="https://github.com/user-attachments/assets/e6530d86-64db-4d02-ba2d-2a66bc80420c" />
