### PR TITLE
Premium Analytics: resolve full ISO Stats dates to the site timezone

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-stats-iso-dates
+++ b/projects/packages/premium-analytics/changelog/fix-stats-iso-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: resolve full ISO from/to dates to the site timezone before reducing them to the date-only range the Stats backend expects.

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -39,6 +39,64 @@ describe( 'reportParamsToStatsQueryParams', () => {
 		);
 	} );
 
+	it( 'resolves offset-bearing dates to the matching calendar day in the site timezone', () => {
+		// 23:00 on 2026-06-23 at -08:00 is 2026-06-24 12:30 in +05:30, so both bounds shift forward a day.
+		expect(
+			reportParamsToStatsQueryParams(
+				{
+					from: '2026-06-23T23:00:00-08:00',
+					to: '2026-06-24T23:00:00-08:00',
+					interval: 'day',
+				},
+				'+05:30'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				start_date: '2026-06-24',
+				end_date: '2026-06-25',
+				days: 2,
+			} )
+		);
+	} );
+
+	it( 'treats the end date as an inclusive calendar day', () => {
+		expect(
+			reportParamsToStatsQueryParams(
+				{
+					from: '2026-06-01T00:00:00Z',
+					to: '2026-06-01T00:00:00Z',
+					interval: 'day',
+				},
+				'+00:00'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				start_date: '2026-06-01',
+				end_date: '2026-06-01',
+				days: 1,
+			} )
+		);
+	} );
+
+	it( 'passes timezone-naive and date-only inputs through as written', () => {
+		expect(
+			reportParamsToStatsQueryParams(
+				{
+					from: '2026-06-01',
+					to: '2026-06-07T23:59:59',
+					interval: 'day',
+				},
+				'+05:30'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				start_date: '2026-06-01',
+				end_date: '2026-06-07',
+				days: 7,
+			} )
+		);
+	} );
+
 	it( 'maps the semantic end date to the Stats API date param', () => {
 		expect(
 			statsQueryParamsToApiParams( {

--- a/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
@@ -9,8 +9,9 @@ import { localTZDate } from './date';
 import type { IntervalType } from './search';
 
 export function getDaysBetweenInclusive( from: string, to: string ): number {
-	const fromDate = new Date( `${ from }T00:00:00Z` );
-	const toDate = new Date( `${ to }T00:00:00Z` );
+	// Compare calendar days only; tolerate full ISO inputs by dropping any time component.
+	const fromDate = new Date( `${ from.split( 'T' )[ 0 ] }T00:00:00Z` );
+	const toDate = new Date( `${ to.split( 'T' )[ 0 ] }T00:00:00Z` );
 	const days = differenceInCalendarDays( toDate, fromDate );
 
 	if ( Number.isNaN( days ) || days < 0 ) {

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -1,6 +1,11 @@
 /**
+ * External dependencies
+ */
+import { formatToTimezoneNaiveString } from '@jetpack-premium-analytics/datetime';
+/**
  * Internal dependencies
  */
+import { getSiteTimezone, localTZDate } from './date';
 import { getDaysBetweenInclusive } from './interval';
 import type { ReportParams } from './search';
 import type { StatsProxyParams } from '../api/stats-proxy-fetch';
@@ -45,8 +50,27 @@ const reportOnlyKeys: ReportOnlyParam[] = [
 	'deviceProperty',
 ];
 
-function datePart( value?: string ) {
-	return value?.split( 'T' )[ 0 ];
+function hasTimeZoneDesignator( value: string ): boolean {
+	const timePart = value.split( 'T' )[ 1 ] ?? '';
+	return /[zZ]|[+-]\d{2}:?\d{2}$/.test( timePart );
+}
+
+/*
+ * The Stats backend interprets date boundaries in the site's timezone, so a full ISO `from` / `to`
+ * has to be resolved to the matching calendar day in that timezone before it is reduced to a date.
+ * Date-only and timezone-naive inputs already carry the intended calendar day, so they pass through
+ * verbatim; only offset-bearing inputs (`Z` / `±hh:mm`) need conversion.
+ */
+function toSiteCalendarDate( value: string | undefined, timezone: string ): string | undefined {
+	if ( ! value ) {
+		return undefined;
+	}
+
+	if ( ! hasTimeZoneDesignator( value ) ) {
+		return value.split( 'T' )[ 0 ];
+	}
+
+	return formatToTimezoneNaiveString( localTZDate( value, timezone ), timezone ).split( 'T' )[ 0 ];
 }
 
 export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
@@ -67,16 +91,18 @@ export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
 }
 
 export function reportParamsToStatsQueryParams(
-	params: StatsQueryParamInput = {}
+	params: StatsQueryParamInput = {},
+	timezone?: string
 ): StatsQueryParams {
+	const tz = timezone ?? getSiteTimezone();
 	const statsParams = { ...params };
 
 	reportOnlyKeys.forEach( key => {
 		delete statsParams[ key ];
 	} );
 
-	const from = datePart( params.from );
-	const to = datePart( params.to );
+	const from = toSiteCalendarDate( params.from, tz );
+	const to = toSiteCalendarDate( params.to, tz );
 	const period = params.period ?? getStatsPeriodFromInterval( params.interval );
 	const endDate = params.end_date ?? params.date ?? to;
 	const startDate = params.start_date ?? from;


### PR DESCRIPTION
## Why this matters

The premium-analytics Stats data layer accepts full ISO `from`/`to` dates (so callers can drive Stats and Woo report hooks from the same date range), but the Stats backend interprets date boundaries in the **site timezone**. Before this change, an offset-bearing range like `2026-06-23T23:00:00-08:00` was reduced with a naive `split('T')[0]`, keeping whatever offset the string carried — so at day boundaries the request landed on the wrong calendar day and returned data for the wrong day.

## Proposed changes
* `reportParamsToStatsQueryParams()` now resolves offset-bearing `from`/`to` (`Z` / `±hh:mm`) into the site timezone before reducing them to the date-only range the Stats backend expects. Date-only and timezone-naive inputs pass through unchanged.
* Added an optional `timezone` argument (defaults to `getSiteTimezone()`) so the conversion is unit-testable without mocking the core-data store.
* Hardened `getDaysBetweenInclusive()` to tolerate full ISO inputs (drops any time component) so a future caller can't silently regress the day count.

## Related product discussion/links
* [WOOA7S-1580](https://linear.app/a8c/issue/WOOA7S-1580/premium-analytics-support-full-iso-fromto-dates-in-stats-data-layer)
* Follow-up to the Stats proxy data layer work ([WOOA7S-1571](https://linear.app/a8c/issue/WOOA7S-1571/premium-analytics-add-stats-proxy-data-hooks)): #49775, #49776, #49777, #49778

## Does this pull request change what data or activity we track or use?
No. It only corrects how an existing date range is normalized before it is sent to the Stats API.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm test packages/data/src/utils/__tests__/stats-params.test.ts`
* Confirm the new cases pass:
  * An offset-bearing range that crosses midnight relative to the site timezone shifts to the correct calendar day (e.g. `2026-06-23T23:00:00-08:00` with site TZ `+05:30` → `2026-06-24`).
  * The end date is treated as an inclusive calendar day.
  * Date-only and timezone-naive inputs are unchanged.
