### PR TITLE
Premium Analytics: add Stats single video endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-single-video-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-single-video-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add single video hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -42,6 +42,7 @@ const statsHookNames = [
 	'useStatsEmailOpensBreakdown',
 	'useStatsEmailClicksBreakdown',
 	'useStatsEmailSummary',
+	'useStatsSingleVideo',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -134,7 +134,11 @@ export {
 	type StatsEmailSummaryParams,
 	type StatsEmailSummarySortField,
 } from './use-stats-email-summary';
-export { useStatsSingleVideo } from './use-stats-single-video';
+export {
+	useStatsSingleVideo,
+	type StatsSingleVideoDataPoint,
+	type StatsSingleVideoResponse,
+} from './use-stats-single-video';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -137,6 +137,7 @@ export {
 export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
+	type StatsSingleVideoPage,
 	type StatsSingleVideoResponse,
 } from './use-stats-single-video';
 export type { UseStatsOptions } from './use-stats-report';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -134,6 +134,7 @@ export {
 	type StatsEmailSummaryParams,
 	type StatsEmailSummarySortField,
 } from './use-stats-email-summary';
+export { useStatsSingleVideo } from './use-stats-single-video';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsSingleVideoQuery } from '../queries/stats-single-video-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSingleVideo(
+	videoId: number,
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery( statsSingleVideoQuery( videoId, params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -6,6 +6,12 @@ import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsSingleVideoDataPoint = [ date: string, views: number ];
+
+export type StatsSingleVideoResponse = {
+	data: StatsSingleVideoDataPoint[];
+};
+
 export function useStatsSingleVideo(
 	videoId: number,
 	params?: StatsQueryParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -4,13 +4,12 @@
 import { statsSingleVideoQuery } from '../queries/stats-single-video-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsSingleVideoReport } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export type StatsSingleVideoDataPoint = [ date: string, views: number ];
+export type { StatsSingleVideoDataPoint, StatsSingleVideoPage } from '../processing/stats';
 
-export type StatsSingleVideoResponse = {
-	data: StatsSingleVideoDataPoint[];
-};
+export type StatsSingleVideoResponse = StatsSingleVideoReport;
 
 export function useStatsSingleVideo(
 	videoId: number,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -139,7 +139,11 @@ export {
 	type StatsEmailSummaryParams,
 	type StatsEmailSummarySortField,
 } from './hooks/use-stats-email-summary';
-export { useStatsSingleVideo } from './hooks/use-stats-single-video';
+export {
+	useStatsSingleVideo,
+	type StatsSingleVideoDataPoint,
+	type StatsSingleVideoResponse,
+} from './hooks/use-stats-single-video';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -139,6 +139,7 @@ export {
 	type StatsEmailSummaryParams,
 	type StatsEmailSummarySortField,
 } from './hooks/use-stats-email-summary';
+export { useStatsSingleVideo } from './hooks/use-stats-single-video';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -142,6 +142,7 @@ export {
 export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
+	type StatsSingleVideoPage,
 	type StatsSingleVideoResponse,
 } from './hooks/use-stats-single-video';
 export type { UseStatsOptions } from './hooks/use-stats-report';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
@@ -1,0 +1,13 @@
+export const singleVideoFixture = {
+	data: [
+		[ '2026-06-12', 1 ],
+		[ '2026-06-13', '4' ],
+		[ '2026-06-14', 0 ],
+	],
+	pages: [ 'https://example.com/intro-video/', 'https://example.com/2026/06/launch-recap/' ],
+};
+
+export const singleVideoEmptyFixture = {
+	data: [],
+	pages: [],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
@@ -1,0 +1,46 @@
+import { sanitizeStatsSingleVideoResponse } from '..';
+import { singleVideoEmptyFixture, singleVideoFixture } from '../__fixtures__/single-video';
+
+describe( 'Stats single video normalizer', () => {
+	it( 'normalizes the views time series and embed pages', () => {
+		const result = sanitizeStatsSingleVideoResponse( singleVideoFixture );
+
+		expect( result ).toEqual( {
+			data: [
+				{ period: '2026-06-12', value: 1 },
+				{ period: '2026-06-13', value: 4 },
+				{ period: '2026-06-14', value: 0 },
+			],
+			pages: [
+				{
+					label: 'https://example.com/intro-video/',
+					link: 'https://example.com/intro-video/',
+				},
+				{
+					label: 'https://example.com/2026/06/launch-recap/',
+					link: 'https://example.com/2026/06/launch-recap/',
+				},
+			],
+		} );
+	} );
+
+	it( 'returns empty collections for an empty payload', () => {
+		expect( sanitizeStatsSingleVideoResponse( singleVideoEmptyFixture ) ).toEqual( {
+			data: [],
+			pages: [],
+		} );
+	} );
+
+	it( 'drops malformed rows and keeps only well-formed [ date, views ] tuples', () => {
+		expect( sanitizeStatsSingleVideoResponse( undefined ) ).toEqual( { data: [], pages: [] } );
+		expect(
+			sanitizeStatsSingleVideoResponse( {
+				data: [ 'not-a-row', [], [ 1, 2 ], [ '2026-06-12', 2 ] ],
+				pages: [ 7 ],
+			} )
+		).toEqual( {
+			data: [ { period: '2026-06-12', value: 2 } ],
+			pages: [],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -32,6 +32,7 @@ export { sanitizeStatsTagsResponse } from './tags';
 export { sanitizeStatsDevicesResponse } from './devices';
 export { sanitizeStatsPublicizeResponse } from './publicize';
 export { sanitizeStatsWordAdsStatsResponse, sanitizeStatsWordAdsEarningsResponse } from './wordads';
+export { sanitizeStatsSingleVideoResponse } from './single-video';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
 	StatsPostMonthValues,
@@ -128,6 +129,11 @@ export type {
 	StatsWordAdsRawResponse,
 	StatsWordAdsResponse,
 } from './wordads';
+export type {
+	StatsSingleVideoDataPoint,
+	StatsSingleVideoPage,
+	StatsSingleVideoReport,
+} from './single-video';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
@@ -1,0 +1,35 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord } from './utils';
+
+export type StatsSingleVideoDataPoint = {
+	period: string;
+	value: number;
+};
+
+export type StatsSingleVideoPage = {
+	label: string;
+	link: string;
+};
+
+export type StatsSingleVideoReport = {
+	data: StatsSingleVideoDataPoint[];
+	pages: StatsSingleVideoPage[];
+};
+
+export function sanitizeStatsSingleVideoResponse( response: unknown ): StatsSingleVideoReport {
+	const payload = coerceStatsRecord( response );
+	const data = coerceStatsArray< unknown >( payload.data )
+		.filter(
+			( row ): row is [ string, unknown ] =>
+				Array.isArray( row ) && row.length >= 2 && typeof row[ 0 ] === 'string'
+		)
+		.map( ( [ period, value ] ) => ( {
+			period,
+			value: safeParseFloat( value ),
+		} ) );
+	const pages = coerceStatsArray< unknown >( payload.pages )
+		.filter( ( page ): page is string => typeof page === 'string' )
+		.map( page => ( { label: page, link: page } ) );
+
+	return { data, pages };
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -23,6 +23,7 @@ import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsPostQuery } from '../stats-post-query';
 import { statsPublicizeQuery } from '../stats-publicize-query';
+import { statsSingleVideoQuery } from '../stats-single-video-query';
 import { statsStreakQuery } from '../stats-streak-query';
 import { statsSubscribersCountsQuery, statsSubscribersQuery } from '../stats-subscribers-query';
 import { statsTagsQuery } from '../stats-tags-query';
@@ -380,6 +381,41 @@ describe( 'Stats query factories', () => {
 			sort_field: 'opens',
 			sort_order: 'asc',
 		} );
+	} );
+
+	it( 'targets the single video endpoint by id with the single video sanitizer', () => {
+		const query = statsSingleVideoQuery( 31533 );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'single-video',
+			'1.1',
+			'stats/video/31533',
+			'GET',
+			{},
+			undefined,
+			'singleVideo',
+		] );
+	} );
+
+	it( 'passes single video params through to the request', () => {
+		const query = statsSingleVideoQuery( 31533, {
+			period: 'day',
+			end_date: '2026-06-14',
+			statType: 'watch_time',
+		} );
+
+		expect( query.queryKey[ 5 ] ).toEqual( {
+			period: 'day',
+			date: '2026-06-14',
+			statType: 'watch_time',
+		} );
+	} );
+
+	it( 'disables the single video query until a valid video id is available', () => {
+		expect( statsSingleVideoQuery( 0 ).enabled ).toBe( false );
+		expect( statsSingleVideoQuery( NaN ).enabled ).toBe( false );
+		expect( statsSingleVideoQuery( 31533 ).enabled ).toBe( true );
 	} );
 
 	it( 'builds app query keys without report param coercion', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -72,3 +72,4 @@ export {
 	type StatsEmailOpensBreakdown,
 } from './stats-email-breakdown-query';
 export { statsEmailSummaryQuery } from './stats-email-summary-query';
+export { statsSingleVideoQuery } from './stats-single-video-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -26,6 +26,7 @@ import {
 	sanitizeStatsPostResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
+	sanitizeStatsSingleVideoResponse,
 	sanitizeStatsSiteResponse,
 	sanitizeStatsSubscribersCountsResponse,
 	sanitizeStatsSubscribersResponse,
@@ -78,6 +79,7 @@ const statsSanitizers = {
 	wordAdsEarnings: sanitizeStatsWordAdsEarningsResponse,
 	emailBreakdown: sanitizeStatsEmailBreakdownResponse,
 	emailSummary: sanitizeStatsEmailSummaryResponse,
+	singleVideo: sanitizeStatsSingleVideoResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'single-video',
+		version: '1.1',
+		endpoint: `stats/video/${ videoId }`,
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
@@ -10,4 +10,6 @@ export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams
 		version: '1.1',
 		endpoint: `stats/video/${ videoId }`,
 		params,
+		sanitizer: 'singleVideo',
+		enabled: Number.isInteger( videoId ) && videoId > 0,
 	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats single video endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check