### PR TITLE
Cookie Consent: keep geo cookies out of the page-cache key and harden geo fetch

### DIFF
--- a/projects/packages/cookie-consent/changelog/fix-cache-safety-geo-cookies
+++ b/projects/packages/cookie-consent/changelog/fix-cache-safety-geo-cookies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cache safety: keep the geolocation cookies out of Jetpack Boost's page-cache key, fetch geolocation with no-store, and document that the banner render must stay geo/consent independent.

--- a/projects/packages/cookie-consent/changelog/fix-cache-safety-geo-cookies
+++ b/projects/packages/cookie-consent/changelog/fix-cache-safety-geo-cookies
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Cache safety: keep the geolocation cookies out of Jetpack Boost's page-cache key, fetch geolocation with no-store, and document that the banner render must stay geo/consent independent.
+Improve Jetpack Boost page-cache hit rates by excluding Cookie Consent geolocation cookies from the cache key and ensuring geolocation lookups aren’t cached.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -162,9 +162,11 @@ class Cookie_Consent {
 	 * @return array Patterns with the geolocation cookies appended.
 	 */
 	public static function ignore_geo_cookies_in_page_cache( $cookies ) {
-		$config    = self::get_config();
-		$cookies[] = preg_quote( $config['country_code_cookie'], '/' );
-		$cookies[] = preg_quote( $config['region_cookie'], '/' );
+		$config       = self::get_config();
+		$country_code = $config['country_code_cookie'] ?? 'country_code';
+		$region       = $config['region_cookie'] ?? 'region';
+		$cookies[]    = preg_quote( $country_code, '/' );
+		$cookies[]    = preg_quote( $region, '/' );
 
 		return $cookies;
 	}

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -75,6 +75,9 @@ class Cookie_Consent {
 		// Register the CCPA page id setting for REST access.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_ccpa_page_setting' ) );
 
+		// Keep the geolocation cookies out of Jetpack Boost's page-cache key.
+		add_filter( 'jetpack_boost_ignore_cookies', array( __CLASS__, 'ignore_geo_cookies_in_page_cache' ) );
+
 		// Consent log REST controller: table, cron cleanup, routes.
 		Consent_Log_Controller::init();
 	}
@@ -144,6 +147,26 @@ class Cookie_Consent {
 				'description'  => __( 'CCPA opt-out page ID', 'jetpack-cookie-consent' ),
 			)
 		);
+	}
+
+	/**
+	 * Exclude the geolocation cookies from Jetpack Boost's page-cache key.
+	 *
+	 * Geo is resolved client-side, so the server response is identical for every
+	 * visitor. Boost keys its cache on the full cookie set, so leaving the
+	 * `country_code`/`region` cookies in would spawn a separate cache file per
+	 * region and make returning visitors miss the cache. They never affect the
+	 * server-rendered HTML, so it is safe to ignore them.
+	 *
+	 * @param array $cookies Regex patterns Boost removes from the cache key.
+	 * @return array Patterns with the geolocation cookies appended.
+	 */
+	public static function ignore_geo_cookies_in_page_cache( $cookies ) {
+		$config    = self::get_config();
+		$cookies[] = preg_quote( $config['country_code_cookie'], '/' );
+		$cookies[] = preg_quote( $config['region_cookie'], '/' );
+
+		return $cookies;
 	}
 
 	/**
@@ -651,17 +674,6 @@ class Cookie_Consent {
 				'forcePreview'      => $force_preview,
 			)
 		);
-	}
-
-	/**
-	 * Check if consent has been set
-	 *
-	 * @return bool True if consent has been set
-	 */
-	private static function has_consent_set() {
-		// Check if any WP Consent API cookie exists.
-		// If user has made a choice, at least one of these should be set.
-		return isset( $_COOKIE['wp_consent_functional'] );
 	}
 
 	/**

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -410,9 +410,8 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				return geoState;
 			}
 
-			// If there is not country_code or region cookie set, fetch geolocation.
-			// `no-store` keeps this visitor-specific response out of any shared/intermediary
-			// cache, so one visitor's geo can never be served to another.
+			// If either the country_code or region cookie is missing, fetch geolocation.
+			// `no-store` avoids using the browser HTTP cache for this visitor-specific response.
 			try {
 				const response = ( yield fetch( config.geoApiUrl, { cache: 'no-store' } ) ) as Response;
 				if ( ! response.ok ) {

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -410,9 +410,11 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				return geoState;
 			}
 
-			// If there is not country_code or region cookie set, fetch geolocation
+			// If there is not country_code or region cookie set, fetch geolocation.
+			// `no-store` keeps this visitor-specific response out of any shared/intermediary
+			// cache, so one visitor's geo can never be served to another.
 			try {
-				const response = ( yield fetch( config.geoApiUrl ) ) as Response;
+				const response = ( yield fetch( config.geoApiUrl, { cache: 'no-store' } ) ) as Response;
 				if ( ! response.ok ) {
 					throw new Error( 'Geolocation request failed' );
 				}


### PR DESCRIPTION
Addresses WOOA7S-1568.

## Proposed changes

**Why** — The cookie-consent banner is rendered server-side and toggled client-side by geolocation. Under full-page caching (Batcache / Boost / CDN), WOOA7S-1568 audited this path for three risks: geo leaking between visitors, per-visitor banner correctness, and cache efficiency.

**What the audit found** — No geo leak: the server response is **identical for every visitor** and all geo/consent decisions happen client-side, so per-visitor correctness holds on every cache layer. The one real issue is efficiency — the client-set geo cookies fragment Jetpack Boost's page-cache key (Boost keys on the full cookie set), so each region spawns a separate cache file and returning visitors miss the cache.

**How (this PR)** —

- Register `jetpack_boost_ignore_cookies` to drop `country_code` / `region` from Boost's cache key. They never affect the server HTML, so ignoring them is safe and restores cache hits — mirroring Boost's existing `eucookielaw` handling.
- Fetch geolocation with `{ cache: 'no-store' }` so the visitor-specific `/geo/` response can't be served from a shared cache.
- Remove the unused `has_consent_set()` helper and document that `render_banner()` must stay geo/consent independent, so a future change can't re-introduce server-side gating that breaks cache safety.

A follow-up issue (WOOA7S-1583) tracks whether wpcom/Atomic's Batcache whitelists the `wp_consent_*` cookies (they are `wp`-prefixed, which trips Batcache's cache-skip rule) — an infra-config question, not a code change here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Prerequisites

The banner is shipped by a host plugin, not by the package alone. On the test site, activate:

- **Premium Analytics** — calls `Cookie_Consent::init()`, which renders the banner.
- **WP Consent API** — provides `window.wp_set_consent`; without it the banner script bails early and nothing renders.
- **Jetpack Boost** (with the **Page Cache** module on) — needed only for the cache-key test below.

### How geo + consent state is controlled (read first)

The module decides what to show entirely from cookies, in this order:

1. It reads the `country_code` and `region` cookies. If both are present it uses them and **skips** the `/geo/` lookup — so setting these two cookies in DevTools (Application → Cookies) lets you simulate any region.
2. The banner only appears when consent has **not** been made yet — it returns early if the `wp_consent_functional` cookie exists. So before re-testing a region you must **clear the consent cookies**: `wp_consent_functional`, `wp_consent_statistics`, `wp_consent_marketing` (and `wp_consent_type` if present).

Tip: append `?preview_cookie_consent=1` to force the banner visible for a quick visual check (this bypasses the geo/consent logic, so don't use it for the region tests below).

### 1. Cache-key fix (the change in this PR — Boost)

- As an anonymous visitor with **no** cookies, load a front-end page to prime the cache.
- Set the geo cookies (e.g. `country_code=FR`) and reload.
- Confirm the response still serves from the **same** Boost cache file rather than generating a new one per region — inspect `wp-content/boost-cache/…`, or check the `country_code`/`region` cookies no longer change which file is hit. On `trunk` (before this PR) each region produced a distinct cache file; with this PR they share one.

### 2. Banner behaviour is unchanged

For each case: clear the `wp_consent_*` cookies, set the geo cookies, reload, observe. (Watch the WP Consent API cookies update in DevTools to confirm the consent model applied.)

- **GDPR region** — `country_code=FR` (region irrelevant): banner **shows**; clicking Accept/Reject/Save sets `wp_consent_*` accordingly and hides it.
- **CCPA region** — `country_code=US`, `region=california`: banner stays **hidden**, consent is auto-granted (opt-out model), and the footer "Your Privacy Choices" link is visible.
- **Other / non-regulated** — `country_code=AU` (or any non-GDPR, non-CCPA value): banner stays **hidden** and consent is auto-granted (implied consent).
