### PR TITLE
SEO AI tab: llms.txt + AI crawler controls (functional spike)

### DIFF
--- a/projects/packages/seo/_inc/data/ai-store.ts
+++ b/projects/packages/seo/_inc/data/ai-store.ts
@@ -3,30 +3,38 @@ import { AI_PATH, getPreloaded } from './get-preloaded';
 import type { AiState } from './ai-types';
 
 /**
- * A tiny `@wordpress/data` store holding the latest-saved AI SEO Enhancer state.
+ * A tiny `@wordpress/data` store holding the latest-saved AI tab state.
  *
- * Same rationale as [settings-store]: the AI tab is its own route, so toggling
- * the Enhancer and saving was lost on the next visit (the form re-seeded from
- * the never-updated bootstrap) until a reload. This store keeps the current
- * enhancer snapshot — seeded from the bootstrap, replaced on each successful
- * save — so `useAiForm` re-seeds from the freshest value across routes.
+ * Same rationale as [settings-store]: the AI tab is its own route, so toggling a
+ * setting and saving was lost on the next visit (the form re-seeded from the
+ * never-updated bootstrap) until a reload. This store keeps the current snapshot
+ * of each AI slice — seeded from the bootstrap, replaced on each successful save
+ * — so `useAiForm` re-seeds from the freshest values across routes.
  */
 
 const STORE_NAME = 'jetpack-seo/ai';
 
 type Enhancer = AiState[ 'enhancer' ];
+type LlmsTxt = AiState[ 'llmsTxt' ];
+type Crawlers = AiState[ 'crawlers' ];
 
 interface State {
 	enhancer: Enhancer | null;
+	llmsTxt: LlmsTxt | null;
+	crawlers: Crawlers | null;
 }
 
-interface SetEnhancerAction {
-	type: 'SET_ENHANCER';
-	enhancer: Enhancer;
-}
+type Action =
+	| { type: 'SET_ENHANCER'; enhancer: Enhancer }
+	| { type: 'SET_LLMS_TXT'; llmsTxt: LlmsTxt }
+	| { type: 'SET_CRAWLERS'; crawlers: Crawlers };
+
+const preloaded = getPreloaded< AiState >( AI_PATH );
 
 const DEFAULT_STATE: State = {
-	enhancer: getPreloaded< AiState >( AI_PATH )?.enhancer ?? null,
+	enhancer: preloaded?.enhancer ?? null,
+	llmsTxt: preloaded?.llmsTxt ?? null,
+	crawlers: preloaded?.crawlers ?? null,
 };
 
 const actions = {
@@ -36,8 +44,26 @@ const actions = {
 	 * @param enhancer - The latest-saved enhancer state.
 	 * @return The action.
 	 */
-	setEnhancer( enhancer: Enhancer ): SetEnhancerAction {
+	setEnhancer( enhancer: Enhancer ): Action {
 		return { type: 'SET_ENHANCER', enhancer };
+	},
+	/**
+	 * Replace the stored llms.txt snapshot with the value just persisted.
+	 *
+	 * @param llmsTxt - The latest-saved llms.txt state.
+	 * @return The action.
+	 */
+	setLlmsTxt( llmsTxt: LlmsTxt ): Action {
+		return { type: 'SET_LLMS_TXT', llmsTxt };
+	},
+	/**
+	 * Replace the stored crawler snapshot with the value just persisted.
+	 *
+	 * @param crawlers - The latest-saved crawler state.
+	 * @return The action.
+	 */
+	setCrawlers( crawlers: Crawlers ): Action {
+		return { type: 'SET_CRAWLERS', crawlers };
 	},
 };
 
@@ -51,14 +77,38 @@ const selectors = {
 	getEnhancer( state: State ): Enhancer | null {
 		return state.enhancer;
 	},
+	/**
+	 * The latest-known llms.txt state (or `null` when the bootstrap was absent).
+	 *
+	 * @param state - Store state.
+	 * @return The llms.txt state.
+	 */
+	getLlmsTxt( state: State ): LlmsTxt | null {
+		return state.llmsTxt;
+	},
+	/**
+	 * The latest-known crawler state (or `null` when the bootstrap was absent).
+	 *
+	 * @param state - Store state.
+	 * @return The crawler state.
+	 */
+	getCrawlers( state: State ): Crawlers | null {
+		return state.crawlers;
+	},
 };
 
 const store = createReduxStore( STORE_NAME, {
-	reducer( state: State = DEFAULT_STATE, action: SetEnhancerAction ): State {
-		if ( action.type === 'SET_ENHANCER' ) {
-			return { enhancer: action.enhancer };
+	reducer( state: State = DEFAULT_STATE, action: Action ): State {
+		switch ( action.type ) {
+			case 'SET_ENHANCER':
+				return { ...state, enhancer: action.enhancer };
+			case 'SET_LLMS_TXT':
+				return { ...state, llmsTxt: action.llmsTxt };
+			case 'SET_CRAWLERS':
+				return { ...state, crawlers: action.crawlers };
+			default:
+				return state;
 		}
-		return state;
 	},
 	actions,
 	selectors,

--- a/projects/packages/seo/_inc/data/ai-types.ts
+++ b/projects/packages/seo/_inc/data/ai-types.ts
@@ -17,6 +17,10 @@ export interface AiCrawler {
 	 * the two AI-crawler sections.
 	 */
 	type: 'answer' | 'training';
+	/** The crawler's user-agent token (e.g. "GPTBot"), shown in the doc link. */
+	userAgent: string;
+	/** The operator's documentation page for this bot; empty when none exists. */
+	docUrl: string;
 }
 
 export interface AiState {

--- a/projects/packages/seo/_inc/data/ai-types.ts
+++ b/projects/packages/seo/_inc/data/ai-types.ts
@@ -11,6 +11,12 @@ export interface AiCrawler {
 	slug: string;
 	/** Human-facing crawler name (e.g. "ChatGPT (OpenAI)"). */
 	label: string;
+	/**
+	 * `answer` = fetches pages to cite in live AI answers (allowed by default);
+	 * `training` = collects content to train models (blocked by default). Drives
+	 * the two AI-crawler sections.
+	 */
+	type: 'answer' | 'training';
 }
 
 export interface AiState {
@@ -31,5 +37,11 @@ export interface AiState {
 		catalog: AiCrawler[];
 		/** Slugs currently blocked from the site. */
 		blocked: string[];
+		/** Whether the site allows search-engine indexing (`blog_public`). */
+		searchEnginesVisible: boolean;
+		/** Whether the site is on a `*.wpcomstaging.com` subdomain that blocks crawling. */
+		restrictedSubdomain: boolean;
+		/** Whether a physical robots.txt at the web root overrides our directives. */
+		staticRobotsTxt: boolean;
 	};
 }

--- a/projects/packages/seo/_inc/data/ai-types.ts
+++ b/projects/packages/seo/_inc/data/ai-types.ts
@@ -1,7 +1,17 @@
 // Shape of the AI tab's initial state, bootstrapped onto
 // `window.JetpackScriptData.seo.ai` (see `Initializer::get_ai_data()`).
-// The AI SEO Enhancer toggle writes through the existing `/jetpack/v4/settings`
-// endpoint (`ai_seo_enhancer_enabled`).
+// Each toggle writes through the existing `/jetpack/v4/settings` endpoint:
+// the Enhancer via `ai_seo_enhancer_enabled`, llms.txt via
+// `jetpack_seo_llms_txt_enabled`, and crawler blocks via
+// `jetpack_seo_blocked_ai_crawlers`.
+
+/** A known AI crawler offered as a per-bot toggle in the AI tab. */
+export interface AiCrawler {
+	/** Stable key persisted in the blocked list and sent on save. */
+	slug: string;
+	/** Human-facing crawler name (e.g. "ChatGPT (OpenAI)"). */
+	label: string;
+}
 
 export interface AiState {
 	enhancer: {
@@ -9,5 +19,17 @@ export interface AiState {
 		available: boolean;
 		/** Whether the SEO Enhancer is currently enabled. */
 		enabled: boolean;
+	};
+	llmsTxt: {
+		/** Whether llms.txt generation is switched on. */
+		enabled: boolean;
+		/** The site's llms.txt URL, for the "view" link. */
+		url: string;
+	};
+	crawlers: {
+		/** The known AI crawlers, each rendered as an allow/block toggle. */
+		catalog: AiCrawler[];
+		/** Slugs currently blocked from the site. */
+		blocked: string[];
 	};
 }

--- a/projects/packages/seo/_inc/data/content-types.ts
+++ b/projects/packages/seo/_inc/data/content-types.ts
@@ -1,5 +1,5 @@
-// Types for the Content tab, which lists posts/pages backed by WordPress core
-// REST (`/wp/v2/posts`, `/wp/v2/pages`) plus the SEO post meta registered in
+// Types for the Content tab, which lists supported post types backed by
+// WordPress core REST plus the SEO post meta registered in
 // `class-jetpack-seo-posts.php`. There is no package REST controller — every
 // field here comes from a core REST record's `meta` object.
 
@@ -15,9 +15,8 @@ export interface SeoPostMeta {
 	jetpack_seo_schema_type: SchemaType;
 }
 
-// The post type the Content tab is currently listing. Switches the core
-// endpoint between `/wp/v2/posts` and `/wp/v2/pages`.
-export type ContentPostType = 'post' | 'page';
+// The post type slug the Content tab is currently listing/editing.
+export type ContentPostType = string;
 
 // A single row in the Content DataViews table. Factual flags only — the table
 // reports the *state* of each SEO field, never a score or quality judgement.
@@ -37,10 +36,19 @@ export interface ContentRow {
 	hasDescription: boolean;
 }
 
-// An option for the post-type filter (Posts / Pages).
+// An option for the post-type filter.
 export interface PostTypeOption {
 	value: ContentPostType;
 	label: string;
+}
+
+// The PHP-selected post types preloaded for the Content tab. This keeps the
+// client aligned with the supported-type rule used for Overview and llms.txt.
+export interface ContentData {
+	post_types: Array< {
+		slug: ContentPostType;
+		label: string;
+	} >;
 }
 
 // Optimistic adjustment applied to the Overview coverage counts when a post's

--- a/projects/packages/seo/_inc/data/get-preloaded.ts
+++ b/projects/packages/seo/_inc/data/get-preloaded.ts
@@ -8,6 +8,7 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 export const OVERVIEW_PATH = '/jetpack/v4/seo/overview';
 export const SETTINGS_PATH = '/jetpack/v4/seo/settings';
 export const AI_PATH = '/jetpack/v4/seo/ai';
+export const CONTENT_PATH = '/jetpack/v4/seo/content';
 
 /** A single preloaded REST response, as emitted by `rest_preload_api_request()`. */
 interface PreloadedResponse {

--- a/projects/packages/seo/_inc/data/test/ai-store.test.ts
+++ b/projects/packages/seo/_inc/data/test/ai-store.test.ts
@@ -21,4 +21,26 @@ describe( 'ai-store', () => {
 		registry.dispatch( aiStore ).setEnhancer( next );
 		expect( registry.select( aiStore ).getEnhancer() ).toEqual( next );
 	} );
+
+	it( 'seeds the llms.txt and crawler state from the page bootstrap', () => {
+		const registry = makeRegistry();
+		expect( registry.select( aiStore ).getLlmsTxt() ).toEqual( SEEDED_AI.llmsTxt );
+		expect( registry.select( aiStore ).getCrawlers() ).toEqual( SEEDED_AI.crawlers );
+	} );
+
+	it( 'replaces the llms.txt state on setLlmsTxt without touching other slices', () => {
+		const registry = makeRegistry();
+		const next = { enabled: true, url: SEEDED_AI.llmsTxt.url };
+		registry.dispatch( aiStore ).setLlmsTxt( next );
+		expect( registry.select( aiStore ).getLlmsTxt() ).toEqual( next );
+		expect( registry.select( aiStore ).getEnhancer() ).toEqual( SEEDED_AI.enhancer );
+	} );
+
+	it( 'replaces the crawler state on setCrawlers without touching other slices', () => {
+		const registry = makeRegistry();
+		const next = { catalog: SEEDED_AI.crawlers.catalog, blocked: [] };
+		registry.dispatch( aiStore ).setCrawlers( next );
+		expect( registry.select( aiStore ).getCrawlers() ).toEqual( next );
+		expect( registry.select( aiStore ).getEnhancer() ).toEqual( SEEDED_AI.enhancer );
+	} );
 } );

--- a/projects/packages/seo/_inc/data/test/ai-store.test.ts
+++ b/projects/packages/seo/_inc/data/test/ai-store.test.ts
@@ -38,7 +38,7 @@ describe( 'ai-store', () => {
 
 	it( 'replaces the crawler state on setCrawlers without touching other slices', () => {
 		const registry = makeRegistry();
-		const next = { catalog: SEEDED_AI.crawlers.catalog, blocked: [] };
+		const next = { ...SEEDED_AI.crawlers, blocked: [] };
 		registry.dispatch( aiStore ).setCrawlers( next );
 		expect( registry.select( aiStore ).getCrawlers() ).toEqual( next );
 		expect( registry.select( aiStore ).getEnhancer() ).toEqual( SEEDED_AI.enhancer );

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -32,6 +32,14 @@ export const SEEDED_SETTINGS: SettingsResponse = {
 
 export const SEEDED_AI: AiState = {
 	enhancer: { available: true, enabled: false },
+	llmsTxt: { enabled: false, url: 'https://example.com/llms.txt' },
+	crawlers: {
+		catalog: [
+			{ slug: 'gptbot', label: 'ChatGPT (OpenAI)' },
+			{ slug: 'claudebot', label: 'Claude (Anthropic)' },
+		],
+		blocked: [ 'gptbot' ],
+	},
 };
 
 ( window as unknown as { JetpackScriptData: unknown } ).JetpackScriptData = {

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -35,10 +35,13 @@ export const SEEDED_AI: AiState = {
 	llmsTxt: { enabled: false, url: 'https://example.com/llms.txt' },
 	crawlers: {
 		catalog: [
-			{ slug: 'gptbot', label: 'ChatGPT (OpenAI)' },
-			{ slug: 'claudebot', label: 'Claude (Anthropic)' },
+			{ slug: 'oai-searchbot', label: 'ChatGPT Search (OpenAI)', type: 'answer' },
+			{ slug: 'gptbot', label: 'ChatGPT (OpenAI)', type: 'training' },
 		],
 		blocked: [ 'gptbot' ],
+		searchEnginesVisible: true,
+		restrictedSubdomain: false,
+		staticRobotsTxt: false,
 	},
 };
 

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -35,8 +35,20 @@ export const SEEDED_AI: AiState = {
 	llmsTxt: { enabled: false, url: 'https://example.com/llms.txt' },
 	crawlers: {
 		catalog: [
-			{ slug: 'oai-searchbot', label: 'ChatGPT Search (OpenAI)', type: 'answer' },
-			{ slug: 'gptbot', label: 'ChatGPT (OpenAI)', type: 'training' },
+			{
+				slug: 'oai-searchbot',
+				label: 'ChatGPT Search (OpenAI)',
+				type: 'answer',
+				userAgent: 'OAI-SearchBot',
+				docUrl: 'https://example.com/openai-bots',
+			},
+			{
+				slug: 'gptbot',
+				label: 'ChatGPT (OpenAI)',
+				type: 'training',
+				userAgent: 'GPTBot',
+				docUrl: 'https://example.com/openai-bots',
+			},
 		],
 		blocked: [ 'gptbot' ],
 		searchEnginesVisible: true,

--- a/projects/packages/seo/_inc/data/test/use-seo-posts.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-seo-posts.test.ts
@@ -1,0 +1,158 @@
+import { jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+type CoreDataSelect = ( store: string ) => {
+	getEntityRecords: ( kind: string, name: string ) => unknown[] | null;
+	hasFinishedResolution: () => boolean;
+	isResolving: () => boolean;
+};
+type UseSelectCallback = ( select: CoreDataSelect ) => unknown;
+
+const useSelect = jest.fn< ( selector: UseSelectCallback ) => unknown >();
+const getPreloaded = jest.fn();
+
+const recordsByType = {
+	post: [
+		{
+			id: 1,
+			title: { rendered: 'Post title' },
+			link: 'https://example.com/post-title/',
+			type: 'post',
+			status: 'publish',
+			meta: {
+				advanced_seo_description: 'Post description.',
+				jetpack_seo_html_title: 'Post SEO title',
+				jetpack_seo_noindex: false,
+				jetpack_seo_schema_type: 'article',
+			},
+		},
+	],
+	page: [],
+	gear_review: [
+		{
+			id: 9,
+			title: { rendered: 'Alpenglow 45' },
+			link: 'https://example.com/gear-reviews/alpenglow-45/',
+			type: 'gear_review',
+			status: 'publish',
+			meta: {
+				advanced_seo_description: 'Backpack field review.',
+				jetpack_seo_html_title: 'Alpenglow 45 Backpack Review',
+				jetpack_seo_noindex: true,
+				jetpack_seo_schema_type: 'faq',
+			},
+		},
+	],
+};
+
+const postTypes = [
+	{
+		slug: 'post',
+		name: 'Posts',
+		rest_base: 'posts',
+		rest_namespace: 'wp/v2',
+		viewable: true,
+		visibility: { show_ui: true },
+	},
+	{
+		slug: 'page',
+		name: 'Pages',
+		rest_base: 'pages',
+		rest_namespace: 'wp/v2',
+		viewable: true,
+		visibility: { show_ui: true },
+	},
+	{
+		slug: 'gear_review',
+		name: 'Gear Reviews',
+		rest_base: 'gear-reviews',
+		rest_namespace: 'custom/v1',
+		viewable: true,
+		visibility: { show_ui: true },
+	},
+	{
+		slug: 'attachment',
+		name: 'Media',
+		rest_base: 'media',
+		rest_namespace: 'wp/v2',
+		viewable: true,
+		visibility: { show_ui: true },
+	},
+	{
+		slug: 'preview_only',
+		name: 'Preview only',
+		rest_base: 'preview-only',
+		rest_namespace: 'wp/v2',
+		viewable: true,
+		visibility: { show_ui: true },
+	},
+];
+
+const contentData = {
+	post_types: [
+		{ slug: 'post', label: 'Posts' },
+		{ slug: 'page', label: 'Pages' },
+		{ slug: 'gear_review', label: 'Gear Reviews' },
+	],
+};
+
+jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect,
+} ) );
+
+jest.unstable_mockModule( '../get-preloaded', () => ( {
+	CONTENT_PATH: '/jetpack/v4/seo/content',
+	getPreloaded,
+} ) );
+
+const { default: useSeoPosts } = await import( '../use-seo-posts' );
+
+describe( 'useSeoPosts', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getPreloaded.mockReturnValue( contentData );
+
+		useSelect.mockImplementation( selector =>
+			selector( () => ( {
+				getEntityRecords: ( kind: string, name: string ) => {
+					if ( kind === 'root' && name === 'postType' ) {
+						return postTypes;
+					}
+					if ( kind === 'postType' ) {
+						return recordsByType[ name as keyof typeof recordsByType ] ?? [];
+					}
+					return [];
+				},
+				hasFinishedResolution: () => true,
+				isResolving: () => false,
+			} ) )
+		);
+	} );
+
+	it( 'uses PHP-provided content type options instead of core REST discovery', () => {
+		const { result } = renderHook( () => useSeoPosts() );
+
+		expect( result.current.items ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 1, type: 'post', title: 'Post title' } ),
+				expect.objectContaining( {
+					id: 9,
+					type: 'gear_review',
+					title: 'Alpenglow 45',
+					schemaType: 'faq',
+					noindex: true,
+				} ),
+			] )
+		);
+		expect( result.current.postTypeOptions ).toEqual( [
+			{ value: 'post', label: 'Posts' },
+			{ value: 'page', label: 'Pages' },
+			{ value: 'gear_review', label: 'Gear Reviews' },
+		] );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+} );

--- a/projects/packages/seo/_inc/data/use-ai.ts
+++ b/projects/packages/seo/_inc/data/use-ai.ts
@@ -12,60 +12,69 @@ const SAVE_NOTICE_ID = 'jetpack-seo-ai-save';
 
 export interface AiForm {
 	enhancer: AiState[ 'enhancer' ] | null;
+	llmsTxt: AiState[ 'llmsTxt' ] | null;
+	crawlers: AiState[ 'crawlers' ] | null;
 	isSaving: boolean;
 	/** Toggle the AI SEO Enhancer and save immediately. */
 	setEnhancerEnabled: ( next: boolean ) => void;
+	/** Toggle llms.txt generation and save immediately. */
+	setLlmsTxtEnabled: ( next: boolean ) => void;
+	/** Block or unblock a single AI crawler and save immediately. */
+	setCrawlerBlocked: ( slug: string, blocked: boolean ) => void;
 }
 
 /**
- * Owns the AI tab's form state: seeds from the page bootstrap and auto-saves the
- * AI SEO Enhancer toggle through `/jetpack/v4/settings` (the same endpoint the
- * legacy Traffic page used). On failure the local value reverts. There's no Save
- * button — the toggle saves on change, surfacing the shared
- * "Updating settings…"→"Settings saved." snackbar.
+ * Owns the AI tab's form state: seeds from the page bootstrap and auto-saves each
+ * toggle through `/jetpack/v4/settings` (the same endpoint the legacy Traffic
+ * page used). There's no Save button — toggles save on change, surfacing the
+ * shared "Updating settings…"→"Settings saved." snackbar. On failure the local
+ * value reverts.
  *
  * The AI tab is its own route, so this controller remounts on every tab switch.
- * The enhancer is seeded from (and written back to) [ai-store] rather than the
- * one-time bootstrap, so a saved toggle persists across route switches without
- * a reload.
+ * Each slice is seeded from (and written back to) [ai-store] rather than the
+ * one-time bootstrap, so a saved toggle persists across route switches without a
+ * reload.
  *
  * @return The AI form controller.
  */
 export function useAiForm(): AiForm {
 	// Seed from the store (latest-saved snapshot), not the one-time bootstrap.
-	const initial = useMemo( () => select( aiStore ).getEnhancer(), [] );
-	const [ enhancer, setEnhancer ] = useState< AiState[ 'enhancer' ] | null >( initial );
-	const [ isSaving, setIsSaving ] = useState( false );
-	const { createInfoNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { setEnhancer: persistEnhancer } = useDispatch( aiStore );
+	const initialEnhancer = useMemo( () => select( aiStore ).getEnhancer(), [] );
+	const initialLlmsTxt = useMemo( () => select( aiStore ).getLlmsTxt(), [] );
+	const initialCrawlers = useMemo( () => select( aiStore ).getCrawlers(), [] );
 
-	const setEnhancerEnabled = useCallback(
-		( next: boolean ) => {
-			setEnhancer( prev => ( prev ? { ...prev, enabled: next } : prev ) );
+	const [ enhancer, setEnhancer ] = useState< AiState[ 'enhancer' ] | null >( initialEnhancer );
+	const [ llmsTxt, setLlmsTxt ] = useState< AiState[ 'llmsTxt' ] | null >( initialLlmsTxt );
+	const [ crawlers, setCrawlers ] = useState< AiState[ 'crawlers' ] | null >( initialCrawlers );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { createInfoNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const {
+		setEnhancer: persistEnhancer,
+		setLlmsTxt: persistLlmsTxt,
+		setCrawlers: persistCrawlers,
+	} = useDispatch( aiStore );
+
+	// Shared save lifecycle: optimistic snackbar, POST, then `onSuccess` (persist
+	// the saved value to the store) or `onError` (revert the optimistic update).
+	const runSave = useCallback(
+		( data: Record< string, unknown >, onSuccess: () => void, onError: () => void ) => {
 			setIsSaving( true );
 			createInfoNotice( __( 'Updating settings…', 'jetpack-seo' ), {
 				id: SAVE_NOTICE_ID,
 				type: 'snackbar',
 				isDismissible: false,
 			} );
-			apiFetch( {
-				path: '/jetpack/v4/settings',
-				method: 'POST',
-				data: { ai_seo_enhancer_enabled: next },
-			} )
+			apiFetch( { path: '/jetpack/v4/settings', method: 'POST', data } )
 				.then( () => {
-					// Persist the saved value so a return to the tab re-seeds from it.
-					if ( initial ) {
-						persistEnhancer( { ...initial, enabled: next } );
-					}
+					onSuccess();
 					createSuccessNotice( __( 'Settings saved.', 'jetpack-seo' ), {
 						id: SAVE_NOTICE_ID,
 						type: 'snackbar',
 					} );
 				} )
 				.catch( ( error: { message?: string } ) => {
-					// Revert the optimistic toggle so the UI reflects the persisted value.
-					setEnhancer( prev => ( prev ? { ...prev, enabled: ! next } : prev ) );
+					onError();
 					createErrorNotice(
 						error?.message ?? __( 'Could not save settings. Please try again.', 'jetpack-seo' ),
 						{ id: SAVE_NOTICE_ID, type: 'snackbar' }
@@ -73,8 +82,77 @@ export function useAiForm(): AiForm {
 				} )
 				.finally( () => setIsSaving( false ) );
 		},
-		[ createInfoNotice, createSuccessNotice, createErrorNotice, persistEnhancer, initial ]
+		[ createInfoNotice, createSuccessNotice, createErrorNotice ]
 	);
 
-	return { enhancer, isSaving, setEnhancerEnabled };
+	const setEnhancerEnabled = useCallback(
+		( next: boolean ) => {
+			setEnhancer( prev => ( prev ? { ...prev, enabled: next } : prev ) );
+			runSave(
+				{ ai_seo_enhancer_enabled: next },
+				() => {
+					if ( initialEnhancer ) {
+						persistEnhancer( { ...initialEnhancer, enabled: next } );
+					}
+				},
+				() => setEnhancer( prev => ( prev ? { ...prev, enabled: ! next } : prev ) )
+			);
+		},
+		[ runSave, persistEnhancer, initialEnhancer ]
+	);
+
+	const setLlmsTxtEnabled = useCallback(
+		( next: boolean ) => {
+			setLlmsTxt( prev => ( prev ? { ...prev, enabled: next } : prev ) );
+			runSave(
+				{ jetpack_seo_llms_txt_enabled: next },
+				() => {
+					if ( initialLlmsTxt ) {
+						persistLlmsTxt( { ...initialLlmsTxt, enabled: next } );
+					}
+				},
+				() => setLlmsTxt( prev => ( prev ? { ...prev, enabled: ! next } : prev ) )
+			);
+		},
+		[ runSave, persistLlmsTxt, initialLlmsTxt ]
+	);
+
+	const setCrawlerBlocked = useCallback(
+		( slug: string, blocked: boolean ) => {
+			if ( ! crawlers ) {
+				return;
+			}
+			// Snapshot the pre-change list so a failed save can revert to it.
+			const previous = crawlers;
+			const set = new Set( crawlers.blocked );
+			if ( blocked ) {
+				set.add( slug );
+			} else {
+				set.delete( slug );
+			}
+			const nextBlocked = Array.from( set );
+
+			setCrawlers( { ...crawlers, blocked: nextBlocked } );
+			runSave(
+				{ jetpack_seo_blocked_ai_crawlers: nextBlocked },
+				() => {
+					if ( initialCrawlers ) {
+						persistCrawlers( { ...initialCrawlers, blocked: nextBlocked } );
+					}
+				},
+				() => setCrawlers( previous )
+			);
+		},
+		[ crawlers, runSave, persistCrawlers, initialCrawlers ]
+	);
+
+	return {
+		enhancer,
+		llmsTxt,
+		crawlers,
+		isSaving,
+		setEnhancerEnabled,
+		setLlmsTxtEnabled,
+		setCrawlerBlocked,
+	};
 }

--- a/projects/packages/seo/_inc/data/use-seo-posts.ts
+++ b/projects/packages/seo/_inc/data/use-seo-posts.ts
@@ -1,7 +1,14 @@
-import { useEntityRecords } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import type { ContentRow, SchemaType, SeoPostMeta } from './content-types';
+import { CONTENT_PATH, getPreloaded } from './get-preloaded';
+import type {
+	ContentData,
+	ContentRow,
+	PostTypeOption,
+	SchemaType,
+	SeoPostMeta,
+} from './content-types';
 
 // Only request the columns the Content tab renders, plus the SEO meta. Core
 // REST returns `meta` as an object keyed by the registered meta names.
@@ -12,8 +19,8 @@ const POST_FIELDS = [ 'id', 'title', 'link', 'type', 'status', 'meta' ].join( ',
 const STATUSES = [ 'publish' ];
 
 // Core REST caps `per_page` at 100. We request the max for each type and merge
-// posts + pages client-side. NOTE: a site with more than 100 posts (or 100
-// pages) won't show the overflow on the Content tab yet — acceptable for now;
+// supported content types client-side. NOTE: a site with more than 100 items
+// per type won't show the overflow on the Content tab yet — acceptable for now;
 // a future iteration can page/virtualize the merged set.
 const PER_PAGE = 100;
 
@@ -30,6 +37,7 @@ interface SeoPostRecord {
 export interface UseSeoPostsReturn {
 	items: ContentRow[];
 	isLoading: boolean;
+	postTypeOptions: PostTypeOption[];
 }
 
 /**
@@ -84,36 +92,45 @@ const QUERY = {
 };
 
 /**
- * Fetch the Content tab's posts *and* pages from WordPress core REST and merge
- * them into a single list. Each type is fetched once (up to {@link PER_PAGE}
- * records) and mapped to a {@link ContentRow}; filtering, sorting and
- * pagination happen client-side in the Content screen via
+ * Fetch the Content tab's PHP-selected post types from WordPress core REST and
+ * merge them into a single list. Each type is fetched once (up to
+ * {@link PER_PAGE} records) and mapped to a {@link ContentRow}; filtering,
+ * sorting and pagination happen client-side in the Content screen via
  * `filterSortAndPaginate`. The SEO meta comes back inside each record's `meta`
  * object via the registered `show_in_rest` post meta (no custom endpoint).
  *
- * @return The merged, mapped rows plus a combined loading state.
+ * @return The merged, mapped rows plus post type options and a combined loading state.
  */
 export default function useSeoPosts(): UseSeoPostsReturn {
-	const { records: postRecords, hasResolved: postsResolved } = useEntityRecords< SeoPostRecord >(
-		'postType',
-		'post',
-		QUERY
-	);
-	const { records: pageRecords, hasResolved: pagesResolved } = useEntityRecords< SeoPostRecord >(
-		'postType',
-		'page',
-		QUERY
-	);
+	const contentData = getPreloaded< ContentData >( CONTENT_PATH );
 
-	const items = useMemo(
-		() => [ ...( postRecords || [] ), ...( pageRecords || [] ) ].map( toContentRow ),
-		[ postRecords, pageRecords ]
-	);
+	return useSelect(
+		select => {
+			const postTypes = contentData?.post_types ?? [];
+			const core = select( coreStore );
+			let recordsResolved = true;
+			const records: SeoPostRecord[] = [];
 
-	return {
-		items,
-		// Show the loading state until *both* queries have resolved, so the
-		// table doesn't flash a posts-only list before pages arrive.
-		isLoading: ! postsResolved || ! pagesResolved,
-	};
+			for ( const postType of postTypes ) {
+				const postTypeRecords = core.getEntityRecords( 'postType', postType.slug, QUERY ) as
+					| SeoPostRecord[]
+					| null;
+
+				records.push( ...( postTypeRecords ?? [] ) );
+				recordsResolved =
+					recordsResolved &&
+					core.hasFinishedResolution( 'getEntityRecords', [ 'postType', postType.slug, QUERY ] );
+			}
+
+			return {
+				items: records.map( toContentRow ),
+				postTypeOptions: postTypes.map( postType => ( {
+					value: postType.slug,
+					label: postType.label,
+				} ) ),
+				isLoading: ! contentData || ! recordsResolved,
+			};
+		},
+		[ contentData ]
+	);
 }

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -93,8 +93,11 @@ const AiScreen: FC< Props > = ( { form } ) => {
 			{ /* Broad → specific: whether AI crawlers may reach the site, then the
 			     content map exposed to them, then AI fine-tuning of specific
 			     metadata. */ }
+			{ /* Collapsed by default: it's the longest section and the one most
+			     people won't need to touch, so it doesn't bury llms.txt and the
+			     Enhancer below it. */ }
 			{ crawlers && (
-				<CollapsibleCard.Root defaultOpen>
+				<CollapsibleCard.Root>
 					<CollapsibleCard.Header>
 						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
 					</CollapsibleCard.Header>

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -2,6 +2,7 @@ import { ToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import './style.scss';
 import type { AiCrawler } from '../../data/ai-types';
 import type { AiForm } from '../../data/use-ai';
 import type { FC } from 'react';
@@ -53,13 +54,15 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 
 /**
  * AI tab. Hosts three sections: the plan-gated AI SEO Enhancer, plus the free
- * llms.txt and AI-crawler controls. State + auto-save live in the `form`
- * controller (passed from the page root so it survives tab switches); this
- * component is the presentation.
+ * llms.txt and AI-crawler controls, laid out in two columns — Enhancer + llms.txt
+ * on the left, the taller AI-crawler list on the right — collapsing to a single
+ * column on narrow screens. State + auto-save live in the `form` controller
+ * (passed from the page root so it survives tab switches); this component is the
+ * presentation.
  *
- * The tab itself is always shown. Only the Enhancer card is plan-gated; the
- * free sections render regardless, so the tab is a home for AI settings whether
- * or not the site's plan includes the Enhancer.
+ * The tab itself is always shown. Only the Enhancer card is plan-gated; the free
+ * sections render regardless, so the tab is a home for AI settings whether or not
+ * the site's plan includes the Enhancer.
  *
  * @param props      - Component props.
  * @param props.form - The AI form controller from `useAiForm`.
@@ -88,85 +91,90 @@ const AiScreen: FC< Props > = ( { form } ) => {
 
 	return (
 		<div className="jetpack-seo-ai">
-			<Stack direction="column" gap="lg">
-				{ /* The Enhancer requires a supporting plan; when unavailable the card
-				     is hidden (parity with the legacy Traffic page) while the free
-				     sections below carry the tab. */ }
-				{ enhancer.available && (
-					<CollapsibleCard.Root defaultOpen>
-						<CollapsibleCard.Header>
-							<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
-						</CollapsibleCard.Header>
-						<CollapsibleCard.Content>
-							<ToggleControl
-								label={ __(
-									'Automatically generate SEO title, SEO description, and image alt text for new posts',
-									'jetpack-seo'
-								) }
-								checked={ enhancer.enabled }
-								onChange={ setEnhancerEnabled }
-								disabled={ isSaving }
-								__nextHasNoMarginBottom
-							/>
-						</CollapsibleCard.Content>
-					</CollapsibleCard.Root>
-				) }
-
-				{ llmsTxt && (
-					<CollapsibleCard.Root defaultOpen>
-						<CollapsibleCard.Header>
-							<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
-						</CollapsibleCard.Header>
-						<CollapsibleCard.Content>
-							<Stack direction="column" gap="md">
+			<div className="jetpack-seo-ai__grid">
+				{ /* Left column: the Enhancer (plan-gated — hidden when the plan
+				     doesn't support it, parity with the legacy Traffic page) and the
+				     free llms.txt controls. */ }
+				<div className="jetpack-seo-ai__column">
+					{ enhancer.available && (
+						<CollapsibleCard.Root defaultOpen>
+							<CollapsibleCard.Header>
+								<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+							</CollapsibleCard.Header>
+							<CollapsibleCard.Content>
 								<ToggleControl
-									label={ __( 'Generate an llms.txt file', 'jetpack-seo' ) }
-									help={ __(
-										'Publishes a curated, AI-readable map of your content at /llms.txt to help AI assistants find and understand your pages and posts.',
+									label={ __(
+										'Automatically generate SEO title, SEO description, and image alt text for new posts',
 										'jetpack-seo'
 									) }
-									checked={ llmsTxt.enabled }
-									onChange={ setLlmsTxtEnabled }
+									checked={ enhancer.enabled }
+									onChange={ setEnhancerEnabled }
 									disabled={ isSaving }
 									__nextHasNoMarginBottom
 								/>
-								{ llmsTxt.enabled && (
-									<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
-										{ __( 'View your llms.txt', 'jetpack-seo' ) }
-									</Link>
-								) }
-							</Stack>
-						</CollapsibleCard.Content>
-					</CollapsibleCard.Root>
-				) }
+							</CollapsibleCard.Content>
+						</CollapsibleCard.Root>
+					) }
 
-				{ crawlers && (
-					<CollapsibleCard.Root defaultOpen>
-						<CollapsibleCard.Header>
-							<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
-						</CollapsibleCard.Header>
-						<CollapsibleCard.Content>
-							<Stack direction="column" gap="md">
-								<p className="jetpack-seo-ai__crawlers-intro">
-									{ __(
-										'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
-										'jetpack-seo'
-									) }
-								</p>
-								{ crawlers.catalog.map( crawler => (
-									<CrawlerToggle
-										key={ crawler.slug }
-										crawler={ crawler }
-										blocked={ crawlers.blocked.includes( crawler.slug ) }
+					{ llmsTxt && (
+						<CollapsibleCard.Root defaultOpen>
+							<CollapsibleCard.Header>
+								<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
+							</CollapsibleCard.Header>
+							<CollapsibleCard.Content>
+								<Stack direction="column" gap="md">
+									<ToggleControl
+										label={ __( 'Generate an llms.txt file', 'jetpack-seo' ) }
+										help={ __(
+											'Publishes a curated, AI-readable map of your content at /llms.txt to help AI assistants find and understand your pages and posts.',
+											'jetpack-seo'
+										) }
+										checked={ llmsTxt.enabled }
+										onChange={ setLlmsTxtEnabled }
 										disabled={ isSaving }
-										onToggle={ setCrawlerBlocked }
+										__nextHasNoMarginBottom
 									/>
-								) ) }
-							</Stack>
-						</CollapsibleCard.Content>
-					</CollapsibleCard.Root>
-				) }
-			</Stack>
+									{ llmsTxt.enabled && (
+										<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
+											{ __( 'View your llms.txt', 'jetpack-seo' ) }
+										</Link>
+									) }
+								</Stack>
+							</CollapsibleCard.Content>
+						</CollapsibleCard.Root>
+					) }
+				</div>
+
+				{ /* Right column: the taller AI-crawler list. */ }
+				<div className="jetpack-seo-ai__column">
+					{ crawlers && (
+						<CollapsibleCard.Root defaultOpen>
+							<CollapsibleCard.Header>
+								<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+							</CollapsibleCard.Header>
+							<CollapsibleCard.Content>
+								<Stack direction="column" gap="md">
+									<p className="jetpack-seo-ai__crawlers-intro">
+										{ __(
+											'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
+											'jetpack-seo'
+										) }
+									</p>
+									{ crawlers.catalog.map( crawler => (
+										<CrawlerToggle
+											key={ crawler.slug }
+											crawler={ crawler }
+											blocked={ crawlers.blocked.includes( crawler.slug ) }
+											disabled={ isSaving }
+											onToggle={ setCrawlerBlocked }
+										/>
+									) ) }
+								</Stack>
+							</CollapsibleCard.Content>
+						</CollapsibleCard.Root>
+					) }
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -34,9 +34,15 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 		[ crawler.slug, onToggle ]
 	);
 
+	// Named variables (not `cond ? __() : __()`) so the production minifier can't
+	// fold the ternary into `__( cond ? … )`, which breaks i18n string extraction.
+	const allowedLabel = __( 'Allowed', 'jetpack-seo' );
+	const blockedLabel = __( 'Blocked', 'jetpack-seo' );
+
 	return (
 		<ToggleControl
 			label={ crawler.label }
+			help={ blocked ? blockedLabel : allowedLabel }
 			checked={ ! blocked }
 			onChange={ handleChange }
 			disabled={ disabled }

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -54,9 +54,10 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 
 /**
  * AI tab. Hosts three sections: the plan-gated AI SEO Enhancer, plus the free
- * llms.txt and AI-crawler controls, laid out in two columns — Enhancer + llms.txt
- * on the left, the taller AI-crawler list on the right — collapsing to a single
- * column on narrow screens. State + auto-save live in the `form` controller
+ * llms.txt and AI-crawler controls, laid out in two columns ordered broad →
+ * specific: AI-crawler access on the left, then llms.txt and the AI SEO Enhancer
+ * on the right — collapsing to a single column on narrow screens. State +
+ * auto-save live in the `form` controller
  * (passed from the page root so it survives tab switches); this component is the
  * presentation.
  *
@@ -92,30 +93,42 @@ const AiScreen: FC< Props > = ( { form } ) => {
 	return (
 		<div className="jetpack-seo-ai">
 			<div className="jetpack-seo-ai__grid">
-				{ /* Left column: the Enhancer (plan-gated — hidden when the plan
-				     doesn't support it, parity with the legacy Traffic page) and the
-				     free llms.txt controls. */ }
+				{ /* Left column: AI crawler access — the broadest control (whether AI
+				     crawlers may reach the site at all). */ }
 				<div className="jetpack-seo-ai__column">
-					{ enhancer.available && (
+					{ crawlers && (
 						<CollapsibleCard.Root defaultOpen>
 							<CollapsibleCard.Header>
-								<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+								<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
 							</CollapsibleCard.Header>
 							<CollapsibleCard.Content>
-								<ToggleControl
-									label={ __(
-										'Automatically generate SEO title, SEO description, and image alt text for new posts',
-										'jetpack-seo'
-									) }
-									checked={ enhancer.enabled }
-									onChange={ setEnhancerEnabled }
-									disabled={ isSaving }
-									__nextHasNoMarginBottom
-								/>
+								<Stack direction="column" gap="md">
+									<p className="jetpack-seo-ai__crawlers-intro">
+										{ __(
+											'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
+											'jetpack-seo'
+										) }
+									</p>
+									{ crawlers.catalog.map( crawler => (
+										<CrawlerToggle
+											key={ crawler.slug }
+											crawler={ crawler }
+											blocked={ crawlers.blocked.includes( crawler.slug ) }
+											disabled={ isSaving }
+											onToggle={ setCrawlerBlocked }
+										/>
+									) ) }
+								</Stack>
 							</CollapsibleCard.Content>
 						</CollapsibleCard.Root>
 					) }
+				</div>
 
+				{ /* Right column, broad → specific: llms.txt (hand AI a formatted
+				     content map), then the AI SEO Enhancer (AI fine-tuning of specific
+				     metadata). The Enhancer is plan-gated — hidden when the plan
+				     doesn't support it (parity with the legacy Traffic page). */ }
+				<div className="jetpack-seo-ai__column">
 					{ llmsTxt && (
 						<CollapsibleCard.Root defaultOpen>
 							<CollapsibleCard.Header>
@@ -143,33 +156,23 @@ const AiScreen: FC< Props > = ( { form } ) => {
 							</CollapsibleCard.Content>
 						</CollapsibleCard.Root>
 					) }
-				</div>
 
-				{ /* Right column: the taller AI-crawler list. */ }
-				<div className="jetpack-seo-ai__column">
-					{ crawlers && (
+					{ enhancer.available && (
 						<CollapsibleCard.Root defaultOpen>
 							<CollapsibleCard.Header>
-								<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+								<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
 							</CollapsibleCard.Header>
 							<CollapsibleCard.Content>
-								<Stack direction="column" gap="md">
-									<p className="jetpack-seo-ai__crawlers-intro">
-										{ __(
-											'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
-											'jetpack-seo'
-										) }
-									</p>
-									{ crawlers.catalog.map( crawler => (
-										<CrawlerToggle
-											key={ crawler.slug }
-											crawler={ crawler }
-											blocked={ crawlers.blocked.includes( crawler.slug ) }
-											disabled={ isSaving }
-											onToggle={ setCrawlerBlocked }
-										/>
-									) ) }
-								</Stack>
+								<ToggleControl
+									label={ __(
+										'Automatically generate SEO title, SEO description, and image alt text for new posts',
+										'jetpack-seo'
+									) }
+									checked={ enhancer.enabled }
+									onChange={ setEnhancerEnabled }
+									disabled={ isSaving }
+									__nextHasNoMarginBottom
+								/>
 							</CollapsibleCard.Content>
 						</CollapsibleCard.Root>
 					) }

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -1,6 +1,8 @@
 import { ToggleControl } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Card, CollapsibleCard, Notice } from '@wordpress/ui';
+import { Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import type { AiCrawler } from '../../data/ai-types';
 import type { AiForm } from '../../data/use-ai';
 import type { FC } from 'react';
 
@@ -8,21 +10,65 @@ interface Props {
 	form: AiForm;
 }
 
+interface CrawlerToggleProps {
+	crawler: AiCrawler;
+	blocked: boolean;
+	disabled: boolean;
+	onToggle: ( slug: string, blocked: boolean ) => void;
+}
+
 /**
- * AI tab. Hosts the AI SEO Enhancer toggle today; llms.txt and AI-crawler
- * controls land here later (tracked separately). State + auto-save live in the
- * `form` controller (passed from the page root so it survives tab switches);
- * this component is the presentation.
+ * A single "allow this crawler" toggle. Extracted so its change handler is a
+ * stable callback (bound to the crawler's slug) rather than an inline arrow.
  *
- * The tab itself is always shown — only the Enhancer card is plan-gated, so the
- * tab stays a home for the free AI settings still to come.
+ * @param props          - Component props.
+ * @param props.crawler  - The crawler this row represents.
+ * @param props.blocked  - Whether the crawler is currently blocked.
+ * @param props.disabled - Whether the toggle is disabled (mid-save).
+ * @param props.onToggle - Called with `(slug, blocked)` on change.
+ * @return The crawler toggle row.
+ */
+const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, onToggle } ) => {
+	const handleChange = useCallback(
+		( allowed: boolean ) => onToggle( crawler.slug, ! allowed ),
+		[ crawler.slug, onToggle ]
+	);
+
+	return (
+		<ToggleControl
+			label={ crawler.label }
+			checked={ ! blocked }
+			onChange={ handleChange }
+			disabled={ disabled }
+			__nextHasNoMarginBottom
+		/>
+	);
+};
+
+/**
+ * AI tab. Hosts three sections: the plan-gated AI SEO Enhancer, plus the free
+ * llms.txt and AI-crawler controls. State + auto-save live in the `form`
+ * controller (passed from the page root so it survives tab switches); this
+ * component is the presentation.
+ *
+ * The tab itself is always shown. Only the Enhancer card is plan-gated; the
+ * free sections render regardless, so the tab is a home for AI settings whether
+ * or not the site's plan includes the Enhancer.
  *
  * @param props      - Component props.
  * @param props.form - The AI form controller from `useAiForm`.
  * @return The AI tab content.
  */
 const AiScreen: FC< Props > = ( { form } ) => {
-	const { enhancer, isSaving, setEnhancerEnabled } = form;
+	const {
+		enhancer,
+		llmsTxt,
+		crawlers,
+		isSaving,
+		setEnhancerEnabled,
+		setLlmsTxtEnabled,
+		setCrawlerBlocked,
+	} = form;
 
 	if ( ! enhancer ) {
 		return (
@@ -34,38 +80,87 @@ const AiScreen: FC< Props > = ( { form } ) => {
 		);
 	}
 
-	// The Enhancer requires a supporting plan; when unavailable the card is
-	// hidden (parity with the legacy Traffic page). The tab stays in place for
-	// the free AI settings still to come.
-	if ( ! enhancer.available ) {
-		return (
-			<Notice.Root intent="info">
-				<Notice.Description>
-					{ __( 'More AI tools for your SEO are on the way.', 'jetpack-seo' ) }
-				</Notice.Description>
-			</Notice.Root>
-		);
-	}
-
 	return (
 		<div className="jetpack-seo-ai">
-			<CollapsibleCard.Root defaultOpen>
-				<CollapsibleCard.Header>
-					<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<ToggleControl
-						label={ __(
-							'Automatically generate SEO title, SEO description, and image alt text for new posts',
-							'jetpack-seo'
-						) }
-						checked={ enhancer.enabled }
-						onChange={ setEnhancerEnabled }
-						disabled={ isSaving }
-						__nextHasNoMarginBottom
-					/>
-				</CollapsibleCard.Content>
-			</CollapsibleCard.Root>
+			<Stack direction="column" gap="lg">
+				{ /* The Enhancer requires a supporting plan; when unavailable the card
+				     is hidden (parity with the legacy Traffic page) while the free
+				     sections below carry the tab. */ }
+				{ enhancer.available && (
+					<CollapsibleCard.Root defaultOpen>
+						<CollapsibleCard.Header>
+							<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+						</CollapsibleCard.Header>
+						<CollapsibleCard.Content>
+							<ToggleControl
+								label={ __(
+									'Automatically generate SEO title, SEO description, and image alt text for new posts',
+									'jetpack-seo'
+								) }
+								checked={ enhancer.enabled }
+								onChange={ setEnhancerEnabled }
+								disabled={ isSaving }
+								__nextHasNoMarginBottom
+							/>
+						</CollapsibleCard.Content>
+					</CollapsibleCard.Root>
+				) }
+
+				{ llmsTxt && (
+					<CollapsibleCard.Root defaultOpen>
+						<CollapsibleCard.Header>
+							<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
+						</CollapsibleCard.Header>
+						<CollapsibleCard.Content>
+							<Stack direction="column" gap="md">
+								<ToggleControl
+									label={ __( 'Generate an llms.txt file', 'jetpack-seo' ) }
+									help={ __(
+										'Publishes a curated, AI-readable map of your content at /llms.txt to help AI assistants find and understand your pages and posts.',
+										'jetpack-seo'
+									) }
+									checked={ llmsTxt.enabled }
+									onChange={ setLlmsTxtEnabled }
+									disabled={ isSaving }
+									__nextHasNoMarginBottom
+								/>
+								{ llmsTxt.enabled && (
+									<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
+										{ __( 'View your llms.txt', 'jetpack-seo' ) }
+									</Link>
+								) }
+							</Stack>
+						</CollapsibleCard.Content>
+					</CollapsibleCard.Root>
+				) }
+
+				{ crawlers && (
+					<CollapsibleCard.Root defaultOpen>
+						<CollapsibleCard.Header>
+							<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+						</CollapsibleCard.Header>
+						<CollapsibleCard.Content>
+							<Stack direction="column" gap="md">
+								<p className="jetpack-seo-ai__crawlers-intro">
+									{ __(
+										'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
+										'jetpack-seo'
+									) }
+								</p>
+								{ crawlers.catalog.map( crawler => (
+									<CrawlerToggle
+										key={ crawler.slug }
+										crawler={ crawler }
+										blocked={ crawlers.blocked.includes( crawler.slug ) }
+										disabled={ isSaving }
+										onToggle={ setCrawlerBlocked }
+									/>
+								) ) }
+							</Stack>
+						</CollapsibleCard.Content>
+					</CollapsibleCard.Root>
+				) }
+			</Stack>
 		</div>
 	);
 };

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -54,10 +54,10 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 
 /**
  * AI tab. Hosts three sections stacked in a single centered column (matching the
- * Settings tab's width), ordered broad → specific: AI-crawler access, then
- * llms.txt, then the plan-gated AI SEO Enhancer. State + auto-save live in the
- * `form` controller (passed from the page root so it survives tab switches);
- * this component is the presentation.
+ * Settings tab's width): llms.txt, then the plan-gated AI SEO enhancer, then
+ * AI-crawler access last — the longest, least-used section, collapsed by
+ * default. State + auto-save live in the `form` controller (passed from the page
+ * root so it survives tab switches); this component is the presentation.
  *
  * The tab itself is always shown. Only the Enhancer card is plan-gated; the free
  * sections render regardless, so the tab is a home for AI settings whether or not
@@ -90,39 +90,6 @@ const AiScreen: FC< Props > = ( { form } ) => {
 
 	return (
 		<div className="jetpack-seo-ai">
-			{ /* Broad → specific: whether AI crawlers may reach the site, then the
-			     content map exposed to them, then AI fine-tuning of specific
-			     metadata. */ }
-			{ /* Collapsed by default: it's the longest section and the one most
-			     people won't need to touch, so it doesn't bury llms.txt and the
-			     Enhancer below it. */ }
-			{ crawlers && (
-				<CollapsibleCard.Root>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Stack direction="column" gap="md">
-							<p className="jetpack-seo-ai__crawlers-intro">
-								{ __(
-									'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
-									'jetpack-seo'
-								) }
-							</p>
-							{ crawlers.catalog.map( crawler => (
-								<CrawlerToggle
-									key={ crawler.slug }
-									crawler={ crawler }
-									blocked={ crawlers.blocked.includes( crawler.slug ) }
-									disabled={ isSaving }
-									onToggle={ setCrawlerBlocked }
-								/>
-							) ) }
-						</Stack>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
-			) }
-
 			{ llmsTxt && (
 				<CollapsibleCard.Root defaultOpen>
 					<CollapsibleCard.Header>
@@ -154,7 +121,7 @@ const AiScreen: FC< Props > = ( { form } ) => {
 			{ enhancer.available && (
 				<CollapsibleCard.Root defaultOpen>
 					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+						<Card.Title>{ __( 'AI SEO enhancer', 'jetpack-seo' ) }</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<ToggleControl
@@ -167,6 +134,35 @@ const AiScreen: FC< Props > = ( { form } ) => {
 							disabled={ isSaving }
 							__nextHasNoMarginBottom
 						/>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			) }
+
+			{ /* Last and collapsed by default: the longest section and the one most
+			     people won't need to touch. */ }
+			{ crawlers && (
+				<CollapsibleCard.Root>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Stack direction="column" gap="md">
+							<p className="jetpack-seo-ai__crawlers-intro">
+								{ __(
+									'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
+									'jetpack-seo'
+								) }
+							</p>
+							{ crawlers.catalog.map( crawler => (
+								<CrawlerToggle
+									key={ crawler.slug }
+									crawler={ crawler }
+									blocked={ crawlers.blocked.includes( crawler.slug ) }
+									disabled={ isSaving }
+									onToggle={ setCrawlerBlocked }
+								/>
+							) ) }
+						</Stack>
 					</CollapsibleCard.Content>
 				</CollapsibleCard.Root>
 			) }

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -1,6 +1,6 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
 import './style.scss';
@@ -42,14 +42,30 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 	const blockedLabel = __( 'Blocked', 'jetpack-seo' );
 
 	return (
-		<ToggleControl
-			label={ crawler.label }
-			help={ blocked ? blockedLabel : allowedLabel }
-			checked={ ! blocked }
-			onChange={ handleChange }
-			disabled={ disabled }
-			__nextHasNoMarginBottom
-		/>
+		<div className="jetpack-seo-ai__crawler-row">
+			<ToggleControl
+				label={ crawler.label }
+				help={ blocked ? blockedLabel : allowedLabel }
+				checked={ ! blocked }
+				onChange={ handleChange }
+				disabled={ disabled }
+				__nextHasNoMarginBottom
+			/>
+			{ crawler.docUrl && (
+				<Link
+					className="jetpack-seo-ai__crawler-doc"
+					href={ crawler.docUrl }
+					openInNewTab
+					rel="noopener noreferrer"
+				>
+					{ sprintf(
+						/* translators: %s is an AI crawler's user-agent name, e.g. "GPTBot". */
+						__( 'Learn what %s does', 'jetpack-seo' ),
+						crawler.userAgent
+					) }
+				</Link>
+			) }
+		</div>
 	);
 };
 

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -1,6 +1,7 @@
-import { ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useNavigate } from '@wordpress/route';
 import { Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
 import './style.scss';
 import type { AiCrawler } from '../../data/ai-types';
@@ -52,16 +53,70 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 	);
 };
 
+interface CrawlerSectionProps {
+	title: string;
+	intro: string;
+	crawlers: AiCrawler[];
+	blocked: string[];
+	disabled: boolean;
+	onToggle: ( slug: string, blocked: boolean ) => void;
+}
+
 /**
- * AI tab. Hosts three sections stacked in a single centered column (matching the
- * Settings tab's width): llms.txt, then the plan-gated AI SEO enhancer, then
- * AI-crawler access last — the longest, least-used section, collapsed by
- * default. State + auto-save live in the `form` controller (passed from the page
- * root so it survives tab switches); this component is the presentation.
+ * A collapsible card listing one group of crawler toggles (answer engines or
+ * training crawlers) with a one-line explanation of what the group does.
+ * Collapsed by default — the AI-crawler controls sit at the bottom of the tab and
+ * most people won't need to open them.
  *
- * The tab itself is always shown. Only the Enhancer card is plan-gated; the free
- * sections render regardless, so the tab is a home for AI settings whether or not
- * the site's plan includes the Enhancer.
+ * @param props          - Component props.
+ * @param props.title    - Section title.
+ * @param props.intro    - One-line description of the group's purpose.
+ * @param props.crawlers - The crawlers in this group.
+ * @param props.blocked  - The full blocked-slug list.
+ * @param props.disabled - Whether toggles are disabled (mid-save).
+ * @param props.onToggle - Called with `(slug, blocked)` on change.
+ * @return The section card.
+ */
+const CrawlerSection: FC< CrawlerSectionProps > = ( {
+	title,
+	intro,
+	crawlers,
+	blocked,
+	disabled,
+	onToggle,
+} ) => (
+	<CollapsibleCard.Root>
+		<CollapsibleCard.Header>
+			<Card.Title>{ title }</Card.Title>
+		</CollapsibleCard.Header>
+		<CollapsibleCard.Content>
+			<Stack direction="column" gap="md">
+				<p className="jetpack-seo-ai__crawlers-intro">{ intro }</p>
+				{ crawlers.map( crawler => (
+					<CrawlerToggle
+						key={ crawler.slug }
+						crawler={ crawler }
+						blocked={ blocked.includes( crawler.slug ) }
+						disabled={ disabled }
+						onToggle={ onToggle }
+					/>
+				) ) }
+			</Stack>
+		</CollapsibleCard.Content>
+	</CollapsibleCard.Root>
+);
+
+/**
+ * AI tab. Stacks (in a single centered column matching the Settings tab's width):
+ * llms.txt, the plan-gated AI SEO enhancer, then the AI-crawler controls — split
+ * into "Answer engines" (allowed by default, so the site stays citable in AI
+ * answers) and "Training crawlers" (blocked by default). When the site can't be
+ * crawled at all — search-engine indexing off, or a `*.wpcomstaging.com` staging
+ * address — the crawler controls are replaced by an explanation instead of
+ * toggles that can't take effect.
+ *
+ * State + auto-save live in the `form` controller (passed from the page root so
+ * it survives tab switches); this component is the presentation.
  *
  * @param props      - Component props.
  * @param props.form - The AI form controller from `useAiForm`.
@@ -78,6 +133,12 @@ const AiScreen: FC< Props > = ( { form } ) => {
 		setCrawlerBlocked,
 	} = form;
 
+	const navigate = useNavigate();
+	const goToVisibility = useCallback(
+		() => navigate( { href: '/settings?focus=visibility' } ),
+		[ navigate ]
+	);
+
 	if ( ! enhancer ) {
 		return (
 			<Notice.Root intent="error">
@@ -87,6 +148,107 @@ const AiScreen: FC< Props > = ( { form } ) => {
 			</Notice.Root>
 		);
 	}
+
+	/**
+	 * The AI-crawler portion of the tab: either the two control sections, or — when
+	 * the site can't be crawled — a single card explaining why.
+	 *
+	 * @return The crawler cards, or null when there's no crawler bootstrap.
+	 */
+	const renderCrawlers = () => {
+		if ( ! crawlers ) {
+			return null;
+		}
+
+		// Staging subdomain blocks all crawling at the platform level, so even an
+		// indexable site can't apply these — explain and stop.
+		if ( crawlers.restrictedSubdomain ) {
+			return (
+				<CollapsibleCard.Root defaultOpen>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Notice.Root intent="info">
+							<Notice.Description>
+								{ __(
+									'This site uses a temporary staging address (a .wpcomstaging.com subdomain), where search engines and AI crawlers are blocked. These settings will take effect once the site is on its own domain.',
+									'jetpack-seo'
+								) }
+							</Notice.Description>
+						</Notice.Root>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			);
+		}
+
+		// Search engines (and therefore AI crawlers) are blocked site-wide — point
+		// the user at the setting that turns indexing back on.
+		if ( ! crawlers.searchEnginesVisible ) {
+			return (
+				<CollapsibleCard.Root defaultOpen>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Stack direction="column" gap="md">
+							<Notice.Root intent="info">
+								<Notice.Description>
+									{ __(
+										"Search engines and AI crawlers are all blocked because this site isn't set to be indexed. To choose which AI crawlers can access your site, allow search engines to index it first.",
+										'jetpack-seo'
+									) }
+								</Notice.Description>
+							</Notice.Root>
+							<Button variant="link" onClick={ goToVisibility }>
+								{ __( 'Open site visibility settings', 'jetpack-seo' ) }
+							</Button>
+						</Stack>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			);
+		}
+
+		const answerCrawlers = crawlers.catalog.filter( crawler => crawler.type === 'answer' );
+		const trainingCrawlers = crawlers.catalog.filter( crawler => crawler.type === 'training' );
+
+		return (
+			<>
+				{ crawlers.staticRobotsTxt && (
+					<Notice.Root intent="warning">
+						<Notice.Description>
+							{ __(
+								"A robots.txt file was found at this site's root, so these settings may not take effect until it's removed. This is common on local, sandbox, and staging sites.",
+								'jetpack-seo'
+							) }
+						</Notice.Description>
+					</Notice.Root>
+				) }
+				<CrawlerSection
+					title={ __( 'Answer engines', 'jetpack-seo' ) }
+					intro={ __(
+						'These crawlers fetch your pages so AI assistants can cite you in their answers. Keep them allowed to stay visible in tools like ChatGPT, Perplexity, and Claude.',
+						'jetpack-seo'
+					) }
+					crawlers={ answerCrawlers }
+					blocked={ crawlers.blocked }
+					disabled={ isSaving }
+					onToggle={ setCrawlerBlocked }
+				/>
+				<CrawlerSection
+					title={ __( 'Training crawlers', 'jetpack-seo' ) }
+					intro={ __(
+						"These crawlers collect your content to train AI models. Blocking them protects your content and doesn't affect whether you appear in AI answers.",
+						'jetpack-seo'
+					) }
+					crawlers={ trainingCrawlers }
+					blocked={ crawlers.blocked }
+					disabled={ isSaving }
+					onToggle={ setCrawlerBlocked }
+				/>
+			</>
+		);
+	};
 
 	return (
 		<div className="jetpack-seo-ai">
@@ -143,34 +305,7 @@ const AiScreen: FC< Props > = ( { form } ) => {
 				</CollapsibleCard.Root>
 			) }
 
-			{ /* Last and collapsed by default: the longest section and the one most
-			     people won't need to touch. */ }
-			{ crawlers && (
-				<CollapsibleCard.Root>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Stack direction="column" gap="md">
-							<p className="jetpack-seo-ai__crawlers-intro">
-								{ __(
-									'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
-									'jetpack-seo'
-								) }
-							</p>
-							{ crawlers.catalog.map( crawler => (
-								<CrawlerToggle
-									key={ crawler.slug }
-									crawler={ crawler }
-									blocked={ crawlers.blocked.includes( crawler.slug ) }
-									disabled={ isSaving }
-									onToggle={ setCrawlerBlocked }
-								/>
-							) ) }
-						</Stack>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
-			) }
+			{ renderCrawlers() }
 		</div>
 	);
 };

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -51,7 +51,7 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 				disabled={ disabled }
 				__nextHasNoMarginBottom
 			/>
-			{ crawler.docUrl && (
+			{ crawler.docUrl ? (
 				<Link
 					className="jetpack-seo-ai__crawler-doc"
 					href={ crawler.docUrl }
@@ -64,6 +64,16 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 						crawler.userAgent
 					) }
 				</Link>
+			) : (
+				// No operator documentation exists for this bot (e.g. Bytespider) —
+				// say so explicitly so the missing link doesn't read as a bug.
+				<span className="jetpack-seo-ai__crawler-doc jetpack-seo-ai__crawler-doc--none">
+					{ sprintf(
+						/* translators: %s is an AI crawler's user-agent name, e.g. "Bytespider". */
+						__( 'No documentation available for %s', 'jetpack-seo' ),
+						crawler.userAgent
+					) }
+				</span>
 			) }
 		</div>
 	);

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -109,7 +109,12 @@ const AiScreen: FC< Props > = ( { form } ) => {
 								__nextHasNoMarginBottom
 							/>
 							{ llmsTxt.enabled && (
-								<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
+								<Link
+									className="jetpack-seo-ai__llms-link"
+									href={ llmsTxt.url }
+									openInNewTab
+									rel="noopener noreferrer"
+								>
 									{ __( 'View your llms.txt', 'jetpack-seo' ) }
 								</Link>
 							) }

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -53,13 +53,11 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 };
 
 /**
- * AI tab. Hosts three sections: the plan-gated AI SEO Enhancer, plus the free
- * llms.txt and AI-crawler controls, laid out in two columns ordered broad →
- * specific: AI-crawler access on the left, then llms.txt and the AI SEO Enhancer
- * on the right — collapsing to a single column on narrow screens. State +
- * auto-save live in the `form` controller
- * (passed from the page root so it survives tab switches); this component is the
- * presentation.
+ * AI tab. Hosts three sections stacked in a single centered column (matching the
+ * Settings tab's width), ordered broad → specific: AI-crawler access, then
+ * llms.txt, then the plan-gated AI SEO Enhancer. State + auto-save live in the
+ * `form` controller (passed from the page root so it survives tab switches);
+ * this component is the presentation.
  *
  * The tab itself is always shown. Only the Enhancer card is plan-gated; the free
  * sections render regardless, so the tab is a home for AI settings whether or not
@@ -92,92 +90,83 @@ const AiScreen: FC< Props > = ( { form } ) => {
 
 	return (
 		<div className="jetpack-seo-ai">
-			<div className="jetpack-seo-ai__grid">
-				{ /* Left column: AI crawler access — the broadest control (whether AI
-				     crawlers may reach the site at all). */ }
-				<div className="jetpack-seo-ai__column">
-					{ crawlers && (
-						<CollapsibleCard.Root defaultOpen>
-							<CollapsibleCard.Header>
-								<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
-							</CollapsibleCard.Header>
-							<CollapsibleCard.Content>
-								<Stack direction="column" gap="md">
-									<p className="jetpack-seo-ai__crawlers-intro">
-										{ __(
-											'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
-											'jetpack-seo'
-										) }
-									</p>
-									{ crawlers.catalog.map( crawler => (
-										<CrawlerToggle
-											key={ crawler.slug }
-											crawler={ crawler }
-											blocked={ crawlers.blocked.includes( crawler.slug ) }
-											disabled={ isSaving }
-											onToggle={ setCrawlerBlocked }
-										/>
-									) ) }
-								</Stack>
-							</CollapsibleCard.Content>
-						</CollapsibleCard.Root>
-					) }
-				</div>
-
-				{ /* Right column, broad → specific: llms.txt (hand AI a formatted
-				     content map), then the AI SEO Enhancer (AI fine-tuning of specific
-				     metadata). The Enhancer is plan-gated — hidden when the plan
-				     doesn't support it (parity with the legacy Traffic page). */ }
-				<div className="jetpack-seo-ai__column">
-					{ llmsTxt && (
-						<CollapsibleCard.Root defaultOpen>
-							<CollapsibleCard.Header>
-								<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
-							</CollapsibleCard.Header>
-							<CollapsibleCard.Content>
-								<Stack direction="column" gap="md">
-									<ToggleControl
-										label={ __( 'Generate an llms.txt file', 'jetpack-seo' ) }
-										help={ __(
-											'Publishes a curated, AI-readable map of your content at /llms.txt to help AI assistants find and understand your pages and posts.',
-											'jetpack-seo'
-										) }
-										checked={ llmsTxt.enabled }
-										onChange={ setLlmsTxtEnabled }
-										disabled={ isSaving }
-										__nextHasNoMarginBottom
-									/>
-									{ llmsTxt.enabled && (
-										<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
-											{ __( 'View your llms.txt', 'jetpack-seo' ) }
-										</Link>
-									) }
-								</Stack>
-							</CollapsibleCard.Content>
-						</CollapsibleCard.Root>
-					) }
-
-					{ enhancer.available && (
-						<CollapsibleCard.Root defaultOpen>
-							<CollapsibleCard.Header>
-								<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
-							</CollapsibleCard.Header>
-							<CollapsibleCard.Content>
-								<ToggleControl
-									label={ __(
-										'Automatically generate SEO title, SEO description, and image alt text for new posts',
-										'jetpack-seo'
-									) }
-									checked={ enhancer.enabled }
-									onChange={ setEnhancerEnabled }
+			{ /* Broad → specific: whether AI crawlers may reach the site, then the
+			     content map exposed to them, then AI fine-tuning of specific
+			     metadata. */ }
+			{ crawlers && (
+				<CollapsibleCard.Root defaultOpen>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Stack direction="column" gap="md">
+							<p className="jetpack-seo-ai__crawlers-intro">
+								{ __(
+									'Choose which AI crawlers may access your site. Blocked crawlers are disallowed in your robots.txt.',
+									'jetpack-seo'
+								) }
+							</p>
+							{ crawlers.catalog.map( crawler => (
+								<CrawlerToggle
+									key={ crawler.slug }
+									crawler={ crawler }
+									blocked={ crawlers.blocked.includes( crawler.slug ) }
 									disabled={ isSaving }
-									__nextHasNoMarginBottom
+									onToggle={ setCrawlerBlocked }
 								/>
-							</CollapsibleCard.Content>
-						</CollapsibleCard.Root>
-					) }
-				</div>
-			</div>
+							) ) }
+						</Stack>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			) }
+
+			{ llmsTxt && (
+				<CollapsibleCard.Root defaultOpen>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<Stack direction="column" gap="md">
+							<ToggleControl
+								label={ __( 'Generate an llms.txt file', 'jetpack-seo' ) }
+								help={ __(
+									'Publishes a curated, AI-readable map of your content at /llms.txt to help AI assistants find and understand your pages and posts.',
+									'jetpack-seo'
+								) }
+								checked={ llmsTxt.enabled }
+								onChange={ setLlmsTxtEnabled }
+								disabled={ isSaving }
+								__nextHasNoMarginBottom
+							/>
+							{ llmsTxt.enabled && (
+								<Link href={ llmsTxt.url } openInNewTab rel="noopener noreferrer">
+									{ __( 'View your llms.txt', 'jetpack-seo' ) }
+								</Link>
+							) }
+						</Stack>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			) }
+
+			{ enhancer.available && (
+				<CollapsibleCard.Root defaultOpen>
+					<CollapsibleCard.Header>
+						<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+					</CollapsibleCard.Header>
+					<CollapsibleCard.Content>
+						<ToggleControl
+							label={ __(
+								'Automatically generate SEO title, SEO description, and image alt text for new posts',
+								'jetpack-seo'
+							) }
+							checked={ enhancer.enabled }
+							onChange={ setEnhancerEnabled }
+							disabled={ isSaving }
+							__nextHasNoMarginBottom
+						/>
+					</CollapsibleCard.Content>
+				</CollapsibleCard.Root>
+			) }
 		</div>
 	);
 };

--- a/projects/packages/seo/_inc/screens/ai/style.scss
+++ b/projects/packages/seo/_inc/screens/ai/style.scss
@@ -23,3 +23,17 @@
 .jetpack-seo-ai__llms-link {
 	margin-inline-start: 40px;
 }
+
+// One crawler row: the allow/block toggle plus its "Learn what … does" link.
+.jetpack-seo-ai__crawler-row {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-xs, 4px);
+}
+
+// Indent the doc link to align with the toggle's label/help text (not the
+// switch), matching the llms.txt link; sized to match the toggle's help text.
+.jetpack-seo-ai__crawler-doc {
+	margin-inline-start: 40px;
+	font-size: 12px;
+}

--- a/projects/packages/seo/_inc/screens/ai/style.scss
+++ b/projects/packages/seo/_inc/screens/ai/style.scss
@@ -1,0 +1,34 @@
+// AI tab layout. The settings read awkwardly full-width, so they sit in a
+// two-column grid: the Enhancer + llms.txt in the left column, and the taller
+// AI-crawler list in the right. Columns top-align (so the short left cards
+// don't stretch), and the grid collapses to a single column on narrow screens.
+.jetpack-seo-ai__grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--wpds-dimension-gap-lg, 16px);
+	align-items: start;
+}
+
+.jetpack-seo-ai__column {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-lg, 16px);
+	// Let cards shrink within their track instead of forcing the column wider.
+	min-inline-size: 0;
+}
+
+// Stack to a single column on narrow viewports (WordPress admin's small-screen
+// breakpoint).
+@media (max-width: 781px) {
+
+	.jetpack-seo-ai__grid {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}
+
+// Muted intro line above the per-crawler toggles; reset the default paragraph
+// margins so it sits flush in the card's Stack.
+.jetpack-seo-ai__crawlers-intro {
+	margin: 0;
+	color: var(--wpds-color-fg-content-neutral-weak, #787c82);
+}

--- a/projects/packages/seo/_inc/screens/ai/style.scss
+++ b/projects/packages/seo/_inc/screens/ai/style.scss
@@ -1,29 +1,12 @@
-// AI tab layout. The settings read awkwardly full-width, so they sit in a
-// two-column grid: the Enhancer + llms.txt in the left column, and the taller
-// AI-crawler list in the right. Columns top-align (so the short left cards
-// don't stretch), and the grid collapses to a single column on narrow screens.
-.jetpack-seo-ai__grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: var(--wpds-dimension-gap-lg, 16px);
-	align-items: start;
-}
-
-.jetpack-seo-ai__column {
+// AI tab layout. A single, centered fixed-width column matching the Settings
+// tab's treatment — 660px is the established Jetpack settings-page width (see
+// settings/style.scss). The cards stack with a consistent gap.
+.jetpack-seo-ai {
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-gap-lg, 16px);
-	// Let cards shrink within their track instead of forcing the column wider.
-	min-inline-size: 0;
-}
-
-// Stack to a single column on narrow viewports (WordPress admin's small-screen
-// breakpoint).
-@media (max-width: 781px) {
-
-	.jetpack-seo-ai__grid {
-		grid-template-columns: minmax(0, 1fr);
-	}
+	max-inline-size: 660px;
+	margin-inline: auto;
 }
 
 // Muted intro line above the per-crawler toggles; reset the default paragraph

--- a/projects/packages/seo/_inc/screens/ai/style.scss
+++ b/projects/packages/seo/_inc/screens/ai/style.scss
@@ -15,3 +15,11 @@
 	margin: 0;
 	color: var(--wpds-color-fg-content-neutral-weak, #787c82);
 }
+
+// Align the "View your llms.txt" link with the toggle's label/help text rather
+// than the switch. 40px matches @wordpress/components ToggleControl's help
+// margin-inline-start (≈ 36px switch + gap) — same treatment as the Settings
+// tab's sitemap link.
+.jetpack-seo-ai__llms-link {
+	margin-inline-start: 40px;
+}

--- a/projects/packages/seo/_inc/screens/ai/style.scss
+++ b/projects/packages/seo/_inc/screens/ai/style.scss
@@ -37,3 +37,8 @@
 	margin-inline-start: 40px;
 	font-size: 12px;
 }
+
+// Muted, non-link caption shown for a bot with no operator documentation.
+.jetpack-seo-ai__crawler-doc--none {
+	color: var(--wpds-color-fg-content-neutral-weak, #787c82);
+}

--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -95,7 +95,7 @@ const ContentScreen: FC = () => {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const navigate = useNavigate();
 
-	const { items, isLoading } = useSeoPosts();
+	const { items, isLoading, postTypeOptions } = useSeoPosts();
 
 	// Select a row for editing by writing it to the URL; the Content route's
 	// `inspector` predicate (`?postId`) then renders the editor in the sidebar.
@@ -119,15 +119,12 @@ const ContentScreen: FC = () => {
 			{
 				id: POST_TYPE_FIELD,
 				label: __( 'Type', 'jetpack-seo' ),
-				elements: [
-					{ value: 'post', label: __( 'Posts', 'jetpack-seo' ) },
-					{ value: 'page', label: __( 'Pages', 'jetpack-seo' ) },
-				],
+				elements: postTypeOptions,
 				filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },
 				enableSorting: false,
 				enableHiding: false,
 				// Filter-only field; not shown as a column. Core REST records
-				// expose `type` as 'post' | 'page', matching the elements, so
+				// expose `type` as the post type slug, matching the elements, so
 				// `filterSortAndPaginate` narrows the merged set.
 				render: () => null,
 				getValue: ( { item } ) => item.type,
@@ -223,7 +220,7 @@ const ContentScreen: FC = () => {
 				render: ( { item } ) => <EditButton item={ item } onEdit={ onEdit } />,
 			},
 		],
-		[ onEdit ]
+		[ onEdit, postTypeOptions ]
 	);
 
 	// Client-side filter, sort and paginate the merged posts+pages set. Returns

--- a/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
+++ b/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
@@ -35,7 +35,7 @@ const SCHEMA_OPTIONS: Array< { value: SchemaType; label: string } > = [
 interface Props {
 	// The selected post id (from the Content route's `?postId`).
 	postId: number;
-	// The core endpoint to save through: 'post' or 'page'.
+	// The core-data post type endpoint slug to save through.
 	postType: ContentPostType;
 	// Dismiss the inspector (clears the URL selection).
 	onClose: () => void;
@@ -68,7 +68,7 @@ const EMPTY_META: EditableMeta = {
  *
  * @param props          - Component props.
  * @param props.postId   - The selected post id.
- * @param props.postType - The core endpoint to save through ('post' | 'page').
+ * @param props.postType - The core-data post type slug to save through.
  * @param props.onClose  - Dismiss the inspector.
  * @return The SEO inspector editor.
  */

--- a/projects/packages/seo/_inc/screens/overview/ai-readiness-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-readiness-card.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Card, Stack } from '@wordpress/ui';
+import StatusDot from './status-dot';
+import type { AiState } from '../../data/ai-types';
+import type { FC } from 'react';
+
+interface Props {
+	enhancer: AiState[ 'enhancer' ] | null;
+	llmsTxt: AiState[ 'llmsTxt' ] | null;
+	crawlers: AiState[ 'crawlers' ] | null;
+	onManage: () => void;
+}
+
+// Module-scope labels so the production minifier can't fold an adjacent
+// `cond ? __(A) : __(B)` into `__(cond ? A : B)`, which would erase the literals
+// from i18n extraction. See feedback_i18n_ternary_minifier_fold.
+const llmsOnLabel = __( 'llms.txt generated', 'jetpack-seo' );
+const llmsOffLabel = __( 'llms.txt not generated', 'jetpack-seo' );
+const answerAllowedLabel = __( 'Answer engines allowed', 'jetpack-seo' );
+const answerBlockedLabel = __( 'Some answer engines blocked', 'jetpack-seo' );
+const trainingConfiguredLabel = __( 'Training privacy configured', 'jetpack-seo' );
+const trainingOpenLabel = __( 'Training crawlers allowed', 'jetpack-seo' );
+const enhancerOnLabel = __( 'AI-enhanced SEO enabled', 'jetpack-seo' );
+const enhancerOffLabel = __( 'AI-enhanced SEO disabled', 'jetpack-seo' );
+const enhancerUnavailableLabel = __( 'AI-enhanced SEO unavailable', 'jetpack-seo' );
+
+/**
+ * Overview "AI readiness" card: a factual snapshot of the four AI-tab settings
+ * (llms.txt, answer-engine access, training-crawler privacy, the AI SEO
+ * enhancer), each shown as a status row, with a button through to the AI tab.
+ * Like the other Overview cards it reports state — it is not a graded score.
+ *
+ * @param props          - Component props.
+ * @param props.enhancer - AI SEO Enhancer state (or null when absent).
+ * @param props.llmsTxt  - llms.txt state (or null when absent).
+ * @param props.crawlers - AI-crawler state (or null when absent).
+ * @param props.onManage - Navigate to the AI tab.
+ * @return The AI readiness card.
+ */
+const AiReadinessCard: FC< Props > = ( { enhancer, llmsTxt, crawlers, onManage } ) => {
+	const llmsOn = !! llmsTxt?.enabled;
+
+	const blocked = crawlers?.blocked ?? [];
+	const catalog = crawlers?.catalog ?? [];
+
+	// Answer engines are "allowed" when none of them are blocked; training
+	// privacy is "configured" when every training crawler is blocked.
+	const answerEngines = catalog.filter( crawler => crawler.type === 'answer' );
+	const answerAllowed =
+		answerEngines.length > 0 &&
+		answerEngines.every( crawler => ! blocked.includes( crawler.slug ) );
+
+	const trainingCrawlers = catalog.filter( crawler => crawler.type === 'training' );
+	const trainingConfigured =
+		trainingCrawlers.length > 0 &&
+		trainingCrawlers.every( crawler => blocked.includes( crawler.slug ) );
+
+	const enhancerOn = !! ( enhancer?.available && enhancer.enabled );
+	// The Enhancer is plan-gated; distinguish "off" from "not on your plan". Typed
+	// as string so the distinct branded `__()` literal types can share the binding.
+	let enhancerLabel: string = enhancerUnavailableLabel;
+	if ( enhancer?.available ) {
+		enhancerLabel = enhancer.enabled ? enhancerOnLabel : enhancerOffLabel;
+	}
+
+	return (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>{ __( 'AI readiness', 'jetpack-seo' ) }</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<Stack direction="column" gap="xs">
+					<StatusDot
+						status={ llmsOn ? 'ok' : 'warn' }
+						label={ llmsOn ? llmsOnLabel : llmsOffLabel }
+					/>
+					<StatusDot
+						status={ answerAllowed ? 'ok' : 'warn' }
+						label={ answerAllowed ? answerAllowedLabel : answerBlockedLabel }
+					/>
+					<StatusDot
+						status={ trainingConfigured ? 'ok' : 'warn' }
+						label={ trainingConfigured ? trainingConfiguredLabel : trainingOpenLabel }
+					/>
+					<StatusDot status={ enhancerOn ? 'ok' : 'warn' } label={ enhancerLabel } />
+				</Stack>
+				<div className="jetpack-seo-overview__card-footer">
+					<Button variant="secondary" onClick={ onManage }>
+						{ __( 'Manage AI', 'jetpack-seo' ) }
+					</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	);
+};
+
+export default AiReadinessCard;

--- a/projects/packages/seo/_inc/screens/overview/index.tsx
+++ b/projects/packages/seo/_inc/screens/overview/index.tsx
@@ -6,9 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Notice } from '@wordpress/ui';
 import EnableSeoCard from '../../components/enable-seo-card';
+import { aiStore } from '../../data/ai-store';
 import { coverageStore } from '../../data/coverage-store';
 import getOverview from '../../data/get-overview';
 import { settingsStore } from '../../data/settings-store';
+import AiReadinessCard from './ai-readiness-card';
 import ContentCoverageCard from './content-coverage-card';
 import DisableSeoTools from './disable-seo-tools';
 import SiteVerificationCard from './site-verification-card';
@@ -30,6 +32,14 @@ const OverviewScreen: FC = () => {
 	// here until a full reload. The "View" link itself lives on the Settings tab.
 	const settings = useSelect( select => select( settingsStore ).getSettings(), [] );
 
+	// AI-tab settings drive the AI readiness card. Read from the AI store (seeded
+	// from the bootstrap, updated on each save in the AI route) so a change there
+	// reflects here on navigation without a reload — same pattern as the stores
+	// above.
+	const aiEnhancer = useSelect( select => select( aiStore ).getEnhancer(), [] );
+	const aiLlmsTxt = useSelect( select => select( aiStore ).getLlmsTxt(), [] );
+	const aiCrawlers = useSelect( select => select( aiStore ).getCrawlers(), [] );
+
 	// Deep-link to a Settings section: navigate to the Settings route with
 	// `?focus=`, which the Settings screen reads to scroll the section to top.
 	const goToSection = useCallback(
@@ -40,6 +50,10 @@ const OverviewScreen: FC = () => {
 
 	// Deep-link to the Content route.
 	const goToContent = useCallback( () => navigate( { href: '/content' } ), [ navigate ] );
+
+	// Deep-link to the AI route. The AI readiness card is comprehensive, so it
+	// targets the tab itself rather than a specific section.
+	const goToAi = useCallback( () => navigate( { href: '/ai' } ), [ navigate ] );
 
 	if ( ! data ) {
 		return (
@@ -86,6 +100,12 @@ const OverviewScreen: FC = () => {
 				<SiteVerificationCard
 					data={ data.site_verification }
 					onManage={ () => goToSection( 'verification' ) }
+				/>
+				<AiReadinessCard
+					enhancer={ aiEnhancer }
+					llmsTxt={ aiLlmsTxt }
+					crawlers={ aiCrawlers }
+					onManage={ goToAi }
 				/>
 			</div>
 			<div className="jetpack-seo-overview__content-card">

--- a/projects/packages/seo/changelog/add-seo-ai-tab-llms-and-crawler-controls
+++ b/projects/packages/seo/changelog/add-seo-ai-tab-llms-and-crawler-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add AI tab controls for llms.txt generation and per-crawler AI bot access, with robots.txt directives and a generated /llms.txt on the front end.

--- a/projects/packages/seo/changelog/add-seo-cpt-support
+++ b/projects/packages/seo/changelog/add-seo-cpt-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support public REST custom post types in Jetpack SEO content management and llms.txt.

--- a/projects/packages/seo/routes/ai/stage.tsx
+++ b/projects/packages/seo/routes/ai/stage.tsx
@@ -25,13 +25,21 @@ const AiReady = () => {
 };
 
 const Stage = () => {
-	const { setEnhancer } = useDispatch( aiStore );
+	const { setEnhancer, setLlmsTxt, setCrawlers } = useDispatch( aiStore );
 	// AI gates on the seo-tools state, which lives in the Overview slice, so ensure
-	// both are available. A recovered AI payload is pushed into the store so the
-	// form (seeded from it) reflects it.
+	// both are available. A recovered AI payload is pushed into the store — every
+	// slice, so the form (seeded from it) reflects llms.txt and crawlers too.
 	const { status, retry } = useEnsureTabData( [
 		{ path: OVERVIEW_PATH },
-		{ path: AI_PATH, seed: body => setEnhancer( ( body as AiState ).enhancer ) },
+		{
+			path: AI_PATH,
+			seed: body => {
+				const ai = body as AiState;
+				setEnhancer( ai.enhancer );
+				setLlmsTxt( ai.llmsTxt );
+				setCrawlers( ai.crawlers );
+			},
+		},
 	] );
 
 	if ( status === 'loading' ) {

--- a/projects/packages/seo/routes/content/inspector.tsx
+++ b/projects/packages/seo/routes/content/inspector.tsx
@@ -2,7 +2,6 @@ import { ThemeProvider } from '@automattic/jetpack-components';
 import { useCallback } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import SeoInspector from '../../_inc/screens/content/seo-inspector';
-import type { ContentPostType } from '../../_inc/data/content-types';
 
 type InspectorSearch = Record< string, unknown > & { postId?: string; postType?: string };
 
@@ -26,7 +25,8 @@ function Inspector() {
 	if ( ! postId ) {
 		return null;
 	}
-	const postType: ContentPostType = search.postType === 'page' ? 'page' : 'post';
+	const postType =
+		typeof search.postType === 'string' && search.postType !== '' ? search.postType : 'post';
 
 	return (
 		<ThemeProvider>

--- a/projects/packages/seo/routes/content/stage.tsx
+++ b/projects/packages/seo/routes/content/stage.tsx
@@ -1,6 +1,10 @@
+import DashboardLoadError from '../../_inc/components/dashboard-load-error';
+import DashboardSkeleton from '../../_inc/components/dashboard-skeleton';
 import SeoDisabledStage from '../../_inc/components/seo-disabled-stage';
 import DashboardPage from '../../_inc/dashboard/dashboard-page';
+import { CONTENT_PATH } from '../../_inc/data/get-preloaded';
 import isSeoToolsActive from '../../_inc/data/is-seo-tools-active';
+import useEnsureTabData from '../../_inc/data/use-ensure-tab-data';
 import ContentScreen from '../../_inc/screens/content';
 
 // The Content route's main area: the DataViews list of posts/pages. Selecting a
@@ -15,7 +19,26 @@ const ContentRoute = () => (
 
 // When the `seo-tools` module is off, show the enable affordance instead of the
 // content list — its per-post SEO meta has no effect while the module is off.
-const Stage = () =>
-	isSeoToolsActive() ? <ContentRoute /> : <SeoDisabledStage active="content" />;
+const Stage = () => {
+	const { status, retry } = useEnsureTabData( [ { path: CONTENT_PATH } ] );
+
+	if ( status === 'loading' ) {
+		return (
+			<DashboardPage active="content" showFooter={ false } flush>
+				<DashboardSkeleton />
+			</DashboardPage>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<DashboardPage active="content" showFooter={ false } flush>
+				<DashboardLoadError onRetry={ retry } />
+			</DashboardPage>
+		);
+	}
+
+	return isSeoToolsActive() ? <ContentRoute /> : <SeoDisabledStage active="content" />;
+};
 
 export { Stage as stage };

--- a/projects/packages/seo/src/class-ai-crawlers.php
+++ b/projects/packages/seo/src/class-ai-crawlers.php
@@ -43,16 +43,18 @@ class Ai_Crawlers {
 	}
 
 	/**
-	 * The known AI crawler catalog: slug => [ label, user_agent ].
+	 * The known AI crawler catalog: slug => [ label, user_agent, type, doc_url ].
 	 *
 	 * `slug` is the stable key persisted in the option and sent by the AI tab;
-	 * `user_agent` is the token written to the `User-agent:` robots line;
-	 * `label` is the human name shown in the UI; `type` is `answer` (fetches to
-	 * cite in live AI answers) or `training` (collects to train models), which
-	 * drives the AI tab's two sections and the per-type default. Kept deliberately
-	 * small and recognizable — the better-known crawlers.
+	 * `user_agent` is the token written to the `User-agent:` robots line (and shown
+	 * in the "Learn what X does" link text); `label` is the human name shown in the
+	 * UI; `type` is `answer` (fetches to cite in live AI answers) or `training`
+	 * (collects to train models), which drives the AI tab's two sections and the
+	 * per-type default; `doc_url` is the operator's own documentation page for that
+	 * bot (empty when none exists, e.g. Bytespider). Kept deliberately small and
+	 * recognizable — the better-known crawlers.
 	 *
-	 * @return array<string, array{label: string, user_agent: string, type: string}>
+	 * @return array<string, array{label: string, user_agent: string, type: string, doc_url: string}>
 	 */
 	public static function get_catalog() {
 		return array(
@@ -62,21 +64,25 @@ class Ai_Crawlers {
 				'label'      => __( 'ChatGPT Search (OpenAI)', 'jetpack-seo' ),
 				'user_agent' => 'OAI-SearchBot',
 				'type'       => 'answer',
+				'doc_url'    => 'https://developers.openai.com/api/docs/bots',
 			),
 			'claude-searchbot'   => array(
 				'label'      => __( 'Claude Search (Anthropic)', 'jetpack-seo' ),
 				'user_agent' => 'Claude-SearchBot',
 				'type'       => 'answer',
+				'doc_url'    => 'https://support.claude.com/en/articles/8896518',
 			),
 			'perplexitybot'      => array(
 				'label'      => __( 'Perplexity', 'jetpack-seo' ),
 				'user_agent' => 'PerplexityBot',
 				'type'       => 'answer',
+				'doc_url'    => 'https://docs.perplexity.ai/guides/bots',
 			),
 			'amzn-searchbot'     => array(
 				'label'      => __( 'Amazon (Alexa)', 'jetpack-seo' ),
 				'user_agent' => 'Amzn-SearchBot',
 				'type'       => 'answer',
+				'doc_url'    => 'https://developer.amazon.com/amazonbot',
 			),
 			// Training crawlers collect content to train AI models. Blocked by
 			// default — blocking protects content with no AI-visibility downside.
@@ -84,36 +90,45 @@ class Ai_Crawlers {
 				'label'      => __( 'ChatGPT (OpenAI)', 'jetpack-seo' ),
 				'user_agent' => 'GPTBot',
 				'type'       => 'training',
+				'doc_url'    => 'https://developers.openai.com/api/docs/bots',
 			),
 			'claudebot'          => array(
 				'label'      => __( 'Claude (Anthropic)', 'jetpack-seo' ),
 				'user_agent' => 'ClaudeBot',
 				'type'       => 'training',
+				'doc_url'    => 'https://support.claude.com/en/articles/8896518',
 			),
 			'google-extended'    => array(
 				'label'      => __( 'Google AI (Gemini)', 'jetpack-seo' ),
 				'user_agent' => 'Google-Extended',
 				'type'       => 'training',
+				'doc_url'    => 'https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers',
 			),
 			'applebot-extended'  => array(
 				'label'      => __( 'Apple Intelligence', 'jetpack-seo' ),
 				'user_agent' => 'Applebot-Extended',
 				'type'       => 'training',
+				'doc_url'    => 'https://support.apple.com/en-us/119829',
 			),
 			'meta-externalagent' => array(
 				'label'      => __( 'Meta AI', 'jetpack-seo' ),
 				'user_agent' => 'meta-externalagent',
 				'type'       => 'training',
+				'doc_url'    => 'https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/',
 			),
 			'bytespider'         => array(
+				// ByteDance publishes no official English documentation page for
+				// Bytespider, so no "Learn what it does" link is shown for it.
 				'label'      => __( 'ByteDance', 'jetpack-seo' ),
 				'user_agent' => 'Bytespider',
 				'type'       => 'training',
+				'doc_url'    => '',
 			),
 			'ccbot'              => array(
 				'label'      => __( 'Common Crawl', 'jetpack-seo' ),
 				'user_agent' => 'CCBot',
 				'type'       => 'training',
+				'doc_url'    => 'https://commoncrawl.org/ccbot',
 			),
 			'amazonbot'          => array(
 				// Amazon's own docs: Amazonbot "may be used to train Amazon AI
@@ -121,6 +136,7 @@ class Ai_Crawlers {
 				'label'      => __( 'Amazon', 'jetpack-seo' ),
 				'user_agent' => 'Amazonbot',
 				'type'       => 'training',
+				'doc_url'    => 'https://developer.amazon.com/amazonbot',
 			),
 		);
 	}

--- a/projects/packages/seo/src/class-ai-crawlers.php
+++ b/projects/packages/seo/src/class-ai-crawlers.php
@@ -73,9 +73,9 @@ class Ai_Crawlers {
 				'user_agent' => 'PerplexityBot',
 				'type'       => 'answer',
 			),
-			'amazonbot'          => array(
+			'amzn-searchbot'     => array(
 				'label'      => __( 'Amazon (Alexa)', 'jetpack-seo' ),
-				'user_agent' => 'Amazonbot',
+				'user_agent' => 'Amzn-SearchBot',
 				'type'       => 'answer',
 			),
 			// Training crawlers collect content to train AI models. Blocked by
@@ -113,6 +113,13 @@ class Ai_Crawlers {
 			'ccbot'              => array(
 				'label'      => __( 'Common Crawl', 'jetpack-seo' ),
 				'user_agent' => 'CCBot',
+				'type'       => 'training',
+			),
+			'amazonbot'          => array(
+				// Amazon's own docs: Amazonbot "may be used to train Amazon AI
+				// models" (Amzn-SearchBot is the answer-engine bot above).
+				'label'      => __( 'Amazon', 'jetpack-seo' ),
+				'user_agent' => 'Amazonbot',
 				'type'       => 'training',
 			),
 		);

--- a/projects/packages/seo/src/class-ai-crawlers.php
+++ b/projects/packages/seo/src/class-ai-crawlers.php
@@ -47,52 +47,73 @@ class Ai_Crawlers {
 	 *
 	 * `slug` is the stable key persisted in the option and sent by the AI tab;
 	 * `user_agent` is the token written to the `User-agent:` robots line;
-	 * `label` is the human name shown in the UI. Kept deliberately small and
-	 * recognizable — the better-known training and answer-engine crawlers.
+	 * `label` is the human name shown in the UI; `type` is `answer` (fetches to
+	 * cite in live AI answers) or `training` (collects to train models), which
+	 * drives the AI tab's two sections and the per-type default. Kept deliberately
+	 * small and recognizable — the better-known crawlers.
 	 *
-	 * @return array<string, array{label: string, user_agent: string}>
+	 * @return array<string, array{label: string, user_agent: string, type: string}>
 	 */
 	public static function get_catalog() {
 		return array(
-			'gptbot'             => array(
-				'label'      => __( 'ChatGPT (OpenAI)', 'jetpack-seo' ),
-				'user_agent' => 'GPTBot',
-			),
+			// Answer-engine crawlers fetch pages so AI assistants can cite them in
+			// live answers. Allowed by default — blocking them costs AI visibility.
 			'oai-searchbot'      => array(
 				'label'      => __( 'ChatGPT Search (OpenAI)', 'jetpack-seo' ),
 				'user_agent' => 'OAI-SearchBot',
+				'type'       => 'answer',
 			),
-			'claudebot'          => array(
-				'label'      => __( 'Claude (Anthropic)', 'jetpack-seo' ),
-				'user_agent' => 'ClaudeBot',
+			'claude-searchbot'   => array(
+				'label'      => __( 'Claude Search (Anthropic)', 'jetpack-seo' ),
+				'user_agent' => 'Claude-SearchBot',
+				'type'       => 'answer',
 			),
 			'perplexitybot'      => array(
 				'label'      => __( 'Perplexity', 'jetpack-seo' ),
 				'user_agent' => 'PerplexityBot',
+				'type'       => 'answer',
+			),
+			'amazonbot'          => array(
+				'label'      => __( 'Amazon (Alexa)', 'jetpack-seo' ),
+				'user_agent' => 'Amazonbot',
+				'type'       => 'answer',
+			),
+			// Training crawlers collect content to train AI models. Blocked by
+			// default — blocking protects content with no AI-visibility downside.
+			'gptbot'             => array(
+				'label'      => __( 'ChatGPT (OpenAI)', 'jetpack-seo' ),
+				'user_agent' => 'GPTBot',
+				'type'       => 'training',
+			),
+			'claudebot'          => array(
+				'label'      => __( 'Claude (Anthropic)', 'jetpack-seo' ),
+				'user_agent' => 'ClaudeBot',
+				'type'       => 'training',
 			),
 			'google-extended'    => array(
 				'label'      => __( 'Google AI (Gemini)', 'jetpack-seo' ),
 				'user_agent' => 'Google-Extended',
+				'type'       => 'training',
 			),
 			'applebot-extended'  => array(
 				'label'      => __( 'Apple Intelligence', 'jetpack-seo' ),
 				'user_agent' => 'Applebot-Extended',
+				'type'       => 'training',
 			),
 			'meta-externalagent' => array(
 				'label'      => __( 'Meta AI', 'jetpack-seo' ),
 				'user_agent' => 'meta-externalagent',
-			),
-			'amazonbot'          => array(
-				'label'      => __( 'Amazon', 'jetpack-seo' ),
-				'user_agent' => 'Amazonbot',
+				'type'       => 'training',
 			),
 			'bytespider'         => array(
-				'label'      => __( 'ByteDance (Bytespider)', 'jetpack-seo' ),
+				'label'      => __( 'ByteDance', 'jetpack-seo' ),
 				'user_agent' => 'Bytespider',
+				'type'       => 'training',
 			),
 			'ccbot'              => array(
 				'label'      => __( 'Common Crawl', 'jetpack-seo' ),
 				'user_agent' => 'CCBot',
+				'type'       => 'training',
 			),
 		);
 	}
@@ -104,11 +125,72 @@ class Ai_Crawlers {
 	 * @return string[]
 	 */
 	public static function get_blocked_slugs() {
-		$stored = get_option( self::OPTION, array() );
+		$stored = get_option( self::OPTION, null );
+		// Unconfigured (option never saved): fall back to the privacy-protective
+		// default — training crawlers blocked, answer engines allowed.
+		if ( null === $stored ) {
+			return self::default_blocked_slugs();
+		}
 		if ( ! is_array( $stored ) ) {
 			return array();
 		}
 		return array_values( array_intersect( $stored, array_keys( self::get_catalog() ) ) );
+	}
+
+	/**
+	 * The slugs blocked by default before the owner has configured anything: every
+	 * training crawler. Answer-engine crawlers stay allowed so the site can still
+	 * be cited in AI answers.
+	 *
+	 * @return string[]
+	 */
+	public static function default_blocked_slugs() {
+		$blocked = array();
+		foreach ( self::get_catalog() as $slug => $info ) {
+			if ( 'training' === $info['type'] ) {
+				$blocked[] = $slug;
+			}
+		}
+		return $blocked;
+	}
+
+	/**
+	 * Whether the site allows search-engine (and therefore AI-crawler) indexing.
+	 *
+	 * When `blog_public` is off, WordPress disallows everything in robots.txt, so
+	 * per-crawler controls are moot — the AI tab surfaces this instead of showing
+	 * toggles that can't take effect.
+	 *
+	 * @return bool
+	 */
+	public static function search_engines_allowed() {
+		return (int) get_option( 'blog_public', 1 ) === 1;
+	}
+
+	/**
+	 * Whether the site is served from a WordPress.com staging subdomain
+	 * (`*.wpcomstaging.com`) where the platform blocks all crawling regardless of
+	 * the site's own settings — so AI-crawler controls can't take effect.
+	 *
+	 * @return bool
+	 */
+	public static function is_crawl_restricted_subdomain() {
+		$host   = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$suffix = '.wpcomstaging.com';
+		return strlen( $host ) > strlen( $suffix )
+			&& substr( $host, -strlen( $suffix ) ) === $suffix;
+	}
+
+	/**
+	 * Whether a physical `robots.txt` exists at the web root. The web server
+	 * serves that file directly, bypassing WordPress's virtual robots.txt — so our
+	 * `robots_txt` filter (and therefore these settings) never run. Common on
+	 * local, sandbox, and staging sites.
+	 *
+	 * @return bool
+	 */
+	public static function has_static_robots_txt() {
+		return file_exists( ABSPATH . 'robots.txt' );
 	}
 
 	/**

--- a/projects/packages/seo/src/class-ai-crawlers.php
+++ b/projects/packages/seo/src/class-ai-crawlers.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * AI crawler access controls.
+ *
+ * Lets a site owner block individual AI crawlers (training and answer-engine
+ * bots) from accessing the site by appending per-user-agent `Disallow` rules to
+ * the WordPress-generated robots.txt. The blocked list is the durable option
+ * `jetpack_seo_blocked_ai_crawlers` (round-tripped through the existing
+ * `/jetpack/v4/settings` endpoint by the AI tab); this catalog is the source of
+ * truth for which slugs map to which user-agent token.
+ *
+ * Caveat: the `robots_txt` filter only feeds WordPress's *virtual* robots.txt.
+ * A site serving a physical robots.txt file bypasses it entirely — a real
+ * limitation to weigh for the production feature (Phase 1: AI Crawler
+ * Management).
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Emits robots.txt directives that block opted-out AI crawlers.
+ */
+class Ai_Crawlers {
+
+	/**
+	 * Option holding the list of blocked AI crawler slugs (array of slugs from
+	 * the catalog below). Mirrored as a literal in the plugin's settings
+	 * endpoint whitelist (`jp_group => 'seo-tools'`).
+	 *
+	 * @var string
+	 */
+	const OPTION = 'jetpack_seo_blocked_ai_crawlers';
+
+	/**
+	 * Wire the robots.txt filter.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'robots_txt', array( __CLASS__, 'append_directives' ), 10, 2 );
+	}
+
+	/**
+	 * The known AI crawler catalog: slug => [ label, user_agent ].
+	 *
+	 * `slug` is the stable key persisted in the option and sent by the AI tab;
+	 * `user_agent` is the token written to the `User-agent:` robots line;
+	 * `label` is the human name shown in the UI. Kept deliberately small and
+	 * recognizable — the better-known training and answer-engine crawlers.
+	 *
+	 * @return array<string, array{label: string, user_agent: string}>
+	 */
+	public static function get_catalog() {
+		return array(
+			'gptbot'             => array(
+				'label'      => __( 'ChatGPT (OpenAI)', 'jetpack-seo' ),
+				'user_agent' => 'GPTBot',
+			),
+			'oai-searchbot'      => array(
+				'label'      => __( 'ChatGPT Search (OpenAI)', 'jetpack-seo' ),
+				'user_agent' => 'OAI-SearchBot',
+			),
+			'claudebot'          => array(
+				'label'      => __( 'Claude (Anthropic)', 'jetpack-seo' ),
+				'user_agent' => 'ClaudeBot',
+			),
+			'perplexitybot'      => array(
+				'label'      => __( 'Perplexity', 'jetpack-seo' ),
+				'user_agent' => 'PerplexityBot',
+			),
+			'google-extended'    => array(
+				'label'      => __( 'Google AI (Gemini)', 'jetpack-seo' ),
+				'user_agent' => 'Google-Extended',
+			),
+			'applebot-extended'  => array(
+				'label'      => __( 'Apple Intelligence', 'jetpack-seo' ),
+				'user_agent' => 'Applebot-Extended',
+			),
+			'meta-externalagent' => array(
+				'label'      => __( 'Meta AI', 'jetpack-seo' ),
+				'user_agent' => 'meta-externalagent',
+			),
+			'amazonbot'          => array(
+				'label'      => __( 'Amazon', 'jetpack-seo' ),
+				'user_agent' => 'Amazonbot',
+			),
+			'bytespider'         => array(
+				'label'      => __( 'ByteDance (Bytespider)', 'jetpack-seo' ),
+				'user_agent' => 'Bytespider',
+			),
+			'ccbot'              => array(
+				'label'      => __( 'Common Crawl', 'jetpack-seo' ),
+				'user_agent' => 'CCBot',
+			),
+		);
+	}
+
+	/**
+	 * Return the sanitized list of currently blocked crawler slugs, limited to
+	 * slugs that exist in the catalog (unknown slugs are ignored).
+	 *
+	 * @return string[]
+	 */
+	public static function get_blocked_slugs() {
+		$stored = get_option( self::OPTION, array() );
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+		return array_values( array_intersect( $stored, array_keys( self::get_catalog() ) ) );
+	}
+
+	/**
+	 * Append `Disallow: /` blocks for each opted-out AI crawler to robots.txt.
+	 *
+	 * @param string $output The robots.txt content assembled so far.
+	 * @param bool   $public Whether the site is public (`blog_public`). When
+	 *                       false WordPress already disallows everything, but the
+	 *                       explicit per-bot blocks are still valid and harmless.
+	 * @return string The robots.txt content with AI-crawler directives appended.
+	 */
+	public static function append_directives( $output, $public ) {
+		unset( $public );
+
+		$catalog = self::get_catalog();
+		$blocked = self::get_blocked_slugs();
+		if ( empty( $blocked ) ) {
+			return $output;
+		}
+
+		$lines = array( '', '# AI crawlers blocked via Jetpack SEO.' );
+		foreach ( $blocked as $slug ) {
+			$lines[] = 'User-agent: ' . $catalog[ $slug ]['user_agent'];
+			$lines[] = 'Disallow: /';
+			$lines[] = '';
+		}
+
+		return $output . implode( "\n", $lines ) . "\n";
+	}
+}

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -196,6 +196,11 @@ class Initializer {
 			// Front-end JSON-LD schema (Article / FAQ). Self-hooks `wp_head`, so it only
 			// emits on front-end requests.
 			Schema_Builder::init();
+			// AI tab front-end behavior: robots directives for blocked AI crawlers and
+			// the /llms.txt handler. Each self-hooks a front-end filter/action, so they
+			// no-op off the front end and stay behind the same gates as the schema above.
+			Ai_Crawlers::init();
+			Llms_Txt::init();
 			add_action( 'rest_api_init', array( __CLASS__, 'register_rest_settings' ) );
 		}
 
@@ -898,10 +903,28 @@ class Initializer {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod -- guarded by class_exists; host plugin provides the class.
 			&& \Automattic\Jetpack\Current_Plan::supports( 'ai-seo-enhancer' );
 
+		// Expose the AI crawler catalog (slug + label only; the user-agent token
+		// stays server-side) so the AI tab can render a toggle per known crawler.
+		$crawler_catalog = array();
+		foreach ( Ai_Crawlers::get_catalog() as $slug => $info ) {
+			$crawler_catalog[] = array(
+				'slug'  => $slug,
+				'label' => $info['label'],
+			);
+		}
+
 		return array(
 			'enhancer' => array(
 				'available' => $filter_on && $plan_supports,
 				'enabled'   => (bool) get_option( 'ai_seo_enhancer_enabled', false ),
+			),
+			'llmsTxt'  => array(
+				'enabled' => Llms_Txt::is_enabled(),
+				'url'     => home_url( '/llms.txt' ),
+			),
+			'crawlers' => array(
+				'catalog' => $crawler_catalog,
+				'blocked' => Ai_Crawlers::get_blocked_slugs(),
 			),
 		);
 	}

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -573,20 +573,30 @@ class Initializer {
 	}
 
 	/**
+	 * Build the supported post type options for the Content tab.
+	 *
+	 * The PHP helper is the single source of truth for every SEO surface that
+	 * works with published content, preventing client-side REST discovery from
+	 * applying different eligibility rules.
+	 *
+	 * @return array{post_types:array<int,array{slug:string,label:string}>}
+	 */
+	public static function get_content_data() {
+		return array(
+			'post_types' => Post_Types::get_supported_content_type_options(),
+		);
+	}
+
+	/**
 	 * Factual content-coverage counts for the Overview card: how many published
-	 * posts/pages have each SEO field set. State, not a score — the card shows
-	 * proportions + raw counts and lets the admin decide what matters.
+	 * supported content items have each SEO field set. State, not a score — the
+	 * card shows proportions + raw counts and lets the admin decide what matters.
 	 *
 	 * @return array{total:int,with_schema:int,with_title:int,with_description:int,with_search_visible:int}
 	 */
 	private static function get_content_coverage() {
-		$post_types = array( 'post', 'page' );
-
-		$total = 0;
-		foreach ( $post_types as $post_type ) {
-			$counts = wp_count_posts( $post_type );
-			$total += isset( $counts->publish ) ? (int) $counts->publish : 0;
-		}
+		$post_types = Post_Types::get_supported_content_types();
+		$total      = self::count_published_posts( $post_types );
 
 		// Search-engine visibility is the inverse of the per-post noindex meta: a
 		// post is visible unless it's explicitly set to noindex (stored as '1'), so
@@ -603,8 +613,33 @@ class Initializer {
 	}
 
 	/**
-	 * Count published posts/pages whose meta is set. With no `$value`, counts a
-	 * non-empty string meta; with a `$value`, counts an exact match.
+	 * Count published supported content items.
+	 *
+	 * @param string[] $post_types Post types to count across.
+	 * @return int
+	 */
+	private static function count_published_posts( $post_types ) {
+		if ( empty( $post_types ) ) {
+			return 0;
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'              => $post_types,
+				'post_status'            => 'publish',
+				'posts_per_page'         => 1,
+				'fields'                 => 'ids',
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		return (int) $query->found_posts;
+	}
+
+	/**
+	 * Count published supported content items whose meta is set. With no
+	 * `$value`, counts a non-empty string meta; with a `$value`, counts an exact match.
 	 *
 	 * @param string[]    $post_types Post types to count across.
 	 * @param string      $meta_key   Meta key to test.
@@ -612,6 +647,10 @@ class Initializer {
 	 * @return int
 	 */
 	private static function count_published_with_meta( $post_types, $meta_key, $value = null ) {
+		if ( empty( $post_types ) ) {
+			return 0;
+		}
+
 		$clause = null === $value
 			? array(
 				'key'     => $meta_key,
@@ -744,6 +783,7 @@ class Initializer {
 			'overview' => array( __CLASS__, 'get_overview_data' ),
 			'settings' => array( __CLASS__, 'get_settings_data' ),
 			'ai'       => array( __CLASS__, 'get_ai_data' ),
+			'content'  => array( __CLASS__, 'get_content_data' ),
 		);
 	}
 

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -903,15 +903,17 @@ class Initializer {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod -- guarded by class_exists; host plugin provides the class.
 			&& \Automattic\Jetpack\Current_Plan::supports( 'ai-seo-enhancer' );
 
-		// Expose the AI crawler catalog (slug + label + type; the user-agent token
-		// stays server-side) so the AI tab can render a toggle per known crawler,
-		// grouped into its answer-engine and training sections.
+		// Expose the AI crawler catalog so the AI tab can render a toggle per known
+		// crawler, grouped into its answer-engine and training sections, each with a
+		// "Learn what <user-agent> does" link to the operator's own docs.
 		$crawler_catalog = array();
 		foreach ( Ai_Crawlers::get_catalog() as $slug => $info ) {
 			$crawler_catalog[] = array(
-				'slug'  => $slug,
-				'label' => $info['label'],
-				'type'  => $info['type'],
+				'slug'      => $slug,
+				'label'     => $info['label'],
+				'type'      => $info['type'],
+				'userAgent' => $info['user_agent'],
+				'docUrl'    => $info['doc_url'],
 			);
 		}
 

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -903,13 +903,15 @@ class Initializer {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod -- guarded by class_exists; host plugin provides the class.
 			&& \Automattic\Jetpack\Current_Plan::supports( 'ai-seo-enhancer' );
 
-		// Expose the AI crawler catalog (slug + label only; the user-agent token
-		// stays server-side) so the AI tab can render a toggle per known crawler.
+		// Expose the AI crawler catalog (slug + label + type; the user-agent token
+		// stays server-side) so the AI tab can render a toggle per known crawler,
+		// grouped into its answer-engine and training sections.
 		$crawler_catalog = array();
 		foreach ( Ai_Crawlers::get_catalog() as $slug => $info ) {
 			$crawler_catalog[] = array(
 				'slug'  => $slug,
 				'label' => $info['label'],
+				'type'  => $info['type'],
 			);
 		}
 
@@ -923,8 +925,13 @@ class Initializer {
 				'url'     => home_url( '/llms.txt' ),
 			),
 			'crawlers' => array(
-				'catalog' => $crawler_catalog,
-				'blocked' => Ai_Crawlers::get_blocked_slugs(),
+				'catalog'              => $crawler_catalog,
+				'blocked'              => Ai_Crawlers::get_blocked_slugs(),
+				// Availability signals: when the site can't be crawled, the AI tab
+				// explains why instead of showing toggles that can't take effect.
+				'searchEnginesVisible' => Ai_Crawlers::search_engines_allowed(),
+				'restrictedSubdomain'  => Ai_Crawlers::is_crawl_restricted_subdomain(),
+				'staticRobotsTxt'      => Ai_Crawlers::has_static_robots_txt(),
 			),
 		);
 	}

--- a/projects/packages/seo/src/class-llms-txt.php
+++ b/projects/packages/seo/src/class-llms-txt.php
@@ -34,10 +34,10 @@ class Llms_Txt {
 	const OPTION = 'jetpack_seo_llms_txt_enabled';
 
 	/**
-	 * Max pages and posts listed, so a large site doesn't dump its whole tree.
+	 * Max items listed per supported content type, so a large site doesn't dump
+	 * its whole tree.
 	 */
-	const MAX_PAGES = 50;
-	const MAX_POSTS = 50;
+	const MAX_POSTS_PER_TYPE = 50;
 
 	/**
 	 * Wire the front-end request handler.
@@ -92,8 +92,8 @@ class Llms_Txt {
 	}
 
 	/**
-	 * Build the llms.txt Markdown document from site identity, published pages,
-	 * and recent posts.
+	 * Build the llms.txt Markdown document from site identity and published
+	 * supported content types.
 	 *
 	 * @return string
 	 */
@@ -108,37 +108,74 @@ class Llms_Txt {
 			$blocks[] = '> ' . $description;
 		}
 
-		$pages = self::link_list(
-			get_posts(
-				array(
-					'post_type'      => 'page',
-					'post_status'    => 'publish',
-					'posts_per_page' => self::MAX_PAGES,
-					'orderby'        => 'menu_order title',
-					'order'          => 'ASC',
-				)
-			)
-		);
-		if ( '' !== $pages ) {
-			$blocks[] = "## Pages\n\n" . $pages;
-		}
-
-		$posts = self::link_list(
-			get_posts(
-				array(
-					'post_type'      => 'post',
-					'post_status'    => 'publish',
-					'posts_per_page' => self::MAX_POSTS,
-					'orderby'        => 'date',
-					'order'          => 'DESC',
-				)
-			)
-		);
-		if ( '' !== $posts ) {
-			$blocks[] = "## Posts\n\n" . $posts;
+		foreach ( self::get_llms_post_type_objects() as $post_type ) {
+			$list = self::link_list( self::get_posts_for_type( $post_type->name ) );
+			if ( '' !== $list ) {
+				$blocks[] = '## ' . self::section_title( $post_type ) . "\n\n" . $list;
+			}
 		}
 
 		return implode( "\n\n", $blocks ) . "\n";
+	}
+
+	/**
+	 * Return supported post types in llms.txt reading order.
+	 *
+	 * @return \WP_Post_Type[]
+	 */
+	private static function get_llms_post_type_objects() {
+		$post_types = Post_Types::get_supported_content_type_objects();
+		$ordered    = array();
+
+		foreach ( array( 'page', 'post' ) as $post_type ) {
+			if ( isset( $post_types[ $post_type ] ) ) {
+				$ordered[ $post_type ] = $post_types[ $post_type ];
+				unset( $post_types[ $post_type ] );
+			}
+		}
+
+		return array_merge( $ordered, $post_types );
+	}
+
+	/**
+	 * Fetch published content for a supported post type.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @return \WP_Post[]
+	 */
+	private static function get_posts_for_type( $post_type ) {
+		$args = array(
+			'post_type'        => $post_type,
+			'post_status'      => 'publish',
+			'posts_per_page'   => self::MAX_POSTS_PER_TYPE,
+			'suppress_filters' => false,
+		);
+
+		if ( 'page' === $post_type ) {
+			$args['orderby'] = 'menu_order title';
+			$args['order']   = 'ASC';
+		} else {
+			$args['orderby'] = 'date';
+			$args['order']   = 'DESC';
+		}
+
+		return get_posts( $args );
+	}
+
+	/**
+	 * Section title for a supported post type.
+	 *
+	 * @param \WP_Post_Type $post_type Post type object.
+	 * @return string
+	 */
+	private static function section_title( $post_type ) {
+		if ( 'page' === $post_type->name ) {
+			return __( 'Pages', 'jetpack-seo' );
+		}
+		if ( 'post' === $post_type->name ) {
+			return __( 'Posts', 'jetpack-seo' );
+		}
+		return wp_strip_all_tags( $post_type->label );
 	}
 
 	/**

--- a/projects/packages/seo/src/class-llms-txt.php
+++ b/projects/packages/seo/src/class-llms-txt.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Generation and serving of the site's llms.txt.
+ *
+ * Serves a root-level `/llms.txt` — the emerging convention (llmstxt.org) for
+ * giving AI assistants a curated, Markdown map of a site's key content. Gated on
+ * the durable option `jetpack_seo_llms_txt_enabled` (round-tripped through the
+ * existing `/jetpack/v4/settings` endpoint by the AI tab).
+ *
+ * Serving approach: this hooks `template_redirect` and inspects the raw request
+ * path rather than registering a rewrite rule, so it needs no rewrite flush and
+ * works under any permalink structure. The tradeoff — it matches a root-level
+ * request only, and like robots.txt won't apply on a multisite subdirectory or
+ * a site fronted by a static file. A proper rewrite rule is worth weighing for
+ * the production feature (Phase 1: llms.txt Generation).
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Builds and serves the site's llms.txt.
+ */
+class Llms_Txt {
+
+	/**
+	 * Option recording whether llms.txt generation is enabled. Mirrored as a
+	 * literal in the plugin's settings endpoint whitelist (`jp_group =>
+	 * 'seo-tools'`).
+	 *
+	 * @var string
+	 */
+	const OPTION = 'jetpack_seo_llms_txt_enabled';
+
+	/**
+	 * Max pages and posts listed, so a large site doesn't dump its whole tree.
+	 */
+	const MAX_PAGES = 50;
+	const MAX_POSTS = 50;
+
+	/**
+	 * Wire the front-end request handler.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'template_redirect', array( __CLASS__, 'maybe_serve' ) );
+	}
+
+	/**
+	 * Whether llms.txt generation is currently switched on.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return (bool) get_option( self::OPTION, false );
+	}
+
+	/**
+	 * The site-root-relative request path, normalized without surrounding
+	 * slashes (e.g. `llms.txt`).
+	 *
+	 * @return string
+	 */
+	private static function request_path() {
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return '';
+		}
+		$uri  = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$path = (string) wp_parse_url( $uri, PHP_URL_PATH );
+		return trim( $path, '/' );
+	}
+
+	/**
+	 * Serve llms.txt when enabled and the request is for it; otherwise no-op.
+	 *
+	 * @return void
+	 */
+	public static function maybe_serve() {
+		if ( ! self::is_enabled() || 'llms.txt' !== self::request_path() ) {
+			return;
+		}
+
+		nocache_headers();
+		status_header( 200 );
+		header( 'Content-Type: text/plain; charset=utf-8' );
+
+		// Content is plain-text Markdown; not HTML, so it's emitted as-is.
+		echo self::generate(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
+	}
+
+	/**
+	 * Build the llms.txt Markdown document from site identity, published pages,
+	 * and recent posts.
+	 *
+	 * @return string
+	 */
+	public static function generate() {
+		$name        = wp_strip_all_tags( get_bloginfo( 'name' ) );
+		$description = wp_strip_all_tags( get_bloginfo( 'description' ) );
+
+		$blocks = array();
+
+		$blocks[] = '# ' . ( '' !== $name ? $name : home_url() );
+		if ( '' !== $description ) {
+			$blocks[] = '> ' . $description;
+		}
+
+		$pages = self::link_list(
+			get_posts(
+				array(
+					'post_type'      => 'page',
+					'post_status'    => 'publish',
+					'posts_per_page' => self::MAX_PAGES,
+					'orderby'        => 'menu_order title',
+					'order'          => 'ASC',
+				)
+			)
+		);
+		if ( '' !== $pages ) {
+			$blocks[] = "## Pages\n\n" . $pages;
+		}
+
+		$posts = self::link_list(
+			get_posts(
+				array(
+					'post_type'      => 'post',
+					'post_status'    => 'publish',
+					'posts_per_page' => self::MAX_POSTS,
+					'orderby'        => 'date',
+					'order'          => 'DESC',
+				)
+			)
+		);
+		if ( '' !== $posts ) {
+			$blocks[] = "## Posts\n\n" . $posts;
+		}
+
+		return implode( "\n\n", $blocks ) . "\n";
+	}
+
+	/**
+	 * Render a list of posts as llms.txt link lines:
+	 * `- [Title](url): summary`.
+	 *
+	 * @param \WP_Post[] $posts Posts to render.
+	 * @return string Newline-joined link lines, or '' when there are none.
+	 */
+	private static function link_list( $posts ) {
+		$lines = array();
+		foreach ( $posts as $post ) {
+			$title = wp_strip_all_tags( get_the_title( $post ) );
+			if ( '' === $title ) {
+				$title = __( '(untitled)', 'jetpack-seo' );
+			}
+			$url  = get_permalink( $post );
+			$line = '- [' . $title . '](' . $url . ')';
+
+			$summary = self::summary( $post );
+			if ( '' !== $summary ) {
+				$line .= ': ' . $summary;
+			}
+			$lines[] = $line;
+		}
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * A short, single-line summary for a post: its excerpt when set, otherwise a
+	 * trimmed slice of the content.
+	 *
+	 * @param \WP_Post $post Post to summarize.
+	 * @return string
+	 */
+	private static function summary( $post ) {
+		$raw = has_excerpt( $post )
+			? get_the_excerpt( $post )
+			: wp_trim_words( wp_strip_all_tags( strip_shortcodes( $post->post_content ) ), 30, '' );
+
+		// Collapse whitespace so a link line stays on one row.
+		return trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( $raw ) ) );
+	}
+}

--- a/projects/packages/seo/src/class-post-types.php
+++ b/projects/packages/seo/src/class-post-types.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Supported content post type discovery for Jetpack SEO.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Discovers the post types Jetpack SEO can list and edit via core REST.
+ */
+class Post_Types {
+
+	/**
+	 * Post types that are REST-visible but not content surfaces for SEO.
+	 *
+	 * @var string[]
+	 */
+	const EXCLUDED_POST_TYPES = array( 'attachment' );
+
+	/**
+	 * Return supported post type slugs.
+	 *
+	 * @return string[]
+	 */
+	public static function get_supported_content_types() {
+		return array_keys( self::get_supported_content_type_objects() );
+	}
+
+	/**
+	 * Return supported post type options for the Content tab.
+	 *
+	 * @return array<int,array{slug:string,label:string}>
+	 */
+	public static function get_supported_content_type_options() {
+		$options = array();
+
+		foreach ( self::get_supported_content_type_objects() as $post_type ) {
+			$options[] = array(
+				'slug'  => $post_type->name,
+				'label' => wp_strip_all_tags( $post_type->label ),
+			);
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Return supported post type objects keyed by slug.
+	 *
+	 * Supported means public, UI-visible, and REST-enabled so the SEO dashboard
+	 * can both display and save the post through core-data. Attachments are
+	 * excluded because their REST endpoint is media-specific, not an editable
+	 * content surface for the SEO Content tab.
+	 *
+	 * @return \WP_Post_Type[]
+	 */
+	public static function get_supported_content_type_objects() {
+		$post_types = get_post_types(
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			),
+			'objects'
+		);
+
+		foreach ( self::EXCLUDED_POST_TYPES as $post_type ) {
+			unset( $post_types[ $post_type ] );
+		}
+
+		uasort( $post_types, array( __CLASS__, 'sort_post_type_objects' ) );
+
+		return $post_types;
+	}
+
+	/**
+	 * Sort core content types first, then custom types alphabetically by label.
+	 *
+	 * @param \WP_Post_Type $a First post type object.
+	 * @param \WP_Post_Type $b Second post type object.
+	 * @return int
+	 */
+	private static function sort_post_type_objects( $a, $b ) {
+		$preferred = array(
+			'post' => 0,
+			'page' => 1,
+		);
+
+		$a_rank = $preferred[ $a->name ] ?? 99;
+		$b_rank = $preferred[ $b->name ] ?? 99;
+
+		if ( $a_rank !== $b_rank ) {
+			return $a_rank - $b_rank;
+		}
+
+		return strcasecmp( $a->label, $b->label );
+	}
+}

--- a/projects/packages/seo/tests/php/AiCrawlersTest.php
+++ b/projects/packages/seo/tests/php/AiCrawlersTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Ai_Crawlers robots.txt directives.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Ai_Crawlers
+ */
+#[CoversClass( Ai_Crawlers::class )]
+class AiCrawlersTest extends TestCase {
+
+	/**
+	 * Clear the blocked-crawlers option before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		delete_option( Ai_Crawlers::OPTION );
+	}
+
+	/**
+	 * Every catalog entry exposes a label and a user-agent token.
+	 *
+	 * @return void
+	 */
+	public function test_catalog_entries_have_label_and_user_agent() {
+		$catalog = Ai_Crawlers::get_catalog();
+		$this->assertNotEmpty( $catalog );
+		foreach ( $catalog as $slug => $info ) {
+			$this->assertIsString( $slug );
+			$this->assertArrayHasKey( 'label', $info );
+			$this->assertArrayHasKey( 'user_agent', $info );
+			$this->assertNotEmpty( $info['user_agent'] );
+		}
+	}
+
+	/**
+	 * With nothing blocked, the robots.txt output is returned untouched.
+	 *
+	 * @return void
+	 */
+	public function test_append_directives_leaves_output_unchanged_when_none_blocked() {
+		$input = "User-agent: *\nDisallow: /wp-admin/\n";
+		$this->assertSame( $input, Ai_Crawlers::append_directives( $input, true ) );
+	}
+
+	/**
+	 * Each blocked slug emits a per-user-agent `Disallow` block, using the
+	 * catalog's user-agent token (not the slug), appended after the input.
+	 *
+	 * @return void
+	 */
+	public function test_append_directives_emits_disallow_per_blocked_crawler() {
+		update_option( Ai_Crawlers::OPTION, array( 'bytespider', 'ccbot' ) );
+
+		$output = Ai_Crawlers::append_directives( "User-agent: *\n", true );
+
+		$this->assertStringStartsWith( "User-agent: *\n", $output );
+		$this->assertStringContainsString( "User-agent: Bytespider\nDisallow: /", $output );
+		$this->assertStringContainsString( "User-agent: CCBot\nDisallow: /", $output );
+	}
+
+	/**
+	 * Unknown slugs stored in the option are ignored — only catalog crawlers count.
+	 *
+	 * @return void
+	 */
+	public function test_get_blocked_slugs_ignores_unknown_slugs() {
+		update_option( Ai_Crawlers::OPTION, array( 'gptbot', 'not-a-real-bot' ) );
+
+		$blocked = Ai_Crawlers::get_blocked_slugs();
+
+		$this->assertContains( 'gptbot', $blocked );
+		$this->assertNotContains( 'not-a-real-bot', $blocked );
+	}
+
+	/**
+	 * A non-array option value degrades to an empty blocked list.
+	 *
+	 * @return void
+	 */
+	public function test_get_blocked_slugs_handles_non_array_option() {
+		update_option( Ai_Crawlers::OPTION, 'oops' );
+		$this->assertSame( array(), Ai_Crawlers::get_blocked_slugs() );
+	}
+}

--- a/projects/packages/seo/tests/php/AiCrawlersTest.php
+++ b/projects/packages/seo/tests/php/AiCrawlersTest.php
@@ -27,11 +27,11 @@ class AiCrawlersTest extends TestCase {
 	}
 
 	/**
-	 * Every catalog entry exposes a label and a user-agent token.
+	 * Every catalog entry exposes a label, a user-agent token, and a known type.
 	 *
 	 * @return void
 	 */
-	public function test_catalog_entries_have_label_and_user_agent() {
+	public function test_catalog_entries_have_label_user_agent_and_type() {
 		$catalog = Ai_Crawlers::get_catalog();
 		$this->assertNotEmpty( $catalog );
 		foreach ( $catalog as $slug => $info ) {
@@ -39,15 +39,17 @@ class AiCrawlersTest extends TestCase {
 			$this->assertArrayHasKey( 'label', $info );
 			$this->assertArrayHasKey( 'user_agent', $info );
 			$this->assertNotEmpty( $info['user_agent'] );
+			$this->assertContains( $info['type'], array( 'answer', 'training' ) );
 		}
 	}
 
 	/**
-	 * With nothing blocked, the robots.txt output is returned untouched.
+	 * With the list explicitly empty (everything allowed), robots.txt is untouched.
 	 *
 	 * @return void
 	 */
-	public function test_append_directives_leaves_output_unchanged_when_none_blocked() {
+	public function test_append_directives_leaves_output_unchanged_when_explicitly_none_blocked() {
+		update_option( Ai_Crawlers::OPTION, array() );
 		$input = "User-agent: *\nDisallow: /wp-admin/\n";
 		$this->assertSame( $input, Ai_Crawlers::append_directives( $input, true ) );
 	}
@@ -69,6 +71,48 @@ class AiCrawlersTest extends TestCase {
 	}
 
 	/**
+	 * The default-blocked set is exactly the training crawlers — no answer engine
+	 * is blocked by default, so the site stays citable in AI answers.
+	 *
+	 * @return void
+	 */
+	public function test_default_blocked_slugs_are_all_training_crawlers() {
+		$defaults = Ai_Crawlers::default_blocked_slugs();
+		$catalog  = Ai_Crawlers::get_catalog();
+
+		$this->assertNotEmpty( $defaults );
+		foreach ( $defaults as $slug ) {
+			$this->assertSame( 'training', $catalog[ $slug ]['type'] );
+		}
+		foreach ( $catalog as $slug => $info ) {
+			if ( 'answer' === $info['type'] ) {
+				$this->assertNotContains( $slug, $defaults );
+			}
+		}
+	}
+
+	/**
+	 * Before the owner configures anything (option unset), the blocked list falls
+	 * back to the training-crawler default.
+	 *
+	 * @return void
+	 */
+	public function test_get_blocked_slugs_defaults_to_training_when_unconfigured() {
+		$this->assertSame( Ai_Crawlers::default_blocked_slugs(), Ai_Crawlers::get_blocked_slugs() );
+	}
+
+	/**
+	 * An explicit empty array (user allowed everything) is respected — it is not
+	 * treated as "unconfigured".
+	 *
+	 * @return void
+	 */
+	public function test_get_blocked_slugs_respects_explicit_empty_array() {
+		update_option( Ai_Crawlers::OPTION, array() );
+		$this->assertSame( array(), Ai_Crawlers::get_blocked_slugs() );
+	}
+
+	/**
 	 * Unknown slugs stored in the option are ignored — only catalog crawlers count.
 	 *
 	 * @return void
@@ -83,12 +127,45 @@ class AiCrawlersTest extends TestCase {
 	}
 
 	/**
-	 * A non-array option value degrades to an empty blocked list.
+	 * A non-array option value (other than the unset sentinel) degrades to empty.
 	 *
 	 * @return void
 	 */
 	public function test_get_blocked_slugs_handles_non_array_option() {
 		update_option( Ai_Crawlers::OPTION, 'oops' );
 		$this->assertSame( array(), Ai_Crawlers::get_blocked_slugs() );
+	}
+
+	/**
+	 * `search_engines_allowed()` reflects the `blog_public` option.
+	 *
+	 * @return void
+	 */
+	public function test_search_engines_allowed_reflects_blog_public() {
+		update_option( 'blog_public', 1 );
+		$this->assertTrue( Ai_Crawlers::search_engines_allowed() );
+		update_option( 'blog_public', 0 );
+		$this->assertFalse( Ai_Crawlers::search_engines_allowed() );
+		update_option( 'blog_public', 1 );
+	}
+
+	/**
+	 * A `*.wpcomstaging.com` home URL is detected as crawl-restricted; an ordinary
+	 * domain is not.
+	 *
+	 * @return void
+	 */
+	public function test_is_crawl_restricted_subdomain_detects_wpcomstaging() {
+		$this->assertFalse( Ai_Crawlers::is_crawl_restricted_subdomain() );
+
+		$staging = static function () {
+			return 'https://example.wpcomstaging.com';
+		};
+		add_filter( 'home_url', $staging );
+		try {
+			$this->assertTrue( Ai_Crawlers::is_crawl_restricted_subdomain() );
+		} finally {
+			remove_filter( 'home_url', $staging );
+		}
 	}
 }

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -9,12 +9,32 @@ namespace Automattic\Jetpack\SEO;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use WorDBless\Posts as WorDBless_Posts;
 
 /**
  * @covers \Automattic\Jetpack\SEO\Initializer
  */
 #[CoversClass( Initializer::class )]
 class InitializerTest extends TestCase {
+
+	use WorDBless_Query_Trait;
+
+	/**
+	 * Clean up test posts and custom post types.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->clear_wordbless_posts_query();
+
+		if ( post_type_exists( 'seo_book' ) ) {
+			unregister_post_type( 'seo_book' );
+		}
+
+		WorDBless_Posts::init()->clear_all_posts();
+
+		parent::tearDown();
+	}
 
 	/**
 	 * The Initializer class exists and exposes the expected menu slug.
@@ -38,6 +58,23 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
+	 * The Content tab receives its supported post types from the same PHP
+	 * discovery helper used by coverage and llms.txt.
+	 *
+	 * @return void
+	 */
+	public function test_rest_reads_include_content_data() {
+		$method = new \ReflectionMethod( Initializer::class, 'rest_reads' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$rest_reads = $method->invoke( null );
+
+		$this->assertArrayHasKey( 'content', $rest_reads );
+	}
+
+	/**
 	 * The factual content-coverage counts expose the expected integer shape
 	 * (state, not a score). Invoked directly to avoid get_overview_data()'s
 	 * Modules dependency, which needs host-plugin option classes absent here.
@@ -57,6 +94,77 @@ class InitializerTest extends TestCase {
 
 		// Search-visible can never exceed the total (it's total minus noindexed).
 		$this->assertLessThanOrEqual( $coverage['total'], $coverage['with_search_visible'] );
+	}
+
+	/**
+	 * Content coverage counts every supported content type, not only core posts
+	 * and pages.
+	 *
+	 * @return void
+	 */
+	public function test_content_coverage_includes_supported_custom_post_types() {
+		register_post_type(
+			'seo_book',
+			array(
+				'label'        => 'Books',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+				'supports'     => array( 'custom-fields' ),
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Post with SEO',
+			)
+		);
+		update_post_meta( $post_id, Initializer::META_TITLE, 'Custom post SEO title' );
+		update_post_meta( $post_id, Initializer::META_DESCRIPTION, 'Custom post description.' );
+		update_post_meta( $post_id, Initializer::META_SCHEMA_TYPE, 'article' );
+
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Visible Page',
+			)
+		);
+
+		$book_id = wp_insert_post(
+			array(
+				'post_type'   => 'seo_book',
+				'post_status' => 'publish',
+				'post_title'  => 'Book with SEO',
+			)
+		);
+		update_post_meta( $book_id, Initializer::META_TITLE, 'Book SEO title' );
+		update_post_meta( $book_id, Initializer::META_DESCRIPTION, 'Book description.' );
+		update_post_meta( $book_id, Initializer::META_SCHEMA_TYPE, 'faq' );
+		update_post_meta( $book_id, Initializer::META_NOINDEX, '1' );
+
+		// Keep the inserted page from being optimized away by WorDBless.
+		$this->assertIsInt( $page_id );
+		$this->hook_wordbless_posts_query( array( $post_id, $page_id, $book_id ) );
+		wp_cache_flush();
+
+		$method = new \ReflectionMethod( Initializer::class, 'get_content_coverage' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$this->assertSame(
+			array(
+				'total'               => 3,
+				'with_schema'         => 2,
+				'with_title'          => 2,
+				'with_description'    => 2,
+				'with_search_visible' => 2,
+			),
+			$method->invoke( null )
+		);
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -185,6 +185,20 @@ class InitializerTest extends TestCase {
 			$this->assertIsBool( $ai['enhancer']['enabled'] );
 			// With the feature filter forced off, the enhancer is never available.
 			$this->assertFalse( $ai['enhancer']['available'] );
+
+			// Crawler bootstrap: catalog (each with slug/label/type) plus the
+			// availability signals the AI tab gates on.
+			$this->assertArrayHasKey( 'crawlers', $ai );
+			$this->assertArrayHasKey( 'blocked', $ai['crawlers'] );
+			$this->assertIsBool( $ai['crawlers']['searchEnginesVisible'] );
+			$this->assertIsBool( $ai['crawlers']['restrictedSubdomain'] );
+			$this->assertIsBool( $ai['crawlers']['staticRobotsTxt'] );
+			$this->assertNotEmpty( $ai['crawlers']['catalog'] );
+			foreach ( $ai['crawlers']['catalog'] as $entry ) {
+				$this->assertArrayHasKey( 'slug', $entry );
+				$this->assertArrayHasKey( 'label', $entry );
+				$this->assertContains( $entry['type'], array( 'answer', 'training' ) );
+			}
 		} finally {
 			remove_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 		}

--- a/projects/packages/seo/tests/php/LlmsTxtTest.php
+++ b/projects/packages/seo/tests/php/LlmsTxtTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Llms_Txt generator.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Llms_Txt
+ */
+#[CoversClass( Llms_Txt::class )]
+class LlmsTxtTest extends TestCase {
+
+	/**
+	 * Reset the enable option before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		delete_option( Llms_Txt::OPTION );
+	}
+
+	/**
+	 * `is_enabled()` reflects the stored option.
+	 *
+	 * @return void
+	 */
+	public function test_is_enabled_reflects_option() {
+		$this->assertFalse( Llms_Txt::is_enabled() );
+		update_option( Llms_Txt::OPTION, true );
+		$this->assertTrue( Llms_Txt::is_enabled() );
+	}
+
+	/**
+	 * The document starts with the site title as an H1.
+	 *
+	 * @return void
+	 */
+	public function test_generate_starts_with_site_title_heading() {
+		update_option( 'blogname', 'Angela Test Site' );
+		$this->assertStringStartsWith( '# Angela Test Site', Llms_Txt::generate() );
+	}
+
+	/**
+	 * The tagline is rendered as a Markdown blockquote when set.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_tagline_as_blockquote() {
+		update_option( 'blogname', 'Site' );
+		update_option( 'blogdescription', 'Just another test site' );
+		$this->assertStringContainsString( '> Just another test site', Llms_Txt::generate() );
+	}
+
+	/**
+	 * With no published content, the Pages/Posts sections are omitted (only the
+	 * site-identity heading remains). The populated-list path is exercised by the
+	 * live front-end test — the package test environment can't query inserted
+	 * posts, the same reason {@see SchemaBuilderTest} builds posts directly.
+	 *
+	 * @return void
+	 */
+	public function test_generate_omits_sections_when_no_content() {
+		update_option( 'blogname', 'Empty Site' );
+
+		$output = Llms_Txt::generate();
+
+		$this->assertStringContainsString( '# Empty Site', $output );
+		$this->assertStringNotContainsString( '## Pages', $output );
+		$this->assertStringNotContainsString( '## Posts', $output );
+	}
+}

--- a/projects/packages/seo/tests/php/LlmsTxtTest.php
+++ b/projects/packages/seo/tests/php/LlmsTxtTest.php
@@ -9,12 +9,15 @@ namespace Automattic\Jetpack\SEO;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use WorDBless\Posts as WorDBless_Posts;
 
 /**
  * @covers \Automattic\Jetpack\SEO\Llms_Txt
  */
 #[CoversClass( Llms_Txt::class )]
 class LlmsTxtTest extends TestCase {
+
+	use WorDBless_Query_Trait;
 
 	/**
 	 * Reset the enable option before each test.
@@ -24,6 +27,23 @@ class LlmsTxtTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		delete_option( Llms_Txt::OPTION );
+	}
+
+	/**
+	 * Reset test content and custom post types.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$this->clear_wordbless_posts_query();
+
+		if ( post_type_exists( 'seo_book' ) ) {
+			unregister_post_type( 'seo_book' );
+		}
+
+		WorDBless_Posts::init()->clear_all_posts();
+
+		parent::tearDown();
 	}
 
 	/**
@@ -74,5 +94,39 @@ class LlmsTxtTest extends TestCase {
 		$this->assertStringContainsString( '# Empty Site', $output );
 		$this->assertStringNotContainsString( '## Pages', $output );
 		$this->assertStringNotContainsString( '## Posts', $output );
+	}
+
+	/**
+	 * Public REST custom post types are included as their own sections.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_supported_custom_post_type_section() {
+		update_option( 'blogname', 'CPT Site' );
+		register_post_type(
+			'seo_book',
+			array(
+				'label'        => 'Books',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		$book_id = wp_insert_post(
+			array(
+				'post_type'    => 'seo_book',
+				'post_status'  => 'publish',
+				'post_title'   => 'Practical Schema',
+				'post_excerpt' => 'A concise guide to schema markup.',
+			)
+		);
+		$this->hook_wordbless_posts_query( array( $book_id ) );
+
+		$output = Llms_Txt::generate();
+
+		$this->assertStringContainsString( "## Books\n\n", $output );
+		$this->assertStringContainsString( 'Practical Schema', $output );
+		$this->assertStringContainsString( 'A concise guide to schema markup.', $output );
 	}
 }

--- a/projects/packages/seo/tests/php/PostTypesTest.php
+++ b/projects/packages/seo/tests/php/PostTypesTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for Jetpack SEO supported post type discovery.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Post_Types
+ */
+#[CoversClass( Post_Types::class )]
+class PostTypesTest extends TestCase {
+
+	/**
+	 * Clean up registered custom post types.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		foreach ( array( 'seo_book', 'seo_hidden', 'seo_no_rest' ) as $post_type ) {
+			if ( post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Supported content types are the public, UI-visible, REST-enabled post
+	 * types Jetpack SEO can list and edit through core-data.
+	 *
+	 * @return void
+	 */
+	public function test_supported_content_types_include_public_rest_cpts_and_exclude_attachments() {
+		register_post_type(
+			'seo_book',
+			array(
+				'label'        => 'Books',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_type(
+			'seo_hidden',
+			array(
+				'label'        => 'Hidden',
+				'public'       => true,
+				'show_ui'      => false,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_type(
+			'seo_no_rest',
+			array(
+				'label'        => 'No REST',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => false,
+			)
+		);
+
+		$post_types = Post_Types::get_supported_content_types();
+
+		$this->assertContains( 'post', $post_types );
+		$this->assertContains( 'page', $post_types );
+		$this->assertContains( 'seo_book', $post_types );
+		$this->assertNotContains( 'attachment', $post_types );
+		$this->assertNotContains( 'seo_hidden', $post_types );
+		$this->assertNotContains( 'seo_no_rest', $post_types );
+	}
+
+	/**
+	 * Supported object discovery keeps labels for UI surfaces such as the
+	 * Content tab filter and llms.txt headings.
+	 *
+	 * @return void
+	 */
+	public function test_supported_content_type_objects_preserve_labels() {
+		register_post_type(
+			'seo_book',
+			array(
+				'label'        => 'Books',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		$post_types = Post_Types::get_supported_content_type_objects();
+
+		$this->assertArrayHasKey( 'seo_book', $post_types );
+		$this->assertSame( 'Books', $post_types['seo_book']->label );
+	}
+
+	/**
+	 * Supported content type options expose the stable data shape consumed by
+	 * the Content tab, so client-side discovery cannot use a divergent rule.
+	 *
+	 * @return void
+	 */
+	public function test_supported_content_type_options_expose_slugs_and_labels() {
+		register_post_type(
+			'seo_book',
+			array(
+				'label'        => 'Books',
+				'public'       => true,
+				'show_ui'      => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		$options = Post_Types::get_supported_content_type_options();
+
+		$this->assertContains(
+			array(
+				'slug'  => 'seo_book',
+				'label' => 'Books',
+			),
+			$options
+		);
+	}
+}

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -18,3 +18,4 @@ define( 'WP_DEBUG', true );
 require_once __DIR__ . '/stubs/class-jetpack-seo-utils.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-posts.php';
 require_once __DIR__ . '/stubs/class-jetpack-options.php';
+require_once __DIR__ . '/traits/wordblessquerytrait.php';

--- a/projects/packages/seo/tests/php/traits/wordblessquerytrait.php
+++ b/projects/packages/seo/tests/php/traits/wordblessquerytrait.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Shared WorDBless WP_Query support for Jetpack SEO tests.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Short-circuits the subset of WP_Query behavior unavailable in WorDBless.
+ */
+trait WorDBless_Query_Trait {
+
+	/**
+	 * Test-only WP_Query short-circuit.
+	 *
+	 * @var callable|null
+	 */
+	private $posts_query_filter = null;
+
+	/**
+	 * Test-only found_posts override for aggregate queries.
+	 *
+	 * @var callable|null
+	 */
+	private $found_posts_filter = null;
+
+	/**
+	 * Short-circuit queries with inserted posts that match their query vars.
+	 *
+	 * @param int[] $post_ids Inserted post IDs.
+	 * @return void
+	 */
+	private function hook_wordbless_posts_query( $post_ids ) {
+		$this->posts_query_filter = function ( $posts, $query ) use ( $post_ids ) {
+			return $this->get_wordbless_query_matches( $post_ids, $query, 'ids' === $query->get( 'fields' ) );
+		};
+		$this->found_posts_filter = function ( $found_posts, $query ) use ( $post_ids ) {
+			return count( $this->get_wordbless_query_matches( $post_ids, $query, true ) );
+		};
+
+		add_filter( 'posts_pre_query', $this->posts_query_filter, 10, 2 );
+		add_filter( 'found_posts', $this->found_posts_filter, 10, 2 );
+	}
+
+	/**
+	 * Remove test-only query filters.
+	 *
+	 * @return void
+	 */
+	private function clear_wordbless_posts_query() {
+		if ( null !== $this->posts_query_filter ) {
+			remove_filter( 'posts_pre_query', $this->posts_query_filter, 10 );
+			$this->posts_query_filter = null;
+		}
+		if ( null !== $this->found_posts_filter ) {
+			remove_filter( 'found_posts', $this->found_posts_filter, 10 );
+			$this->found_posts_filter = null;
+		}
+	}
+
+	/**
+	 * Match inserted posts against the query shape needed by SEO tests.
+	 *
+	 * @param int[]     $post_ids Inserted post IDs.
+	 * @param \WP_Query $query    Query to match.
+	 * @param bool      $ids_only Whether to return IDs instead of post objects.
+	 * @return array
+	 */
+	private function get_wordbless_query_matches( $post_ids, $query, $ids_only ) {
+		$post_types = (array) $query->get( 'post_type' );
+		$meta_query = $query->get( 'meta_query' );
+		$matches    = array();
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post || 'publish' !== $post->post_status || ! in_array( $post->post_type, $post_types, true ) ) {
+				continue;
+			}
+
+			if ( is_array( $meta_query ) && isset( $meta_query[0]['key'] ) ) {
+				$meta    = get_post_meta( $post_id, $meta_query[0]['key'], true );
+				$value   = isset( $meta_query[0]['value'] ) ? $meta_query[0]['value'] : '';
+				$compare = isset( $meta_query[0]['compare'] ) ? $meta_query[0]['compare'] : '=';
+
+				if ( '!=' === $compare && $meta === $value ) {
+					continue;
+				}
+				if ( '!=' !== $compare && $meta !== $value ) {
+					continue;
+				}
+			}
+
+			$matches[] = $ids_only ? (int) $post_id : $post;
+		}
+
+		return $matches;
+	}
+}

--- a/projects/packages/seo/tests/routes/content/inspector.test.tsx
+++ b/projects/packages/seo/tests/routes/content/inspector.test.tsx
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+const useSearch = jest.fn();
+const useNavigate = jest.fn();
+
+jest.unstable_mockModule( '@automattic/jetpack-components', () => ( {
+	ThemeProvider: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.unstable_mockModule( '@wordpress/route', () => ( {
+	useSearch,
+	useNavigate,
+} ) );
+
+jest.unstable_mockModule( '../../../_inc/screens/content/seo-inspector', () => ( {
+	default: ( { postId, postType }: { postId: number; postType: string } ) => (
+		<div>
+			<span>Post ID: { postId }</span>
+			<span>Post type: { postType }</span>
+		</div>
+	),
+} ) );
+
+const { inspector: Inspector } = await import( '../../../routes/content/inspector' );
+
+describe( 'Content route inspector', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useNavigate.mockReturnValue( jest.fn() );
+	} );
+
+	it( 'passes custom post type slugs through to the SEO inspector', () => {
+		useSearch.mockReturnValue( { postId: '9', postType: 'gear_review' } );
+
+		render( <Inspector /> );
+
+		expect( screen.getByText( 'Post ID: 9' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Post type: gear_review' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2950,6 +2950,27 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'sanitize_callback' => 'Jetpack_SEO_Titles::sanitize_title_formats',
 			),
 
+			// AI tab (Jetpack > SEO). Plain options the SEO package reads to emit
+			// robots directives for AI crawlers and to serve /llms.txt. The
+			// front-end behavior is gated inside the package; these only round-trip
+			// the persisted state alongside the other seo-tools settings.
+			'jetpack_seo_blocked_ai_crawlers'           => array(
+				'description'       => esc_html__( 'AI crawlers blocked from accessing this site.', 'jetpack' ),
+				'type'              => 'array',
+				'items'             => array( 'type' => 'string' ),
+				'default'           => array(),
+				'sanitize_callback' => __CLASS__ . '::sanitize_ai_crawler_slugs',
+				'jp_group'          => 'seo-tools',
+			),
+
+			'jetpack_seo_llms_txt_enabled'              => array(
+				'description'       => esc_html__( 'Generate an llms.txt file to guide AI assistants around your content.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'seo-tools',
+			),
+
 			// VideoPress.
 			'videopress_private_enabled_for_site'       => array(
 				'description'       => esc_html__( 'Video Privacy: Restrict views to members of this site', 'jetpack' ),
@@ -3645,6 +3666,26 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return array( 'administrator' );
 		}
 		return $value;
+	}
+
+	/**
+	 * Sanitize the list of AI crawler slugs blocked from the site.
+	 *
+	 * Accepts the slugs the SEO AI tab sends (see the catalog in
+	 * `Automattic\Jetpack\SEO\Ai_Crawlers`) and reduces them to a clean,
+	 * de-duplicated list of key-safe strings. The SEO package treats its own
+	 * catalog as the source of truth when emitting robots directives, so any
+	 * unknown slug stored here is simply inert.
+	 *
+	 * @param mixed $value Raw value from the request.
+	 * @return string[] Sanitized slug list.
+	 */
+	public static function sanitize_ai_crawler_slugs( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+		$slugs = array_map( 'sanitize_key', $value );
+		return array_values( array_unique( array_filter( $slugs ) ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-seo-ai-tab-llms-and-crawler-controls
+++ b/projects/plugins/jetpack/changelog/add-seo-ai-tab-llms-and-crawler-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register llms.txt and AI crawler settings in the Jetpack settings REST endpoint so the new SEO AI tab can persist them.

--- a/projects/plugins/jetpack/changelog/add-seo-ai-tab-llms-and-crawler-controls
+++ b/projects/plugins/jetpack/changelog/add-seo-ai-tab-llms-and-crawler-controls
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 Register llms.txt and AI crawler settings in the Jetpack settings REST endpoint so the new SEO AI tab can persist them.


### PR DESCRIPTION
Fixes # N/A — exploration spike. Tracked in Linear: JETPACK-1761 (llms.txt) and JETPACK-1762 (AI crawler management), under the "Explore: AI SEO Settings" project.

## Proposed changes

A **functional spike** building out the **Jetpack > SEO → AI tab** plus an Overview summary card, to review how these settings behave and reuse the patterns for the Phase 1 features (llms.txt Generation, AI Crawler Management). Everything is gated behind the existing `rsm_jetpack_seo` flag (+ surface visibility + seo-tools module), mirroring `Schema_Builder`.

**AI tab** (single centered column, Settings-tab width):
* **llms.txt** — toggle that serves a generated root-level `/llms.txt` (site identity + published pages/posts), with a "View your llms.txt" link.
* **AI crawler access — two sections with informed defaults:**
  * **Answer engines** (OAI-SearchBot, Claude-SearchBot, PerplexityBot, Amzn-SearchBot) — **allowed by default**, so the site stays citable in AI answers.
  * **Training crawlers** (GPTBot, ClaudeBot, Google-Extended, Applebot-Extended, Meta-ExternalAgent, Bytespider, CCBot, Amazonbot) — **blocked by default**.
  * Each crawler shows an Allowed/Blocked state and a **"Learn what <bot> does"** link to the operator's own docs (Bytespider has no official doc → shows "No documentation available"). Classifications verified against each operator's crawler docs (e.g. Amazon's docs put Amazonbot in *training*, Amzn-SearchBot in *answers*).
  * Blocking emits per-user-agent `Disallow` rules via an `Ai_Crawlers` `robots_txt` filter.
* **AI SEO enhancer** — the existing plan-gated toggle.
* **Crawler gating:** when the site can't be crawled, the toggles are replaced by an explanation — search-engine indexing off (with a link to Settings → visibility), or a `*.wpcomstaging.com` staging subdomain — and a warning is shown when a static robots.txt would override the directives.

**Overview**: a new **AI readiness card** (third card in the top row) summarizing the four AI settings as factual status rows, with a **"Manage AI"** button to the AI tab. Reads from the AI store so AI-tab saves reflect on navigation.

**Persistence** reuses `/jetpack/v4/settings`: `jetpack_seo_llms_txt_enabled` (bool) + `jetpack_seo_blocked_ai_crawlers` (array) registered in the plugin whitelist; unset crawler list defaults to "training blocked, answer allowed".

## Spike findings (for Phase 1)

* **`robots_txt` filter is defeated by a static/host robots.txt** (JN test sites, `*.wpcomstaging.com`, any physical robots.txt) — detect + warn in production. *(JETPACK-1762)*
* **Default-blocking is "unconfigured-only":** once a site saves crawler settings, the default no longer applies — so a training bot added later silently isn't blocked on already-configured sites. Decide whether to store a literal list (+ migrate) or store intent. *(JETPACK-1762)*
* **Readiness card still needs visibility-gating:** it reads crawler state even when indexing is off, where those controls don't apply. *(follow-up, JETPACK-1762)*
* **llms.txt** is hygiene, not a ranking lever (independent studies show near-zero fetches; Google says it won't use it). Competitor scan recorded in JETPACK-1759.

## Tests

* **PHP** (40 package tests): robots directive generation, blocked-slug sanitization/defaults, crawler detection helpers (search-engine visibility, staging subdomain, static robots.txt), llms.txt generation + enable state.
* **JS** (70 tests): AI store slices seed/update independently.
* **Manual:** verified end to end on a public custom-domain Atomic site — blocking crawlers produced the expected robots.txt directives; `/llms.txt` renders.

## Does this pull request change what data or activity we track or use?

No new Tracks events or data collection. Adds public front-end outputs (`/llms.txt`, AI-crawler robots.txt directives) generated from already-public content, controlled by site admins.

## Testing instructions

On a site where **WordPress serves robots.txt** (local/Studio or a public custom-domain Atomic site — NOT a JN site or `*.wpcomstaging.com`, which intercept robots.txt), with the SEO surface enabled (`rsm_jetpack_seo` on, surface visible, SEO Tools active) and search engines allowed:

* **AI tab → llms.txt:** toggle on, click "View your llms.txt", confirm `/llms.txt` lists site title + Pages/Posts. Toggle off → no longer served.
* **AI tab → crawlers:** confirm two sections (answer engines default-allowed, training default-blocked). Block a crawler, visit `/robots.txt`, confirm its `User-agent` / `Disallow: /` block appears. Click a "Learn what <bot> does" link → opens the operator's docs in a new tab.
* **Gating:** turn off "Allow search engines to index this site" (Settings → visibility) → the crawler section shows the explanation + link instead of toggles.
* **Overview:** confirm the AI readiness card appears as the third top-row card, its four rows reflect the AI-tab state, and "Manage AI" opens the AI tab.

_Note: a site that configured crawler settings on an earlier build keeps that saved list; `wp option delete jetpack_seo_blocked_ai_crawlers` resets it to the default._
