### PR TITLE
SEO Overview: responsive grid for Content SEO coverage rings

### DIFF
--- a/projects/packages/seo/_inc/screens/overview/style.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.scss
@@ -46,9 +46,9 @@
 }
 
 // Content SEO card: factual coverage rings. An auto-fit grid (matching the
-// Overview card grid above) so the rings wrap from four columns down to two,
-// then one, as the screen narrows — rather than shrinking to share a single
-// row at every width.
+// Overview card grid above) so the rings flow into as many columns as fit
+// (up to four) and stack down to a single column as the screen narrows —
+// rather than shrinking to share a single row at every width.
 .jetpack-seo-overview__coverage-rings {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/projects/packages/seo/_inc/screens/overview/style.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.scss
@@ -45,20 +45,25 @@
 	padding-top: var(--wpds-dimension-gap-md, 12px);
 }
 
-// Content SEO card: factual coverage rings, side by side.
+// Content SEO card: factual coverage rings. An auto-fit grid (matching the
+// Overview card grid above) so the rings wrap from four columns down to two,
+// then one, as the screen narrows — rather than shrinking to share a single
+// row at every width.
 .jetpack-seo-overview__coverage-rings {
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 	gap: var(--wpds-dimension-gap-lg, 16px);
 }
 
 .jetpack-seo-overview__coverage-ring {
 	display: flex;
-	flex: 1 1 0;
 	flex-direction: column;
 	align-items: center;
 	text-align: center;
 	gap: var(--wpds-dimension-gap-xs, 4px);
+	// Let the cell shrink below its content width so long labels wrap inside
+	// the grid track instead of forcing the column wider.
+	min-width: 0;
 }
 
 .jetpack-seo-overview__coverage-count {

--- a/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
+++ b/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-SEO Overview: lay out the Content SEO coverage rings in a responsive grid so they wrap and stack as the screen narrows, instead of staying in a single row.
+Lay out the Content SEO coverage rings in a responsive grid so they wrap and stack as the screen narrows, instead of staying in a single row.

--- a/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
+++ b/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-SEO Overview: lay the Content SEO coverage rings out in a responsive grid so they wrap and stack as the screen narrows, instead of staying in a single row.
+SEO Overview: lay out the Content SEO coverage rings in a responsive grid so they wrap and stack as the screen narrows, instead of staying in a single row.

--- a/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
+++ b/projects/packages/seo/changelog/update-seo-coverage-rings-responsive-grid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+SEO Overview: lay the Content SEO coverage rings out in a responsive grid so they wrap and stack as the screen narrows, instead of staying in a single row.


### PR DESCRIPTION
Fixes # N/A — tracked in Linear JETPACK-1758.

## Proposed changes
* Switch the Content SEO card's coverage-rings container (**Jetpack > SEO → Overview** tab) from a flex row to an auto-fit CSS grid (`repeat(auto-fit, minmax(160px, 1fr))`), matching the Overview card grid above it.
* The four coverage rings now wrap responsively — four across on desktop, two on tablet, one on phone widths — instead of all four shrinking to share a single row at every width (the old `flex: 1 1 0` gave each ring a flex-basis of `0`, so `flex-wrap` never triggered).
* Add `min-width: 0` to each ring so longer labels (e.g. "Visible to search engines") wrap within their grid cell rather than widening the column.

**Screenshots**

Current:
<img width="493" height="812" alt="Jetpack SEO content completion flex" src="https://github.com/user-attachments/assets/0e7fbf65-794a-43a7-9f42-4f0ef1cecd1b" />

Change w/ this PR:
<img width="1164" height="1636" alt="Jetpack SEO content completion grid" src="https://github.com/user-attachments/assets/e50fea31-14c5-41d9-854b-33520bd05e57" />


## Related product discussion/links
* Linear: JETPACK-1758 — https://linear.app/a8c/issue/JETPACK-1758/seo-overview-make-content-seo-completion-rings-stack-responsively
* Part of the **Phase 1: Jetpack SEO — The Home Base** project (Fast Follow milestone).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Load a site with the `rsm_jetpack_seo` feature flag enabled and the SEO Tools module on, with at least a few published posts/pages.
* Go to **Jetpack > SEO → Overview** tab and find the **Content SEO** card with its four coverage rings (Schema applied / SEO title set / Meta description added / Visible to search engines).
* At a wide desktop width, confirm the four rings sit in a single row.
* Narrow the browser window (or use the browser's responsive/device mode). Confirm the rings **wrap to two columns, then to a single column** at phone widths — rather than all four staying on one line and shrinking.
* Confirm the longer labels wrap cleanly within each cell and the rings stay centered.
