### PR TITLE
Premium Analytics: add Stats app purchases endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-app-purchases-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-app-purchases-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add app purchases hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -19,6 +19,7 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsAppPlanUsage',
+	'useStatsAppPurchases',
 	'useStatsArchives',
 	'useStatsCommentFollowers',
 	'useStatsFollowers',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -36,6 +36,13 @@ export type {
 	StatsAppPlanPriceTier,
 	StatsAppPlanUsage,
 } from './use-stats-app-plan-usage';
+export {
+	useStatsAppPurchases,
+	type StatsAppPurchase,
+	type StatsAppPurchaseExpiryStatus,
+	type StatsAppPurchasesParams,
+	type StatsAppPurchasesResponse,
+} from './use-stats-app-purchases';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
 export {
 	useStatsCommentFollowers,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-purchases.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-purchases.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppPurchasesQuery } from '../queries/stats-app-purchases-query';
+import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type {
+	StatsAppPurchase,
+	StatsAppPurchaseExpiryStatus,
+	StatsAppPurchasesParams,
+	StatsAppPurchasesResponse,
+} from '../queries/stats-app-purchases-query';
+
+export type {
+	StatsAppPurchase,
+	StatsAppPurchaseExpiryStatus,
+	StatsAppPurchasesParams,
+	StatsAppPurchasesResponse,
+};
+
+export function useStatsAppPurchases(
+	params?: StatsAppPurchasesParams,
+	options?: UseStatsAppOptions
+) {
+	return useStatsAppQuery( statsAppPurchasesQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -41,6 +41,13 @@ export type {
 	StatsAppPlanPriceTier,
 	StatsAppPlanUsage,
 } from './hooks/use-stats-app-plan-usage';
+export {
+	useStatsAppPurchases,
+	type StatsAppPurchase,
+	type StatsAppPurchaseExpiryStatus,
+	type StatsAppPurchasesParams,
+	type StatsAppPurchasesResponse,
+} from './hooks/use-stats-app-purchases';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
 export {
 	useStatsCommentFollowers,

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { statsAppPurchasesQuery } from '../stats-app-purchases-query';
 import { statsAppProxyQuery } from '../stats-app-query';
 import {
 	statsAppReferrersMarkSpamMutation,
@@ -540,6 +541,30 @@ describe( 'Stats query factories', () => {
 				params: {},
 			} ).queryKey
 		);
+	} );
+
+	it( 'builds app purchases query keys for the upgrades endpoint', () => {
+		expect( statsAppPurchasesQuery( { site: 41 } ).queryKey ).toEqual( [
+			'stats-app',
+			'purchases',
+			'1.2',
+			'upgrades',
+			'GET',
+			{ site: 41 },
+			{},
+		] );
+	} );
+
+	it( 'passes purchases endpoint filters without report param coercion', () => {
+		expect( statsAppPurchasesQuery( { type: 'transferred' } ).queryKey ).toEqual( [
+			'stats-app',
+			'purchases',
+			'1.2',
+			'upgrades',
+			'GET',
+			{ type: 'transferred' },
+			{},
+		] );
 	} );
 
 	it( 'builds subscribers query keys with Calypso endpoint params and default stat fields', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -25,6 +25,13 @@ export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
+export { statsAppPurchasesQuery } from './stats-app-purchases-query';
+export type {
+	StatsAppPurchase,
+	StatsAppPurchaseExpiryStatus,
+	StatsAppPurchasesParams,
+	StatsAppPurchasesResponse,
+} from './stats-app-purchases-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsCommentFollowersQuery } from './stats-comment-followers-query';
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-app-purchases-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-app-purchases-query.ts
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { statsAppProxyQuery } from './stats-app-query';
+
+export type StatsAppPurchasesParams = {
+	site?: number | string;
+	type?: 'transferred';
+};
+
+export type StatsAppPurchaseExpiryStatus =
+	| 'active'
+	| 'auto-renewing'
+	| 'expired'
+	| 'expiring'
+	| 'included'
+	| 'manual-renew'
+	| 'one-time-purchase';
+
+export type StatsAppPurchase = {
+	ID: number | string;
+	amount: number;
+	attached_to_purchase_id: number | string | null;
+	blog_id: number | string;
+	blogname: string;
+	currency_code: string;
+	currency_symbol: string;
+	expiry_date: string;
+	expiry_status: StatsAppPurchaseExpiryStatus;
+	is_auto_renew_enabled: boolean;
+	is_cancelable: boolean;
+	is_free_jetpack_stats_product: boolean;
+	is_jetpack_plan_or_product: boolean;
+	is_jetpack_stats_product: boolean;
+	is_plan: boolean;
+	is_refundable: boolean;
+	is_removable: boolean;
+	is_renewable: boolean;
+	price_text: string;
+	product_id: number | string;
+	product_name: string;
+	product_slug: string;
+	product_type: string;
+	site_slug: string;
+	subscribed_date: string;
+	subscription_status: 'active' | 'inactive';
+	user_id: number | string;
+};
+
+export type StatsAppPurchasesResponse = StatsAppPurchase[];
+
+export const statsAppPurchasesQuery = ( params: StatsAppPurchasesParams = {} ) =>
+	statsAppProxyQuery< StatsAppPurchasesResponse >( {
+		name: 'purchases',
+		version: '1.2',
+		endpoint: 'upgrades',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats app purchases endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check