### PR TITLE
VideoPress: show poster thumbnail for core/video blocks in newsletter emails

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-core-video-block-email-thumbnail
+++ b/projects/packages/videopress/changelog/fix-videopress-core-video-block-email-thumbnail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show a poster thumbnail for VideoPress videos in core Video blocks in newsletter emails.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -171,22 +171,19 @@ class Initializer {
 
 		Divi::init();
 
-		// Priority 20 to override the email editor's own core/video renderer (priority 10).
-		add_filter( 'block_type_metadata_settings', array( __CLASS__, 'add_core_video_email_renderer' ), 20 );
+		// Hook render start, not block_type_metadata_settings: the WordPress.com mailer re-assigns
+		// core/video's render_email_callback after registration, so setting it here runs last.
+		add_action( 'woocommerce_email_editor_render_start', array( __CLASS__, 'add_core_video_email_renderer' ) );
 	}
 
 	/**
-	 * Attach the VideoPress email renderer to the core/video block.
-	 *
-	 * @param array $settings The block type registration settings.
-	 * @return array The settings, with the email renderer attached for core/video.
+	 * Attach the VideoPress email renderer to the core/video block for email rendering.
 	 */
-	public static function add_core_video_email_renderer( $settings ) {
-		if ( isset( $settings['name'] ) && 'core/video' === $settings['name'] ) {
-			$settings['render_email_callback'] = array( Video_Block_Email_Renderer::class, 'render' );
+	public static function add_core_video_email_renderer() {
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/video' );
+		if ( $block_type ) {
+			$block_type->render_email_callback = array( Video_Block_Email_Renderer::class, 'render' );
 		}
-
-		return $settings;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -170,6 +170,23 @@ class Initializer {
 		}
 
 		Divi::init();
+
+		// Priority 20 to override the email editor's own core/video renderer (priority 10).
+		add_filter( 'block_type_metadata_settings', array( __CLASS__, 'add_core_video_email_renderer' ), 20 );
+	}
+
+	/**
+	 * Attach the VideoPress email renderer to the core/video block.
+	 *
+	 * @param array $settings The block type registration settings.
+	 * @return array The settings, with the email renderer attached for core/video.
+	 */
+	public static function add_core_video_email_renderer( $settings ) {
+		if ( isset( $settings['name'] ) && 'core/video' === $settings['name'] ) {
+			$settings['render_email_callback'] = array( Video_Block_Email_Renderer::class, 'render' );
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -85,14 +85,15 @@ class Video_Block_Email_Renderer {
 	 * @return string
 	 */
 	private static function render_core_video( $block_content, $parsed_block, $rendering_context ) {
-		$renderer_class = '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video';
-
-		if ( ! class_exists( $renderer_class ) ) {
+		if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video' ) ) {
 			return $block_content;
 		}
 
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
-		return ( new $renderer_class() )->render( $block_content, $parsed_block, $rendering_context );
+		$woo_video_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video();
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
+		return $woo_video_renderer->render( $block_content, $parsed_block, $rendering_context );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -89,8 +89,10 @@ class Video_Block_Email_Renderer {
 	 * @return string
 	 */
 	private static function render_core_video( $block_content, $parsed_block, $rendering_context ) {
+		// Match the rest of this class: render nothing when the required renderer is unavailable,
+		// rather than passing raw block markup (e.g. a <video> tag) through to the email.
 		if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video' ) ) {
-			return $block_content;
+			return '';
 		}
 
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -32,9 +32,13 @@ class Video_Block_Email_Renderer {
 		// Get the VideoPress URL from the guid attribute.
 		$videopress_url = self::get_videopress_url( $attributes );
 
-		// No guid: a plain uploaded video. Let the core video renderer handle it.
+		// No guid: a core/video block is a plain uploaded video, so let the core video renderer
+		// handle it. Other blocks (e.g. a malformed videopress/video) keep returning empty.
 		if ( empty( $videopress_url ) ) {
-			return self::render_core_video( $block_content, $parsed_block, $rendering_context );
+			if ( isset( $parsed_block['blockName'] ) && 'core/video' === $parsed_block['blockName'] ) {
+				return self::render_core_video( $block_content, $parsed_block, $rendering_context );
+			}
+			return '';
 		}
 
 		// For private videos, render a simple link to the post since the video isn't accessible on VideoPress.

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -22,9 +22,8 @@ class Video_Block_Email_Renderer {
 	 * @return string
 	 */
 	public static function render( $block_content, $parsed_block, $rendering_context ) {
-		// Validate input parameters and required dependencies.
-		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
-			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
+		// Validate input parameters.
+		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ) {
 			return '';
 		}
 
@@ -42,6 +41,11 @@ class Video_Block_Email_Renderer {
 		// The isPrivate attribute is pre-computed by the block editor based on video and site settings.
 		if ( isset( $attributes['isPrivate'] ) && true === $attributes['isPrivate'] ) {
 			return self::render_link( $parsed_block );
+		}
+
+		// The VideoPress embed path needs WooCommerce's Embed renderer.
+		if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Embed' ) ) {
+			return '';
 		}
 
 		// Create a mock embed block structure that WooCommerce's embed renderer can handle.

--- a/projects/packages/videopress/src/class-video-block-email-renderer.php
+++ b/projects/packages/videopress/src/class-video-block-email-renderer.php
@@ -33,8 +33,9 @@ class Video_Block_Email_Renderer {
 		// Get the VideoPress URL from the guid attribute.
 		$videopress_url = self::get_videopress_url( $attributes );
 
+		// No guid: a plain uploaded video. Let the core video renderer handle it.
 		if ( empty( $videopress_url ) ) {
-			return '';
+			return self::render_core_video( $block_content, $parsed_block, $rendering_context );
 		}
 
 		// For private videos, render a simple link to the post since the video isn't accessible on VideoPress.
@@ -68,6 +69,26 @@ class Video_Block_Email_Renderer {
 
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
 		return $woo_embed_renderer->render( $mock_embed_block['innerHTML'], $mock_embed_block, $rendering_context );
+	}
+
+	/**
+	 * Render a non-VideoPress core/video block using the email editor's core video renderer.
+	 *
+	 * @param string $block_content     The original block HTML content.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context.
+	 *
+	 * @return string
+	 */
+	private static function render_core_video( $block_content, $parsed_block, $rendering_context ) {
+		$renderer_class = '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video';
+
+		if ( ! class_exists( $renderer_class ) ) {
+			return $block_content;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Optional WooCommerce dependency, checked with class_exists() above.
+		return ( new $renderer_class() )->render( $block_content, $parsed_block, $rendering_context );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -243,20 +243,32 @@ class Initializer_Test extends BaseTestCase {
 		);
 	}
 
-	/** The core/video block should get the VideoPress email renderer attached. */
-	public function test_add_core_video_email_renderer_targets_core_video() {
-		$settings = VideoPress_Initializer::add_core_video_email_renderer( array( 'name' => 'core/video' ) );
+	/** On email render start, the registered core/video block gets the VideoPress email renderer attached. */
+	public function test_add_core_video_email_renderer_sets_callback_on_core_video() {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( ! $registry->is_registered( 'core/video' ) ) {
+			register_block_type( 'core/video' );
+		}
+
+		VideoPress_Initializer::add_core_video_email_renderer();
 
 		$this->assertSame(
 			array( \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::class, 'render' ),
-			$settings['render_email_callback']
+			$registry->get_registered( 'core/video' )->render_email_callback
 		);
+
+		unregister_block_type( 'core/video' );
 	}
 
-	/** Other block types should be left untouched. */
-	public function test_add_core_video_email_renderer_ignores_other_blocks() {
-		$settings = VideoPress_Initializer::add_core_video_email_renderer( array( 'name' => 'core/paragraph' ) );
+	/** It is a no-op (no error) when core/video is not registered. */
+	public function test_add_core_video_email_renderer_noop_when_core_video_unregistered() {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'core/video' ) ) {
+			unregister_block_type( 'core/video' );
+		}
 
-		$this->assertArrayNotHasKey( 'render_email_callback', $settings );
+		VideoPress_Initializer::add_core_video_email_renderer();
+
+		$this->assertFalse( $registry->is_registered( 'core/video' ) );
 	}
 }

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -242,4 +242,21 @@ class Initializer_Test extends BaseTestCase {
 			'Active-module VideoPress route should register on rest_api_init via the active_initialization deferral block.'
 		);
 	}
+
+	/** The core/video block should get the VideoPress email renderer attached. */
+	public function test_add_core_video_email_renderer_targets_core_video() {
+		$settings = VideoPress_Initializer::add_core_video_email_renderer( array( 'name' => 'core/video' ) );
+
+		$this->assertSame(
+			array( \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::class, 'render' ),
+			$settings['render_email_callback']
+		);
+	}
+
+	/** Other block types should be left untouched. */
+	public function test_add_core_video_email_renderer_ignores_other_blocks() {
+		$settings = VideoPress_Initializer::add_core_video_email_renderer( array( 'name' => 'core/paragraph' ) );
+
+		$this->assertArrayNotHasKey( 'render_email_callback', $settings );
+	}
 }

--- a/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
@@ -20,10 +20,12 @@ use WorDBless\BaseTestCase;
  * Tests for VideoPress video block email renderer.
  *
  * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::render
+ * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::render_core_video
  * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::get_videopress_url
  * @covers \Automattic\Jetpack\VideoPress\Video_Block_Email_Renderer::render_link
  */
 #[CoversMethod( Video_Block_Email_Renderer::class, 'render' )]
+#[CoversMethod( Video_Block_Email_Renderer::class, 'render_core_video' )]
 #[CoversMethod( Video_Block_Email_Renderer::class, 'get_videopress_url' )]
 #[CoversMethod( Video_Block_Email_Renderer::class, 'render_link' )]
 class Video_Block_Email_Renderer_Test extends BaseTestCase {

--- a/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\VideoPress;
 // Include mock classes for WooCommerce Email Editor helpers FIRST.
 // This ensures the mock class is available when Video_Block_Email_Renderer checks for it.
 require_once __DIR__ . '/mocks/class-mock-woocommerce-embed-renderer.php';
+require_once __DIR__ . '/mocks/class-mock-woocommerce-video-renderer.php';
 
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -393,5 +394,38 @@ class Video_Block_Email_Renderer_Test extends BaseTestCase {
 
 		// Should return empty string when no post URL available.
 		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render routes a VideoPress core/video block (guid present) through the embed path,
+	 * the same as a videopress/video block.
+	 */
+	public function test_render_email_core_video_with_guid_renders_embed() {
+		$parsed_block              = $this->create_parsed_block( array( 'guid' => 'nfbj0J36' ) );
+		$parsed_block['blockName'] = 'core/video';
+		$mock_context              = $this->create_rendering_context_mock();
+
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
+
+		$this->assertStringContainsString( 'email-embed-video', $result );
+		$this->assertStringContainsString( 'https://videopress.com/v/nfbj0J36', $result );
+	}
+
+	/**
+	 * Test render delegates a non-VideoPress core/video block (no guid) to WooCommerce's core
+	 * video renderer, preserving its poster handling instead of blanking the block.
+	 */
+	public function test_render_email_plain_core_video_delegates_to_core_renderer() {
+		$parsed_block              = $this->create_parsed_block( array( 'poster' => 'https://example.com/poster.jpg' ) );
+		$parsed_block['blockName'] = 'core/video';
+		$mock_context              = $this->create_rendering_context_mock();
+
+		$result = Video_Block_Email_Renderer::render( '<figure class="wp-block-video"></figure>', $parsed_block, $mock_context );
+
+		// Delegated to the (mock) core video renderer, which renders the poster.
+		$this->assertStringContainsString( 'email-core-video', $result );
+		$this->assertStringContainsString( 'https://example.com/poster.jpg', $result );
+		// Should not take the VideoPress embed path.
+		$this->assertStringNotContainsString( 'email-embed-video', $result );
 	}
 }

--- a/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Block_Email_Renderer_Test.php
@@ -428,4 +428,18 @@ class Video_Block_Email_Renderer_Test extends BaseTestCase {
 		// Should not take the VideoPress embed path.
 		$this->assertStringNotContainsString( 'email-embed-video', $result );
 	}
+
+	/**
+	 * Test render does not delegate non core/video blocks (e.g. a malformed videopress/video
+	 * block with no guid) to the core video renderer; it returns empty as before.
+	 */
+	public function test_render_email_non_core_video_without_guid_returns_empty() {
+		$parsed_block              = $this->create_parsed_block( array( 'poster' => 'https://example.com/poster.jpg' ) );
+		$parsed_block['blockName'] = 'videopress/video';
+		$mock_context              = $this->create_rendering_context_mock();
+
+		$result = Video_Block_Email_Renderer::render( '', $parsed_block, $mock_context );
+
+		$this->assertSame( '', $result );
+	}
 }

--- a/projects/packages/videopress/tests/php/mocks/class-mock-woocommerce-video-renderer.php
+++ b/projects/packages/videopress/tests/php/mocks/class-mock-woocommerce-video-renderer.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mock class for WooCommerce Email Editor core/video Renderer
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+// Mock WooCommerce core/video Renderer class for testing.
+if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video' ) ) {
+	/**
+	 * Mock implementation of WooCommerce core/video renderer for testing.
+	 */
+	class Mock_WooCommerce_Video_Renderer {
+		/**
+		 * Mock render method.
+		 *
+		 * @param string $block_content     The block content.
+		 * @param array  $parsed_block      The parsed block data.
+		 * @param object $rendering_context The email rendering context.
+		 * @return string
+		 */
+		public function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$attrs  = $parsed_block['attrs'] ?? array();
+			$poster = $attrs['poster'] ?? '';
+
+			// Mirror the real renderer: no poster means no output.
+			if ( empty( $poster ) ) {
+				return '';
+			}
+
+			// Return simple HTML that tests can verify.
+			return sprintf( '<div class="email-core-video"><img src="%s" /></div>', esc_url( $poster ) );
+		}
+	}
+	class_alias( 'Mock_WooCommerce_Video_Renderer', '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Video' );
+}


### PR DESCRIPTION
Fixes #39662

## Proposed changes
A VideoPress video inserted via the **core Video block** (`core/video`, not the VideoPress block) showed no poster thumbnail in newsletter emails. The same video as a `videopress/video` block renders fine.

Root cause: the email editor renders `core/video` with its own `Video` renderer, which returns nothing when the block has no `poster` attribute. VideoPress `core/video` blocks carry a `guid` but no `poster` (the poster lives on VideoPress), so the email rendered empty. (This is also why the issue couldn't be reproduced with a plain video that has a *custom* poster.)

* Override `core/video`'s `render_email_callback` (via `block_type_metadata_settings`, priority 20 so it runs after the email editor's own priority-10 callback) to route the block through `Video_Block_Email_Renderer`.
* VideoPress videos (guid present) now render through the existing embed path — the same working path as the `videopress/video` block.
* Plain uploaded `core/video` blocks (no guid) are delegated back to the email editor's `Video` renderer, so their existing poster handling is unchanged.
* Added unit tests for both branches and the filter callback.

## Related product discussion/links
* https://github.com/Automattic/jetpack/issues/39662

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Requires a site with VideoPress and the block-based newsletter/email editor active.

* Upload a video to VideoPress, then add it to a post using the **core Video block** (`core/video`) — e.g. via the VideoPress embed/oEmbed, so the block carries a VideoPress `guid`.
* Add the same video as a **VideoPress block** (`videopress/video`) for comparison.
* Send the post as a newsletter (or use "Send a test email").
* **Before:** the core Video block shows no thumbnail; the VideoPress block does.
* **After:** both show a poster thumbnail.
* Regression check: add a **plain uploaded video** (no VideoPress) with a custom poster in a core Video block and confirm its poster still appears in the email.
