### PR TITLE
Premium Analytics: add Stats highlights endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-highlights-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-highlights-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add highlights hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -23,6 +23,7 @@ const statsHookNames = [
 	'useStatsVisits',
 	'useStatsInsights',
 	'useStatsUtm',
+	'useStatsHighlights',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -51,7 +51,15 @@ export type {
 } from './use-stats-insights';
 export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
 export { useStatsHighlights } from './use-stats-highlights';
-export type { StatsHighlightsResponse } from './use-stats-highlights';
+export type {
+	StatsHighlightsParams,
+	StatsHighlightsPeriod,
+	StatsHighlightsRange,
+	StatsHighlightsRawPeriod,
+	StatsHighlightsRawRange,
+	StatsHighlightsRawResponse,
+	StatsHighlightsResponse,
+} from './use-stats-highlights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -50,6 +50,7 @@ export type {
 	StatsInsightsYear,
 } from './use-stats-insights';
 export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
+export { useStatsHighlights } from './use-stats-highlights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -51,12 +51,7 @@ export type {
 } from './use-stats-insights';
 export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
 export { useStatsHighlights } from './use-stats-highlights';
-export type {
-	StatsHighlightsParams,
-	StatsHighlightsPeriod,
-	StatsHighlightsRange,
-	StatsHighlightsResponse,
-} from './use-stats-highlights';
+export type { StatsHighlightsParams, StatsHighlightsResponse } from './use-stats-highlights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -51,6 +51,7 @@ export type {
 } from './use-stats-insights';
 export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
 export { useStatsHighlights } from './use-stats-highlights';
+export type { StatsHighlightsResponse } from './use-stats-highlights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -55,9 +55,6 @@ export type {
 	StatsHighlightsParams,
 	StatsHighlightsPeriod,
 	StatsHighlightsRange,
-	StatsHighlightsRawPeriod,
-	StatsHighlightsRawRange,
-	StatsHighlightsRawResponse,
 	StatsHighlightsResponse,
 } from './use-stats-highlights';
 export type { UseStatsOptions } from './use-stats-report';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -6,6 +6,8 @@ import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type { StatsHighlightsResponse } from '../queries/stats-highlights-query';
+
 export function useStatsHighlights( params?: StatsQueryParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsHighlightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -4,10 +4,18 @@
 import { statsHighlightsQuery } from '../queries/stats-highlights-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsHighlightsParams } from '../queries/stats-highlights-query';
 
-export type { StatsHighlightsResponse } from '../queries/stats-highlights-query';
+export type {
+	StatsHighlightsParams,
+	StatsHighlightsPeriod,
+	StatsHighlightsRange,
+	StatsHighlightsRawPeriod,
+	StatsHighlightsRawRange,
+	StatsHighlightsRawResponse,
+	StatsHighlightsResponse,
+} from '../queries/stats-highlights-query';
 
-export function useStatsHighlights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+export function useStatsHighlights( params?: StatsHighlightsParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsHighlightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -8,8 +8,6 @@ import type { StatsHighlightsParams } from '../queries/stats-highlights-query';
 
 export type {
 	StatsHighlightsParams,
-	StatsHighlightsPeriod,
-	StatsHighlightsRange,
 	StatsHighlightsResponse,
 } from '../queries/stats-highlights-query';
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -10,9 +10,6 @@ export type {
 	StatsHighlightsParams,
 	StatsHighlightsPeriod,
 	StatsHighlightsRange,
-	StatsHighlightsRawPeriod,
-	StatsHighlightsRawRange,
-	StatsHighlightsRawResponse,
 	StatsHighlightsResponse,
 } from '../queries/stats-highlights-query';
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsHighlightsQuery } from '../queries/stats-highlights-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsHighlights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsHighlightsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -65,9 +65,6 @@ export type {
 	StatsHighlightsParams,
 	StatsHighlightsPeriod,
 	StatsHighlightsRange,
-	StatsHighlightsRawPeriod,
-	StatsHighlightsRawRange,
-	StatsHighlightsRawResponse,
 	StatsHighlightsResponse,
 } from './hooks/use-stats-highlights';
 export type { UseStatsOptions } from './hooks/use-stats-report';

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -61,7 +61,15 @@ export type {
 export { useStatsUtm } from './hooks/use-stats-utm';
 export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
 export { useStatsHighlights } from './hooks/use-stats-highlights';
-export type { StatsHighlightsResponse } from './hooks/use-stats-highlights';
+export type {
+	StatsHighlightsParams,
+	StatsHighlightsPeriod,
+	StatsHighlightsRange,
+	StatsHighlightsRawPeriod,
+	StatsHighlightsRawRange,
+	StatsHighlightsRawResponse,
+	StatsHighlightsResponse,
+} from './hooks/use-stats-highlights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -61,12 +61,7 @@ export type {
 export { useStatsUtm } from './hooks/use-stats-utm';
 export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
 export { useStatsHighlights } from './hooks/use-stats-highlights';
-export type {
-	StatsHighlightsParams,
-	StatsHighlightsPeriod,
-	StatsHighlightsRange,
-	StatsHighlightsResponse,
-} from './hooks/use-stats-highlights';
+export type { StatsHighlightsParams, StatsHighlightsResponse } from './hooks/use-stats-highlights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -60,6 +60,7 @@ export type {
 } from './hooks/use-stats-insights';
 export { useStatsUtm } from './hooks/use-stats-utm';
 export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
+export { useStatsHighlights } from './hooks/use-stats-highlights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -61,6 +61,7 @@ export type {
 export { useStatsUtm } from './hooks/use-stats-utm';
 export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
 export { useStatsHighlights } from './hooks/use-stats-highlights';
+export type { StatsHighlightsResponse } from './hooks/use-stats-highlights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/highlights.ts
@@ -1,3 +1,5 @@
+import type { StatsHighlightsRawResponse } from '../highlights';
+
 export const highlightsFixture = {
 	past_seven_days: {
 		range: {
@@ -19,4 +21,14 @@ export const highlightsFixture = {
 		views: 23,
 		visitors: '17',
 	},
-};
+	past_thirty_days: {
+		range: {
+			start: '2026-05-23',
+			end: '2026-06-21',
+		},
+		comments: '3',
+		likes: '6',
+		views: '10001',
+		visitors: '220',
+	},
+} satisfies StatsHighlightsRawResponse;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/highlights.ts
@@ -1,0 +1,22 @@
+export const highlightsFixture = {
+	past_seven_days: {
+		range: {
+			start: '2026-06-15',
+			end: '2026-06-21',
+		},
+		comments: '2',
+		likes: 5,
+		views: '106',
+		visitors: 28,
+	},
+	between_past_eight_and_fifteen_days: {
+		range: {
+			start: '2026-06-07',
+			end: '2026-06-14',
+		},
+		comments: 0,
+		likes: '1',
+		views: 23,
+		visitors: '17',
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/highlights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/highlights.test.ts
@@ -24,6 +24,45 @@ describe( 'Stats highlights normalizer', () => {
 				views: 23,
 				visitors: 17,
 			},
+			past_thirty_days: {
+				range: {
+					start: '2026-05-23',
+					end: '2026-06-21',
+				},
+				comments: 3,
+				likes: 6,
+				views: 10001,
+				visitors: 220,
+			},
+		} );
+	} );
+
+	it( 'returns an empty response for empty payloads', () => {
+		expect( sanitizeStatsHighlightsResponse( null ) ).toEqual( {} );
+	} );
+
+	it( 'falls back for missing or malformed period fields', () => {
+		expect(
+			sanitizeStatsHighlightsResponse( {
+				past_seven_days: {
+					range: null,
+					comments: undefined,
+					likes: '',
+					views: '0',
+					visitors: '12',
+				},
+			} )
+		).toEqual( {
+			past_seven_days: {
+				range: {
+					start: '',
+					end: '',
+				},
+				comments: 0,
+				likes: 0,
+				views: 0,
+				visitors: 12,
+			},
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/highlights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/highlights.test.ts
@@ -1,0 +1,29 @@
+import { sanitizeStatsHighlightsResponse } from '..';
+import { highlightsFixture } from '../__fixtures__/highlights';
+
+describe( 'Stats highlights normalizer', () => {
+	it( 'normalizes keyed highlights periods', () => {
+		expect( sanitizeStatsHighlightsResponse( highlightsFixture ) ).toEqual( {
+			past_seven_days: {
+				range: {
+					start: '2026-06-15',
+					end: '2026-06-21',
+				},
+				comments: 2,
+				likes: 5,
+				views: 106,
+				visitors: 28,
+			},
+			between_past_eight_and_fifteen_days: {
+				range: {
+					start: '2026-06-07',
+					end: '2026-06-14',
+				},
+				comments: 0,
+				likes: 1,
+				views: 23,
+				visitors: 17,
+			},
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/highlights.ts
@@ -2,6 +2,23 @@ import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsRecord } from './utils';
 import type { StatsRecord } from './types';
 
+type StatsHighlightsMetricValue = number | string;
+
+export type StatsHighlightsRawRange = {
+	start: string;
+	end: string;
+};
+
+export type StatsHighlightsRawPeriod = {
+	range: StatsHighlightsRawRange;
+	comments: StatsHighlightsMetricValue;
+	likes: StatsHighlightsMetricValue;
+	views: StatsHighlightsMetricValue;
+	visitors: StatsHighlightsMetricValue;
+};
+
+export type StatsHighlightsRawResponse = Record< string, StatsHighlightsRawPeriod >;
+
 export type StatsHighlightsRange = {
 	start: string;
 	end: string;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/highlights.ts
@@ -1,0 +1,46 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsRecord } from './utils';
+import type { StatsRecord } from './types';
+
+export type StatsHighlightsRange = {
+	start: string;
+	end: string;
+};
+
+export type StatsHighlightsPeriod = {
+	range: StatsHighlightsRange;
+	comments: number;
+	likes: number;
+	views: number;
+	visitors: number;
+};
+
+export type StatsHighlightsResponse = Record< string, StatsHighlightsPeriod >;
+
+function getString( value: unknown ) {
+	return typeof value === 'string' ? value : '';
+}
+
+function normalizeStatsHighlightsPeriod( value: StatsRecord ): StatsHighlightsPeriod {
+	const range = coerceStatsRecord( value.range );
+
+	return {
+		range: {
+			start: getString( range.start ),
+			end: getString( range.end ),
+		},
+		comments: safeParseFloat( value.comments ),
+		likes: safeParseFloat( value.likes ),
+		views: safeParseFloat( value.views ),
+		visitors: safeParseFloat( value.visitors ),
+	};
+}
+
+export function sanitizeStatsHighlightsResponse( response: unknown ): StatsHighlightsResponse {
+	return Object.fromEntries(
+		Object.entries( coerceStatsRecord( response ) ).map( ( [ key, value ] ) => [
+			key,
+			normalizeStatsHighlightsPeriod( coerceStatsRecord( value ) ),
+		] )
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -9,6 +9,7 @@ export { sanitizeStatsClicksResponse } from './clicks';
 export { sanitizeStatsSearchTermsResponse } from './search-terms';
 export { sanitizeStatsFileDownloadsResponse } from './file-downloads';
 export { sanitizeStatsTopAuthorsResponse } from './top-authors';
+export { sanitizeStatsHighlightsResponse } from './highlights';
 export { sanitizeStatsLocationsResponse } from './locations';
 export { sanitizeStatsVideoPlaysResponse } from './video-plays';
 export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './time-series';
@@ -25,6 +26,7 @@ export type { StatsClicksItem } from './clicks';
 export type { StatsSearchTermsItem } from './search-terms';
 export type { StatsFileDownloadsItem } from './file-downloads';
 export type { StatsTopAuthorsItem } from './top-authors';
+export type { StatsHighlightsResponse } from './highlights';
 export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -26,7 +26,14 @@ export type { StatsClicksItem } from './clicks';
 export type { StatsSearchTermsItem } from './search-terms';
 export type { StatsFileDownloadsItem } from './file-downloads';
 export type { StatsTopAuthorsItem } from './top-authors';
-export type { StatsHighlightsResponse } from './highlights';
+export type {
+	StatsHighlightsPeriod,
+	StatsHighlightsRange,
+	StatsHighlightsRawPeriod,
+	StatsHighlightsRawRange,
+	StatsHighlightsRawResponse,
+	StatsHighlightsResponse,
+} from './highlights';
 export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -3,6 +3,7 @@
  */
 import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
+import { statsHighlightsQuery } from '../stats-highlights-query';
 import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsStreakQuery } from '../stats-streak-query';
@@ -142,6 +143,21 @@ describe( 'Stats query factories', () => {
 			'GET',
 			{ date: '2026-06-16' },
 			{},
+		] );
+	} );
+
+	it( 'builds highlights query keys with endpoint params and sanitizer', () => {
+		const query = statsHighlightsQuery( { source: 'stats-feedback' } );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'highlights',
+			'1.1',
+			'stats/highlights',
+			'GET',
+			{ source: 'stats-feedback' },
+			undefined,
+			'highlights',
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -3,7 +3,7 @@
  */
 import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
-import { statsHighlightsQuery } from '../stats-highlights-query';
+import { STATS_HIGHLIGHTS_STALE_TIME, statsHighlightsQuery } from '../stats-highlights-query';
 import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsStreakQuery } from '../stats-streak-query';
@@ -159,6 +159,7 @@ describe( 'Stats query factories', () => {
 			undefined,
 			'highlights',
 		] );
+		expect( query.staleTime ).toBe( STATS_HIGHLIGHTS_STALE_TIME );
 	} );
 
 	it( 'shares app query keys for empty and omitted params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -29,3 +29,4 @@ export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';
 export { statsUtmQuery } from './stats-utm-query';
+export { statsHighlightsQuery } from './stats-highlights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -2,15 +2,18 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
-import type { StatsHighlightsResponse } from '../processing/stats';
+import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
-import type { UseQueryOptions } from '@tanstack/react-query';
 
-export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
+export type { StatsHighlightsResponse } from '../processing/stats';
+
+export const statsHighlightsQuery = (
+	params: StatsQueryParams = {}
+): StatsReportQueryOptions< 'highlights' > =>
 	statsProxyQuery( {
 		name: 'highlights',
 		version: '1.1',
 		endpoint: 'stats/highlights',
 		params,
 		sanitizer: 'highlights',
-	} ) as UseQueryOptions< StatsHighlightsResponse >;
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -8,9 +8,6 @@ import type { StatsQueryParams } from '../utils/stats-params';
 export type {
 	StatsHighlightsPeriod,
 	StatsHighlightsRange,
-	StatsHighlightsRawPeriod,
-	StatsHighlightsRawRange,
-	StatsHighlightsRawResponse,
 	StatsHighlightsResponse,
 } from '../processing/stats';
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -18,13 +18,19 @@ export type StatsHighlightsParams = StatsQueryParams & {
 	source?: string;
 };
 
+export const STATS_HIGHLIGHTS_STALE_TIME = 24 * 60 * 60 * 1000;
+
 export const statsHighlightsQuery = (
 	params: StatsHighlightsParams = {}
-): StatsReportQueryOptions< 'highlights' > =>
-	statsProxyQuery( {
-		name: 'highlights',
-		version: '1.1',
-		endpoint: 'stats/highlights',
-		params,
-		sanitizer: 'highlights',
-	} );
+): StatsReportQueryOptions< 'highlights' > => {
+	return {
+		...statsProxyQuery( {
+			name: 'highlights',
+			version: '1.1',
+			endpoint: 'stats/highlights',
+			params,
+			sanitizer: 'highlights',
+		} ),
+		staleTime: STATS_HIGHLIGHTS_STALE_TIME,
+	};
+};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -5,11 +5,7 @@ import { statsProxyQuery } from './stats-query';
 import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export type {
-	StatsHighlightsPeriod,
-	StatsHighlightsRange,
-	StatsHighlightsResponse,
-} from '../processing/stats';
+export type { StatsHighlightsResponse } from '../processing/stats';
 
 export type StatsHighlightsParams = StatsQueryParams & {
 	source?: string;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -5,10 +5,21 @@ import { statsProxyQuery } from './stats-query';
 import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export type { StatsHighlightsResponse } from '../processing/stats';
+export type {
+	StatsHighlightsPeriod,
+	StatsHighlightsRange,
+	StatsHighlightsRawPeriod,
+	StatsHighlightsRawRange,
+	StatsHighlightsRawResponse,
+	StatsHighlightsResponse,
+} from '../processing/stats';
+
+export type StatsHighlightsParams = StatsQueryParams & {
+	source?: string;
+};
 
 export const statsHighlightsQuery = (
-	params: StatsQueryParams = {}
+	params: StatsHighlightsParams = {}
 ): StatsReportQueryOptions< 'highlights' > =>
 	statsProxyQuery( {
 		name: 'highlights',

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'highlights', version: '1.1', endpoint: 'stats/highlights', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-highlights-query.ts
@@ -2,7 +2,15 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
+import type { StatsHighlightsResponse } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 export const statsHighlightsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'highlights', version: '1.1', endpoint: 'stats/highlights', params } );
+	statsProxyQuery( {
+		name: 'highlights',
+		version: '1.1',
+		endpoint: 'stats/highlights',
+		params,
+		sanitizer: 'highlights',
+	} ) as UseQueryOptions< StatsHighlightsResponse >;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -7,6 +7,7 @@ import {
 import {
 	sanitizeStatsClicksResponse,
 	sanitizeStatsFileDownloadsResponse,
+	sanitizeStatsHighlightsResponse,
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsArchivesResponse,
 	sanitizeStatsInsightsResponse,
@@ -40,6 +41,7 @@ const statsSanitizers = {
 	clicks: sanitizeStatsClicksResponse,
 	searchTerms: sanitizeStatsSearchTermsResponse,
 	fileDownloads: sanitizeStatsFileDownloadsResponse,
+	highlights: sanitizeStatsHighlightsResponse,
 	topAuthors: sanitizeStatsTopAuthorsResponse,
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats highlights endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check