### PR TITLE
AI Chat block: stop prompting to enable Search when only Instant Search is off

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-chat-block-theme-search-nudge-fd29
+++ b/projects/plugins/jetpack/changelog/fix-ai-chat-block-theme-search-nudge-fd29
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Chat block: Stop prompting to enable Jetpack Search when the Search module is active in a non-Instant Search experience (Theme, Inline, or Embedded).

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -88,6 +88,11 @@ function add_ai_chat_block_data() {
 	$plan          = new Search_Plan();
 	$initial_state = array(
 		'jetpackSettings' => array(
+			// `module_active` reflects whether the Jetpack Search module is on, which is
+			// what controls site indexing — independent of the chosen front-end experience
+			// (Overlay / Theme / Inline / Embedded). The AI Chat block only needs the
+			// index, so it gates on this rather than on `instant_search_enabled`.
+			'module_active'          => $search->is_active(),
 			'instant_search_enabled' => $search->is_instant_search_enabled(),
 			'plan_supports_search'   => $plan->supports_instant_search(),
 		),

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/components/nudge-enable-search/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/components/nudge-enable-search/index.js
@@ -12,7 +12,13 @@ const EnableJetpackSearchPrompt = () => {
 	const checkoutUrl = `${ wpAdminUrl }admin.php?page=jetpack-search`;
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
 
-	if ( window?.Jetpack_AIChatBlock?.jetpackSettings?.instant_search_enabled ) {
+	// Jetpack AI only needs the Search module to be active so the site is indexed —
+	// any front-end experience (Overlay / Theme / Inline / Embedded) works. Older
+	// PHP versions of this block only exposed `instant_search_enabled`, so we fall
+	// back to it to stay correct against an unbuilt/cached editor bundle.
+	const jetpackSettings = window?.Jetpack_AIChatBlock?.jetpackSettings;
+	const searchEnabled = jetpackSettings?.module_active ?? jetpackSettings?.instant_search_enabled;
+	if ( searchEnabled ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/components/nudge-enable-search/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/components/nudge-enable-search/index.js
@@ -13,9 +13,9 @@ const EnableJetpackSearchPrompt = () => {
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
 
 	// Jetpack AI only needs the Search module to be active so the site is indexed —
-	// any front-end experience (Overlay / Theme / Inline / Embedded) works. Older
-	// PHP versions of this block only exposed `instant_search_enabled`, so we fall
-	// back to it to stay correct against an unbuilt/cached editor bundle.
+	// any front-end experience (Overlay / Theme / Inline / Embedded) works. Fall back
+	// to the legacy `instant_search_enabled` field so this newer editor bundle stays
+	// correct when paired with an older PHP build that doesn't yet emit `module_active`.
 	const jetpackSettings = window?.Jetpack_AIChatBlock?.jetpackSettings;
 	const searchEnabled = jetpackSettings?.module_active ?? jetpackSettings?.instant_search_enabled;
 	if ( searchEnabled ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

The AI Chat (Jetpack AI Search) block was showing the **"You need to enable Jetpack Search so that Jetpack AI can index your site"** banner whenever the Instant Search overlay was off — even on sites that have Jetpack Search active in **Theme**, **Inline**, or **Embedded** mode.

Jetpack AI indexes a site whenever the Jetpack Search module is active, independent of the chosen front-end experience. The block's nudge was reading the wrong signal (`instant_search_enabled`).

* Expose `module_active` (from `Module_Control::is_active()`) on `window.Jetpack_AIChatBlock.jetpackSettings` alongside the existing fields.
* Update `EnableJetpackSearchPrompt` to suppress the nudge when the module is active; fall back to `instant_search_enabled` so a cached/unrebuilt editor bundle running against the new PHP still behaves correctly.
* No behavioural change for sites where Search is off — the nudge still appears with the same copy and CTA.

## Related product discussion/links

* Zendesk: 11366343-zen (friendshipbridge.eu)
* p1782250859743769-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack site with a paid Search plan, ensure Jetpack Search is **enabled** and the experience is set to **Theme search** (overlay off). Confirm Theme search states that Search blocks remain available to drop into pages/templates.
2. In the block editor, add the **Jetpack AI Search** block to a page or template.
3. **Before** this PR: the block shows the banner "You need to enable Jetpack Search so that Jetpack AI can index your site" with the **Enable Jetpack Search** button.
4. **After** this PR: no banner. The block renders normally.
5. Also verify the banner *still* appears when the Search module is fully off (Experience = Off / module deactivated).
6. Switch the experience between Overlay, Theme, Inline, Embedded — the banner should stay hidden in each case while the module is active.

## Notes

End-to-end manual verification in a live editor was not performed from the cloud-agent VM (no Docker/PHP runtime available); the change was lint-checked locally. The reproduction in the testing steps above is the recommended pre-merge check.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SEARCH-300](https://linear.app/a8c/issue/SEARCH-300/jetpack-ai-search-block-prompts-enable-jetpack-search-in-theme-search)

<div><a href="https://cursor.com/agents/bc-e0b0a546-6593-4845-8cf0-fd3c1259fd29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b0a546-6593-4845-8cf0-fd3c1259fd29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>