### PR TITLE
Run package tests with PHP 7.2 and 7.3 again

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -64,11 +64,12 @@ $matrix = array();
 // Add PHP tests.
 foreach ( array( '7.2', '7.3' ) as $php ) {
 	$matrix[] = array(
-		'name'    => "PHP tests: PHP $php WP previous",
-		'script'  => 'test-php',
-		'php'     => $php,
-		'wp'      => 'previous',
-		'timeout' => 20, // 2025-11-06: Successful runs seem to take ~7 minutes.
+		'name'                => "PHP tests: PHP $php WP previous",
+		'script'              => 'test-php',
+		'php'                 => $php,
+		'wp'                  => 'previous',
+		'force-package-tests' => true,
+		'timeout'             => 20, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	);
 }
 foreach ( array( '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ) as $php ) {

--- a/projects/packages/connection/changelog/fix-php-72-73-package-tests
+++ b/projects/packages/connection/changelog/fix-php-72-73-package-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix test that was broken in PHP 7.2.
+
+

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  * The nonce handler tests.
  */
 class Connection_Notice_Test extends TestCase {
+	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Database query filter.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #49017 switched these runs from WP latest to WP previous, which has the side effect of not running package tests. Set the flag to have the tests be run.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Package tests being run for 7.2 and 7.3 now?