### PR TITLE
Forms: honor webhook destinations for template, template-part and widget forms

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-honor-webhooks-template-widget-sources
+++ b/projects/packages/forms/changelog/fix-forms-honor-webhooks-template-widget-sources
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: restore webhook, Post to URL and Salesforce delivery for forms placed in block templates, template parts and widgets, which stopped firing in 15.9.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -146,15 +146,36 @@ class Jetpack_Forms {
 	 * Whether author-configured outbound destinations from a form source should be honored.
 	 *
 	 * Destinations declared in the form content (webhooks, the legacy postToUrl attribute and
-	 * the Salesforce integration) are only honored when the source post's author has the
-	 * `manage_options` capability. Returns false when no post author can be determined (for
-	 * example, widget or block-template forms whose source id is not a numeric post).
+	 * the Salesforce integration) carry submission data to an outbound URL, so they are only
+	 * honored when whoever placed the form had an administrator-level capability:
 	 *
-	 * @param int|string $source_id The form source id: a post id for post/page forms, or a
-	 *                              non-numeric value for widget or block-template sources.
+	 * - For post/page forms (`single`, numeric source id) the source post's author must have
+	 *   the `manage_options` capability. Editor/Author/Contributor-authored forms are dropped.
+	 * - For block templates, block template parts and widgets the source id is not a numeric
+	 *   post, so there is no author to check. Editing any of those surfaces already requires
+	 *   the `edit_theme_options` capability — administrator-tier, strictly above the
+	 *   capabilities an Editor/Author/Contributor holds — so their destinations are trusted.
+	 *
+	 * The source type is established server-side (from the signed JWT, or by re-rendering the
+	 * real template/template part on the legacy path) and is not forgeable by the submitter.
+	 *
+	 * Returns false for any other unresolved source (non-numeric id of an unknown type, or a
+	 * numeric id with no admin-capable author).
+	 *
+	 * @param int|string $source_id   The form source id: a post id for post/page forms, or a
+	 *                                non-numeric value for widget or block-template sources.
+	 * @param string     $source_type The form source type: single, widget, block_template or
+	 *                                block_template_part. Defaults to 'single'.
 	 * @return boolean
 	 */
-	public static function should_honor_content_destinations( $source_id ) {
+	public static function should_honor_content_destinations( $source_id, $source_type = 'single' ) {
+		// Block templates, template parts and widgets can only be authored by users with the
+		// administrator-tier `edit_theme_options` capability, so their destinations are trusted
+		// even though the source id is not a numeric post.
+		if ( in_array( $source_type, array( 'block_template', 'block_template_part', 'widget' ), true ) ) {
+			return true;
+		}
+
 		if ( ! is_numeric( $source_id ) ) {
 			return false;
 		}

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms;
 
+use Automattic\Jetpack\Forms\ContactForm\Feedback_Source;
 use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 /**
@@ -172,7 +173,7 @@ class Jetpack_Forms {
 		// Block templates, template parts and widgets can only be authored by users with the
 		// administrator-tier `edit_theme_options` capability, so their destinations are trusted
 		// even though the source id is not a numeric post.
-		if ( in_array( $source_type, array( 'block_template', 'block_template_part', 'widget' ), true ) ) {
+		if ( in_array( $source_type, Feedback_Source::ADMIN_TIER_SOURCE_TYPES, true ) ) {
 			return true;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2011,8 +2011,10 @@ class Contact_Form_Plugin {
 	 * Enforcement point for outbound-destination authorization on a submitted form.
 	 *
 	 * Destinations declared in the form content — webhooks, the legacy postToUrl attribute and
-	 * the Salesforce integration — are kept only when the source post's author may configure
-	 * them; otherwise they are removed from the form attributes in place, before the submission
+	 * the Salesforce integration — are kept only when whoever placed the form had an
+	 * administrator-level capability (an admin author for post/page forms, or the
+	 * `edit_theme_options` required to author block templates, template parts and widgets);
+	 * otherwise they are removed from the form attributes in place, before the submission
 	 * is processed and the Form_Webhooks / Post_To_Url services read those attributes. The
 	 * mutation is safe because nothing re-reads the original attribute values within the request
 	 * and the form attributes are not persisted after this point.
@@ -2029,7 +2031,8 @@ class Contact_Form_Plugin {
 			return;
 		}
 
-		if ( ! Jetpack_Forms::should_honor_content_destinations( $form->get_source()->get_id() ) ) {
+		$source = $form->get_source();
+		if ( ! Jetpack_Forms::should_honor_content_destinations( $source->get_id(), $source->get_source_type() ) ) {
 			// Drop every content-configured destination before the services read them.
 			// postToUrl and salesforceData are read directly by Post_To_Url.
 			$form->attributes['webhooks']       = array();

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -299,6 +299,17 @@ class Feedback_Source {
 	}
 
 	/**
+	 * Get the source type of the feedback entry.
+	 *
+	 * Possible values: single, widget, block_template, block_template_part.
+	 *
+	 * @return string The source type.
+	 */
+	public function get_source_type() {
+		return $this->source_type;
+	}
+
+	/**
 	 * Whether this feedback was submitted from a form preview (test submission).
 	 *
 	 * @return bool

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -193,17 +193,23 @@ class Feedback_Source {
 		// at submission time to branch the response into the test pipeline.
 		$is_test = Form_Preview::is_preview_mode();
 
+		// The widget context is resolved server-side in Contact_Form::parse() (it overwrites the
+		// widget attribute before the form is built), so the value seen here is trustworthy.
 		if ( isset( $attributes['widget'] ) && ! empty( $attributes['widget'] ) ) {
 			return new self( $attributes['widget'], self::get_source_title(), 1, 'widget', $current_url, $is_test );
 		}
 
-		if ( isset( $attributes['block_template'] ) && ! empty( $attributes['block_template'] ) ) {
-			global $_wp_current_template_id;
-			return new self( $_wp_current_template_id, self::get_source_title(), $page, 'block_template', $current_url, $is_test );
+		// Block template part and block template sources are determined from render-scoped
+		// globals that are set only while the actual template part / template renders — never
+		// from a content attribute. A content attribute can be supplied by a post author (who
+		// need not hold edit_theme_options), so trusting it would let post-content forms
+		// masquerade as admin-authored template sources. See Util for the globals' lifecycle.
+		if ( ! empty( $GLOBALS['grunion_block_template_part_id'] ) ) {
+			return new self( $GLOBALS['grunion_block_template_part_id'], self::get_source_title(), $page, 'block_template_part', $current_url, $is_test );
 		}
 
-		if ( isset( $attributes['block_template_part'] ) && ! empty( $attributes['block_template_part'] ) ) {
-			return new self( $attributes['block_template_part'], self::get_source_title(), $page, 'block_template_part', $current_url, $is_test );
+		if ( ! empty( $GLOBALS['grunion_block_template_id'] ) ) {
+			return new self( $GLOBALS['grunion_block_template_id'], self::get_source_title(), $page, 'block_template', $current_url, $is_test );
 		}
 
 		return new Feedback_Source( \get_the_ID(), \get_the_title(), $page, 'single', $current_url, $is_test );

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -15,6 +15,15 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 class Feedback_Source {
 
 	/**
+	 * Source types whose forms can only be placed by a user with the administrator-tier
+	 * `edit_theme_options` capability. Destinations declared in these surfaces are trusted
+	 * even though they have no numeric post author to check.
+	 *
+	 * @var string[]
+	 */
+	const ADMIN_TIER_SOURCE_TYPES = array( 'block_template', 'block_template_part', 'widget' );
+
+	/**
 	 * The ID of the post or page that the feedback was created on.
 	 *
 	 * @var string

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -14,6 +14,16 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 class Util {
 
 	/**
+	 * Saved values of the block_template global while core/post-content blocks render.
+	 *
+	 * A stack so nested or sequential post-content renders (e.g. a query loop) restore
+	 * correctly. @see grunion_contact_form_suspend_block_template_id_in_post_content().
+	 *
+	 * @var array
+	 */
+	private static $block_template_id_suspended = array();
+
+	/**
 	 * Registers all relevant actions and filters for this class.
 	 */
 	public static function init() {
@@ -28,6 +38,11 @@ class Util {
 
 		add_filter( 'render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global', 10, 2 );
 		add_filter( 'widget_block_content', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content', 1, 3 );
+
+		// Suspend the block_template global while core/post-content renders, so forms in the post
+		// body are attributed to the post (and gated on the author), not to the template.
+		add_filter( 'pre_render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_suspend_block_template_id_in_post_content', 10, 2 );
+		add_filter( 'render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_restore_block_template_id_after_post_content', 10, 2 );
 
 		// Register the default for the `central-form-management` feature flag at bootstrap
 		// so that early callers of Contact_Form_Plugin::has_editor_feature_flag() — such as
@@ -201,6 +216,14 @@ class Util {
 					'block_template' => 'canvas',
 				)
 			);
+
+			// Mark that we are rendering a block template, so forms in the template chrome are
+			// attributed to it. This global is the trusted signal Feedback_Source::get_current()
+			// uses for the block_template source type (the content attribute is not trusted). It
+			// is suspended while core/post-content renders so a form in the post body is not
+			// mistaken for a template-authored form.
+			global $_wp_current_template_id;
+			$GLOBALS['grunion_block_template_id'] = ! empty( $_wp_current_template_id ) ? $_wp_current_template_id : 'canvas';
 		}
 		return $template;
 	}
@@ -229,6 +252,50 @@ class Util {
 			&& 'core/template-part' === $block['blockName']
 			&& isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			unset( $GLOBALS['grunion_block_template_part_id'] );
+		}
+		return $content;
+	}
+
+	/**
+	 * Suspends the block_template global while a core/post-content block renders.
+	 *
+	 * The core/post-content block renders the post body, which may contain a contact form
+	 * authored by a user without edit_theme_options. Such a form must be attributed to the post
+	 * (and gated on the post author), not to the surrounding template, so the trusted
+	 * block_template signal is removed for the duration of the render and restored afterwards.
+	 *
+	 * Hooked on `pre_render_block`; returns its first argument unchanged so rendering proceeds.
+	 *
+	 * @param string|null $pre_render   The pre-rendered content. Default null.
+	 * @param array       $parsed_block The block being rendered.
+	 * @return string|null Unchanged $pre_render.
+	 */
+	public static function grunion_contact_form_suspend_block_template_id_in_post_content( $pre_render, $parsed_block ) {
+		if ( isset( $parsed_block['blockName'] ) && 'core/post-content' === $parsed_block['blockName'] ) {
+			self::$block_template_id_suspended[] = $GLOBALS['grunion_block_template_id'] ?? null;
+			unset( $GLOBALS['grunion_block_template_id'] );
+		}
+		return $pre_render;
+	}
+
+	/**
+	 * Restores the block_template global once a core/post-content block has finished rendering.
+	 *
+	 * Counterpart to grunion_contact_form_suspend_block_template_id_in_post_content(). Hooked on
+	 * `render_block`; returns the block content unchanged.
+	 *
+	 * @param string $content Rendered block content.
+	 * @param array  $block   The full block, including name and attributes.
+	 * @return string Unchanged $content.
+	 */
+	public static function grunion_contact_form_restore_block_template_id_after_post_content( $content, $block ) {
+		if ( isset( $block['blockName'] )
+			&& 'core/post-content' === $block['blockName']
+			&& ! empty( self::$block_template_id_suspended ) ) {
+			$restored = array_pop( self::$block_template_id_suspended );
+			if ( null !== $restored ) {
+				$GLOBALS['grunion_block_template_id'] = $restored;
+			}
 		}
 		return $content;
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4143,6 +4143,22 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Resolve a Feedback_Source through get_current() with a render-scoped global set, then clear
+	 * the global. Mirrors how a real template/template-part render establishes the source type.
+	 *
+	 * @param string $global_key The render-scoped global to set (e.g. grunion_block_template_id).
+	 * @param string $value      The value to set it to (the template/part id).
+	 * @param array  $attributes Attributes to pass to get_current().
+	 * @return Feedback_Source
+	 */
+	private function source_from_render_global( $global_key, $value, $attributes = array() ) {
+		$GLOBALS[ $global_key ] = $value;
+		$source                 = Feedback_Source::get_current( $attributes );
+		unset( $GLOBALS[ $global_key ] );
+		return $source;
+	}
+
+	/**
 	 * Invoke the private reconcile_content_destinations() method on the plugin singleton.
 	 *
 	 * @param Contact_Form $form Form to reconcile.
@@ -4320,9 +4336,7 @@ class Contact_Form_Test extends BaseTestCase {
 	 * webhooks/postToUrl/Salesforce destinations were silently dropped from Jetpack 15.9.
 	 */
 	public function test_reconcile_content_destinations_keeps_destinations_for_block_template_source() {
-		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
-		$source                               = Feedback_Source::get_current( array() );
-		unset( $GLOBALS['grunion_block_template_id'] );
+		$source = $this->source_from_render_global( 'grunion_block_template_id', 'mytheme//single' );
 
 		$this->assertSame( 'block_template', $source->get_source_type(), 'Render-scoped global should yield a block_template source.' );
 
@@ -4393,18 +4407,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 * (the legitimate path) is honored.
 	 */
 	public function test_render_anchored_template_sources_are_trusted() {
-		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
-		$template_source                      = Feedback_Source::get_current( array() );
-		unset( $GLOBALS['grunion_block_template_id'] );
+		$template_source = $this->source_from_render_global( 'grunion_block_template_id', 'mytheme//single' );
 
 		$this->assertSame( 'block_template', $template_source->get_source_type() );
 		$this->assertTrue(
 			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( $template_source->get_id(), $template_source->get_source_type() )
 		);
 
-		$GLOBALS['grunion_block_template_part_id'] = 'mytheme//footer';
-		$part_source                               = Feedback_Source::get_current( array() );
-		unset( $GLOBALS['grunion_block_template_part_id'] );
+		$part_source = $this->source_from_render_global( 'grunion_block_template_part_id', 'mytheme//footer' );
 
 		$this->assertSame( 'block_template_part', $part_source->get_source_type() );
 		$this->assertTrue(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4085,15 +4085,17 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Build a Contact_Form whose source resolves to the given post id.
 	 *
-	 * @param array $attributes Form attributes.
-	 * @param int   $source_id  Source (post) id the form should report.
+	 * @param array  $attributes  Form attributes.
+	 * @param int    $source_id   Source (post) id the form should report.
+	 * @param string $source_type Source type (single, widget, block_template, block_template_part).
 	 * @return Contact_Form
 	 */
-	private function make_form_with_source( $attributes, $source_id ) {
+	private function make_form_with_source( $attributes, $source_id, $source_type = 'single' ) {
 		$source = Feedback_Source::from_serialized(
 			array(
-				'source_id' => $source_id,
-				'title'     => 'Test Post',
+				'source_id'   => $source_id,
+				'title'       => 'Test Post',
+				'source_type' => $source_type,
 			)
 		);
 
@@ -4187,6 +4189,46 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test should_honor_content_destinations honors block-template, template-part and widget
+	 * sources, whose (non-numeric) ids have no post author but require an administrator-tier
+	 * `edit_theme_options` capability to author.
+	 *
+	 * @dataProvider data_admin_tier_source_types
+	 *
+	 * @param string $source_type The source type to honor.
+	 */
+	#[DataProvider( 'data_admin_tier_source_types' )]
+	public function test_should_honor_content_destinations_for_admin_tier_sources( $source_type ) {
+		$this->assertTrue(
+			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( 'mytheme//page', $source_type ),
+			"Destinations should be honored for $source_type sources."
+		);
+	}
+
+	/**
+	 * Source types that can only be authored with an administrator-tier capability.
+	 *
+	 * @return array
+	 */
+	public static function data_admin_tier_source_types() {
+		return array(
+			'block template'      => array( 'block_template' ),
+			'block template part' => array( 'block_template_part' ),
+			'widget'              => array( 'widget' ),
+		);
+	}
+
+	/**
+	 * Test should_honor_content_destinations still denies an unresolved non-numeric source whose
+	 * type is not an admin-tier authoring surface (the conservative catch-all).
+	 */
+	public function test_should_not_honor_content_destinations_for_unknown_non_numeric_source() {
+		$this->assertFalse(
+			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( 'mytheme//page', 'single' )
+		);
+	}
+
+	/**
 	 * Test reconcile_content_destinations drops every content-configured destination
 	 * when the source post author may not configure them.
 	 */
@@ -4271,6 +4313,42 @@ class Contact_Form_Test extends BaseTestCase {
 		// postToUrl is migrated into the webhooks collection, so both entries survive.
 		$this->assertCount( 2, $form->attributes['webhooks'], 'Configured webhook and migrated postToUrl should remain.' );
 		$this->assertSame( array( 'organizationId' => '12345' ), $form->attributes['salesforceData'], 'salesforceData should be preserved.' );
+	}
+
+	/**
+	 * Test reconcile_content_destinations keeps destinations for a block-template source whose
+	 * (non-numeric) id has no post author but requires an admin-tier capability to author.
+	 *
+	 * Regression test for forms placed in FSE block templates, template parts and widgets whose
+	 * webhooks/postToUrl/Salesforce destinations were silently dropped from Jetpack 15.9.
+	 */
+	public function test_reconcile_content_destinations_keeps_destinations_for_block_template_source() {
+		$form = $this->make_form_with_source(
+			array(
+				'webhooks'       => array(
+					array(
+						'webhook_id' => 'w',
+						'url'        => 'https://example.com/hook',
+						'enabled'    => true,
+						'format'     => 'json',
+						'method'     => 'POST',
+					),
+				),
+				'postToUrl'      => array(
+					'url'     => 'https://example.com/post',
+					'enabled' => true,
+				),
+				'salesforceData' => array( 'organizationId' => '12345' ),
+			),
+			'mytheme//page',
+			'block_template'
+		);
+
+		$this->invoke_reconcile_content_destinations( $form );
+
+		// postToUrl is migrated into the webhooks collection, so both entries survive.
+		$this->assertCount( 2, $form->attributes['webhooks'], 'Configured webhook and migrated postToUrl should remain for a block-template form.' );
+		$this->assertSame( array( 'organizationId' => '12345' ), $form->attributes['salesforceData'], 'salesforceData should be preserved for a block-template form.' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4193,30 +4193,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Test should_honor_content_destinations honors block-template, template-part and widget
 	 * sources, whose (non-numeric) ids have no post author but require an administrator-tier
 	 * `edit_theme_options` capability to author.
-	 *
-	 * @dataProvider data_admin_tier_source_types
-	 *
-	 * @param string $source_type The source type to honor.
 	 */
-	#[DataProvider( 'data_admin_tier_source_types' )]
-	public function test_should_honor_content_destinations_for_admin_tier_sources( $source_type ) {
-		$this->assertTrue(
-			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( 'mytheme//page', $source_type ),
-			"Destinations should be honored for $source_type sources."
-		);
-	}
-
-	/**
-	 * Source types that can only be authored with an administrator-tier capability.
-	 *
-	 * @return array
-	 */
-	public static function data_admin_tier_source_types() {
-		return array(
-			'block template'      => array( 'block_template' ),
-			'block template part' => array( 'block_template_part' ),
-			'widget'              => array( 'widget' ),
-		);
+	public function test_should_honor_content_destinations_for_admin_tier_sources() {
+		foreach ( Feedback_Source::ADMIN_TIER_SOURCE_TYPES as $source_type ) {
+			$this->assertTrue(
+				\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( 'mytheme//page', $source_type ),
+				"Destinations should be honored for $source_type sources."
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4085,9 +4085,10 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Build a Contact_Form whose source resolves to the given post id.
 	 *
-	 * @param array  $attributes  Form attributes.
-	 * @param int    $source_id   Source (post) id the form should report.
-	 * @param string $source_type Source type (single, widget, block_template, block_template_part).
+	 * @param array      $attributes  Form attributes.
+	 * @param int|string $source_id   Source id the form should report: a numeric post id, or a
+	 *                                non-numeric widget/block-template id.
+	 * @param string     $source_type Source type (single, widget, block_template, block_template_part).
 	 * @return Contact_Form
 	 */
 	private function make_form_with_source( $attributes, $source_id, $source_type = 'single' ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4100,6 +4100,17 @@ class Contact_Form_Test extends BaseTestCase {
 			)
 		);
 
+		return $this->make_form_with_source_object( $attributes, $source );
+	}
+
+	/**
+	 * Build a Contact_Form that reports the given (already constructed) source.
+	 *
+	 * @param array           $attributes Form attributes.
+	 * @param Feedback_Source $source     Source to report from get_source().
+	 * @return Contact_Form
+	 */
+	private function make_form_with_source_object( $attributes, $source ) {
 		return new class( $attributes, $source ) extends Contact_Form {
 			/**
 			 * Source to report from get_source().
@@ -4301,14 +4312,21 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test reconcile_content_destinations keeps destinations for a block-template source whose
-	 * (non-numeric) id has no post author but requires an admin-tier capability to author.
+	 * Test reconcile_content_destinations keeps destinations for a block-template source built
+	 * through the real render path: the source type comes from the render-scoped global, not from
+	 * a content attribute, so this exercises a reachable state.
 	 *
 	 * Regression test for forms placed in FSE block templates, template parts and widgets whose
 	 * webhooks/postToUrl/Salesforce destinations were silently dropped from Jetpack 15.9.
 	 */
 	public function test_reconcile_content_destinations_keeps_destinations_for_block_template_source() {
-		$form = $this->make_form_with_source(
+		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
+		$source                               = Feedback_Source::get_current( array() );
+		unset( $GLOBALS['grunion_block_template_id'] );
+
+		$this->assertSame( 'block_template', $source->get_source_type(), 'Render-scoped global should yield a block_template source.' );
+
+		$form = $this->make_form_with_source_object(
 			array(
 				'webhooks'       => array(
 					array(
@@ -4325,8 +4343,7 @@ class Contact_Form_Test extends BaseTestCase {
 				),
 				'salesforceData' => array( 'organizationId' => '12345' ),
 			),
-			'mytheme//page',
-			'block_template'
+			$source
 		);
 
 		$this->invoke_reconcile_content_destinations( $form );
@@ -4334,6 +4351,65 @@ class Contact_Form_Test extends BaseTestCase {
 		// postToUrl is migrated into the webhooks collection, so both entries survive.
 		$this->assertCount( 2, $form->attributes['webhooks'], 'Configured webhook and migrated postToUrl should remain for a block-template form.' );
 		$this->assertSame( array( 'organizationId' => '12345' ), $form->attributes['salesforceData'], 'salesforceData should be preserved for a block-template form.' );
+	}
+
+	/**
+	 * Test that Feedback_Source::get_current() anchors the block_template / block_template_part
+	 * source types to render-scoped globals, NOT to content attributes.
+	 *
+	 * A content attribute can be supplied by a post author who lacks edit_theme_options, so
+	 * trusting it would let a post-content form masquerade as an admin-authored template source
+	 * and have its content-declared destinations honored. This guards that hole.
+	 */
+	public function test_content_supplied_template_markers_are_not_trusted() {
+		unset( $GLOBALS['grunion_block_template_id'], $GLOBALS['grunion_block_template_part_id'] );
+
+		foreach ( array( 'block_template', 'block_template_part' ) as $marker ) {
+			$source = Feedback_Source::get_current(
+				array(
+					$marker    => 'mytheme//evil',
+					'webhooks' => array(
+						array(
+							'webhook_id' => 'w',
+							'url'        => 'https://example.com/x',
+							'enabled'    => true,
+							'format'     => 'json',
+							'method'     => 'POST',
+						),
+					),
+				)
+			);
+
+			$this->assertNotContains(
+				$source->get_source_type(),
+				Feedback_Source::ADMIN_TIER_SOURCE_TYPES,
+				"A content-supplied $marker attribute must not yield an admin-tier source type."
+			);
+		}
+	}
+
+	/**
+	 * Test that a block_template / block_template_part source built from the render-scoped global
+	 * (the legitimate path) is honored.
+	 */
+	public function test_render_anchored_template_sources_are_trusted() {
+		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
+		$template_source                      = Feedback_Source::get_current( array() );
+		unset( $GLOBALS['grunion_block_template_id'] );
+
+		$this->assertSame( 'block_template', $template_source->get_source_type() );
+		$this->assertTrue(
+			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( $template_source->get_id(), $template_source->get_source_type() )
+		);
+
+		$GLOBALS['grunion_block_template_part_id'] = 'mytheme//footer';
+		$part_source                               = Feedback_Source::get_current( array() );
+		unset( $GLOBALS['grunion_block_template_part_id'] );
+
+		$this->assertSame( 'block_template_part', $part_source->get_source_type() );
+		$this->assertTrue(
+			\Automattic\Jetpack\Forms\Jetpack_Forms::should_honor_content_destinations( $part_source->get_id(), $part_source->get_source_type() )
+		);
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4423,6 +4423,19 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that get_current() still resolves a widget source from the widget attribute, which
+	 * Contact_Form::parse() sets from the server-resolved widget context (not from content).
+	 */
+	public function test_get_current_resolves_widget_source_from_attribute() {
+		unset( $GLOBALS['grunion_block_template_id'], $GLOBALS['grunion_block_template_part_id'] );
+
+		$source = Feedback_Source::get_current( array( 'widget' => 'sidebar-1' ) );
+
+		$this->assertSame( 'widget', $source->get_source_type() );
+		$this->assertSame( 'sidebar-1', (string) $source->get_id() );
+	}
+
+	/**
 	 * Test prepare_submit_button adds interactivity attributes to submit buttons.
 	 *
 	 * @dataProvider data_provider_prepare_submit_button

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -781,8 +781,9 @@ EOT
 	 */
 	public function test_set_block_template_attribute_marks_block_template_global() {
 		global $_wp_current_template_content, $_wp_current_template_id;
-		$prev_content = $_wp_current_template_content ?? null;
-		$prev_id      = $_wp_current_template_id ?? null;
+		// The `global` declaration above defines both (null if unset), so no null-guard is needed.
+		$prev_content = $_wp_current_template_content;
+		$prev_id      = $_wp_current_template_id;
 
 		$_wp_current_template_content = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
 		$_wp_current_template_id      = 'twentytwentyfour//single';

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -763,6 +763,8 @@ EOT
 		$pc                                   = array( 'blockName' => 'core/post-content' );
 
 		Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, $pc ); // outer
+		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Outer post-content suspends the global' );
+
 		Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, $pc ); // inner (already absent)
 		Util::grunion_contact_form_restore_block_template_id_after_post_content( '', $pc ); // inner: was absent, stays absent
 		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Inner restore (value was absent) leaves the global absent' );
@@ -779,8 +781,8 @@ EOT
 	 */
 	public function test_set_block_template_attribute_marks_block_template_global() {
 		global $_wp_current_template_content, $_wp_current_template_id;
-		$prev_content = isset( $_wp_current_template_content ) ? $_wp_current_template_content : null;
-		$prev_id      = isset( $_wp_current_template_id ) ? $_wp_current_template_id : null;
+		$prev_content = $_wp_current_template_content ?? null;
+		$prev_id      = $_wp_current_template_id ?? null;
 
 		$_wp_current_template_content = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
 		$_wp_current_template_id      = 'twentytwentyfour//single';

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -688,6 +688,16 @@ EOT
 		);
 
 		$this->assertNotFalse(
+			has_filter( 'pre_render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_suspend_block_template_id_in_post_content' ),
+			'pre_render_block filter should suspend the block_template global'
+		);
+
+		$this->assertNotFalse(
+			has_filter( 'render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_restore_block_template_id_after_post_content' ),
+			'render_block filter should restore the block_template global'
+		);
+
+		$this->assertNotFalse(
 			has_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init' ),
 			'Contact_Form_Plugin::init should be registered on init action'
 		);
@@ -701,6 +711,94 @@ EOT
 			has_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent' ),
 			'grunion_pre_message_sent action should be registered'
 		);
+	}
+
+	/**
+	 * Test that the post-content bracket suspends the block_template global for a
+	 * core/post-content block and leaves it untouched for other blocks.
+	 */
+	public function test_suspend_block_template_id_only_for_post_content() {
+		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
+
+		// A non-post-content block must not touch the global.
+		$ret = Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, array( 'blockName' => 'core/paragraph' ) );
+		$this->assertNull( $ret, 'pre_render value is returned unchanged' );
+		$this->assertSame( 'mytheme//single', $GLOBALS['grunion_block_template_id'], 'Non post-content block leaves the global in place' );
+
+		// core/post-content suspends it.
+		$ret = Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, array( 'blockName' => 'core/post-content' ) );
+		$this->assertNull( $ret, 'pre_render value is returned unchanged' );
+		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Global is suspended while post-content renders' );
+
+		unset( $GLOBALS['grunion_block_template_id'] );
+	}
+
+	/**
+	 * Test that suspending then restoring around a core/post-content block returns the global
+	 * to its previous value, and that a non-post-content block does not restore.
+	 */
+	public function test_restore_block_template_id_after_post_content() {
+		$GLOBALS['grunion_block_template_id'] = 'mytheme//single';
+		$pc                                   = array( 'blockName' => 'core/post-content' );
+
+		Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, $pc );
+
+		// A non-post-content block must not restore anything.
+		Util::grunion_contact_form_restore_block_template_id_after_post_content( '', array( 'blockName' => 'core/paragraph' ) );
+		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Non post-content block does not restore the global' );
+
+		$ret = Util::grunion_contact_form_restore_block_template_id_after_post_content( 'BODY', $pc );
+		$this->assertSame( 'BODY', $ret, 'Block content is returned unchanged' );
+		$this->assertSame( 'mytheme//single', $GLOBALS['grunion_block_template_id'], 'Global is restored after post-content' );
+
+		unset( $GLOBALS['grunion_block_template_id'] );
+	}
+
+	/**
+	 * Test that nested core/post-content renders (e.g. a query loop) restore the OUTER value,
+	 * which is the reason the suspended values are stacked rather than stored in a scalar.
+	 */
+	public function test_nested_post_content_restores_outer_block_template_id() {
+		$GLOBALS['grunion_block_template_id'] = 'theme//tmpl';
+		$pc                                   = array( 'blockName' => 'core/post-content' );
+
+		Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, $pc ); // outer
+		Util::grunion_contact_form_suspend_block_template_id_in_post_content( null, $pc ); // inner (already absent)
+		Util::grunion_contact_form_restore_block_template_id_after_post_content( '', $pc ); // inner: was absent, stays absent
+		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Inner restore (value was absent) leaves the global absent' );
+
+		Util::grunion_contact_form_restore_block_template_id_after_post_content( '', $pc ); // outer
+		$this->assertSame( 'theme//tmpl', $GLOBALS['grunion_block_template_id'], 'Outer value is restored after nested post-content' );
+
+		unset( $GLOBALS['grunion_block_template_id'] );
+	}
+
+	/**
+	 * Test that the canvas injector marks the block_template global when (and only when) a block
+	 * template is being rendered (template-canvas.php).
+	 */
+	public function test_set_block_template_attribute_marks_block_template_global() {
+		global $_wp_current_template_content, $_wp_current_template_id;
+		$prev_content = isset( $_wp_current_template_content ) ? $_wp_current_template_content : null;
+		$prev_id      = isset( $_wp_current_template_id ) ? $_wp_current_template_id : null;
+
+		$_wp_current_template_content = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
+		$_wp_current_template_id      = 'twentytwentyfour//single';
+		unset( $GLOBALS['grunion_block_template_id'] );
+
+		$ret = Util::grunion_contact_form_set_block_template_attribute( '/themes/x/template-canvas.php' );
+		$this->assertSame( '/themes/x/template-canvas.php', $ret, 'Template path is returned unchanged' );
+		$this->assertSame( 'twentytwentyfour//single', $GLOBALS['grunion_block_template_id'], 'Block template global is set while the canvas renders' );
+
+		// A non-canvas template must not set the global.
+		unset( $GLOBALS['grunion_block_template_id'] );
+		Util::grunion_contact_form_set_block_template_attribute( '/themes/x/single.php' );
+		$this->assertArrayNotHasKey( 'grunion_block_template_id', $GLOBALS, 'Non-canvas template does not set the global' );
+
+		// Restore globals.
+		unset( $GLOBALS['grunion_block_template_id'] );
+		$_wp_current_template_content = $prev_content;
+		$_wp_current_template_id      = $prev_id;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Jetpack 15.9 added capability hardening to outbound form destinations (`should_honor_content_destinations`): webhooks, the legacy Post to URL, and the Salesforce integration are only honored when the form was placed by an admin-capable author. That gate bailed out for any form whose source id is not a numeric post — which is the case for forms living in **block templates**, **block template parts**, and **widgets** — silently dropping their destinations. Webhooks for those forms stopped firing as of 15.9.

This PR honors those three source types. Editing a block template, template part, or widget already requires the administrator-tier `edit_theme_options` capability — strictly above what an Editor/Author/Contributor holds — so destinations declared there are trusted.

* `Jetpack_Forms::should_honor_content_destinations()` now takes the source type and returns `true` for `block_template`, `block_template_part`, and `widget` sources, before the numeric-id guard.
* Added `Feedback_Source::get_source_type()` and pass the type through from `reconcile_content_destinations()`.
* The numeric post-author `manage_options` check is unchanged: post-content forms authored by non-admins remain gated.

### Why this is safe

The source type is established server-side and is not forgeable by the submitter: on the JWT submission path the form (attributes + source) is rebuilt from the signed token; on the legacy path the destinations are loaded from the real server-side template/post-meta, never from request input. A non-admin cannot smuggle a destination into a "trusted" source type, because reaching one requires `edit_theme_options`. This does not reopen the exfiltration/SSRF vector the original hardening closed.

## Related product discussion/links

* p1782156764346269-slack-C087DQUSFAN

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a block (FSE) theme, edit a template or template part (e.g. the footer) in the Site Editor and add a Jetpack Form with a Webhook integration pointing at a request bin (e.g. webhook.site). Save.
2. On the front end, submit the form.
3. **Before this PR (Jetpack 15.9+):** no request reaches the webhook endpoint; a `content_destinations_dropped` / `author_unauthorized` log entry is recorded.
4. **After this PR:** the submission is POSTed to the webhook URL as expected.
5. Repeat with a legacy widget form. As a regression check, confirm a form on a normal admin-authored page still delivers, while a form on a page authored by a non-admin (Editor) still has its destinations dropped.
6. `jetpack test php packages/forms` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
