### PR TITLE
Scan: scope wp-build polyfill registration to the Scan admin page

### DIFF
--- a/projects/packages/scan/changelog/fix-scan-wp-build-polyfills-scope
+++ b/projects/packages/scan/changelog/fix-scan-wp-build-polyfills-scope
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Scope wp-build polyfill registration to the Scan admin page so it no longer force-replaces core script handles (wp-private-apis) on other admin pages. Gated behind the Scan modernization flag.
+
+

--- a/projects/packages/scan/src/class-jetpack-scan.php
+++ b/projects/packages/scan/src/class-jetpack-scan.php
@@ -22,6 +22,7 @@ use function current_user_can;
 use function did_action;
 use function do_action;
 use function function_exists;
+use function is_admin;
 use function is_multisite;
 use function remove_action;
 use function remove_all_actions;
@@ -101,10 +102,18 @@ class Jetpack_Scan {
 	 * Load wp-build generated registration files. Mirrors Newsletter / Forms.
 	 */
 	public static function load_wp_build() {
-		WP_Build_Polyfills::register(
-			'jetpack-scan',
-			array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
-		);
+		// The polyfills force-replace core script handles (notably
+		// `wp-private-apis`, a stateful singleton shared by every @wordpress
+		// package on the page) during `wp_default_scripts`. Scope registration
+		// to the Scan admin page so it never runs on other admin pages such as
+		// the block editor. `$_GET['page']` is reliable this early — it's the
+		// raw query param, available well before `current_screen` exists.
+		if ( self::is_scan_admin_request() ) {
+			WP_Build_Polyfills::register(
+				'jetpack-scan',
+				array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
+			);
+		}
 
 		$wp_build_index = dirname( __DIR__ ) . '/build/build.php';
 		if ( file_exists( $wp_build_index ) ) {
@@ -119,6 +128,26 @@ class Jetpack_Scan {
 			'admin_init',
 			'jetpack_scan_jetpack_scan_intercept_render'
 		);
+	}
+
+	/**
+	 * Whether the current request targets the Scan admin page.
+	 *
+	 * Used to scope the wp-build polyfill registration (which force-replaces
+	 * core script handles) to this one page, so it never affects other admin
+	 * pages. Reads the menu page slug directly so it is cheap and safe to call
+	 * at plugin-load time, before `current_screen` exists.
+	 *
+	 * @return bool True when serving the Scan page in wp-admin.
+	 */
+	public static function is_scan_admin_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! is_admin() || ! isset( $_GET['page'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return self::PAGE_SLUG === sanitize_text_field( wp_unslash( $_GET['page'] ) );
 	}
 
 	/**

--- a/projects/packages/scan/tests/php/Jetpack_Scan_Page_Request_Test.php
+++ b/projects/packages/scan/tests/php/Jetpack_Scan_Page_Request_Test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests for the page-scoping predicate that gates wp-build polyfill
+ * registration. The polyfills force-replace core script handles
+ * (notably `wp-private-apis`) on `wp_default_scripts`, so registration
+ * must be confined to the Scan admin page and never run on other admin
+ * pages such as the block editor.
+ *
+ * @package automattic/jetpack-scan-page
+ */
+
+namespace Automattic\Jetpack\Scan_Page;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Jetpack_Scan::is_scan_admin_request().
+ *
+ * @covers \Automattic\Jetpack\Scan_Page\Jetpack_Scan
+ */
+#[CoversClass( Jetpack_Scan::class )]
+class Jetpack_Scan_Page_Request_Test extends TestCase {
+
+	/**
+	 * Reset request and screen globals touched by these tests so a stuck
+	 * `$_GET` / screen from one case can't leak into the next.
+	 */
+	protected function tearDown(): void {
+		unset( $_GET['page'] );
+		unset( $GLOBALS['current_screen'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * The Scan page slug in wp-admin is recognized as a Scan admin request.
+	 */
+	public function test_is_scan_admin_request_true_for_scan_page() {
+		set_current_screen( 'toplevel_page_jetpack-scan' );
+		$_GET['page'] = 'jetpack-scan';
+
+		$this->assertTrue( Jetpack_Scan::is_scan_admin_request() );
+	}
+
+	/**
+	 * Any other admin page is not a Scan admin request, so the polyfills
+	 * (which force-replace core handles) must not load there.
+	 */
+	public function test_is_scan_admin_request_false_for_other_admin_page() {
+		set_current_screen( 'edit-post' );
+		$_GET['page'] = 'some-other-plugin';
+
+		$this->assertFalse( Jetpack_Scan::is_scan_admin_request() );
+	}
+
+	/**
+	 * An admin request with no `page` parameter is not a Scan admin request.
+	 */
+	public function test_is_scan_admin_request_false_when_no_page_param() {
+		set_current_screen( 'edit-post' );
+		unset( $_GET['page'] );
+
+		$this->assertFalse( Jetpack_Scan::is_scan_admin_request() );
+	}
+
+	/**
+	 * A front-end request carrying the Scan slug is not a Scan admin request.
+	 */
+	public function test_is_scan_admin_request_false_on_front_end() {
+		set_current_screen( 'front' );
+		$_GET['page'] = 'jetpack-scan';
+
+		$this->assertFalse( Jetpack_Scan::is_scan_admin_request() );
+	}
+}


### PR DESCRIPTION
Fixes # N/A

Follow-up to #49838. That PR contained the `@wordpress/private-apis` blast radius for **Premium Analytics**, which called `WP_Build_Polyfills::register()` unconditionally at plugin load. While auditing the other wp-build dashboards, **Scan** turned out to share the same anti-pattern.

`WP_Build_Polyfills::register()` hooks `wp_default_scripts` and **force-replaces** core script handles — notably `wp-private-apis`, a stateful singleton (a module-private `Symbol` + `WeakMap` for `lock`/`unlock`) shared by every `@wordpress` package on the page. Substituting an incompatible bundled copy can break the block editor and the rest of wp-admin, not just the dashboard.

`Jetpack_Scan::initialize()` runs from `Jetpack::late_initialization()` on `plugins_loaded` (every request) and called `load_wp_build()` → `register()` gated **only** on the `rsm_jetpack_ui_modernization_scan` filter, with no page check. So whenever that flag is enabled, the force-replace would apply on every admin request — including the block editor.

This is **latent today** (the flag defaults off and isn't enabled in production, and the force-replace itself only fires on WP < 7.1 without a recent Gutenberg), but it's the same loaded gun #49838 defused for Premium Analytics. The other wp-build dashboards (Forms, Newsletter, Podcast, SEO, VideoPress, Social, AI Launchpad, Backup) are already correctly page-scoped.

## Proposed changes
* Add a `public static Jetpack_Scan::is_scan_admin_request()` predicate (the same `is_admin() && $_GET['page'] === PAGE_SLUG` idiom the other dashboards use; reads the menu slug directly so it's safe to call at plugin-load time, before `current_screen` exists).
* Gate **only** the `WP_Build_Polyfills::register()` call inside `load_wp_build()` behind it, so the polyfills register only on `?page=jetpack-scan`. The `build.php` load, the enqueue/boot bridges, the interceptor removal, and the menu wiring are unchanged — the menu render callback still needs the build's render function available on every admin request, exactly as #49838 keeps Premium Analytics' build load global while scoping only `register()`.
* Add unit tests for `is_scan_admin_request()` (Scan page, other admin page, no `page` param, front-end).

## Related product discussion/links
* Follow-up to #49838 (Premium Analytics: scope wp-build polyfills to dashboard pages).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the package: `jetpack build packages/scan`.
* On a site **without** a recent Gutenberg (so the polyfill's force-replace path is active), enable the Scan modernization flag (`add_filter( 'rsm_jetpack_ui_modernization_scan', '__return_true' );`).
* Open a non-Scan admin page — e.g. **Posts → Add New** (block editor). Confirm it loads normally and that `wp-private-apis` is **not** swapped to the polyfill build (the registration should still point at core). Before this change, the polyfill replaced it here.
* Open **Jetpack → Scan** (`admin.php?page=jetpack-scan`). Confirm the dashboard loads and the polyfill scripts/modules are registered from the polyfill build on this page.
* Run the PHP tests: `cd projects/packages/scan && composer phpunit` — 13 pass, including the new `is_scan_admin_request` tests.
