### PR TITLE
Premium Analytics: add Stats WordAds endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-wordads-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-wordads-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add WordAds hooks.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -34,6 +34,8 @@ const statsHookNames = [
 	'useStatsTags',
 	'useStatsDevices',
 	'useStatsAppSiteHasNeverPublishedPost',
+	'useStatsWordAdsStats',
+	'useStatsWordAdsEarnings',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -105,11 +105,11 @@ export {
 	type StatsWordAdsEarningsRawPeriod,
 	type StatsWordAdsEarningsRawResponse,
 	type StatsWordAdsEarningsResponse,
-	type StatsWordAdsStatsDataPoint,
-	type StatsWordAdsStatsParams,
-	type StatsWordAdsStatsRawField,
-	type StatsWordAdsStatsRawResponse,
-	type StatsWordAdsStatsResponse,
+	type StatsWordAdsDataPoint,
+	type StatsWordAdsParams,
+	type StatsWordAdsRawField,
+	type StatsWordAdsRawResponse,
+	type StatsWordAdsResponse,
 } from './use-stats-wordads';
 export type { UseStatsOptions } from './use-stats-report';
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -93,6 +93,24 @@ export {
 	type StatsAppSiteHasNeverPublishedPostParams,
 	type StatsAppSiteHasNeverPublishedPostResponse,
 } from './use-stats-app-site-has-never-published-post';
+export {
+	useStatsWordAdsStats,
+	useStatsWordAdsEarnings,
+	type StatsWordAdsEarnings,
+	type StatsWordAdsEarningsBreakdown,
+	type StatsWordAdsEarningsParams,
+	type StatsWordAdsEarningsPeriod,
+	type StatsWordAdsEarningsRaw,
+	type StatsWordAdsEarningsRawBreakdown,
+	type StatsWordAdsEarningsRawPeriod,
+	type StatsWordAdsEarningsRawResponse,
+	type StatsWordAdsEarningsResponse,
+	type StatsWordAdsStatsDataPoint,
+	type StatsWordAdsStatsParams,
+	type StatsWordAdsStatsRawField,
+	type StatsWordAdsStatsRawResponse,
+	type StatsWordAdsStatsResponse,
+} from './use-stats-wordads';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -4,10 +4,19 @@
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsWordAdsStatsResponse } from '../queries/stats-wordads-query';
 import type { StatsQueryParams } from '../utils/stats-params';
 
+export type {
+	StatsWordAdsEarnings,
+	StatsWordAdsEarningsBreakdown,
+	StatsWordAdsEarningsPeriod,
+	StatsWordAdsEarningsResponse,
+	StatsWordAdsStatsResponse,
+} from '../queries/stats-wordads-query';
+
 export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery( statsWordAdsStatsQuery( params ), options );
+	return useStatsQuery< StatsWordAdsStatsResponse >( statsWordAdsStatsQuery( params ), options );
 }
 
 export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -4,10 +4,10 @@
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
 import { useStatsQuery } from './use-stats-query';
 import { useStatsReport, type UseStatsOptions } from './use-stats-report';
-import type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse } from '../processing/stats';
+import type { StatsWordAdsEarningsResponse, StatsWordAdsResponse } from '../processing/stats';
 import type {
 	StatsWordAdsEarningsParams,
-	StatsWordAdsStatsParams,
+	StatsWordAdsParams,
 } from '../queries/stats-wordads-query';
 
 export type {
@@ -19,18 +19,18 @@ export type {
 	StatsWordAdsEarningsRawPeriod,
 	StatsWordAdsEarningsRawResponse,
 	StatsWordAdsEarningsResponse,
-	StatsWordAdsStatsDataPoint,
-	StatsWordAdsStatsRawField,
-	StatsWordAdsStatsRawResponse,
-	StatsWordAdsStatsResponse,
+	StatsWordAdsDataPoint,
+	StatsWordAdsRawField,
+	StatsWordAdsRawResponse,
+	StatsWordAdsResponse,
 } from '../processing/stats';
 export type {
 	StatsWordAdsEarningsParams,
-	StatsWordAdsStatsParams,
+	StatsWordAdsParams,
 } from '../queries/stats-wordads-query';
 
-export function useStatsWordAdsStats( params: StatsWordAdsStatsParams, options?: UseStatsOptions ) {
-	return useStatsReport< StatsWordAdsStatsParams, StatsWordAdsStatsResponse >(
+export function useStatsWordAdsStats( params: StatsWordAdsParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsWordAdsParams, StatsWordAdsResponse >(
 		statsWordAdsStatsQuery,
 		params,
 		[ 'stats', 'wordads-stats', '__comparison__', 'disabled' ],

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsWordAdsStatsQuery( params ), options );
+}
+
+export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
+	return useStatsQuery( statsWordAdsEarningsQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -3,22 +3,47 @@
  */
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
 import { useStatsQuery } from './use-stats-query';
-import type { UseStatsOptions } from './use-stats-report';
-import type { StatsWordAdsStatsResponse } from '../queries/stats-wordads-query';
-import type { StatsQueryParams } from '../utils/stats-params';
+import { useStatsReport, type UseStatsOptions } from './use-stats-report';
+import type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse } from '../processing/stats';
+import type {
+	StatsWordAdsEarningsParams,
+	StatsWordAdsStatsParams,
+} from '../queries/stats-wordads-query';
 
 export type {
 	StatsWordAdsEarnings,
 	StatsWordAdsEarningsBreakdown,
 	StatsWordAdsEarningsPeriod,
+	StatsWordAdsEarningsRaw,
+	StatsWordAdsEarningsRawBreakdown,
+	StatsWordAdsEarningsRawPeriod,
+	StatsWordAdsEarningsRawResponse,
 	StatsWordAdsEarningsResponse,
+	StatsWordAdsStatsDataPoint,
+	StatsWordAdsStatsRawField,
+	StatsWordAdsStatsRawResponse,
 	StatsWordAdsStatsResponse,
+} from '../processing/stats';
+export type {
+	StatsWordAdsEarningsParams,
+	StatsWordAdsStatsParams,
 } from '../queries/stats-wordads-query';
 
-export function useStatsWordAdsStats( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery< StatsWordAdsStatsResponse >( statsWordAdsStatsQuery( params ), options );
+export function useStatsWordAdsStats( params: StatsWordAdsStatsParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsWordAdsStatsParams, StatsWordAdsStatsResponse >(
+		statsWordAdsStatsQuery,
+		params,
+		[ 'stats', 'wordads-stats', '__comparison__', 'disabled' ],
+		options
+	);
 }
 
-export function useStatsWordAdsEarnings( params?: StatsQueryParams, options?: UseStatsOptions ) {
-	return useStatsQuery( statsWordAdsEarningsQuery( params ), options );
+export function useStatsWordAdsEarnings(
+	params?: StatsWordAdsEarningsParams,
+	options?: UseStatsOptions
+) {
+	return useStatsQuery< StatsWordAdsEarningsResponse >(
+		statsWordAdsEarningsQuery( params ),
+		options
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -98,6 +98,24 @@ export {
 	type StatsAppSiteHasNeverPublishedPostParams,
 	type StatsAppSiteHasNeverPublishedPostResponse,
 } from './hooks/use-stats-app-site-has-never-published-post';
+export {
+	useStatsWordAdsStats,
+	useStatsWordAdsEarnings,
+	type StatsWordAdsEarnings,
+	type StatsWordAdsEarningsBreakdown,
+	type StatsWordAdsEarningsParams,
+	type StatsWordAdsEarningsPeriod,
+	type StatsWordAdsEarningsRaw,
+	type StatsWordAdsEarningsRawBreakdown,
+	type StatsWordAdsEarningsRawPeriod,
+	type StatsWordAdsEarningsRawResponse,
+	type StatsWordAdsEarningsResponse,
+	type StatsWordAdsStatsDataPoint,
+	type StatsWordAdsStatsParams,
+	type StatsWordAdsStatsRawField,
+	type StatsWordAdsStatsRawResponse,
+	type StatsWordAdsStatsResponse,
+} from './hooks/use-stats-wordads';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -110,11 +110,11 @@ export {
 	type StatsWordAdsEarningsRawPeriod,
 	type StatsWordAdsEarningsRawResponse,
 	type StatsWordAdsEarningsResponse,
-	type StatsWordAdsStatsDataPoint,
-	type StatsWordAdsStatsParams,
-	type StatsWordAdsStatsRawField,
-	type StatsWordAdsStatsRawResponse,
-	type StatsWordAdsStatsResponse,
+	type StatsWordAdsDataPoint,
+	type StatsWordAdsParams,
+	type StatsWordAdsRawField,
+	type StatsWordAdsRawResponse,
+	type StatsWordAdsResponse,
 } from './hooks/use-stats-wordads';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/wordads.ts
@@ -1,4 +1,4 @@
-import type { StatsWordAdsStatsRawResponse } from '../wordads';
+import type { StatsWordAdsRawResponse } from '../wordads';
 
 export const wordAdsStatsFixture = {
 	unit: 'month',
@@ -7,13 +7,13 @@ export const wordAdsStatsFixture = {
 		[ '2026-05', '1200', '6.50', '5.42' ],
 		[ '2026-06', 800, 3.25, 4.06 ],
 	],
-} satisfies StatsWordAdsStatsRawResponse;
+} satisfies StatsWordAdsRawResponse;
 
 export const wordAdsStatsEmptyFixture = {
 	unit: 'day',
 	fields: [ 'period', 'impressions', 'revenue', 'cpm' ],
 	data: [],
-} satisfies StatsWordAdsStatsRawResponse;
+} satisfies StatsWordAdsRawResponse;
 
 export const wordAdsEarningsFixture = {
 	earnings: {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/wordads.ts
@@ -1,0 +1,53 @@
+import type { StatsWordAdsStatsRawResponse } from '../wordads';
+
+export const wordAdsStatsFixture = {
+	unit: 'month',
+	fields: [ 'period', 'impressions', 'revenue', 'cpm' ],
+	data: [
+		[ '2026-05', '1200', '6.50', '5.42' ],
+		[ '2026-06', 800, 3.25, 4.06 ],
+	],
+} satisfies StatsWordAdsStatsRawResponse;
+
+export const wordAdsStatsEmptyFixture = {
+	unit: 'day',
+	fields: [ 'period', 'impressions', 'revenue', 'cpm' ],
+	data: [],
+} satisfies StatsWordAdsStatsRawResponse;
+
+export const wordAdsEarningsFixture = {
+	earnings: {
+		total_earnings: '25.75',
+		total_amount_owed: '7.25',
+		wordads: {
+			'2026-05': {
+				amount: '6.50',
+				pageviews: '1200',
+				status: 1,
+			},
+			'2026-06': {
+				amount: 3.25,
+				pageviews: 800,
+				status: '0',
+			},
+		},
+		sponsored: {
+			'2026-06': {
+				amount: '16.00',
+				pageviews: '450',
+				status: 3,
+			},
+		},
+		adjustment: {
+			'2026-06': {
+				amount: '0',
+				pageviews: 0,
+				status: 4,
+			},
+		},
+	},
+};
+
+export const wordAdsEarningsEmptyFixture = {
+	earnings: {},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/wordads.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/wordads.test.ts
@@ -1,0 +1,108 @@
+import { sanitizeStatsWordAdsEarningsResponse, sanitizeStatsWordAdsStatsResponse } from '..';
+import {
+	wordAdsEarningsEmptyFixture,
+	wordAdsEarningsFixture,
+	wordAdsStatsEmptyFixture,
+	wordAdsStatsFixture,
+} from '../__fixtures__/wordads';
+
+describe( 'Stats WordAds normalizers', () => {
+	it( 'normalizes raw WordAds stats matrix rows into a time-series report', () => {
+		const result = sanitizeStatsWordAdsStatsResponse( wordAdsStatsFixture, {
+			period: 'month',
+			date: '2026-06-30',
+		} );
+
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				impressions: 2000,
+				revenue: 9.75,
+				cpm: 4.875,
+				date_start: '2026-05-01T00:00:00+00:00',
+				date_end: '2026-06-30T23:59:59+00:00',
+			} )
+		);
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-05-01',
+				date_start: '2026-05-01T00:00:00+00:00',
+				date_end: '2026-05-31T23:59:59+00:00',
+				label: '2026-05-01',
+				value: 1200,
+				impressions: 1200,
+				revenue: 6.5,
+				cpm: 5.42,
+				items: [],
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-30T23:59:59+00:00',
+				value: 800,
+				impressions: 800,
+				revenue: 3.25,
+				cpm: 4.06,
+			} ),
+		] );
+	} );
+
+	it( 'returns an empty report for empty WordAds stats payloads', () => {
+		expect( sanitizeStatsWordAdsStatsResponse( wordAdsStatsEmptyFixture ) ).toEqual( {
+			summary: {
+				date_start: '',
+				date_end: '',
+			},
+			data: [],
+		} );
+	} );
+
+	it( 'normalizes raw WordAds earnings payloads while preserving breakdown fields', () => {
+		expect( sanitizeStatsWordAdsEarningsResponse( wordAdsEarningsFixture ) ).toEqual( {
+			total_earnings: 25.75,
+			total_amount_owed: 7.25,
+			wordads: {
+				'2026-05': {
+					amount: 6.5,
+					pageviews: 1200,
+					status: 1,
+				},
+				'2026-06': {
+					amount: 3.25,
+					pageviews: 800,
+					status: 0,
+				},
+			},
+			sponsored: {
+				'2026-06': {
+					amount: 16,
+					pageviews: 450,
+					status: 3,
+				},
+			},
+			adjustment: {
+				'2026-06': {
+					amount: 0,
+					pageviews: 0,
+					status: 4,
+				},
+			},
+		} );
+	} );
+
+	it( 'returns numeric defaults and empty breakdowns for missing earnings fields', () => {
+		expect( sanitizeStatsWordAdsEarningsResponse( wordAdsEarningsEmptyFixture ) ).toEqual( {
+			total_earnings: 0,
+			total_amount_owed: 0,
+			wordads: {},
+			sponsored: {},
+			adjustment: {},
+		} );
+		expect( sanitizeStatsWordAdsEarningsResponse( {} ) ).toEqual( {
+			total_earnings: 0,
+			total_amount_owed: 0,
+			wordads: {},
+			sponsored: {},
+			adjustment: {},
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -31,6 +31,7 @@ export { sanitizeStatsStreakResponse } from './streak';
 export { sanitizeStatsTagsResponse } from './tags';
 export { sanitizeStatsDevicesResponse } from './devices';
 export { sanitizeStatsPublicizeResponse } from './publicize';
+export { sanitizeStatsWordAdsStatsResponse, sanitizeStatsWordAdsEarningsResponse } from './wordads';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
 	StatsPostMonthValues,
@@ -64,6 +65,7 @@ export type { StatsUtmItem, StatsUtmParam, StatsUtmTopPostItem } from './utm';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type { StatsArchivesItem } from './archives';
+export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
 export type {
 	StatsCommentFollowersItem,
 	StatsCommentFollowersRawPost,
@@ -104,7 +106,6 @@ export type {
 	StatsSubscribersResponse,
 } from './subscribers';
 export type { StatsStreakRawResponse, StatsStreakResponse } from './streak';
-export type { StatsTimeSeriesDataPoint, StatsTimeSeriesReport } from './time-series';
 export type {
 	StatsTagsChildItem,
 	StatsTagsItem,
@@ -113,6 +114,20 @@ export type {
 	StatsTagsRawResponse,
 	StatsTagsRawTag,
 } from './tags';
+export type {
+	StatsWordAdsEarnings,
+	StatsWordAdsEarningsBreakdown,
+	StatsWordAdsEarningsPeriod,
+	StatsWordAdsEarningsRaw,
+	StatsWordAdsEarningsRawBreakdown,
+	StatsWordAdsEarningsRawPeriod,
+	StatsWordAdsEarningsRawResponse,
+	StatsWordAdsEarningsResponse,
+	StatsWordAdsStatsDataPoint,
+	StatsWordAdsStatsRawField,
+	StatsWordAdsStatsRawResponse,
+	StatsWordAdsStatsResponse,
+} from './wordads';
 export type {
 	StatsItemAction,
 	StatsNormalizedDataPoint,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -123,10 +123,10 @@ export type {
 	StatsWordAdsEarningsRawPeriod,
 	StatsWordAdsEarningsRawResponse,
 	StatsWordAdsEarningsResponse,
-	StatsWordAdsStatsDataPoint,
-	StatsWordAdsStatsRawField,
-	StatsWordAdsStatsRawResponse,
-	StatsWordAdsStatsResponse,
+	StatsWordAdsDataPoint,
+	StatsWordAdsRawField,
+	StatsWordAdsRawResponse,
+	StatsWordAdsResponse,
 } from './wordads';
 export type {
 	StatsItemAction,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
@@ -4,22 +4,22 @@ import { coerceStatsRecord } from './utils';
 import type { StatsNormalizedReport, StatsNormalizedSummary, StatsRecord } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
-export type StatsWordAdsStatsRawField = 'period' | 'impressions' | 'revenue' | 'cpm';
+export type StatsWordAdsRawField = 'period' | 'impressions' | 'revenue' | 'cpm';
 
-export type StatsWordAdsStatsRawResponse = {
+export type StatsWordAdsRawResponse = {
 	unit?: string;
-	fields?: StatsWordAdsStatsRawField[];
+	fields?: StatsWordAdsRawField[];
 	data?: Array< Array< string | number | null > >;
 };
 
-export type StatsWordAdsStatsDataPoint = StatsTimeSeriesDataPoint & {
+export type StatsWordAdsDataPoint = StatsTimeSeriesDataPoint & {
 	impressions?: number;
 	revenue?: number;
 	cpm?: number;
 };
 
-export type StatsWordAdsStatsResponse = StatsNormalizedReport & {
-	data: StatsWordAdsStatsDataPoint[];
+export type StatsWordAdsResponse = StatsNormalizedReport & {
+	data: StatsWordAdsDataPoint[];
 };
 
 export type StatsWordAdsEarningsRawPeriod = {
@@ -63,7 +63,7 @@ export type StatsWordAdsEarningsResponse = StatsWordAdsEarnings;
 const earningsBreakdownKeys = [ 'wordads', 'sponsored', 'adjustment' ] as const;
 
 function summarizeWordAdsStats(
-	data: StatsWordAdsStatsDataPoint[],
+	data: StatsWordAdsDataPoint[],
 	baseSummary: StatsNormalizedSummary
 ): StatsNormalizedSummary {
 	if ( ! data.length ) {
@@ -104,14 +104,14 @@ function normalizeEarningsBreakdown( value: unknown ): StatsWordAdsEarningsBreak
 }
 
 export function sanitizeStatsWordAdsStatsResponse(
-	response: StatsWordAdsStatsRawResponse,
+	response: StatsWordAdsRawResponse,
 	query?: StatsQueryParams
-): StatsWordAdsStatsResponse;
+): StatsWordAdsResponse;
 export function sanitizeStatsWordAdsStatsResponse(
 	response: unknown,
 	query?: StatsQueryParams
-): StatsWordAdsStatsResponse {
-	const report = sanitizeStatsTimeSeriesResponse( response, query ) as StatsWordAdsStatsResponse;
+): StatsWordAdsResponse {
+	const report = sanitizeStatsTimeSeriesResponse( response, query ) as StatsWordAdsResponse;
 
 	return {
 		...report,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
@@ -1,0 +1,137 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { sanitizeStatsTimeSeriesResponse, type StatsTimeSeriesDataPoint } from './time-series';
+import { coerceStatsRecord } from './utils';
+import type { StatsNormalizedReport, StatsNormalizedSummary, StatsRecord } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsWordAdsStatsRawField = 'period' | 'impressions' | 'revenue' | 'cpm';
+
+export type StatsWordAdsStatsRawResponse = {
+	unit?: string;
+	fields?: StatsWordAdsStatsRawField[];
+	data?: Array< Array< string | number | null > >;
+};
+
+export type StatsWordAdsStatsDataPoint = StatsTimeSeriesDataPoint & {
+	impressions?: number;
+	revenue?: number;
+	cpm?: number;
+};
+
+export type StatsWordAdsStatsResponse = StatsNormalizedReport & {
+	data: StatsWordAdsStatsDataPoint[];
+};
+
+export type StatsWordAdsEarningsRawPeriod = {
+	amount?: number | string | null;
+	pageviews?: number | string | null;
+	status?: number | string | null;
+};
+
+export type StatsWordAdsEarningsRawBreakdown = Record< string, StatsWordAdsEarningsRawPeriod >;
+
+export type StatsWordAdsEarningsRaw = {
+	total_earnings?: number | string | null;
+	total_amount_owed?: number | string | null;
+	wordads?: StatsWordAdsEarningsRawBreakdown;
+	sponsored?: StatsWordAdsEarningsRawBreakdown;
+	adjustment?: StatsWordAdsEarningsRawBreakdown;
+};
+
+export type StatsWordAdsEarningsRawResponse = {
+	earnings?: StatsWordAdsEarningsRaw;
+};
+
+export type StatsWordAdsEarningsPeriod = {
+	amount: number;
+	pageviews: number;
+	status: number;
+};
+
+export type StatsWordAdsEarningsBreakdown = Record< string, StatsWordAdsEarningsPeriod >;
+
+export type StatsWordAdsEarnings = {
+	total_earnings: number;
+	total_amount_owed: number;
+	wordads: StatsWordAdsEarningsBreakdown;
+	sponsored: StatsWordAdsEarningsBreakdown;
+	adjustment: StatsWordAdsEarningsBreakdown;
+};
+
+export type StatsWordAdsEarningsResponse = StatsWordAdsEarnings;
+
+const earningsBreakdownKeys = [ 'wordads', 'sponsored', 'adjustment' ] as const;
+
+function summarizeWordAdsStats(
+	data: StatsWordAdsStatsDataPoint[],
+	baseSummary: StatsNormalizedSummary
+): StatsNormalizedSummary {
+	if ( ! data.length ) {
+		return baseSummary;
+	}
+
+	const totals = data.reduce(
+		( summary, row ) => ( {
+			impressions: summary.impressions + safeParseFloat( row.impressions ),
+			revenue: summary.revenue + safeParseFloat( row.revenue ),
+		} ),
+		{ impressions: 0, revenue: 0 }
+	);
+
+	return {
+		...baseSummary,
+		impressions: totals.impressions,
+		revenue: totals.revenue,
+		cpm: totals.impressions ? ( totals.revenue / totals.impressions ) * 1000 : 0,
+	};
+}
+
+function normalizeEarningsPeriod( value: StatsRecord ): StatsWordAdsEarningsPeriod {
+	return {
+		amount: safeParseFloat( value.amount ),
+		pageviews: safeParseFloat( value.pageviews ),
+		status: safeParseFloat( value.status ),
+	};
+}
+
+function normalizeEarningsBreakdown( value: unknown ): StatsWordAdsEarningsBreakdown {
+	return Object.fromEntries(
+		Object.entries( coerceStatsRecord( value ) ).map( ( [ period, item ] ) => [
+			period,
+			normalizeEarningsPeriod( coerceStatsRecord( item ) ),
+		] )
+	);
+}
+
+export function sanitizeStatsWordAdsStatsResponse(
+	response: StatsWordAdsStatsRawResponse,
+	query?: StatsQueryParams
+): StatsWordAdsStatsResponse;
+export function sanitizeStatsWordAdsStatsResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsWordAdsStatsResponse {
+	const report = sanitizeStatsTimeSeriesResponse( response, query ) as StatsWordAdsStatsResponse;
+
+	return {
+		...report,
+		summary: summarizeWordAdsStats( report.data, report.summary ),
+	};
+}
+
+export function sanitizeStatsWordAdsEarningsResponse(
+	response: StatsWordAdsEarningsRawResponse
+): StatsWordAdsEarningsResponse;
+export function sanitizeStatsWordAdsEarningsResponse(
+	response: unknown
+): StatsWordAdsEarningsResponse {
+	const earnings = coerceStatsRecord( coerceStatsRecord( response ).earnings );
+
+	return {
+		total_earnings: safeParseFloat( earnings.total_earnings ),
+		total_amount_owed: safeParseFloat( earnings.total_amount_owed ),
+		...Object.fromEntries(
+			earningsBreakdownKeys.map( key => [ key, normalizeEarningsBreakdown( earnings[ key ] ) ] )
+		),
+	} as StatsWordAdsEarningsResponse;
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -19,6 +19,7 @@ import { statsTagsQuery } from '../stats-tags-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
 import { statsVisitsQuery } from '../stats-visits-query';
+import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../stats-wordads-query';
 import type { StatsReportParams } from '../stats-query';
 
 describe( 'Stats query factories', () => {
@@ -438,6 +439,83 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'subscribersCounts',
+		] );
+	} );
+
+	it( 'builds WordAds stats query keys with Calypso endpoint params', () => {
+		const query = statsWordAdsStatsQuery( {
+			from: '2026-05-01',
+			to: '2026-06-30',
+			interval: 'month',
+		} );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'wordads-stats',
+			'1.1',
+			'wordads/stats',
+			'GET',
+			{
+				unit: 'month',
+				date: '2026-06-30',
+				quantity: 30,
+			},
+			undefined,
+			'wordAdsStats',
+			{
+				period: 'month',
+				date: '2026-06-30',
+			},
+		] );
+	} );
+
+	it( 'uses the WordAds yearly quantity default and preserves explicit quantity params', () => {
+		expect(
+			statsWordAdsStatsQuery( {
+				from: '2026-01-01',
+				to: '2026-12-31',
+				interval: 'year',
+			} ).queryKey
+		).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					unit: 'year',
+					quantity: 10,
+				} ),
+			] )
+		);
+		expect(
+			statsWordAdsStatsQuery( {
+				from: '2026-06-01',
+				to: '2026-06-30',
+				interval: 'day',
+				quantity: 14,
+			} ).queryKey
+		).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					unit: 'day',
+					quantity: 14,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'disables WordAds stats queries until a date is available', () => {
+		expect( statsWordAdsStatsQuery( {} as StatsReportParams ).enabled ).toBe( false );
+	} );
+
+	it( 'builds WordAds earnings query keys without request params', () => {
+		expect( statsWordAdsEarningsQuery().queryKey ).toEqual( [
+			'stats',
+			'wordads-earnings',
+			'1.1',
+			'wordads/earnings',
+			'GET',
+			{},
+			undefined,
+			'wordAdsEarnings',
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -57,5 +57,5 @@ export {
 	statsWordAdsStatsQuery,
 	statsWordAdsEarningsQuery,
 	type StatsWordAdsEarningsParams,
-	type StatsWordAdsStatsParams,
+	type StatsWordAdsParams,
 } from './stats-wordads-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -53,3 +53,9 @@ export {
 	type StatsAppSiteHasNeverPublishedPostParams,
 	type StatsAppSiteHasNeverPublishedPostResponse,
 } from './stats-app-site-has-never-published-post-query';
+export {
+	statsWordAdsStatsQuery,
+	statsWordAdsEarningsQuery,
+	type StatsWordAdsEarningsParams,
+	type StatsWordAdsStatsParams,
+} from './stats-wordads-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -31,6 +31,8 @@ import {
 	sanitizeStatsTopPostsResponse,
 	sanitizeStatsUtmResponse,
 	sanitizeStatsVideoPlaysResponse,
+	sanitizeStatsWordAdsEarningsResponse,
+	sanitizeStatsWordAdsStatsResponse,
 } from '../processing/stats';
 import {
 	reportParamsToStatsQueryParams,
@@ -70,6 +72,8 @@ const statsSanitizers = {
 	subscribers: sanitizeStatsSubscribersResponse,
 	subscribersCounts: sanitizeStatsSubscribersCountsResponse,
 	publicize: sanitizeStatsPublicizeResponse,
+	wordAdsStats: sanitizeStatsWordAdsStatsResponse,
+	wordAdsEarnings: sanitizeStatsWordAdsEarningsResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -8,16 +8,16 @@ import {
 	type StatsReportQueryOptions,
 } from './stats-query';
 import type { StatsProxyParams } from '../api';
-import type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse } from '../processing/stats';
+import type { StatsWordAdsEarningsResponse, StatsWordAdsResponse } from '../processing/stats';
 
-export type StatsWordAdsStatsParams = StatsReportParams & {
+export type StatsWordAdsParams = StatsReportParams & {
 	quantity?: number;
 };
 
 export type StatsWordAdsEarningsParams = Record< string, never >;
 
 export const statsWordAdsStatsQuery = (
-	params: StatsWordAdsStatsParams
+	params: StatsWordAdsParams
 ): StatsReportQueryOptions< 'wordAdsStats' > => {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
@@ -54,4 +54,4 @@ export const statsWordAdsEarningsQuery = (
 		sanitizer: 'wordAdsEarnings',
 	} );
 
-export type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse };
+export type { StatsWordAdsEarningsResponse, StatsWordAdsResponse };

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -1,48 +1,57 @@
 /**
  * Internal dependencies
  */
-import { statsProxyQuery } from './stats-query';
-import type { StatsReportQueryOptions } from './stats-query';
-import type { StatsTimeSeriesReport } from '../processing/stats';
-import type { StatsQueryParams } from '../utils/stats-params';
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
+import type { StatsProxyParams } from '../api';
+import type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse } from '../processing/stats';
 
-export type StatsWordAdsStatsResponse = StatsTimeSeriesReport;
-
-export type StatsWordAdsEarningsPeriod = {
-	amount: number | string;
-	pageviews: number | string;
-	status: number;
+export type StatsWordAdsStatsParams = StatsReportParams & {
+	quantity?: number;
 };
 
-export type StatsWordAdsEarningsBreakdown = Record< string, StatsWordAdsEarningsPeriod >;
-
-export type StatsWordAdsEarnings = {
-	total_earnings?: number | string;
-	total_amount_owed?: number | string;
-	wordads?: StatsWordAdsEarningsBreakdown;
-	sponsored?: StatsWordAdsEarningsBreakdown;
-	adjustment?: StatsWordAdsEarningsBreakdown;
-};
-
-export type StatsWordAdsEarningsResponse = {
-	earnings: StatsWordAdsEarnings;
-};
+export type StatsWordAdsEarningsParams = Record< string, never >;
 
 export const statsWordAdsStatsQuery = (
-	params: StatsQueryParams = {}
-): StatsReportQueryOptions< 'timeSeries' > =>
-	statsProxyQuery( {
+	params: StatsWordAdsStatsParams
+): StatsReportQueryOptions< 'wordAdsStats' > => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const unit = String( apiParams.period ?? 'day' );
+	const date = typeof apiParams.date === 'string' ? apiParams.date : undefined;
+	const wordAdsParams: StatsProxyParams = {
+		unit,
+		...( date ? { date } : {} ),
+		quantity: params.quantity ?? ( unit === 'year' ? 10 : 30 ),
+	};
+
+	return statsProxyQuery( {
 		name: 'wordads-stats',
 		version: '1.1',
 		endpoint: 'wordads/stats',
-		params,
-		sanitizer: 'timeSeries',
+		params: wordAdsParams,
+		sanitizer: 'wordAdsStats',
+		sanitizerParams: {
+			period: unit,
+			...( date ? { date } : {} ),
+		},
+		enabled: !! date,
 	} );
+};
 
-export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+export const statsWordAdsEarningsQuery = (
+	params: StatsWordAdsEarningsParams = {}
+): StatsReportQueryOptions< 'wordAdsEarnings' > =>
 	statsProxyQuery( {
 		name: 'wordads-earnings',
 		version: '1.1',
 		endpoint: 'wordads/earnings',
 		params,
+		sanitizer: 'wordAdsEarnings',
 	} );
+
+export type { StatsWordAdsEarningsResponse, StatsWordAdsStatsResponse };

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsQueryParams } from '../utils/stats-params';
+
+export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-stats',
+		version: '1.1',
+		endpoint: 'wordads/stats',
+		params,
+		sanitizer: 'timeSeries',
+	} );
+
+export const statsWordAdsEarningsQuery = ( params: StatsQueryParams = {} ) =>
+	statsProxyQuery( {
+		name: 'wordads-earnings',
+		version: '1.1',
+		endpoint: 'wordads/earnings',
+		params,
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -2,9 +2,35 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
+import type { StatsReportQueryOptions } from './stats-query';
+import type { StatsTimeSeriesReport } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
 
-export const statsWordAdsStatsQuery = ( params: StatsQueryParams = {} ) =>
+export type StatsWordAdsStatsResponse = StatsTimeSeriesReport;
+
+export type StatsWordAdsEarningsPeriod = {
+	amount: number | string;
+	pageviews: number | string;
+	status: number;
+};
+
+export type StatsWordAdsEarningsBreakdown = Record< string, StatsWordAdsEarningsPeriod >;
+
+export type StatsWordAdsEarnings = {
+	total_earnings?: number | string;
+	total_amount_owed?: number | string;
+	wordads?: StatsWordAdsEarningsBreakdown;
+	sponsored?: StatsWordAdsEarningsBreakdown;
+	adjustment?: StatsWordAdsEarningsBreakdown;
+};
+
+export type StatsWordAdsEarningsResponse = {
+	earnings: StatsWordAdsEarnings;
+};
+
+export const statsWordAdsStatsQuery = (
+	params: StatsQueryParams = {}
+): StatsReportQueryOptions< 'timeSeries' > =>
 	statsProxyQuery( {
 		name: 'wordads-stats',
 		version: '1.1',


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add Premium Analytics data package support for the Stats wordads endpoint, following the Stats endpoint patterns established in #49886.
* Wire the endpoint-specific query, hook, public exports, and sanitizer/normalizer registration where applicable.
* Keep endpoint typing tied to sanitizer keys or passthrough query inference, with focused fixtures/tests for the raw endpoint payload shape where normalization is introduced.

## Related product discussion/links
* Builds on #49886.

## Does this pull request change what data or activity we track or use?
No. This only adds typed client data/query integration for an existing Stats API endpoint.

## Testing instructions
* pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
* pnpm exec eslint --max-warnings=0 <touched Premium Analytics data files>
* pnpm --dir projects/packages/premium-analytics run typecheck
* git diff --check