### PR TITLE
Premium Analytics: align Stats normalizers with legacy rows

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-stats-normalizer-calypso-parity
+++ b/projects/packages/premium-analytics/changelog/fix-stats-normalizer-calypso-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Align traffic normalizer row metadata with legacy Stats behavior.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -103,4 +103,38 @@ describe( 'Stats clicks normalizer', () => {
 			} )
 		);
 	} );
+
+	it( 'removes only the first parent-name occurrence from child labels', () => {
+		const result = sanitizeStatsClicksResponse(
+			{
+				date: '2026-06-22',
+				days: {
+					'2026-06-16': {
+						clicks: [
+							{
+								name: 'example.com',
+								views: 1,
+								children: [
+									{
+										name: 'example.com/path/example.com',
+										views: 1,
+									},
+								],
+							},
+						],
+					},
+				},
+			},
+			{
+				end_date: '2026-06-16',
+			}
+		);
+
+		expect( result.data[ 0 ].items[ 0 ].children?.[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: '/path/example.com',
+				views: 1,
+			} )
+		);
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
@@ -169,4 +169,44 @@ describe( 'Stats referrers normalizer', () => {
 			} ),
 		] );
 	} );
+
+	it( 'adds spam actions when referrer URLs include the group name', () => {
+		const result = sanitizeStatsReferrersResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					groups: [
+						{
+							name: 'example.com',
+							group: 'Example Domain',
+							total: 3,
+							url: 'https://example.com/source',
+							results: [
+								{
+									name: 'Example landing page',
+									views: 3,
+									url: 'https://example.com/source',
+								},
+							],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'Example landing page',
+				actions: [ { type: 'spam', data: { domain: 'example.com' } } ],
+				actionMenu: 1,
+			} ),
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
@@ -93,4 +93,80 @@ describe( 'Stats referrers normalizer', () => {
 			],
 		} );
 	} );
+
+	it( 'strips parent names from nested referrer labels', () => {
+		const result = sanitizeStatsReferrersResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					groups: [
+						{
+							name: 'Search Engines',
+							total: 2,
+							results: [
+								{
+									name: 'Google Search',
+									views: 2,
+									children: [
+										{ name: 'Google Search', views: 1, url: 'https://www.google.com/' },
+										{
+											name: 'Google Search google.com/search',
+											views: 1,
+											url: 'https://www.google.com/search',
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items[ 0 ].children ).toEqual( [
+			expect.objectContaining( { label: '/' } ),
+			expect.objectContaining( { label: ' google.com/search' } ),
+		] );
+	} );
+
+	it( 'only adds spam actions to legacy-eligible referrer rows', () => {
+		const result = sanitizeStatsReferrersResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					groups: [
+						{ name: 'example.com', group: 'example.com', total: 3 },
+						{ name: 'Search Engines', group: 'Search Engines', total: 2 },
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'example.com',
+				actions: [ { type: 'spam', data: { domain: 'example.com' } } ],
+				actionMenu: 1,
+			} ),
+			expect.objectContaining( {
+				label: 'Search Engines',
+				actions: [],
+				actionMenu: 0,
+			} ),
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
@@ -209,4 +209,37 @@ describe( 'Stats referrers normalizer', () => {
 			} ),
 		] );
 	} );
+
+	it( 'does not add spam actions when referrer URLs exclude the group name', () => {
+		const result = sanitizeStatsReferrersResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					groups: [
+						{
+							name: 'example.com',
+							group: 'Example Domain',
+							total: 3,
+							url: 'https://partner.test/source',
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'example.com',
+				actions: [],
+				actionMenu: 0,
+			} ),
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
@@ -65,4 +65,36 @@ describe( 'Stats top authors normalizer', () => {
 			} )
 		);
 	} );
+
+	it( 'does not add link actions when author posts have no URL', () => {
+		const result = sanitizeStatsTopAuthorsResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					authors: [
+						{
+							name: 'Jetpack Team',
+							views: 3,
+							posts: [ { id: 123, title: 'Homepage', views: 3 } ],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items[ 0 ].children ).toEqual( [
+			expect.objectContaining( {
+				label: 'Homepage',
+				link: null,
+				actions: [],
+			} ),
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
@@ -25,6 +25,7 @@ describe( 'Stats top authors normalizer', () => {
 						label: 'Homepage',
 						views: 4157,
 						link: 'https://example.com/?p=265143',
+						actions: [ { type: 'link', data: 'https://example.com/?p=265143' } ],
 					} ),
 					expect.objectContaining( {
 						id: 345724,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
@@ -14,6 +14,7 @@ describe( 'Stats video plays normalizer', () => {
 				label: 'Launch video',
 				plays: 11,
 				link: 'https://example.com/video/',
+				actions: [ { type: 'link', data: 'https://example.com/video/' } ],
 			} )
 		);
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts
@@ -48,4 +48,36 @@ describe( 'Stats video plays normalizer', () => {
 			} )
 		);
 	} );
+
+	it( 'does not add link actions when video rows have no URL', () => {
+		const result = sanitizeStatsVideoPlaysResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				days: {
+					'2026-06-22': {
+						plays: [
+							{
+								post_id: 12,
+								title: 'Launch video',
+								plays: 11,
+							},
+						],
+					},
+				},
+			},
+			{
+				period: 'day',
+				end_date: '2026-06-22',
+			}
+		);
+
+		expect( result.data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'Launch video',
+				link: null,
+				actions: [],
+			} )
+		);
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
@@ -28,7 +28,7 @@ export function sanitizeStatsClicksResponse(
 		children: mapNestedItems( coerceStatsArray( item.children ), child => ( {
 			label:
 				typeof child.name === 'string' && typeof item.name === 'string' && item.name
-					? child.name.split( item.name ).join( '' ) || '/'
+					? child.name.replace( item.name, '' ) || '/'
 					: '/',
 			views: safeParseFloat( child.views ),
 			link: typeof child.url === 'string' ? child.url : null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
@@ -26,14 +26,22 @@ export function sanitizeStatsReferrersResponse(
 	response: unknown,
 	query?: StatsQueryParams
 ): StatsNormalizedReport< StatsReferrersItem > {
-	const parse = ( item: StatsRecord ): StatsReferrersItem => ( {
-		label: item.name ?? item.group ?? '',
-		views: safeParseFloat( item.views ?? item.total ),
-		link: typeof item.url === 'string' ? item.url : null,
-		icon: typeof item.icon === 'string' ? item.icon : null,
-		labelIcon: item.results || item.children ? null : 'external',
-		children: mapNestedItems( coerceStatsArray( item.results ?? item.children ), parse ),
-	} );
+	const parse = ( item: StatsRecord, parentName?: string ): StatsReferrersItem => {
+		const name = typeof item.name === 'string' ? item.name : undefined;
+		const label = name ?? item.group ?? '';
+
+		return {
+			label:
+				parentName && typeof label === 'string' ? label.replace( parentName, '' ) || '/' : label,
+			views: safeParseFloat( item.views ?? item.total ),
+			link: typeof item.url === 'string' ? item.url : null,
+			icon: typeof item.icon === 'string' ? item.icon : null,
+			labelIcon: item.results || item.children ? null : 'external',
+			children: mapNestedItems( coerceStatsArray( item.results ?? item.children ), child =>
+				parse( child, name )
+			),
+		};
+	};
 
 	return {
 		summary: normalizeStatsReportSummary( response, query, [ 'groups' ] ),
@@ -41,8 +49,12 @@ export function sanitizeStatsReferrersResponse(
 			const results = coerceStatsArray< StatsRecord >( item.results );
 			// Single-result groups display as the result itself, matching the legacy Stats UI.
 			const normalized = parse( results.length === 1 ? results[ 0 ] : item );
-			const domain = item.name ?? item.group;
-			const canSpam = typeof domain === 'string' && domain.includes( '.' );
+			const domain = typeof item.name === 'string' ? item.name : item.group;
+			const url = typeof item.url === 'string' ? item.url : undefined;
+			const canSpam =
+				typeof item.name === 'string' &&
+				( ( url && url.includes( item.name ) ) ||
+					( ! url && item.name === item.group && item.name.includes( '.' ) ) );
 
 			return {
 				...normalized,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
@@ -34,6 +34,7 @@ export function sanitizeStatsTopAuthorsResponse(
 				views: safeParseFloat( post.views ),
 				link: typeof post.url === 'string' ? post.url : null,
 				page: post.id ? `/stats/post/${ post.id }` : null,
+				actions: typeof post.url === 'string' ? [ { type: 'link', data: post.url } ] : [],
 				children: null,
 			} ) ),
 		} ) ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/video-plays.ts
@@ -9,6 +9,7 @@ import {
 	normalizeStatsSummary,
 } from './utils';
 import type {
+	StatsItemAction,
 	StatsNormalizedDataPoint,
 	StatsNormalizedItemBase,
 	StatsNormalizedReport,
@@ -23,6 +24,7 @@ export type StatsVideoPlaysItem = StatsNormalizedItemBase & {
 	watch_time: number;
 	retention_rate: number;
 	link: string | null;
+	actions?: StatsItemAction[];
 	children: null;
 };
 
@@ -42,6 +44,7 @@ export function sanitizeStatsVideoPlaysResponse(
 		watch_time: safeParseFloat( item.watch_time ),
 		retention_rate: safeParseFloat( item.retention_rate ),
 		link: typeof item.url === 'string' ? item.url : null,
+		actions: typeof item.url === 'string' ? [ { type: 'link', data: item.url } ] : [],
 		children: null,
 	} );
 	const getSummarySource = () => {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Align Stats traffic row metadata with the legacy Calypso Stats list normalizers.
* Strip parent names from nested referrer labels and preserve the legacy spam-action eligibility logic.
* Preserve link actions for top-author post children and video-play rows.
* Match legacy click child-label behavior by removing only the first parent-name occurrence.
* Add regression tests for the adjusted row metadata.

## Related product discussion/links
* Follow-up to #49779 after comparing the new data layer with the legacy Calypso Stats list normalizers.

## Does this pull request change what data or activity we track or use?
No. This only adjusts client-side normalization of existing Stats API response data.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand projects/packages/premium-analytics/packages/data/src/processing/stats`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm run lint-file projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts projects/packages/premium-analytics/packages/data/src/processing/stats/video-plays.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/video-plays.test.ts --max-warnings=0`.
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
