### PR TITLE
Cookie Consent: classic-theme fallback for required Privacy/CCPA/Manage-Preferences links

### DIFF
--- a/projects/packages/cookie-consent/changelog/add-classic-theme-footer-links-fallback
+++ b/projects/packages/cookie-consent/changelog/add-classic-theme-footer-links-fallback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add classic-theme fallback for required privacy/CCPA/manage-preferences links.

--- a/projects/packages/cookie-consent/changelog/fix-footer-links-fallback-hidden
+++ b/projects/packages/cookie-consent/changelog/fix-footer-links-fallback-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the classic-theme footer-links control hidden until needed so it no longer overlaps the consent banner.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -147,6 +147,7 @@ class Cookie_Consent {
 		// with init() whenever a hook is added there.
 		remove_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		remove_action( 'wp_footer', array( __CLASS__, 'render_banner' ), 999 );
+		remove_action( 'wp_footer', array( __CLASS__, 'maybe_render_footer_links_fallback' ), 999 );
 		remove_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );
 
 		remove_filter( 'hooked_block_types', array( __CLASS__, 'register_footer_navigation_links' ), 10 );
@@ -154,6 +155,7 @@ class Cookie_Consent {
 		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_ccpa_interactivity_directives' ), 10 );
 		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'maybe_suppress_privacy_policy_link' ), 10 );
 		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_gdpr_manage_preferences_directives' ), 10 );
+		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'mark_footer_links_injected' ), 10 );
 		remove_filter( 'render_block_core/button', array( __CLASS__, 'add_ccpa_button_directive' ), 10 );
 		remove_filter( 'render_block_core/group', array( __CLASS__, 'add_ccpa_group_directives' ), 10 );
 		remove_filter( 'get_pages', array( __CLASS__, 'exclude_ccpa_from_get_pages' ), 10 );
@@ -688,13 +690,14 @@ class Cookie_Consent {
 	 * @return array{url: string, label: string} CCPA page URL and label.
 	 */
 	private static function get_ccpa_page_link() {
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		if ( ! $ccpa_page_id || ! get_post( $ccpa_page_id ) ) {
+		if ( ! self::ccpa_page_is_published() ) {
 			return array(
 				'url'   => '',
 				'label' => '',
 			);
 		}
+
+		$ccpa_page_id = get_option( self::CCPA_PAGE_ID_OPTION );
 
 		return array(
 			'url'   => (string) get_permalink( $ccpa_page_id ),

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -63,6 +63,18 @@ class Cookie_Consent {
 	private static $initialized = false;
 
 	/**
+	 * Whether the required footer legal links were injected into a footer
+	 * navigation block (Block Hooks) for the current rendered response.
+	 *
+	 * Set true by the navigation-link render filter when one of our hooked
+	 * links renders; consulted by the wp_footer fallback to avoid duplicating
+	 * the links on block themes that already received them.
+	 *
+	 * @var bool
+	 */
+	private static $footer_links_injected = false;
+
+	/**
 	 * Initialize the package. Idempotent; safe to call multiple times.
 	 *
 	 * Public entry point a consumer calls to activate cookie consent. Registers
@@ -78,6 +90,11 @@ class Cookie_Consent {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'render_banner' ), 999 );
 
+		// Classic-theme (and footer-nav-less block theme) fallback for the required
+		// legal links. Runs late so any Block Hooks injection has already happened
+		// and flipped self::$footer_links_injected.
+		add_action( 'wp_footer', array( __CLASS__, 'maybe_render_footer_links_fallback' ), 999 );
+
 		// Create the CCPA opt-out page once (guarded), now that the Atomic
 		// garden_site_provisioning hook is no longer available in this context.
 		add_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );
@@ -88,6 +105,10 @@ class Cookie_Consent {
 		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_ccpa_interactivity_directives' ), 10, 2 );
 		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'maybe_suppress_privacy_policy_link' ), 10, 2 );
 		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_gdpr_manage_preferences_directives' ), 10, 2 );
+		// Flag that the required links were injected into a footer nav (covers all
+		// three, including the Privacy Policy link which has no directive filter),
+		// so the wp_footer fallback does not duplicate them.
+		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'mark_footer_links_injected' ), 10, 2 );
 
 		// Add Interactivity API directive to CCPA opt-out button.
 		add_filter( 'render_block_core/button', array( __CLASS__, 'add_ccpa_button_directive' ), 10, 2 );
@@ -582,6 +603,140 @@ class Cookie_Consent {
 		}
 
 		return $tags->get_updated_html();
+	}
+
+	/**
+	 * Mark that one of our required footer legal links was injected into a
+	 * footer navigation block, so the wp_footer fallback does not duplicate it.
+	 *
+	 * Keyed on the metadata.name set by set_footer_navigation_link_attributes().
+	 * Covers the Privacy Policy link too, which has no directive filter of its own.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Unmodified block content.
+	 */
+	public static function mark_footer_links_injected( $block_content, $block ) {
+		if ( ! isset( $block['attrs']['metadata']['name'] ) ) {
+			return $block_content;
+		}
+
+		$names = array(
+			'jetpack-cookie-consent-privacy-policy-link',
+			'jetpack-cookie-consent-ccpa-privacy-link',
+			'jetpack-cookie-consent-gdpr-manage-preferences-link',
+		);
+
+		if ( in_array( $block['attrs']['metadata']['name'], $names, true ) ) {
+			self::$footer_links_injected = true;
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Decide whether the floating footer-links fallback should render.
+	 *
+	 * Minimal gate modeled on Jetpack_Subscribe_Floating_Button::should_user_see_floating_button():
+	 * frontend only, never on 404, and never in customizer/theme/post previews.
+	 *
+	 * @return bool True when the fallback control should be rendered.
+	 */
+	private static function should_show_fallback() {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		if ( is_404() ) {
+			return false;
+		}
+
+		// Don't show in customizer/theme/post previews.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['preview'] ) || isset( $_GET['theme_preview'] ) || isset( $_GET['customize_preview'] ) || isset( $_GET['hide_banners'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the published Privacy Policy page URL, or '' when none exists.
+	 *
+	 * @return string Privacy Policy permalink or empty string.
+	 */
+	private static function get_privacy_policy_url() {
+		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
+		if ( ! $privacy_policy_page_id ) {
+			return '';
+		}
+
+		$page = get_post( $privacy_policy_page_id );
+		if ( ! $page || 'publish' !== $page->post_status ) {
+			return '';
+		}
+
+		return (string) get_permalink( $privacy_policy_page_id );
+	}
+
+	/**
+	 * Get the CCPA opt-out page URL and title, or empty strings when none exists.
+	 *
+	 * Mirrors the Block Hooks footer nav-link, which uses the CCPA page's own
+	 * title (e.g. "Your Privacy Choices") as the link label.
+	 *
+	 * @return array{url: string, label: string} CCPA page URL and label.
+	 */
+	private static function get_ccpa_page_link() {
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		if ( ! $ccpa_page_id || ! get_post( $ccpa_page_id ) ) {
+			return array(
+				'url'   => '',
+				'label' => '',
+			);
+		}
+
+		return array(
+			'url'   => (string) get_permalink( $ccpa_page_id ),
+			'label' => (string) get_the_title( $ccpa_page_id ),
+		);
+	}
+
+	/**
+	 * Render the classic-theme fallback for the required legal links.
+	 *
+	 * Bails when the Block Hooks footer-nav injection already ran for this
+	 * response (self::$footer_links_injected) or when the visibility gate is
+	 * false. Otherwise builds a fixed-corner floating control, processes its
+	 * Interactivity directives, and echoes it — same pattern as render_banner().
+	 */
+	public static function maybe_render_footer_links_fallback() {
+		if ( self::$footer_links_injected ) {
+			return;
+		}
+
+		if ( ! self::should_show_fallback() ) {
+			return;
+		}
+
+		$template_path = plugin_dir_path( __FILE__ ) . 'footer-links-fallback.php';
+		if ( ! file_exists( $template_path ) ) {
+			return;
+		}
+
+		// Resolve which links to show (same checks the Block Hooks path uses).
+		// These are consumed by footer-links-fallback.php via the include scope.
+		$privacy_policy_url = self::get_privacy_policy_url(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$ccpa_link          = self::get_ccpa_page_link();
+		$ccpa_url           = $ccpa_link['url']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$ccpa_label         = $ccpa_link['label']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		ob_start();
+		include $template_path;
+		$html = ob_get_clean();
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_interactivity_process_directives( $html );
 	}
 
 	/**

--- a/projects/packages/cookie-consent/src/footer-links-fallback.php
+++ b/projects/packages/cookie-consent/src/footer-links-fallback.php
@@ -8,6 +8,11 @@
  * navigation). Provides a fixed-corner floating control holding the Privacy
  * Policy, CCPA opt-out, and "Manage Privacy Preferences" links.
  *
+ * The control renders hidden and is revealed client-side only when there is a
+ * region-specific required link to show (CCPA opt-out or GDPR manage
+ * preferences); see state.showFallbackControl in view.ts. This keeps the server
+ * HTML geo-independent (cache-safe) and avoids a persistent global control.
+ *
  * Variables provided by the caller:
  *
  * @var string $privacy_policy_url Privacy Policy permalink, or '' when none.
@@ -34,6 +39,8 @@ $ccpa_label = isset( $ccpa_label ) ? (string) $ccpa_label : '';
 	data-wp-context='{"fallbackExpanded": false, "isCcpaRegion": false, "isGdprManageLink": false}'
 	data-wp-init="callbacks.init"
 	data-wp-on--keydown="actions.onFallbackKeyDown"
+	hidden
+	data-wp-bind--hidden="!state.showFallbackControl"
 >
 	<button
 		type="button"

--- a/projects/packages/cookie-consent/src/footer-links-fallback.php
+++ b/projects/packages/cookie-consent/src/footer-links-fallback.php
@@ -31,7 +31,7 @@ $ccpa_label = isset( $ccpa_label ) ? (string) $ccpa_label : '';
 <div
 	class="jetpack-cookie-consent-footer-links"
 	data-wp-interactive="jetpack/cookie-consent"
-	data-wp-context='{"fallbackExpanded": false, "isCcpaRegion": false}'
+	data-wp-context='{"fallbackExpanded": false, "isCcpaRegion": false, "isGdprManageLink": false}'
 	data-wp-init="callbacks.init"
 	data-wp-on--keydown="actions.onFallbackKeyDown"
 >
@@ -83,7 +83,10 @@ $ccpa_label = isset( $ccpa_label ) ? (string) $ccpa_label : '';
 				</li>
 			<?php endif; ?>
 
-			<li class="jetpack-cookie-consent-footer-links__item">
+			<li
+				class="jetpack-cookie-consent-footer-links__item jetpack-cookie-consent-gdpr-manage-link-hidden"
+				data-wp-class--jetpack-cookie-consent-gdpr-manage-link-hidden="!context.isGdprManageLink"
+			>
 				<a
 					class="jetpack-cookie-consent-footer-links__link"
 					href="#manage-preferences"

--- a/projects/packages/cookie-consent/src/footer-links-fallback.php
+++ b/projects/packages/cookie-consent/src/footer-links-fallback.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Cookie Consent: classic-theme fallback for the required legal links.
+ *
+ * Rendered on wp_footer by Cookie_Consent::maybe_render_footer_links_fallback()
+ * only when the Block Hooks footer-nav injection did not run for this response
+ * (classic themes, or block themes whose rendered template has no footer
+ * navigation). Provides a fixed-corner floating control holding the Privacy
+ * Policy, CCPA opt-out, and "Manage Privacy Preferences" links.
+ *
+ * Variables provided by the caller:
+ *
+ * @var string $privacy_policy_url Privacy Policy permalink, or '' when none.
+ * @var string $ccpa_url           CCPA opt-out page permalink, or '' when none.
+ * @var string $ccpa_label         CCPA opt-out page title (link label), or '' when none.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$privacy_policy_url = isset( $privacy_policy_url ) ? (string) $privacy_policy_url : '';
+$ccpa_url           = isset( $ccpa_url ) ? (string) $ccpa_url : '';
+// Mirror the Block Hooks footer nav-link, which labels this with the CCPA
+// page's own title.
+$ccpa_label = isset( $ccpa_label ) ? (string) $ccpa_label : '';
+?>
+
+<div
+	class="jetpack-cookie-consent-footer-links"
+	data-wp-interactive="jetpack/cookie-consent"
+	data-wp-context='{"fallbackExpanded": false, "isCcpaRegion": false}'
+	data-wp-init="callbacks.init"
+	data-wp-on--keydown="actions.onFallbackKeyDown"
+>
+	<button
+		type="button"
+		class="jetpack-cookie-consent-footer-links__toggle"
+		id="jetpack-cookie-consent-footer-links-toggle"
+		aria-haspopup="true"
+		aria-expanded="false"
+		data-wp-bind--aria-expanded="context.fallbackExpanded"
+		aria-controls="jetpack-cookie-consent-footer-links-panel"
+		data-wp-on--click="actions.toggleFallbackPanel"
+	>
+		<span class="jetpack-cookie-consent-footer-links__toggle-icon" aria-hidden="true">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" focusable="false">
+				<path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16zm0 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13zM11.25 7h1.5v1.5h-1.5V7zm0 3h1.5v7h-1.5v-7z"></path>
+			</svg>
+		</span>
+		<span class="jetpack-cookie-consent-footer-links__toggle-text">
+			<?php echo esc_html__( 'Privacy', 'jetpack-cookie-consent' ); ?>
+		</span>
+	</button>
+
+	<div
+		class="jetpack-cookie-consent-footer-links__panel"
+		id="jetpack-cookie-consent-footer-links-panel"
+		role="region"
+		aria-label="<?php echo esc_attr__( 'Privacy links', 'jetpack-cookie-consent' ); ?>"
+		hidden
+		data-wp-bind--hidden="!context.fallbackExpanded"
+	>
+		<ul class="jetpack-cookie-consent-footer-links__list">
+			<?php if ( '' !== $privacy_policy_url ) : ?>
+				<li class="jetpack-cookie-consent-footer-links__item">
+					<a class="jetpack-cookie-consent-footer-links__link" href="<?php echo esc_url( $privacy_policy_url ); ?>">
+						<?php echo esc_html__( 'Privacy Policy', 'jetpack-cookie-consent' ); ?>
+					</a>
+				</li>
+			<?php endif; ?>
+
+			<?php if ( '' !== $ccpa_url ) : ?>
+				<li
+					class="jetpack-cookie-consent-footer-links__item jetpack-cookie-consent-ccpa-privacy-link-hidden"
+					data-wp-class--jetpack-cookie-consent-ccpa-privacy-link-hidden="!state.isCcpaRegion"
+				>
+					<a class="jetpack-cookie-consent-footer-links__link" href="<?php echo esc_url( $ccpa_url ); ?>">
+						<?php echo esc_html( $ccpa_label ); ?>
+					</a>
+				</li>
+			<?php endif; ?>
+
+			<li class="jetpack-cookie-consent-footer-links__item">
+				<a
+					class="jetpack-cookie-consent-footer-links__link"
+					href="#manage-preferences"
+					data-wp-on--click="actions.openManagePreferences"
+				>
+					<?php echo esc_html__( 'Manage Privacy Preferences', 'jetpack-cookie-consent' ); ?>
+				</a>
+			</li>
+		</ul>
+	</div>
+</div>

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -473,10 +473,109 @@ input[type="checkbox"]:focus-visible + label
 	}
 }
 
+/* ==========================================================================
+   Classic-theme fallback for required legal links
+   Fixed-corner floating control rendered on wp_footer when the Block Hooks
+   footer-nav injection did not run (classic themes / footer-nav-less templates).
+   ========================================================================== */
+
+.jetpack-cookie-consent-footer-links {
+	position: fixed;
+	bottom: 20px;
+	left: 20px;
+	z-index: 50000;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.jetpack-cookie-consent-footer-links__toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin: 0;
+	padding: 8px 14px;
+	font-size: 14px;
+	line-height: 1.4;
+	cursor: pointer;
+	color: var(--wp--preset--color--contrast, #1e1e1e);
+	background: var(--wp--preset--color--base, #fff);
+	border: 1px solid var(--wp--preset--color--contrast-3, #dcdcde);
+	border-radius: 4px;
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.12);
+}
+
+.jetpack-cookie-consent-footer-links__toggle:hover {
+	background: var(--wp--preset--color--contrast-3, #f0f0f0);
+}
+
+.jetpack-cookie-consent-footer-links__toggle:focus-visible {
+	outline: 2px solid var(--wp--preset--color--accent-1, #243dc8);
+	outline-offset: 2px;
+}
+
+.jetpack-cookie-consent-footer-links__toggle-icon {
+	display: inline-flex;
+	align-items: center;
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.jetpack-cookie-consent-footer-links__panel {
+	min-width: 220px;
+	max-width: calc(100vw - 40px);
+	padding: 8px 0;
+	background: var(--wp--preset--color--base, #fff);
+	border: 1px solid var(--wp--preset--color--contrast-3, #dcdcde);
+	border-radius: 4px;
+	box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.16);
+}
+
+.jetpack-cookie-consent-footer-links__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.jetpack-cookie-consent-footer-links__item {
+	margin: 0;
+}
+
+.jetpack-cookie-consent-footer-links__link {
+	display: block;
+	padding: 8px 16px;
+	font-size: 14px;
+	line-height: 1.5;
+	text-decoration: none;
+	color: var(--wp--preset--color--contrast, #1e1e1e);
+}
+
+.jetpack-cookie-consent-footer-links__link:hover {
+	text-decoration: underline;
+	background: var(--wp--preset--color--contrast-3, #f0f0f0);
+}
+
+.jetpack-cookie-consent-footer-links__link:focus-visible {
+	outline: 2px solid var(--wp--preset--color--accent-1, #243dc8);
+	outline-offset: -2px;
+}
+
+/* Reduced Motion */
+@media ( prefers-reduced-motion: reduce ) {
+
+	.jetpack-cookie-consent-footer-links__toggle {
+		transition: none;
+	}
+}
+
 /* Print */
 @media print {
 
-	.jetpack-cookie-consent {
+	.jetpack-cookie-consent,
+	.jetpack-cookie-consent-footer-links {
 		display: none;
 	}
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -476,7 +476,7 @@ input[type="checkbox"]:focus-visible + label
 /* ==========================================================================
    Classic-theme fallback for required legal links
    Fixed-corner floating control rendered on wp_footer when the Block Hooks
-   footer-nav injection did not run (classic themes / footer-nav-less templates).
+   footer-nav injection did not run (classic themes / no footer nav).
    ========================================================================== */
 
 .jetpack-cookie-consent-footer-links {

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -490,6 +490,15 @@ input[type="checkbox"]:focus-visible + label
 	gap: 8px;
 }
 
+/* The control ships with `hidden` and is only revealed when there's a
+   region-specific required link (see data-wp-bind--hidden in the template). The
+   `display: flex` above out-specifies the UA `[hidden] { display: none }`, so
+   restore it explicitly — otherwise the control stays visible and overlaps the
+   consent banner. */
+.jetpack-cookie-consent-footer-links[hidden] {
+	display: none;
+}
+
 .jetpack-cookie-consent-footer-links__toggle {
 	display: inline-flex;
 	align-items: center;

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -150,6 +150,13 @@ const { actions } = store( 'jetpack/cookie-consent', {
 			const context = getContext< CcpaContext >();
 			return context.showSnackbar;
 		},
+		// Classic-theme fallback control: only surface it when there's a
+		// region-specific required link to show (CCPA opt-out or GDPR manage
+		// preferences). The Privacy Policy link just rides along when shown.
+		get showFallbackControl() {
+			const context = getContext< FooterLinksFallbackContext >();
+			return context.isCcpaRegion || context.isGdprManageLink;
+		},
 	},
 	actions: {
 		/**

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -54,6 +54,7 @@ interface GdprManageLinkContext {
 interface FooterLinksFallbackContext {
 	fallbackExpanded: boolean;
 	isCcpaRegion: boolean;
+	isGdprManageLink: boolean;
 }
 
 interface StoreConfig {

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -51,6 +51,11 @@ interface GdprManageLinkContext {
 	isGdprManageLink: boolean;
 }
 
+interface FooterLinksFallbackContext {
+	fallbackExpanded: boolean;
+	isCcpaRegion: boolean;
+}
+
 interface StoreConfig {
 	geoApiUrl: string;
 	geoCookieDuration: number;
@@ -387,6 +392,35 @@ const { actions } = store( 'jetpack/cookie-consent', {
 		},
 
 		/**
+		 * Toggle the classic-theme footer-links fallback panel.
+		 */
+		toggleFallbackPanel() {
+			const context = getContext< FooterLinksFallbackContext >();
+			context.fallbackExpanded = ! context.fallbackExpanded;
+		},
+
+		/**
+		 * Handle keyboard events on the footer-links fallback control.
+		 * Escape closes the panel and returns focus to the toggle button.
+		 */
+		onFallbackKeyDown: withSyncEvent( ( event: KeyboardEvent ) => {
+			if ( event.key !== 'Escape' ) {
+				return;
+			}
+
+			const context = getContext< FooterLinksFallbackContext >();
+			if ( ! context.fallbackExpanded ) {
+				return;
+			}
+
+			event.preventDefault();
+			context.fallbackExpanded = false;
+
+			// Return focus to the toggle button.
+			document.getElementById( 'jetpack-cookie-consent-footer-links-toggle' )?.focus();
+		} ),
+
+		/**
 		 * Initialize geolocation (singleton pattern - runs once)
 		 */
 		*initializeGeolocation() {
@@ -456,6 +490,7 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				| CookieBannerContext
 				| CcpaContext
 				| GdprManageLinkContext
+				| FooterLinksFallbackContext
 				| ( CookieBannerContext & CcpaContext );
 			// getConfig() is not typed, so we need to assert the type.
 			const config = getConfig() as unknown as StoreConfig;
@@ -499,14 +534,20 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				| CookieBannerContext
 				| CcpaContext
 				| GdprManageLinkContext
+				| FooterLinksFallbackContext
 				| ( CookieBannerContext & CcpaContext );
 
-			// Initialize CCPA-specific context if present
+			// Initialize CCPA-specific context if present.
+			// The footer-links fallback context also exposes isCcpaRegion (to gate
+			// the "Do Not Sell" link) but has no snackbar; only touch those keys
+			// when this is the full CCPA context.
 			if ( 'isCcpaRegion' in context ) {
-				const ccpaCtx = context as CcpaContext;
-				ccpaCtx.isCcpaRegion = false;
-				ccpaCtx.showSnackbar = false;
-				ccpaCtx.snackbarTimeout = null;
+				context.isCcpaRegion = false;
+				if ( 'showSnackbar' in context ) {
+					const ccpaCtx = context as CcpaContext;
+					ccpaCtx.showSnackbar = false;
+					ccpaCtx.snackbarTimeout = null;
+				}
 			}
 
 			// Initialize cookie banner context if present


### PR DESCRIPTION
Fixes # WOOA7S-1564

## Proposed changes

**Why:** Privacy Policy / CCPA "Do Not Sell" / GDPR "Manage Privacy Preferences" links are injected only via Block Hooks into a `core/navigation` block in a footer template part. Classic themes and block themes with no footer nav get nothing, and the CCPA link is legally required to be conspicuous, so this is a legal gap.

**How:** A `wp_footer` fallback renders the **floating control**, but only when Block Hooks injection didn't run for this response. Dedup uses a server-side "did-inject" flag set by a `render_block_core/navigation-link` callback. The footer template part renders before `wp_footer`, so the flag is authoritative.

**Why a floating control (not inline injection):** Classic themes have no standardized footer region/hook to target the way Block Hooks gives us on block themes, so generic inline injection isn't feasible. A fixed-corner floating control is theme-independent, guarantees the links are present, and is the same pattern popular consent plugins already use.

**Region gating (cache-safe):** Mirrors the nav-link gating and goes one step further to gate the whole control:


**What:**

- `maybe_render_footer_links_fallback()` (`wp_footer`, registered in `init()`) — gated by the inject flag + a visibility check (skips admin / 404 / previews).
- `mark_footer_links_injected()` render filter — flips the inject flag for all three links.
- `footer-links-fallback.php` — accessible `<button>` toggle (`aria-haspopup`/`aria-expanded`/`aria-controls`) + the three links; the container and region-specific links render `hidden`.
- Interactivity: `state.showFallbackControl`, context-local `fallbackExpanded` toggle, Escape-to-close with focus return; reuses the `jetpack/cookie-consent` store, no new global state.
- Styles for the fixed control (focus-visible, reduced-motion, print-hidden).

## Related product discussion/links

- WOOA7S-1564
- WOOA7S-1545 (cross-theme banner/controls styling — follow-up)

## Does this pull request change what data or activity we track or use?

No new data is tracked. The "Manage Privacy Preferences" control reuses the existing consent events already fired by the nav-link version.

## Testing instructions

Setup:

- Use a site with the **premium-analytics** plugin active (it calls `Cookie_Consent::init()`), plus the **WP Consent API** plugin (`wp-consent-api`) active — the latter is required for the consent banner/modal to function (`window.wp_set_consent`); without it the "Manage Privacy Preferences" control cannot open the modal.
- Set a published **Privacy Policy** page (Settings → Privacy). The CCPA "Your Privacy Choices" page is auto-created on init.
- To simulate a region, set the geolocation cookies (when both are present the client skips the geo API and uses them; 6-hour TTL). In DevTools → Application → Cookies (or the console), set `country_code` and `region`: CCPA → `country_code=US`, `region=CA`; GDPR → `country_code=FR`, `region=` (any value). Reload after changing.

Classic theme (e.g. Twenty Twenty-One):

- **CCPA region:** a fixed **"Privacy"** control appears at the bottom-left. Expand it → **Privacy Policy**, **Your Privacy Choices**, and (after consent is set) **Manage Privacy Preferences**.
- **GDPR region:** once consent is saved (banner dismissed), the control appears with **Privacy Policy** and **Manage Privacy Preferences**.
- **Neither region:** the floating control does **not** appear (its only link would be Privacy Policy, already reachable in the footer).
- Click **Manage Privacy Preferences** → the consent preferences modal opens.
- Keyboard: Tab to the toggle, Enter/Space opens the panel, Escape closes it and returns focus to the toggle.

Block theme with a footer navigation (e.g. Twenty Twenty-Four):

- The links are injected into the footer navigation and the floating control does **not** appear (no duplication).

> [!IMPORTANT]
>  Note: this PR adds the classic-theme fallback **rendering**. Broader cross-theme polish (contrast across theme palettes, CSS isolation, aligning the z-index with the monorepo's `50000+` convention) is tracked in WOOA7S-1545; the styling here is intentionally minimal.

CCPA:

<img width="2556" height="1322" alt="Screenshot 2026-06-23 at 5 01 57 PM" src="https://github.com/user-attachments/assets/351791e1-8706-45a2-9d35-7cc32f12073c" />

GDPR:

<img width="2560" height="1320" alt="Screenshot 2026-06-23 at 5 03 24 PM" src="https://github.com/user-attachments/assets/0934bcd1-b8c3-4183-96db-3029794854c0" />

