### PR TITLE
Premium Analytics: add Stats app dashboard modules endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-dashboard-modules-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-dashboard-modules-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app dashboard modules hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -48,6 +48,8 @@ const statsHookNames = [
 	'useStatsSingleVideo',
 	'useStatsEmailOpensTimeSeries',
 	'useStatsEmailClicksTimeSeries',
+	'useStatsAppDashboardModules',
+	'useStatsAppDashboardModulesMutation',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -172,7 +172,6 @@ export {
 } from './use-stats-app-dashboard-modules';
 export type {
 	StatsAppDashboardModules,
-	StatsAppDashboardModulesSettings,
 	StatsAppDashboardModuleValue,
 	StatsAppDashboardTrafficModule,
 } from './use-stats-app-dashboard-modules';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -172,8 +172,13 @@ export {
 } from './use-stats-app-dashboard-modules';
 export type {
 	StatsAppDashboardModules,
+	StatsAppDashboardModulesMutationResponse,
 	StatsAppDashboardModuleValue,
 	StatsAppDashboardTrafficModule,
+	StatsAppDashboardInsightsModule,
+	StatsAppDashboardSubscribersModule,
+	StatsAppDashboardWordAdsModule,
+	StatsAppDashboardStoreModule,
 } from './use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './use-stats-report';
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -166,6 +166,10 @@ export {
 	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesSummary,
 } from './use-stats-email-time-series';
+export {
+	useStatsAppDashboardModules,
+	useStatsAppDashboardModulesMutation,
+} from './use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -170,7 +170,12 @@ export {
 	useStatsAppDashboardModules,
 	useStatsAppDashboardModulesMutation,
 } from './use-stats-app-dashboard-modules';
-export type { StatsAppDashboardModules } from './use-stats-app-dashboard-modules';
+export type {
+	StatsAppDashboardModules,
+	StatsAppDashboardModulesSettings,
+	StatsAppDashboardModuleValue,
+	StatsAppDashboardTrafficModule,
+} from './use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -170,6 +170,7 @@ export {
 	useStatsAppDashboardModules,
 	useStatsAppDashboardModulesMutation,
 } from './use-stats-app-dashboard-modules';
+export type { StatsAppDashboardModules } from './use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -9,18 +9,37 @@ import {
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsAppDashboardModules = Record< string, Record< string, boolean > >;
+
+/**
+ * @example
+ * ```tsx
+ * const { data: dashboardModules } = useStatsAppDashboardModules();
+ * const { mutate: updateDashboardModules } = useStatsAppDashboardModulesMutation();
+ *
+ * updateDashboardModules( {
+ * 	traffic: {
+ * 		authors: true,
+ * 		'search-terms': false,
+ * 	},
+ * } );
+ * ```
+ */
 export function useStatsAppDashboardModules(
 	params?: StatsQueryParams,
 	options?: UseStatsAppOptions
 ) {
-	return useStatsAppQuery( statsAppDashboardModulesQuery( params ), options );
+	return useStatsAppQuery< StatsAppDashboardModules >(
+		statsAppDashboardModulesQuery< StatsAppDashboardModules >( params ),
+		options
+	);
 }
 
 export function useStatsAppDashboardModulesMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
-		mutationFn: ( body: unknown ) =>
+		mutationFn: ( body: StatsAppDashboardModules ) =>
 			fetchStatsProxy( {
 				version: STATS_APP_DASHBOARD_MODULES_VERSION,
 				endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -7,11 +7,12 @@ import {
 	statsAppDashboardModulesQuery,
 } from '../queries/stats-app-dashboard-modules-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 /**
- * Keep the traffic-page subset in sync with
- * wp-content/lib/jetpack-stats-dashboard/class-module-settings.php on WPCOM.
+ * Module keys per dashboard page, mirroring ALLOWED_MODULE_SETTINGS_SCHEMA in
+ * wp-content/lib/jetpack-stats-dashboard/class-module-settings.php on WPCOM. The
+ * server filters writes against this exact set, so the stored map only ever holds
+ * these keys.
  */
 export type StatsAppDashboardTrafficModule =
 	| 'highlights'
@@ -25,10 +26,58 @@ export type StatsAppDashboardTrafficModule =
 	| 'videos'
 	| 'app-promo';
 
+export type StatsAppDashboardInsightsModule =
+	| 'year-in-review'
+	| 'all-time-highlights'
+	| 'latest-post'
+	| 'most-popular-post'
+	| 'posting-activities'
+	| 'all-time-insights'
+	| 'tags-categories'
+	| 'comments'
+	| 'subscribers'
+	| 'number-of-subscribers';
+
+export type StatsAppDashboardSubscribersModule =
+	| 'all-time-stats'
+	| 'chart'
+	| 'subscribers-overview'
+	| 'subscribers'
+	| 'number-of-subscribers';
+
+export type StatsAppDashboardWordAdsModule = 'totals' | 'chart' | 'earning-history' | 'app-promo';
+
+export type StatsAppDashboardStoreModule =
+	| 'chart'
+	| 'store-stats-table-1'
+	| 'store-stats-table-2'
+	| 'most-popular-products'
+	| 'top-categories'
+	| 'most-used-coupons';
+
 export type StatsAppDashboardModuleValue = boolean;
 
+/**
+ * The stored on/off visibility toggles, keyed by page then module. Per-module
+ * config (e.g. `traffic.highlights.period_in_days`) lives on the separate
+ * `module-settings` endpoint, not here.
+ *
+ * WPCOM serializes an empty page map as `[]` rather than `{}`, and injects
+ * `traffic.authors = false` at read time on sites with a single author, so a
+ * page value may be absent, empty, or a partial map.
+ */
 export type StatsAppDashboardModules = {
 	traffic?: Partial< Record< StatsAppDashboardTrafficModule, StatsAppDashboardModuleValue > >;
+	insights?: Partial< Record< StatsAppDashboardInsightsModule, StatsAppDashboardModuleValue > >;
+	subscribers?: Partial<
+		Record< StatsAppDashboardSubscribersModule, StatsAppDashboardModuleValue >
+	>;
+	wordads?: Partial< Record< StatsAppDashboardWordAdsModule, StatsAppDashboardModuleValue > >;
+	store?: Partial< Record< StatsAppDashboardStoreModule, StatsAppDashboardModuleValue > >;
+};
+
+export type StatsAppDashboardModulesMutationResponse = {
+	updated: boolean;
 };
 
 /**
@@ -45,12 +94,9 @@ export type StatsAppDashboardModules = {
  * } );
  * ```
  */
-export function useStatsAppDashboardModules(
-	params?: StatsQueryParams,
-	options?: UseStatsAppOptions
-) {
+export function useStatsAppDashboardModules( options?: UseStatsAppOptions ) {
 	return useStatsAppQuery< StatsAppDashboardModules >(
-		statsAppDashboardModulesQuery< StatsAppDashboardModules >( params ),
+		statsAppDashboardModulesQuery< StatsAppDashboardModules >(),
 		options
 	);
 }
@@ -60,7 +106,7 @@ export function useStatsAppDashboardModulesMutation() {
 
 	return useMutation( {
 		mutationFn: ( body: StatsAppDashboardModules ) =>
-			fetchStatsProxy< StatsAppDashboardModules, StatsAppDashboardModules >( {
+			fetchStatsProxy< StatsAppDashboardModulesMutationResponse, StatsAppDashboardModules >( {
 				version: STATS_APP_DASHBOARD_MODULES_VERSION,
 				endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,
 				method: 'POST',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -1,7 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
-import { queryClient } from '../providers';
-import { statsAppDashboardModulesQuery } from '../queries/stats-app-dashboard-modules-query';
+import {
+	STATS_APP_DASHBOARD_MODULES_ENDPOINT,
+	STATS_APP_DASHBOARD_MODULES_NAME,
+	STATS_APP_DASHBOARD_MODULES_VERSION,
+	statsAppDashboardModulesQuery,
+} from '../queries/stats-app-dashboard-modules-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
@@ -13,16 +17,20 @@ export function useStatsAppDashboardModules(
 }
 
 export function useStatsAppDashboardModulesMutation() {
+	const queryClient = useQueryClient();
+
 	return useMutation( {
 		mutationFn: ( body: unknown ) =>
 			fetchStatsProxy( {
-				version: '2',
-				endpoint: 'jetpack-stats-dashboard/modules',
+				version: STATS_APP_DASHBOARD_MODULES_VERSION,
+				endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,
 				method: 'POST',
 				body,
 			} ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'dashboard-modules' ] } );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'stats-app', STATS_APP_DASHBOARD_MODULES_NAME ],
+			} );
 		},
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -9,7 +9,44 @@ import {
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export type StatsAppDashboardModules = Record< string, Record< string, boolean > >;
+/**
+ * Keep the traffic-page subset in sync with
+ * wp-content/lib/jetpack-stats-dashboard/class-module-settings.php on WPCOM.
+ */
+export type StatsAppDashboardTrafficModule =
+	| 'highlights'
+	| 'chart'
+	| 'posts-pages'
+	| 'referrers'
+	| 'countries'
+	| 'authors'
+	| 'search-terms'
+	| 'clicks'
+	| 'videos'
+	| 'app-promo';
+
+export type StatsAppDashboardModuleValue = boolean | Record< string, unknown >;
+
+export type StatsAppDashboardModules = {
+	traffic?: Partial< Record< StatsAppDashboardTrafficModule, StatsAppDashboardModuleValue > >;
+};
+
+export type StatsAppDashboardModulesSettings = {
+	traffic?: {
+		highlights?: {
+			period_in_days?: 7 | 30;
+		};
+		chart?: null;
+		'posts-pages'?: null;
+		referrers?: null;
+		countries?: null;
+		authors?: null;
+		'search-terms'?: null;
+		clicks?: null;
+		videos?: null;
+		'app-promo'?: null;
+	};
+};
 
 /**
  * @example

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -25,27 +25,10 @@ export type StatsAppDashboardTrafficModule =
 	| 'videos'
 	| 'app-promo';
 
-export type StatsAppDashboardModuleValue = boolean | Record< string, unknown >;
+export type StatsAppDashboardModuleValue = boolean;
 
 export type StatsAppDashboardModules = {
 	traffic?: Partial< Record< StatsAppDashboardTrafficModule, StatsAppDashboardModuleValue > >;
-};
-
-export type StatsAppDashboardModulesSettings = {
-	traffic?: {
-		highlights?: {
-			period_in_days?: 7 | 30;
-		};
-		chart?: null;
-		'posts-pages'?: null;
-		referrers?: null;
-		countries?: null;
-		authors?: null;
-		'search-terms'?: null;
-		clicks?: null;
-		videos?: null;
-		'app-promo'?: null;
-	};
 };
 
 /**
@@ -77,7 +60,7 @@ export function useStatsAppDashboardModulesMutation() {
 
 	return useMutation( {
 		mutationFn: ( body: StatsAppDashboardModules ) =>
-			fetchStatsProxy( {
+			fetchStatsProxy< StatsAppDashboardModules, StatsAppDashboardModules >( {
 				version: STATS_APP_DASHBOARD_MODULES_VERSION,
 				endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,
 				method: 'POST',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-modules.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchStatsProxy } from '../api';
+import { queryClient } from '../providers';
+import { statsAppDashboardModulesQuery } from '../queries/stats-app-dashboard-modules-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppDashboardModules(
+	params?: StatsQueryParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppDashboardModulesQuery( params ), options );
+}
+
+export function useStatsAppDashboardModulesMutation() {
+	return useMutation( {
+		mutationFn: ( body: unknown ) =>
+			fetchStatsProxy( {
+				version: '2',
+				endpoint: 'jetpack-stats-dashboard/modules',
+				method: 'POST',
+				body,
+			} ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'dashboard-modules' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -177,7 +177,6 @@ export {
 } from './hooks/use-stats-app-dashboard-modules';
 export type {
 	StatsAppDashboardModules,
-	StatsAppDashboardModulesSettings,
 	StatsAppDashboardModuleValue,
 	StatsAppDashboardTrafficModule,
 } from './hooks/use-stats-app-dashboard-modules';

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -175,7 +175,12 @@ export {
 	useStatsAppDashboardModules,
 	useStatsAppDashboardModulesMutation,
 } from './hooks/use-stats-app-dashboard-modules';
-export type { StatsAppDashboardModules } from './hooks/use-stats-app-dashboard-modules';
+export type {
+	StatsAppDashboardModules,
+	StatsAppDashboardModulesSettings,
+	StatsAppDashboardModuleValue,
+	StatsAppDashboardTrafficModule,
+} from './hooks/use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -177,8 +177,13 @@ export {
 } from './hooks/use-stats-app-dashboard-modules';
 export type {
 	StatsAppDashboardModules,
+	StatsAppDashboardModulesMutationResponse,
 	StatsAppDashboardModuleValue,
 	StatsAppDashboardTrafficModule,
+	StatsAppDashboardInsightsModule,
+	StatsAppDashboardSubscribersModule,
+	StatsAppDashboardWordAdsModule,
+	StatsAppDashboardStoreModule,
 } from './hooks/use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -171,6 +171,10 @@ export {
 	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesSummary,
 } from './hooks/use-stats-email-time-series';
+export {
+	useStatsAppDashboardModules,
+	useStatsAppDashboardModulesMutation,
+} from './hooks/use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -175,6 +175,7 @@ export {
 	useStatsAppDashboardModules,
 	useStatsAppDashboardModulesMutation,
 } from './hooks/use-stats-app-dashboard-modules';
+export type { StatsAppDashboardModules } from './hooks/use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -94,3 +94,4 @@ export {
 	statsEmailOpensTimeSeriesQuery,
 	statsEmailClicksTimeSeriesQuery,
 } from './stats-email-time-series-query';
+export { statsAppDashboardModulesQuery } from './stats-app-dashboard-modules-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
@@ -2,16 +2,14 @@
  * Internal dependencies
  */
 import { statsAppProxyQuery } from './stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export const STATS_APP_DASHBOARD_MODULES_NAME = 'dashboard-modules';
 export const STATS_APP_DASHBOARD_MODULES_VERSION = '2';
 export const STATS_APP_DASHBOARD_MODULES_ENDPOINT = 'jetpack-stats-dashboard/modules';
 
-export const statsAppDashboardModulesQuery = < TData = unknown >( params: StatsQueryParams = {} ) =>
+export const statsAppDashboardModulesQuery = < TData = unknown >() =>
 	statsAppProxyQuery< TData >( {
 		name: STATS_APP_DASHBOARD_MODULES_NAME,
 		version: STATS_APP_DASHBOARD_MODULES_VERSION,
 		endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,
-		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
@@ -8,8 +8,8 @@ export const STATS_APP_DASHBOARD_MODULES_NAME = 'dashboard-modules';
 export const STATS_APP_DASHBOARD_MODULES_VERSION = '2';
 export const STATS_APP_DASHBOARD_MODULES_ENDPOINT = 'jetpack-stats-dashboard/modules';
 
-export const statsAppDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
-	statsAppProxyQuery( {
+export const statsAppDashboardModulesQuery = < TData = unknown >( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery< TData >( {
 		name: STATS_APP_DASHBOARD_MODULES_NAME,
 		version: STATS_APP_DASHBOARD_MODULES_VERSION,
 		endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
@@ -4,10 +4,14 @@
 import { statsAppProxyQuery } from './stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export const STATS_APP_DASHBOARD_MODULES_NAME = 'dashboard-modules';
+export const STATS_APP_DASHBOARD_MODULES_VERSION = '2';
+export const STATS_APP_DASHBOARD_MODULES_ENDPOINT = 'jetpack-stats-dashboard/modules';
+
 export const statsAppDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
 	statsAppProxyQuery( {
-		name: 'dashboard-modules',
-		version: '2',
-		endpoint: 'jetpack-stats-dashboard/modules',
+		name: STATS_APP_DASHBOARD_MODULES_NAME,
+		version: STATS_APP_DASHBOARD_MODULES_VERSION,
+		endpoint: STATS_APP_DASHBOARD_MODULES_ENDPOINT,
 		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-dashboard-modules-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppDashboardModulesQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'dashboard-modules',
+		version: '2',
+		endpoint: 'jetpack-stats-dashboard/modules',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats app dashboard modules endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check