### PR TITLE
SEO Settings: simplify search/social preview card borders

### DIFF
--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -141,21 +141,21 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 				<div className="jetpack-seo-settings__preview-list">
 					{ /* Each block: a platform heading above its preview. The border is on
 					   the preview itself (not a group box around heading + preview). */ }
-					<div className="jetpack-seo-settings__preview-block">
+					<div>
 						<h3 className="jetpack-seo-settings__preview-label">
 							<GoogleIcon />
 							{ __( 'Google search result', 'jetpack-seo' ) }
 						</h3>
 						<GooglePreview site={ site } description={ description } />
 					</div>
-					<div className="jetpack-seo-settings__preview-block">
+					<div>
 						<h3 className="jetpack-seo-settings__preview-label">
 							<FacebookIcon />
 							{ __( 'Facebook', 'jetpack-seo' ) }
 						</h3>
 						<LinkCardPreview site={ site } description={ description } />
 					</div>
-					<div className="jetpack-seo-settings__preview-block">
+					<div>
 						<h3 className="jetpack-seo-settings__preview-label">
 							<XIcon />
 							{ __( 'X (Twitter)', 'jetpack-seo' ) }

--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -23,6 +23,27 @@ function hostname( url: string ): string {
 // Small inline brand marks for the preview headings (no icon dependency). Each
 // is hidden from assistive tech — the heading text already names the platform.
 
+const GoogleIcon: FC = () => (
+	<svg className="jetpack-seo-preview__platform-icon" viewBox="0 0 48 48" aria-hidden="true">
+		<path
+			fill="#EA4335"
+			d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+		/>
+		<path
+			fill="#4285F4"
+			d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+		/>
+		<path
+			fill="#FBBC05"
+			d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+		/>
+		<path
+			fill="#34A853"
+			d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+		/>
+	</svg>
+);
+
 const FacebookIcon: FC = () => (
 	<svg
 		className="jetpack-seo-preview__platform-icon"
@@ -118,10 +139,15 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 					) }
 				</p>
 				<div className="jetpack-seo-settings__preview-list">
-					{ /* The Google result carries the only border (added in CSS) and no
-					   heading — the bordered search-result chrome reads as Google on its
-					   own. */ }
-					<GooglePreview site={ site } description={ description } />
+					{ /* Each block: a platform heading above its preview. The border is on
+					   the preview itself (not a group box around heading + preview). */ }
+					<div className="jetpack-seo-settings__preview-block">
+						<h3 className="jetpack-seo-settings__preview-label">
+							<GoogleIcon />
+							{ __( 'Google search result', 'jetpack-seo' ) }
+						</h3>
+						<GooglePreview site={ site } description={ description } />
+					</div>
 					<div className="jetpack-seo-settings__preview-block">
 						<h3 className="jetpack-seo-settings__preview-label">
 							<FacebookIcon />

--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -23,27 +23,6 @@ function hostname( url: string ): string {
 // Small inline brand marks for the preview headings (no icon dependency). Each
 // is hidden from assistive tech — the heading text already names the platform.
 
-const GoogleIcon: FC = () => (
-	<svg className="jetpack-seo-preview__platform-icon" viewBox="0 0 48 48" aria-hidden="true">
-		<path
-			fill="#EA4335"
-			d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
-		/>
-		<path
-			fill="#4285F4"
-			d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
-		/>
-		<path
-			fill="#FBBC05"
-			d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
-		/>
-		<path
-			fill="#34A853"
-			d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
-		/>
-	</svg>
-);
-
 const FacebookIcon: FC = () => (
 	<svg
 		className="jetpack-seo-preview__platform-icon"
@@ -138,26 +117,25 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 						'jetpack-seo'
 					) }
 				</p>
-				<div className="jetpack-seo-settings__preview-group">
-					<h3 className="jetpack-seo-settings__preview-label">
-						<GoogleIcon />
-						{ __( 'Google search result', 'jetpack-seo' ) }
-					</h3>
+				<div className="jetpack-seo-settings__preview-list">
+					{ /* The Google result carries the only border (added in CSS) and no
+					   heading — the bordered search-result chrome reads as Google on its
+					   own. */ }
 					<GooglePreview site={ site } description={ description } />
-				</div>
-				<div className="jetpack-seo-settings__preview-group">
-					<h3 className="jetpack-seo-settings__preview-label">
-						<FacebookIcon />
-						{ __( 'Facebook', 'jetpack-seo' ) }
-					</h3>
-					<LinkCardPreview site={ site } description={ description } />
-				</div>
-				<div className="jetpack-seo-settings__preview-group">
-					<h3 className="jetpack-seo-settings__preview-label">
-						<XIcon />
-						{ __( 'X (Twitter)', 'jetpack-seo' ) }
-					</h3>
-					<LinkCardPreview site={ site } description={ description } />
+					<div className="jetpack-seo-settings__preview-block">
+						<h3 className="jetpack-seo-settings__preview-label">
+							<FacebookIcon />
+							{ __( 'Facebook', 'jetpack-seo' ) }
+						</h3>
+						<LinkCardPreview site={ site } description={ description } />
+					</div>
+					<div className="jetpack-seo-settings__preview-block">
+						<h3 className="jetpack-seo-settings__preview-label">
+							<XIcon />
+							{ __( 'X (Twitter)', 'jetpack-seo' ) }
+						</h3>
+						<LinkCardPreview site={ site } description={ description } />
+					</div>
 				</div>
 			</CollapsibleCard.Content>
 		</CollapsibleCard.Root>

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -111,9 +111,9 @@
 	margin: 0 0 var(--wpds-dimension-gap-xl, 24px);
 }
 
-// The previews stack with generous separation between them. No bordered group
-// wrapper — only the Google result is bordered (below), so the section avoids a
-// box-in-box look.
+// The previews stack with generous separation between them. Each preview is
+// bordered individually (below); there's no bordered group wrapping a heading
+// together with its preview, which avoids the box-in-box look.
 .jetpack-seo-settings__preview-list {
 	display: flex;
 	flex-direction: column;
@@ -149,8 +149,8 @@
 	color: var(--wpds-color-fg-content-neutral-weak, #757575);
 }
 
-// Google search result — the one bordered preview, so it's set off as a result
-// without needing a heading.
+// Google search result — bordered around the preview itself (it has none
+// otherwise), set off as a result beneath its heading.
 .jetpack-seo-preview--google {
 	padding: var(--wpds-dimension-padding-md, 12px);
 	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dadde1);
@@ -186,10 +186,12 @@
 	}
 }
 
-// Facebook / X shared link card. Borderless (only Google is bordered); the
-// filled card body + image still read as a shared-link card.
+// Facebook / X shared link card — bordered around the preview itself (matching
+// how the platforms render a shared link), but not wrapped in a group box with
+// its heading.
 .jetpack-seo-preview--card {
 	overflow: hidden;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dadde1);
 	border-radius: var(--wpds-border-radius-md, 4px);
 
 	.jetpack-seo-preview__image {

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -111,16 +111,13 @@
 	margin: 0 0 var(--wpds-dimension-gap-xl, 24px);
 }
 
-// Each preview + its heading grouped inside a bordered, padded box so it reads
-// as one unit, with generous separation between groups.
-.jetpack-seo-settings__preview-group {
-	padding: 16px;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dadde1);
-	border-radius: var(--wpds-border-radius-md, 4px);
-}
-
-.jetpack-seo-settings__preview-group + .jetpack-seo-settings__preview-group {
-	margin-block-start: var(--wpds-dimension-gap-2xl, 32px);
+// The previews stack with generous separation between them. No bordered group
+// wrapper — only the Google result is bordered (below), so the section avoids a
+// box-in-box look.
+.jetpack-seo-settings__preview-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-2xl, 32px);
 }
 
 // Platform label above each preview: brand icon + name, prominent enough to
@@ -152,8 +149,12 @@
 	color: var(--wpds-color-fg-content-neutral-weak, #757575);
 }
 
-// Google search result.
+// Google search result — the one bordered preview, so it's set off as a result
+// without needing a heading.
 .jetpack-seo-preview--google {
+	padding: var(--wpds-dimension-padding-md, 12px);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dadde1);
+	border-radius: var(--wpds-border-radius-md, 4px);
 
 	.jetpack-seo-preview__google-site {
 		display: flex;
@@ -185,10 +186,10 @@
 	}
 }
 
-// Facebook / X shared link card.
+// Facebook / X shared link card. Borderless (only Google is bordered); the
+// filled card body + image still read as a shared-link card.
 .jetpack-seo-preview--card {
 	overflow: hidden;
-	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #dadde1);
 	border-radius: var(--wpds-border-radius-md, 4px);
 
 	.jetpack-seo-preview__image {

--- a/projects/packages/seo/changelog/add-jetpack-seo-simplify-preview-borders
+++ b/projects/packages/seo/changelog/add-jetpack-seo-simplify-preview-borders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Simplify the search/social preview card borders on the SEO Settings tab: drop the box-in-box grouping so only the Google search result is bordered (with its redundant heading removed); the Facebook/X cards render borderless.

--- a/projects/packages/seo/changelog/add-jetpack-seo-simplify-preview-borders
+++ b/projects/packages/seo/changelog/add-jetpack-seo-simplify-preview-borders
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Simplify the search/social preview card borders on the SEO Settings tab: drop the box-in-box grouping so only the Google search result is bordered (with its redundant heading removed); the Facebook/X cards render borderless.
+Simplify the search/social preview cards on the SEO Settings tab: drop the group border that boxed each platform heading together with its preview. Each preview keeps its own border (the Google result gains one; Facebook/X keep their card border) with the platform heading above it, removing the box-in-box look.


### PR DESCRIPTION
Resolves [JETPACK-1753](https://linear.app/a8c/issue/JETPACK-1753). Follow-up polish to the social previews (JETPACK-1704).

### Proposed changes

The "Search & social previews" card had a box-in-box-in-box look: the section card → a bordered group wrapping each platform heading **and** its preview → the inner preview/card border. This removes only the redundant **group** border:

- Each preview keeps a border **around the preview itself**: the Google search result gains one, and the Facebook/X cards keep their existing link-card border.
- The **group** border (which boxed a platform heading together with its preview) is gone — headings now sit directly above their preview, outside any box.
- All three platform headings remain, including **"Google search result"** (above the preview, not inside the border).

**Frontend only — no data/behavior change.**

**Screenshots**

<img width="1703" height="945" alt="Jetpack SEO social preview cards" src="https://github.com/user-attachments/assets/f814717c-b894-49b2-8ad6-83e5793e881b" />


### Testing instructions

1. Jetpack → SEO → Settings → expand **Search & social previews**.
2. Confirm each preview (Google, Facebook, X) has a border around the preview itself, with its platform heading above it.
3. Confirm there's no extra outer box wrapping the heading + preview together (no box-in-box).
4. Edit the front-page description above → previews update live.

#### Test environments
- [ ] Simple
- [x] Atomic
- [x] Self-hosted
- [x] Connected
- [ ] Offline mode

### Screenshots

_Screenshots to be added by author._

## Does this pull request change what data or activity we track or use?

No. Purely a visual/CSS change to existing previews; no tracking or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
