### PR TITLE
Premium Analytics: add Stats endpoint foundation

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-endpoint-foundation
+++ b/projects/packages/premium-analytics/changelog/add-stats-endpoint-foundation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add shared endpoint query helpers.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-query.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-query.test.ts
@@ -1,0 +1,30 @@
+import { getStatsQueryEnabled } from '../use-stats-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+describe( 'Stats query hook helpers', () => {
+	it( 'preserves query enabled state when no caller override is passed', () => {
+		expect( getStatsQueryEnabled( { queryKey: [ 'stats' ], enabled: false } ) ).toBe( false );
+		expect( getStatsQueryEnabled( { queryKey: [ 'stats' ], enabled: true } ) ).toBe( true );
+		expect( getStatsQueryEnabled( { queryKey: [ 'stats' ] } ) ).toBeUndefined();
+	} );
+
+	it( 'does not let caller options force-enable a disabled query', () => {
+		const queryOptions = {
+			queryKey: [ 'stats' ],
+			enabled: false,
+		} satisfies UseQueryOptions;
+
+		expect( getStatsQueryEnabled( queryOptions, { enabled: true } ) ).toBe( false );
+		expect( getStatsQueryEnabled( queryOptions, { enabled: false } ) ).toBe( false );
+	} );
+
+	it( 'allows caller options to disable an otherwise enabled query', () => {
+		const queryOptions = {
+			queryKey: [ 'stats' ],
+			enabled: true,
+		} satisfies UseQueryOptions;
+
+		expect( getStatsQueryEnabled( queryOptions, { enabled: false } ) ).toBe( false );
+		expect( getStatsQueryEnabled( queryOptions, { enabled: true } ) ).toBe( true );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-query.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-query.test.ts
@@ -27,4 +27,16 @@ describe( 'Stats query hook helpers', () => {
 		expect( getStatsQueryEnabled( queryOptions, { enabled: false } ) ).toBe( false );
 		expect( getStatsQueryEnabled( queryOptions, { enabled: true } ) ).toBe( true );
 	} );
+
+	it( 'preserves a function predicate enabled instead of collapsing it to a boolean', () => {
+		const predicate = () => true;
+		const queryOptions = {
+			queryKey: [ 'stats' ],
+			enabled: predicate,
+		} satisfies UseQueryOptions;
+
+		expect( getStatsQueryEnabled( queryOptions ) ).toBe( predicate );
+		expect( getStatsQueryEnabled( queryOptions, { enabled: true } ) ).toBe( predicate );
+		expect( getStatsQueryEnabled( queryOptions, { enabled: false } ) ).toBe( false );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
@@ -1,8 +1,8 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { getStatsQueryEnabled } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
 
-export type UseStatsAppOptions = {
-	enabled?: boolean;
-};
+export type UseStatsAppOptions = UseStatsOptions;
 
 export function useStatsAppQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
@@ -10,6 +10,6 @@ export function useStatsAppQuery< TData = unknown >(
 ) {
 	return useQuery( {
 		...queryOptions,
-		enabled: options?.enabled ?? true,
+		enabled: getStatsQueryEnabled( queryOptions, options ),
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+export type UseStatsAppOptions = {
+	enabled?: boolean;
+};
+
+export function useStatsAppQuery< TData = unknown >(
+	queryOptions: UseQueryOptions< TData >,
+	options?: UseStatsAppOptions
+) {
+	return useQuery( {
+		...queryOptions,
+		enabled: options?.enabled ?? true,
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -1,14 +1,21 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import type { UseStatsOptions } from './use-stats-report';
 
+export function getStatsQueryEnabled< TData = unknown >(
+	queryOptions: UseQueryOptions< TData >,
+	options?: UseStatsOptions
+) {
+	return options?.enabled === undefined
+		? queryOptions.enabled
+		: options.enabled && queryOptions.enabled !== false;
+}
+
 export function useStatsQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsOptions
 ) {
-	const enabled =
-		options?.enabled === undefined
-			? queryOptions.enabled
-			: options.enabled && queryOptions.enabled !== false;
-
-	return useQuery( { ...queryOptions, enabled } );
+	return useQuery( {
+		...queryOptions,
+		enabled: getStatsQueryEnabled( queryOptions, options ),
+	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -5,9 +5,7 @@ export function getStatsQueryEnabled< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsOptions
 ) {
-	return options?.enabled === undefined
-		? queryOptions.enabled
-		: options.enabled && queryOptions.enabled !== false;
+	return options?.enabled === false ? false : queryOptions.enabled;
 }
 
 export function useStatsQuery< TData = unknown >(

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import type { UseStatsOptions } from './use-stats-report';
+
+export function useStatsQuery< TData = unknown >(
+	queryOptions: UseQueryOptions< TData >,
+	options?: UseStatsOptions
+) {
+	const enabled =
+		options?.enabled === undefined
+			? queryOptions.enabled
+			: options.enabled && queryOptions.enabled !== false;
+
+	return useQuery( { ...queryOptions, enabled } );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -8,16 +8,22 @@ export type UseStatsOptions = {
 	enabled?: boolean;
 };
 
-type StatsReportQueryFactory = ( params: StatsReportParams ) => StatsReportQueryOptions;
+type StatsReportQueryFactory< TParams extends StatsReportParams > = (
+	params: TParams
+) => StatsReportQueryOptions;
 
-export function useStatsReport(
-	queryFactory: StatsReportQueryFactory,
-	params: StatsReportParams,
-	reportSlug: string,
+export function useStatsReport< TParams extends StatsReportParams >(
+	queryFactory: StatsReportQueryFactory< TParams >,
+	params: TParams,
+	reportSlugOrDisabledComparisonKey: string | string[],
 	options?: UseStatsOptions
 ) {
-	return useReport( p => queryFactory( p as StatsReportParams ), params, {
+	const disabledComparisonKey = Array.isArray( reportSlugOrDisabledComparisonKey )
+		? reportSlugOrDisabledComparisonKey
+		: [ 'stats', reportSlugOrDisabledComparisonKey, '__comparison__', 'disabled' ];
+
+	return useReport( p => queryFactory( p as TParams ), params, {
 		enabled: options?.enabled,
-		disabledComparisonKey: [ 'stats', reportSlug, '__comparison__', 'disabled' ],
+		disabledComparisonKey,
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { combineStatsNormalizedReports, sanitizeStatsTopPostsResponse } from '..';
 import { topPostsFixture, topPostsSummaryFixture } from '../__fixtures__/top-posts';
-import { getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
+import { getStatsLabel, getStatsSummaryIntervalFields, normalizeStatsSummary } from '../utils';
 
 describe( 'Stats report utilities', () => {
 	it( 'combines separately requested summary and by-date data', () => {
@@ -59,5 +59,12 @@ describe( 'Stats report utilities', () => {
 			date_start: '2026-06-16T00:00:00+00:00',
 			date_end: '2026-06-22T23:59:59+00:00',
 		} );
+	} );
+
+	it( 'decodes labels and falls back to malformed strings', () => {
+		expect( getStatsLabel( 'News%20%26%20Updates' ) ).toBe( 'News & Updates' );
+		expect( getStatsLabel( 'broken%label' ) ).toBe( 'broken%label' );
+		expect( getStatsLabel( 42 ) ).toBe( '42' );
+		expect( getStatsLabel( { label: 'Example' } ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -26,6 +26,31 @@ export function coerceStatsArray< T = StatsRecord >( value: unknown ): T[] {
 	return Array.isArray( value ) ? ( value as T[] ) : [];
 }
 
+export function emptyStatsReport<
+	TItem extends StatsNormalizedItem,
+>(): StatsNormalizedReport< TItem > {
+	return {
+		summary: {},
+		data: [],
+	};
+}
+
+export function getStatsLabel( value: unknown ): string {
+	if ( typeof value === 'string' ) {
+		try {
+			return decodeURIComponent( value );
+		} catch {
+			return value;
+		}
+	}
+
+	if ( typeof value === 'number' || typeof value === 'boolean' ) {
+		return String( value );
+	}
+
+	return '';
+}
+
 function isStatsNumericSummaryValue( value: unknown ): boolean {
 	return (
 		typeof value === 'number' ||

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { statsAppProxyQuery } from '../stats-app-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import type { StatsReportParams } from '../stats-query';
@@ -66,6 +67,42 @@ describe( 'Stats query factories', () => {
 					summarize: false,
 				} ),
 			] )
+		);
+	} );
+
+	it( 'builds app query keys without report param coercion', () => {
+		const query = statsAppProxyQuery( {
+			name: 'plan-usage',
+			version: '2',
+			endpoint: 'stats-app/plan-usage',
+			params: { date: '2026-06-16' },
+		} );
+
+		expect( query.queryKey ).toEqual( [
+			'stats-app',
+			'plan-usage',
+			'2',
+			'stats-app/plan-usage',
+			'GET',
+			{ date: '2026-06-16' },
+			{},
+		] );
+	} );
+
+	it( 'shares app query keys for empty and omitted params', () => {
+		expect(
+			statsAppProxyQuery( {
+				name: 'purchases',
+				version: '1.1',
+				endpoint: 'stats-app/purchases',
+			} ).queryKey
+		).toEqual(
+			statsAppProxyQuery( {
+				name: 'purchases',
+				version: '1.1',
+				endpoint: 'stats-app/purchases',
+				params: {},
+			} ).queryKey
 		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { fetchStatsProxy, type StatsProxyMethod, type StatsProxyVersion } from '../api';
+import type { StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+export const statsAppQueryKeyPart = ( value: unknown ) => value ?? {};
+
+type StatsAppQueryConfig = {
+	name: string;
+	version: StatsProxyVersion;
+	endpoint: string;
+	params?: StatsQueryParams;
+	method?: StatsProxyMethod;
+	body?: unknown;
+};
+
+export function statsAppProxyQuery< TData = unknown >( {
+	name,
+	version,
+	endpoint,
+	params,
+	method = 'GET',
+	body,
+}: StatsAppQueryConfig ): UseQueryOptions< TData > {
+	return {
+		queryKey: [
+			'stats-app',
+			name,
+			version,
+			endpoint,
+			method,
+			statsAppQueryKeyPart( params ),
+			statsAppQueryKeyPart( body ),
+		],
+		queryFn: () => fetchStatsProxy< TData >( { version, endpoint, params, method, body } ),
+		placeholderData: previousData => previousData,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
@@ -16,6 +16,8 @@ type StatsAppQueryConfig = {
 	body?: unknown;
 };
 
+// App/admin resources use the Stats proxy transport but do not use report param
+// coercion or response sanitizers, so they keep a separate query-key namespace.
 export function statsAppProxyQuery< TData = unknown >( {
 	name,
 	version,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add shared Stats endpoint query helpers used by the endpoint-level PRs.
* Add shared app-query helpers for app/admin resources.
* Add shared processing helpers used by the endpoint normalizers.

## Related product discussion/links
* Foundation for the endpoint-level replacement PRs.
* Replaces the closed split-by-layer stack: #49780, #49781, and #49782.

## Does this pull request change what data or activity we track or use?
No. This adds shared client-side helpers only.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics build`.
