### PR TITLE
Premium Analytics: add Stats app resource endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-hooks
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app resource query hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -36,6 +36,19 @@ const statsHookNames = [
 	'useStatsEmailClicksTimeSeries',
 	'useStatsWordAdsStats',
 	'useStatsWordAdsEarnings',
+	'useStatsAppReferrersSpam',
+	'useStatsAppSiteHasNeverPublishedPost',
+	'useStatsAppPlanUsage',
+	'useStatsAppDashboardModules',
+	'useStatsAppDashboardModuleSettings',
+	'useStatsAppPurchases',
+	'useStatsAppNotices',
+	'useStatsAppReferrersMarkSpamMutation',
+	'useStatsAppReferrersUnmarkSpamMutation',
+	'useStatsAppDashboardModulesMutation',
+	'useStatsAppDashboardModuleSettingsMutation',
+	'useStatsAppNoticeMutation',
+	'useStatsAppCommercialClassificationMutation',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -41,6 +41,29 @@ export {
 	useStatsEmailClicksTimeSeries,
 } from './use-stats-email-time-series';
 export { useStatsWordAdsStats, useStatsWordAdsEarnings } from './use-stats-wordads';
+export {
+	useStatsAppReferrersSpam,
+	useStatsAppReferrersMarkSpamMutation,
+	useStatsAppReferrersUnmarkSpamMutation,
+} from './use-stats-app-referrers-spam';
+export { useStatsAppSiteHasNeverPublishedPost } from './use-stats-app-site-has-never-published-post';
+export { useStatsAppPlanUsage } from './use-stats-app-plan-usage';
+export {
+	useStatsAppDashboardModules,
+	useStatsAppDashboardModulesMutation,
+} from './use-stats-app-dashboard-modules';
+export {
+	useStatsAppDashboardModuleSettings,
+	useStatsAppDashboardModuleSettingsMutation,
+} from './use-stats-app-dashboard-module-settings';
+export { useStatsAppPurchases } from './use-stats-app-purchases';
+export {
+	useStatsAppNotices,
+	useStatsAppNoticeMutation,
+	type StatsAppNoticeMutationParams,
+} from './use-stats-app-notices';
+export { useStatsAppCommercialClassificationMutation } from './use-stats-app-commercial-classification';
+export type { UseStatsAppOptions } from './use-stats-app-query';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppCommercialClassificationMutation() {
+	return useMutation( {
+		mutationFn: ( params?: StatsQueryParams ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'commercial-classification',
+				method: 'POST',
+				params,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'plan-usage' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import { statsAppDashboardModuleSettingsQuery } from '../queries/stats-app-dashboard-module-settings-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppDashboardModuleSettings(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppDashboardModuleSettingsQuery( params ), options );
+}
+
+export function useStatsAppDashboardModuleSettingsMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/module-settings',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'stats-app', 'dashboard-module-settings' ],
+			} );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import { statsAppDashboardModulesQuery } from '../queries/stats-app-dashboard-modules-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppDashboardModules(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppDashboardModulesQuery( params ), options );
+}
+
+export function useStatsAppDashboardModulesMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/modules',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'dashboard-modules' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-notices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-notices.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { queryClient } from '../providers';
+import {
+	statsAppNoticesQuery,
+	updateStatsAppNotice,
+	type StatsAppNoticeMutationParams,
+} from '../queries/stats-app-notices-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export type { StatsAppNoticeMutationParams } from '../queries/stats-app-notices-query';
+
+export function useStatsAppNotices( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppNoticesQuery( params ), options );
+}
+
+export function useStatsAppNoticeMutation() {
+	return useMutation( {
+		mutationFn: ( data: StatsAppNoticeMutationParams ) => updateStatsAppNotice( data ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'notices' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppPlanUsageQuery } from '../queries/stats-app-plan-usage-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppPlanUsage( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppPlanUsageQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-purchases.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-purchases.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppPurchasesQuery } from '../queries/stats-app-purchases-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppPurchases( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppPurchasesQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+export type UseStatsAppOptions = {
+	enabled?: boolean;
+};
+
+export function useStatsAppQuery< TData = unknown >(
+	queryOptions: UseQueryOptions< TData >,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...queryOptions,
+		enabled: options?.enabled ?? true,
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-referrers-spam.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-referrers-spam.ts
@@ -1,0 +1,45 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import { statsAppReferrersSpamQuery } from '../queries/stats-app-referrers-spam-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+
+function invalidateReferrersSpamQueries() {
+	// Spam mutations affect both the report data and the app-managed spam list.
+	queryClient.invalidateQueries( { queryKey: [ 'stats', 'referrers' ] } );
+	queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'referrers-spam' ] } );
+}
+
+export function useStatsAppReferrersSpam( options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppReferrersSpamQuery(), options );
+}
+
+export function useStatsAppReferrersMarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/new',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			invalidateReferrersSpamQueries();
+		},
+	} );
+}
+
+export function useStatsAppReferrersUnmarkSpamMutation() {
+	return useMutation( {
+		mutationFn: ( domain: string ) =>
+			fetchStatsProxy( {
+				version: '1.1',
+				endpoint: 'stats/referrers/spam/delete',
+				method: 'POST',
+				params: { domain },
+			} ),
+		onSuccess: () => {
+			invalidateReferrersSpamQueries();
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-site-has-never-published-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-site-has-never-published-post.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppSiteHasNeverPublishedPostQuery } from '../queries/stats-app-site-has-never-published-post-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppSiteHasNeverPublishedPost(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppSiteHasNeverPublishedPostQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -50,6 +50,29 @@ export {
 	useStatsEmailClicksTimeSeries,
 } from './hooks/use-stats-email-time-series';
 export { useStatsWordAdsStats, useStatsWordAdsEarnings } from './hooks/use-stats-wordads';
+export {
+	useStatsAppReferrersSpam,
+	useStatsAppReferrersMarkSpamMutation,
+	useStatsAppReferrersUnmarkSpamMutation,
+} from './hooks/use-stats-app-referrers-spam';
+export { useStatsAppSiteHasNeverPublishedPost } from './hooks/use-stats-app-site-has-never-published-post';
+export { useStatsAppPlanUsage } from './hooks/use-stats-app-plan-usage';
+export {
+	useStatsAppDashboardModules,
+	useStatsAppDashboardModulesMutation,
+} from './hooks/use-stats-app-dashboard-modules';
+export {
+	useStatsAppDashboardModuleSettings,
+	useStatsAppDashboardModuleSettingsMutation,
+} from './hooks/use-stats-app-dashboard-module-settings';
+export { useStatsAppPurchases } from './hooks/use-stats-app-purchases';
+export {
+	useStatsAppNotices,
+	useStatsAppNoticeMutation,
+	type StatsAppNoticeMutationParams,
+} from './hooks/use-stats-app-notices';
+export { useStatsAppCommercialClassificationMutation } from './hooks/use-stats-app-commercial-classification';
+export type { UseStatsAppOptions } from './hooks/use-stats-app-query';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -48,3 +48,15 @@ export {
 	statsEmailClicksTimeSeriesQuery,
 } from './stats-email-time-series-query';
 export { statsWordAdsStatsQuery, statsWordAdsEarningsQuery } from './stats-wordads-query';
+export { statsAppProxyQuery } from './stats-app-query';
+export { statsAppReferrersSpamQuery } from './stats-app-referrers-spam-query';
+export { statsAppSiteHasNeverPublishedPostQuery } from './stats-app-site-has-never-published-post-query';
+export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
+export { statsAppDashboardModulesQuery } from './stats-app-dashboard-modules-query';
+export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
+export { statsAppPurchasesQuery } from './stats-app-purchases-query';
+export {
+	statsAppNoticesQuery,
+	updateStatsAppNotice,
+	type StatsAppNoticeMutationParams,
+} from './stats-app-notices-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-module-settings',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/module-settings',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-modules',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/modules',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-notices-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-notices-query.ts
@@ -1,0 +1,32 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { statsAppQueryKeyPart } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+const noticesPath = '/jetpack-premium-analytics/v1/notices';
+
+export const statsAppNoticesQuery = (
+	params: StatsQueryParams = {}
+): UseQueryOptions< unknown > => ( {
+	// Notices are served by the local plugin REST route, not the Stats proxy.
+	queryKey: [ 'stats-app', 'notices', statsAppQueryKeyPart( params ) ],
+	queryFn: () =>
+		apiFetch( {
+			path: addQueryArgs( noticesPath, params ),
+		} ),
+	placeholderData: previousData => previousData,
+} );
+
+export type StatsAppNoticeMutationParams = {
+	id: string;
+	status: string;
+	postponed_for?: number;
+};
+
+export const updateStatsAppNotice = ( data: StatsAppNoticeMutationParams ) =>
+	apiFetch( {
+		path: noticesPath,
+		method: 'POST',
+		data,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'plan-usage',
+		version: '2',
+		endpoint: 'jetpack-stats/usage',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-purchases-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-purchases-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppPurchasesQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'purchases',
+		version: '1.2',
+		endpoint: 'upgrades',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { fetchStatsProxy, type StatsProxyMethod, type StatsProxyVersion } from '../api';
+import type { StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+export const statsAppQueryKeyPart = ( value: unknown ) => value ?? {};
+
+type StatsAppQueryConfig = {
+	name: string;
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsQueryParams;
+	method?: StatsProxyMethod;
+	body?: unknown;
+};
+
+export function statsAppProxyQuery< TData = unknown >( {
+	name,
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+}: StatsAppQueryConfig ): UseQueryOptions< TData > {
+	return {
+		queryKey: [
+			'stats-app',
+			name,
+			version,
+			endpoint,
+			method,
+			statsAppQueryKeyPart( params ),
+			statsAppQueryKeyPart( body ),
+		],
+		queryFn: () => fetchStatsProxy< TData >( { version, endpoint, params, method, body } ),
+		placeholderData: previousData => previousData,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-referrers-spam-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-referrers-spam-query.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+
+export const statsAppReferrersSpamQuery = () =>
+	statsAppProxyQuery( {
+		name: 'referrers-spam',
+		version: '1.1',
+		endpoint: 'stats/referrers/spam',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-site-has-never-published-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-site-has-never-published-post-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppSiteHasNeverPublishedPostQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'site-has-never-published-post',
+		version: '2',
+		endpoint: 'site-has-never-published-post',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Stats app/admin resource endpoints for referrers spam, site publish state, plan usage, dashboard modules, dashboard module settings, purchases, notices, and commercial classification.
* Keep each app resource's query factory, hook/mutation, exports, and invalidation behavior in the same PR.
* Keep app/admin resources in the `stats-app` query-key namespace, separate from normalized report hooks.

## Related product discussion/links
* Stacked on #49884.
* Replaces the old split-by-layer stack: #49780, #49781, and #49782.

## Does this pull request change what data or activity we track or use?
No. This adds client-side wrappers and mutations for existing app/admin resources.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
