### PR TITLE
wpcom-admin-bar: fix site plan node spacing to match core

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-plan-node-spacing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-plan-node-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: fix spacing of the site plan submenu node by matching core's margin-top instead of zeroing padding.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -123,10 +123,11 @@
 /**
  * Site badge and plan info in the dropdown
  */
-// Drop core's .ab-submenu padding here to match Calypso.
-#wpadminbar #wp-admin-bar-site-name-default,
+
+// Match core's spacing for added submenu nodes instead of zeroing padding.
+// https://github.com/WordPress/WordPress/blob/c06456a36202fdb76787228f007b28e5028216fe/wp-includes/css/admin-bar.css#L546
 #wpadminbar #wp-admin-bar-site-plan {
-	padding: 0;
+	margin-top: -12px;
 }
 
 // Pad the wrapper top instead, pushing Visit Site down to match Calypso.


### PR DESCRIPTION
Fixes DOTMSD-1341

## Proposed changes
* Fixes the vertical spacing of the site plan node in the admin bar dropdown.
* I introduced this issue in https://github.com/Automattic/jetpack/pull/49611, where I zeroed out core's `.ab-submenu` padding (`padding: 0` on `#wp-admin-bar-site-plan`) to tighten the spacing. That was not the correct approach.
* This switches to doing the same thing core does for its own submenu nodes: applying `margin-top: -12px` to `#wp-admin-bar-site-plan`, matching [`wp-includes/css/admin-bar.css`](https://github.com/WordPress/WordPress/blob/c06456a36202fdb76787228f007b28e5028216fe/wp-includes/css/admin-bar.css#L546).

**Screenshot**

**Frontend**
Disregard the different items, environment related.
| Before | After |
|--------|--------|
| <img width="266" height="206" alt="Screenshot 2026-06-23 at 2 46 33 PM" src="https://github.com/user-attachments/assets/47cb601c-b85f-4ba9-b7f8-d857a4476b56" /> | <img width="262" height="205" alt="Screenshot 2026-06-23 at 2 46 59 PM" src="https://github.com/user-attachments/assets/26db052a-0a5f-401a-87f4-763187c98d0f" /> | 

**Backend**
<img width="265" height="158" alt="Screenshot 2026-06-23 at 2 49 02 PM" src="https://github.com/user-attachments/assets/b6032faf-a3d2-414d-aaeb-806fb74ab2e9" />




## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the `jetpack-mu-wpcom` package: `jetpack build packages/jetpack-mu-wpcom`.
* On a WordPress.com / Atomic-style site with the wpcom admin bar enabled, open the admin bar **Site Name** dropdown.
* Confirm the **Plan** node lines up with the other submenu items with consistent vertical spacing (no extra gap above/below it).
* Compare against `trunk` — the spacing should look the same or better, now driven by `margin-top: -12px` rather than zeroed padding.
