### PR TITLE
Premium Analytics: add Stats app notices endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-notices-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-notices-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app notices hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -19,6 +19,8 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsAppPlanUsage',
+	'useStatsAppNotices',
+	'useStatsAppNoticeMutation',
 	'useStatsAppPurchases',
 	'useStatsArchives',
 	'useStatsCommentFollowers',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -37,6 +37,16 @@ export type {
 	StatsAppPlanUsage,
 } from './use-stats-app-plan-usage';
 export {
+	useStatsAppNotices,
+	useStatsAppNoticeMutation,
+	type StatsAppNoticeId,
+	type StatsAppNoticeMutationParams,
+	type StatsAppNoticeMutationResponse,
+	type StatsAppNotices,
+	type StatsAppNoticesParams,
+	type StatsAppNoticeStatus,
+} from './use-stats-app-notices';
+export {
 	useStatsAppPurchases,
 	type StatsAppPurchase,
 	type StatsAppPurchaseExpiryStatus,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-notices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-notices.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	statsAppNoticesQuery,
+	updateStatsAppNotice,
+	type StatsAppNoticeId,
+	type StatsAppNoticeMutationParams,
+	type StatsAppNoticeMutationResponse,
+	type StatsAppNotices,
+	type StatsAppNoticesParams,
+	type StatsAppNoticeStatus,
+} from '../queries/stats-app-notices-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+
+export type {
+	StatsAppNoticeId,
+	StatsAppNoticeMutationParams,
+	StatsAppNoticeMutationResponse,
+	StatsAppNotices,
+	StatsAppNoticesParams,
+	StatsAppNoticeStatus,
+};
+
+export function useStatsAppNotices( params?: StatsAppNoticesParams, options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppNoticesQuery( params ), options );
+}
+
+export function useStatsAppNoticeMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: ( data: StatsAppNoticeMutationParams ) => updateStatsAppNotice( data ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'stats-app', 'notices' ] } );
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -42,6 +42,16 @@ export type {
 	StatsAppPlanUsage,
 } from './hooks/use-stats-app-plan-usage';
 export {
+	useStatsAppNotices,
+	useStatsAppNoticeMutation,
+	type StatsAppNoticeId,
+	type StatsAppNoticeMutationParams,
+	type StatsAppNoticeMutationResponse,
+	type StatsAppNotices,
+	type StatsAppNoticesParams,
+	type StatsAppNoticeStatus,
+} from './hooks/use-stats-app-notices';
+export {
 	useStatsAppPurchases,
 	type StatsAppPurchase,
 	type StatsAppPurchaseExpiryStatus,

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1,6 +1,11 @@
 /**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
  * Internal dependencies
  */
+import { statsAppNoticesQuery, updateStatsAppNotice } from '../stats-app-notices-query';
 import { statsAppPurchasesQuery } from '../stats-app-purchases-query';
 import { statsAppProxyQuery } from '../stats-app-query';
 import {
@@ -38,7 +43,15 @@ import { statsVisitsQuery } from '../stats-visits-query';
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../stats-wordads-query';
 import type { StatsReportParams } from '../stats-query';
 
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
 describe( 'Stats query factories', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+	} );
+
 	it( 'disables report queries until a date range is available', () => {
 		expect( statsTopPostsQuery( {} as StatsReportParams ).enabled ).toBe( false );
 	} );
@@ -512,6 +525,35 @@ describe( 'Stats query factories', () => {
 			{ date: '2026-06-16' },
 			{},
 		] );
+	} );
+
+	it( 'builds app notices query keys for the local REST endpoint', () => {
+		expect( statsAppNoticesQuery().queryKey ).toEqual( [ 'stats-app', 'notices', {} ] );
+		expect( statsAppNoticesQuery( { force_refresh: true } ).queryKey ).toEqual( [
+			'stats-app',
+			'notices',
+			{ force_refresh: true },
+		] );
+	} );
+
+	it( 'updates app notices through the local REST endpoint', async () => {
+		mockApiFetch.mockResolvedValue( { opt_in_new_stats: false } );
+
+		await updateStatsAppNotice( {
+			id: 'opt_in_new_stats',
+			status: 'postponed',
+			postponed_for: 300,
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack-premium-analytics/v1/notices',
+			method: 'POST',
+			data: {
+				id: 'opt_in_new_stats',
+				status: 'postponed',
+				postponed_for: 300,
+			},
+		} );
 	} );
 
 	it( 'builds highlights query keys with endpoint params and sanitizer', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -25,6 +25,16 @@ export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
+export {
+	statsAppNoticesQuery,
+	updateStatsAppNotice,
+	type StatsAppNoticeId,
+	type StatsAppNoticeMutationParams,
+	type StatsAppNoticeMutationResponse,
+	type StatsAppNotices,
+	type StatsAppNoticesParams,
+	type StatsAppNoticeStatus,
+} from './stats-app-notices-query';
 export { statsAppPurchasesQuery } from './stats-app-purchases-query';
 export type {
 	StatsAppPurchase,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-notices-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-notices-query.ts
@@ -1,0 +1,56 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { statsAppQueryKeyPart } from './stats-app-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+
+const noticesPath = '/jetpack-premium-analytics/v1/notices';
+
+export type StatsAppNoticeId =
+	| 'able_to_submit_user_feedback'
+	| 'client_free_plan_purchase_success'
+	| 'client_paid_plan_purchase_success'
+	| 'commercial_site_upgrade'
+	| 'do_you_love_jetpack_stats'
+	| 'gdpr_cookie_consent'
+	| 'new_stats_feedback'
+	| 'opt_in_new_stats'
+	| 'opt_out_new_stats'
+	| 'show_floating_user_feedback_panel'
+	| 'tier_upgrade'
+	| 'traffic_page_highlights_module_settings'
+	| 'traffic_page_settings';
+
+export type StatsAppNotices = Partial< Record< StatsAppNoticeId, boolean > >;
+
+export type StatsAppNoticesParams = {
+	force_refresh?: true | 1;
+};
+
+export type StatsAppNoticeStatus = 'dismissed' | 'postponed';
+
+export const statsAppNoticesQuery = (
+	params: StatsAppNoticesParams = {}
+): UseQueryOptions< StatsAppNotices > => ( {
+	// Notices are served by the local plugin REST route, not the Stats proxy.
+	queryKey: [ 'stats-app', 'notices', statsAppQueryKeyPart( params ) ],
+	queryFn: () =>
+		apiFetch< StatsAppNotices >( {
+			path: addQueryArgs( noticesPath, params ),
+		} ),
+	placeholderData: previousData => previousData,
+} );
+
+export type StatsAppNoticeMutationParams = {
+	id: StatsAppNoticeId;
+	status: StatsAppNoticeStatus;
+	postponed_for?: number;
+};
+
+export type StatsAppNoticeMutationResponse = StatsAppNotices;
+
+export const updateStatsAppNotice = ( data: StatsAppNoticeMutationParams ) =>
+	apiFetch< StatsAppNoticeMutationResponse >( {
+		path: noticesPath,
+		method: 'POST',
+		data,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats app notices endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check