### PR TITLE
Premium Analytics: add Stats insights endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-insights-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-insights-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add insights hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -19,6 +19,7 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsArchives',
 	'useStatsVisits',
+	'useStatsInsights',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -33,7 +33,11 @@ export {
 	type StatsVisitsStatFields,
 } from './use-stats-visits';
 export { useStatsInsights } from './use-stats-insights';
-export type { StatsInsightsResponse, StatsInsightsYear } from './use-stats-insights';
+export type {
+	StatsInsightsParams,
+	StatsInsightsResponse,
+	StatsInsightsYear,
+} from './use-stats-insights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -33,6 +33,7 @@ export {
 	type StatsVisitsStatFields,
 } from './use-stats-visits';
 export { useStatsInsights } from './use-stats-insights';
+export type { StatsInsightsResponse, StatsInsightsYear } from './use-stats-insights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -32,6 +32,7 @@ export {
 	type StatsVisitsStatField,
 	type StatsVisitsStatFields,
 } from './use-stats-visits';
+export { useStatsInsights } from './use-stats-insights';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
@@ -4,10 +4,14 @@
 import { statsInsightsQuery } from '../queries/stats-insights-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsInsightsParams } from '../queries/stats-insights-query';
 
-export type { StatsInsightsResponse, StatsInsightsYear } from '../queries/stats-insights-query';
+export type {
+	StatsInsightsParams,
+	StatsInsightsResponse,
+	StatsInsightsYear,
+} from '../queries/stats-insights-query';
 
-export function useStatsInsights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+export function useStatsInsights( params?: StatsInsightsParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsInsightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
@@ -6,6 +6,8 @@ import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type { StatsInsightsResponse, StatsInsightsYear } from '../queries/stats-insights-query';
+
 export function useStatsInsights( params?: StatsQueryParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsInsightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsInsightsQuery } from '../queries/stats-insights-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsInsights( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsInsightsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -41,6 +41,7 @@ export {
 	type StatsVisitsStatField,
 	type StatsVisitsStatFields,
 } from './hooks/use-stats-visits';
+export { useStatsInsights } from './hooks/use-stats-insights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -42,6 +42,7 @@ export {
 	type StatsVisitsStatFields,
 } from './hooks/use-stats-visits';
 export { useStatsInsights } from './hooks/use-stats-insights';
+export type { StatsInsightsResponse, StatsInsightsYear } from './hooks/use-stats-insights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -42,7 +42,11 @@ export {
 	type StatsVisitsStatFields,
 } from './hooks/use-stats-visits';
 export { useStatsInsights } from './hooks/use-stats-insights';
-export type { StatsInsightsResponse, StatsInsightsYear } from './hooks/use-stats-insights';
+export type {
+	StatsInsightsParams,
+	StatsInsightsResponse,
+	StatsInsightsYear,
+} from './hooks/use-stats-insights';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/insights.ts
@@ -1,0 +1,33 @@
+export const insightsFixture = {
+	highest_hour: 11,
+	highest_day_percent: 10,
+	highest_day_of_week: 6,
+	highest_hour_percent: 5,
+	days: {
+		'0': 103,
+		'1': 99,
+	},
+	hours: {
+		'00': 101,
+		'01': 43,
+	},
+	hourly_views: {
+		'2022-11-26 04:00:00': 0,
+		'2022-11-26 05:00:00': 4,
+		'2022-11-26 06:00:00': 8,
+	},
+	years: [
+		{
+			year: '2022',
+			total_posts: 2,
+			total_words: 35,
+			avg_words: 17.5,
+			total_likes: 1,
+			avg_likes: 0.5,
+			total_comments: 0,
+			avg_comments: 0,
+			total_images: 2,
+			avg_images: 1,
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
@@ -1,0 +1,37 @@
+import { sanitizeStatsInsightsResponse } from '..';
+import { insightsFixture } from '../__fixtures__/insights';
+
+describe( 'Stats insights normalizer', () => {
+	it( 'returns an empty object for invalid payloads', () => {
+		expect( sanitizeStatsInsightsResponse( undefined ) ).toEqual( {} );
+		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: false } ) ).toEqual( {} );
+	} );
+
+	it( 'normalizes insights using the Calypso payload shape', () => {
+		expect( sanitizeStatsInsightsResponse( insightsFixture ) ).toEqual( {
+			day: 'Sunday',
+			hour: '11:00 AM',
+			hourPercent: 5,
+			percent: 10,
+			hourlyViews: {
+				'2022-11-26 04:00:00': 0,
+				'2022-11-26 05:00:00': 4,
+				'2022-11-26 06:00:00': 8,
+			},
+			years: [
+				{
+					year: '2022',
+					total_posts: 2,
+					total_words: 35,
+					avg_words: 17.5,
+					total_likes: 1,
+					avg_likes: 0.5,
+					total_comments: 0,
+					avg_comments: 0,
+					total_images: 2,
+					avg_images: 1,
+				},
+			],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -13,6 +13,7 @@ export { sanitizeStatsLocationsResponse } from './locations';
 export { sanitizeStatsVideoPlaysResponse } from './video-plays';
 export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './time-series';
 export { sanitizeStatsVisitsResponse } from './visits';
+export { sanitizeStatsInsightsResponse } from './insights';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
@@ -24,6 +25,11 @@ export type { StatsFileDownloadsItem } from './file-downloads';
 export type { StatsTopAuthorsItem } from './top-authors';
 export type { StatsLocationsItem } from './locations';
 export type { StatsVideoPlaysItem } from './video-plays';
+export type {
+	StatsInsightsHourlyViews,
+	StatsInsightsResponse,
+	StatsInsightsYear,
+} from './insights';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type { StatsArchivesItem } from './archives';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -29,7 +29,7 @@ type StatsInsightsData = {
 export type StatsInsightsResponse = Partial< StatsInsightsData >;
 
 function getDayName( highestDayOfWeek: number ) {
-	const dayOfWeek = highestDayOfWeek + 1 > 6 ? 0 : highestDayOfWeek + 1;
+	const dayOfWeek = ( highestDayOfWeek + 1 ) % 7;
 	const date = new Date( 2026, 0, 4 + dayOfWeek, 12 );
 
 	return format( date, 'EEEE' );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -1,0 +1,84 @@
+import { format } from 'date-fns';
+import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { coerceStatsRecord } from './utils';
+
+export type StatsInsightsYear = {
+	year: string;
+	total_posts: number;
+	total_comments: number;
+	avg_comments: number;
+	total_likes: number;
+	avg_likes: number;
+	total_words: number;
+	avg_words: number;
+	total_images: number;
+	avg_images: number;
+};
+
+export type StatsInsightsHourlyViews = Record< string, number >;
+
+type StatsInsightsData = {
+	day: string;
+	percent: number;
+	hour: string;
+	hourPercent: number;
+	hourlyViews: StatsInsightsHourlyViews;
+	years: StatsInsightsYear[];
+};
+
+export type StatsInsightsResponse = Partial< StatsInsightsData >;
+
+function getDayName( highestDayOfWeek: number ) {
+	const dayOfWeek = highestDayOfWeek + 1 > 6 ? 0 : highestDayOfWeek + 1;
+	const date = new Date( 2026, 0, 4 + dayOfWeek, 12 );
+
+	return format( date, 'EEEE' );
+}
+
+function getHourLabel( hour: unknown ) {
+	const date = new Date( 2026, 0, 4, safeParseInt( hour ) );
+
+	return format( date, 'p' );
+}
+
+function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
+	const payload = coerceStatsRecord( year );
+
+	return {
+		year: String( payload.year ?? '' ),
+		total_posts: safeParseInt( payload.total_posts ),
+		total_comments: safeParseInt( payload.total_comments ),
+		avg_comments: safeParseFloat( payload.avg_comments ),
+		total_likes: safeParseInt( payload.total_likes ),
+		avg_likes: safeParseFloat( payload.avg_likes ),
+		total_words: safeParseInt( payload.total_words ),
+		avg_words: safeParseFloat( payload.avg_words ),
+		total_images: safeParseInt( payload.total_images ),
+		avg_images: safeParseFloat( payload.avg_images ),
+	};
+}
+
+function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews {
+	const payload = coerceStatsRecord( hourlyViews );
+
+	return Object.fromEntries(
+		Object.entries( payload ).map( ( [ key, value ] ) => [ key, safeParseInt( value ) ] )
+	);
+}
+
+export function sanitizeStatsInsightsResponse( response: unknown ): StatsInsightsResponse {
+	const payload = coerceStatsRecord( response );
+
+	if ( typeof payload.highest_day_of_week !== 'number' ) {
+		return {};
+	}
+
+	return {
+		day: getDayName( payload.highest_day_of_week ),
+		percent: Math.round( safeParseFloat( payload.highest_day_percent ) ),
+		hour: getHourLabel( payload.highest_hour ),
+		hourPercent: Math.round( safeParseFloat( payload.highest_hour_percent ) ),
+		hourlyViews: normalizeHourlyViews( payload.hourly_views ),
+		years: Array.isArray( payload.years ) ? payload.years.map( normalizeInsightsYear ) : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -3,6 +3,7 @@
  */
 import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
+import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsVisitsQuery } from '../stats-visits-query';
@@ -194,5 +195,18 @@ describe( 'Stats query factories', () => {
 			} )
 		);
 		expect( apiParams ).not.toHaveProperty( 'quantity' );
+	} );
+
+	it( 'builds insights query keys without report params', () => {
+		expect( statsInsightsQuery().queryKey ).toEqual( [
+			'stats',
+			'insights',
+			'1.1',
+			'stats/insights',
+			'GET',
+			{},
+			undefined,
+			'insights',
+		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -25,3 +25,4 @@ export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsVisitsQuery } from './stats-visits-query';
+export { statsInsightsQuery } from './stats-insights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
@@ -4,5 +4,30 @@
 import { statsProxyQuery } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsInsightsYear = {
+	year: string;
+	total_posts: number;
+	total_comments: number;
+	avg_comments: number;
+	total_likes: number;
+	avg_likes: number;
+	total_words: number;
+	avg_words: number;
+};
+
+export type StatsInsightsResponse = {
+	highest_hour: number;
+	highest_day_percent: number;
+	highest_day_of_week: number;
+	highest_hour_percent: number;
+	hourly_views: unknown[];
+	years: StatsInsightsYear[];
+};
+
 export const statsInsightsQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'insights', version: '1.1', endpoint: 'stats/insights', params } );
+	statsProxyQuery( {
+		name: 'insights',
+		version: '1.1',
+		endpoint: 'stats/insights',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
@@ -2,32 +2,19 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsReportQueryOptions } from './stats-query';
 
-export type StatsInsightsYear = {
-	year: string;
-	total_posts: number;
-	total_comments: number;
-	avg_comments: number;
-	total_likes: number;
-	avg_likes: number;
-	total_words: number;
-	avg_words: number;
-};
+export type StatsInsightsParams = Record< string, never >;
 
-export type StatsInsightsResponse = {
-	highest_hour: number;
-	highest_day_percent: number;
-	highest_day_of_week: number;
-	highest_hour_percent: number;
-	hourly_views: unknown[];
-	years: StatsInsightsYear[];
-};
+export type { StatsInsightsResponse, StatsInsightsYear } from '../processing/stats';
 
-export const statsInsightsQuery = ( params: StatsQueryParams = {} ) =>
+export const statsInsightsQuery = (
+	params: StatsInsightsParams = {}
+): StatsReportQueryOptions< 'insights' > =>
 	statsProxyQuery( {
 		name: 'insights',
 		version: '1.1',
 		endpoint: 'stats/insights',
 		params,
+		sanitizer: 'insights',
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-insights-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsInsightsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'insights', version: '1.1', endpoint: 'stats/insights', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -9,6 +9,7 @@ import {
 	sanitizeStatsFileDownloadsResponse,
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsArchivesResponse,
+	sanitizeStatsInsightsResponse,
 	sanitizeStatsVisitsResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsReferrersResponse,
@@ -41,6 +42,7 @@ const statsSanitizers = {
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
 	archives: sanitizeStatsArchivesResponse,
+	insights: sanitizeStatsInsightsResponse,
 	visits: sanitizeStatsVisitsResponse,
 } satisfies Record< string, StatsSanitizer >;
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats insights endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check