### PR TITLE
Premium Analytics: add Stats tags endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-tags-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-tags-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add tags report hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -26,6 +26,7 @@ const statsHookNames = [
 	'useStatsInsights',
 	'useStatsUtm',
 	'useStatsHighlights',
+	'useStatsTags',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -63,6 +63,7 @@ export type {
 export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
 export { useStatsHighlights } from './use-stats-highlights';
 export type { StatsHighlightsParams, StatsHighlightsResponse } from './use-stats-highlights';
+export { useStatsTags, type StatsTagsParams, type StatsTagsResponse } from './use-stats-tags';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -4,13 +4,14 @@
 import { statsTagsQuery } from '../queries/stats-tags-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsReportParams } from '../queries/stats-query';
-import type { StatsTagsResponse } from '../queries/stats-tags-query';
+import type { StatsNormalizedReport, StatsTagsItem } from '../processing/stats';
+import type { StatsTagsParams } from '../queries/stats-tags-query';
 
-export type { StatsTagsResponse } from '../queries/stats-tags-query';
+export type StatsTagsResponse = StatsNormalizedReport< StatsTagsItem >;
+export type { StatsTagsParams } from '../queries/stats-tags-query';
 
-export function useStatsTags( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport< StatsReportParams, StatsTagsResponse >(
+export function useStatsTags( params: StatsTagsParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsTagsParams, StatsTagsResponse >(
 		statsTagsQuery,
 		params,
 		'tags',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -7,10 +7,5 @@ import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsTags( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport(
-		statsTagsQuery,
-		params,
-		[ 'stats', 'tags', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsReport( statsTagsQuery, params, 'tags', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { statsTagsQuery } from '../queries/stats-tags-query';
-import { useStatsReport } from './use-stats-report';
+import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsNormalizedReport, StatsTagsItem } from '../processing/stats';
 import type { StatsTagsParams } from '../queries/stats-tags-query';
@@ -10,11 +10,6 @@ import type { StatsTagsParams } from '../queries/stats-tags-query';
 export type StatsTagsResponse = StatsNormalizedReport< StatsTagsItem >;
 export type { StatsTagsParams } from '../queries/stats-tags-query';
 
-export function useStatsTags( params: StatsTagsParams, options?: UseStatsOptions ) {
-	return useStatsReport< StatsTagsParams, StatsTagsResponse >(
-		statsTagsQuery,
-		params,
-		'tags',
-		options
-	);
+export function useStatsTags( params: StatsTagsParams = {}, options?: UseStatsOptions ) {
+	return useStatsQuery< StatsTagsResponse >( statsTagsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -5,7 +5,15 @@ import { statsTagsQuery } from '../queries/stats-tags-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsReportParams } from '../queries/stats-query';
+import type { StatsTagsResponse } from '../queries/stats-tags-query';
+
+export type { StatsTagsResponse } from '../queries/stats-tags-query';
 
 export function useStatsTags( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport( statsTagsQuery, params, 'tags', options );
+	return useStatsReport< StatsReportParams, StatsTagsResponse >(
+		statsTagsQuery,
+		params,
+		'tags',
+		options
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { statsTagsQuery } from '../queries/stats-tags-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export function useStatsTags( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsTagsQuery,
+		params,
+		[ 'stats', 'tags', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -69,6 +69,7 @@ export { useStatsUtm } from './hooks/use-stats-utm';
 export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
 export { useStatsHighlights } from './hooks/use-stats-highlights';
 export type { StatsHighlightsParams, StatsHighlightsResponse } from './hooks/use-stats-highlights';
+export { useStatsTags, type StatsTagsParams, type StatsTagsResponse } from './hooks/use-stats-tags';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
@@ -129,6 +130,12 @@ export type {
 	StatsReferrersItem,
 	StatsSearchTermsItem,
 	StatsStreakRawResponse,
+	StatsTagsChildItem,
+	StatsTagsItem,
+	StatsTagsLabel,
+	StatsTagsRawItem,
+	StatsTagsRawResponse,
+	StatsTagsRawTag,
 	StatsTimeSeriesDataPoint,
 	StatsTimeSeriesReport,
 	StatsTopAuthorsItem,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
@@ -1,4 +1,6 @@
 export const tagsFixture = {
+	date: '2026-06-22',
+	period: 'day',
 	tags: [
 		{
 			tags: [
@@ -26,4 +28,46 @@ export const tagsFixture = {
 			views: '7',
 		},
 	],
+};
+
+export const tagsByDateFixture = {
+	date: '2026-06-22',
+	period: 'day',
+	days: {
+		'2026-06-16': {
+			tags: [
+				{
+					tags: [
+						{
+							type: 'category',
+							name: 'By date',
+							link: 'https://example.com/category/by-date/',
+						},
+					],
+					views: 0,
+				},
+			],
+			total_views: 0,
+		},
+	},
+};
+
+export const tagsSummaryFixture = {
+	date: '2026-06-22',
+	period: 'day',
+	summary: {
+		tags: [
+			{
+				tags: [
+					{
+						type: 'tag',
+						name: 'Summary',
+						link: 'https://example.com/tag/summary/',
+					},
+				],
+				views: '34',
+			},
+		],
+		total_views: '34',
+	},
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
@@ -1,0 +1,14 @@
+export const tagsFixture = {
+	tags: [
+		{
+			tags: [
+				{
+					type: 'category',
+					name: 'News',
+					link: 'https://example.com/category/news/',
+				},
+			],
+			views: '18',
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/tags.ts
@@ -10,5 +10,20 @@ export const tagsFixture = {
 			],
 			views: '18',
 		},
+		{
+			tags: [
+				{
+					type: 'category',
+					name: 'Announcements',
+					link: 'https://example.com/category/announcements/',
+				},
+				{
+					type: 'tag',
+					name: 'Release',
+					link: 'https://example.com/tag/release/',
+				},
+			],
+			views: '7',
+		},
 	],
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -1,0 +1,14 @@
+import { sanitizeStatsTagsResponse } from '..';
+import { tagsFixture } from '../__fixtures__/tags';
+
+describe( 'Stats tags normalizer', () => {
+	it( 'normalizes tag rows', () => {
+		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'News',
+				value: 18,
+				link: 'https://example.com/category/news/',
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -1,13 +1,31 @@
 import { sanitizeStatsTagsResponse } from '..';
-import { tagsFixture } from '../__fixtures__/tags';
+import { tagsByDateFixture, tagsFixture, tagsSummaryFixture } from '../__fixtures__/tags';
 
 describe( 'Stats tags normalizer', () => {
-	it( 'normalizes tag rows', () => {
-		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 0 ] ).toEqual(
+	it( 'normalizes top-level tag rows from the Calypso payload shape', () => {
+		const result = sanitizeStatsTagsResponse( tagsFixture );
+
+		expect( result.summary ).toEqual( {} );
+		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
-				label: 'News',
-				value: 18,
-				link: 'https://example.com/category/news/',
+				time_interval: '2026-06-22',
+				date_start: '2026-06-22T00:00:00+00:00',
+				date_end: '2026-06-22T23:59:59+00:00',
+				items: [
+					expect.objectContaining( {
+						label: 'News',
+						labels: [
+							{
+								label: 'News',
+								labelIcon: 'folder',
+								link: 'https://example.com/category/news/',
+							},
+						],
+						value: 18,
+						link: 'https://example.com/category/news/',
+					} ),
+					expect.any( Object ),
+				],
 			} )
 		);
 	} );
@@ -16,20 +34,32 @@ describe( 'Stats tags normalizer', () => {
 		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 1 ] ).toEqual(
 			expect.objectContaining( {
 				label: 'Announcements, Release',
+				labels: [
+					{
+						label: 'Announcements',
+						labelIcon: 'folder',
+						link: null,
+					},
+					{
+						label: 'Release',
+						labelIcon: 'tag',
+						link: null,
+					},
+				],
 				value: 7,
 				link: null,
 				children: [
 					expect.objectContaining( {
 						label: 'Announcements',
 						labelIcon: 'folder',
-						value: 0,
+						value: null,
 						link: 'https://example.com/category/announcements/',
 						children: null,
 					} ),
 					expect.objectContaining( {
 						label: 'Release',
 						labelIcon: 'tag',
-						value: 0,
+						value: null,
 						link: 'https://example.com/tag/release/',
 						children: null,
 					} ),
@@ -38,15 +68,77 @@ describe( 'Stats tags normalizer', () => {
 		);
 	} );
 
-	it( 'aggregates summary totals', () => {
-		expect( sanitizeStatsTagsResponse( tagsFixture ).summary.total ).toBe( 25 );
+	it( 'normalizes by-date tag buckets and preserves zero values', () => {
+		const result = sanitizeStatsTagsResponse( tagsByDateFixture, {
+			period: 'day',
+			end_date: '2026-06-16',
+		} );
+
+		expect( result.summary ).toEqual( {} );
+		expect( result.data ).toEqual( [
+			{
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16T00:00:00+00:00',
+				date_end: '2026-06-16T23:59:59+00:00',
+				items: [
+					expect.objectContaining( {
+						label: 'By date',
+						labels: [
+							{
+								label: 'By date',
+								labelIcon: 'folder',
+								link: 'https://example.com/category/by-date/',
+							},
+						],
+						value: 0,
+						link: 'https://example.com/category/by-date/',
+					} ),
+				],
+			},
+		] );
+	} );
+
+	it( 'normalizes summarized tag rows into range data', () => {
+		const result = sanitizeStatsTagsResponse( tagsSummaryFixture, {
+			period: 'day',
+			start_date: '2026-06-16',
+			end_date: '2026-06-22',
+			summarize: true,
+		} );
+
+		expect( result ).toEqual( {
+			summary: {
+				total_views: 34,
+				date_start: '2026-06-16T00:00:00+00:00',
+				date_end: '2026-06-22T23:59:59+00:00',
+			},
+			data: [
+				{
+					time_interval: '2026-06-22',
+					date_start: '2026-06-16T00:00:00+00:00',
+					date_end: '2026-06-22T23:59:59+00:00',
+					items: [
+						expect.objectContaining( {
+							label: 'Summary',
+							labels: [
+								{
+									label: 'Summary',
+									labelIcon: 'tag',
+									link: 'https://example.com/tag/summary/',
+								},
+							],
+							value: 34,
+							link: 'https://example.com/tag/summary/',
+						} ),
+					],
+				},
+			],
+		} );
 	} );
 
 	it( 'normalizes empty responses', () => {
 		expect( sanitizeStatsTagsResponse( { tags: [] } ) ).toMatchObject( {
-			summary: {
-				total: 0,
-			},
+			summary: {},
 			data: [],
 		} );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -13,14 +13,14 @@ describe( 'Stats tags normalizer', () => {
 				date_end: '2026-06-22T23:59:59+00:00',
 				items: [
 					expect.objectContaining( {
-						label: 'News',
-						labels: [
+						label: [
 							{
 								label: 'News',
 								labelIcon: 'folder',
 								link: 'https://example.com/category/news/',
 							},
 						],
+						labelText: 'News',
 						value: 18,
 						link: 'https://example.com/category/news/',
 					} ),
@@ -33,8 +33,7 @@ describe( 'Stats tags normalizer', () => {
 	it( 'normalizes multi-tag rows with children', () => {
 		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 1 ] ).toEqual(
 			expect.objectContaining( {
-				label: 'Announcements, Release',
-				labels: [
+				label: [
 					{
 						label: 'Announcements',
 						labelIcon: 'folder',
@@ -46,6 +45,7 @@ describe( 'Stats tags normalizer', () => {
 						link: null,
 					},
 				],
+				labelText: 'Announcements, Release',
 				value: 7,
 				link: null,
 				children: [
@@ -82,14 +82,14 @@ describe( 'Stats tags normalizer', () => {
 				date_end: '2026-06-16T23:59:59+00:00',
 				items: [
 					expect.objectContaining( {
-						label: 'By date',
-						labels: [
+						label: [
 							{
 								label: 'By date',
 								labelIcon: 'folder',
 								link: 'https://example.com/category/by-date/',
 							},
 						],
+						labelText: 'By date',
 						value: 0,
 						link: 'https://example.com/category/by-date/',
 					} ),
@@ -119,14 +119,14 @@ describe( 'Stats tags normalizer', () => {
 					date_end: '2026-06-22T23:59:59+00:00',
 					items: [
 						expect.objectContaining( {
-							label: 'Summary',
-							labels: [
+							label: [
 								{
 									label: 'Summary',
 									labelIcon: 'tag',
 									link: 'https://example.com/tag/summary/',
 								},
 							],
+							labelText: 'Summary',
 							value: 34,
 							link: 'https://example.com/tag/summary/',
 						} ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -11,4 +11,43 @@ describe( 'Stats tags normalizer', () => {
 			} )
 		);
 	} );
+
+	it( 'normalizes multi-tag rows with children', () => {
+		expect( sanitizeStatsTagsResponse( tagsFixture ).data[ 0 ].items[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'Announcements, Release',
+				value: 7,
+				link: null,
+				children: [
+					expect.objectContaining( {
+						label: 'Announcements',
+						labelIcon: 'folder',
+						value: 0,
+						link: 'https://example.com/category/announcements/',
+						children: null,
+					} ),
+					expect.objectContaining( {
+						label: 'Release',
+						labelIcon: 'tag',
+						value: 0,
+						link: 'https://example.com/tag/release/',
+						children: null,
+					} ),
+				],
+			} )
+		);
+	} );
+
+	it( 'aggregates summary totals', () => {
+		expect( sanitizeStatsTagsResponse( tagsFixture ).summary.total ).toBe( 25 );
+	} );
+
+	it( 'normalizes empty responses', () => {
+		expect( sanitizeStatsTagsResponse( { tags: [] } ) ).toMatchObject( {
+			summary: {
+				total: 0,
+			},
+			data: [],
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -22,6 +22,7 @@ export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
 export { sanitizeStatsCommentsResponse } from './comments';
 export { sanitizeStatsStreakResponse } from './streak';
+export { sanitizeStatsTagsResponse } from './tags';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
 	StatsPostMonthValues,
@@ -68,6 +69,14 @@ export type {
 } from './comments';
 export type { StatsStreakRawResponse, StatsStreakResponse } from './streak';
 export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
+export type {
+	StatsTagsChildItem,
+	StatsTagsItem,
+	StatsTagsLabel,
+	StatsTagsRawItem,
+	StatsTagsRawResponse,
+	StatsTagsRawTag,
+} from './tags';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,0 +1,52 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsItem > {
+	value: number;
+	link?: unknown;
+	labels?: Array< { label: unknown; labelIcon: string; link: unknown } >;
+	labelIcon?: string;
+}
+
+const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
+
+export function sanitizeStatsTagsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsTagsItem > {
+	const tags = coerceStatsArray< StatsRecord >( coerceStatsRecord( response ).tags );
+	const items = tags.map( item => {
+		const tagItems = coerceStatsArray< StatsRecord >( item.tags );
+		const hasChildren = tagItems.length > 1;
+		const labels = tagItems.map( tag => ( {
+			label: tag.name,
+			labelIcon: tagIcon( tag.type ),
+			link: hasChildren ? null : tag.link,
+		} ) );
+
+		return {
+			label: labels.map( label => label.label ).join( ', ' ),
+			labels,
+			link: hasChildren ? null : labels[ 0 ]?.link,
+			value: safeParseFloat( item.views ),
+			children: hasChildren
+				? tagItems.map( tag => ( {
+						label: tag.name,
+						labelIcon: tagIcon( tag.type ),
+						value: 0,
+						link: tag.link,
+						children: null,
+				  } ) )
+				: null,
+		};
+	} );
+
+	return {
+		summary: {
+			total: items.reduce( ( total, item ) => total + item.value, 0 ),
+		},
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -32,49 +32,58 @@ export type StatsTagsRawResponse = {
 };
 
 export type StatsTagsLabel = {
-	label: unknown;
+	label: string;
 	labelIcon: string;
-	link: unknown;
+	link: string | null;
 };
 
 export interface StatsTagsChildItem extends StatsNormalizedItemBase< null > {
+	label: string;
 	labelIcon: string;
 	value: null;
-	link: unknown;
+	link: string | null;
 	children: null;
 }
 
 export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsChildItem > {
-	label: string;
-	labels: StatsTagsLabel[];
+	label: StatsTagsLabel[];
+	labelText: string;
 	value: number;
-	link: unknown;
+	link: string | null;
 	children?: StatsTagsChildItem[];
 }
 
 const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
 
+function getTagName( tag: StatsRecord ): string {
+	return typeof tag.name === 'string' ? tag.name : '';
+}
+
+function getTagLink( tag: StatsRecord ): string | null {
+	return typeof tag.link === 'string' ? tag.link : null;
+}
+
 function normalizeStatsTagsItem( item: StatsRecord ): StatsTagsItem {
 	const tagItems = coerceStatsArray< StatsRecord >( item.tags );
 	const hasChildren = tagItems.length > 1;
 	const labels = tagItems.map( tag => ( {
-		label: tag.name,
+		label: getTagName( tag ),
 		labelIcon: tagIcon( tag.type ),
-		link: hasChildren ? null : tag.link,
+		link: hasChildren ? null : getTagLink( tag ),
 	} ) );
 
 	return {
-		label: labels.map( label => label.label ).join( ', ' ),
-		labels,
-		link: hasChildren ? null : labels[ 0 ]?.link,
+		label: labels,
+		labelText: labels.map( label => label.label ).join( ', ' ),
+		link: hasChildren ? null : labels[ 0 ]?.link ?? null,
 		value: safeParseFloat( item.views ),
 		...( hasChildren
 			? {
 					children: tagItems.map( tag => ( {
-						label: tag.name,
+						label: getTagName( tag ),
 						labelIcon: tagIcon( tag.type ),
 						value: null,
-						link: tag.link,
+						link: getTagLink( tag ),
 						children: null,
 					} ) ),
 			  }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,52 +1,103 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import {
+	coerceStatsArray,
+	coerceStatsRecord,
+	createStatsListDataPoint,
+	mapStatsReportDataPoints,
+	normalizeStatsReportSummary,
+} from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
-export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsItem > {
+export type StatsTagsRawTag = {
+	type?: string;
+	name?: string;
+	link?: string | null;
+	[ key: string ]: unknown;
+};
+
+export type StatsTagsRawItem = {
+	tags?: StatsTagsRawTag[];
+	views?: number | string;
+	[ key: string ]: unknown;
+};
+
+export type StatsTagsRawResponse = {
+	date?: string;
+	period?: string;
+	tags?: StatsTagsRawItem[];
+	days?: Record< string, { tags?: StatsTagsRawItem[]; [ key: string ]: unknown } >;
+	summary?: { tags?: StatsTagsRawItem[]; [ key: string ]: unknown };
+	[ key: string ]: unknown;
+};
+
+export type StatsTagsLabel = {
+	label: unknown;
+	labelIcon: string;
+	link: unknown;
+};
+
+export interface StatsTagsChildItem extends StatsNormalizedItemBase< null > {
+	labelIcon: string;
+	value: null;
+	link: unknown;
+	children: null;
+}
+
+export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsChildItem > {
+	label: string;
+	labels: StatsTagsLabel[];
 	value: number;
-	link?: unknown;
-	labels?: Array< { label: unknown; labelIcon: string; link: unknown } >;
-	labelIcon?: string;
+	link: unknown;
+	children?: StatsTagsChildItem[];
 }
 
 const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
+
+function normalizeStatsTagsItem( item: StatsRecord ): StatsTagsItem {
+	const tagItems = coerceStatsArray< StatsRecord >( item.tags );
+	const hasChildren = tagItems.length > 1;
+	const labels = tagItems.map( tag => ( {
+		label: tag.name,
+		labelIcon: tagIcon( tag.type ),
+		link: hasChildren ? null : tag.link,
+	} ) );
+
+	return {
+		label: labels.map( label => label.label ).join( ', ' ),
+		labels,
+		link: hasChildren ? null : labels[ 0 ]?.link,
+		value: safeParseFloat( item.views ),
+		...( hasChildren
+			? {
+					children: tagItems.map( tag => ( {
+						label: tag.name,
+						labelIcon: tagIcon( tag.type ),
+						value: null,
+						link: tag.link,
+						children: null,
+					} ) ),
+			  }
+			: {} ),
+	};
+}
 
 export function sanitizeStatsTagsResponse(
 	response: unknown,
 	query?: StatsQueryParams
 ): StatsNormalizedReport< StatsTagsItem > {
-	const tags = coerceStatsArray< StatsRecord >( coerceStatsRecord( response ).tags );
-	const items = tags.map( item => {
-		const tagItems = coerceStatsArray< StatsRecord >( item.tags );
-		const hasChildren = tagItems.length > 1;
-		const labels = tagItems.map( tag => ( {
-			label: tag.name,
-			labelIcon: tagIcon( tag.type ),
-			link: hasChildren ? null : tag.link,
-		} ) );
+	const data = mapStatsReportDataPoints( response, query, [ 'tags' ], normalizeStatsTagsItem );
+	const topLevelTags = coerceStatsArray< StatsRecord >( coerceStatsRecord( response ).tags ).map(
+		normalizeStatsTagsItem
+	);
+	const normalizedData = [ ...data ];
 
-		return {
-			label: labels.map( label => label.label ).join( ', ' ),
-			labels,
-			link: hasChildren ? null : labels[ 0 ]?.link,
-			value: safeParseFloat( item.views ),
-			children: hasChildren
-				? tagItems.map( tag => ( {
-						label: tag.name,
-						labelIcon: tagIcon( tag.type ),
-						value: 0,
-						link: tag.link,
-						children: null,
-				  } ) )
-				: null,
-		};
-	} );
+	if ( ! normalizedData.length && topLevelTags.length ) {
+		normalizedData.push( createStatsListDataPoint( response, query, topLevelTags ) );
+	}
 
 	return {
-		summary: {
-			total: items.reduce( ( total, item ) => total + item.value, 0 ),
-		},
-		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+		summary: normalizeStatsReportSummary( response, query, [ 'tags' ] ),
+		data: normalizedData,
 	};
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
@@ -7,6 +7,7 @@ import type { StatsFileDownloadsItem } from './file-downloads';
 import type { StatsLocationsItem } from './locations';
 import type { StatsReferrersItem } from './referrers';
 import type { StatsSearchTermsItem } from './search-terms';
+import type { StatsTagsItem } from './tags';
 import type { StatsTopAuthorsItem } from './top-authors';
 import type { StatsTopPostsItem } from './top-posts';
 import type { StatsUtmItem } from './utm';
@@ -35,7 +36,8 @@ export type StatsNormalizedItem =
 	| StatsEmailSummaryItem
 	| StatsEmailBreakdownItem
 	| StatsArchivesItem
-	| StatsCommentsItem;
+	| StatsCommentsItem
+	| StatsTagsItem;
 
 export type StatsNormalizedDataPoint< TItem extends StatsNormalizedItem = StatsNormalizedItem > = {
 	time_interval: string;

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -9,10 +9,12 @@ import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsPostQuery } from '../stats-post-query';
 import { statsStreakQuery } from '../stats-streak-query';
+import { statsTagsQuery } from '../stats-tags-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
 import { statsVisitsQuery } from '../stats-visits-query';
 import type { StatsReportParams } from '../stats-query';
+import type { StatsTagsParams } from '../stats-tags-query';
 
 describe( 'Stats query factories', () => {
 	it( 'disables report queries until a date range is available', () => {
@@ -143,6 +145,45 @@ describe( 'Stats query factories', () => {
 				expect.objectContaining( {
 					date: '2026-06-07',
 					start_date: '2026-06-01',
+					summarize: 1,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'builds tags query keys for the Calypso endpoint path', () => {
+		const query = statsTagsQuery( {} as StatsTagsParams );
+
+		expect( query.enabled ).toBe( false );
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'tags',
+			'1.1',
+			'stats/tags',
+			'GET',
+			expect.objectContaining( { period: 'day' } ),
+			undefined,
+			'tags',
+		] );
+	} );
+
+	it( 'passes report range params through tags query keys', () => {
+		const query = statsTagsQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+			max: 10,
+		} );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				'stats/tags',
+				expect.objectContaining( {
+					date: '2026-06-07',
+					start_date: '2026-06-01',
+					days: 7,
+					max: 10,
 					summarize: 1,
 				} ),
 			] )

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -14,7 +14,6 @@ import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
 import { statsVisitsQuery } from '../stats-visits-query';
 import type { StatsReportParams } from '../stats-query';
-import type { StatsTagsParams } from '../stats-tags-query';
 
 describe( 'Stats query factories', () => {
 	it( 'disables report queries until a date range is available', () => {
@@ -152,42 +151,41 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'builds tags query keys for the Calypso endpoint path', () => {
-		const query = statsTagsQuery( {} as StatsTagsParams );
+		const query = statsTagsQuery( {} );
 
-		expect( query.enabled ).toBe( false );
+		expect( query.enabled ).toBe( true );
 		expect( query.queryKey ).toEqual( [
 			'stats',
 			'tags',
 			'1.1',
 			'stats/tags',
 			'GET',
-			expect.objectContaining( { period: 'day' } ),
+			{},
 			undefined,
 			'tags',
 		] );
 	} );
 
-	it( 'passes report range params through tags query keys', () => {
+	it( 'passes supported tags params through query keys', () => {
 		const query = statsTagsQuery( {
-			from: '2026-06-01',
 			to: '2026-06-07',
-			interval: 'day',
 			max: 10,
 		} );
 
 		expect( query.enabled ).toBe( true );
-		expect( query.queryKey ).toEqual(
-			expect.arrayContaining( [
-				'stats/tags',
-				expect.objectContaining( {
-					date: '2026-06-07',
-					start_date: '2026-06-01',
-					days: 7,
-					max: 10,
-					summarize: 1,
-				} ),
-			] )
-		);
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'tags',
+			'1.1',
+			'stats/tags',
+			'GET',
+			{
+				date: '2026-06-07',
+				max: 10,
+			},
+			undefined,
+			'tags',
+		] );
 	} );
 
 	it( 'preserves explicit summarize params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -32,3 +32,4 @@ export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';
 export { statsUtmQuery } from './stats-utm-query';
 export { statsHighlightsQuery } from './stats-highlights-query';
+export { statsTagsQuery } from './stats-tags-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -14,6 +14,7 @@ import {
 	sanitizeStatsInsightsResponse,
 	sanitizeStatsStreakResponse,
 	sanitizeStatsVisitsResponse,
+	sanitizeStatsTagsResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsPostResponse,
 	sanitizeStatsReferrersResponse,
@@ -52,6 +53,7 @@ const statsSanitizers = {
 	comments: sanitizeStatsCommentsResponse,
 	insights: sanitizeStatsInsightsResponse,
 	streak: sanitizeStatsStreakResponse,
+	tags: sanitizeStatsTagsResponse,
 	utm: sanitizeStatsUtmResponse,
 	visits: sanitizeStatsVisitsResponse,
 } satisfies Record< string, StatsSanitizer >;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,7 +1,14 @@
 /**
  * Internal dependencies
  */
-import { statsReportQuery, type StatsReportParams } from './stats-query';
+import {
+	statsReportQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
+import type { StatsNormalizedReport, StatsTagsItem } from '../processing/stats';
 
-export const statsTagsQuery = ( params: StatsReportParams ) =>
+export type StatsTagsResponse = StatsNormalizedReport< StatsTagsItem >;
+
+export const statsTagsQuery = ( params: StatsReportParams ): StatsReportQueryOptions< 'tags' > =>
 	statsReportQuery( 'tags', 'stats/tags', params, 'tags' );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -6,9 +6,10 @@ import {
 	type StatsReportParams,
 	type StatsReportQueryOptions,
 } from './stats-query';
-import type { StatsNormalizedReport, StatsTagsItem } from '../processing/stats';
 
-export type StatsTagsResponse = StatsNormalizedReport< StatsTagsItem >;
+export type StatsTagsParams = StatsReportParams & {
+	max?: number;
+};
 
-export const statsTagsQuery = ( params: StatsReportParams ): StatsReportQueryOptions< 'tags' > =>
+export const statsTagsQuery = ( params: StatsTagsParams ): StatsReportQueryOptions< 'tags' > =>
 	statsReportQuery( 'tags', 'stats/tags', params, 'tags' );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,15 +1,33 @@
 /**
  * Internal dependencies
  */
+import { reportParamsToStatsQueryParams } from '../utils/stats-params';
 import {
-	statsReportQuery,
+	statsProxyQuery,
 	type StatsReportParams,
 	type StatsReportQueryOptions,
 } from './stats-query';
+import type { StatsProxyParams } from '../api';
 
-export type StatsTagsParams = StatsReportParams & {
+export type StatsTagsParams = Partial< StatsReportParams > & {
 	max?: number;
 };
 
-export const statsTagsQuery = ( params: StatsTagsParams ): StatsReportQueryOptions< 'tags' > =>
-	statsReportQuery( 'tags', 'stats/tags', params, 'tags' );
+function statsTagsParamsToApiParams( params: StatsTagsParams = {} ): StatsProxyParams {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const date = statsParams.date ?? statsParams.end_date;
+
+	return {
+		...( date ? { date } : {} ),
+		...( statsParams.max !== undefined ? { max: statsParams.max } : {} ),
+	};
+}
+
+export const statsTagsQuery = ( params: StatsTagsParams = {} ): StatsReportQueryOptions< 'tags' > =>
+	statsProxyQuery( {
+		name: 'tags',
+		version: '1.1',
+		endpoint: 'stats/tags',
+		params: statsTagsParamsToApiParams( params ),
+		sanitizer: 'tags',
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { statsReportQuery, type StatsReportParams } from './stats-query';
+
+export const statsTagsQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'tags', 'stats/tags', params, 'tags' );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats tags endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check