### PR TITLE
jetpack: Fix tests against WooCommerce

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-woocommerce-tests
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-woocommerce-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix tests against WooCommerce
+
+

--- a/projects/plugins/jetpack/tests/php/trait-woo-tests.php
+++ b/projects/plugins/jetpack/tests/php/trait-woo-tests.php
@@ -47,7 +47,6 @@ trait WooCommerceTestTrait {
 		// test cases
 		require_once $woo_tests_dir . '/legacy/includes/wp-http-testcase.php';
 		require_once $woo_tests_dir . '/legacy/framework/class-wc-unit-test-case.php';
-		require_once $woo_tests_dir . '/legacy/framework/class-wc-api-unit-test-case.php';
 		require_once $woo_tests_dir . '/legacy/framework/class-wc-rest-unit-test-case.php';
 
 		// Helpers


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Woo 10.9.0 deleted a test file we had been loading. It seems that deleting the `require` is all that's needed to make things work again.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1782241747497649-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?