### PR TITLE
Premium Analytics: add remaining Stats resource endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-remaining-hooks
+++ b/projects/packages/premium-analytics/changelog/add-stats-remaining-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add remaining report hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -14,6 +14,7 @@ const statsHookNames = [
 	'useStatsLocations',
 	'useStatsCountryViews',
 	'useStatsVideoPlays',
+	'useStatsVisits',
 	'useStatsDevices',
 	'useStatsArchives',
 	'useStatsPublicize',
@@ -21,6 +22,20 @@ const statsHookNames = [
 	'useStatsTags',
 	'useStatsComments',
 	'useStatsCommentFollowers',
+	'useStatsStreak',
+	'useStatsInsights',
+	'useStatsHighlights',
+	'useStatsSubscribers',
+	'useStatsSubscribersCounts',
+	'useStatsSinglePost',
+	'useStatsSingleVideo',
+	'useStatsEmailSummary',
+	'useStatsEmailOpensBreakdown',
+	'useStatsEmailClicksBreakdown',
+	'useStatsEmailOpensTimeSeries',
+	'useStatsEmailClicksTimeSeries',
+	'useStatsWordAdsStats',
+	'useStatsWordAdsEarnings',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -15,6 +15,7 @@ export { useStatsTopAuthors } from './use-stats-top-authors';
 export { useStatsLocations } from './use-stats-locations';
 export { useStatsCountryViews } from './use-stats-country-views';
 export { useStatsVideoPlays } from './use-stats-video-plays';
+export { useStatsVisits, type StatsVisitsParams } from './use-stats-visits';
 export { useStatsDevices, type StatsDevicesParams } from './use-stats-devices';
 export { useStatsArchives } from './use-stats-archives';
 export { useStatsPublicize } from './use-stats-publicize';
@@ -22,6 +23,24 @@ export { useStatsFollowers } from './use-stats-followers';
 export { useStatsTags } from './use-stats-tags';
 export { useStatsComments } from './use-stats-comments';
 export { useStatsCommentFollowers } from './use-stats-comment-followers';
+export { useStatsStreak } from './use-stats-streak';
+export { useStatsInsights } from './use-stats-insights';
+export { useStatsHighlights } from './use-stats-highlights';
+export { useStatsSubscribers, useStatsSubscribersCounts } from './use-stats-subscribers';
+export { useStatsSinglePost } from './use-stats-single-post';
+export { useStatsSingleVideo } from './use-stats-single-video';
+export { useStatsEmailSummary } from './use-stats-email-summary';
+export {
+	useStatsEmailOpensBreakdown,
+	useStatsEmailClicksBreakdown,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './use-stats-email-breakdown';
+export {
+	useStatsEmailOpensTimeSeries,
+	useStatsEmailClicksTimeSeries,
+} from './use-stats-email-time-series';
+export { useStatsWordAdsStats, useStatsWordAdsEarnings } from './use-stats-wordads';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import {
+	statsEmailClicksBreakdownQuery,
+	statsEmailOpensBreakdownQuery,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from '../queries/stats-email-breakdown-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsEmailOpensBreakdown(
+	postId: number,
+	breakdown: StatsEmailOpensBreakdown,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailOpensBreakdownQuery( postId, breakdown, params ), options );
+}
+
+export function useStatsEmailClicksBreakdown(
+	postId: number,
+	breakdown: StatsEmailClicksBreakdown,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown, params ), options );
+}
+
+export type { StatsEmailClicksBreakdown, StatsEmailOpensBreakdown };

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-summary.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsEmailSummaryQuery } from '../queries/stats-email-summary-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsEmailSummary( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsEmailSummaryQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import {
+	statsEmailClicksTimeSeriesQuery,
+	statsEmailOpensTimeSeriesQuery,
+} from '../queries/stats-email-time-series-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsEmailOpensTimeSeries(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailOpensTimeSeriesQuery( postId, params ), options );
+}
+
+export function useStatsEmailClicksTimeSeries(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailClicksTimeSeriesQuery( postId, params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsHighlightsQuery } from '../queries/stats-highlights-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsHighlights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsHighlightsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsInsightsQuery } from '../queries/stats-insights-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsInsights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsInsightsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import type { UseStatsOptions } from './use-stats-report';
+
+export function useStatsQuery< TData = unknown >(
+	queryOptions: UseQueryOptions< TData >,
+	options?: UseStatsOptions
+) {
+	const enabled =
+		options?.enabled === undefined
+			? queryOptions.enabled
+			: options.enabled && queryOptions.enabled !== false;
+
+	return useQuery( { ...queryOptions, enabled } );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsSinglePostQuery } from '../queries/stats-single-post-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSinglePost(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsSinglePostQuery( postId, params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsSingleVideoQuery } from '../queries/stats-single-video-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSingleVideo(
+	videoId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsSingleVideoQuery( videoId, params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsStreakQuery } from '../queries/stats-streak-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsStreak( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsStreakQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import {
+	statsSubscribersCountsQuery,
+	statsSubscribersQuery,
+} from '../queries/stats-subscribers-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSubscribers( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsSubscribersQuery( params ), options );
+}
+
+export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsSubscribersCountsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { statsVisitsQuery } from '../queries/stats-visits-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export type StatsVisitsParams = StatsReportParams & {
+	stat_fields?: string;
+};
+
+export function useStatsVisits( params: StatsVisitsParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsVisitsQuery,
+		params,
+		[ 'stats', 'visits', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsWordAdsStatsQuery( params ), options );
+}
+
+export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsWordAdsEarningsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -24,6 +24,7 @@ export { useStatsTopAuthors } from './hooks/use-stats-top-authors';
 export { useStatsLocations } from './hooks/use-stats-locations';
 export { useStatsCountryViews } from './hooks/use-stats-country-views';
 export { useStatsVideoPlays } from './hooks/use-stats-video-plays';
+export { useStatsVisits, type StatsVisitsParams } from './hooks/use-stats-visits';
 export { useStatsDevices, type StatsDevicesParams } from './hooks/use-stats-devices';
 export { useStatsArchives } from './hooks/use-stats-archives';
 export { useStatsPublicize } from './hooks/use-stats-publicize';
@@ -31,6 +32,24 @@ export { useStatsFollowers } from './hooks/use-stats-followers';
 export { useStatsTags } from './hooks/use-stats-tags';
 export { useStatsComments } from './hooks/use-stats-comments';
 export { useStatsCommentFollowers } from './hooks/use-stats-comment-followers';
+export { useStatsStreak } from './hooks/use-stats-streak';
+export { useStatsInsights } from './hooks/use-stats-insights';
+export { useStatsHighlights } from './hooks/use-stats-highlights';
+export { useStatsSubscribers, useStatsSubscribersCounts } from './hooks/use-stats-subscribers';
+export { useStatsSinglePost } from './hooks/use-stats-single-post';
+export { useStatsSingleVideo } from './hooks/use-stats-single-video';
+export { useStatsEmailSummary } from './hooks/use-stats-email-summary';
+export {
+	useStatsEmailOpensBreakdown,
+	useStatsEmailClicksBreakdown,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './hooks/use-stats-email-breakdown';
+export {
+	useStatsEmailOpensTimeSeries,
+	useStatsEmailClicksTimeSeries,
+} from './hooks/use-stats-email-time-series';
+export { useStatsWordAdsStats, useStatsWordAdsEarnings } from './hooks/use-stats-wordads';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -22,6 +22,7 @@ export { statsTopAuthorsQuery } from './stats-top-authors-query';
 export { statsLocationsQuery } from './stats-locations-query';
 export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
+export { statsVisitsQuery } from './stats-visits-query';
 export { statsDevicesQuery } from './stats-devices-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsPublicizeQuery } from './stats-publicize-query';
@@ -29,3 +30,21 @@ export { statsFollowersQuery } from './stats-followers-query';
 export { statsTagsQuery } from './stats-tags-query';
 export { statsCommentsQuery } from './stats-comments-query';
 export { statsCommentFollowersQuery } from './stats-comment-followers-query';
+export { statsStreakQuery } from './stats-streak-query';
+export { statsInsightsQuery } from './stats-insights-query';
+export { statsHighlightsQuery } from './stats-highlights-query';
+export { statsSubscribersQuery, statsSubscribersCountsQuery } from './stats-subscribers-query';
+export { statsSinglePostQuery } from './stats-single-post-query';
+export { statsSingleVideoQuery } from './stats-single-video-query';
+export { statsEmailSummaryQuery } from './stats-email-summary-query';
+export {
+	statsEmailOpensBreakdownQuery,
+	statsEmailClicksBreakdownQuery,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './stats-email-breakdown-query';
+export {
+	statsEmailOpensTimeSeriesQuery,
+	statsEmailClicksTimeSeriesQuery,
+} from './stats-email-time-series-query';
+export { statsWordAdsStatsQuery, statsWordAdsEarningsQuery } from './stats-wordads-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export type StatsEmailOpensBreakdown = 'client' | 'device' | 'country' | 'rate';
+export type StatsEmailClicksBreakdown = StatsEmailOpensBreakdown | 'link' | 'user-content-link';
+
+export const statsEmailOpensBreakdownQuery = (
+	postId: number,
+	breakdown: StatsEmailOpensBreakdown,
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-opens-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/opens/emails/${ postId }/${ breakdown }`,
+		params,
+		sanitizer: 'emailBreakdown',
+	} );
+
+export const statsEmailClicksBreakdownQuery = (
+	postId: number,
+	breakdown: StatsEmailClicksBreakdown,
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-clicks-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/clicks/emails/${ postId }/${ breakdown }`,
+		params,
+		sanitizer: 'emailBreakdown',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-summary-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-summary-query.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsEmailSummaryQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-summary',
+		version: '1.1',
+		endpoint: 'stats/emails/summary',
+		params,
+		sanitizer: 'emailSummary',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsEmailOpensTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-opens-time-series',
+		version: '1.1',
+		endpoint: `stats/opens/emails/${ postId }`,
+		params,
+		sanitizer: 'timeSeries',
+	} );
+
+export const statsEmailClicksTimeSeriesQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'email-clicks-time-series',
+		version: '1.1',
+		endpoint: `stats/clicks/emails/${ postId }`,
+		params,
+		sanitizer: 'timeSeries',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'highlights', version: '1.1', endpoint: 'stats/highlights', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsInsightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'insights', version: '1.1', endpoint: 'stats/insights', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -7,6 +7,8 @@ import {
 	sanitizeStatsCommentFollowersResponse,
 	sanitizeStatsCommentsResponse,
 	sanitizeStatsDevicesResponse,
+	sanitizeStatsEmailBreakdownResponse,
+	sanitizeStatsEmailSummaryResponse,
 	sanitizeStatsFollowersResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsPublicizeResponse,
@@ -14,8 +16,10 @@ import {
 	sanitizeStatsSearchTermsResponse,
 	sanitizeStatsSiteResponse,
 	sanitizeStatsTagsResponse,
+	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsTopAuthorsResponse,
 	sanitizeStatsTopPostsResponse,
+	sanitizeStatsVisitsResponse,
 	sanitizeStatsVideoPlaysResponse,
 } from '../processing/stats';
 import {
@@ -40,6 +44,8 @@ const statsSanitizers = {
 	topAuthors: sanitizeStatsTopAuthorsResponse,
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
+	visits: sanitizeStatsVisitsResponse,
+	timeSeries: sanitizeStatsTimeSeriesResponse,
 	devices: sanitizeStatsDevicesResponse,
 	archives: sanitizeStatsArchivesResponse,
 	publicize: sanitizeStatsPublicizeResponse,
@@ -47,6 +53,8 @@ const statsSanitizers = {
 	tags: sanitizeStatsTagsResponse,
 	comments: sanitizeStatsCommentsResponse,
 	commentFollowers: sanitizeStatsCommentFollowersResponse,
+	emailSummary: sanitizeStatsEmailSummaryResponse,
+	emailBreakdown: sanitizeStatsEmailBreakdownResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-post',
+		version: '1.1',
+		endpoint: `stats/post/${ postId }`,
+		params,
+		sanitizer: 'timeSeries',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-video',
+		version: '1.1',
+		endpoint: `stats/video/${ videoId }`,
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'streak', version: '1.1', endpoint: 'stats/streak', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers',
+		version: '1.1',
+		endpoint: 'stats/subscribers',
+		params,
+		sanitizer: 'timeSeries',
+	} );
+
+export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers-counts',
+		version: '2',
+		endpoint: 'subscribers/counts',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import { statsProxyQuery, type StatsReportParams } from './stats-query';
+import type { StatsProxyParams } from '../api';
+
+type StatsVisitsParams = StatsReportParams & {
+	stat_fields?: string;
+};
+
+export const statsVisitsQuery = ( params: StatsVisitsParams ) => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const visitsParams: StatsProxyParams = {
+		unit: apiParams.period,
+		date: apiParams.date,
+		start_date: apiParams.start_date,
+		quantity: apiParams.days,
+		stat_fields: params.stat_fields ?? 'views,visitors',
+	};
+
+	return statsProxyQuery( {
+		name: 'visits',
+		version: '1.1',
+		endpoint: 'stats/visits',
+		params: visitsParams,
+		sanitizer: 'visits',
+		enabled: !! ( visitsParams.date || visitsParams.start_date ),
+	} );
+};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-stats',
+		version: '1.1',
+		endpoint: 'wordads/stats',
+		params,
+		sanitizer: 'timeSeries',
+	} );
+
+export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-earnings',
+		version: '1.1',
+		endpoint: 'wordads/earnings',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add remaining non-app Stats resource endpoints for visits, streak, insights, highlights, subscribers, single post/video, email reports, and WordAds reports.
* Keep each resource's query factory, hook, exports, and any sanitizer wiring in the same PR.
* Reuse the existing Stats data package query/hook patterns from the earlier traffic endpoints.

## Related product discussion/links
* Stacked on #49883.
* Replaces the old split-by-layer stack: #49780, #49781, and #49782.
* Stack continues in a follow-up app/admin resources PR.

## Does this pull request change what data or activity we track or use?
No. This adds client-side wrappers for existing Stats API responses.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
