### PR TITLE
Premium Analytics: add Stats email breakdown endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-email-breakdown-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-email-breakdown-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add email breakdown hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -39,6 +39,8 @@ const statsHookNames = [
 	'useStatsAppReferrersSpam',
 	'useStatsAppReferrersMarkSpamMutation',
 	'useStatsAppReferrersUnmarkSpamMutation',
+	'useStatsEmailOpensBreakdown',
+	'useStatsEmailClicksBreakdown',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -124,6 +124,7 @@ export type {
 export {
 	useStatsEmailOpensBreakdown,
 	useStatsEmailClicksBreakdown,
+	type StatsEmailBreakdown,
 	type StatsEmailClicksBreakdown,
 	type StatsEmailOpensBreakdown,
 } from './use-stats-email-breakdown';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -121,6 +121,12 @@ export type {
 	StatsAppReferrersSpamMutationResponse,
 	StatsAppReferrersSpamResponse,
 } from './use-stats-app-referrers-spam';
+export {
+	useStatsEmailOpensBreakdown,
+	useStatsEmailClicksBreakdown,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './use-stats-email-breakdown';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import {
+	statsEmailClicksBreakdownQuery,
+	statsEmailOpensBreakdownQuery,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from '../queries/stats-email-breakdown-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsEmailOpensBreakdown(
+	postId: number,
+	breakdown: StatsEmailOpensBreakdown,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailOpensBreakdownQuery( postId, breakdown, params ), options );
+}
+
+export function useStatsEmailClicksBreakdown(
+	postId: number,
+	breakdown: StatsEmailClicksBreakdown,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown, params ), options );
+}
+
+export type { StatsEmailClicksBreakdown, StatsEmailOpensBreakdown };

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
@@ -4,6 +4,7 @@
 import {
 	statsEmailClicksBreakdownQuery,
 	statsEmailOpensBreakdownQuery,
+	type StatsEmailBreakdown,
 	type StatsEmailClicksBreakdown,
 	type StatsEmailOpensBreakdown,
 } from '../queries/stats-email-breakdown-query';
@@ -29,4 +30,4 @@ export function useStatsEmailClicksBreakdown(
 	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown, params ), options );
 }
 
-export type { StatsEmailClicksBreakdown, StatsEmailOpensBreakdown };
+export type { StatsEmailBreakdown, StatsEmailClicksBreakdown, StatsEmailOpensBreakdown };

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
@@ -10,24 +10,21 @@ import {
 } from '../queries/stats-email-breakdown-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export function useStatsEmailOpensBreakdown(
 	postId: number,
 	breakdown: StatsEmailOpensBreakdown,
-	params?: StatsQueryParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsQuery( statsEmailOpensBreakdownQuery( postId, breakdown, params ), options );
+	return useStatsQuery( statsEmailOpensBreakdownQuery( postId, breakdown ), options );
 }
 
 export function useStatsEmailClicksBreakdown(
 	postId: number,
 	breakdown: StatsEmailClicksBreakdown,
-	params?: StatsQueryParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown, params ), options );
+	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown ), options );
 }
 
 export type { StatsEmailBreakdown, StatsEmailClicksBreakdown, StatsEmailOpensBreakdown };

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -126,6 +126,12 @@ export type {
 	StatsAppReferrersSpamMutationResponse,
 	StatsAppReferrersSpamResponse,
 } from './hooks/use-stats-app-referrers-spam';
+export {
+	useStatsEmailOpensBreakdown,
+	useStatsEmailClicksBreakdown,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './hooks/use-stats-email-breakdown';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -181,6 +181,7 @@ export type {
 	StatsCommentsRawFollowData,
 	StatsCommentsRawPost,
 	StatsCommentsRawResponse,
+	StatsEmailBreakdownItem,
 	StatsFileDownloadsItem,
 	StatsFollowersItem,
 	StatsFollowersRawItem,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -129,6 +129,7 @@ export type {
 export {
 	useStatsEmailOpensBreakdown,
 	useStatsEmailClicksBreakdown,
+	type StatsEmailBreakdown,
 	type StatsEmailClicksBreakdown,
 	type StatsEmailOpensBreakdown,
 } from './hooks/use-stats-email-breakdown';

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -12,6 +12,10 @@ import { statsArchivesQuery } from '../stats-archives-query';
 import { statsCommentFollowersQuery } from '../stats-comment-followers-query';
 import { statsCommentsQuery } from '../stats-comments-query';
 import { statsDevicesQuery } from '../stats-devices-query';
+import {
+	statsEmailClicksBreakdownQuery,
+	statsEmailOpensBreakdownQuery,
+} from '../stats-email-breakdown-query';
 import { statsFollowersQuery } from '../stats-followers-query';
 import { STATS_HIGHLIGHTS_STALE_TIME, statsHighlightsQuery } from '../stats-highlights-query';
 import { statsInsightsQuery } from '../stats-insights-query';
@@ -69,6 +73,42 @@ describe( 'Stats query factories', () => {
 	it( 'disables post stats queries until a positive post ID is available', () => {
 		expect( statsPostQuery( { postId: -1 } ).enabled ).toBe( false );
 		expect( statsPostQuery( { postId: 0 } ).enabled ).toBe( false );
+	} );
+
+	it( 'builds all-time email opens breakdown query keys without query params', () => {
+		const query = statsEmailOpensBreakdownQuery( 41, 'country' );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'email-opens-country',
+			'1.1',
+			'stats/opens/emails/41/country',
+			'GET',
+			{},
+			undefined,
+			'emailBreakdown',
+		] );
+	} );
+
+	it( 'builds all-time email clicks breakdown query keys per breakdown dimension', () => {
+		const query = statsEmailClicksBreakdownQuery( 41, 'user-content-link' );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'email-clicks-user-content-link',
+			'1.1',
+			'stats/clicks/emails/41/user-content-link',
+			'GET',
+			{},
+			undefined,
+			'emailBreakdown',
+		] );
+	} );
+
+	it( 'disables email breakdown queries until a positive post ID is available', () => {
+		expect( statsEmailOpensBreakdownQuery( 0, 'client' ).enabled ).toBe( false );
+		expect( statsEmailClicksBreakdownQuery( -1, 'link' ).enabled ).toBe( false );
 	} );
 
 	it( 'includes filter_by_country in query params when provided', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -65,3 +65,9 @@ export type {
 	StatsAppReferrersSpamMutationResponse,
 	StatsAppReferrersSpamResponse,
 } from './stats-app-referrers-spam-query';
+export {
+	statsEmailOpensBreakdownQuery,
+	statsEmailClicksBreakdownQuery,
+	type StatsEmailClicksBreakdown,
+	type StatsEmailOpensBreakdown,
+} from './stats-email-breakdown-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
@@ -4,34 +4,35 @@
 import { statsProxyQuery } from './stats-query';
 import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsEmailBreakdownItem, StatsNormalizedReport } from '../processing/stats';
-import type { StatsQueryParams } from '../utils/stats-params';
 
 export type StatsEmailOpensBreakdown = 'client' | 'device' | 'country' | 'rate';
 export type StatsEmailClicksBreakdown = StatsEmailOpensBreakdown | 'link' | 'user-content-link';
 export type StatsEmailBreakdown = StatsNormalizedReport< StatsEmailBreakdownItem >;
 
+const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postId > 0;
+
+// The all-time breakdown endpoints are keyed entirely by post ID and breakdown; unlike the
+// timeline endpoint they take no period/date query params (see Calypso PERIOD_ALL_TIME handling).
 export const statsEmailOpensBreakdownQuery = (
 	postId: number,
-	breakdown: StatsEmailOpensBreakdown,
-	params: StatsQueryParams = {}
+	breakdown: StatsEmailOpensBreakdown
 ): StatsReportQueryOptions< 'emailBreakdown' > =>
 	statsProxyQuery( {
 		name: `email-opens-${ breakdown }`,
 		version: '1.1',
 		endpoint: `stats/opens/emails/${ postId }/${ breakdown }`,
-		params,
 		sanitizer: 'emailBreakdown',
+		enabled: hasValidPostId( postId ),
 	} );
 
 export const statsEmailClicksBreakdownQuery = (
 	postId: number,
-	breakdown: StatsEmailClicksBreakdown,
-	params: StatsQueryParams = {}
+	breakdown: StatsEmailClicksBreakdown
 ): StatsReportQueryOptions< 'emailBreakdown' > =>
 	statsProxyQuery( {
 		name: `email-clicks-${ breakdown }`,
 		version: '1.1',
 		endpoint: `stats/clicks/emails/${ postId }/${ breakdown }`,
-		params,
 		sanitizer: 'emailBreakdown',
+		enabled: hasValidPostId( postId ),
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export type StatsEmailOpensBreakdown = 'client' | 'device' | 'country' | 'rate';
+export type StatsEmailClicksBreakdown = StatsEmailOpensBreakdown | 'link' | 'user-content-link';
+
+export const statsEmailOpensBreakdownQuery = (
+	postId: number,
+	breakdown: StatsEmailOpensBreakdown,
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-opens-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/opens/emails/${ postId }/${ breakdown }`,
+		params,
+		sanitizer: 'emailBreakdown',
+	} );
+
+export const statsEmailClicksBreakdownQuery = (
+	postId: number,
+	breakdown: StatsEmailClicksBreakdown,
+	params: StatsQueryParams = {}
+) =>
+	statsProxyQuery( {
+		name: `email-clicks-${ breakdown }`,
+		version: '1.1',
+		endpoint: `stats/clicks/emails/${ postId }/${ breakdown }`,
+		params,
+		sanitizer: 'emailBreakdown',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-breakdown-query.ts
@@ -2,16 +2,19 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
+import type { StatsReportQueryOptions } from './stats-query';
+import type { StatsEmailBreakdownItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
 
 export type StatsEmailOpensBreakdown = 'client' | 'device' | 'country' | 'rate';
 export type StatsEmailClicksBreakdown = StatsEmailOpensBreakdown | 'link' | 'user-content-link';
+export type StatsEmailBreakdown = StatsNormalizedReport< StatsEmailBreakdownItem >;
 
 export const statsEmailOpensBreakdownQuery = (
 	postId: number,
 	breakdown: StatsEmailOpensBreakdown,
 	params: StatsQueryParams = {}
-) =>
+): StatsReportQueryOptions< 'emailBreakdown' > =>
 	statsProxyQuery( {
 		name: `email-opens-${ breakdown }`,
 		version: '1.1',
@@ -24,7 +27,7 @@ export const statsEmailClicksBreakdownQuery = (
 	postId: number,
 	breakdown: StatsEmailClicksBreakdown,
 	params: StatsQueryParams = {}
-) =>
+): StatsReportQueryOptions< 'emailBreakdown' > =>
 	statsProxyQuery( {
 		name: `email-clicks-${ breakdown }`,
 		version: '1.1',

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -20,6 +20,7 @@ import {
 	sanitizeStatsTagsResponse,
 	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsPublicizeResponse,
+	sanitizeStatsEmailBreakdownResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsPostResponse,
 	sanitizeStatsReferrersResponse,
@@ -74,6 +75,7 @@ const statsSanitizers = {
 	publicize: sanitizeStatsPublicizeResponse,
 	wordAdsStats: sanitizeStatsWordAdsStatsResponse,
 	wordAdsEarnings: sanitizeStatsWordAdsEarningsResponse,
+	emailBreakdown: sanitizeStatsEmailBreakdownResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats email breakdown endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check