### PR TITLE
RTC: re-enable real-time collaboration by default

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17579-disable-rtc-by-default-on-wpcom-atomic-sites
+++ b/projects/packages/rtc/changelog/dotcom-17579-disable-rtc-by-default-on-wpcom-atomic-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-RTC: Disable real-time collaboration by default while keeping the existing opt-in setting.

--- a/projects/packages/rtc/changelog/dotcom-17705-re-enable-rtc-by-default
+++ b/projects/packages/rtc/changelog/dotcom-17705-re-enable-rtc-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+RTC: Re-enable real-time collaboration by default on WP.com sites.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -228,16 +228,13 @@ class RTC {
 	}
 
 	/**
-	 * When the option is NOT stored yet, default it to disabled (0).
+	 * When RTC is allowed and the option is NOT stored yet,
+	 * default the option to enabled (1), unless the old option
+	 * has a stored value to migrate from.
 	 *
-	 * RTC is no longer enabled by default on WP.com sites while it remains
-	 * in development; sites can still opt in through the existing setting.
-	 *
-	 * The old option is still migrated to the new one to preserve the choice
-	 * of sites that had explicitly opted in before the Gutenberg rename: e.g.
-	 * a site on 22.7 stored wp_enable_real_time_collaboration, then upgraded to
-	 * 22.8 which reads wp_collaboration_enabled — the new option inherits the
-	 * old stored value.
+	 * This handles the Gutenberg upgrade path: e.g. a site on 22.7 stored
+	 * wp_enable_real_time_collaboration, then upgraded to 22.8 which reads
+	 * wp_collaboration_enabled — the new option inherits the old value.
 	 *
 	 * @param mixed  $default The default value.
 	 * @param string $option  The option name.
@@ -248,13 +245,13 @@ class RTC {
 		if ( ! self::is_allowed() ) {
 			return '0';
 		}
-		// When the new option is not stored yet, migrate from the old option's
-		// stored value so sites that previously opted in keep their setting.
+		// RTC allowed and option is not stored yet
 		if ( $option === self::OPTION_NEW ) {
+			// If the old option is set, use that.
 			return get_option( self::OPTION_OLD );
 		}
-		// Default to disabled.
-		return '0';
+		// Default to enabled.
+		return '1';
 	}
 
 	/**
@@ -276,7 +273,7 @@ class RTC {
 	}
 
 	/**
-	 * Override the default for the Gutenberg RTC setting so it defaults to disabled in the UI.
+	 * Override the default for the Gutenberg RTC setting so it defaults to enabled in the UI.
 	 *
 	 * @return void
 	 */
@@ -304,7 +301,7 @@ class RTC {
 					'type'              => 'boolean',
 					'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-rtc' ),
 					'sanitize_callback' => 'rest_sanitize_boolean',
-					'default'           => false,
+					'default'           => true,
 					'show_in_rest'      => true,
 				)
 			);

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -184,9 +184,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		// Short-circuit get_option so the stored value is independent of how the
-		// test harness persists this option across WP versions.
-		add_filter( 'pre_option_' . RTC::OPTION_NEW, '__return_true' );
+		RTC::init();
 		$this->assertTrue( RTC::is_enabled() );
 	}
 
@@ -242,7 +240,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_returns_providers_when_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -259,7 +256,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_filters_unknown_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -292,7 +288,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_reindexes_after_filtering() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -328,7 +323,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_default_passes_allowlist() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 
 		$this->assertSame( array( 'pinghub' ), RTC::get_providers() );
@@ -361,7 +355,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_enqueues_when_pinghub() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -380,7 +373,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_enqueues_with_multiple_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -399,7 +391,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_register_providers_does_not_include_jwt_token() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_NEW, '1' );
 		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
@@ -513,14 +504,12 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that default_rtc_option returns '0' when RTC is allowed but no option is stored.
-	 *
-	 * RTC is disabled by default; sites must explicitly opt in via the setting.
+	 * Tests that default_rtc_option returns '1' when RTC is allowed and no option is stored.
 	 */
-	public function test_default_rtc_option_returns_0_when_allowed_and_not_stored() {
+	public function test_default_rtc_option_returns_1_when_allowed() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
+		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
 	}
 
 	/**
@@ -528,9 +517,9 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_default_rtc_option_migrates_old_to_new() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_OLD, '1' );
+		update_option( RTC::OPTION_OLD, '0' );
 
-		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes DOTCOM-17705

This reverts #49607 (which disabled RTC by default on WP.com sites, DOTCOM-17579).

## Proposed changes
* Re-enable the RTC setting by default on WP.com sites.
* The opt-in setting (Settings > Writing) and the migration of previously stored values are preserved.

Following the product discussion, we're going with Proposal B: RTC active by default on all sites, at least until June 30. WP.com is the best source for testing RTC on real production sites, and there's now an active feedback loop (incl. LLM monitoring of Zendesk) so the time between identifying and fixing bugs is short. We can move to a more controlled rollout afterwards if user reports keep coming in.

No user-facing notice is added: a notice was already shown when RTC was first enabled by default, and none was shown when it was disabled on June 12, so introducing a new notice now would likely confuse users.

## Related product discussion/links
* Internal P2 discussion (see DOTCOM-17705).
* Reverts #49607 (DOTCOM-17579).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply these changes to a WP.com site (either Simple or Atomic).
* Make sure the `wp_collaboration_enabled` option is not stored on your site: `delete_option( 'wp_collaboration_enabled' )`.
* Go to Settings > Writing.
* Make sure the RTC setting is **enabled** by default.
* Make sure you can disable it.
