### PR TITLE
Premium Analytics: add Stats app commercial classification endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-commercial-classification-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-commercial-classification-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app commercial classification hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -14,6 +14,7 @@ const statsHookNames = [
 	'useStatsLocations',
 	'useStatsCountryViews',
 	'useStatsVideoPlays',
+	'useStatsAppCommercialClassificationMutation',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -15,6 +15,7 @@ export { useStatsTopAuthors } from './use-stats-top-authors';
 export { useStatsLocations } from './use-stats-locations';
 export { useStatsCountryViews } from './use-stats-country-views';
 export { useStatsVideoPlays } from './use-stats-video-plays';
+export { useStatsAppCommercialClassificationMutation } from './use-stats-app-commercial-classification';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -15,7 +15,10 @@ export { useStatsTopAuthors } from './use-stats-top-authors';
 export { useStatsLocations } from './use-stats-locations';
 export { useStatsCountryViews } from './use-stats-country-views';
 export { useStatsVideoPlays } from './use-stats-video-plays';
-export { useStatsAppCommercialClassificationMutation } from './use-stats-app-commercial-classification';
+export {
+	useStatsAppCommercialClassificationMutation,
+	type StatsAppCommercialClassificationParams,
+} from './use-stats-app-commercial-classification';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -1,9 +1,10 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
-import { queryClient } from '../providers';
 import type { StatsQueryParams } from '../utils/stats-params';
 
 export function useStatsAppCommercialClassificationMutation() {
+	const queryClient = useQueryClient();
+
 	return useMutation( {
 		mutationFn: ( params?: StatsQueryParams ) =>
 			fetchStatsProxy( {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -1,17 +1,17 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
-import type { StatsQueryParams } from '../utils/stats-params';
+
+export type StatsAppCommercialClassificationParams = Record< string, never >;
 
 export function useStatsAppCommercialClassificationMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
-		mutationFn: ( params?: StatsQueryParams ) =>
+		mutationFn: ( params?: StatsAppCommercialClassificationParams ) =>
 			fetchStatsProxy( {
 				version: '2',
 				endpoint: 'commercial-classification',
 				method: 'POST',
-				// The WPCOM endpoint reads POST inputs from the query string.
 				params,
 			} ),
 		onSuccess: () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppCommercialClassificationMutation() {
+	return useMutation( {
+		mutationFn: ( params?: StatsQueryParams ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'commercial-classification',
+				method: 'POST',
+				params,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'plan-usage' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -10,9 +10,11 @@ export function useStatsAppCommercialClassificationMutation() {
 				version: '2',
 				endpoint: 'commercial-classification',
 				method: 'POST',
+				// The WPCOM endpoint reads POST inputs from the query string.
 				params,
 			} ),
 		onSuccess: () => {
+			// Plan usage lands in a sibling endpoint PR and shares this app query prefix.
 			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'plan-usage' ] } );
 		},
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -24,6 +24,7 @@ export { useStatsTopAuthors } from './hooks/use-stats-top-authors';
 export { useStatsLocations } from './hooks/use-stats-locations';
 export { useStatsCountryViews } from './hooks/use-stats-country-views';
 export { useStatsVideoPlays } from './hooks/use-stats-video-plays';
+export { useStatsAppCommercialClassificationMutation } from './hooks/use-stats-app-commercial-classification';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -24,7 +24,10 @@ export { useStatsTopAuthors } from './hooks/use-stats-top-authors';
 export { useStatsLocations } from './hooks/use-stats-locations';
 export { useStatsCountryViews } from './hooks/use-stats-country-views';
 export { useStatsVideoPlays } from './hooks/use-stats-video-plays';
-export { useStatsAppCommercialClassificationMutation } from './hooks/use-stats-app-commercial-classification';
+export {
+	useStatsAppCommercialClassificationMutation,
+	type StatsAppCommercialClassificationParams,
+} from './hooks/use-stats-app-commercial-classification';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add the Stats app-commercial-classification endpoint query/hook/export wiring.
* Keep endpoint-owned processing, sanitizer, fixtures, and tests in this PR where this endpoint introduces them.
* Build on the shared foundation from #49886, now merged to trunk.

## Related product discussion/links
* Builds on #49886, now merged to trunk.
* Replaces the closed split-by-layer stack: #49780, #49781, and #49782.

## Does this pull request change what data or activity we track or use?
No. This adds client-side wrappers and normalization for existing Stats API responses.

## Testing instructions
* Run pnpm --dir projects/packages/premium-analytics typecheck.
* For endpoints with processing changes, run pnpm --dir projects/packages/premium-analytics test --runInBand.
* Build coverage was checked on the foundation plus representative resource/app endpoint branches with pnpm --dir projects/packages/premium-analytics build.

