### PR TITLE
Fix stats raw bucket period matching

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-stats-raw-buckets-period-start
+++ b/projects/packages/premium-analytics/changelog/fix-stats-raw-buckets-period-start
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Resolve single-period raw data buckets keyed by period start date.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -79,4 +79,45 @@ describe( 'Stats report utilities', () => {
 			)
 		).toEqual( [ [ '2026-06-16', { total_views: 24 } ] ] );
 	} );
+
+	it( 'falls through to the range filter when no single raw bucket matches', () => {
+		expect(
+			getStatsBuckets(
+				{
+					date: '2026-06-23',
+					period: 'week',
+					days: {
+						'2026-06-09': { total_views: 12 },
+						'2026-06-16': { total_views: 24 },
+					},
+				},
+				{
+					period: 'week',
+					end_date: '2026-06-23',
+				}
+			)
+		).toEqual( [
+			[ '2026-06-09', { total_views: 12 } ],
+			[ '2026-06-16', { total_views: 24 } ],
+		] );
+	} );
+
+	it( 'resolves month raw buckets by normalized period start date', () => {
+		expect(
+			getStatsBuckets(
+				{
+					date: '2026-06',
+					period: 'month',
+					days: {
+						'2026-05-01': { total_views: 31 },
+						'2026-06-01': { total_views: 62 },
+					},
+				},
+				{
+					period: 'month',
+					end_date: '2026-06',
+				}
+			)
+		).toEqual( [ [ '2026-06-01', { total_views: 62 } ] ] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { combineStatsNormalizedReports, sanitizeStatsTopPostsResponse } from '..';
 import { topPostsFixture, topPostsSummaryFixture } from '../__fixtures__/top-posts';
-import { getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
+import { getStatsBuckets, getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
 
 describe( 'Stats report utilities', () => {
 	it( 'combines separately requested summary and by-date data', () => {
@@ -59,5 +59,24 @@ describe( 'Stats report utilities', () => {
 			date_start: '2026-06-16T00:00:00+00:00',
 			date_end: '2026-06-22T23:59:59+00:00',
 		} );
+	} );
+
+	it( 'resolves single raw buckets by period start date', () => {
+		expect(
+			getStatsBuckets(
+				{
+					date: '2026-06-22',
+					period: 'week',
+					days: {
+						'2026-06-09': { total_views: 12 },
+						'2026-06-16': { total_views: 24 },
+					},
+				},
+				{
+					period: 'week',
+					end_date: '2026-06-22',
+				}
+			)
+		).toEqual( [ [ '2026-06-16', { total_views: 24 } ] ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -134,6 +134,26 @@ export function normalizeStatsReportSummary(
 		: {};
 }
 
+function getStatsSingleBucketDate(
+	days: StatsRecord,
+	endDate: string,
+	period?: string
+): string | undefined {
+	if ( days[ endDate ] ) {
+		return endDate;
+	}
+
+	const startDate = getDateIntervalDateParts( endDate, period ).startDate;
+
+	if ( days[ startDate ] ) {
+		return startDate;
+	}
+
+	return Object.keys( days ).find(
+		key => getDateIntervalDateParts( key, period ).endDate === endDate
+	);
+}
+
 export function getStatsBuckets( response: unknown, query: StatsQueryParams = {} ) {
 	if ( query.summarize ) {
 		return [];
@@ -144,8 +164,12 @@ export function getStatsBuckets( response: unknown, query: StatsQueryParams = {}
 	const startDate = getDatePart( query.start_date );
 	const endDate = getStatsEndDateParam( query );
 
-	if ( endDate && ! startDate && days[ endDate ] ) {
-		return [ [ endDate, coerceStatsRecord( days[ endDate ] ) ] ] as const;
+	if ( endDate && ! startDate ) {
+		const bucketDate = getStatsSingleBucketDate( days, endDate, query.period );
+
+		if ( bucketDate ) {
+			return [ [ bucketDate, coerceStatsRecord( days[ bucketDate ] ) ] ] as const;
+		}
 	}
 
 	return Object.entries( days )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -139,13 +139,13 @@ function getStatsSingleBucketDate(
 	endDate: string,
 	period?: string
 ): string | undefined {
-	if ( days[ endDate ] ) {
+	if ( Object.prototype.hasOwnProperty.call( days, endDate ) ) {
 		return endDate;
 	}
 
 	const startDate = getDateIntervalDateParts( endDate, period ).startDate;
 
-	if ( days[ startDate ] ) {
+	if ( Object.prototype.hasOwnProperty.call( days, startDate ) ) {
 		return startDate;
 	}
 


### PR DESCRIPTION
Fixes WOOA7S-1577

## Proposed changes
* Resolve single-period Stats raw data buckets when the response keys the bucket by the period start date instead of the query end date.
* Keep range requests unchanged while preventing older raw buckets from being included in a single-period response.
* Add regression coverage for a weekly response keyed by the period start date.

## Related product discussion/links
* WOOA7S-1577

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
