### PR TITLE
Premium Analytics: add Stats visits endpoint

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-visits-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-visits-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add visits report hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -18,6 +18,7 @@ const statsHookNames = [
 	'useStatsAppDashboardModuleSettings',
 	'useStatsAppDashboardModuleSettingsMutation',
 	'useStatsArchives',
+	'useStatsVisits',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,7 +25,13 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
-export { useStatsVisits, type StatsVisitsParams } from './use-stats-visits';
+export {
+	useStatsVisits,
+	type StatsVisitsParams,
+	type StatsVisitsResponse,
+	type StatsVisitsStatField,
+	type StatsVisitsStatFields,
+} from './use-stats-visits';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -25,6 +25,7 @@ export {
 } from './use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './use-stats-archives';
+export { useStatsVisits, type StatsVisitsParams } from './use-stats-visits';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
@@ -4,14 +4,17 @@
 import { statsVisitsQuery } from '../queries/stats-visits-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsReportParams } from '../queries/stats-query';
+import type { StatsVisitsParams, StatsVisitsResponse } from '../queries/stats-visits-query';
 
-export type StatsVisitsParams = StatsReportParams & {
-	stat_fields?: string;
-};
+export type {
+	StatsVisitsParams,
+	StatsVisitsResponse,
+	StatsVisitsStatField,
+	StatsVisitsStatFields,
+} from '../queries/stats-visits-query';
 
 export function useStatsVisits( params: StatsVisitsParams, options?: UseStatsOptions ) {
-	return useStatsReport(
+	return useStatsReport< StatsVisitsParams, StatsVisitsResponse >(
 		statsVisitsQuery,
 		params,
 		[ 'stats', 'visits', '__comparison__', 'disabled' ],

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { statsVisitsQuery } from '../queries/stats-visits-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsReportParams } from '../queries/stats-query';
+
+export type StatsVisitsParams = StatsReportParams & {
+	stat_fields?: string;
+};
+
+export function useStatsVisits( params: StatsVisitsParams, options?: UseStatsOptions ) {
+	return useStatsReport(
+		statsVisitsQuery,
+		params,
+		[ 'stats', 'visits', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
+export { useStatsVisits, type StatsVisitsParams } from './hooks/use-stats-visits';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -34,7 +34,13 @@ export {
 } from './hooks/use-stats-app-dashboard-module-settings';
 export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
 export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
-export { useStatsVisits, type StatsVisitsParams } from './hooks/use-stats-visits';
+export {
+	useStatsVisits,
+	type StatsVisitsParams,
+	type StatsVisitsResponse,
+	type StatsVisitsStatField,
+	type StatsVisitsStatFields,
+} from './hooks/use-stats-visits';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
@@ -81,6 +87,8 @@ export type {
 	StatsNormalizedSummary,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
+	StatsTimeSeriesDataPoint,
+	StatsTimeSeriesReport,
 	StatsTopAuthorsItem,
 	StatsTopPostsItem,
 	StatsVideoPlaysItem,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -27,6 +27,7 @@ export type { StatsVideoPlaysItem } from './video-plays';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type { StatsArchivesItem } from './archives';
+export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -19,6 +19,15 @@ import {
 import type { StatsNormalizedDataPoint, StatsNormalizedReport, StatsRecord } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
+export type StatsTimeSeriesDataPoint = StatsNormalizedDataPoint & {
+	label: string;
+	value: number;
+};
+
+export type StatsTimeSeriesReport = StatsNormalizedReport & {
+	data: StatsTimeSeriesDataPoint[];
+};
+
 const nonMetricFields = [ 'period', 'time_interval', 'date', 'date_start', 'date_end' ];
 const dateFormat = 'yyyy-MM-dd';
 const referenceDate = new Date( 2001, 0, 1 );
@@ -183,7 +192,7 @@ export function isStatsTimeSeriesPayload( payload: unknown ) {
 export function sanitizeStatsTimeSeriesResponse(
 	payload: unknown,
 	query?: StatsQueryParams
-): StatsNormalizedReport {
+): StatsTimeSeriesReport {
 	const response = coerceStatsRecord( payload );
 	const unit = String( response.unit ?? query?.period ?? 'day' );
 	const rows = parseTimeSeriesRows( payload );
@@ -196,7 +205,7 @@ export function sanitizeStatsTimeSeriesResponse(
 
 		return totals;
 	}, {} );
-	const data = rows.map< StatsNormalizedDataPoint >( row => {
+	const data = rows.map< StatsTimeSeriesDataPoint >( row => {
 		const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
 		const range =
 			typeof row.date_start === 'string' && typeof row.date_end === 'string'

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/visits.ts
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import { sanitizeStatsTimeSeriesResponse } from './time-series';
-import type { StatsNormalizedReport } from './types';
+import type { StatsTimeSeriesReport } from './time-series';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
 export function sanitizeStatsVisitsResponse(
 	response: unknown,
 	query?: StatsQueryParams
-): StatsNormalizedReport {
+): StatsTimeSeriesReport {
 	return sanitizeStatsTimeSeriesResponse( response, query );
 }

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -5,6 +5,7 @@ import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
+import { statsVisitsQuery } from '../stats-visits-query';
 import type { StatsReportParams } from '../stats-query';
 
 describe( 'Stats query factories', () => {
@@ -156,5 +157,42 @@ describe( 'Stats query factories', () => {
 				params: {},
 			} ).queryKey
 		);
+	} );
+
+	it( 'sets visits quantity for day ranges', () => {
+		const query = statsVisitsQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					unit: 'day',
+					date: '2026-06-07',
+					start_date: '2026-06-01',
+					quantity: 7,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'omits visits quantity for non-day ranges', () => {
+		const query = statsVisitsQuery( {
+			from: '2026-06-01',
+			to: '2026-06-30',
+			interval: 'month',
+		} );
+		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
+
+		expect( apiParams ).toEqual(
+			expect.objectContaining( {
+				unit: 'month',
+				date: '2026-06-30',
+				start_date: '2026-06-01',
+			} )
+		);
+		expect( apiParams ).not.toHaveProperty( 'quantity' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -24,3 +24,4 @@ export { statsCountryViewsQuery } from './stats-country-views-query';
 export { statsVideoPlaysQuery } from './stats-video-plays-query';
 export { statsAppDashboardModuleSettingsQuery } from './stats-app-dashboard-module-settings-query';
 export { statsArchivesQuery } from './stats-archives-query';
+export { statsVisitsQuery } from './stats-visits-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -9,6 +9,7 @@ import {
 	sanitizeStatsFileDownloadsResponse,
 	sanitizeStatsLocationsResponse,
 	sanitizeStatsArchivesResponse,
+	sanitizeStatsVisitsResponse,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
@@ -40,6 +41,7 @@ const statsSanitizers = {
 	locations: sanitizeStatsLocationsResponse,
 	videoPlays: sanitizeStatsVideoPlaysResponse,
 	archives: sanitizeStatsArchivesResponse,
+	visits: sanitizeStatsVisitsResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -16,7 +16,7 @@ export const statsVisitsQuery = ( params: StatsVisitsParams ) => {
 		unit: apiParams.period,
 		date: apiParams.date,
 		start_date: apiParams.start_date,
-		quantity: apiParams.days,
+		...( apiParams.period === 'day' ? { quantity: apiParams.days } : {} ),
 		stat_fields: params.stat_fields ?? 'views,visitors',
 	};
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import { statsProxyQuery, type StatsReportParams } from './stats-query';
+import type { StatsProxyParams } from '../api';
+
+type StatsVisitsParams = StatsReportParams & {
+	stat_fields?: string;
+};
+
+export const statsVisitsQuery = ( params: StatsVisitsParams ) => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const visitsParams: StatsProxyParams = {
+		unit: apiParams.period,
+		date: apiParams.date,
+		start_date: apiParams.start_date,
+		quantity: apiParams.days,
+		stat_fields: params.stat_fields ?? 'views,visitors',
+	};
+
+	return statsProxyQuery( {
+		name: 'visits',
+		version: '1.1',
+		endpoint: 'stats/visits',
+		params: visitsParams,
+		sanitizer: 'visits',
+		enabled: !! ( visitsParams.date || visitsParams.start_date ),
+	} );
+};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -2,14 +2,32 @@
  * Internal dependencies
  */
 import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
-import { statsProxyQuery, type StatsReportParams } from './stats-query';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
 import type { StatsProxyParams } from '../api';
+import type { StatsTimeSeriesReport } from '../processing/stats';
 
-type StatsVisitsParams = StatsReportParams & {
-	stat_fields?: string;
+export type StatsVisitsStatField = 'views' | 'visitors' | 'likes' | 'comments' | 'post_titles';
+
+export type StatsVisitsStatFields =
+	| StatsVisitsStatField
+	| `${ StatsVisitsStatField },${ StatsVisitsStatField }`
+	| `${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField }`
+	| `${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField }`
+	| `${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField },${ StatsVisitsStatField }`;
+
+export type StatsVisitsParams = StatsReportParams & {
+	stat_fields?: StatsVisitsStatFields;
 };
 
-export const statsVisitsQuery = ( params: StatsVisitsParams ) => {
+export type StatsVisitsResponse = StatsTimeSeriesReport;
+
+export const statsVisitsQuery = (
+	params: StatsVisitsParams
+): StatsReportQueryOptions< 'visits' > => {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
 	const visitsParams: StatsProxyParams = {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats visits endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check