### PR TITLE
Cookie Consent: set host-only cookies to support multi-level TLDs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2427,6 +2427,9 @@ importers:
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.14)
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2
       postcss:
         specifier: 8.5.14
         version: 8.5.14

--- a/projects/packages/cookie-consent/changelog/fix-cookie-consent-multilevel-tld-cookie-domain
+++ b/projects/packages/cookie-consent/changelog/fix-cookie-consent-multilevel-tld-cookie-domain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set host-only cookies instead of deriving a cross-subdomain domain, which browsers reject on multi-level TLDs such as .co.uk and .com.br.

--- a/projects/packages/cookie-consent/jest.config.cjs
+++ b/projects/packages/cookie-consent/jest.config.cjs
@@ -1,0 +1,5 @@
+const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
+
+module.exports = {
+	...baseConfig,
+};

--- a/projects/packages/cookie-consent/package.json
+++ b/projects/packages/cookie-consent/package.json
@@ -21,6 +21,8 @@
 		"clean": "rm -rf build/",
 		"module:build": "webpack --config ./tools/webpack.config.modules.js",
 		"module:watch": "webpack --watch --config ./tools/webpack.config.modules.js",
+		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
+		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"watch": "pnpm run module:watch"
 	},
@@ -36,6 +38,7 @@
 		"@wordpress/base-styles": "10.0.1",
 		"@wordpress/browserslist-config": "6.48.1",
 		"autoprefixer": "10.4.20",
+		"jest": "30.4.2",
 		"postcss": "8.5.14",
 		"postcss-loader": "8.2.0",
 		"sass-embedded": "1.97.3",

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
@@ -36,11 +36,10 @@ export function setCookie(
 	const date = new Date();
 	date.setTime( date.getTime() + durationSeconds * 1000 );
 	const expires = `expires=${ date.toUTCString() }`;
-	const domain = window.location.hostname;
-	const domainPart = domain.includes( '.' )
-		? `domain=.${ domain.split( '.' ).slice( -2 ).join( '.' ) }`
-		: '';
-	document.cookie = `${ name }=${ value };${ expires };path=/;${ domainPart };SameSite=${ sameSite }`;
+	// Host-only cookie (no domain attribute), matching the WP Consent API. Deriving a
+	// cross-subdomain domain from the hostname breaks on multi-level TLDs (e.g. `.co.uk`,
+	// `.com.br`), where the last two labels are a public suffix that browsers reject.
+	document.cookie = `${ name }=${ value };${ expires };path=/;SameSite=${ sameSite }`;
 }
 
 export function hasConsentSet(): boolean {

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for cookie-consent utils.
+ *
+ * @jest-environment-options {"url": "https://shop.example.co.uk/"}
+ */
+
+import { getCookie, setCookie } from '../src/modules/cookie-consent/utils';
+
+describe( 'setCookie', () => {
+	let writes: string[];
+	let originalCookie: PropertyDescriptor | undefined;
+
+	beforeEach( () => {
+		writes = [];
+		originalCookie = Object.getOwnPropertyDescriptor( Document.prototype, 'cookie' );
+		Object.defineProperty( document, 'cookie', {
+			configurable: true,
+			get: () => '',
+			set: ( value: string ) => {
+				writes.push( value );
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		delete ( document as unknown as { cookie?: string } ).cookie;
+		if ( originalCookie ) {
+			Object.defineProperty( Document.prototype, 'cookie', originalCookie );
+		}
+	} );
+
+	it( 'writes the name, value, path, expiry and SameSite attributes', () => {
+		setCookie( 'my_cookie', 'yes', 3600 );
+
+		expect( writes ).toHaveLength( 1 );
+		expect( writes[ 0 ] ).toContain( 'my_cookie=yes' );
+		expect( writes[ 0 ] ).toContain( 'path=/' );
+		expect( writes[ 0 ] ).toContain( 'expires=' );
+		expect( writes[ 0 ] ).toContain( 'SameSite=Strict' );
+	} );
+
+	it( 'honours a custom SameSite value', () => {
+		setCookie( 'my_cookie', 'yes', 3600, 'Lax' );
+
+		expect( writes[ 0 ] ).toContain( 'SameSite=Lax' );
+	} );
+
+	it( 'sets a host-only cookie with no domain attribute, even on multi-level TLDs', () => {
+		// Regression: deriving `domain=.<last-two-labels>` yields an invalid public-suffix
+		// domain on multi-level TLDs (e.g. `.co.uk`, `.com.br`) that browsers reject, so the
+		// cookie never sets. Host-only cookies (no domain attribute) avoid this entirely.
+		setCookie( 'my_cookie', 'yes', 3600 );
+
+		expect( writes[ 0 ] ).not.toContain( 'domain=' );
+	} );
+} );
+
+describe( 'getCookie', () => {
+	let originalCookie: PropertyDescriptor | undefined;
+
+	beforeEach( () => {
+		originalCookie = Object.getOwnPropertyDescriptor( Document.prototype, 'cookie' );
+	} );
+
+	afterEach( () => {
+		delete ( document as unknown as { cookie?: string } ).cookie;
+		if ( originalCookie ) {
+			Object.defineProperty( Document.prototype, 'cookie', originalCookie );
+		}
+	} );
+
+	const stubCookies = ( value: string ) =>
+		Object.defineProperty( document, 'cookie', {
+			configurable: true,
+			get: () => value,
+		} );
+
+	it( 'returns the value of a cookie that is present', () => {
+		stubCookies( 'a=1; wp_consent_functional=allow; b=2' );
+
+		expect( getCookie( 'wp_consent_functional' ) ).toBe( 'allow' );
+	} );
+
+	it( 'returns null when the cookie is absent', () => {
+		stubCookies( 'a=1; b=2' );
+
+		expect( getCookie( 'missing' ) ).toBeNull();
+	} );
+} );

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Unit tests for cookie-consent utils.
  *
  * @jest-environment-options {"url": "https://shop.example.co.uk/"}

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -86,4 +86,24 @@ describe( 'getCookie', () => {
 
 		expect( getCookie( 'missing' ) ).toBeNull();
 	} );
+
+	it( 'does not match a name that is only a substring of another cookie', () => {
+		stubCookies( 'wp_consent_functional=allow' );
+
+		expect( getCookie( 'consent' ) ).toBeNull();
+	} );
+
+	it( 'preserves "=" characters inside the value', () => {
+		stubCookies( 'token=a=b=c; x=1' );
+
+		expect( getCookie( 'token' ) ).toBe( 'a=b=c' );
+	} );
+
+	it( 'treats an explicitly empty cookie value as null', () => {
+		// Current behavior: the `|| null` fallback collapses an empty string to null, so an
+		// explicitly-empty cookie is indistinguishable from an absent one.
+		stubCookies( 'wp_consent_functional=; x=1' );
+
+		expect( getCookie( 'wp_consent_functional' ) ).toBeNull();
+	} );
 } );


### PR DESCRIPTION
Fixes WOOA7S-1567

## Proposed changes

**Why**
`setCookie` derived a cross-subdomain cookie domain by taking the last two labels of the hostname (`domain=.${hostname.split('.').slice(-2).join('.')}`). On multi-level TLDs (e.g. `shop.example.co.uk`, `loja.example.com.br`) those last two labels are a public suffix (`.co.uk`, `.com.br`), which browsers reject — so the cookie silently fails to set on those sites.

**How**
Drop the domain derivation and write a host-only cookie (no `domain` attribute). This matches the WP Consent API, whose own JS writes consent cookies host-only, and the common-plugin default (CookieYes/Complianz treat cross-subdomain consent sharing as an opt-in, off-by-default feature). `setCookie` here only backs the geo-cache cookies (country/region); the `wp_consent_*` cookies are written by `wp_set_consent`. A host-only cookie is always a valid domain, so it fixes the multi-level-TLD case while keeping single-host behavior identical.

**What**
* `setCookie` (`src/modules/cookie-consent/utils.ts`): write a host-only cookie instead of computing a `domain` attribute from the hostname.
* Add the first jest unit tests for the package (`tests/utils.test.ts`, `jest.config.cjs`, `test`/`test-coverage` scripts, `jest` devDep) covering `setCookie`/`getCookie`, including a regression test asserting no `domain` attribute is emitted even on a multi-level-TLD host.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?

No. This only changes the scope of the cookies that were already being set (cross-subdomain → host-only); no new data is collected.

## Testing instructions

Automated:

* `cd projects/packages/cookie-consent && pnpm test` — all tests should pass. The host-only regression test runs under a simulated `https://shop.example.co.uk/` host and asserts no `domain` attribute is written. Reverting `utils.ts` to the old domain-derivation logic makes that test fail.

Manual (optional):

* On a site served from a multi-level-TLD domain (e.g. `*.co.uk` / `*.com.br`), trigger the geo-cache cookie write (e.g. the country/region detection in the consent flow) and confirm in DevTools → Application → Cookies that the cookie is now set (previously it was rejected). The cookie should have no `Domain` value (host-only).
* On a regular `.com` domain, confirm consent/geo behavior is unchanged.
