### PR TITLE
SEO Content: completion rings for all four content settings, in page order

### DIFF
--- a/projects/packages/seo/_inc/data/content-types.ts
+++ b/projects/packages/seo/_inc/data/content-types.ts
@@ -47,6 +47,8 @@ export interface PostTypeOption {
 // SEO is saved on the Content tab: +1 / -1 / 0 per metric depending on whether
 // the field became set or unset.
 export interface CoverageDelta {
-	description: number;
 	schema: number;
+	title: number;
+	description: number;
+	search_visible: number;
 }

--- a/projects/packages/seo/_inc/data/coverage-store.ts
+++ b/projects/packages/seo/_inc/data/coverage-store.ts
@@ -60,8 +60,10 @@ const store = createReduxStore( STORE_NAME, {
 			return {
 				coverage: {
 					...state.coverage,
-					with_description: state.coverage.with_description + action.delta.description,
 					with_schema: state.coverage.with_schema + action.delta.schema,
+					with_title: state.coverage.with_title + action.delta.title,
+					with_description: state.coverage.with_description + action.delta.description,
+					with_search_visible: state.coverage.with_search_visible + action.delta.search_visible,
 				},
 			};
 		}

--- a/projects/packages/seo/_inc/data/overview-types.ts
+++ b/projects/packages/seo/_inc/data/overview-types.ts
@@ -18,8 +18,10 @@ export interface SiteVerification {
 
 export interface ContentCoverage {
 	total: number;
-	with_description: number;
 	with_schema: number;
+	with_title: number;
+	with_description: number;
+	with_search_visible: number;
 }
 
 export interface OverviewResponse {

--- a/projects/packages/seo/_inc/data/test/coverage-store.test.ts
+++ b/projects/packages/seo/_inc/data/test/coverage-store.test.ts
@@ -17,27 +17,34 @@ describe( 'coverage-store', () => {
 
 	it( 'applies a positive description delta to the counts', () => {
 		const registry = makeRegistry();
-		registry.dispatch( coverageStore ).applyCoverageDelta( { description: 1, schema: 0 } );
+		registry
+			.dispatch( coverageStore )
+			.applyCoverageDelta( { schema: 0, title: 0, description: 1, search_visible: 0 } );
 		expect( registry.select( coverageStore ).getCoverage() ).toEqual( {
-			total: 10,
+			...SEEDED_COVERAGE,
 			with_description: 5,
-			with_schema: 3,
 		} );
 	} );
 
-	it( 'applies a negative description and positive schema delta', () => {
+	it( 'applies deltas across all four metrics at once', () => {
 		const registry = makeRegistry();
-		registry.dispatch( coverageStore ).applyCoverageDelta( { description: -1, schema: 1 } );
+		registry
+			.dispatch( coverageStore )
+			.applyCoverageDelta( { schema: 1, title: -1, description: -1, search_visible: 1 } );
 		expect( registry.select( coverageStore ).getCoverage() ).toEqual( {
 			total: 10,
-			with_description: 3,
 			with_schema: 4,
+			with_title: 5,
+			with_description: 3,
+			with_search_visible: 9,
 		} );
 	} );
 
-	it( 'ignores unrelated actions', () => {
+	it( 'ignores a zero delta', () => {
 		const registry = makeRegistry();
-		registry.dispatch( coverageStore ).applyCoverageDelta( { description: 0, schema: 0 } );
+		registry
+			.dispatch( coverageStore )
+			.applyCoverageDelta( { schema: 0, title: 0, description: 0, search_visible: 0 } );
 		expect( registry.select( coverageStore ).getCoverage() ).toEqual( SEEDED_COVERAGE );
 	} );
 } );

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -11,8 +11,10 @@ import type { SettingsResponse } from '../../settings-types';
 
 export const SEEDED_COVERAGE: ContentCoverage = {
 	total: 10,
-	with_description: 4,
 	with_schema: 3,
+	with_title: 6,
+	with_description: 4,
+	with_search_visible: 8,
 };
 
 export const SEEDED_SETTINGS: SettingsResponse = {

--- a/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
+++ b/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
@@ -131,6 +131,8 @@ const SeoInspector: FC< Props > = ( { postId, postType, onClose } ) => {
 				recordMeta?.jetpack_seo_schema_type === 'article' ||
 				recordMeta?.jetpack_seo_schema_type === 'faq';
 			const priorHasTitle = ( recordMeta?.jetpack_seo_html_title ?? '' ) !== '';
+			// Normalize noindex to a boolean first (matching how local state is seeded
+			// above) so visibility is computed consistently regardless of the raw shape.
 			const priorVisible = ! recordMeta?.jetpack_seo_noindex;
 			applyCoverageDelta( {
 				schema: Number( local.jetpack_seo_schema_type !== '' ) - Number( priorHasSchema ),

--- a/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
+++ b/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
@@ -131,9 +131,10 @@ const SeoInspector: FC< Props > = ( { postId, postType, onClose } ) => {
 				recordMeta?.jetpack_seo_schema_type === 'article' ||
 				recordMeta?.jetpack_seo_schema_type === 'faq';
 			const priorHasTitle = ( recordMeta?.jetpack_seo_html_title ?? '' ) !== '';
-			// Normalize noindex to a boolean first (matching how local state is seeded
-			// above) so visibility is computed consistently regardless of the raw shape.
-			const priorVisible = ! recordMeta?.jetpack_seo_noindex;
+			// Coerce noindex to a boolean (matching how local state is seeded above) so
+			// visibility is computed consistently.
+			const priorNoindex = !! recordMeta?.jetpack_seo_noindex;
+			const priorVisible = ! priorNoindex;
 			applyCoverageDelta( {
 				schema: Number( local.jetpack_seo_schema_type !== '' ) - Number( priorHasSchema ),
 				title: Number( local.jetpack_seo_html_title !== '' ) - Number( priorHasTitle ),

--- a/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
+++ b/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
@@ -123,15 +123,21 @@ const SeoInspector: FC< Props > = ( { postId, postType, onClose } ) => {
 				type: 'snackbar',
 			} );
 			// Reflect the edit on the Overview coverage card without a reload,
-			// baselining the delta against the live pre-save record's meta.
+			// baselining the delta against the live pre-save record's meta. Search
+			// visibility is the inverse of noindex, so a post counts as "visible"
+			// when noindex is off.
 			const priorHasDescription = ( recordMeta?.advanced_seo_description ?? '' ) !== '';
 			const priorHasSchema =
 				recordMeta?.jetpack_seo_schema_type === 'article' ||
 				recordMeta?.jetpack_seo_schema_type === 'faq';
+			const priorHasTitle = ( recordMeta?.jetpack_seo_html_title ?? '' ) !== '';
+			const priorVisible = ! recordMeta?.jetpack_seo_noindex;
 			applyCoverageDelta( {
+				schema: Number( local.jetpack_seo_schema_type !== '' ) - Number( priorHasSchema ),
+				title: Number( local.jetpack_seo_html_title !== '' ) - Number( priorHasTitle ),
 				description:
 					Number( local.advanced_seo_description !== '' ) - Number( priorHasDescription ),
-				schema: Number( local.jetpack_seo_schema_type !== '' ) - Number( priorHasSchema ),
+				search_visible: Number( ! local.jetpack_seo_noindex ) - Number( priorVisible ),
 			} );
 			onClose();
 		} catch ( error ) {

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -55,7 +55,7 @@ const CoverageRing: FC< RingProps > = ( { label, segment, total } ) => (
 );
 
 const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
-	const { total, with_description, with_schema } = data;
+	const { total, with_schema, with_title, with_description, with_search_visible } = data;
 
 	return (
 		<Card.Root>
@@ -68,13 +68,23 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
 				) : (
 					<div className="jetpack-seo-overview__coverage-rings">
 						<CoverageRing
+							label={ __( 'Schema', 'jetpack-seo' ) }
+							segment={ with_schema }
+							total={ total }
+						/>
+						<CoverageRing
+							label={ __( 'SEO title', 'jetpack-seo' ) }
+							segment={ with_title }
+							total={ total }
+						/>
+						<CoverageRing
 							label={ __( 'Meta description', 'jetpack-seo' ) }
 							segment={ with_description }
 							total={ total }
 						/>
 						<CoverageRing
-							label={ __( 'Schema type', 'jetpack-seo' ) }
-							segment={ with_schema }
+							label={ __( 'Search engine visibility', 'jetpack-seo' ) }
+							segment={ with_search_visible }
 							total={ total }
 						/>
 					</div>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -68,22 +68,22 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
 				) : (
 					<div className="jetpack-seo-overview__coverage-rings">
 						<CoverageRing
-							label={ __( 'Schema', 'jetpack-seo' ) }
+							label={ __( 'Schema applied', 'jetpack-seo' ) }
 							segment={ with_schema }
 							total={ total }
 						/>
 						<CoverageRing
-							label={ __( 'SEO title', 'jetpack-seo' ) }
+							label={ __( 'SEO title set', 'jetpack-seo' ) }
 							segment={ with_title }
 							total={ total }
 						/>
 						<CoverageRing
-							label={ __( 'Meta description', 'jetpack-seo' ) }
+							label={ __( 'Meta description added', 'jetpack-seo' ) }
 							segment={ with_description }
 							total={ total }
 						/>
 						<CoverageRing
-							label={ __( 'Search engine visibility', 'jetpack-seo' ) }
+							label={ __( 'Visible to search engines', 'jetpack-seo' ) }
 							segment={ with_search_visible }
 							total={ total }
 						/>

--- a/projects/packages/seo/_inc/screens/overview/style.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.scss
@@ -66,7 +66,8 @@
 }
 
 .jetpack-seo-overview__coverage-label {
-	color: var(--wpds-color-fg-content-neutral-weak, #787c82);
+	// Inherit the card's text color rather than the muted `-neutral-weak` variant,
+	// so the metric labels match the rest of the text on the page.
 	font-size: 12px;
 }
 

--- a/projects/packages/seo/changelog/add-jetpack-seo-content-coverage-four-rings
+++ b/projects/packages/seo/changelog/add-jetpack-seo-content-coverage-four-rings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Show completion rings for all four Content SEO settings — schema, SEO title, meta description, and search-engine visibility — in the order they appear on the Content page, instead of only schema and meta description.

--- a/projects/packages/seo/changelog/add-jetpack-seo-content-coverage-four-rings
+++ b/projects/packages/seo/changelog/add-jetpack-seo-content-coverage-four-rings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Show completion rings for all four Content SEO settings — schema, SEO title, meta description, and search-engine visibility — in the order they appear on the Content page, instead of only schema and meta description.
+Show completion rings for all four Content SEO settings — schema, SEO title, meta description, and search engine visibility — in the order they appear on the Content page, instead of only schema and meta description.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -81,6 +81,8 @@ class Initializer {
 	 */
 	const META_DESCRIPTION = 'advanced_seo_description';
 	const META_SCHEMA_TYPE = 'jetpack_seo_schema_type';
+	const META_TITLE       = 'jetpack_seo_html_title';
+	const META_NOINDEX     = 'jetpack_seo_noindex';
 
 	/**
 	 * Option recording whether sitemap generation is enabled.
@@ -550,7 +552,7 @@ class Initializer {
 	 * posts/pages have each SEO field set. State, not a score — the card shows
 	 * proportions + raw counts and lets the admin decide what matters.
 	 *
-	 * @return array{total:int,with_description:int,with_schema:int}
+	 * @return array{total:int,with_schema:int,with_title:int,with_description:int,with_search_visible:int}
 	 */
 	private static function get_content_coverage() {
 		$post_types = array( 'post', 'page' );
@@ -561,10 +563,17 @@ class Initializer {
 			$total += isset( $counts->publish ) ? (int) $counts->publish : 0;
 		}
 
+		// Search-engine visibility is the inverse of the per-post noindex meta: a
+		// post is visible unless it's explicitly set to noindex (stored as '1'), so
+		// most posts (no meta row) count as visible.
+		$noindexed = self::count_published_with_meta( $post_types, self::META_NOINDEX, '1' );
+
 		return array(
-			'total'            => $total,
-			'with_description' => self::count_published_with_meta( $post_types, self::META_DESCRIPTION ),
-			'with_schema'      => self::count_published_with_meta( $post_types, self::META_SCHEMA_TYPE ),
+			'total'               => $total,
+			'with_schema'         => self::count_published_with_meta( $post_types, self::META_SCHEMA_TYPE ),
+			'with_title'          => self::count_published_with_meta( $post_types, self::META_TITLE ),
+			'with_description'    => self::count_published_with_meta( $post_types, self::META_DESCRIPTION ),
+			'with_search_visible' => max( 0, $total - $noindexed ),
 		);
 	}
 

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -50,12 +50,13 @@ class InitializerTest extends TestCase {
 		}
 		$coverage = $method->invoke( null );
 
-		$this->assertArrayHasKey( 'total', $coverage );
-		$this->assertArrayHasKey( 'with_description', $coverage );
-		$this->assertArrayHasKey( 'with_schema', $coverage );
-		$this->assertIsInt( $coverage['total'] );
-		$this->assertIsInt( $coverage['with_description'] );
-		$this->assertIsInt( $coverage['with_schema'] );
+		foreach ( array( 'total', 'with_schema', 'with_title', 'with_description', 'with_search_visible' ) as $key ) {
+			$this->assertArrayHasKey( $key, $coverage );
+			$this->assertIsInt( $coverage[ $key ] );
+		}
+
+		// Search-visible can never exceed the total (it's total minus noindexed).
+		$this->assertLessThanOrEqual( $coverage['total'], $coverage['with_search_visible'] );
 	}
 
 	/**


### PR DESCRIPTION
Resolves [JETPACK-1754](https://linear.app/a8c/issue/JETPACK-1754). Follow-up to the Content tab / coverage card (JETPACK-1680).

### Proposed changes

The Content SEO coverage card showed completion rings for only **2** settings (schema + meta description), and not in the order they appear on the Content page. This shows a ring for **all four** per-post settings, in page order:

1. Schema
2. SEO title
3. Meta description
4. Search-engine visibility

Changes:
- **PHP** `Initializer::get_content_coverage()` adds two counts — posts with an **SEO title** set (`jetpack_seo_html_title`) and posts that are **search-engine visible**. Search-visibility is the inverse of the per-post noindex meta: `total − (posts with jetpack_seo_noindex set)`, so the common case (no noindex meta) counts as visible.
- **Frontend** `ContentCoverage`, the coverage store, and `CoverageDelta` extended to the four metrics; the Content inspector's optimistic update now adjusts all four, so editing a post reflects on the Overview card without a reload.
- Rings render in the order above (the container already wraps responsively).
- Coverage tests updated: PHP shape/bounds + JS store deltas across all four metrics.

> Interpretation note: "search-engine visibility" is the **per-post** setting (share of published posts that are search-visible), matching the Content tab's per-post "Search visibility" column — not the site-level toggle. Easy to change if you meant site-level.

**Screenshots**

<img width="2762" height="1598" alt="Jetpack SEO content card 4 circles" src="https://github.com/user-attachments/assets/39998e32-5dd6-4281-8aa9-7c8c5ed1c540" />


### Testing instructions

1. Jetpack → SEO → Overview → **Content SEO** card.
2. Confirm **four** rings in order: Schema, SEO title, Meta description, Search engine visibility, each showing `n / total`.
3. On the Content tab, edit a post's SEO (set a title, toggle search visibility, etc.), save → return to Overview → the matching ring(s) update without a reload.

#### Test environments
- [ ] Simple
- [x] Atomic
- [x] Self-hosted
- [x] Connected
- [ ] Offline mode

### Screenshots

_Screenshots to be added by author._

## Does this pull request change what data or activity we track or use?

No. It reads existing per-post SEO meta to count coverage for the admin-only Overview card; no tracking or new data collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)