### PR TITLE
Search Blocks: fix result and filter lists not rendering after results load

### DIFF
--- a/projects/packages/search/changelog/fix-search-blocks-data-wp-each-rerender
+++ b/projects/packages/search/changelog/fix-search-blocks-data-wp-each-rerender
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Fix result and filter lists rendering after results load.

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -101,7 +101,7 @@ $wrapper_attrs   = get_block_wrapper_attributes(
 		>
 			<template
 				data-wp-each--citation="state.aiVisibleCitations"
-				data-wp-key="context.citation.key"
+				data-wp-each-key="context.citation.key"
 			>
 				<li>
 					<a

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -161,7 +161,7 @@ if ( '' === $error_message ) {
 		<?php endfor; ?>
 		<template
 			data-wp-each--result="state.results"
-			data-wp-key="context.result.id"
+			data-wp-each-key="context.result.id"
 		>
 			<li
 				class="jetpack-search-results__item"
@@ -197,7 +197,7 @@ if ( '' === $error_message ) {
 							></span>
 							<template
 								data-wp-each--piece="context.result.titlePieces"
-								data-wp-key="context.piece.index"
+								data-wp-each-key="context.piece.index"
 							>
 								<span
 									data-wp-text="context.piece.text"
@@ -213,7 +213,7 @@ if ( '' === $error_message ) {
 						>
 							<template
 								data-wp-each--piece="context.result.contentPieces"
-								data-wp-key="context.piece.index"
+								data-wp-each-key="context.piece.index"
 							>
 								<span
 									data-wp-text="context.piece.text"

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -550,46 +550,38 @@ function recordResultRenders( results ) {
 }
 
 /**
- * Replace an array state slot without swapping its reference. The Interactivity
- * runtime observes `data-wp-each` updates reliably when the initially-bound
- * array is mutated in place.
+ * Replace an array state slot in place. The Interactivity runtime keeps
+ * re-rendering `data-wp-each` only while the initially-bound array is mutated;
+ * swapping the slot's reference silently stops updates. Both slots this touches
+ * (`results`) are declared as arrays on the initial state, so splicing is safe.
  *
  * @param {string} slot - State property name.
  * @param {Array}  next - Next array contents.
  * @return {Array} The live state array.
  */
 function replaceStateArray( slot, next ) {
-	const value = Array.isArray( next ) ? next : [];
-	if ( Array.isArray( state[ slot ] ) ) {
-		state[ slot ].splice( 0, state[ slot ].length, ...value );
-		return state[ slot ];
-	}
-	state[ slot ] = value;
+	state[ slot ].splice( 0, state[ slot ].length, ...next );
 	return state[ slot ];
 }
 
 /**
- * Replace an object state slot without swapping its reference.
+ * Replace an object state slot in place (same reason as replaceStateArray):
+ * drop keys missing from `next`, then assign the rest onto the existing object.
  *
  * @param {string} slot - State property name.
  * @param {object} next - Next object contents.
  * @return {object} The live state object.
  */
 function replaceStateObject( slot, next ) {
-	const value = next && typeof next === 'object' && ! Array.isArray( next ) ? next : {};
 	const current = state[ slot ];
-	if ( current === value ) {
-		return current;
-	}
-	if ( current && typeof current === 'object' && ! Array.isArray( current ) ) {
-		for ( const key of Object.keys( current ) ) {
+	const keep = new Set( Object.keys( next ) );
+	for ( const key of Object.keys( current ) ) {
+		if ( ! keep.has( key ) ) {
 			delete current[ key ];
 		}
-		Object.assign( current, value );
-		return current;
 	}
-	state[ slot ] = { ...value };
-	return state[ slot ];
+	Object.assign( current, next );
+	return current;
 }
 
 const { state, actions } = store( NAMESPACE, {

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -549,6 +549,49 @@ function recordResultRenders( results ) {
 	}
 }
 
+/**
+ * Replace an array state slot without swapping its reference. The Interactivity
+ * runtime observes `data-wp-each` updates reliably when the initially-bound
+ * array is mutated in place.
+ *
+ * @param {string} slot - State property name.
+ * @param {Array}  next - Next array contents.
+ * @return {Array} The live state array.
+ */
+function replaceStateArray( slot, next ) {
+	const value = Array.isArray( next ) ? next : [];
+	if ( Array.isArray( state[ slot ] ) ) {
+		state[ slot ].splice( 0, state[ slot ].length, ...value );
+		return state[ slot ];
+	}
+	state[ slot ] = value;
+	return state[ slot ];
+}
+
+/**
+ * Replace an object state slot without swapping its reference.
+ *
+ * @param {string} slot - State property name.
+ * @param {object} next - Next object contents.
+ * @return {object} The live state object.
+ */
+function replaceStateObject( slot, next ) {
+	const value = next && typeof next === 'object' && ! Array.isArray( next ) ? next : {};
+	const current = state[ slot ];
+	if ( current === value ) {
+		return current;
+	}
+	if ( current && typeof current === 'object' && ! Array.isArray( current ) ) {
+		for ( const key of Object.keys( current ) ) {
+			delete current[ key ];
+		}
+		Object.assign( current, value );
+		return current;
+	}
+	state[ slot ] = { ...value };
+	return state[ slot ];
+}
+
 const { state, actions } = store( NAMESPACE, {
 	state: {
 		// Mutually exclusive popovers — only one open at a time.
@@ -584,6 +627,13 @@ const { state, actions } = store( NAMESPACE, {
 		aiExtendedLoadingText: '',
 		aiShowExtended: false,
 		aiSessionId: null,
+
+		// Server state seeds these too, but declaring them on the client store
+		// gives `data-wp-each` directives stable containers before async fetches
+		// replace their contents.
+		results: [],
+		aggregations: {},
+		retainedFilterOptions: {},
 
 		// `resultsCountText` lives on seeded state (not a getter) so SSR can
 		// resolve `data-wp-text` to a real string on first paint. See
@@ -838,7 +888,7 @@ const { state, actions } = store( NAMESPACE, {
 				// Pre-resolve href so `data-wp-bind--href` reads a plain string.
 				href: /^https?:\/\//i.test( url ) ? url : '#',
 				// `index`-prefixed key so duplicate URLs don't collide on the IA
-				// `data-wp-each --key` dedupe pass.
+				// `data-wp-each-key` dedupe pass.
 				key: `${ index }-${ url }`,
 			} ) );
 		},
@@ -985,21 +1035,25 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken !== searchToken ) {
 					return;
 				}
-				state.results = ( data.results ?? [] ).map( ( r, i ) => ( {
+				const nextResults = ( data.results ?? [] ).map( ( r, i ) => ( {
 					...normalizeResult( r, state.locale, state.searchQuery ),
 					index: i,
 				} ) );
-				recordResultRenders( state.results );
+				replaceStateArray( 'results', nextResults );
+				recordResultRenders( nextResults );
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
-				state.aggregations = remapAggregationsToFilterKeys(
-					data.aggregations,
-					state.filterConfigs
+				replaceStateObject(
+					'aggregations',
+					remapAggregationsToFilterKeys( data.aggregations, state.filterConfigs )
 				);
-				state.retainedFilterOptions = mergeRetainedFilterOptions(
-					state.retainedFilterOptions,
-					state.aggregations,
-					state.filterConfigs
+				replaceStateObject(
+					'retainedFilterOptions',
+					mergeRetainedFilterOptions(
+						state.retainedFilterOptions,
+						state.aggregations,
+						state.filterConfigs
+					)
 				);
 				if ( syncUrl ) {
 					actions.syncToUrl();
@@ -1011,10 +1065,10 @@ const { state, actions } = store( NAMESPACE, {
 					// `role="alert"` error. `loadMore()` deliberately doesn't do
 					// this — its existing pages are still valid.
 					state.hasError = true;
-					state.results = [];
+					replaceStateArray( 'results', [] );
 					state.totalResults = 0;
 					state.pageHandle = null;
-					state.aggregations = {};
+					replaceStateObject( 'aggregations', {} );
 				}
 			} finally {
 				if ( myToken === searchToken ) {
@@ -1047,7 +1101,7 @@ const { state, actions } = store( NAMESPACE, {
 					...normalizeResult( r, state.locale, state.searchQuery ),
 					index: offset + i,
 				} ) );
-				state.results = [ ...state.results, ...appended ];
+				state.results.push( ...appended );
 				recordResultRenders( appended );
 				state.pageHandle = data.page_handle ?? null;
 			} catch {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -391,6 +391,113 @@ describe( 'store actions', () => {
 		expect( state.retainedFilterOptions.category ).toEqual( [ { value: 'news', label: 'News' } ] );
 	} );
 
+	it( 'overwrites a kept aggregation key in place when a re-search returns the same key', async () => {
+		// The happy-path stability test starts from `{}`, so it only exercises
+		// replaceStateObject's add branch. Here `category` is present in BOTH
+		// the prior and the next aggregations — proving the keep-branch
+		// overwrites the bucket contents while holding the same object
+		// reference (the load-bearing property for `data-wp-each`).
+		state.results = [];
+		state.aggregations = { category: { buckets: [ { key: 'old/Old', doc_count: 1 } ] } };
+		state.retainedFilterOptions = {};
+		state.filterConfigs = {
+			category: {
+				filterKey: 'category',
+				filterType: 'taxonomy',
+				taxonomy: 'category',
+				effectiveSlug: 'category',
+				maxItems: 10,
+			},
+		};
+		const aggregationsRef = state.aggregations;
+
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Fresh result' ) ],
+				total: 1,
+				page_handle: null,
+				aggregations: { category: { buckets: [ { key: 'news/News', doc_count: 4 } ] } },
+			} )
+		);
+
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect( state.aggregations ).toBe( aggregationsRef );
+		expect( state.aggregations.category.buckets ).toEqual( [ { key: 'news/News', doc_count: 4 } ] );
+	} );
+
+	it( 'drops an aggregation key absent from the next response while keeping the container reference', async () => {
+		// replaceStateObject's delete-stale branch: a prior response had both
+		// `category` and `tag`; the next response only returns `category`. The
+		// stale `tag` key must be deleted from the SAME object (not a fresh
+		// one), or a `data-wp-each` bound to it would render a ghost facet.
+		state.results = [];
+		state.aggregations = {
+			category: { buckets: [ { key: 'news/News', doc_count: 4 } ] },
+			tag: { buckets: [ { key: 'react/React', doc_count: 2 } ] },
+		};
+		state.retainedFilterOptions = {};
+		state.filterConfigs = {
+			category: {
+				filterKey: 'category',
+				filterType: 'taxonomy',
+				taxonomy: 'category',
+				effectiveSlug: 'category',
+				maxItems: 10,
+			},
+			tag: {
+				filterKey: 'tag',
+				filterType: 'taxonomy',
+				taxonomy: 'tag',
+				effectiveSlug: 'tag',
+				maxItems: 10,
+			},
+		};
+		const aggregationsRef = state.aggregations;
+
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Fresh result' ) ],
+				total: 1,
+				page_handle: null,
+				aggregations: { category: { buckets: [ { key: 'updates/Updates', doc_count: 7 } ] } },
+			} )
+		);
+
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect( state.aggregations ).toBe( aggregationsRef );
+		expect( state.aggregations.category.buckets ).toEqual( [
+			{ key: 'updates/Updates', doc_count: 7 },
+		] );
+		expect( Object.hasOwn( state.aggregations, 'tag' ) ).toBe( false );
+	} );
+
+	it( 'appends loadMore() results in place, keeping the results array reference', async () => {
+		// loadMore does `state.results.push( ...appended )` rather than
+		// reassigning, so the each-bound array keeps its reference and the
+		// runtime keeps re-rendering. Without this the second page would
+		// silently never paint.
+		state.results = [ { id: 'page1-1', title: 'Page 1 result', index: 0 } ];
+		state.pageHandle = 'next-page';
+		const resultsRef = state.results;
+
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Page 2 result' ) ],
+				page_handle: 'page-3',
+			} )
+		);
+
+		await runGenerator( actions.loadMore() );
+
+		expect( state.results ).toBe( resultsRef );
+		expect( state.results ).toHaveLength( 2 );
+		expect( state.results[ 0 ].title ).toBe( 'Page 1 result' );
+		expect( state.results[ 1 ].title ).toBe( 'Page 2 result' );
+		expect( state.pageHandle ).toBe( 'page-3' );
+	} );
+
 	it( 'leaves the existing results in place when loadMore() errors out', async () => {
 		// loadMore failures must not clear the first-page results — they're
 		// still valid; only the *next* page failed to fetch. The success

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -281,14 +281,18 @@ describe( 'store actions', () => {
 		state.pageHandle = 'old-page';
 		state.aggregations = { category: { buckets: [ { key: 'news', doc_count: 3 } ] } };
 		state.hasError = false;
+		const resultsRef = state.results;
+		const aggregationsRef = state.aggregations;
 
 		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) );
 		await runGenerator( actions.search( { syncUrl: false } ) );
 
 		expect( state.hasError ).toBe( true );
+		expect( state.results ).toBe( resultsRef );
 		expect( state.results ).toEqual( [] );
 		expect( state.totalResults ).toBe( 0 );
 		expect( state.pageHandle ).toBeNull();
+		expect( state.aggregations ).toBe( aggregationsRef );
 		expect( state.aggregations ).toEqual( {} );
 		// `resultsCountText` reads from `totalResults` via `computeResultsCountText`,
 		// so an empty count string falls out for free — no extra wiring.
@@ -344,6 +348,47 @@ describe( 'store actions', () => {
 		// Slot key must not leak into state — downstream readers key off
 		// `filterKey`, never `effectiveSlug`.
 		expect( state.aggregations[ 'jetpack-search-tag1' ] ).toBeUndefined();
+	} );
+
+	it( 'keeps each-bound result and aggregation containers stable when search() resolves', async () => {
+		state.results = [];
+		state.aggregations = {};
+		state.retainedFilterOptions = {};
+		state.filterConfigs = {
+			category: {
+				filterKey: 'category',
+				filterType: 'taxonomy',
+				taxonomy: 'category',
+				effectiveSlug: 'category',
+				maxItems: 10,
+			},
+		};
+		const resultsRef = state.results;
+		const aggregationsRef = state.aggregations;
+		const retainedRef = state.retainedFilterOptions;
+
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Fresh result' ) ],
+				total: 1,
+				page_handle: null,
+				aggregations: {
+					category: {
+						buckets: [ { key: 'news/News', doc_count: 4 } ],
+					},
+				},
+			} )
+		);
+
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect( state.results ).toBe( resultsRef );
+		expect( state.results ).toHaveLength( 1 );
+		expect( state.results[ 0 ].title ).toBe( 'Fresh result' );
+		expect( state.aggregations ).toBe( aggregationsRef );
+		expect( state.aggregations.category.buckets[ 0 ].key ).toBe( 'news/News' );
+		expect( state.retainedFilterOptions ).toBe( retainedRef );
+		expect( state.retainedFilterOptions.category ).toEqual( [ { value: 'news', label: 'News' } ] );
 	} );
 
 	it( 'leaves the existing results in place when loadMore() errors out', async () => {

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -147,6 +147,8 @@ class Ai_Answer_Render_Test extends TestCase {
 	public function test_show_citations_true_renders_citations_list() {
 		$markup = $this->render( array( 'showCitations' => true ) );
 		$this->assertStringContainsString( 'jp-search-answers-panel__citations', $markup );
+		$this->assertStringContainsString( 'data-wp-each-key="context.citation.key"', $markup );
+		$this->assertStringNotContainsString( 'data-wp-key=', $markup );
 	}
 
 	public function test_show_citations_false_omits_citations_list() {

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -218,6 +218,17 @@ class Results_List_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'context.result.contentPieces', $markup );
 	}
 
+	public function test_each_templates_use_interactivity_each_keys() {
+		$markup = $this->render( array( 'layout' => 'expanded' ) );
+
+		$this->assertStringContainsString( 'data-wp-each--result="state.results"', $markup );
+		$this->assertStringContainsString( 'data-wp-each-key="context.result.id"', $markup );
+		$this->assertStringContainsString( 'data-wp-each--piece="context.result.titlePieces"', $markup );
+		$this->assertStringContainsString( 'data-wp-each--piece="context.result.contentPieces"', $markup );
+		$this->assertStringContainsString( 'data-wp-each-key="context.piece.index"', $markup );
+		$this->assertStringNotContainsString( 'data-wp-key=', $markup );
+	}
+
 	/**
 	 * Compact layout should NOT render the content-snippet section — the
 	 * dense single-line row only carries a title and a date.


### PR DESCRIPTION
Related to FG-38

## What

Fix the Search Blocks result list and filter buckets rendering empty after results load.

## Why

Once `@wordpress/interactivity` is supplied by the host runtime (externalized from the build), the `data-wp-each` directive stops re-rendering a list when the bound array's **reference is replaced** after the initial render. The store replaced the arrays on every search (`state.results = ( data.results ?? [] ).map( ... )`, `state.aggregations = remapAggregationsToFilterKeys( ... )`).

At hydration `state.results` is the empty seeded array, so the each subscribes to that array instance and renders zero items. The fetch then assigns a brand-new array, so the each never re-renders — even though the store data, the result count, and scalar (`data-wp-text` / `data-wp-bind`) bindings all update correctly. Result: the results list and the filter buckets stay empty.

## Fix

- **Mutate the each-bound arrays/objects in place** instead of reassigning, so the runtime keeps tracking the same container — `results`, `aggregations`, `retainedFilterOptions`, and `loadMore`'s append (`replaceStateArray` / `replaceStateObject`). This is the load-bearing change.
- Declare those slots in the client store `state` so there is always a stable container.
- Correct the result/citation templates' `data-wp-key` → `data-wp-each-key`; `data-wp-each` reads its key from its own `each-key` directive, so `data-wp-key` on the `<template>` was a no-op.

## Testing

- Added a store test asserting the each-bound containers keep their reference (in-place mutation) with updated contents after `search()`; all search-blocks JS tests pass (597).
- Verified end-to-end against a live page running the host Interactivity runtime that exhibits the bug: with the fix, the result list and filter facets render again (before: skeletons only / zero items; after: full results + facets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
