### PR TITLE
Sync: refresh get_plugins callable when a plugin is deleted

### DIFF
--- a/projects/packages/sync/changelog/fix-get-plugins-callable-sync-on-plugin-delete
+++ b/projects/packages/sync/changelog/fix-get-plugins-callable-sync-on-plugin-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refresh the synced get_plugins callable when a plugin is deleted, so removed plugins no longer linger in cached plugin lists.

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -164,6 +164,9 @@ class Callables extends Module {
 		// gets fired when new code gets installed, updates etc.
 		add_action( 'upgrader_process_complete', array( $this, 'unlock_plugin_action_link_and_callables' ) );
 		add_action( 'update_option_active_plugins', array( $this, 'unlock_plugin_action_link_and_callables' ) );
+		// Deleting an inactive plugin fires neither of the above, so without this the synced
+		// get_plugins callable stays stale until the periodic re-check happens to run.
+		add_action( 'deleted_plugin', array( $this, 'unlock_plugin_action_link_and_callables' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-get-plugins-callable-sync-on-plugin-delete
+++ b/projects/plugins/jetpack/changelog/fix-get-plugins-callable-sync-on-plugin-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: add test coverage for refreshing the plugin list callable when a plugin is deleted.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -1096,6 +1096,34 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 	}
 
 	/**
+	 * Test that deleting a plugin forces a callable sync.
+	 *
+	 * Deleting an inactive plugin fires neither 'upgrader_process_complete' nor
+	 * 'update_option_active_plugins', so the 'deleted_plugin' action must unlock
+	 * callables on its own to keep the synced get_plugins list fresh.
+	 */
+	public function test_force_sync_callable_on_plugin_delete() {
+		// fake the cron so that we really prevent the callables from being called.
+		Settings::$is_doing_cron = true;
+
+		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable_random' ) );
+		$this->sender->do_sync();
+		$this->server_replica_storage->get_callable( 'jetpack_foo' );
+
+		$this->server_replica_storage->reset();
+
+		$synced_value2 = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertEmpty( $synced_value2 );
+
+		do_action( 'deleted_plugin', 'the/the.php', true );
+
+		$this->sender->do_sync();
+		$synced_value3           = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		Settings::$is_doing_cron = false;
+		$this->assertNotEmpty( $synced_value3, 'value is empty!' );
+	}
+
+	/**
 	 * Test "xml_rpc_request_callables_has_actor".
 	 */
 	public function test_xml_rpc_request_callables_has_actor() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -1115,6 +1115,10 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		$synced_value2 = $this->server_replica_storage->get_callable( 'jetpack_foo' );
 		$this->assertEmpty( $synced_value2 );
 
+		// WordPress fires 'delete_plugin' before 'deleted_plugin'; the former
+		// captures the plugin info that the latter reads, so fire both to mirror
+		// real deletion and avoid an "undefined array key" warning.
+		do_action( 'delete_plugin', 'the/the.php' );
 		do_action( 'deleted_plugin', 'the/the.php', true );
 
 		$this->sender->do_sync();


### PR DESCRIPTION
## Proposed changes

Deleting an inactive plugin does not immediately refresh the synced get_plugins callable. As a result, consumers who read it, such as WordPress.com’s `/me/sites/plugins`, which backs the Multi-site Dashboard’s Manage Plugins list, may continue showing the deleted plugin until the callable cooldown expires and a subsequent sync cycle recomputes it.

The callable does eventually update: `maybe_sync_callables()` computes fresh values and detects the changed checksum once the one-minute jetpack_sync_callables_await cooldown transient has expired. The issue is therefore refresh latency, rather than the plugin list remaining permanently stale.

* The Callables sync module only force-refreshes the `get_plugins` callable on `upgrader_process_complete` (install/update) and `update_option_active_plugins` (activate/deactivate). Deleting an *already-inactive* plugin fires neither, so the callable goes stale.
* Add the `deleted_plugin` action to the callable unlock listeners (`Callables::init_listeners`) so a bare delete also calls `unlock_plugin_action_link_and_callables()`, matching install/activate/deactivate behavior. This fixes every consumer of the `get_plugins` callable, not just the dashboard.
* Add a regression test (`test_force_sync_callable_on_plugin_delete`) mirroring the existing `test_force_sync_callable_on_plugin_update`.

## Related product discussion/links

* DOTMSD-1302

## Does this pull request change what data or activity we track or use?

No. It only changes *when* the already-synced `get_plugins` callable is refreshed (on plugin deletion), not what is collected.

## Testing instructions

* On a Jetpack-connected (or Atomic) site, install + activate any plugin, then deactivate it so it's inactive. Confirm it appears in the synced plugin list (e.g. `GET /me/sites/plugins`, or the MSD Manage Plugins list).
* Delete the inactive plugin from wp-admin (Plugins → Delete).
  * **Before this change:** the deleted plugin lingers in the synced `get_plugins` callable / `/me/sites/plugins` until the periodic callable re-check runs.
  * **After this change:** deletion fires `deleted_plugin`, which unlocks and resyncs the `get_plugins` callable, so the plugin drops out of the synced list on the next sync.
* Automated: run `test_force_sync_callable_on_plugin_delete` in `Jetpack_Sync_Functions_Test.php` (cron faked + single-callable whitelist, so the callable only syncs if the delete forces the unlock).
