### PR TITLE
Premium Analytics: add Top Posts primary metric adapter

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1585-top-posts-row-contract
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1585-top-posts-row-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Top Posts: Add opt-in primary value fields for Stats rows.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-top-posts.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-top-posts.test.ts
@@ -1,0 +1,44 @@
+import { sanitizeStatsTopPostsResponse } from '../../processing/stats';
+import { topPostsSummaryFixture } from '../../processing/stats/__fixtures__/top-posts';
+import { withStatsTopPostsPrimaryMetric } from '../use-stats-top-posts';
+
+describe( 'useStatsTopPosts adapters', () => {
+	it( 'returns the normalized report unchanged when no primary metric is requested', () => {
+		const report = sanitizeStatsTopPostsResponse( topPostsSummaryFixture, {
+			period: 'day',
+			start_date: '2026-06-16',
+			end_date: '2026-06-22',
+			summarize: true,
+		} );
+
+		expect( withStatsTopPostsPrimaryMetric( report, undefined ) ).toBe( report );
+	} );
+
+	it( 'adds opt-in primary value fields without replacing semantic top-posts fields', () => {
+		const report = sanitizeStatsTopPostsResponse( topPostsSummaryFixture, {
+			period: 'day',
+			start_date: '2026-06-16',
+			end_date: '2026-06-22',
+			summarize: true,
+		} );
+
+		const result = withStatsTopPostsPrimaryMetric( report, {
+			primaryMetric: 'views',
+			primaryMetricLabel: 'Views',
+		} );
+		const item = result?.data[ 0 ].items[ 0 ];
+
+		expect( item ).toEqual(
+			expect.objectContaining( {
+				label: 'Homepage',
+				views: 4157,
+				value: 4157,
+				valueKey: 'views',
+				valueLabel: 'Views',
+				link: 'https://example.com/home-2/',
+				href: 'https://example.com/home-2/',
+			} )
+		);
+		expect( report.data[ 0 ].items[ 0 ] ).not.toHaveProperty( 'value' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -6,7 +6,7 @@ export { useReportCustomers } from './use-report-customers';
 export { useReportConversionRate } from './use-report-conversion-rate';
 export { useReportBookings } from './use-report-bookings';
 export { useStatsSite } from './use-stats-site';
-export { useStatsTopPosts } from './use-stats-top-posts';
+export { useStatsTopPosts, withStatsTopPostsPrimaryMetric } from './use-stats-top-posts';
 export { useStatsReferrers } from './use-stats-referrers';
 export { useStatsClicks } from './use-stats-clicks';
 export { useStatsSearchTerms } from './use-stats-search-terms';
@@ -16,6 +16,12 @@ export { useStatsLocations } from './use-stats-locations';
 export { useStatsCountryViews } from './use-stats-country-views';
 export { useStatsVideoPlays } from './use-stats-video-plays';
 export type { UseStatsOptions } from './use-stats-report';
+export type {
+	StatsTopPostsPrimaryMetric,
+	StatsTopPostsPrimaryMetricOptions,
+	StatsTopPostsPrimaryValueItem,
+	UseStatsTopPostsOptions,
+} from './use-stats-top-posts';
 
 /**
  * @deprecated Use individual hooks instead: useReportOrders, useReportOrderAttribution, useReportCoupons

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
@@ -1,11 +1,176 @@
 /**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+/**
  * Internal dependencies
  */
 import { statsTopPostsQuery } from '../queries/stats-top-posts-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type {
+	StatsNormalizedDataPoint,
+	StatsNormalizedReport,
+	StatsTopPostsItem,
+} from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsTopPosts( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport( statsTopPostsQuery, params, 'top-posts', options );
+type NumericStatsTopPostsKey = {
+	[ Key in keyof StatsTopPostsItem ]: StatsTopPostsItem[ Key ] extends number ? Key : never;
+}[ keyof StatsTopPostsItem ];
+
+export type StatsTopPostsPrimaryMetric = NumericStatsTopPostsKey;
+
+export type StatsTopPostsPrimaryMetricOptions<
+	TMetric extends StatsTopPostsPrimaryMetric = StatsTopPostsPrimaryMetric,
+> = {
+	/**
+	 * Numeric top-posts field to expose as the generic `value`.
+	 */
+	primaryMetric: TMetric;
+	/**
+	 * Display label for the chosen metric.
+	 */
+	primaryMetricLabel: string;
+};
+
+export type StatsTopPostsPrimaryValueItem<
+	TMetric extends StatsTopPostsPrimaryMetric = StatsTopPostsPrimaryMetric,
+> = Omit< StatsTopPostsItem, 'children' > & {
+	value: number;
+	valueKey: TMetric;
+	valueLabel: string;
+	href: string | null;
+	children: Array< StatsTopPostsPrimaryValueItem< TMetric > > | null;
+};
+
+export type UseStatsTopPostsOptions<
+	TMetric extends StatsTopPostsPrimaryMetric = StatsTopPostsPrimaryMetric,
+> = UseStatsOptions &
+	(
+		| {
+				primaryMetric?: undefined;
+				primaryMetricLabel?: undefined;
+		  }
+		| StatsTopPostsPrimaryMetricOptions< TMetric >
+	);
+
+type UseStatsReportResult = ReturnType< typeof useStatsReport >;
+
+type UseStatsTopPostsResult< TItem extends StatsTopPostsItem > = Omit<
+	UseStatsReportResult,
+	'primary' | 'comparison'
+> & {
+	primary: Omit< UseStatsReportResult[ 'primary' ], 'data' > & {
+		data: StatsNormalizedReport< TItem > | undefined;
+	};
+	comparison: Omit< UseStatsReportResult[ 'comparison' ], 'data' > & {
+		data: StatsNormalizedReport< TItem > | undefined;
+	};
+};
+
+function withPrimaryMetricItem< TMetric extends StatsTopPostsPrimaryMetric >(
+	item: StatsTopPostsItem,
+	options: StatsTopPostsPrimaryMetricOptions< TMetric >
+): StatsTopPostsPrimaryValueItem< TMetric > {
+	return {
+		...item,
+		value: item[ options.primaryMetric ],
+		valueKey: options.primaryMetric,
+		valueLabel: options.primaryMetricLabel,
+		href: item.link,
+		children: item.children?.map( child => withPrimaryMetricItem( child, options ) ) ?? null,
+	};
+}
+
+export function withStatsTopPostsPrimaryMetric<
+	TMetric extends StatsTopPostsPrimaryMetric = StatsTopPostsPrimaryMetric,
+>(
+	report: StatsNormalizedReport< StatsTopPostsItem > | undefined,
+	options: StatsTopPostsPrimaryMetricOptions< TMetric > | undefined
+): StatsNormalizedReport< StatsTopPostsPrimaryValueItem< TMetric > > | undefined {
+	if ( ! report || ! options ) {
+		return report as StatsNormalizedReport< StatsTopPostsPrimaryValueItem< TMetric > > | undefined;
+	}
+
+	return {
+		...report,
+		data: report.data.map(
+			( point ): StatsNormalizedDataPoint< StatsTopPostsPrimaryValueItem< TMetric > > => ( {
+				...point,
+				items: point.items.map( item => withPrimaryMetricItem( item, options ) ),
+			} )
+		),
+	};
+}
+
+export function useStatsTopPosts< TMetric extends StatsTopPostsPrimaryMetric >(
+	params: StatsReportParams,
+	options: UseStatsOptions & StatsTopPostsPrimaryMetricOptions< TMetric >
+): UseStatsTopPostsResult< StatsTopPostsPrimaryValueItem< TMetric > >;
+
+export function useStatsTopPosts(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseStatsTopPostsResult< StatsTopPostsItem >;
+
+export function useStatsTopPosts<
+	TMetric extends StatsTopPostsPrimaryMetric = StatsTopPostsPrimaryMetric,
+>(
+	params: StatsReportParams,
+	options?: UseStatsTopPostsOptions< TMetric >
+):
+	| UseStatsTopPostsResult< StatsTopPostsItem >
+	| UseStatsTopPostsResult< StatsTopPostsPrimaryValueItem< TMetric > > {
+	const report = useStatsReport(
+		statsTopPostsQuery,
+		params,
+		'top-posts',
+		options
+	) as UseStatsTopPostsResult< StatsTopPostsItem >;
+	const primaryMetric = options?.primaryMetric;
+	const primaryMetricLabel = options?.primaryMetricLabel;
+	const primaryMetricOptions = useMemo( () => {
+		if ( ! primaryMetric ) {
+			return undefined;
+		}
+
+		return {
+			primaryMetric,
+			primaryMetricLabel,
+		} as StatsTopPostsPrimaryMetricOptions< TMetric >;
+	}, [ primaryMetric, primaryMetricLabel ] );
+
+	const primaryData = useMemo(
+		() =>
+			withStatsTopPostsPrimaryMetric(
+				report.primary.data as StatsNormalizedReport< StatsTopPostsItem > | undefined,
+				primaryMetricOptions
+			),
+		[ report.primary.data, primaryMetricOptions ]
+	);
+	const comparisonData = useMemo(
+		() =>
+			withStatsTopPostsPrimaryMetric(
+				report.comparison.data as StatsNormalizedReport< StatsTopPostsItem > | undefined,
+				primaryMetricOptions
+			),
+		[ report.comparison.data, primaryMetricOptions ]
+	);
+
+	if ( ! primaryMetricOptions ) {
+		return report;
+	}
+
+	return {
+		...report,
+		primary: {
+			...report.primary,
+			data: primaryData,
+		},
+		comparison: {
+			...report.comparison,
+			data: comparisonData,
+		},
+	} as UseStatsTopPostsResult< StatsTopPostsPrimaryValueItem< TMetric > >;
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -15,7 +15,7 @@ export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-loca
 export { useReportBookings } from './hooks/use-report-bookings';
 export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
 export { useStatsSite } from './hooks/use-stats-site';
-export { useStatsTopPosts } from './hooks/use-stats-top-posts';
+export { useStatsTopPosts, withStatsTopPostsPrimaryMetric } from './hooks/use-stats-top-posts';
 export { useStatsReferrers } from './hooks/use-stats-referrers';
 export { useStatsClicks } from './hooks/use-stats-clicks';
 export { useStatsSearchTerms } from './hooks/use-stats-search-terms';
@@ -57,6 +57,12 @@ export type {
 	StatsProxyParams,
 	StatsProxyVersion,
 } from './api';
+export type {
+	StatsTopPostsPrimaryMetric,
+	StatsTopPostsPrimaryMetricOptions,
+	StatsTopPostsPrimaryValueItem,
+	UseStatsTopPostsOptions,
+} from './hooks/use-stats-top-posts';
 export type {
 	StatsClicksItem,
 	StatsFileDownloadsItem,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1585/premium-analytics-align-top-posts-stats-row-data-contract

## Why
Top Posts data should keep the Stats endpoint's semantic fields, while chart consumers still need a generic primary value. This gives consumers an opt-in `value` contract without pushing display-specific fields into every normalized Stats response.

## Proposed changes
* Add an opt-in primary metric adapter to `useStatsTopPosts`.
* Preserve semantic Top Posts fields like `views` and `link`, and add `value`, `valueKey`, `valueLabel`, and `href` only when a primary metric is requested.
* Export the adapter helper and related types from the data package.
* Add regression tests for unchanged default reports and adapted primary-value rows.

## Verification
Confirmed with unit tests, typecheck, builds, and local WordPress reachability.

<details>
<summary>Output</summary>

```text
$ CI=true pnpm --dir projects/packages/premium-analytics test --runInBand packages/data/src/hooks/__tests__/use-stats-top-posts.test.ts
Test Suites: 1 passed, 1 total
Tests: 2 passed, 2 total

$ CI=true pnpm --dir projects/packages/premium-analytics typecheck
$ tsgo --noEmit

$ CI=true pnpm --dir projects/packages/premium-analytics test --runInBand
Test Suites: 33 passed, 33 total
Tests: 250 passed, 250 total

$ CI=true jp build packages/my-jetpack
Build packages/my-jetpack [complete]

$ CI=true jp build plugins/jetpack -v
build-extensions was killed with exit 137 in the concurrent build path; rerunning the failed extension phase standalone passed:
$ CI=true pnpm --dir projects/plugins/jetpack run build-extensions
webpack 5.107.2 compiled successfully
Generated block manifest

$ CI=true pnpm --dir projects/plugins/jetpack run build-asset-cdn-json
$ php tools/build-asset-cdn-json.php

$ CI=true jp build packages/premium-analytics -v
wp-build completed; provide-boot-asset-file hit a generated-file permission issue on build/modules/boot/index.min.asset.php.
Manual substeps with the local artifact permission corrected passed:
$ CI=true pnpm --dir projects/packages/premium-analytics run build:wp-build
All packages built successfully.
$ CI=true pnpm --dir projects/packages/premium-analytics run build:boot-asset

$ CI=true jp build plugins/premium-analytics
Build plugins/premium-analytics [complete]

Local env:
http://localhost:18120/ -> HTTP 200
http://localhost:18120/wp-admin/ -> HTTP 200 after redirects
https://jp-raven.jurassic.tube/wp-admin/ -> HTTP 200 after redirects
Jurassic Tube: Connection established, URL: https://jp-raven.jurassic.tube
```

</details>

## Related product discussion/links
* WOOA7S-1585
* https://github.com/Automattic/jetpack/pull/49568#discussion_r3460150355

## Does this pull request change what data or activity we track or use?
No. It only adds an opt-in client-side row adapter for already-normalized Top Posts data.

## Testing instructions
Acceptance criteria from WOOA7S-1585:

* [ ] Decide the canonical field names for Top Posts rows across the Premium Analytics data layer and widget/chart components.
* [ ] Avoid duplicate remapping where practical.
* [ ] Preserve existing widget behavior and rendering.
* [ ] Update or add tests for the chosen data contract.

Reviewer checks:

* Run `CI=true pnpm --dir projects/packages/premium-analytics test --runInBand packages/data/src/hooks/__tests__/use-stats-top-posts.test.ts`.
* Run `CI=true pnpm --dir projects/packages/premium-analytics typecheck`.
* Confirm `useStatsTopPosts( params )` still returns semantic Top Posts items without `value`.
* Confirm `useStatsTopPosts( params, { primaryMetric: 'views', primaryMetricLabel: 'Views' } )` exposes `value`, `valueKey`, `valueLabel`, and `href` while preserving `views` and `link`.
