### PR TITLE
Premium Analytics: add Stats streak endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-streak-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-streak-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add streak hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -18,6 +18,7 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsArchives',
+	'useStatsStreak',
 	'useStatsVisits',
 	'useStatsInsights',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,6 +25,7 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
+export { useStatsStreak } from './use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,7 +25,7 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
-export { useStatsStreak } from './use-stats-streak';
+export { useStatsStreak, type StatsStreakResponse } from './use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,7 +25,11 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
-export { useStatsStreak, type StatsStreakResponse } from './use-stats-streak';
+export {
+	useStatsStreak,
+	type StatsStreakParams,
+	type StatsStreakResponse,
+} from './use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
@@ -6,6 +6,11 @@ import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsStreakResponse = {
+	data: Record< string, number >;
+	streak?: Record< string, unknown >;
+};
+
 export function useStatsStreak( params?: StatsQueryParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsStreakQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { statsStreakQuery } from '../queries/stats-streak-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsStreak( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsStreakQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
@@ -4,13 +4,10 @@
 import { statsStreakQuery } from '../queries/stats-streak-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsStreakParams, StatsStreakResponse } from '../queries/stats-streak-query';
 
-export type StatsStreakResponse = {
-	data: Record< string, number >;
-	streak?: Record< string, unknown >;
-};
+export type { StatsStreakParams, StatsStreakResponse } from '../queries/stats-streak-query';
 
-export function useStatsStreak( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery( statsStreakQuery( params ), options );
+export function useStatsStreak( params: StatsStreakParams, options?: UseStatsOptions ) {
+	return useStatsQuery< StatsStreakResponse >( statsStreakQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,7 +34,11 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
-export { useStatsStreak, type StatsStreakResponse } from './hooks/use-stats-streak';
+export {
+	useStatsStreak,
+	type StatsStreakParams,
+	type StatsStreakResponse,
+} from './hooks/use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,
@@ -94,6 +98,7 @@ export type {
 	StatsNormalizedSummary,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
+	StatsStreakRawResponse,
 	StatsTimeSeriesDataPoint,
 	StatsTimeSeriesReport,
 	StatsTopAuthorsItem,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
+export { useStatsStreak } from './hooks/use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
-export { useStatsStreak } from './hooks/use-stats-streak';
+export { useStatsStreak, type StatsStreakResponse } from './hooks/use-stats-streak';
 export {
 	useStatsVisits,
 	type StatsVisitsParams,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/streak.ts
@@ -1,0 +1,10 @@
+import type { StatsStreakRawResponse } from '../streak';
+
+export const streakFixture = {
+	streak: {},
+	data: {
+		1461889800: 1,
+		1461972600: 1,
+		1462059000: 1,
+	},
+} satisfies StatsStreakRawResponse;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
@@ -1,0 +1,36 @@
+import { sanitizeStatsStreakResponse } from '..';
+import { streakFixture } from '../__fixtures__/streak';
+
+describe( 'Stats streak normalizer', () => {
+	it( 'normalizes timestamp counts into date buckets', () => {
+		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
+			'2016-04-29': 2,
+			'2016-04-30': 1,
+		} );
+	} );
+
+	it( 'applies the site GMT offset before bucketing counts', () => {
+		expect( sanitizeStatsStreakResponse( streakFixture, { gmtOffset: 10 } ) ).toEqual( {
+			'2016-04-29': 1,
+			'2016-04-30': 1,
+			'2016-05-01': 1,
+		} );
+		expect( sanitizeStatsStreakResponse( streakFixture, { gmtOffset: -10 } ) ).toEqual( {
+			'2016-04-28': 1,
+			'2016-04-29': 1,
+			'2016-04-30': 1,
+		} );
+	} );
+
+	it( 'preserves fractional site GMT offsets', () => {
+		expect(
+			sanitizeStatsStreakResponse( { data: { 1461955500: 1 } }, { gmtOffset: 5.5 } )
+		).toEqual( {
+			'2016-04-30': 1,
+		} );
+	} );
+
+	it( 'returns an empty response for malformed data', () => {
+		expect( sanitizeStatsStreakResponse( { data: [ 1461889800 ] } ) ).toEqual( {} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -17,6 +17,7 @@ export { sanitizeStatsInsightsResponse } from './insights';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
+export { sanitizeStatsStreakResponse } from './streak';
 export type { StatsTopPostsItem } from './top-posts';
 export type { StatsReferrersItem } from './referrers';
 export type { StatsClicksItem } from './clicks';
@@ -33,6 +34,7 @@ export type {
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type { StatsArchivesItem } from './archives';
+export type { StatsStreakRawResponse, StatsStreakResponse } from './streak';
 export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
 export type {
 	StatsItemAction,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
@@ -1,0 +1,36 @@
+import { tz } from '@date-fns/tz';
+import { addHours, format, fromUnixTime } from 'date-fns';
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsRecord } from './utils';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsStreakResponse = Record< string, number >;
+
+export type StatsStreakRawResponse = {
+	streak?: Record< string, unknown >;
+	data?: Record< string, number >;
+};
+
+export function sanitizeStatsStreakResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsStreakResponse {
+	const data = coerceStatsRecord( coerceStatsRecord( response ).data );
+	const gmtOffset = safeParseFloat( query?.gmtOffset );
+	const streak: StatsStreakResponse = {};
+
+	for ( const [ timestamp, count ] of Object.entries( data ) ) {
+		const seconds = Number( timestamp );
+
+		if ( ! Number.isFinite( seconds ) ) {
+			continue;
+		}
+
+		const date = format( addHours( fromUnixTime( seconds ), gmtOffset ), 'yyyy-MM-dd', {
+			in: tz( 'UTC' ),
+		} );
+		streak[ date ] = ( streak[ date ] ?? 0 ) + safeParseFloat( count );
+	}
+
+	return streak;
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -5,6 +5,7 @@ import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
 import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
+import { statsStreakQuery } from '../stats-streak-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsVisitsQuery } from '../stats-visits-query';
 import type { StatsReportParams } from '../stats-query';
@@ -208,5 +209,36 @@ describe( 'Stats query factories', () => {
 			undefined,
 			'insights',
 		] );
+	} );
+
+	it( 'builds streak query keys with Calypso endpoint params', () => {
+		const query = statsStreakQuery( {
+			from: '2026-06-01',
+			to: '2026-06-30',
+			interval: 'day',
+			gmtOffset: 12,
+			max: 3000,
+		} );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'streak',
+			'1.1',
+			'stats/streak',
+			'GET',
+			{
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+				gmtOffset: 12,
+				max: 3000,
+			},
+			undefined,
+			'streak',
+		] );
+	} );
+
+	it( 'disables streak queries until start and end dates are available', () => {
+		expect( statsStreakQuery( {} as StatsReportParams ).enabled ).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -24,5 +24,6 @@ export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsArchivesQuery } from './stats-archives-query';
+export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -10,6 +10,7 @@ import {
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsArchivesResponse,
 	sanitizeStatsInsightsResponse,
+	sanitizeStatsStreakResponse,
 	sanitizeStatsVisitsResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsReferrersResponse,
@@ -43,6 +44,7 @@ const statsSanitizers = {
 	videoPlays: sanitizeStatsVideoPlaysResponse,
 	archives: sanitizeStatsArchivesResponse,
 	insights: sanitizeStatsInsightsResponse,
+	streak: sanitizeStatsStreakResponse,
 	visits: sanitizeStatsVisitsResponse,
 } satisfies Record< string, StatsSanitizer >;
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
@@ -1,13 +1,33 @@
-/**
- * Internal dependencies
- */
+import { getDatePart } from '@jetpack-premium-analytics/datetime';
 import { statsProxyQuery } from './stats-query';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsReportParams, StatsReportQueryOptions } from './stats-query';
+import type { StatsProxyParams } from '../api';
+import type { StatsStreakResponse } from '../processing/stats';
 
-export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( {
+export type StatsStreakParams = StatsReportParams & {
+	startDate?: string;
+	endDate?: string;
+	gmtOffset?: number;
+};
+
+export type { StatsStreakResponse };
+
+export const statsStreakQuery = (
+	params: StatsStreakParams
+): StatsReportQueryOptions< 'streak' > => {
+	const streakParams: StatsProxyParams = {
+		startDate: params.startDate ?? getDatePart( params.from ) ?? params.start_date,
+		endDate: params.endDate ?? getDatePart( params.to ) ?? params.end_date ?? params.date,
+		...( params.gmtOffset !== undefined ? { gmtOffset: params.gmtOffset } : {} ),
+		...( params.max !== undefined ? { max: params.max } : {} ),
+	};
+
+	return statsProxyQuery( {
 		name: 'streak',
 		version: '1.1',
 		endpoint: 'stats/streak',
-		params,
+		params: streakParams,
+		sanitizer: 'streak',
+		enabled: !! ( streakParams.startDate && streakParams.endDate ),
 	} );
+};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( { name: 'streak', version: '1.1', endpoint: 'stats/streak', params } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
@@ -5,4 +5,9 @@ import { statsProxyQuery } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
 export const statsStreakQuery = ( params: StatsQueryParams = {} ) =>
-	statsProxyQuery( { name: 'streak', version: '1.1', endpoint: 'stats/streak', params } );
+	statsProxyQuery( {
+		name: 'streak',
+		version: '1.1',
+		endpoint: 'stats/streak',
+		params,
+	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats streak endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Normalize raw timestamp-count streak payloads into date-keyed post counts aligned with Calypso's posting activity parsing.
* Keep endpoint typing tied to sanitizer keys, with focused fixtures/tests for the raw endpoint payload shape.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts packages/data/src/processing/stats/__tests__/streak.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check
