### PR TITLE
Premium Analytics: tighten stats date bucket fallback

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1578-tighten-stats-date-bucket-fallback
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1578-tighten-stats-date-bucket-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Fix single-day reports to return no data when the requested date bucket is missing.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
@@ -75,6 +75,15 @@ describe( 'Stats top posts normalizer', () => {
 		] );
 	} );
 
+	it( 'returns no by-date data when the requested date bucket is missing', () => {
+		const result = sanitizeStatsTopPostsResponse( topPostsFixture, {
+			period: 'day',
+			end_date: '2026-06-17',
+		} );
+
+		expect( result.data ).toEqual( [] );
+	} );
+
 	it( 'keeps all by-date buckets when the query has a range end date', () => {
 		const result = sanitizeStatsTopPostsResponse( topPostsFixture, {
 			period: 'day',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { combineStatsNormalizedReports, sanitizeStatsTopPostsResponse } from '..';
 import { topPostsFixture, topPostsSummaryFixture } from '../__fixtures__/top-posts';
-import { getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
+import { getStatsBuckets, getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
 
 describe( 'Stats report utilities', () => {
 	it( 'combines separately requested summary and by-date data', () => {
@@ -59,5 +59,22 @@ describe( 'Stats report utilities', () => {
 			date_start: '2026-06-16T00:00:00+00:00',
 			date_end: '2026-06-22T23:59:59+00:00',
 		} );
+	} );
+
+	it( 'does not fall back to earlier buckets when a single requested date is missing', () => {
+		expect(
+			getStatsBuckets(
+				{
+					days: {
+						'2026-06-15': { views: [ { value: 'older' } ] },
+						'2026-06-16': { views: [ { value: 'newer' } ] },
+					},
+				},
+				{
+					period: 'day',
+					end_date: '2026-06-17',
+				}
+			)
+		).toEqual( [] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -144,8 +144,10 @@ export function getStatsBuckets( response: unknown, query: StatsQueryParams = {}
 	const startDate = getDatePart( query.start_date );
 	const endDate = getStatsEndDateParam( query );
 
-	if ( endDate && ! startDate && days[ endDate ] ) {
-		return [ [ endDate, coerceStatsRecord( days[ endDate ] ) ] ] as const;
+	if ( endDate && ! startDate ) {
+		return days[ endDate ]
+			? ( [ [ endDate, coerceStatsRecord( days[ endDate ] ) ] ] as const )
+			: [];
 	}
 
 	return Object.entries( days )


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1578/stats-normalizers-tighten-missing-date-bucket-fallback

## Proposed changes
* Return no normalized by-date data for single-day Stats report requests when the requested date bucket is missing.
* Keep range requests unchanged, so explicit `start_date`/`end_date` requests still include all matching buckets.
* Add utility and top-posts normalizer regression coverage.

## Related product discussion/links
* WOOA7S-1578

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Confirm both commands pass.
