### PR TITLE
Write: return the back button to the source the user came from

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-back-to-source
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-back-to-source
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: return the back button to the place the user came from (e.g. the Reader) when a known source is provided

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3524,7 +3524,7 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 			allowLeave = true;
-			window.location.href = state.adminUrl;
+			window.location.href = state.backUrl;
 		},
 
 		async saveAndLeave() {
@@ -3550,7 +3550,7 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 			allowLeave = true;
-			window.location.href = state.adminUrl;
+			window.location.href = state.backUrl;
 		},
 
 		checkFormatting() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -70,7 +70,7 @@ function wpcom_write_resolve_back_url( $source ) {
 		'reader' => 'https://wordpress.com/read',
 	);
 
-	return isset( $destinations[ $source ] ) ? $destinations[ $source ] : admin_url();
+	return $destinations[ $source ] ?? admin_url();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -53,6 +53,27 @@ function wpcom_write_url() {
 }
 
 /**
+ * Resolve the editor's back/close destination from the source the user arrived from.
+ *
+ * Maps a short allowlist of known source tokens to known internal destinations.
+ * Anything not in the allowlist (including an empty or inferred source) falls back
+ * to the default destination — the site dashboard — so behavior is unchanged.
+ *
+ * This is the single lookup point for back-button destinations: never echo an
+ * arbitrary return URL from the query string, only map to vetted destinations.
+ *
+ * @param string $source Sanitized source token (see wpcom_write_render_admin_page()).
+ * @return string The destination URL for the back/close button.
+ */
+function wpcom_write_resolve_back_url( $source ) {
+	$destinations = array(
+		'reader' => 'https://wordpress.com/read',
+	);
+
+	return isset( $destinations[ $source ] ) ? $destinations[ $source ] : admin_url();
+}
+
+/**
  * Translated UI strings consumed by view.js as `window.wpcomWriteStrings`.
  *
  * Exposed as a helper so callers that render the Write editor outside the
@@ -781,6 +802,9 @@ function wpcom_write_render_admin_page() {
 		}
 	}
 
+	// Resolve where the back/close button should return the user, based on source.
+	$back_url = wpcom_write_resolve_back_url( $source );
+
 	if ( function_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_record_tracks_event' ) ) {
 		$event_props = array(
 			'is_new_post' => (int) ( 0 === $edit_post_id ),
@@ -851,6 +875,7 @@ function wpcom_write_render_admin_page() {
 			'mediaPath'              => '/wp/v2/media',
 			'homeUrl'                => home_url( '/' ),
 			'adminUrl'               => admin_url(),
+			'backUrl'                => $back_url,
 			'writeUrl'               => wpcom_write_url(),
 			'editPostId'             => $edit_post_id,
 			'postStatus'             => $post_status,
@@ -912,7 +937,7 @@ function wpcom_write_render_admin_page() {
 	);
 
 	// Output the editor UI inside wp-admin's wrapper.
-	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status, $video_placeholders, $show_cat_row, $cat_label, $recent_drafts, $open_post_error );
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status, $video_placeholders, $show_cat_row, $cat_label, $recent_drafts, $open_post_error, $back_url );
 }
 
 /**
@@ -931,14 +956,18 @@ function wpcom_write_render_admin_page() {
  * @param string $cat_label           Full "Writing in X, Y" label text; empty string if none selected.
  * @param array  $recent_drafts       Array of recent draft objects for the post picker.
  * @param string $open_post_error     Error message for post picker, empty if no error.
+ * @param string $back_url            Destination for the back/close button; defaults to the dashboard.
  */
-function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array(), $show_cat_row = false, $cat_label = '', $recent_drafts = array(), $open_post_error = '' ) {
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array(), $show_cat_row = false, $cat_label = '', $recent_drafts = array(), $open_post_error = '', $back_url = '' ) {
+	if ( '' === $back_url ) {
+		$back_url = admin_url();
+	}
 	?>
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
 	<!-- Top bar -->
 	<header class="bw-topbar">
-		<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-back" title="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.handleBack">&larr;</a>
+		<a href="<?php echo esc_url( $back_url ); ?>" class="bw-back" title="<?php echo esc_attr__( 'Back', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Back', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.handleBack">&larr;</a>
 		<div class="bw-help-wrap" data-wp-on--keydown="actions.handleHelpKeyDown" data-wp-on--focusout="actions.handleHelpFocusOut">
 		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>"><span class="bw-help-i" aria-hidden="true">i</span></button>
 		<div class="bw-help-popover" hidden data-wp-bind--hidden="!state.showHelp">

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -67,7 +67,7 @@ function wpcom_write_url() {
  */
 function wpcom_write_resolve_back_url( $source ) {
 	$destinations = array(
-		'reader' => 'https://wordpress.com/read',
+		'reader' => 'https://wordpress.com/reader',
 	);
 
 	return $destinations[ $source ] ?? admin_url();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -783,8 +783,9 @@ function wpcom_write_render_admin_page() {
 	// 1. Explicit query param (highest priority).
 	// 2. Infer from HTTP referer.
 	// 3. Fall back to 'direct' (bookmarks, typed URLs, stripped referers).
-	// Note: When the /write → wp-admin redirect is implemented, it must forward the source query param.
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter used for analytics only.
+	// The /write-editor redirect forwards this param into wp-admin, so an explicit
+	// source (e.g. 'reader') survives the hop and drives the back-button destination.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter, no state change.
 	$source = isset( $_GET['source'] ) ? sanitize_key( $_GET['source'] ) : '';
 	if ( ! $source ) {
 		$referer = wp_get_referer();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -82,6 +82,50 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that a known source token resolves to its mapped back destination.
+	 */
+	public function test_resolve_back_url_maps_known_source() {
+		$this->assertSame(
+			'https://wordpress.com/read',
+			wpcom_write_resolve_back_url( 'reader' )
+		);
+	}
+
+	/**
+	 * Test that an unknown or empty source falls back to the dashboard (default behavior).
+	 */
+	public function test_resolve_back_url_falls_back_to_dashboard() {
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( '' ) );
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( 'something_unknown' ) );
+		// Inferred analytics sources should not change the back destination.
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( 'dashboard' ) );
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( 'direct' ) );
+	}
+
+	/**
+	 * Test that the back button href reflects the resolved destination, defaulting to the dashboard.
+	 */
+	public function test_template_back_button_defaults_to_dashboard() {
+		ob_start();
+		wpcom_write_template();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="bw-back"', $html );
+		$this->assertStringContainsString( 'href="' . esc_url( admin_url() ) . '"', $html );
+	}
+
+	/**
+	 * Test that a resolved back URL is rendered into the back button href.
+	 */
+	public function test_template_back_button_uses_resolved_url() {
+		ob_start();
+		wpcom_write_template( '', '', 0, array(), 'new', array(), false, '', array(), '', 'https://wordpress.com/read' );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'href="' . esc_url( 'https://wordpress.com/read' ) . '"', $html );
+	}
+
+	/**
 	 * Test that the wpcom-write script module is registered after init.
 	 */
 	public function test_script_module_is_registered() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -86,7 +86,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_resolve_back_url_maps_known_source() {
 		$this->assertSame(
-			'https://wordpress.com/read',
+			'https://wordpress.com/reader',
 			wpcom_write_resolve_back_url( 'reader' )
 		);
 	}
@@ -119,10 +119,10 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_template_back_button_uses_resolved_url() {
 		ob_start();
-		wpcom_write_template( '', '', 0, array(), 'new', array(), false, '', array(), '', 'https://wordpress.com/read' );
+		wpcom_write_template( '', '', 0, array(), 'new', array(), false, '', array(), '', 'https://wordpress.com/reader' );
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'href="' . esc_url( 'https://wordpress.com/read' ) . '"', $html );
+		$this->assertStringContainsString( 'href="' . esc_url( 'https://wordpress.com/reader' ) . '"', $html );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* Adds a single allowlist lookup, `wpcom_write_resolve_back_url( $source )`, that maps the Write editor's existing sanitized `source` token to a known internal destination. Currently `reader` → the Reader (`https://wordpress.com/reader`); any other (or absent/inferred) value falls back to the dashboard, so behavior is unchanged.
* Reuses the editor's existing `source` query param (previously analytics-only) rather than introducing a new param. There is no open-redirect surface — only vetted tokens map to vetted URLs; an arbitrary return URL is never echoed from the query string.
* Wires the resolved destination into the back/close button `href` and the two leave-confirm JS paths (`confirmLeave` / `saveAndLeave`). `state.adminUrl` is left intact for the preview and unsupported-content flows.
* Updates the back button label from "Back to dashboard" to "Back" since the destination is now contextual.

## Related product discussion/links
* p1782242657672779/1782149312.318369-slack-C03NLNTPZ2T

## Does this pull request change what data or activity we track or use?
No. The `source` param is already read and recorded; this PR only uses it to compute the back-button destination.

## Testing instructions
* On a WordPress.com / Atomic site, open the Write editor with a known source: `admin.php?page=write&source=reader`.
* Click the back arrow (top-left) — it should navigate to the Reader (`https://wordpress.com/reader`).
* Open the editor with no `source` (or an unknown value, e.g. `&source=foo`) — the back arrow should go to the site dashboard, exactly as before.
* Make an edit, then click back: the "unsaved changes" modal appears. Choosing **Discard** or **Save** should navigate to the same source-resolved destination.
* Run the package tests: `composer phpunit -- --filter Write_Test` inside `projects/packages/jetpack-mu-wpcom`.

Note: the consuming `/write-editor` redirect lives on the wpcom side and forwards the `source` param into `admin.php?page=write` (now shipped); the editor reads it from `$_GET`. The Reader entry point that sets `source=reader` ships via wp-calypso.
