### PR TITLE
Premium Analytics: add Stats single post endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-single-post-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-single-post-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add single post hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -18,6 +18,7 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsArchives',
+	'useStatsSinglePost',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,6 +25,7 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
+export { useStatsSinglePost } from './use-stats-single-post';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,7 +25,7 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
-export { useStatsSinglePost } from './use-stats-single-post';
+export { useStatsSinglePost, type StatsSinglePostResponse } from './use-stats-single-post';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsSinglePostQuery } from '../queries/stats-single-post-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSinglePost(
+	postId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsSinglePostQuery( postId, params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-post.ts
@@ -4,12 +4,18 @@
 import { statsSinglePostQuery } from '../queries/stats-single-post-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
+
+export type StatsSinglePostResponse = StatsNormalizedReport;
 
 export function useStatsSinglePost(
 	postId: number,
 	params?: StatsQueryParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsQuery( statsSinglePostQuery( postId, params ), options );
+	return useStatsQuery< StatsSinglePostResponse >(
+		statsSinglePostQuery( postId, params ),
+		options
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
-export { useStatsSinglePost } from './hooks/use-stats-single-post';
+export { useStatsSinglePost, type StatsSinglePostResponse } from './hooks/use-stats-single-post';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
+export { useStatsSinglePost } from './hooks/use-stats-single-post';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -24,3 +24,4 @@ export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsArchivesQuery } from './stats-archives-query';
+export { statsSinglePostQuery } from './stats-single-post-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -9,6 +9,7 @@ import {
 	sanitizeStatsFileDownloadsResponse,
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsArchivesResponse,
+	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
@@ -40,6 +41,7 @@ const statsSanitizers = {
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
 	archives: sanitizeStatsArchivesResponse,
+	timeSeries: sanitizeStatsTimeSeriesResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
@@ -11,4 +11,5 @@ export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams =
 		endpoint: `stats/post/${ postId }`,
 		params,
 		sanitizer: 'timeSeries',
+		enabled: postId > 0,
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-post',
+		version: '1.1',
+		endpoint: `stats/post/${ postId }`,
+		params,
+		sanitizer: 'timeSeries',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-post-query.ts
@@ -2,9 +2,13 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
+import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export const statsSinglePostQuery = ( postId: number, params: StatsQueryParams = {} ) =>
+export const statsSinglePostQuery = (
+	postId: number,
+	params: StatsQueryParams = {}
+): StatsReportQueryOptions< 'timeSeries' > =>
 	statsProxyQuery( {
 		name: 'single-post',
 		version: '1.1',


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats single post endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check