### PR TITLE
Write editor: allow spaces inside #tags

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-4459-allow-spaces-in-tags
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-4459-allow-spaces-in-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: allow spaces inside #tags (e.g. "#New York") by treating # as the tag delimiter instead of whitespace.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5967,11 +5967,22 @@ async function savePost( postStatus, isAutosave = false ) {
 
 	// Extract #tags from lines that contain only hashtag tokens (e.g. "#travel #food").
 	// Those paragraphs are metadata, not body text — strip them from the saved content.
+	// Each # starts a new tag whose name runs until the next # (or end of line), so a
+	// tag may contain spaces ("#New York"). The char right after # must be non-whitespace
+	// so a line like "# Heading" stays body text rather than becoming one giant tag.
 	const tagNames = [];
 	clone.querySelectorAll( ':scope > p' ).forEach( p => {
 		const text = p.textContent.trim();
-		if ( /^(#[\w-]+\s*)+$/.test( text ) ) {
-			text.match( /#([\w-]+)/g ).forEach( t => tagNames.push( t.slice( 1 ) ) );
+		if ( /^(#\S[^#]*)+$/.test( text ) ) {
+			text
+				.split( '#' )
+				.slice( 1 )
+				.forEach( name => {
+					const trimmed = name.trim();
+					if ( trimmed ) {
+						tagNames.push( trimmed );
+					}
+				} );
 			p.remove();
 		}
 	} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5967,13 +5967,14 @@ async function savePost( postStatus, isAutosave = false ) {
 
 	// Extract #tags from lines that contain only hashtag tokens (e.g. "#travel #food").
 	// Those paragraphs are metadata, not body text — strip them from the saved content.
-	// Each # starts a new tag whose name runs until the next # (or end of line), so a
-	// tag may contain spaces ("#New York"). The char right after # must be non-whitespace
-	// so a line like "# Heading" stays body text rather than becoming one giant tag.
+	// Each # starts a new tag, and a tag may contain spaces ("#New York"). To keep prose
+	// that merely starts with a # ("#1 reason you should read this") out of the tag list,
+	// each tag is capped at three whitespace-separated words. The char right after # must
+	// be a non-# non-space, so "# Heading" and "## Heading" stay body text.
 	const tagNames = [];
 	clone.querySelectorAll( ':scope > p' ).forEach( p => {
 		const text = p.textContent.trim();
-		if ( /^(#\S[^#]*)+$/.test( text ) ) {
+		if ( /^(#[^#\s]+(?:\s+[^#\s]+){0,2}\s*)+$/.test( text ) ) {
 			text
 				.split( '#' )
 				.slice( 1 )


### PR DESCRIPTION
## Proposed changes

In the Write editor, tags are entered as a line containing only `#tags` (e.g. `#travel #food`). The parser previously used whitespace as the tag delimiter, so a multi-word tag like `#New York` was never recognized — the space "broke" the tags line and the whole line was saved as body text.

This PR makes `#` the delimiter instead: each `#` starts a new tag whose name runs until the next `#` or the end of the line, so tags may contain spaces. `#New York #Los Angeles` now yields the tags "New York" and "Los Angeles".

* `view.js`: recognize a tags line with `/^(#[^#\s]+(?:\s+[^#\s]+){0,2}\s*)+$/` and split tag names on `#` (trim, drop empties).
* **Each tag is capped at three whitespace-separated words.** Once spaces are allowed inside a tag, a line like `#1 reason you should read this` is ambiguous between "a long tag" and "prose that starts with a hashtag". Capping at three words keeps real multi-word tags working (`#New York City`) while leaving prose paragraphs in the post body instead of silently stripping them.
* The character right after a `#` must be a non-`#`, non-space char, so `# Heading` and `## Heading` stay body text rather than becoming tags.
* Side benefit: tag names now accept accents, apostrophes, and other punctuation that the old `[\w-]` pattern rejected.

## Related product discussion/links

* RSM-4459

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Write editor (`wp-admin` → `admin.php?page=write`), write some body text, then add a paragraph containing only tags.
2. Add the line `#New York #Los Angeles` and Save draft / Publish.
3. Open the post in the block editor (or check the Tags panel / `/wp/v2/tags`) — confirm two tags, **"New York"** and **"Los Angeles"**, and that the `#…` line is stripped from the post body.
4. Multi-word / regression: `#New York City` → one tag "New York City"; `#travel #food` → "travel", "food"; `#single` → one tag; `#multi-word-hyphen` → one tag.
5. Lines that should stay as body text (no tags created, not stripped):
   * `#1 reason you should read this` (prose starting with `#`, more than three words)
   * `# Heading` (space after `#`) and `## Heading`
   * `Hello #world` (text before `#`)
   * a line containing only `#`
6. Reopen the published post in the Write editor and save again — confirm tags aren't duplicated.