### PR TITLE
Social: fix missing editor sharing controls and blank admin page on WordPress 6.9.x

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-wp69-theme-shim
+++ b/projects/packages/publicize/changelog/fix-social-wp69-theme-shim
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Social admin page rendering blank, and restore the editor sharing panel, on WordPress 6.9.

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
  * Publicize_Assets class.
@@ -58,6 +59,8 @@ class Publicize_Assets {
 
 		$script_to_load = class_exists( 'Jetpack' ) ? 'block-editor-jetpack' : 'block-editor-social';
 
+		self::register_wp_build_polyfills();
+
 		// Dequeue the old Social assets.
 		wp_dequeue_script( 'jetpack-social-editor' );
 		wp_dequeue_style( 'jetpack-social-editor' );
@@ -71,6 +74,21 @@ class Publicize_Assets {
 				'textdomain' => 'jetpack-publicize-pkg',
 				'enqueue'    => true,
 			)
+		);
+	}
+
+	/**
+	 * Register polyfills for the wp-theme / wp-private-apis handles the Social bundles
+	 * depend on but WP < 7.0 does not ship (or ships with an incomplete allowlist).
+	 */
+	public static function register_wp_build_polyfills() {
+		if ( ! class_exists( WP_Build_Polyfills::class ) ) {
+			return;
+		}
+
+		WP_Build_Polyfills::register(
+			'jetpack-social',
+			array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
 		);
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -80,6 +80,9 @@ class Publicize_Assets {
 	/**
 	 * Register polyfills for the wp-theme / wp-private-apis handles the Social bundles
 	 * depend on but WP < 7.0 does not ship (or ships with an incomplete allowlist).
+	 *
+	 * Only the two handles Social actually uses are requested, to keep the polyfill's
+	 * `wp-private-apis` force-replacement off any handle we don't need.
 	 */
 	public static function register_wp_build_polyfills() {
 		if ( ! class_exists( WP_Build_Polyfills::class ) ) {
@@ -88,7 +91,7 @@ class Publicize_Assets {
 
 		WP_Build_Polyfills::register(
 			'jetpack-social',
-			array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
+			array( 'wp-theme', 'wp-private-apis' )
 		);
 	}
 }

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -220,7 +220,19 @@ class Social_Admin_Page {
 
 		require_once $build_index;
 
-		Publicize_Assets::register_wp_build_polyfills();
+		// The wp-build dashboard (unlike the Social bundles) uses the full polyfill set:
+		// the @wordpress/boot|route|a11y modules, wp-notices, wp-views, etc.
+		if ( ! class_exists( '\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills' ) ) {
+			return;
+		}
+
+		\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
+			'jetpack-social',
+			array_merge(
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::SCRIPT_HANDLES,
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::MODULE_IDS
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -185,6 +185,8 @@ class Social_Admin_Page {
 			return;
 		}
 
+		Publicize_Assets::register_wp_build_polyfills();
+
 		// Dequeue the old Social assets.
 		wp_dequeue_script( 'jetpack-social' );
 		wp_dequeue_style( 'jetpack-social' );
@@ -218,17 +220,7 @@ class Social_Admin_Page {
 
 		require_once $build_index;
 
-		if ( ! class_exists( '\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills' ) ) {
-			return;
-		}
-
-		\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
-			'jetpack-social',
-			array_merge(
-				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::SCRIPT_HANDLES,
-				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::MODULE_IDS
-			)
-		);
+		Publicize_Assets::register_wp_build_polyfills();
 	}
 
 	/**

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -2,26 +2,6 @@ const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 
-// Service-walkthrough illustrations referenced by
-// `_inc/components/services/utils.tsx` via runtime URLs (so the chassis esbuild
-// pipeline, which doesn't configure a binary loader, can consume them too). Copy
-// them verbatim into the shared `build/assets/` directory; both bundlers resolve
-// via `JetpackScriptData.social.assets_url + 'assets/<file>'`.
-const copyAssetsPlugin = new CopyWebpackPlugin( {
-	patterns: [
-		{
-			from: path.resolve( __dirname, '_inc/assets' ),
-			to: 'assets',
-		},
-	],
-} );
-
-// Standard plugin set, optionally overriding dependency extraction.
-const standardPlugins = ( extractionOptions = {} ) => [
-	...jetpackWebpackConfig.StandardPlugins( extractionOptions ),
-	copyAssetsPlugin,
-];
-
 const socialWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
@@ -36,6 +16,23 @@ const socialWebpackConfig = {
 		...jetpackWebpackConfig.resolve,
 	},
 	node: false,
+	plugins: [
+		...jetpackWebpackConfig.StandardPlugins(),
+		// Service-walkthrough illustrations referenced by
+		// `_inc/components/services/utils.tsx` via runtime URLs (so the
+		// chassis esbuild pipeline, which doesn't configure a binary
+		// loader, can consume them too). Copy them verbatim into the
+		// shared `build/assets/` directory; both bundlers resolve via
+		// `JetpackScriptData.social.assets_url + 'assets/<file>'`.
+		new CopyWebpackPlugin( {
+			patterns: [
+				{
+					from: path.resolve( __dirname, '_inc/assets' ),
+					to: 'assets',
+				},
+			],
+		} ),
+	],
 	module: {
 		strictExportPresence: true,
 		rules: [
@@ -81,41 +78,16 @@ const socialWebpackConfig = {
 module.exports = [
 	{
 		...socialWebpackConfig,
-		// Editor and classic-editor bundles: keep @wordpress/theme and
-		// @wordpress/private-apis EXTERNAL. These load inside the block editor and must
-		// share WordPress's canonical private-apis instance; bundling a copy inline
-		// breaks lock()/unlock() across bundles ("Cannot unlock an object that was not
-		// locked before"). On WP 6.9.x the wp-theme handle is absent, so these stay
-		// unenqueued there (unchanged from before); on newer WP they enqueue normally.
-		plugins: standardPlugins(),
 		entry: {
 			'classic-editor': './_inc/entry-points/classic-editor.js',
-			'block-editor-jetpack': './_inc/entry-points/block-editor-jetpack.tsx',
-			'block-editor-social': './_inc/entry-points/block-editor-social.tsx',
 		},
-		devServer: jetpackWebpackConfig.DevServer( {
-			static: { directory: path.resolve( './build' ) },
-		} ),
 	},
 	{
 		...socialWebpackConfig,
-		// Standalone Social admin page: bundle @wordpress/theme and
-		// @wordpress/private-apis inline so the page renders on WP 6.9.x, whose wp-theme
-		// script handle is missing (externalizing it makes the bundle silently fail to
-		// enqueue). Safe here because this is a standalone admin page, not the block
-		// editor, so there is no shared canonical private-apis instance to conflict with.
-		// Both are bundled jointly so @wordpress/theme's module-init lock() lands on the
-		// same private-apis consent map. See PR #48173.
-		plugins: standardPlugins( {
-			DependencyExtractionPlugin: {
-				requestMap: {
-					'@wordpress/theme': { external: false },
-					'@wordpress/private-apis': { external: false },
-				},
-			},
-		} ),
 		entry: {
 			'social-admin-page': './_inc/entry-points/social-admin-page.tsx',
+			'block-editor-jetpack': './_inc/entry-points/block-editor-jetpack.tsx',
+			'block-editor-social': './_inc/entry-points/block-editor-social.tsx',
 		},
 		devServer: jetpackWebpackConfig.DevServer( {
 			static: { directory: path.resolve( './build' ) },

--- a/projects/plugins/jetpack/changelog/fix-social-wp69-theme-shim
+++ b/projects/plugins/jetpack/changelog/fix-social-wp69-theme-shim
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the Social admin page rendering blank, and restore the editor sharing panel, on WordPress 6.9.

--- a/projects/plugins/social/changelog/fix-social-wp69-theme-shim
+++ b/projects/plugins/social/changelog/fix-social-wp69-theme-shim
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Social admin page rendering blank, and restore the editor sharing panel, on WordPress 6.9.


### PR DESCRIPTION
Fixes JETPACK-1750

## Proposed changes

On WordPress 6.9.x, `@wordpress/theme` (pulled in transitively via `@wordpress/ui`) is externalized to the `wp-theme` script handle, which only exists on WP 7.0+ — and even WP 7.0's `wp-private-apis` ships a core-module allowlist too old for `@wordpress/theme` / `@wordpress/ui`. WordPress silently refuses to enqueue any script with an unregistered dependency, so the Social bundles never load: the **Social admin page renders blank** and the editor **"Share to social media" controls are missing**.

This reuses the existing `jetpack-wp-build-polyfills` package — which already provides `wp-theme` / `wp-private-apis` for the wp-build (chassis) Social dashboard — and wires it into the two surfaces that still lacked it:

* **Revert #49654.** That PR fixed only the admin page, by bundling `@wordpress/theme` + `@wordpress/private-apis` inline for the `social-admin-page` entry. The block-editor entries kept externalizing both, so the editor controls stayed missing — and inlining `private-apis` there breaks `lock()`/`unlock()` across bundles (`Cannot unlock an object that was not locked before`).
* Register the polyfills in the **legacy admin-page** and **block-editor** enqueue paths via a shared `Publicize_Assets::register_wp_build_polyfills()` helper, and de-duplicate the existing chassis call to reuse it.

All bundles keep externalizing `wp-theme` / `wp-private-apis` uniformly; the polyfills provide a single shared `private-apis` instance whose allowlist permits `@wordpress/theme` and `@wordpress/ui`, so every consumer — WordPress core included — shares one instance and `lock()`/`unlock()` stays consistent. No-op on WP 7.0+.

This matches the fix suggested in the issue (`WP_Build_Polyfills::register()`).

## Related product discussion/links

* JETPACK-1750
* JETPACK-1716 (original report)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a site on **WordPress 6.9.x** with Jetpack Social active.

1. **Editor controls:** Posts → Add New → open the Jetpack sidebar panel. Confirm the **"Share to social media"** section appears (auto-share toggle, per-connection toggles, Manage connections, Preview & customize, Link preview).
2. **Admin page:** Go to **Jetpack → Social** and confirm the dashboard renders (not blank). Verify both the modernized dashboard and the legacy dashboard — force the legacy one with `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_false' )`.
3. Confirm the browser console shows no `Cannot unlock an object that was not locked before` error.
4. On **WP 7.0+**, confirm nothing changes — the polyfills are a no-op since core already registers `wp-theme`.

| Before | After |
| --- | --- |
|  |  |
