### PR TITLE
Premium Analytics: add Stats app plan usage endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-plan-usage-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-plan-usage-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app plan usage hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -17,6 +17,7 @@ const statsHookNames = [
 	'useStatsAppCommercialClassificationMutation',
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
+	'useStatsAppPlanUsage',
 	'useStatsArchives',
 	'useStatsStreak',
 	'useStatsVisits',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -24,6 +24,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
+export { useStatsAppPlanUsage } from './use-stats-app-plan-usage';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,6 +25,11 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsAppPlanUsage } from './use-stats-app-plan-usage';
+export type {
+	StatsAppPlanPeriodUsage,
+	StatsAppPlanPriceTier,
+	StatsAppPlanUsage,
+} from './use-stats-app-plan-usage';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -14,9 +14,9 @@ export type StatsAppPlanPeriodUsage = {
 
 export type StatsAppPlanPriceTier = {
 	maximum_price: number;
-	maximum_price_display: string;
-	maximum_price_monthly_display: string;
-	maximum_units: number;
+	maximum_price_display: string | null;
+	maximum_price_monthly_display: string | null;
+	maximum_units: number | null;
 	minimum_price: number;
 	minimum_price_display: string;
 	minimum_price_monthly_display: string;

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -5,6 +5,43 @@ import { statsAppPlanUsageQuery } from '../queries/stats-app-plan-usage-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsAppPlanPeriodUsage = {
+	current_start: string | null;
+	next_start: string | null;
+	views_count: number;
+	days_to_reset: number;
+};
+
+export type StatsAppPlanPriceTier = {
+	maximum_price: number;
+	maximum_price_display: string;
+	maximum_price_monthly_display: string;
+	maximum_units: number;
+	minimum_price: number;
+	minimum_price_display: string;
+	minimum_price_monthly_display: string;
+	minimum_units: number;
+	per_unit_fee?: number;
+	transform_quantity_divide_by?: number | null;
+	limit?: number;
+};
+
+export type StatsAppPlanUsage = {
+	current_usage: StatsAppPlanPeriodUsage;
+	recent_usages: StatsAppPlanPeriodUsage[];
+	views_limit: number;
+	over_limit_months: number;
+	current_tier: StatsAppPlanPriceTier;
+	is_internal: boolean;
+	billable_monthly_views: number;
+	should_show_paywall: boolean;
+	paywall_date_from: string | null;
+	upgrade_deadline_date: string | null;
+};
+
 export function useStatsAppPlanUsage( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
-	return useStatsAppQuery( statsAppPlanUsageQuery( params ), options );
+	return useStatsAppQuery< StatsAppPlanUsage >(
+		statsAppPlanUsageQuery< StatsAppPlanUsage >( params ),
+		options
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppPlanUsageQuery } from '../queries/stats-app-plan-usage-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsAppPlanUsage( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+	return useStatsAppQuery( statsAppPlanUsageQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -3,7 +3,6 @@
  */
 import { statsAppPlanUsageQuery } from '../queries/stats-app-plan-usage-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export type StatsAppPlanPeriodUsage = {
 	current_start: string | null;
@@ -39,9 +38,9 @@ export type StatsAppPlanUsage = {
 	upgrade_deadline_date: string | null;
 };
 
-export function useStatsAppPlanUsage( params?: StatsQueryParams, options?: UseStatsAppOptions ) {
+export function useStatsAppPlanUsage( options?: UseStatsAppOptions ) {
 	return useStatsAppQuery< StatsAppPlanUsage >(
-		statsAppPlanUsageQuery< StatsAppPlanUsage >( params ),
+		statsAppPlanUsageQuery< StatsAppPlanUsage >(),
 		options
 	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,6 +34,11 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsAppPlanUsage } from './hooks/use-stats-app-plan-usage';
+export type {
+	StatsAppPlanPeriodUsage,
+	StatsAppPlanPriceTier,
+	StatsAppPlanUsage,
+} from './hooks/use-stats-app-plan-usage';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -33,6 +33,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
+export { useStatsAppPlanUsage } from './hooks/use-stats-app-plan-usage';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -23,6 +23,7 @@ export { statsLocationsQuery } from './stats-locations-query';
 export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
+export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
@@ -2,12 +2,10 @@
  * Internal dependencies
  */
 import { statsAppProxyQuery } from './stats-app-query';
-import type { StatsQueryParams } from '../utils/stats-params';
 
-export const statsAppPlanUsageQuery = < TData = unknown >( params: StatsQueryParams = {} ) =>
+export const statsAppPlanUsageQuery = < TData = unknown >() =>
 	statsAppProxyQuery< TData >( {
 		name: 'plan-usage',
 		version: '2',
 		endpoint: 'jetpack-stats/usage',
-		params,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
@@ -4,8 +4,8 @@
 import { statsAppProxyQuery } from './stats-app-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export const statsAppPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
-	statsAppProxyQuery( {
+export const statsAppPlanUsageQuery = < TData = unknown >( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery< TData >( {
 		name: 'plan-usage',
 		version: '2',
 		endpoint: 'jetpack-stats/usage',

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-plan-usage-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsAppPlanUsageQuery = ( params: StatsQueryParams = {} ) =>
+	statsAppProxyQuery( {
+		name: 'plan-usage',
+		version: '2',
+		endpoint: 'jetpack-stats/usage',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats app plan usage endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check