### PR TITLE
Premium Analytics: add Stats subscribers endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-subscribers-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-subscribers-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add subscribers hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -21,6 +21,8 @@ const statsHookNames = [
 	'useStatsAppPlanUsage',
 	'useStatsArchives',
 	'useStatsComments',
+	'useStatsSubscribers',
+	'useStatsSubscribersCounts',
 	'useStatsStreak',
 	'useStatsVisits',
 	'useStatsInsights',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -46,7 +46,9 @@ export {
 	useStatsSubscribers,
 	useStatsSubscribersCounts,
 	type StatsSubscribersCounts,
+	type StatsSubscribersCountsParams,
 	type StatsSubscribersCountsResponse,
+	type StatsSubscribersParams,
 	type StatsSubscribersResponse,
 } from './use-stats-subscribers';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -42,7 +42,13 @@ export {
 	type StatsCommentsParams,
 	type StatsCommentsResponse,
 } from './use-stats-comments';
-export { useStatsSubscribers, useStatsSubscribersCounts } from './use-stats-subscribers';
+export {
+	useStatsSubscribers,
+	useStatsSubscribersCounts,
+	type StatsSubscribersCounts,
+	type StatsSubscribersCountsResponse,
+	type StatsSubscribersResponse,
+} from './use-stats-subscribers';
 export {
 	useStatsStreak,
 	type StatsStreakParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -42,6 +42,7 @@ export {
 	type StatsCommentsParams,
 	type StatsCommentsResponse,
 } from './use-stats-comments';
+export { useStatsSubscribers, useStatsSubscribersCounts } from './use-stats-subscribers';
 export {
 	useStatsStreak,
 	type StatsStreakParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -7,10 +7,24 @@ import {
 } from '../queries/stats-subscribers-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type StatsSubscribersResponse = StatsNormalizedReport;
+
+export type StatsSubscribersCounts = {
+	total_subscribers: number;
+	email_subscribers: number;
+	paid_subscribers: number;
+	social_followers: number;
+};
+
+export type StatsSubscribersCountsResponse = {
+	counts: StatsSubscribersCounts;
+};
+
 export function useStatsSubscribers( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery( statsSubscribersQuery( params ), options );
+	return useStatsQuery< StatsSubscribersResponse >( statsSubscribersQuery( params ), options );
 }
 
 export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import {
+	statsSubscribersCountsQuery,
+	statsSubscribersQuery,
+} from '../queries/stats-subscribers-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsSubscribers( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsSubscribersQuery( params ), options );
+}
+
+export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsSubscribersCountsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -7,26 +7,26 @@ import {
 } from '../queries/stats-subscribers-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsNormalizedReport } from '../processing/stats';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsSubscribersCounts } from '../processing/stats';
+import type {
+	StatsSubscribersCountsParams,
+	StatsSubscribersParams,
+} from '../queries/stats-subscribers-query';
 
-export type StatsSubscribersResponse = StatsNormalizedReport;
+export type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
+export type {
+	StatsSubscribersCountsParams,
+	StatsSubscribersParams,
+} from '../queries/stats-subscribers-query';
+export type StatsSubscribersCountsResponse = StatsSubscribersCounts;
 
-export type StatsSubscribersCounts = {
-	total_subscribers: number;
-	email_subscribers: number;
-	paid_subscribers: number;
-	social_followers: number;
-};
-
-export type StatsSubscribersCountsResponse = {
-	counts: StatsSubscribersCounts;
-};
-
-export function useStatsSubscribers( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery< StatsSubscribersResponse >( statsSubscribersQuery( params ), options );
+export function useStatsSubscribers( params: StatsSubscribersParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsSubscribersQuery( params ), options );
 }
 
-export function useStatsSubscribersCounts( params?: StatsQueryParams, options?: UseStatsOptions ) {
+export function useStatsSubscribersCounts(
+	params?: StatsSubscribersCountsParams,
+	options?: UseStatsOptions
+) {
 	return useStatsQuery( statsSubscribersCountsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -47,6 +47,7 @@ export {
 	type StatsCommentsParams,
 	type StatsCommentsResponse,
 } from './hooks/use-stats-comments';
+export { useStatsSubscribers, useStatsSubscribersCounts } from './hooks/use-stats-subscribers';
 export {
 	useStatsStreak,
 	type StatsStreakParams,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -47,7 +47,13 @@ export {
 	type StatsCommentsParams,
 	type StatsCommentsResponse,
 } from './hooks/use-stats-comments';
-export { useStatsSubscribers, useStatsSubscribersCounts } from './hooks/use-stats-subscribers';
+export {
+	useStatsSubscribers,
+	useStatsSubscribersCounts,
+	type StatsSubscribersCounts,
+	type StatsSubscribersCountsResponse,
+	type StatsSubscribersResponse,
+} from './hooks/use-stats-subscribers';
 export {
 	useStatsStreak,
 	type StatsStreakParams,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -51,7 +51,9 @@ export {
 	useStatsSubscribers,
 	useStatsSubscribersCounts,
 	type StatsSubscribersCounts,
+	type StatsSubscribersCountsParams,
 	type StatsSubscribersCountsResponse,
+	type StatsSubscribersParams,
 	type StatsSubscribersResponse,
 } from './hooks/use-stats-subscribers';
 export {
@@ -136,6 +138,9 @@ export type {
 	StatsPostYear,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
+	StatsSubscribersCountsRawResponse,
+	StatsSubscribersDataPoint,
+	StatsSubscribersRawResponse,
 	StatsStreakRawResponse,
 	StatsTagsChildItem,
 	StatsTagsItem,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
@@ -1,0 +1,25 @@
+import type {
+	StatsSubscribersCountsRawResponse,
+	StatsSubscribersRawResponse,
+} from '../subscribers';
+
+export const subscribersFixture = {
+	date: '2026-06-25',
+	unit: 'day',
+	fields: [ 'period', 'subscribers', 'subscribers_paid' ],
+	data: [
+		[ '2026-06-24', '10', '2' ],
+		[ '2026-06-25', 12, 3 ],
+	],
+} satisfies StatsSubscribersRawResponse;
+
+export const subscribersCountsFixture = {
+	counts: {
+		total_subscribers: 42,
+		email_subscribers: 31,
+		paid_subscribers: 5,
+		social_followers: 9,
+	},
+} satisfies StatsSubscribersCountsRawResponse;
+
+export const emptySubscribersCountsFixture = {} satisfies StatsSubscribersCountsRawResponse;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/subscribers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/subscribers.test.ts
@@ -1,0 +1,55 @@
+import { sanitizeStatsSubscribersCountsResponse, sanitizeStatsSubscribersResponse } from '..';
+import {
+	emptySubscribersCountsFixture,
+	subscribersCountsFixture,
+	subscribersFixture,
+} from '../__fixtures__/subscribers';
+
+describe( 'Stats subscribers normalizers', () => {
+	it( 'normalizes raw subscribers matrix rows into time-series data points', () => {
+		const result = sanitizeStatsSubscribersResponse( subscribersFixture );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				subscribers: 22,
+				subscribers_paid: 5,
+				date_start: '2026-06-24T00:00:00+00:00',
+				date_end: '2026-06-25T23:59:59+00:00',
+			} )
+		);
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-24',
+				value: 10,
+				subscribers: 10,
+				subscribers_paid: 2,
+				items: [],
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-25',
+				value: 12,
+				subscribers: 12,
+				subscribers_paid: 3,
+				items: [],
+			} ),
+		] );
+	} );
+
+	it( 'normalizes subscribers counts by flattening the raw counts object', () => {
+		expect( sanitizeStatsSubscribersCountsResponse( subscribersCountsFixture ) ).toEqual( {
+			total_subscribers: 42,
+			email_subscribers: 31,
+			paid_subscribers: 5,
+			social_followers: 9,
+		} );
+	} );
+
+	it( 'preserves missing counts as unset fields', () => {
+		expect( sanitizeStatsSubscribersCountsResponse( emptySubscribersCountsFixture ) ).toEqual( {
+			total_subscribers: undefined,
+			email_subscribers: undefined,
+			paid_subscribers: undefined,
+			social_followers: undefined,
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -21,6 +21,10 @@ export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
 export { sanitizeStatsCommentsResponse } from './comments';
+export {
+	sanitizeStatsSubscribersResponse,
+	sanitizeStatsSubscribersCountsResponse,
+} from './subscribers';
 export { sanitizeStatsStreakResponse } from './streak';
 export { sanitizeStatsTagsResponse } from './tags';
 export type { StatsTopPostsItem } from './top-posts';
@@ -67,6 +71,13 @@ export type {
 	StatsCommentsRawResponse,
 	StatsCommentsResponse,
 } from './comments';
+export type {
+	StatsSubscribersCounts,
+	StatsSubscribersCountsRawResponse,
+	StatsSubscribersDataPoint,
+	StatsSubscribersRawResponse,
+	StatsSubscribersResponse,
+} from './subscribers';
 export type { StatsStreakRawResponse, StatsStreakResponse } from './streak';
 export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/subscribers.ts
@@ -1,0 +1,67 @@
+import { sanitizeStatsTimeSeriesResponse } from './time-series';
+import { coerceStatsRecord } from './utils';
+import type { StatsNormalizedDataPoint, StatsNormalizedReport } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsSubscribersRawResponse = {
+	date?: string;
+	unit?: string;
+	fields?: string[];
+	data?: Array< Array< string | number | null > >;
+};
+
+export type StatsSubscribersDataPoint = StatsNormalizedDataPoint & {
+	value: number;
+	subscribers?: number;
+	subscribers_paid?: number;
+};
+
+export type StatsSubscribersResponse = StatsNormalizedReport & {
+	data: StatsSubscribersDataPoint[];
+};
+
+export type StatsSubscribersCounts = {
+	total_subscribers?: number;
+	email_subscribers?: number;
+	paid_subscribers?: number;
+	social_followers?: number;
+};
+
+export type StatsSubscribersCountsRawResponse = {
+	counts?: StatsSubscribersCounts;
+};
+
+const countFields = [
+	'total_subscribers',
+	'email_subscribers',
+	'paid_subscribers',
+	'social_followers',
+] as const satisfies ReadonlyArray< keyof StatsSubscribersCounts >;
+
+function normalizeCountValue( value: unknown ) {
+	return typeof value === 'number' ? value : undefined;
+}
+
+export function sanitizeStatsSubscribersResponse(
+	response: StatsSubscribersRawResponse,
+	query?: StatsQueryParams
+): StatsSubscribersResponse;
+export function sanitizeStatsSubscribersResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsSubscribersResponse {
+	return sanitizeStatsTimeSeriesResponse( response, query ) as StatsSubscribersResponse;
+}
+
+export function sanitizeStatsSubscribersCountsResponse(
+	response: StatsSubscribersCountsRawResponse
+): StatsSubscribersCounts;
+export function sanitizeStatsSubscribersCountsResponse(
+	response: unknown
+): StatsSubscribersCounts {
+	const counts = coerceStatsRecord( coerceStatsRecord( response ).counts );
+
+	return Object.fromEntries(
+		countFields.map( field => [ field, normalizeCountValue( counts[ field ] ) ] )
+	) as StatsSubscribersCounts;
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -9,6 +9,7 @@ import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsPostQuery } from '../stats-post-query';
 import { statsStreakQuery } from '../stats-streak-query';
+import { statsSubscribersCountsQuery, statsSubscribersQuery } from '../stats-subscribers-query';
 import { statsTagsQuery } from '../stats-tags-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
@@ -273,6 +274,62 @@ describe( 'Stats query factories', () => {
 				params: {},
 			} ).queryKey
 		);
+	} );
+
+	it( 'builds subscribers query keys with Calypso endpoint params and default stat fields', () => {
+		const query = statsSubscribersQuery( {
+			unit: 'week',
+			quantity: 12,
+			date: '2026-06-25',
+		} );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'subscribers',
+			'1.1',
+			'stats/subscribers',
+			'GET',
+			{
+				unit: 'week',
+				quantity: 12,
+				date: '2026-06-25',
+				stat_fields: 'subscribers,subscribers_paid',
+			},
+			undefined,
+			'subscribers',
+		] );
+	} );
+
+	it( 'preserves explicit subscribers stat fields', () => {
+		const query = statsSubscribersQuery( {
+			unit: 'day',
+			quantity: 30,
+			date: '2026-06-25',
+			stat_fields: 'subscribers',
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					stat_fields: 'subscribers',
+				} ),
+			] )
+		);
+	} );
+
+	it( 'builds subscribers counts query keys with a typed sanitizer', () => {
+		const query = statsSubscribersCountsQuery();
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'subscribers-counts',
+			'2',
+			'subscribers/counts',
+			'GET',
+			{},
+			undefined,
+			'subscribersCounts',
+		] );
 	} );
 
 	it( 'sets visits quantity for day ranges', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -27,7 +27,12 @@ export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-modu
 export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsCommentsQuery, type StatsCommentsParams } from './stats-comments-query';
-export { statsSubscribersQuery, statsSubscribersCountsQuery } from './stats-subscribers-query';
+export {
+	statsSubscribersCountsQuery,
+	statsSubscribersQuery,
+	type StatsSubscribersCountsParams,
+	type StatsSubscribersParams,
+} from './stats-subscribers-query';
 export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -27,6 +27,7 @@ export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-modu
 export { statsAppPlanUsageQuery } from './stats-app-plan-usage-query';
 export { statsArchivesQuery } from './stats-archives-query';
 export { statsCommentsQuery, type StatsCommentsParams } from './stats-comments-query';
+export { statsSubscribersQuery, statsSubscribersCountsQuery } from './stats-subscribers-query';
 export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -21,6 +21,8 @@ import {
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
 	sanitizeStatsSiteResponse,
+	sanitizeStatsSubscribersCountsResponse,
+	sanitizeStatsSubscribersResponse,
 	sanitizeStatsTopAuthorsResponse,
 	sanitizeStatsTopPostsResponse,
 	sanitizeStatsUtmResponse,
@@ -58,6 +60,8 @@ const statsSanitizers = {
 	utm: sanitizeStatsUtmResponse,
 	visits: sanitizeStatsVisitsResponse,
 	timeSeries: sanitizeStatsTimeSeriesResponse,
+	subscribers: sanitizeStatsSubscribersResponse,
+	subscribersCounts: sanitizeStatsSubscribersCountsResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -15,6 +15,7 @@ import {
 	sanitizeStatsStreakResponse,
 	sanitizeStatsVisitsResponse,
 	sanitizeStatsTagsResponse,
+	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsPostResponse,
 	sanitizeStatsReferrersResponse,
@@ -56,6 +57,7 @@ const statsSanitizers = {
 	tags: sanitizeStatsTagsResponse,
 	utm: sanitizeStatsUtmResponse,
 	visits: sanitizeStatsVisitsResponse,
+	timeSeries: sanitizeStatsTimeSeriesResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -3,23 +3,42 @@
  */
 import { statsProxyQuery } from './stats-query';
 import type { StatsReportQueryOptions } from './stats-query';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsPeriod } from '../utils/stats-params';
+
+export const statsSubscribersDefaultStatFields = 'subscribers,subscribers_paid';
+
+export type StatsSubscribersParams = {
+	unit: StatsPeriod | string;
+	quantity: number;
+	date: string;
+	stat_fields?: string;
+};
+
+export type StatsSubscribersCountsParams = Record< string, never >;
 
 export const statsSubscribersQuery = (
-	params: StatsQueryParams = {}
-): StatsReportQueryOptions< 'timeSeries' > =>
+	params: StatsSubscribersParams
+): StatsReportQueryOptions< 'subscribers' > =>
 	statsProxyQuery( {
 		name: 'subscribers',
 		version: '1.1',
 		endpoint: 'stats/subscribers',
-		params,
-		sanitizer: 'timeSeries',
+		params: {
+			unit: params.unit,
+			quantity: params.quantity,
+			date: params.date,
+			stat_fields: params.stat_fields ?? statsSubscribersDefaultStatFields,
+		},
+		sanitizer: 'subscribers',
 	} );
 
-export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+export const statsSubscribersCountsQuery = (
+	params: StatsSubscribersCountsParams = {}
+): StatsReportQueryOptions< 'subscribersCounts' > =>
 	statsProxyQuery( {
 		name: 'subscribers-counts',
 		version: '2',
 		endpoint: 'subscribers/counts',
 		params,
+		sanitizer: 'subscribersCounts',
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers',
+		version: '1.1',
+		endpoint: 'stats/subscribers',
+		params,
+		sanitizer: 'timeSeries',
+	} );
+
+export const statsSubscribersCountsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'subscribers-counts',
+		version: '2',
+		endpoint: 'subscribers/counts',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -2,9 +2,12 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
+import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export const statsSubscribersQuery = ( params: StatsQueryParams = {} ) =>
+export const statsSubscribersQuery = (
+	params: StatsQueryParams = {}
+): StatsReportQueryOptions< 'timeSeries' > =>
 	statsProxyQuery( {
 		name: 'subscribers',
 		version: '1.1',


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats subscribers endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check