### PR TITLE
SEO: admin-page style tweaks (canvas, preview cards, sticky tabs)

### DIFF
--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -10,7 +10,27 @@
 body.jetpack_page_jetpack-seo,
 body.toplevel_page_jetpack-seo {
 
+	// Canvas color for the modernized SEO dashboard. Bound here so the rule
+	// below references a real token (no silent `var(... , #fcfcfc)` fallback)
+	// and future tweaks have one place to land. `#fcfcfc` matches the off-white
+	// canvas adopted by the other modernized pages (Newsletter, Social,
+	// VideoPress) so the product stays consistent.
+	--jetpack-seo-page-bg-canvas: #fcfcfc;
+
 	@include jetpack-admin-page-layout-wp-build;
+
+	// Off-white canvas so the white settings cards stand out against the
+	// background. Three layers paint here: the body (the page outside the
+	// admin-ui chrome), `.jp-admin-page` (AdminPage's outer wrapper, white by
+	// default via `showBackground`), and `.jp-admin-page__page` (the
+	// `@wordpress/admin-ui` `<Page>` shell, which also defaults to white and is
+	// what a color-picker on the page surface reads). All three need overriding
+	// so every SEO tab shares the canvas without each one having to opt out.
+	&,
+	.jp-admin-page,
+	.jp-admin-page__page {
+		background-color: var(--jetpack-seo-page-bg-canvas);
+	}
 }
 
 // `<AdminPage>` renders content with `horizontalSpacing={0}` and no

--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -33,6 +33,39 @@ body.toplevel_page_jetpack-seo {
 	}
 }
 
+// The route content is rendered inside `Tabs.Root` (`.jetpack-seo-tabs`), so
+// the sticky tab strip (`.jp-admin-page-tabs`) has a full-height containing
+// block and stays pinned while the content scrolls. Mirrors Newsletter.
+// Continue the page's flex column through `Tabs.Root`: size it to its full
+// content height (`flex: 0 0 auto`) so the strip stays stuck the whole way
+// down — capping it to the viewport would shrink the containing block to one
+// screen and drop the strip after the first scroll.
+.jetpack-seo-tabs {
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
+}
+
+// The full-bleed Content (DataViews) tab opts out of the `0 0 auto` sizing:
+// it used to be a direct flex child of the page column and so inherited the
+// layout mixin's fill treatment (`flex: 1 1 auto; min-height: 0; display:
+// flex; flex-direction: column`). Now that it lives inside `Tabs.Root`, let
+// `Tabs.Root` fill and re-apply that same treatment to the content div, so
+// the Content tab's layout is unchanged. Nothing below the content div is
+// touched — the original chain stopped here (`.jetpack-seo-content` keeps its
+// own sizing), so the DataViews surface behaves exactly as it does today.
+.jetpack-seo-tabs:has(.jetpack-seo-page-content--flush) {
+	flex: 1 1 auto;
+	min-block-size: 0;
+
+	.jetpack-seo-page-content--flush {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-block-size: 0;
+	}
+}
+
 // `<AdminPage>` renders content with `horizontalSpacing={0}` and no
 // `hasPadding`, so the content area gets no padding from admin-ui or the layout
 // mixin — only the header does (at `padding-inline: 2xl`). Pad our content to

--- a/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
+++ b/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
@@ -2,6 +2,7 @@ import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
+import type { ReactNode } from 'react';
 
 export type SeoTab = 'overview' | 'settings' | 'content' | 'ai';
 
@@ -20,11 +21,18 @@ const ROUTE_BY_TAB: Record< SeoTab, string > = {
  * stage). The active tab is supplied by the current route's stage rather than
  * derived from the URL, mirroring the Jetpack Forms dashboard.
  *
- * @param props        - Component props.
- * @param props.active - The tab for the currently rendered route.
- * @return The dashboard tab navigation.
+ * The route's content is rendered as `children` INSIDE `Tabs.Root`, so the
+ * sticky tab strip's containing block spans the full page height and stays
+ * pinned while the content scrolls. This mirrors the modernized Newsletter and
+ * VideoPress dashboards; rendering the content as a sibling of `Tabs.Root`
+ * leaves the strip in a strip-height containing block and it unsticks on scroll.
+ *
+ * @param props          - Component props.
+ * @param props.active   - The tab for the currently rendered route.
+ * @param props.children - The route's content, rendered inside `Tabs.Root`.
+ * @return The dashboard tab navigation wrapping the route content.
  */
-const DashboardNav = ( { active }: { active: SeoTab } ) => {
+const DashboardNav = ( { active, children }: { active: SeoTab; children: ReactNode } ) => {
 	const navigate = useNavigate();
 
 	const onTabChange = useCallback(
@@ -37,7 +45,7 @@ const DashboardNav = ( { active }: { active: SeoTab } ) => {
 	);
 
 	return (
-		<Tabs.Root value={ active } onValueChange={ onTabChange }>
+		<Tabs.Root className="jetpack-seo-tabs" value={ active } onValueChange={ onTabChange }>
 			<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 				<Tabs.List variant="minimal">
 					<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-seo' ) }</Tabs.Tab>
@@ -46,6 +54,7 @@ const DashboardNav = ( { active }: { active: SeoTab } ) => {
 					<Tabs.Tab value="ai">{ __( 'AI', 'jetpack-seo' ) }</Tabs.Tab>
 				</Tabs.List>
 			</div>
+			{ children }
 		</Tabs.Root>
 	);
 };

--- a/projects/packages/seo/_inc/dashboard/dashboard-page.tsx
+++ b/projects/packages/seo/_inc/dashboard/dashboard-page.tsx
@@ -47,12 +47,15 @@ const DashboardPage = ( { active, showFooter = true, flush = false, children }: 
 			) }
 			showFooter={ showFooter }
 		>
-			<DashboardNav active={ active } />
-			<div
-				className={ `jetpack-seo-page-content${ flush ? ' jetpack-seo-page-content--flush' : '' }` }
-			>
-				{ children }
-			</div>
+			<DashboardNav active={ active }>
+				<div
+					className={ `jetpack-seo-page-content${
+						flush ? ' jetpack-seo-page-content--flush' : ''
+					}` }
+				>
+					{ children }
+				</div>
+			</DashboardNav>
 		</AdminPage>
 	</ThemeProvider>
 );

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -203,10 +203,11 @@
 
 	.jetpack-seo-preview__card-body {
 		padding: var(--wpds-dimension-padding-md, 12px);
-		// Recessed surface (`#f4f4f4`) rather than `bg-surface-neutral` (#fcfcfc):
-		// the latter now matches the page canvas and reads as white on the white
-		// card, so the link-preview body needs the darker step to stand apart from
-		// both the card and the page. The image keeps `bg-surface-neutral`.
+		// Recessed surface so the link-preview body stands apart from both the
+		// white card and the page canvas. The canvas already uses
+		// `bg-surface-neutral`, so reusing that token here would read as the same
+		// surface — step down to the weaker surface instead. The preview image
+		// above keeps `bg-surface-neutral`.
 		background: var(--wpds-color-bg-surface-neutral-weak, #f4f4f4);
 	}
 

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -203,7 +203,11 @@
 
 	.jetpack-seo-preview__card-body {
 		padding: var(--wpds-dimension-padding-md, 12px);
-		background: var(--wpds-color-bg-surface-neutral, #f2f3f5);
+		// Recessed surface (`#f4f4f4`) rather than `bg-surface-neutral` (#fcfcfc):
+		// the latter now matches the page canvas and reads as white on the white
+		// card, so the link-preview body needs the darker step to stand apart from
+		// both the card and the page. The image keeps `bg-surface-neutral`.
+		background: var(--wpds-color-bg-surface-neutral-weak, #f4f4f4);
 	}
 
 	.jetpack-seo-preview__card-domain {

--- a/projects/packages/seo/changelog/fix-seo-sticky-header-tabs
+++ b/projects/packages/seo/changelog/fix-seo-sticky-header-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the SEO dashboard tab strip pinned while scrolling instead of letting it scroll away with the page content.

--- a/projects/packages/seo/changelog/update-seo-admin-page-style-tweaks
+++ b/projects/packages/seo/changelog/update-seo-admin-page-style-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Visual polish for the SEO admin pages: a slightly off-white (#fcfcfc) page canvas so the white settings cards stand out (matching the Newsletter, Social, and VideoPress dashboards), and a recessed gray body on the social link-preview card so its content reads apart from the card and the page.

--- a/projects/packages/seo/changelog/update-seo-admin-page-style-tweaks
+++ b/projects/packages/seo/changelog/update-seo-admin-page-style-tweaks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Visual polish for the SEO admin pages: a slightly off-white (#fcfcfc) page canvas so the white settings cards stand out (matching the Newsletter, Social, and VideoPress dashboards), and a recessed gray body on the social link-preview card so its content reads apart from the card and the page.
+Improve contrast on the SEO admin pages: add an off-white page canvas so the white content cards stand out, and give the social link-preview body a recessed gray so it reads apart from the card and the page.

--- a/projects/packages/seo/changelog/update-seo-off-white-page-canvas
+++ b/projects/packages/seo/changelog/update-seo-off-white-page-canvas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Give the SEO admin pages a slightly off-white (#fcfcfc) canvas so the white settings cards stand out against the background, matching the Newsletter, Social, and VideoPress dashboards. Applies to every tab.

--- a/projects/packages/seo/changelog/update-seo-off-white-page-canvas
+++ b/projects/packages/seo/changelog/update-seo-off-white-page-canvas
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Give the SEO admin pages a slightly off-white (#fcfcfc) canvas so the white settings cards stand out against the background, matching the Newsletter, Social, and VideoPress dashboards. Applies to every tab.


### PR DESCRIPTION
Fixes # N/A

Tracking issue: [JETPACK-1764](https://linear.app/a8c/issue/JETPACK-1764)

## Proposed changes

A few visual-polish tweaks to the modernized Jetpack **SEO** admin pages, so they read more clearly and stay consistent with the other recently-refreshed dashboards (Newsletter, Social, VideoPress).

* **Off-white page canvas** — paint the page shell `#fcfcfc` (via `--jetpack-seo-page-bg-canvas`) on every SEO tab so the white settings cards stand out instead of white-on-white. Matches the Newsletter/Social/VideoPress convention.
* **Social link-preview body contrast** — the `__card-body` (domain/title/description block) used `bg-surface-neutral`, which now matches the canvas and read as white on the white card. Stepped it to `bg-surface-neutral-weak` so it reads as a recessed panel, distinct from both the card and the page. The preview image is unchanged.
* **Sticky tab strip fix** — the dashboard tab strip scrolled away instead of staying pinned. SEO is route-based, so `Tabs.Root` wrapped only the strip and its sticky containing block was strip-height. Fixed by rendering the route content **inside** `Tabs.Root` (passed as `children`) — mirroring the Newsletter and VideoPress dashboards — so the strip's containing block spans the full page. `.jetpack-seo-tabs` is `flex: 0 0 auto` for the scrolling tabs, with a `:has(.jetpack-seo-page-content--flush)` branch that re-applies the layout mixin's fill treatment to the full-bleed DataViews **Content** tab so it is unchanged.

CSS + small markup change (content moved inside `Tabs.Root`); no behavior/logic changes.

## Related product discussion/links

* Tracking issue: JETPACK-1764 (Phase 1: Jetpack SEO — The Home Base → Fast Follow)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Install this PR's build (Jetpack Beta, by PR number) and go to **Jetpack → SEO**.
* **Canvas:** the background behind the cards reads faint off-white; white cards stand out; consistent across Overview / Settings / Content / AI; matches the Newsletter page.
* **Sticky tabs:** on a long tab (Settings or AI), scroll down — the tab strip stays pinned at the top the whole way.
* **Content tab (regression check):** open **Content** (the DataViews list) — confirm it still fills the width, loads, and behaves as before.
* **Preview body:** on **Settings**, the social (Facebook/X) link preview's lower content block should be a soft gray, clearly distinct from the white card and the page. The Google preview and the preview image are unchanged.
* Note: a separate, pre-existing washed-out look on WordPress.com (Dotcom) is environmental and out of scope here.
