### PR TITLE
Premium Analytics: wire existing Stats sanitizers

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-stats-processing-existing-code
+++ b/projects/packages/premium-analytics/changelog/update-stats-processing-existing-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: export the StatsEmailSummaryItem type from the data package.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -263,6 +263,7 @@ export type {
 	StatsCommentsRawPost,
 	StatsCommentsRawResponse,
 	StatsEmailBreakdownItem,
+	StatsEmailSummaryItem,
 	StatsDevicesComparisonItem,
 	StatsDevicesItem,
 	StatsFileDownloadsComparisonItem,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Wire the existing Stats time-series, visits, email summary, and email breakdown sanitizers into the shared stats query sanitizer map.
* Export the existing email stats item types from the Premium Analytics data package root.
* Add query coverage so every current stats sanitizer key is accepted by `statsProxyQuery`.

## Related product discussion/links
* Follow-up split from #49780.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `CI=true jp pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/processing/stats`
* Run `CI=true jp pnpm --dir projects/packages/premium-analytics typecheck`
