### PR TITLE
SEO Settings: two-column grid layout

### DIFF
--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -108,145 +108,151 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 
 	return (
 		<div className="jetpack-seo-settings">
-			<div id="visibility" className="jetpack-seo-settings__section">
-				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Stack direction="row" justify="space-between" align="center" gap="sm">
-							<Card.Title>{ __( 'Site visibility', 'jetpack-seo' ) }</Card.Title>
-							<Badge intent={ visibilityEnabledCount === 2 ? 'stable' : 'draft' }>
-								{ sprintf(
-									/* translators: %1$d: number of enabled visibility settings, %2$d: total. */
-									__( '%1$d of %2$d enabled', 'jetpack-seo' ),
-									visibilityEnabledCount,
-									2
-								) }
-							</Badge>
-						</Stack>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Stack direction="column" gap="lg">
+			<div className="jetpack-seo-settings__grid">
+				<div className="jetpack-seo-settings__column">
+					<div id="visibility" className="jetpack-seo-settings__section">
+						<CollapsibleCard.Root defaultOpen>
+							<CollapsibleCard.Header>
+								<Stack direction="row" justify="space-between" align="center" gap="sm">
+									<Card.Title>{ __( 'Site visibility', 'jetpack-seo' ) }</Card.Title>
+									<Badge intent={ visibilityEnabledCount === 2 ? 'stable' : 'draft' }>
+										{ sprintf(
+											/* translators: %1$d: number of enabled visibility settings, %2$d: total. */
+											__( '%1$d of %2$d enabled', 'jetpack-seo' ),
+											visibilityEnabledCount,
+											2
+										) }
+									</Badge>
+								</Stack>
+							</CollapsibleCard.Header>
+							<CollapsibleCard.Content>
+								<Stack direction="column" gap="lg">
+									<ToggleControl
+										label={ __( 'Allow search engines to index this site', 'jetpack-seo' ) }
+										help={ __(
+											'Mirrors Settings → Reading → "Discourage search engines from indexing this site". Turning this off asks search engines to stop indexing your site; honored by Google and Bing, ignored by others. Use only for staging or pre-launch sites.',
+											'jetpack-seo'
+										) }
+										checked={ local.search_engines_visible }
+										onChange={ next => commit( { search_engines_visible: next } ) }
+										disabled={ isSaving }
+										__nextHasNoMarginBottom
+									/>
+									<div className="jetpack-seo-settings__sitemap-field">
+										<ToggleControl
+											label={ __( 'Generate an XML sitemap', 'jetpack-seo' ) }
+											help={ local.search_engines_visible ? sitemapHelp : sitemapBlockedHelp }
+											// Reflect the effective state: a sitemap can't be generated while
+											// indexing is blocked, so show it off (the stored preference is kept
+											// and restored when indexing is re-enabled).
+											checked={ sitemapEffectivelyOn }
+											onChange={ next => commit( { sitemap_active: next } ) }
+											disabled={ isSaving || ! local.search_engines_visible }
+											__nextHasNoMarginBottom
+										/>
+										{ sitemapEffectivelyOn &&
+											( local.sitemap_url ? (
+												<Link
+													className="jetpack-seo-settings__sitemap-link"
+													href={ local.sitemap_url }
+													openInNewTab
+													rel="noopener noreferrer"
+												>
+													{ sitemapViewLabel }
+												</Link>
+											) : (
+												<span className="jetpack-seo-settings__sitemap-hint">
+													{ sitemapGeneratingLabel }
+												</span>
+											) ) }
+									</div>
+								</Stack>
+							</CollapsibleCard.Content>
+						</CollapsibleCard.Root>
+					</div>
+
+					<div id="verification" className="jetpack-seo-settings__section">
+						<VerificationCard
+							value={ local.verification }
+							onChange={ setVerification }
+							onCommit={ () => commitFields( [ 'verification' ] ) }
+							disabled={ isSaving }
+							open={ verificationOpen }
+							onOpenChange={ setVerificationOpen }
+						/>
+					</div>
+
+					<CollapsibleCard.Root defaultOpen={ false }>
+						<CollapsibleCard.Header>
+							<Stack direction="row" justify="space-between" align="center" gap="sm">
+								<Card.Title>{ __( 'Canonical URLs', 'jetpack-seo' ) }</Card.Title>
+								<Badge intent={ local.canonical_active ? 'stable' : 'draft' }>
+									{ local.canonical_active ? enabledLabel : disabledLabel }
+								</Badge>
+							</Stack>
+						</CollapsibleCard.Header>
+						<CollapsibleCard.Content>
 							<ToggleControl
-								label={ __( 'Allow search engines to index this site', 'jetpack-seo' ) }
+								label={ __( 'Add canonical URLs to archive pages', 'jetpack-seo' ) }
 								help={ __(
-									'Mirrors Settings → Reading → "Discourage search engines from indexing this site". Turning this off asks search engines to stop indexing your site; honored by Google and Bing, ignored by others. Use only for staging or pre-launch sites.',
+									'Adds a rel="canonical" link to archive pages, helping search engines identify the preferred URL and avoid indexing duplicate content.',
 									'jetpack-seo'
 								) }
-								checked={ local.search_engines_visible }
-								onChange={ next => commit( { search_engines_visible: next } ) }
+								checked={ local.canonical_active }
+								onChange={ next => commit( { canonical_active: next } ) }
 								disabled={ isSaving }
 								__nextHasNoMarginBottom
 							/>
-							<div className="jetpack-seo-settings__sitemap-field">
-								<ToggleControl
-									label={ __( 'Generate an XML sitemap', 'jetpack-seo' ) }
-									help={ local.search_engines_visible ? sitemapHelp : sitemapBlockedHelp }
-									// Reflect the effective state: a sitemap can't be generated while
-									// indexing is blocked, so show it off (the stored preference is kept
-									// and restored when indexing is re-enabled).
-									checked={ sitemapEffectivelyOn }
-									onChange={ next => commit( { sitemap_active: next } ) }
-									disabled={ isSaving || ! local.search_engines_visible }
+						</CollapsibleCard.Content>
+					</CollapsibleCard.Root>
+
+					<TitleStructureField
+						formats={ local.title_formats }
+						onChange={ ( pageType, next ) =>
+							setField( { title_formats: { ...local.title_formats, [ pageType ]: next } } )
+						}
+						onSaveFormat={ pageType => commitTitleFormat( pageType ) }
+						isFormatDirty={ pageType => isTitleFormatDirty( pageType ) }
+						disabled={ isSaving }
+					/>
+				</div>
+
+				<div className="jetpack-seo-settings__column">
+					<CollapsibleCard.Root defaultOpen={ false }>
+						<CollapsibleCard.Header>
+							<Stack direction="row" justify="space-between" align="center" gap="sm">
+								<Card.Title>{ __( 'Front-page description', 'jetpack-seo' ) }</Card.Title>
+								<Badge intent={ local.front_page_description ? 'stable' : 'draft' }>
+									{ local.front_page_description ? setLabel : notSetLabel }
+								</Badge>
+							</Stack>
+						</CollapsibleCard.Header>
+						<CollapsibleCard.Content>
+							<Stack direction="column" gap="md">
+								<TextareaControl
+									label={ __( 'Meta description shown on the home page', 'jetpack-seo' ) }
+									value={ local.front_page_description }
+									onChange={ next => setField( { front_page_description: next } ) }
+									rows={ 3 }
+									disabled={ isSaving }
 									__nextHasNoMarginBottom
 								/>
-								{ sitemapEffectivelyOn &&
-									( local.sitemap_url ? (
-										<Link
-											className="jetpack-seo-settings__sitemap-link"
-											href={ local.sitemap_url }
-											openInNewTab
-											rel="noopener noreferrer"
-										>
-											{ sitemapViewLabel }
-										</Link>
-									) : (
-										<span className="jetpack-seo-settings__sitemap-hint">
-											{ sitemapGeneratingLabel }
-										</span>
-									) ) }
-							</div>
-						</Stack>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
+								<div className="jetpack-seo-settings__save">
+									<Button
+										variant="primary"
+										onClick={ () => commitFields( [ 'front_page_description' ] ) }
+										disabled={ isSaving || ! isDirty( [ 'front_page_description' ] ) }
+									>
+										{ saveLabel }
+									</Button>
+								</div>
+							</Stack>
+						</CollapsibleCard.Content>
+					</CollapsibleCard.Root>
+
+					<SocialPreviewsCard description={ local.front_page_description } />
+				</div>
 			</div>
-
-			<div id="verification" className="jetpack-seo-settings__section">
-				<VerificationCard
-					value={ local.verification }
-					onChange={ setVerification }
-					onCommit={ () => commitFields( [ 'verification' ] ) }
-					disabled={ isSaving }
-					open={ verificationOpen }
-					onOpenChange={ setVerificationOpen }
-				/>
-			</div>
-
-			<CollapsibleCard.Root defaultOpen={ false }>
-				<CollapsibleCard.Header>
-					<Stack direction="row" justify="space-between" align="center" gap="sm">
-						<Card.Title>{ __( 'Canonical URLs', 'jetpack-seo' ) }</Card.Title>
-						<Badge intent={ local.canonical_active ? 'stable' : 'draft' }>
-							{ local.canonical_active ? enabledLabel : disabledLabel }
-						</Badge>
-					</Stack>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<ToggleControl
-						label={ __( 'Add canonical URLs to archive pages', 'jetpack-seo' ) }
-						help={ __(
-							'Adds a rel="canonical" link to archive pages, helping search engines identify the preferred URL and avoid indexing duplicate content.',
-							'jetpack-seo'
-						) }
-						checked={ local.canonical_active }
-						onChange={ next => commit( { canonical_active: next } ) }
-						disabled={ isSaving }
-						__nextHasNoMarginBottom
-					/>
-				</CollapsibleCard.Content>
-			</CollapsibleCard.Root>
-
-			<TitleStructureField
-				formats={ local.title_formats }
-				onChange={ ( pageType, next ) =>
-					setField( { title_formats: { ...local.title_formats, [ pageType ]: next } } )
-				}
-				onSaveFormat={ pageType => commitTitleFormat( pageType ) }
-				isFormatDirty={ pageType => isTitleFormatDirty( pageType ) }
-				disabled={ isSaving }
-			/>
-
-			<CollapsibleCard.Root defaultOpen={ false }>
-				<CollapsibleCard.Header>
-					<Stack direction="row" justify="space-between" align="center" gap="sm">
-						<Card.Title>{ __( 'Front-page description', 'jetpack-seo' ) }</Card.Title>
-						<Badge intent={ local.front_page_description ? 'stable' : 'draft' }>
-							{ local.front_page_description ? setLabel : notSetLabel }
-						</Badge>
-					</Stack>
-				</CollapsibleCard.Header>
-				<CollapsibleCard.Content>
-					<Stack direction="column" gap="md">
-						<TextareaControl
-							label={ __( 'Meta description shown on the home page', 'jetpack-seo' ) }
-							value={ local.front_page_description }
-							onChange={ next => setField( { front_page_description: next } ) }
-							rows={ 3 }
-							disabled={ isSaving }
-							__nextHasNoMarginBottom
-						/>
-						<div className="jetpack-seo-settings__save">
-							<Button
-								variant="primary"
-								onClick={ () => commitFields( [ 'front_page_description' ] ) }
-								disabled={ isSaving || ! isDirty( [ 'front_page_description' ] ) }
-							>
-								{ saveLabel }
-							</Button>
-						</div>
-					</Stack>
-				</CollapsibleCard.Content>
-			</CollapsibleCard.Root>
-
-			<SocialPreviewsCard description={ local.front_page_description } />
 		</div>
 	);
 };

--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -127,7 +127,7 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 	}
 
 	return (
-		<CollapsibleCard.Root defaultOpen={ false }>
+		<CollapsibleCard.Root defaultOpen>
 			<CollapsibleCard.Header>
 				<Card.Title>{ __( 'Search & social previews', 'jetpack-seo' ) }</Card.Title>
 			</CollapsibleCard.Header>

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -1,12 +1,30 @@
-// Centered fixed-width column. 660px is the established Jetpack settings-page
-// width (see Newsletter's settings/style.scss: "MSD and future JP settings
-// pages are 660px wide"); there is no design token for it.
+// Centered content column. Wider than a single settings form (660px) because
+// the Settings tab now lays its cards out in two columns — matches the Overview
+// tab's content width.
 .jetpack-seo-settings {
+	max-inline-size: 1128px;
+	margin-inline: auto;
+}
+
+// Two-column card grid, mirroring the Overview tab's grid technique: an
+// auto-fit grid that gives two columns when there's room and collapses to one
+// as the screen narrows. `align-items: start` so the two columns sit at the top
+// independently — they hold different cards and aren't equal height.
+.jetpack-seo-settings__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: var(--wpds-dimension-gap-lg, 16px);
+	align-items: start;
+}
+
+// Each column stacks its cards vertically with the same gap as the grid.
+// `min-width: 0` lets long content (e.g. the title preview) wrap inside the
+// column instead of forcing the track wider.
+.jetpack-seo-settings__column {
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-gap-lg, 16px);
-	max-inline-size: 660px;
-	margin-inline: auto;
+	min-width: 0;
 }
 
 // Deep-link target wrapper. `scroll-margin-top` clears the fixed header +

--- a/projects/packages/seo/changelog/update-jetpack-seo-settings-two-column-grid
+++ b/projects/packages/seo/changelog/update-jetpack-seo-settings-two-column-grid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Lay out the SEO Settings tab in a two-column grid, mirroring the Overview tab, so the cards use the available width instead of a single column.


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Lay out the Jetpack SEO **Settings** tab in a two-column grid instead of a single column, mirroring the **Overview** tab's grid technique (`repeat(auto-fit, minmax(280px, 1fr))`), so the cards use the available width and collapse back to one column on narrow screens.
* **Left column:** Site visibility (open), Site verification (closed), Canonical URLs (closed), Title structure (closed).
* **Right column:** Front-page description (closed), Search & social previews — now **open by default** (was collapsed).
* Widen the Settings content column from 660px to 1128px to match the Overview tab.
* Cards' open/closed defaults are otherwise unchanged; deep-link anchors (`#visibility` / `#verification`) and their scroll behavior are preserved.

## Related product discussion/links
* Part of the Jetpack SEO product work (settings UI polish).

## Does this pull request change what data or activity we track or use?
No. This is a presentation-only layout change — no tracking or data changes.

## Testing instructions
* Spin up the PR build on a Jurassic Ninja site (Jetpack Beta → install this PR), or build the `jetpack-seo` package locally.
* Connect Jetpack and make sure the SEO product/page is available, then open **Jetpack → SEO → Settings**.
* Confirm the settings cards render in **two columns** on a wide screen:
  * Left: Site visibility, Site verification, Canonical URLs, Title structure.
  * Right: Front-page description, Search & social previews.
* Confirm **Site visibility** and **Search & social previews** are expanded by default; the others are collapsed.
* Narrow the browser window and confirm the grid collapses to a single column.
* Confirm the per-section save flows (Front-page description, Title structure) and the visibility/sitemap toggles still work as before.
* Deep-link check: from the Overview tab, use the "Manage" links for visibility/verification and confirm they still scroll to the correct section on the Settings tab.
