### PR TITLE
SEO: default post-list columns to hidden in Screen Options

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-seo-admin-columns-default-hidden
+++ b/projects/plugins/jetpack/changelog/fix-seo-admin-columns-default-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: default the Schema, Meta description, and Search post-list columns to hidden in Screen Options so they no longer crowd out the title column.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-admin-columns.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-admin-columns.php
@@ -30,10 +30,10 @@ class Jetpack_SEO_Admin_Columns {
 	 * Hide the SEO columns by default in Screen Options.
 	 *
 	 * Three extra always-on columns squeeze the title column unreadably narrow,
-	 * so we default them to hidden — the same way core hides Categories and Tags.
-	 * The `default_hidden_columns` filter only applies to users who have never
-	 * customized Screen Options for the screen, so anyone who explicitly enabled
-	 * the columns keeps them.
+	 * so we default them to hidden using core's `default_hidden_columns` filter —
+	 * the standard mechanism for choosing which columns start hidden in Screen
+	 * Options. It only applies to users who have never customized Screen Options
+	 * for the screen, so anyone who explicitly enabled the columns keeps them.
 	 *
 	 * @param string[]  $hidden Column IDs hidden by default.
 	 * @param WP_Screen $screen Current screen.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-admin-columns.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-admin-columns.php
@@ -23,6 +23,30 @@ class Jetpack_SEO_Admin_Columns {
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'register_columns_for_post_types' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+		add_filter( 'default_hidden_columns', array( __CLASS__, 'default_hidden_columns' ), 10, 2 );
+	}
+
+	/**
+	 * Hide the SEO columns by default in Screen Options.
+	 *
+	 * Three extra always-on columns squeeze the title column unreadably narrow,
+	 * so we default them to hidden — the same way core hides Categories and Tags.
+	 * The `default_hidden_columns` filter only applies to users who have never
+	 * customized Screen Options for the screen, so anyone who explicitly enabled
+	 * the columns keeps them.
+	 *
+	 * @param string[]  $hidden Column IDs hidden by default.
+	 * @param WP_Screen $screen Current screen.
+	 * @return string[]
+	 */
+	public static function default_hidden_columns( $hidden, $screen ) {
+		if ( isset( $screen->base ) && 'edit' === $screen->base ) {
+			$hidden = array_merge(
+				$hidden,
+				array( 'jetpack_seo_schema', 'jetpack_seo_description', 'jetpack_seo_search' )
+			);
+		}
+		return $hidden;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Admin_Columns_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Admin_Columns_Test.php
@@ -82,4 +82,33 @@ class Jetpack_SEO_Admin_Columns_Test extends WP_UnitTestCase {
 		update_post_meta( $post_id, Jetpack_SEO_Posts::NOINDEX_META_KEY, '1' );
 		$this->assertStringContainsString( 'Hidden', $this->render( 'jetpack_seo_search', $post_id ) );
 	}
+
+	/**
+	 * On a post-list screen the three SEO columns are added to the default-hidden
+	 * set, so they don't crowd out the title column for users who never touched
+	 * Screen Options.
+	 */
+	public function test_columns_hidden_by_default_on_edit_screen() {
+		$screen = WP_Screen::get( 'edit-post' );
+
+		$hidden = Jetpack_SEO_Admin_Columns::default_hidden_columns( array( 'comments' ), $screen );
+
+		$this->assertContains( 'jetpack_seo_schema', $hidden );
+		$this->assertContains( 'jetpack_seo_description', $hidden );
+		$this->assertContains( 'jetpack_seo_search', $hidden );
+		// Existing defaults are preserved.
+		$this->assertContains( 'comments', $hidden );
+	}
+
+	/**
+	 * Off the post-list tables (e.g. the dashboard) the filter is a no-op, so it
+	 * never pollutes unrelated screens' hidden-column defaults.
+	 */
+	public function test_columns_untouched_off_edit_screen() {
+		$screen = WP_Screen::get( 'dashboard' );
+
+		$hidden = Jetpack_SEO_Admin_Columns::default_hidden_columns( array( 'welcome_panel' ), $screen );
+
+		$this->assertSame( array( 'welcome_panel' ), $hidden );
+	}
 }


### PR DESCRIPTION
Fixes # N/A — tracked in Linear [JETPACK-1755](https://linear.app/a8c/issue/JETPACK-1755) (no GitHub issue).

## Proposed changes

* The SEO Tools module (since #49351, Jetpack 16.0) adds three read-only columns — **Schema**, **Meta description**, **Search** — to every public post-list table (Posts, Pages, Products, and any custom post type), registered via `manage_{post_type}_posts_columns`. Columns registered that way are **visible by default**, and they were never opted into the screen's default-hidden set — so three extra columns landed right after Title, squeezing the Title / Product Name column to an unreadable vertical sliver.
* Hook the core `default_hidden_columns` filter to add the three columns to the default-hidden set on post-list (`base === 'edit'`) screens — the same mechanism core uses to hide Categories and Tags. No-op on every other screen.
* This filter only applies to users who have **never** customized Screen Options for that screen, so anyone who explicitly enabled the columns keeps them. The columns and their renderers are untouched — only the default visibility changes.
* Out of scope by design: the SEO dashboard's own **Content** tab is a separate `@wordpress/dataviews` table whose default columns are defined in JS; it is not a Screen Options table and is structurally unaffected by this change.

## Related product discussion/links

* Linear: [JETPACK-1755](https://linear.app/a8c/issue/JETPACK-1755) (this fix) — related to [JETPACK-1680](https://linear.app/a8c/issue/JETPACK-1680)
* Regression introduced by: #49351

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Test on a self-hosted or Atomic site with the **SEO Tools** module active, as a user who has **never** opened Screen Options on the post list (use a fresh user/site — a user who already enabled these columns will correctly keep them).

1. **Before** (trunk / Jetpack 16.0): go to **Posts → All Posts** — Schema / Meta description / Search columns show by default and the Title column is squished.
2. **After** (this PR): the three columns are unchecked (hidden) by default; Title renders at full width. Repeat on **Pages** and **WooCommerce → Products**.
3. Open **Screen Options**, check the three columns — they appear and persist across a reload.
4. Confirm the **Jetpack → SEO → Content** tab is unchanged (its columns are still shown — by design).

Covered by unit tests in `Jetpack_SEO_Admin_Columns_Test` (`test_columns_hidden_by_default_on_edit_screen`, `test_columns_untouched_off_edit_screen`).
