### PR TITLE
Cookie Consent: make the auto-created CCPA page removable

### DIFF
--- a/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
+++ b/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Cookie Consent: make the auto-created "Your Privacy Choices" page removable. It is now created only once, is no longer locked from deletion, and its footer link is hidden if the page is deleted.
+CCPA: Make the auto-created "Your Privacy Choices" page removable. It is now created only once, is no longer locked from deletion, and its footer link is hidden if the page is deleted.

--- a/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
+++ b/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-CCPA: Make the auto-created "Your Privacy Choices" page removable. It is now created only once, is no longer locked from deletion, and its footer link is hidden if the page is deleted.
+CCPA: Make the auto-created "Your Privacy Choices" page removable. It is now created only once, is no longer locked from deletion, and the footer links for both the privacy-choices and Privacy Policy pages are hidden if their page is deleted.

--- a/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
+++ b/projects/packages/cookie-consent/changelog/fix-ccpa-page-removable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cookie Consent: make the auto-created "Your Privacy Choices" page removable. It is now created only once, is no longer locked from deletion, and its footer link is hidden if the page is deleted.

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -6,6 +6,11 @@
 	"require": {
 		"php": ">=7.2"
 	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-test-environment": "@dev",
+		"automattic/phpunit-select-config": "@dev"
+	},
 	"autoload": {
 		"classmap": [
 			"src/"
@@ -17,6 +22,12 @@
 		],
 		"build-production": [
 			"pnpm run build-production"
+		],
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-php": [
+			"@composer phpunit"
 		]
 	},
 	"repositories": [

--- a/projects/packages/cookie-consent/phpunit.11.xml.dist
+++ b/projects/packages/cookie-consent/phpunit.11.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/cookie-consent/phpunit.12.xml.dist
+++ b/projects/packages/cookie-consent/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/cookie-consent/phpunit.8.xml.dist
+++ b/projects/packages/cookie-consent/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/cookie-consent/phpunit.9.xml.dist
+++ b/projects/packages/cookie-consent/phpunit.9.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	colors="true"
+	convertDeprecationsToExceptions="true"
+	beStrictAboutOutputDuringTests="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<coverage>
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+	</coverage>
+</phpunit>

--- a/projects/packages/cookie-consent/phpunit.9.xml.dist
+++ b/projects/packages/cookie-consent/phpunit.9.xml.dist
@@ -3,7 +3,6 @@
 	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
 	bootstrap="tests/php/bootstrap.php"
 	colors="true"
-	convertDeprecationsToExceptions="true"
 	beStrictAboutOutputDuringTests="true"
 >
 	<testsuites>

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -368,6 +368,14 @@ class Cookie_Consent {
 			return $block_content;
 		}
 
+		// If the CCPA page no longer exists (e.g. the owner deleted it), suppress
+		// the link instead of rendering a dead 404. This covers persisted hooked
+		// links that bypass the injection-time existence gate.
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		if ( ! $ccpa_page_id || ! get_post( $ccpa_page_id ) ) {
+			return '';
+		}
+
 		// Use WP_HTML_Tag_Processor to safely add Interactivity API directives.
 		$tags = new WP_HTML_Tag_Processor( $block_content );
 

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -86,24 +86,30 @@ class Cookie_Consent {
 	 * Create CCPA opt-out page if it doesn't exist
 	 */
 	public static function maybe_create_ccpa_page() {
-		// Check if we've already created the page (by ID, since slug can be changed).
-		$page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		if ( $page_id && get_post( $page_id ) ) {
+		// Create the page at most once per site. Once we have created or adopted
+		// a page, never recreate it — even if the owner later deletes it.
+		if ( get_option( 'jetpack_cookie_consent_ccpa_page_created' ) ) {
 			return;
 		}
 
-		// If we have a stale page ID (option exists but post doesn't), clear it.
+		// A page already exists for the stored ID: record that and stop.
+		$page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		if ( $page_id && get_post( $page_id ) ) {
+			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
+			return;
+		}
+
+		// Stale ID (option set but post gone): clear it before trying the slug.
 		if ( $page_id && ! get_post( $page_id ) ) {
 			delete_option( 'jetpack_cookie_consent_ccpa_page_id' );
 		}
 
-		// Fallback: check if page exists by slug (for backwards compatibility).
+		// Fallback: adopt an existing page by slug (backwards compatibility).
 		$page_slug = 'your-privacy-choices';
 		$page      = get_page_by_path( $page_slug );
-
-		// If page exists by slug, save its ID and we're done.
 		if ( $page ) {
 			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page->ID );
+			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
 			return;
 		}
 
@@ -122,9 +128,10 @@ class Cookie_Consent {
 			)
 		);
 
-		// Store the page ID and update with content to create a first revision.
+		// Store the page ID, mark as created, and add content for a first revision.
 		if ( $page_id && ! is_wp_error( $page_id ) ) {
 			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
+			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
 			wp_update_post(
 				array(
 					'ID'           => $page_id,

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -54,9 +54,6 @@ class Cookie_Consent {
 		// garden_site_provisioning hook is no longer available in this context.
 		add_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );
 
-		// Prevent CCPA and Privacy Policy page deletion.
-		add_filter( 'map_meta_cap', array( __CLASS__, 'prevent_privacy_pages_deletion' ), 10, 4 );
-
 		// Hook Privacy Policy and CCPA links into navigation blocks using Block Hooks API.
 		add_filter( 'hooked_block_types', array( __CLASS__, 'register_footer_navigation_links' ), 10, 4 );
 		add_filter( 'hooked_block_core/navigation-link', array( __CLASS__, 'set_footer_navigation_link_attributes' ), 10, 4 );
@@ -223,38 +220,6 @@ class Cookie_Consent {
 				return (int) $page->ID !== (int) $ccpa_page_id;
 			}
 		);
-	}
-
-	/**
-	 * Prevent CCPA and Privacy Policy pages from being deleted
-	 *
-	 * @param array  $caps    Required capabilities.
-	 * @param string $cap     Capability being checked.
-	 * @param int    $user_id User ID.
-	 * @param array  $args    Additional arguments.
-	 * @return array Modified capabilities.
-	 */
-	public static function prevent_privacy_pages_deletion( $caps, $cap, $user_id, $args ) {
-		// Only intercept delete_post capability checks.
-		if ( 'delete_post' !== $cap ) {
-			return $caps;
-		}
-
-		$post_id = isset( $args[0] ) ? (int) $args[0] : 0;
-
-		// Prevent deletion of CCPA page.
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		if ( $ccpa_page_id && $post_id === (int) $ccpa_page_id ) {
-			return array( 'do_not_allow' );
-		}
-
-		// Prevent deletion of Privacy Policy page.
-		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
-		if ( $privacy_policy_page_id && $post_id === $privacy_policy_page_id ) {
-			return array( 'do_not_allow' );
-		}
-
-		return $caps;
 	}
 
 	/**

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -179,6 +179,23 @@ class Cookie_Consent {
 	}
 
 	/**
+	 * Whether the auto-created CCPA page exists and is published.
+	 *
+	 * A trashed page still resolves via get_post(), so callers must check the
+	 * status too — otherwise links would point at a trashed page and 404.
+	 *
+	 * @return bool
+	 */
+	private static function ccpa_page_is_published() {
+		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		if ( ! $ccpa_page_id ) {
+			return false;
+		}
+		$page = get_post( $ccpa_page_id );
+		return $page && 'publish' === $page->post_status;
+	}
+
+	/**
 	 * Get CCPA page content in block format
 	 *
 	 * @return string Page content with WordPress blocks
@@ -260,9 +277,8 @@ class Cookie_Consent {
 			}
 		}
 
-		// Check CCPA page.
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		if ( $ccpa_page_id && get_post( $ccpa_page_id ) ) {
+		// Check CCPA page (must be published — a trashed page still resolves).
+		if ( self::ccpa_page_is_published() ) {
 			$ccpa_page_exists = true;
 		}
 
@@ -312,8 +328,8 @@ class Cookie_Consent {
 			}
 		}
 
+		$ccpa_page_exists = self::ccpa_page_is_published();
 		$ccpa_page_id     = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		$ccpa_page_exists = $ccpa_page_id && get_post( $ccpa_page_id );
 
 		// Process Privacy Policy first (if it exists and hasn't been processed).
 		if ( $privacy_policy_exists && ! $privacy_policy_processed ) {
@@ -368,11 +384,10 @@ class Cookie_Consent {
 			return $block_content;
 		}
 
-		// If the CCPA page no longer exists (e.g. the owner deleted it), suppress
-		// the link instead of rendering a dead 404. This covers persisted hooked
-		// links that bypass the injection-time existence gate.
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
-		if ( ! $ccpa_page_id || ! get_post( $ccpa_page_id ) ) {
+		// If the CCPA page is gone or unpublished (e.g. the owner trashed or
+		// deleted it), suppress the link instead of rendering a dead 404. This
+		// covers persisted hooked links that bypass the injection-time gate.
+		if ( ! self::ccpa_page_is_published() ) {
 			return '';
 		}
 

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -58,6 +58,7 @@ class Cookie_Consent {
 		add_filter( 'hooked_block_types', array( __CLASS__, 'register_footer_navigation_links' ), 10, 4 );
 		add_filter( 'hooked_block_core/navigation-link', array( __CLASS__, 'set_footer_navigation_link_attributes' ), 10, 4 );
 		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_ccpa_interactivity_directives' ), 10, 2 );
+		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'maybe_suppress_privacy_policy_link' ), 10, 2 );
 		add_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_gdpr_manage_preferences_directives' ), 10, 2 );
 
 		// Add Interactivity API directive to CCPA opt-out button.
@@ -116,28 +117,26 @@ class Cookie_Consent {
 		// Build the page content with blocks.
 		$content = self::get_ccpa_page_content();
 
-		// Create the page without content first.
+		// Create the page in a single call so the created-once flag is only set
+		// once the full page (with content) has actually persisted. A two-step
+		// insert-then-update would latch the flag before the content write, and a
+		// failed update would leave a permanently published, empty page.
 		$page_id = wp_insert_post(
 			array(
 				'post_title'     => __( 'Your Privacy Choices', 'jetpack-cookie-consent' ),
 				'post_name'      => $page_slug,
 				'post_status'    => 'publish',
 				'post_type'      => 'page',
+				'post_content'   => $content,
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 			)
 		);
 
-		// Store the page ID, mark as created, and add content for a first revision.
+		// Store the page ID and mark as created.
 		if ( $page_id && ! is_wp_error( $page_id ) ) {
 			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
 			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
-			wp_update_post(
-				array(
-					'ID'           => $page_id,
-					'post_content' => $content,
-				)
-			);
 		}
 	}
 
@@ -192,6 +191,23 @@ class Cookie_Consent {
 			return false;
 		}
 		$page = get_post( $ccpa_page_id );
+		return $page && 'publish' === $page->post_status;
+	}
+
+	/**
+	 * Whether the site's Privacy Policy page exists and is published.
+	 *
+	 * Mirrors ccpa_page_is_published(): a trashed page still resolves via
+	 * get_post(), so the status must be checked too.
+	 *
+	 * @return bool
+	 */
+	private static function privacy_policy_is_published() {
+		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
+		if ( ! $privacy_policy_page_id ) {
+			return false;
+		}
+		$page = get_post( $privacy_policy_page_id );
 		return $page && 'publish' === $page->post_status;
 	}
 
@@ -268,13 +284,9 @@ class Cookie_Consent {
 		$privacy_policy_exists = false;
 		$ccpa_page_exists      = false;
 
-		// Check Privacy Policy page.
-		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
-		if ( $privacy_policy_page_id ) {
-			$page = get_post( $privacy_policy_page_id );
-			if ( $page && 'publish' === $page->post_status ) {
-				$privacy_policy_exists = true;
-			}
+		// Check Privacy Policy page (must be published — a trashed page still resolves).
+		if ( self::privacy_policy_is_published() ) {
+			$privacy_policy_exists = true;
 		}
 
 		// Check CCPA page (must be published — a trashed page still resolves).
@@ -320,13 +332,7 @@ class Cookie_Consent {
 
 		// Check which pages exist (same logic as registration).
 		$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
-		$privacy_policy_exists  = false;
-		if ( $privacy_policy_page_id ) {
-			$page = get_post( $privacy_policy_page_id );
-			if ( $page && 'publish' === $page->post_status ) {
-				$privacy_policy_exists = true;
-			}
-		}
+		$privacy_policy_exists  = self::privacy_policy_is_published();
 
 		$ccpa_page_exists = self::ccpa_page_is_published();
 		$ccpa_page_id     = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
@@ -403,6 +409,31 @@ class Cookie_Consent {
 			$tags->set_attribute( 'data-wp-init', 'callbacks.init' );
 
 			return $tags->get_updated_html();
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Suppress the hooked Privacy Policy link when its page is gone or unpublished.
+	 *
+	 * Making the Privacy Policy page deletable (the deletion lock was removed)
+	 * means a persisted, Site-Editor-materialized footer link can outlive the
+	 * page and 404. The injection-time gate only runs for non-persisted hooks, so
+	 * this render-time guard mirrors the CCPA one to avoid a dead link.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Modified block content.
+	 */
+	public static function maybe_suppress_privacy_policy_link( $block_content, $block ) {
+		// Only act on our hooked Privacy Policy link.
+		if ( ! isset( $block['attrs']['metadata']['name'] ) || 'jetpack-cookie-consent-privacy-policy-link' !== $block['attrs']['metadata']['name'] ) {
+			return $block_content;
+		}
+
+		if ( ! self::privacy_policy_is_published() ) {
+			return '';
 		}
 
 		return $block_content;

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -83,7 +83,10 @@ class Cookie_Consent {
 	}
 
 	/**
-	 * Create CCPA opt-out page if it doesn't exist
+	 * Create the CCPA opt-out page at most once per site.
+	 *
+	 * Once the created-once flag is set, the page is never recreated — even if
+	 * the site owner later deletes it.
 	 */
 	public static function maybe_create_ccpa_page() {
 		// Create the page at most once per site. Once we have created or adopted

--- a/projects/packages/cookie-consent/tests/.phpcs.dir.xml
+++ b/projects/packages/cookie-consent/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
@@ -50,6 +50,21 @@ class Ccpa_Link_Render_Test extends TestCase {
 	}
 
 	/**
+	 * The CCPA link is suppressed when the page is trashed (not yet permanently deleted).
+	 */
+	public function test_suppresses_link_when_page_trashed() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Your Privacy Choices',
+				'post_status' => 'trash',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
+		$this->assertSame( '', Cookie_Consent::add_ccpa_interactivity_directives( self::HTML, $this->ccpa_block() ) );
+	}
+
+	/**
 	 * The CCPA link still renders (with directives) when its page exists.
 	 */
 	public function test_renders_link_when_page_exists() {

--- a/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
@@ -42,6 +42,14 @@ class Ccpa_Link_Render_Test extends TestCase {
 	}
 
 	/**
+	 * The CCPA link is suppressed when the option points to a deleted page.
+	 */
+	public function test_suppresses_link_when_page_deleted() {
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', 99999 ); // ID that no longer exists.
+		$this->assertSame( '', Cookie_Consent::add_ccpa_interactivity_directives( self::HTML, $this->ccpa_block() ) );
+	}
+
+	/**
 	 * The CCPA link still renders (with directives) when its page exists.
 	 */
 	public function test_renders_link_when_page_exists() {

--- a/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Ccpa_Link_Render_Test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for Cookie_Consent::add_ccpa_interactivity_directives().
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * @covers \Automattic\Jetpack\CookieConsent\Cookie_Consent::add_ccpa_interactivity_directives
+ */
+#[CoversMethod( Cookie_Consent::class, 'add_ccpa_interactivity_directives' )]
+class Ccpa_Link_Render_Test extends TestCase {
+
+	const HTML = '<ul><li><a href="/your-privacy-choices">Your Privacy Choices</a></li></ul>';
+
+	private function ccpa_block() {
+		return array(
+			'attrs' => array(
+				'metadata' => array( 'name' => 'jetpack-cookie-consent-ccpa-privacy-link' ),
+			),
+		);
+	}
+
+	/**
+	 * A non-CCPA block is returned untouched.
+	 */
+	public function test_passes_through_other_blocks() {
+		$block = array( 'attrs' => array() );
+		$this->assertSame( self::HTML, Cookie_Consent::add_ccpa_interactivity_directives( self::HTML, $block ) );
+	}
+
+	/**
+	 * The CCPA link is suppressed when its page no longer exists.
+	 */
+	public function test_suppresses_link_when_page_missing() {
+		// No jetpack_cookie_consent_ccpa_page_id option set.
+		$this->assertSame( '', Cookie_Consent::add_ccpa_interactivity_directives( self::HTML, $this->ccpa_block() ) );
+	}
+
+	/**
+	 * The CCPA link still renders (with directives) when its page exists.
+	 */
+	public function test_renders_link_when_page_exists() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Your Privacy Choices',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
+
+		$out = Cookie_Consent::add_ccpa_interactivity_directives( self::HTML, $this->ccpa_block() );
+		$this->assertStringContainsString( 'data-wp-interactive', $out );
+	}
+}

--- a/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\CookieConsent;
 use PHPUnit\Framework\Attributes\CoversMethod;
 
 /**
+ * Tests for the create-once behavior of the auto-created CCPA page.
+ *
  * @covers \Automattic\Jetpack\CookieConsent\Cookie_Consent::maybe_create_ccpa_page
  */
 #[CoversMethod( Cookie_Consent::class, 'maybe_create_ccpa_page' )]
@@ -38,7 +40,9 @@ class Maybe_Create_Ccpa_Page_Test extends TestCase {
 		Cookie_Consent::maybe_create_ccpa_page();
 		$second_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
 
+		// The stored page id must be unchanged and the created-once flag must remain set.
 		$this->assertSame( $first_id, $second_id );
+		$this->assertSame( 1, (int) get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
 	}
 
 	/**

--- a/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
@@ -62,6 +62,16 @@ class Maybe_Create_Ccpa_Page_Test extends TestCase {
 	}
 
 	/**
+	 * The deletion lock is gone: the method no longer exists.
+	 */
+	public function test_deletion_lock_removed() {
+		$this->assertFalse(
+			method_exists( Cookie_Consent::class, 'prevent_privacy_pages_deletion' ),
+			'prevent_privacy_pages_deletion() should be removed so pages are deletable.'
+		);
+	}
+
+	/**
 	 * Migration: a pre-existing page with no flag gets the flag backfilled.
 	 */
 	public function test_backfills_flag_for_existing_page() {

--- a/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
@@ -91,4 +91,44 @@ class Maybe_Create_Ccpa_Page_Test extends TestCase {
 		$this->assertSame( 1, get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
 		$this->assertSame( (int) $page_id, (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' ) );
 	}
+
+	/**
+	 * A stale option id (post gone) with no flag is cleared, then a fresh page is created.
+	 */
+	public function test_clears_stale_id_and_recreates_when_flag_absent() {
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', 99999 ); // Points at nothing.
+		// No created flag — this is NOT the "owner deleted it" case.
+
+		Cookie_Consent::maybe_create_ccpa_page();
+
+		$new_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$this->assertNotSame( 99999, $new_id );
+		$this->assertGreaterThan( 0, $new_id );
+		$this->assertNotNull( get_post( $new_id ) );
+		$this->assertSame( 1, (int) get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
+	}
+
+	/**
+	 * A trashed stored page still latches the created flag (create-once is permanent).
+	 *
+	 * Pins current behavior: the by-ID guard checks existence, not status, so a
+	 * trashed page is never regenerated. The footer link is suppressed separately
+	 * via ccpa_page_is_published().
+	 */
+	public function test_backfill_flag_set_even_when_stored_page_trashed() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Your Privacy Choices',
+				'post_name'   => 'your-privacy-choices',
+				'post_status' => 'trash',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
+
+		Cookie_Consent::maybe_create_ccpa_page();
+
+		$this->assertSame( 1, (int) get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
+		$this->assertSame( (int) $page_id, (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' ) );
+	}
 }

--- a/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Maybe_Create_Ccpa_Page_Test.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for Cookie_Consent::maybe_create_ccpa_page().
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * @covers \Automattic\Jetpack\CookieConsent\Cookie_Consent::maybe_create_ccpa_page
+ */
+#[CoversMethod( Cookie_Consent::class, 'maybe_create_ccpa_page' )]
+class Maybe_Create_Ccpa_Page_Test extends TestCase {
+
+	/**
+	 * A fresh site gets a published page and the created-once flag.
+	 */
+	public function test_creates_page_and_sets_created_flag() {
+		Cookie_Consent::maybe_create_ccpa_page();
+
+		$page_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$this->assertGreaterThan( 0, $page_id );
+		$this->assertNotNull( get_post( $page_id ) );
+		$this->assertSame( 'publish', get_post( $page_id )->post_status );
+		$this->assertSame( 1, get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
+	}
+
+	/**
+	 * A second call is a no-op: no duplicate page is created.
+	 */
+	public function test_second_call_does_not_duplicate() {
+		Cookie_Consent::maybe_create_ccpa_page();
+		$first_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+
+		Cookie_Consent::maybe_create_ccpa_page();
+		$second_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+
+		$this->assertSame( $first_id, $second_id );
+	}
+
+	/**
+	 * Once the flag is set, deleting the page does not bring it back.
+	 */
+	public function test_does_not_recreate_after_deletion() {
+		Cookie_Consent::maybe_create_ccpa_page();
+		$page_id = (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+
+		wp_delete_post( $page_id, true );
+		delete_option( 'jetpack_cookie_consent_ccpa_page_id' );
+
+		Cookie_Consent::maybe_create_ccpa_page();
+
+		$this->assertFalse( (bool) get_option( 'jetpack_cookie_consent_ccpa_page_id' ) );
+		$this->assertSame( 1, get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
+	}
+
+	/**
+	 * Migration: a pre-existing page with no flag gets the flag backfilled.
+	 */
+	public function test_backfills_flag_for_existing_page() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Your Privacy Choices',
+				'post_name'   => 'your-privacy-choices',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
+		// No created flag yet — simulates a site from before this change.
+
+		Cookie_Consent::maybe_create_ccpa_page();
+
+		$this->assertSame( 1, get_option( 'jetpack_cookie_consent_ccpa_page_created' ) );
+		$this->assertSame( (int) $page_id, (int) get_option( 'jetpack_cookie_consent_ccpa_page_id' ) );
+	}
+}

--- a/projects/packages/cookie-consent/tests/php/Privacy_Policy_Link_Render_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Privacy_Policy_Link_Render_Test.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Tests for Cookie_Consent::maybe_suppress_privacy_policy_link().
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * @covers \Automattic\Jetpack\CookieConsent\Cookie_Consent::maybe_suppress_privacy_policy_link
+ */
+#[CoversMethod( Cookie_Consent::class, 'maybe_suppress_privacy_policy_link' )]
+class Privacy_Policy_Link_Render_Test extends TestCase {
+
+	const HTML = '<ul><li><a href="/privacy-policy">Privacy Policy</a></li></ul>';
+
+	private function privacy_policy_block() {
+		return array(
+			'attrs' => array(
+				'metadata' => array( 'name' => 'jetpack-cookie-consent-privacy-policy-link' ),
+			),
+		);
+	}
+
+	/**
+	 * A non-privacy-policy block is returned untouched.
+	 */
+	public function test_passes_through_other_blocks() {
+		$block = array( 'attrs' => array() );
+		$this->assertSame( self::HTML, Cookie_Consent::maybe_suppress_privacy_policy_link( self::HTML, $block ) );
+	}
+
+	/**
+	 * The link is suppressed when no privacy policy page is configured.
+	 */
+	public function test_suppresses_link_when_page_missing() {
+		$this->assertSame( '', Cookie_Consent::maybe_suppress_privacy_policy_link( self::HTML, $this->privacy_policy_block() ) );
+	}
+
+	/**
+	 * The link is suppressed when the configured page is trashed.
+	 */
+	public function test_suppresses_link_when_page_trashed() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Privacy Policy',
+				'post_status' => 'trash',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'wp_page_for_privacy_policy', $page_id );
+		$this->assertSame( '', Cookie_Consent::maybe_suppress_privacy_policy_link( self::HTML, $this->privacy_policy_block() ) );
+	}
+
+	/**
+	 * The link renders unchanged when the privacy policy page is published.
+	 */
+	public function test_renders_link_when_page_published() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Privacy Policy',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( 'wp_page_for_privacy_policy', $page_id );
+		$this->assertSame( self::HTML, Cookie_Consent::maybe_suppress_privacy_policy_link( self::HTML, $this->privacy_policy_block() ) );
+	}
+}

--- a/projects/packages/cookie-consent/tests/php/Scaffold_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Scaffold_Test.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Smoke test proving the scaffold runs.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+/**
+ * @coversNothing
+ */
+#[CoversNothing]
+class Scaffold_Test extends TestCase {
+
+	/**
+	 * WorDBless options round-trip works.
+	 */
+	public function test_scaffold_runs() {
+		update_option( 'jetpack_cookie_consent_scaffold_probe', 'ok' );
+		$this->assertSame( 'ok', get_option( 'jetpack_cookie_consent_scaffold_probe' ) );
+	}
+}

--- a/projects/packages/cookie-consent/tests/php/bootstrap.php
+++ b/projects/packages/cookie-consent/tests/php/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Initialize the testing environment.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/class-testcase.php';
+
+define( 'WP_DEBUG', true );
+
+// Initialize the WordPress test environment (WorDBless).
+\Automattic\Jetpack\Test_Environment::init();

--- a/projects/packages/cookie-consent/tests/php/class-testcase.php
+++ b/projects/packages/cookie-consent/tests/php/class-testcase.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Base TestCase for the cookie-consent package.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Base TestCase: resets WorDBless state between tests.
+ */
+abstract class TestCase extends PHPUnit_TestCase {
+
+	/**
+	 * Set up: clear WorDBless state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Tear down: clear WorDBless state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+		wp_set_current_user( 0 );
+	}
+}

--- a/projects/plugins/premium-analytics/changelog/fix-composer-lock-cookie-consent-dev-deps
+++ b/projects/plugins/premium-analytics/changelog/fix-composer-lock-cookie-consent-dev-deps
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock for cookie-consent dev dependencies.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -555,10 +555,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/cookie-consent",
-                "reference": "ce46d635c3d3a1d2fb704440093bd52e6347cf0a"
+                "reference": "d5a3c6a3661fd4437cf1817016e3e94778e878c1"
             },
             "require": {
                 "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "jetpack-library",
             "extra": {
@@ -583,6 +588,12 @@
                 ],
                 "build-production": [
                     "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
                 ]
             },
             "license": [


### PR DESCRIPTION
Fixes WOOA7S-1566

## Proposed changes

**Why:** The package auto-creates a "Your Privacy Choices" CCPA page on `init` and locks it (and the Privacy Policy page) from deletion via `map_meta_cap`. That fits CIAB's controlled site but is intrusive on third-party sites: the owner can't remove the page, and even unlocked it would resurrect on the next `init`. Locking deletion is also non-standard in WordPress (core never locks the privacy policy page).

**How:** Treat the page like the rest of the ecosystem — "create once, then it's the owner's to keep or remove".

- A created-once flag (`jetpack_cookie_consent_ccpa_page_created`) runs `maybe_create_ccpa_page()` at most once per site (backfilled for existing sites on next `init`), so deletion sticks and the page never resurrects. Creation is a single `wp_insert_post()` so the flag only latches after the full page persists.
- Removed the `prevent_privacy_pages_deletion()` lock, so both the CCPA and Privacy Policy pages are deletable.
- `ccpa_page_is_published()` / `privacy_policy_is_published()` gate every place those links render (Block-Hooks injection + a `render_block_core/navigation-link` guard). They require `publish` status, so a trashed/deleted page never leaves a dead 404 link — including persisted (Site-Editor-materialized) nav links.

**What:**

- `src/class-cookie-consent.php`: created-once flag + backfill (single atomic insert); removed the deletion lock; added the two `*_is_published()` helpers and `maybe_suppress_privacy_policy_link()`, wired into the existing link callbacks.
- The package's first PHPUnit scaffold (mirroring `jetpack-stats-admin`) plus tests for create-once / no-resurrect / backfill / stale-id / trashed-page / lock-removed / CCPA + Privacy Policy link suppression.
- Changelog entry.

## Related product discussion/links

- WOOA7S-1566
- Parent: WOOA7S-1544 (Cookie Consent engineering hardening for all-sites rollout)

## Does this pull request change what data or activity we track or use?

No. No new data is tracked or used.

## Testing instructions

Use a site with the **premium-analytics** plugin active (it calls `Cookie_Consent::init()`), on a block theme with a footer navigation (e.g. Twenty Twenty-Four).

1. Activate premium-analytics and load the front end. A published **"Your Privacy Choices"** page is auto-created (`wp option get jetpack_cookie_consent_ccpa_page_created` returns `1`).
2. Trash the page from **Pages** (deletion is no longer blocked). Reload / trigger another request so `init` runs again — the page is **not** recreated and stays gone.
3. On the front end, confirm the footer **"Your Privacy Choices"** link is gone once the page is trashed/deleted (no dead 404 link). The same now applies to the **Privacy Policy** footer link if that page is trashed/deleted. Note: on Atomic/JN the homepage is page-cached — confirm a `cache;desc=MISS` (server-timing header) before trusting the rendered HTML.
4. Permanently delete the page — it still does not come back.
5. Run the package unit tests: `cd projects/packages/cookie-consent && composer phpunit` (17 tests).

Verified live on a fresh Jurassic Ninja site (Twenty Twenty-Four + premium-analytics): auto-create → trash/delete sticks → footer link disappears → trashed page URL returns 404.
