### PR TITLE
Premium Analytics: add Stats archives endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-archives-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-archives-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add archives report hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -17,6 +17,7 @@ const statsHookNames = [
 	'useStatsAppCommercialClassificationMutation',
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
+	'useStatsArchives',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -24,6 +24,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
+export { useStatsArchives } from './use-stats-archives';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -24,7 +24,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
-export { useStatsArchives } from './use-stats-archives';
+export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { statsArchivesQuery } from '../queries/stats-archives-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsArchives( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsArchivesQuery,
+		params,
+		[ 'stats', 'archives', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
@@ -4,7 +4,10 @@
 import { statsArchivesQuery } from '../queries/stats-archives-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsArchivesItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
+
+export type StatsArchivesResponse = StatsNormalizedReport< StatsArchivesItem >;
 
 export function useStatsArchives( params: StatsReportParams, options?: UseStatsOptions ) {
 	return useStatsReport(

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -2,18 +2,19 @@
  * Internal dependencies
  */
 import { useReport } from './use-report';
-import type { StatsReportParams, StatsReportQueryOptions } from '../queries/stats-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import type { StatsReportParams } from '../queries/stats-query';
 
 export type UseStatsOptions = {
 	enabled?: boolean;
 };
 
-type StatsReportQueryFactory< TParams extends StatsReportParams > = (
+type StatsReportQueryFactory< TParams extends StatsReportParams, TData > = (
 	params: TParams
-) => StatsReportQueryOptions;
+) => UseQueryOptions< TData >;
 
-export function useStatsReport< TParams extends StatsReportParams >(
-	queryFactory: StatsReportQueryFactory< TParams >,
+export function useStatsReport< TParams extends StatsReportParams, TData >(
+	queryFactory: StatsReportQueryFactory< TParams, TData >,
 	params: TParams,
 	reportSlugOrDisabledComparisonKey: string | string[],
 	options?: UseStatsOptions

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import { useReport } from './use-report';
-import type { UseQueryOptions } from '@tanstack/react-query';
 import type { StatsReportParams } from '../queries/stats-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 export type UseStatsOptions = {
 	enabled?: boolean;

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -33,6 +33,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
+export { useStatsArchives } from './hooks/use-stats-archives';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
@@ -78,6 +79,7 @@ export type {
 	StatsNormalizedSummary,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
+	StatsArchivesItem,
 	StatsTopAuthorsItem,
 	StatsTopPostsItem,
 	StatsVideoPlaysItem,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -33,7 +33,7 @@ export {
 	useStatsAppDashboardModuleSettingsMutation,
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
-export { useStatsArchives } from './hooks/use-stats-archives';
+export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
@@ -68,6 +68,7 @@ export type {
 	StatsProxyVersion,
 } from './api';
 export type {
+	StatsArchivesItem,
 	StatsClicksItem,
 	StatsFileDownloadsItem,
 	StatsItemAction,
@@ -79,7 +80,6 @@ export type {
 	StatsNormalizedSummary,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
-	StatsArchivesItem,
 	StatsTopAuthorsItem,
 	StatsTopPostsItem,
 	StatsVideoPlaysItem,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
@@ -32,3 +32,67 @@ export const archivesFixture = {
 		},
 	},
 };
+
+export const archivesSummaryFixture = {
+	date: '2025-06-02',
+	period: 'day',
+	summary: {
+		search: [
+			{
+				href: 'http://jetpack.com/?s=',
+				value: '',
+				views: 4,
+			},
+			{
+				href: 'http://jetpack.com/?s=I+can',
+				value: 'I can',
+				views: 2,
+			},
+			{
+				href: 'http://jetpack.com/?s=plugin',
+				value: 'plugin',
+				views: 1,
+			},
+		],
+		cat: [
+			{
+				href: 'http://jetpack.com/category/rrr/',
+				value: 'rrr',
+				views: 51,
+			},
+		],
+		home: [
+			{
+				href: 'http://jetpack.com/',
+				value: 1,
+				views: 89,
+			},
+		],
+		tax: {
+			topics: [
+				{
+					href: 'http://jetpack.com/?taxonomy=topics&term=aaa',
+					value: 'aaa',
+					views: 6,
+				},
+				{
+					href: 'http://jetpack.com/?taxonomy=topics&term=bbb',
+					value: 'bbb',
+					views: 4,
+				},
+			],
+		},
+		date: [
+			{
+				href: 'http://jetpack.com/2024/05',
+				value: '2024/05',
+				views: 4,
+			},
+			{
+				href: 'http://jetpack.com/2023/06',
+				value: '2023/06',
+				views: 3,
+			},
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/archives.ts
@@ -1,0 +1,34 @@
+export const archivesFixture = {
+	days: {
+		'2026-06-16': {
+			home: [
+				{
+					value: 'home',
+					href: 'https://example.com/',
+					views: '3',
+				},
+			],
+			post_type: [
+				{
+					value: 'post',
+					href: 'https://example.com/type/post/',
+					views: '4',
+				},
+				{
+					value: 'page',
+					href: 'https://example.com/type/page/',
+					views: '0',
+				},
+			],
+			tax: {
+				category: [
+					{
+						value: 'News%20%26%20Updates',
+						href: 'https://example.com/category/news/',
+						views: '8',
+					},
+				],
+			},
+		},
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
@@ -1,0 +1,28 @@
+import { sanitizeStatsArchivesResponse } from '..';
+import { archivesFixture } from '../__fixtures__/archives';
+
+describe( 'Stats archives normalizer', () => {
+	it( 'normalizes archives into sorted grouped rows', () => {
+		const result = sanitizeStatsArchivesResponse( archivesFixture, {
+			period: 'day',
+			end_date: '2026-06-16',
+		} );
+
+		expect( result.summary ).toEqual( expect.objectContaining( { total: 15 } ) );
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'tax',
+				value: 8,
+			} ),
+			expect.objectContaining( {
+				label: 'post_type',
+				value: 4,
+			} ),
+			expect.objectContaining( {
+				label: 'home',
+				value: 3,
+				children: null,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
@@ -1,5 +1,5 @@
 import { sanitizeStatsArchivesResponse } from '..';
-import { archivesFixture } from '../__fixtures__/archives';
+import { archivesFixture, archivesSummaryFixture } from '../__fixtures__/archives';
 
 describe( 'Stats archives normalizer', () => {
 	it( 'normalizes archives into sorted grouped rows', () => {
@@ -22,6 +22,105 @@ describe( 'Stats archives normalizer', () => {
 				label: 'home',
 				value: 3,
 				children: null,
+			} ),
+		] );
+	} );
+
+	it( 'normalizes summarized archives from the backend summary payload', () => {
+		const result = sanitizeStatsArchivesResponse( archivesSummaryFixture, {
+			period: 'day',
+			start_date: '2025-06-01',
+			date: '2025-06-02',
+			summarize: 1,
+		} );
+
+		expect( result.summary ).toEqual( {
+			total: 160,
+		} );
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2025-06-02',
+				date_start: '2025-06-01T00:00:00+00:00',
+				date_end: '2025-06-02T23:59:59+00:00',
+				items: [
+					{
+						label: 'home',
+						value: 89,
+						children: null,
+					},
+					{
+						label: 'cat',
+						value: 51,
+						children: [
+							{
+								label: 'rrr',
+								value: 51,
+								link: 'http://jetpack.com/category/rrr/',
+								children: null,
+							},
+						],
+					},
+					{
+						label: 'tax',
+						value: 10,
+						children: [
+							{
+								label: 'topics',
+								value: 10,
+								children: [
+									{
+										label: 'aaa',
+										value: 6,
+										link: 'http://jetpack.com/?taxonomy=topics&term=aaa',
+										children: null,
+									},
+									{
+										label: 'bbb',
+										value: 4,
+										link: 'http://jetpack.com/?taxonomy=topics&term=bbb',
+										children: null,
+									},
+								],
+							},
+						],
+					},
+					{
+						label: 'date',
+						value: 7,
+						children: [
+							{
+								label: '2024/05',
+								value: 4,
+								link: 'http://jetpack.com/2024/05',
+								children: null,
+							},
+							{
+								label: '2023/06',
+								value: 3,
+								link: 'http://jetpack.com/2023/06',
+								children: null,
+							},
+						],
+					},
+					{
+						label: 'search',
+						value: 3,
+						children: [
+							{
+								label: 'I can',
+								value: 2,
+								link: 'http://jetpack.com/?s=I+can',
+								children: null,
+							},
+							{
+								label: 'plugin',
+								value: 1,
+								link: 'http://jetpack.com/?s=plugin',
+								children: null,
+							},
+						],
+					},
+				],
 			} ),
 		] );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -44,6 +44,7 @@ function normalizeArchiveChildren(
 	}
 
 	return coerceStatsArray< StatsRecord >( archiveItems )
+		.filter( item => Boolean( item.value ) )
 		.map( item => ( {
 			label: archiveType === 'home' ? getStatsLabel( item.href ) : getStatsLabel( item.value ),
 			value: safeParseFloat( item.views ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -1,0 +1,128 @@
+import { safeParseFloat } from '../../utils/parsing';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	createStatsSummaryDataPoint,
+	emptyStatsReport,
+	getStatsBuckets,
+	getStatsLabel,
+	getStatsTopLevelDataDate,
+} from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsArchivesItem extends StatsNormalizedItemBase< StatsArchivesItem > {
+	value: number;
+	link?: unknown;
+}
+
+function normalizeArchiveChildren(
+	archiveType: string,
+	archiveItems: unknown
+): StatsArchivesItem[] {
+	if ( archiveType === 'tax' ) {
+		return Object.entries( coerceStatsRecord( archiveItems ) )
+			.map( ( [ taxonomy, terms ] ) => {
+				const children = coerceStatsArray< StatsRecord >( terms )
+					.map( term => ( {
+						label: getStatsLabel( term.value ),
+						value: safeParseFloat( term.views ),
+						link: term.href,
+						children: null,
+					} ) )
+					.filter( item => item.value > 0 );
+				const value = children.reduce( ( total, term ) => total + term.value, 0 );
+
+				return {
+					label: taxonomy,
+					value,
+					children,
+				};
+			} )
+			.filter( item => item.value > 0 );
+	}
+
+	return coerceStatsArray< StatsRecord >( archiveItems )
+		.map( item => ( {
+			label: archiveType === 'home' ? getStatsLabel( item.href ) : getStatsLabel( item.value ),
+			value: safeParseFloat( item.views ),
+			link: item.href,
+			children: null,
+		} ) )
+		.filter( item => item.value > 0 );
+}
+
+export function sanitizeStatsArchivesResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsArchivesItem > {
+	const payload = coerceStatsRecord( response );
+	const summary = coerceStatsRecord( payload.summary );
+
+	if ( query?.summarize && Object.keys( summary ).length ) {
+		const items = Object.entries( summary )
+			.map( ( [ archiveType, archiveItems ] ) => {
+				const children = normalizeArchiveChildren( archiveType, archiveItems );
+				const value = children.reduce( ( total, item ) => total + item.value, 0 );
+
+				return {
+					label: archiveType,
+					value,
+					children: archiveType === 'home' && children.length < 2 ? null : children,
+				};
+			} )
+			.filter( item => item.value > 0 )
+			.sort( ( a, b ) => b.value - a.value );
+		const summaryDate = getStatsTopLevelDataDate( response, query );
+
+		return {
+			summary: {
+				total: items.reduce( ( total, item ) => total + item.value, 0 ),
+			},
+			data: summaryDate
+				? [ createStatsSummaryDataPoint( summaryDate, response, query, items ) ]
+				: [],
+		};
+	}
+
+	const buckets = getStatsBuckets( response, query );
+
+	if ( ! buckets.length ) {
+		return emptyStatsReport();
+	}
+
+	const data = buckets
+		.map( ( [ date, bucket ] ) => {
+			const items = Object.entries( bucket )
+				.map( ( [ archiveType, archiveItems ] ) => {
+					const children = normalizeArchiveChildren( archiveType, archiveItems );
+					const value = children.reduce( ( total, item ) => total + item.value, 0 );
+
+					return {
+						label: archiveType,
+						value,
+						children: archiveType === 'home' && children.length < 2 ? null : children,
+					};
+				} )
+				.filter( item => item.value > 0 )
+				.sort( ( a, b ) => b.value - a.value );
+
+			return {
+				...createStatsListDataPoint( { date }, query, items ),
+				time_interval: date,
+			};
+		} )
+		.filter( point => point.items.length );
+
+	return {
+		summary: {
+			total: data.reduce(
+				( total, point ) =>
+					total + point.items.reduce( ( itemTotal, item ) => itemTotal + item.value, 0 ),
+				0
+			),
+		},
+		data,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -15,6 +15,7 @@ export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './tim
 export { sanitizeStatsVisitsResponse } from './visits';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
+export { sanitizeStatsArchivesResponse } from './archives';
 export type { StatsTopPostsItem } from './top-posts';
 export type { StatsReferrersItem } from './referrers';
 export type { StatsClicksItem } from './clicks';
@@ -25,6 +26,7 @@ export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
+export type { StatsArchivesItem } from './archives';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
@@ -1,3 +1,4 @@
+import type { StatsArchivesItem } from './archives';
 import type { StatsClicksItem } from './clicks';
 import type { StatsEmailBreakdownItem } from './email-breakdown';
 import type { StatsEmailSummaryItem } from './email-summary';
@@ -29,7 +30,8 @@ export type StatsNormalizedItem =
 	| StatsLocationsItem
 	| StatsVideoPlaysItem
 	| StatsEmailSummaryItem
-	| StatsEmailBreakdownItem;
+	| StatsEmailBreakdownItem
+	| StatsArchivesItem;
 
 export type StatsNormalizedDataPoint< TItem extends StatsNormalizedItem = StatsNormalizedItem > = {
 	time_interval: string;

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { statsAppProxyQuery } from '../stats-app-query';
+import { statsArchivesQuery } from '../stats-archives-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import type { StatsReportParams } from '../stats-query';
@@ -77,6 +78,25 @@ describe( 'Stats query factories', () => {
 					date: '2026-06-07',
 					start_date: '2026-06-01',
 					days: 7,
+					summarize: 1,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'requests summarized archives data for multi-day ranges', () => {
+		const query = statsArchivesQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				'stats/archives',
+				expect.objectContaining( {
+					date: '2026-06-07',
+					start_date: '2026-06-01',
 					summarize: 1,
 				} ),
 			] )

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -23,3 +23,4 @@ export { statsLocationsQuery } from './stats-locations-query';
 export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
+export { statsArchivesQuery } from './stats-archives-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-archives-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-archives-query.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { statsReportQuery, type StatsReportParams } from './stats-query';
+
+export const statsArchivesQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'archives', 'stats/archives', params, 'archives' );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -43,20 +43,28 @@ const statsSanitizers = {
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;
-type StatsSanitizerData = ReturnType< ( typeof statsSanitizers )[ StatsSanitizerKey ] >;
-export type StatsReportQueryOptions = UseQueryOptions< StatsSanitizerData >;
+type StatsSanitizerData< TSanitizer extends StatsSanitizerKey = StatsSanitizerKey > = ReturnType<
+	( typeof statsSanitizers )[ TSanitizer ]
+>;
+export type StatsReportQueryOptions<
+	TSanitizer extends StatsSanitizerKey = StatsSanitizerKey,
+> = UseQueryOptions< StatsSanitizerData< TSanitizer > >;
 
-export type StatsQueryConfig = {
+export type StatsQueryConfig< TSanitizer extends StatsSanitizerKey = StatsSanitizerKey > = {
 	name: string;
 	version: StatsProxyVersion;
 	endpoint: string;
 	params?: StatsQueryParams;
 	method?: StatsProxyMethod;
 	body?: unknown;
-	sanitizer?: StatsSanitizerKey;
+	sanitizer?: TSanitizer;
 	enabled?: boolean;
 };
 
+export function statsProxyQuery< TSanitizer extends StatsSanitizerKey >(
+	config: StatsQueryConfig< TSanitizer > & { sanitizer: TSanitizer }
+): StatsReportQueryOptions< TSanitizer >;
+export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions< 'passthrough' >;
 export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions {
 	const { name, version, endpoint, params, method = 'GET', body, enabled = true } = config;
 	const sanitizer = config.sanitizer ?? 'passthrough';
@@ -79,16 +87,16 @@ export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOpt
 	};
 }
 
-export function statsReportQuery(
+export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 	name: string,
 	endpoint: string,
 	params: StatsReportParams,
-	sanitizer: StatsSanitizerKey,
+	sanitizer: TSanitizer,
 	version: StatsProxyVersion = '1.1',
 	// Endpoint-specific params that should reach the API but are not in the
 	// reportParamsToStatsQueryParams allow-list (e.g. filter_by_country).
 	extraParams?: StatsProxyParams
-): StatsReportQueryOptions {
+): StatsReportQueryOptions< TSanitizer > {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const reportParams = {
 		...statsParams,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -46,9 +46,8 @@ export type StatsSanitizerKey = keyof typeof statsSanitizers;
 type StatsSanitizerData< TSanitizer extends StatsSanitizerKey = StatsSanitizerKey > = ReturnType<
 	( typeof statsSanitizers )[ TSanitizer ]
 >;
-export type StatsReportQueryOptions<
-	TSanitizer extends StatsSanitizerKey = StatsSanitizerKey,
-> = UseQueryOptions< StatsSanitizerData< TSanitizer > >;
+export type StatsReportQueryOptions< TSanitizer extends StatsSanitizerKey = StatsSanitizerKey > =
+	UseQueryOptions< StatsSanitizerData< TSanitizer > >;
 
 export type StatsQueryConfig< TSanitizer extends StatsSanitizerKey = StatsSanitizerKey > = {
 	name: string;
@@ -64,7 +63,9 @@ export type StatsQueryConfig< TSanitizer extends StatsSanitizerKey = StatsSaniti
 export function statsProxyQuery< TSanitizer extends StatsSanitizerKey >(
 	config: StatsQueryConfig< TSanitizer > & { sanitizer: TSanitizer }
 ): StatsReportQueryOptions< TSanitizer >;
-export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions< 'passthrough' >;
+export function statsProxyQuery(
+	config: StatsQueryConfig
+): StatsReportQueryOptions< 'passthrough' >;
 export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions {
 	const { name, version, endpoint, params, method = 'GET', body, enabled = true } = config;
 	const sanitizer = config.sanitizer ?? 'passthrough';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -8,6 +8,7 @@ import {
 	sanitizeStatsClicksResponse,
 	sanitizeStatsFileDownloadsResponse,
 	sanitizeStatsLocationsResponse,
+	sanitizeStatsArchivesResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
@@ -38,6 +39,7 @@ const statsSanitizers = {
 	topAuthors: sanitizeStatsTopAuthorsResponse,
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
+	archives: sanitizeStatsArchivesResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add the Stats archives endpoint query/hook/export wiring.
* Keep endpoint-owned processing, sanitizer, fixtures, and tests in this PR where this endpoint introduces them.
* Build on the shared foundation from #49886, now merged to trunk.

## Related product discussion/links
* Builds on #49886, now merged to trunk.
* Replaces the closed split-by-layer stack: #49780, #49781, and #49782.

## Does this pull request change what data or activity we track or use?
No. This adds client-side wrappers and normalization for existing Stats API responses.

## Testing instructions
* Run pnpm --dir projects/packages/premium-analytics typecheck.
* For endpoints with processing changes, run pnpm --dir projects/packages/premium-analytics test --runInBand.
* Build coverage was checked on the foundation plus representative resource/app endpoint branches with pnpm --dir projects/packages/premium-analytics build.




### Fixture coverage note

The local fixture covers the days-bucket response shape used by the archives normalizer. The summary-path behavior is typed and normalized conservatively, but there was no original endpoint fixture available to mirror that response shape in this PR.
