### PR TITLE
Write: create a quote block from the `>` markdown shortcut

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-4461-should-create-quote
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-4461-should-create-quote
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: typing "> " at the start of an empty line now creates a quote block

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3857,6 +3857,38 @@ const { state } = store( 'wpcom-write', {
 				}
 			}
 
+			// Backspace in an empty blockquote: convert it back to a paragraph.
+			// Must run before the first-block Backspace guard below, otherwise the
+			// guard swallows Backspace when the quote is the editor's first block
+			// (e.g. just after the `>` markdown shortcut on a fresh post), leaving
+			// the user with no way to remove the quote.
+			if ( event.key === 'Backspace' ) {
+				const sel = window.getSelection();
+				if ( sel.rangeCount && sel.isCollapsed && ! getActiveCite() ) {
+					const bq = getActiveBlockquote();
+					if ( bq ) {
+						// Ignore the <cite> placeholder when checking for empty body.
+						const probe = bq.cloneNode( true );
+						const probeCite = probe.querySelector( 'cite' );
+						if ( probeCite ) {
+							probeCite.remove();
+						}
+						if ( probe.textContent.trim() === '' ) {
+							event.preventDefault();
+							flushUndoDebounce();
+							const p = document.createElement( 'p' );
+							p.innerHTML = '<br>';
+							bq.after( p );
+							bq.remove();
+							placeCursorAt( p );
+							state.formatQuote = false;
+							pushToUndoHistory();
+							return;
+						}
+					}
+				}
+			}
+
 			// Block Backspace at the very start of the first block. With nothing
 			// to merge into, some browsers respond by unwrapping the structure
 			// — including the .bw-content-inner wrapper that protects user

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2441,6 +2441,39 @@ function applyMarkdownListShortcut( paragraph, listTag ) {
 }
 
 /**
+ * Detect a markdown blockquote shortcut in a paragraph's text.
+ *
+ * Returns true for a lone `>` marker. Captured before the trigger space is
+ * inserted, so the marker should be the only content — trailing whitespace is
+ * allowed to tolerate a stray <br>-only text node that contentEditable can
+ * leave in an otherwise-empty block, matching parseMarkdownListShortcut.
+ *
+ * @param {string} text - The paragraph's text content.
+ * @return {boolean} Whether the text is a blockquote shortcut.
+ */
+function parseMarkdownQuoteShortcut( text ) {
+	return /^>\s*$/.test( text );
+}
+
+/**
+ * Replace a paragraph with an empty blockquote, and move the cursor into it.
+ *
+ * Mirrors the slash-menu quote insert (insertNewBlock( 'blockquote' )): the
+ * <cite> attribution placeholder is added by the citation lifecycle once the
+ * cursor lands inside the blockquote.
+ *
+ * @param {HTMLElement} paragraph - The paragraph to convert.
+ */
+function applyMarkdownQuoteShortcut( paragraph ) {
+	const blockquote = document.createElement( 'blockquote' );
+	blockquote.innerHTML = '<br>';
+	paragraph.after( blockquote );
+	paragraph.remove();
+	placeCursorAt( blockquote );
+	state.formatQuote = true;
+}
+
+/**
  * Find the blockquote element containing the current cursor, if any.
  *
  * @return {HTMLElement|null} The blockquote element or null.
@@ -3895,9 +3928,10 @@ const { state } = store( 'wpcom-write', {
 				}
 			}
 
-			// Markdown list shortcut: typing space after `-`, `*`, `+`, or `1.` at the
-			// start of an otherwise-empty paragraph converts it to a list. The space
-			// itself is swallowed so the user lands at column 0 of the new <li>.
+			// Markdown shortcuts: typing space after `-`, `*`, `+`, or `1.` at the
+			// start of an otherwise-empty paragraph converts it to a list, and `>`
+			// converts it to a blockquote. The space itself is swallowed so the user
+			// lands at column 0 of the new block.
 			if ( event.key === ' ' && ! state.showSlashMenu ) {
 				const sel = window.getSelection();
 				if ( sel.rangeCount && sel.isCollapsed ) {
@@ -3914,6 +3948,13 @@ const { state } = store( 'wpcom-write', {
 							event.preventDefault();
 							flushUndoDebounce();
 							applyMarkdownListShortcut( block, listTag );
+							pushToUndoHistory();
+							return;
+						}
+						if ( parseMarkdownQuoteShortcut( block.textContent ) ) {
+							event.preventDefault();
+							flushUndoDebounce();
+							applyMarkdownQuoteShortcut( block );
 							pushToUndoHistory();
 							return;
 						}


### PR DESCRIPTION
## Proposed changes

* In the Write editor, typing `>` followed by a space at the start of an otherwise-empty paragraph now converts it into a quote block.
* This brings `>` in line with the existing markdown shortcuts that the editor already supports for lists (`-`, `*`, `+`, and `1.`).
* The trigger space is swallowed so the cursor lands at the start of the new quote, and the existing citation-placeholder lifecycle adds the `<cite>` element on entry — so a markdown-created quote behaves identically to one inserted via the slash menu.
* The shortcut only fires on an empty top-level paragraph where `>` is the sole content, so it won't hijack a `>` typed mid-sentence or inside headings/lists.
* Backspace in an empty blockquote now converts it back to a paragraph. The editor's first-block Backspace guard previously swallowed the keystroke for a quote created as the first block (easy to do with this shortcut on a fresh post), leaving no way to remove it. Lists already had this escape hatch; quotes now match. Quotes that still contain text are left untouched.

## Related product discussion/links

* RSM-4461

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Write editor (`wp-admin/admin.php?page=write`).
* On an empty line, type `>` then a space.
  * Expected: the line immediately becomes a quote block (left border, italic), the cursor is inside it, and there is no leading space or visible `>`.
* Type some text, then **Save draft** and open the post in the block editor (Code editor view).
  * Expected: a real quote block in the markup:
    ```
    <!-- wp:quote -->
    <blockquote class="wp-block-quote"><p>…</p></blockquote>
    <!-- /wp:quote -->
    ```
* Backspace behaviour:
  * Create a quote as the very first block (`>` + space on a fresh post), leave it empty, and press Backspace → it converts back to a normal paragraph (previously it was stuck).
  * A quote that still contains text is preserved when you press Backspace at its start.
* Negative checks:
  * Type `text >` then space mid-line → stays a paragraph (only a lone `>` at line start converts).
  * Confirm the existing list shortcuts (`-`/`1.` + space) still work.
* Press Ctrl/Cmd+Z right after conversion → reverts to the `>` paragraph.