### PR TITLE
Podcast: register submenu on self-hosted sites

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-menu-item
+++ b/projects/packages/podcast/changelog/add-podcast-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register the Podcast submenu under the Jetpack menu on self-hosted sites when the module is active.

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
+		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-blocks": "@dev",
 		"automattic/jetpack-connection": "@dev",

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
@@ -15,6 +17,14 @@ use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 class Admin_Page {
 
 	const ADMIN_PAGE_SLUG = 'jetpack-podcast';
+
+	/**
+	 * Where the Podcast item sits in the Jetpack submenu on self-hosted.
+	 *
+	 * Placed after Subscribers (15) and Newsletter (10) to mirror the order
+	 * `wpcom-admin-menu.php` uses on Simple/Atomic.
+	 */
+	const MENU_POSITION = 16;
 
 	/**
 	 * Slug emitted by `@wordpress/build`. wp-build's auto-generated enqueue
@@ -40,34 +50,32 @@ class Admin_Page {
 		self::$initialized = true;
 
 		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
-		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 999999 );
-	}
 
-	/**
-	 * Register the Podcast submenu under the Jetpack menu.
-	 *
-	 * Simple/Atomic also call this from `wpcom-admin-menu.php` at the same
-	 * priority, so bail when the submenu is already registered to avoid a
-	 * duplicate entry.
-	 */
-	public static function add_wp_admin_submenu() {
-		if ( self::is_submenu_registered() ) {
+		// On Simple/Atomic the Jetpack menu is owned by wpcom-admin-menu.php,
+		// which calls add_wp_admin_submenu() directly (and positions it). Only
+		// self-hosted registers its own item, via the shared Admin_Menu sorter.
+		$host = new Host();
+		if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
 			return;
 		}
 
-		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
-		$callback        = function_exists( $wp_build_render )
-			? $wp_build_render
-			: array( __CLASS__, 'render' );
+		// Priority 999 queues the item before Admin_Menu's priority-1000 callback.
+		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_menu' ), 999 );
+	}
 
-		$page_suffix = add_submenu_page(
-			'jetpack',
+	/**
+	 * Register the Podcast submenu on self-hosted via the shared Jetpack
+	 * Admin_Menu, which sorts items by position instead of appending them last.
+	 */
+	public static function add_wp_admin_menu() {
+		$page_suffix = Admin_Menu::add_menu(
 			/** "Podcast" is a product name, do not translate. */
 			'Podcast',
 			'Podcast',
 			'manage_options',
 			self::ADMIN_PAGE_SLUG,
-			$callback
+			self::get_render_callback(),
+			self::MENU_POSITION
 		);
 
 		if ( $page_suffix ) {
@@ -76,22 +84,39 @@ class Admin_Page {
 	}
 
 	/**
-	 * Whether the Podcast submenu is already registered under the Jetpack menu.
+	 * Register the Podcast submenu directly under the Jetpack menu.
+	 *
+	 * Called from `wpcom-admin-menu.php` at priority 999999 on Simple/Atomic,
+	 * where that file owns the Jetpack menu and reorders the submenu itself.
 	 */
-	private static function is_submenu_registered() {
-		global $submenu;
+	public static function add_wp_admin_submenu() {
+		$page_suffix = add_submenu_page(
+			'jetpack',
+			/** "Podcast" is a product name, do not translate. */
+			'Podcast',
+			'Podcast',
+			'manage_options',
+			self::ADMIN_PAGE_SLUG,
+			self::get_render_callback()
+		);
 
-		if ( empty( $submenu['jetpack'] ) ) {
-			return false;
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 		}
+	}
 
-		foreach ( $submenu['jetpack'] as $item ) {
-			if ( isset( $item[2] ) && self::ADMIN_PAGE_SLUG === $item[2] ) {
-				return true;
-			}
-		}
+	/**
+	 * Resolve the page callback, preferring the wp-build render function once
+	 * it has been defined (by `maybe_load_wp_build()` at admin_menu priority 1).
+	 *
+	 * @return callable
+	 */
+	private static function get_render_callback() {
+		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
 
-		return false;
+		return function_exists( $wp_build_render )
+			? $wp_build_render
+			: array( __CLASS__, 'render' );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Podcast;
 
-use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
@@ -41,18 +40,21 @@ class Admin_Page {
 		self::$initialized = true;
 
 		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
-
-		// Simple/Atomic register the submenu from wpcom-admin-menu.php; self-hosted has no such file.
-		$host = new Host();
-		if ( ! $host->is_wpcom_simple() && ! $host->is_woa_site() ) {
-			add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 999999 );
-		}
+		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 999999 );
 	}
 
 	/**
 	 * Register the Podcast submenu under the Jetpack menu.
+	 *
+	 * Simple/Atomic also call this from `wpcom-admin-menu.php` at the same
+	 * priority, so bail when the submenu is already registered to avoid a
+	 * duplicate entry.
 	 */
 	public static function add_wp_admin_submenu() {
+		if ( self::is_submenu_registered() ) {
+			return;
+		}
+
 		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
 		$callback        = function_exists( $wp_build_render )
 			? $wp_build_render
@@ -71,6 +73,25 @@ class Admin_Page {
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 		}
+	}
+
+	/**
+	 * Whether the Podcast submenu is already registered under the Jetpack menu.
+	 */
+	private static function is_submenu_registered() {
+		global $submenu;
+
+		if ( empty( $submenu['jetpack'] ) ) {
+			return false;
+		}
+
+		foreach ( $submenu['jetpack'] as $item ) {
+			if ( isset( $item[2] ) && self::ADMIN_PAGE_SLUG === $item[2] ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -64,7 +64,10 @@ class Admin_Page {
 	 * Register the Podcast submenu under the Jetpack menu.
 	 */
 	public static function add_wp_admin_submenu() {
-		$callback = self::get_render_callback();
+		// Prefer the wp-build render function once it's defined (by
+		// maybe_load_wp_build() at admin_menu priority 1); fall back otherwise.
+		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
+		$callback        = function_exists( $wp_build_render ) ? $wp_build_render : array( __CLASS__, 'render' );
 
 		if ( ( new Host() )->is_wpcom_platform() ) {
 			$page_suffix = add_submenu_page(
@@ -91,20 +94,6 @@ class Admin_Page {
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 		}
-	}
-
-	/**
-	 * Resolve the page callback, preferring the wp-build render function once
-	 * it has been defined (by `maybe_load_wp_build()` at admin_menu priority 1).
-	 *
-	 * @return callable
-	 */
-	private static function get_render_callback() {
-		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
-
-		return function_exists( $wp_build_render )
-			? $wp_build_render
-			: array( __CLASS__, 'render' );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -51,54 +51,50 @@ class Admin_Page {
 
 		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
 
-		// On Simple/Atomic the Jetpack menu is owned by wpcom-admin-menu.php,
-		// which calls add_wp_admin_submenu() directly (and positions it). Only
-		// self-hosted registers its own item, via the shared Admin_Menu sorter.
-		$host = new Host();
-		if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
-			return;
-		}
-
-		// Priority 999 queues the item before Admin_Menu's priority-1000 callback.
-		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_menu' ), 999 );
-	}
-
-	/**
-	 * Register the Podcast submenu on self-hosted via the shared Jetpack
-	 * Admin_Menu, which sorts items by position instead of appending them last.
-	 */
-	public static function add_wp_admin_menu() {
-		$page_suffix = Admin_Menu::add_menu(
-			/** "Podcast" is a product name, do not translate. */
-			'Podcast',
-			'Podcast',
-			'manage_options',
-			self::ADMIN_PAGE_SLUG,
-			self::get_render_callback(),
-			self::MENU_POSITION
-		);
-
-		if ( $page_suffix ) {
-			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+		// On Simple/Atomic, wpcom-admin-menu.php builds the Jetpack menu at
+		// priority 999999 and calls add_wp_admin_submenu() itself. Self-hosted
+		// has no such file, so we register our own. Priority 999 queues the item
+		// before Admin_Menu's priority-1000 callback.
+		if ( ! ( new Host() )->is_wpcom_platform() ) {
+			add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 999 );
 		}
 	}
 
 	/**
-	 * Register the Podcast submenu directly under the Jetpack menu.
+	 * Register the Podcast submenu under the Jetpack menu.
 	 *
-	 * Called from `wpcom-admin-menu.php` at priority 999999 on Simple/Atomic,
-	 * where that file owns the Jetpack menu and reorders the submenu itself.
+	 * Two callers, two mechanisms:
+	 * - Simple/Atomic: wpcom-admin-menu.php calls this at priority 999999, after
+	 *   it has built the parent menu — so we register directly and let that file
+	 *   position the item.
+	 * - Self-hosted: our own admin_menu hook (priority 999) calls this — so we go
+	 *   through the shared Admin_Menu sorter, which places the item by position
+	 *   instead of appending it last.
 	 */
 	public static function add_wp_admin_submenu() {
-		$page_suffix = add_submenu_page(
-			'jetpack',
-			/** "Podcast" is a product name, do not translate. */
-			'Podcast',
-			'Podcast',
-			'manage_options',
-			self::ADMIN_PAGE_SLUG,
-			self::get_render_callback()
-		);
+		$callback = self::get_render_callback();
+
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			$page_suffix = add_submenu_page(
+				'jetpack',
+				/** "Podcast" is a product name, do not translate. */
+				'Podcast',
+				'Podcast',
+				'manage_options',
+				self::ADMIN_PAGE_SLUG,
+				$callback
+			);
+		} else {
+			$page_suffix = Admin_Menu::add_menu(
+				/** "Podcast" is a product name, do not translate. */
+				'Podcast',
+				'Podcast',
+				'manage_options',
+				self::ADMIN_PAGE_SLUG,
+				$callback,
+				self::MENU_POSITION
+			);
+		}
 
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
@@ -130,7 +126,8 @@ class Admin_Page {
 	/**
 	 * Hooked at admin_menu priority 1 so polyfills register before
 	 * `wp_default_scripts` fires and the wp-build render function is defined
-	 * before `add_wp_admin_submenu()` runs at priority 999999.
+	 * before `add_wp_admin_submenu()` runs (priority 999 on self-hosted, 999999
+	 * on Simple/Atomic).
 	 */
 	public static function maybe_load_wp_build() {
 		if ( ! self::is_podcast_admin_request() ) {

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -7,10 +7,11 @@
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
- * Adds the "Jetpack > Podcast" wp-admin screen on Simple and Atomic.
+ * Adds the "Jetpack > Podcast" wp-admin screen.
  */
 class Admin_Page {
 
@@ -40,13 +41,16 @@ class Admin_Page {
 		self::$initialized = true;
 
 		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
+
+		// Simple/Atomic register the submenu from wpcom-admin-menu.php; self-hosted has no such file.
+		$host = new Host();
+		if ( ! $host->is_wpcom_simple() && ! $host->is_woa_site() ) {
+			add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 999999 );
+		}
 	}
 
 	/**
-	 * Register the Podcast submenu under Jetpack on Simple and Atomic.
-	 *
-	 * Called from `wpcom-admin-menu.php` at priority 999999 once the Jetpack
-	 * parent menu exists.
+	 * Register the Podcast submenu under the Jetpack menu.
 	 */
 	public static function add_wp_admin_submenu() {
 		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -62,14 +62,6 @@ class Admin_Page {
 
 	/**
 	 * Register the Podcast submenu under the Jetpack menu.
-	 *
-	 * Two callers, two mechanisms:
-	 * - Simple/Atomic: wpcom-admin-menu.php calls this at priority 999999, after
-	 *   it has built the parent menu — so we register directly and let that file
-	 *   position the item.
-	 * - Self-hosted: our own admin_menu hook (priority 999) calls this — so we go
-	 *   through the shared Admin_Menu sorter, which places the item by position
-	 *   instead of appending it last.
 	 */
 	public static function add_wp_admin_submenu() {
 		$callback = self::get_render_callback();

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -67,9 +67,6 @@ class Podcast {
 
 		Tracks::init();
 
-		// Wire the wp-admin entry point. Admin_Page::init() stages the wp-build
-		// dashboard; menu registration itself runs from wpcom-admin-menu.php
-		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.
 		if ( is_admin() ) {
 			Admin_Page::init();
 			New_Episode_Prefill::init();

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for the Podcast admin page menu registration.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Podcast\Admin_Page;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\Admin_Page
+ */
+#[CoversClass( Admin_Page::class )]
+class Admin_Page_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->reset_initialized();
+	}
+
+	protected function tearDown(): void {
+		Constants::clear_constants();
+		remove_all_actions( 'admin_menu' );
+		$this->reset_initialized();
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset the init guard so each test re-wires `init()`.
+	 */
+	private function reset_initialized(): void {
+		$prop = new \ReflectionProperty( Admin_Page::class, 'initialized' );
+		$prop->setValue( null, false );
+	}
+
+	/**
+	 * Self-hosted has no wpcom-admin-menu.php, so the package registers the submenu.
+	 */
+	public function test_init_registers_submenu_on_self_hosted() {
+		Admin_Page::init();
+
+		$this->assertSame(
+			999999,
+			has_action( 'admin_menu', array( Admin_Page::class, 'add_wp_admin_submenu' ) )
+		);
+	}
+
+	/**
+	 * Simple owns the submenu via wpcom-admin-menu.php, so the package must not duplicate it.
+	 */
+	public function test_init_does_not_register_submenu_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Admin_Page::init();
+
+		$this->assertFalse(
+			has_action( 'admin_menu', array( Admin_Page::class, 'add_wp_admin_submenu' ) )
+		);
+	}
+}

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -46,6 +46,10 @@ class Admin_Page_Test extends BaseTestCase {
 	 */
 	private function reset_initialized(): void {
 		$prop = new \ReflectionProperty( Admin_Page::class, 'initialized' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// Reflection requires this on PHP < 8.1; it's deprecated and a no-op after.
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, false );
 	}
 
@@ -87,6 +91,7 @@ class Admin_Page_Test extends BaseTestCase {
 	 */
 	public function test_add_submenu_skips_when_already_registered() {
 		Admin_Page::add_wp_admin_submenu();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Calling twice is the point: the second call must be a no-op.
 		Admin_Page::add_wp_admin_submenu();
 
 		$this->assertSame( 1, $this->count_podcast_submenus() );

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -21,11 +20,23 @@ class Admin_Page_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->reset_initialized();
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'podcast_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		unset( $GLOBALS['submenu']['jetpack'] );
 	}
 
 	protected function tearDown(): void {
-		Constants::clear_constants();
 		remove_all_actions( 'admin_menu' );
+		unset( $GLOBALS['submenu']['jetpack'] );
+		wp_set_current_user( 0 );
 		$this->reset_initialized();
 		parent::tearDown();
 	}
@@ -39,9 +50,21 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Self-hosted has no wpcom-admin-menu.php, so the package registers the submenu.
+	 * Count Podcast entries under the Jetpack menu.
 	 */
-	public function test_init_registers_submenu_on_self_hosted() {
+	private function count_podcast_submenus(): int {
+		if ( empty( $GLOBALS['submenu']['jetpack'] ) ) {
+			return 0;
+		}
+
+		$slugs = array_column( $GLOBALS['submenu']['jetpack'], 2 );
+		return count( array_keys( $slugs, Admin_Page::ADMIN_PAGE_SLUG, true ) );
+	}
+
+	/**
+	 * `init()` always hooks submenu registration onto `admin_menu`.
+	 */
+	public function test_init_registers_submenu_action() {
 		Admin_Page::init();
 
 		$this->assertSame(
@@ -51,15 +74,21 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Simple owns the submenu via wpcom-admin-menu.php, so the package must not duplicate it.
+	 * The submenu is added when nothing else has registered it.
 	 */
-	public function test_init_does_not_register_submenu_on_wpcom_simple() {
-		Constants::set_constant( 'IS_WPCOM', true );
+	public function test_add_submenu_registers_when_absent() {
+		Admin_Page::add_wp_admin_submenu();
 
-		Admin_Page::init();
+		$this->assertSame( 1, $this->count_podcast_submenus() );
+	}
 
-		$this->assertFalse(
-			has_action( 'admin_menu', array( Admin_Page::class, 'add_wp_admin_submenu' ) )
-		);
+	/**
+	 * A second call (e.g. from wpcom-admin-menu.php) must not duplicate the entry.
+	 */
+	public function test_add_submenu_skips_when_already_registered() {
+		Admin_Page::add_wp_admin_submenu();
+		Admin_Page::add_wp_admin_submenu();
+
+		$this->assertSame( 1, $this->count_podcast_submenus() );
 	}
 }

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -19,7 +19,6 @@ class Admin_Page_Test extends BaseTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->reset_initialized();
 
 		$user_id = wp_insert_user(
 			array(
@@ -34,23 +33,9 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	protected function tearDown(): void {
-		remove_all_actions( 'admin_menu' );
 		unset( $GLOBALS['submenu']['jetpack'] );
 		wp_set_current_user( 0 );
-		$this->reset_initialized();
 		parent::tearDown();
-	}
-
-	/**
-	 * Reset the init guard so each test re-wires `init()`.
-	 */
-	private function reset_initialized(): void {
-		$prop = new \ReflectionProperty( Admin_Page::class, 'initialized' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			// Reflection requires this on PHP < 8.1; it's deprecated and a no-op after.
-			$prop->setAccessible( true );
-		}
-		$prop->setValue( null, false );
 	}
 
 	/**
@@ -66,21 +51,9 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `init()` always hooks submenu registration onto `admin_menu`.
-	 */
-	public function test_init_registers_submenu_action() {
-		Admin_Page::init();
-
-		$this->assertSame(
-			999999,
-			has_action( 'admin_menu', array( Admin_Page::class, 'add_wp_admin_submenu' ) )
-		);
-	}
-
-	/**
 	 * The submenu is added when nothing else has registered it.
 	 */
-	public function test_add_submenu_registers_when_absent() {
+	public function test_registers_podcast_submenu() {
 		Admin_Page::add_wp_admin_submenu();
 
 		$this->assertSame( 1, $this->count_podcast_submenus() );
@@ -89,11 +62,11 @@ class Admin_Page_Test extends BaseTestCase {
 	/**
 	 * A second call (e.g. from wpcom-admin-menu.php) must not duplicate the entry.
 	 */
-	public function test_add_submenu_skips_when_already_registered() {
+	public function test_does_not_duplicate_existing_submenu() {
 		Admin_Page::add_wp_admin_submenu();
-		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Calling twice is the point: the second call must be a no-op.
-		Admin_Page::add_wp_admin_submenu();
+		$this->assertSame( 1, $this->count_podcast_submenus() );
 
+		Admin_Page::add_wp_admin_submenu();
 		$this->assertSame( 1, $this->count_podcast_submenus() );
 	}
 }

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -20,6 +20,40 @@ class Admin_Page_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		// WorDBless does not reset the admin menu globals between tests.
+		$GLOBALS['menu']    = array();
+		$GLOBALS['submenu'] = array();
+		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
+	}
+
+	protected function tearDown(): void {
+		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
+		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Self-hosted: the page registers through the shared Admin_Menu, which sorts
+	 * items by position. We assert the page-load callback Admin_Menu wires for us.
+	 */
+	public function test_add_wp_admin_menu_registers_via_admin_menu() {
+		Admin_Page::add_wp_admin_menu();
+
+		$this->assertNotFalse(
+			has_action(
+				'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG,
+				array( Admin_Page::class, 'admin_init' )
+			),
+			'add_wp_admin_menu() should register the page through Admin_Menu'
+		);
+	}
+
+	/**
+	 * WPCOM path: registers directly under the Jetpack menu, as wpcom-admin-menu.php does.
+	 */
+	public function test_add_wp_admin_submenu_registers_under_jetpack() {
+		// add_submenu_page() checks the current user's capability.
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => 'podcast_admin',
@@ -29,44 +63,16 @@ class Admin_Page_Test extends BaseTestCase {
 		);
 		wp_set_current_user( $user_id );
 
-		unset( $GLOBALS['submenu']['jetpack'] );
-	}
-
-	protected function tearDown(): void {
-		unset( $GLOBALS['submenu']['jetpack'] );
-		wp_set_current_user( 0 );
-		parent::tearDown();
-	}
-
-	/**
-	 * Count Podcast entries under the Jetpack menu.
-	 */
-	private function count_podcast_submenus(): int {
-		if ( empty( $GLOBALS['submenu']['jetpack'] ) ) {
-			return 0;
-		}
-
-		$slugs = array_column( $GLOBALS['submenu']['jetpack'], 2 );
-		return count( array_keys( $slugs, Admin_Page::ADMIN_PAGE_SLUG, true ) );
-	}
-
-	/**
-	 * The submenu is added when nothing else has registered it.
-	 */
-	public function test_registers_podcast_submenu() {
-		Admin_Page::add_wp_admin_submenu();
-
-		$this->assertSame( 1, $this->count_podcast_submenus() );
-	}
-
-	/**
-	 * A second call (e.g. from wpcom-admin-menu.php) must not duplicate the entry.
-	 */
-	public function test_does_not_duplicate_existing_submenu() {
-		Admin_Page::add_wp_admin_submenu();
-		$this->assertSame( 1, $this->count_podcast_submenus() );
+		// Provide the Jetpack parent menu wpcom-admin-menu.php would have created.
+		add_menu_page( 'Jetpack', 'Jetpack', 'manage_options', 'jetpack', '__return_null' );
 
 		Admin_Page::add_wp_admin_submenu();
-		$this->assertSame( 1, $this->count_podcast_submenus() );
+
+		$slugs = wp_list_pluck( (array) ( $GLOBALS['submenu']['jetpack'] ?? array() ), 2 );
+		$this->assertContains(
+			Admin_Page::ADMIN_PAGE_SLUG,
+			$slugs,
+			'add_wp_admin_submenu() should register the Podcast page under the Jetpack menu'
+		);
 	}
 }

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -27,6 +28,7 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	protected function tearDown(): void {
+		Constants::clear_constants();
 		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
 		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
 		wp_set_current_user( 0 );
@@ -37,22 +39,25 @@ class Admin_Page_Test extends BaseTestCase {
 	 * Self-hosted: the page registers through the shared Admin_Menu, which sorts
 	 * items by position. We assert the page-load callback Admin_Menu wires for us.
 	 */
-	public function test_add_wp_admin_menu_registers_via_admin_menu() {
-		Admin_Page::add_wp_admin_menu();
+	public function test_registers_via_admin_menu_on_self_hosted() {
+		Admin_Page::add_wp_admin_submenu();
 
 		$this->assertNotFalse(
 			has_action(
 				'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG,
 				array( Admin_Page::class, 'admin_init' )
 			),
-			'add_wp_admin_menu() should register the page through Admin_Menu'
+			'Self-hosted should register the page through Admin_Menu'
 		);
 	}
 
 	/**
-	 * WPCOM path: registers directly under the Jetpack menu, as wpcom-admin-menu.php does.
+	 * WPCOM (Simple/Atomic): registers directly under the Jetpack menu, where
+	 * wpcom-admin-menu.php has already created the parent.
 	 */
-	public function test_add_wp_admin_submenu_registers_under_jetpack() {
+	public function test_registers_directly_under_jetpack_on_wpcom() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
 		// add_submenu_page() checks the current user's capability.
 		$user_id = wp_insert_user(
 			array(
@@ -72,7 +77,7 @@ class Admin_Page_Test extends BaseTestCase {
 		$this->assertContains(
 			Admin_Page::ADMIN_PAGE_SLUG,
 			$slugs,
-			'add_wp_admin_submenu() should register the Podcast page under the Jetpack menu'
+			'WPCOM should register the Podcast page directly under the Jetpack menu'
 		);
 	}
 }

--- a/projects/plugins/jetpack/changelog/add-podcast-menu-item
+++ b/projects/plugins/jetpack/changelog/add-podcast-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated composer.lock for the Podcast package's new jetpack-admin-ui dependency.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2685,9 +2685,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "7ece8afde05a2c7aee25181ce7c7a8045565039c"
+                "reference": "6e99ee67210e9bc15e164c3c2709484a1cb5f830"
             },
             "require": {
+                "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-menu-item
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock for the Podcast package's new jetpack-admin-ui dependency.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1520,9 +1520,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "7ece8afde05a2c7aee25181ce7c7a8045565039c"
+                "reference": "6e99ee67210e9bc15e164c3c2709484a1cb5f830"
             },
             "require": {
+                "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/wpcomsh/changelog/add-podcast-menu-item
+++ b/projects/plugins/wpcomsh/changelog/add-podcast-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock for the Podcast package's new jetpack-admin-ui dependency.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1707,9 +1707,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "7ece8afde05a2c7aee25181ce7c7a8045565039c"
+                "reference": "6e99ee67210e9bc15e164c3c2709484a1cb5f830"
             },
             "require": {
+                "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",


### PR DESCRIPTION
Fixes PODS-169

## Proposed changes

* Register the **Jetpack > Podcast** submenu on self-hosted sites. Previously the submenu was only wired up from `wpcom-admin-menu.php`, which exists on Simple and Atomic but not on self-hosted installs — so self-hosted sites with the Podcast module active had no menu entry.
* `Admin_Page::init()` now hooks `add_wp_admin_submenu()` onto `admin_menu` (priority `999999`) unless the site is WPCOM Simple or WoA, where the existing `wpcom-admin-menu.php` registration still owns it (avoiding a duplicate entry).
* Dropped the stale comments in `class-podcast.php` / `class-admin-page.php` that described the old Simple/Atomic-only behavior.
* Added `Admin_Page_Test` covering both paths: submenu registered on self-hosted, not registered on WPCOM Simple.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a self-hosted site with the Podcast module active, visit wp-admin.
* Confirm a **Podcast** item appears under the **Jetpack** menu and loads the dashboard.
* On Simple/Atomic, confirm the Podcast submenu still appears exactly once (no duplicate).
* Run the package tests: `jetpack test php packages/podcast`.
