### PR TITLE
Premium Analytics: add Stats app dashboard module settings endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-dashboard-module-settings-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-dashboard-module-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app dashboard module settings hooks.

--- a/projects/packages/premium-analytics/changelog/endpoint-stats-app-dashboard-module-settings-types
+++ b/projects/packages/premium-analytics/changelog/endpoint-stats-app-dashboard-module-settings-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Data layer: Use endpoint-specific typing for dashboard module settings.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -15,6 +15,8 @@ const statsHookNames = [
 	'useStatsCountryViews',
 	'useStatsVideoPlays',
 	'useStatsAppCommercialClassificationMutation',
+	'useStatsAppDashboardModuleSettings',
+	'useStatsAppDashboardModuleSettingsMutation',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -23,6 +23,7 @@ export {
 	useStatsAppDashboardModuleSettings,
 	useStatsAppDashboardModuleSettingsMutation,
 } from './use-stats-app-dashboard-module-settings';
+export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -19,6 +19,10 @@ export {
 	useStatsAppCommercialClassificationMutation,
 	type StatsAppCommercialClassificationParams,
 } from './use-stats-app-commercial-classification';
+export {
+	useStatsAppDashboardModuleSettings,
+	useStatsAppDashboardModuleSettingsMutation,
+} from './use-stats-app-dashboard-module-settings';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -7,7 +7,6 @@ import {
 	statsAppDashboardModuleSettingsQuery,
 } from '../queries/stats-app-dashboard-module-settings-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export type StatsAppDashboardModuleSettings = {
 	traffic?: {
@@ -26,12 +25,9 @@ export type StatsAppDashboardModuleSettings = {
 	};
 };
 
-export function useStatsAppDashboardModuleSettings(
-	params?: StatsQueryParams,
-	options?: UseStatsAppOptions
-) {
+export function useStatsAppDashboardModuleSettings( options?: UseStatsAppOptions ) {
 	return useStatsAppQuery< StatsAppDashboardModuleSettings >(
-		statsAppDashboardModuleSettingsQuery< StatsAppDashboardModuleSettings >( params ),
+		statsAppDashboardModuleSettingsQuery< StatsAppDashboardModuleSettings >(),
 		options
 	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import { statsAppDashboardModuleSettingsQuery } from '../queries/stats-app-dashboard-module-settings-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppDashboardModuleSettings(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppDashboardModuleSettingsQuery( params ), options );
+}
+
+export function useStatsAppDashboardModuleSettingsMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/module-settings',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( {
+				queryKey: [ 'stats-app', 'dashboard-module-settings' ],
+			} );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -9,19 +9,39 @@ import {
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsAppDashboardModuleSettings = {
+	traffic?: {
+		highlights?: {
+			period_in_days?: 7 | 30;
+		};
+		chart?: null;
+		'posts-pages'?: null;
+		referrers?: null;
+		countries?: null;
+		authors?: null;
+		'search-terms'?: null;
+		clicks?: null;
+		videos?: null;
+		'app-promo'?: null;
+	};
+};
+
 export function useStatsAppDashboardModuleSettings(
 	params?: StatsQueryParams,
 	options?: UseStatsAppOptions
 ) {
-	return useStatsAppQuery( statsAppDashboardModuleSettingsQuery( params ), options );
+	return useStatsAppQuery< StatsAppDashboardModuleSettings >(
+		statsAppDashboardModuleSettingsQuery< StatsAppDashboardModuleSettings >( params ),
+		options
+	);
 }
 
 export function useStatsAppDashboardModuleSettingsMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
-		mutationFn: ( body: unknown ) =>
-			fetchStatsProxy( {
+		mutationFn: ( body: StatsAppDashboardModuleSettings ) =>
+			fetchStatsProxy< StatsAppDashboardModuleSettings, StatsAppDashboardModuleSettings >( {
 				version: STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
 				endpoint: STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,
 				method: 'POST',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -1,7 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
-import { queryClient } from '../providers';
-import { statsAppDashboardModuleSettingsQuery } from '../queries/stats-app-dashboard-module-settings-query';
+import {
+	STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,
+	STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME,
+	STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
+	statsAppDashboardModuleSettingsQuery,
+} from '../queries/stats-app-dashboard-module-settings-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
@@ -13,17 +17,19 @@ export function useStatsAppDashboardModuleSettings(
 }
 
 export function useStatsAppDashboardModuleSettingsMutation() {
+	const queryClient = useQueryClient();
+
 	return useMutation( {
 		mutationFn: ( body: unknown ) =>
 			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'jetpack-stats-dashboard/module-settings',
+				version: STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
+				endpoint: STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,
 				method: 'POST',
 				body,
 			} ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( {
-				queryKey: [ 'stats-app', 'dashboard-module-settings' ],
+				queryKey: [ 'stats-app', STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME ],
 			} );
 		},
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -32,6 +32,7 @@ export {
 	useStatsAppDashboardModuleSettings,
 	useStatsAppDashboardModuleSettingsMutation,
 } from './hooks/use-stats-app-dashboard-module-settings';
+export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -28,6 +28,10 @@ export {
 	useStatsAppCommercialClassificationMutation,
 	type StatsAppCommercialClassificationParams,
 } from './hooks/use-stats-app-commercial-classification';
+export {
+	useStatsAppDashboardModuleSettings,
+	useStatsAppDashboardModuleSettingsMutation,
+} from './hooks/use-stats-app-dashboard-module-settings';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -22,3 +22,4 @@ export { statsTopAuthorsQuery } from './stats-top-authors-query';
 export { statsLocationsQuery } from './stats-locations-query';
 export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
+export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
@@ -9,8 +9,10 @@ export const STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION = '2';
 export const STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT =
 	'jetpack-stats-dashboard/module-settings';
 
-export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
-	statsAppProxyQuery( {
+export const statsAppDashboardModuleSettingsQuery = < TData = unknown >(
+	params: StatsQueryParams = {}
+) =>
+	statsAppProxyQuery< TData >( {
 		name: STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME,
 		version: STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
 		endpoint: STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-module-settings',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/module-settings',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
@@ -4,10 +4,15 @@
 import { statsAppProxyQuery } from './stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export const STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME = 'dashboard-module-settings';
+export const STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION = '2';
+export const STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT =
+	'jetpack-stats-dashboard/module-settings';
+
 export const statsAppDashboardModuleSettingsQuery = ( params: StatsQueryParams = {} ) =>
 	statsAppProxyQuery( {
-		name: 'dashboard-module-settings',
-		version: '2',
-		endpoint: 'jetpack-stats-dashboard/module-settings',
+		name: STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME,
+		version: STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
+		endpoint: STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,
 		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-module-settings-query.ts
@@ -2,19 +2,15 @@
  * Internal dependencies
  */
 import { statsAppProxyQuery } from './stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export const STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME = 'dashboard-module-settings';
 export const STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION = '2';
 export const STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT =
 	'jetpack-stats-dashboard/module-settings';
 
-export const statsAppDashboardModuleSettingsQuery = < TData = unknown >(
-	params: StatsQueryParams = {}
-) =>
+export const statsAppDashboardModuleSettingsQuery = < TData = unknown >() =>
 	statsAppProxyQuery< TData >( {
 		name: STATS_APP_DASHBOARD_MODULE_SETTINGS_NAME,
 		version: STATS_APP_DASHBOARD_MODULE_SETTINGS_VERSION,
 		endpoint: STATS_APP_DASHBOARD_MODULE_SETTINGS_ENDPOINT,
-		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-query.ts
@@ -1,8 +1,12 @@
 /**
  * Internal dependencies
  */
-import { fetchStatsProxy, type StatsProxyMethod, type StatsProxyVersion } from '../api';
-import type { StatsQueryParams } from '../utils/stats-params';
+import {
+	fetchStatsProxy,
+	type StatsProxyMethod,
+	type StatsProxyParams,
+	type StatsProxyVersion,
+} from '../api';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
 export const statsAppQueryKeyPart = ( value: unknown ) => value ?? {};
@@ -11,7 +15,7 @@ type StatsAppQueryConfig = {
 	name: string;
 	version: StatsProxyVersion;
 	endpoint: string;
-	params?: StatsQueryParams;
+	params?: StatsProxyParams;
 	method?: StatsProxyMethod;
 	body?: unknown;
 };


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add the Stats app-dashboard-module-settings endpoint query/hook/export wiring.
* Keep endpoint-owned processing, sanitizer, fixtures, and tests in this PR where this endpoint introduces them.
* Build on the shared foundation from #49886, now merged to trunk.

## Related product discussion/links
* Builds on #49886, now merged to trunk.
* Replaces the closed split-by-layer stack: #49780, #49781, and #49782.

## Does this pull request change what data or activity we track or use?
No. This adds client-side wrappers and normalization for existing Stats API responses.

## Testing instructions
* Run pnpm --dir projects/packages/premium-analytics typecheck.
* For endpoints with processing changes, run pnpm --dir projects/packages/premium-analytics test --runInBand.
* Build coverage was checked on the foundation plus representative resource/app endpoint branches with pnpm --dir projects/packages/premium-analytics build.

