### PR TITLE
Premium Analytics: tidy the hello-world widget and add widget audit tooling

### DIFF
--- a/.agents/rules/widgets.md
+++ b/.agents/rules/widgets.md
@@ -1,0 +1,18 @@
+# Widgets
+
+A widget is a folder under `widgets/`, auto-discovered by convention (no registration):
+
+- `widget.json` — static metadata (name, title, description, category, presentation).
+- `widget.ts` — live metadata (default export: title, icon, attributes, example).
+- `render.tsx` — default-export React component.
+- `style.module.css` — optional; CSS Modules, tokens from `@wordpress/theme` (`--wpds-*`).
+
+The render component is bound by `WidgetRenderProps<Item>` from
+`@wordpress/widget-primitives`: it receives only `{ attributes, setAttributes }`.
+`attributes` may arrive empty — default it (`= {}`).
+
+The host owns all chrome. The widget renders body only — never a `Card`, header,
+title, or remove control. `presentation` in `widget.json` declares how the widget
+wants to be framed; the host decides how.
+
+<!-- TODO: link to the canonical widget API declaration (contract types). -->

--- a/.agents/skills/widget-audit.md
+++ b/.agents/skills/widget-audit.md
@@ -1,0 +1,64 @@
+---
+description: Audit a widget folder against the widget contract and conventions
+allowed-tools: Read, Glob, Grep, Bash(grep:*), Bash(find:*), Bash(ls:*), Bash(cat:*)
+---
+
+Audit one `widgets/<slug>/` against the widget contract and this repo's conventions.
+Report only — do not rewrite files unless the user asks.
+
+**Argument**: `$ARGUMENTS` is a widget slug or path. If it resolves to a
+`widgets/<slug>/`, audit it; otherwise list the `widgets/` folder and ask which.
+
+The invariants live in the shared widgets rule (`.agents/rules/widgets.md`). This
+command is how to verify a widget against them, plus the specifics the rule cannot
+assume: namespace, text domain, and the dependency versions the package resolves.
+
+## Pre-flight — derive, never assume
+
+1. **Namespace + text domain**: take the `name` prefix from a sibling
+   `widgets/*/widget.json` (e.g. `jpa`) and the text domain from the second
+   argument used in `__()` across the package (e.g. `jetpack-premium-analytics`).
+2. **Resolved versions**: check tokens and props against what the package actually
+   resolves, not against trunk or memory:
+   - Tokens → `@wordpress/theme`'s `design-tokens.css` in `node_modules/.pnpm`.
+   - UI props → the resolved `@wordpress/ui` `build-types`.
+   - Contract types → `@wordpress/widget-primitives` `build-types`.
+
+## Checklist — one line per item: `PASS`, or a violation with `file:line` + fix
+
+**Shape**
+- `widget.json` has `name` (`<namespace>/<slug>`), `title`, `description`,
+  `category`, `presentation` (`framed` | `content-bleed` | `full-bleed`).
+- `widget.ts` default-exports `title`, `icon`, and — when configurable —
+  `attributes` + `example`. The attribute TS shape is declared once and reused.
+- `render.tsx` default-exports the component.
+- `package.json` `dependencies` mirror the imports across the widget source:
+  nothing missing, nothing unused.
+
+**Contract**
+- `render.tsx` props are typed by `WidgetRenderProps<Item>` from
+  `@wordpress/widget-primitives`, not a hand-rolled shape.
+- `attributes` is defended — the host may pass it empty or undefined, so default it.
+- The component receives only `{ attributes, setAttributes }`; no dashboard /
+  surface / wp-admin imports, no `onRemove` / header / kebab.
+
+**Chrome**
+- The body renders content only — never a `Card`, header, title bar, or remove
+  control (the host owns chrome). `presentation` in `widget.json` is a valid value.
+
+**Style + i18n**
+- Every `--wpds-*` token in the CSS exists in the resolved `@wordpress/theme`
+  `design-tokens.css` (grep it; do not infer renamed names). Styles are CSS
+  Modules, never global CSS.
+- User-visible strings go through `__( …, '<text-domain>' )`.
+
+## How to verify tokens
+
+```bash
+TOK=$(find node_modules/.pnpm -path '*@wordpress+theme*/css/design-tokens.css' | head -1)
+grep -rhoE '\-\-wpds-[a-z0-9-]+' widgets/<slug>/*.css | sort -u | while read -r t; do
+  grep -qE -- "$t\b" "$TOK" || echo "MISSING from resolved theme: $t"
+done
+```
+
+Never run builds, Docker, or the dev server from this command.

--- a/.claude/commands/widget-audit.md
+++ b/.claude/commands/widget-audit.md
@@ -1,0 +1,12 @@
+---
+description: Audit a widget folder against the widget contract and conventions
+---
+
+Audit a `widgets/<slug>/` against the widget contract and repo conventions. Reports
+only; does not rewrite files unless you ask.
+
+Usage: `/widget-audit <slug-or-path>`
+
+@../../.agents/skills/widget-audit.md
+
+Arguments: $ARGUMENTS

--- a/projects/packages/premium-analytics/changelog/update-widget-audit
+++ b/projects/packages/premium-analytics/changelog/update-widget-audit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard widgets: align the hello-world example widget with the widget render contract and translate its strings.

--- a/projects/packages/premium-analytics/widgets/AGENTS.md
+++ b/projects/packages/premium-analytics/widgets/AGENTS.md
@@ -1,0 +1,1 @@
+@../../../../.agents/rules/widgets.md

--- a/projects/packages/premium-analytics/widgets/CLAUDE.md
+++ b/projects/packages/premium-analytics/widgets/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/projects/packages/premium-analytics/widgets/hello-world/package.json
+++ b/projects/packages/premium-analytics/widgets/hello-world/package.json
@@ -4,8 +4,9 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
-		"clsx": "^2.1.1"
+		"@wordpress/widget-primitives": "next"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/hello-world/render.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/render.tsx
@@ -1,32 +1,31 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
-import clsx from 'clsx';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
+import type { HelloWorldAttributes } from './widget';
 import styles from './style.module.css';
 
-interface HelloWorldAttributes {
-	message?: string;
-}
-
-type HelloWorldRenderProps = {
-	attributes?: HelloWorldAttributes;
-};
+type HelloWorldRenderProps = WidgetRenderProps< HelloWorldAttributes >;
 
 /**
  * Renders the Hello World widget.
  *
- * @param root0            - Component props.
- * @param root0.attributes - Widget attributes.
- * @return The rendered widget.
+ * @param {HelloWorldRenderProps} props - Component props
+ * @return {React.ReactNode} The rendered widget.
  */
-export default function HelloWorld( { attributes }: HelloWorldRenderProps ) {
+export default function HelloWorld( {
+	attributes = {},
+}: HelloWorldRenderProps ): React.ReactNode {
 	return (
-		<Stack align="center" justify="center" className={ clsx( styles.root ) }>
-			<Text variant="heading-2xl">{ attributes?.message || 'Hello World' }</Text>
+		<Stack align="center" justify="center" className={ styles.root }>
+			<Text variant="heading-2xl" render={ <h2 /> }>
+				{ attributes.message || __( 'Hello World', 'jetpack-premium-analytics' ) }
+			</Text>
 		</Stack>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/hello-world/render.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/render.tsx
@@ -3,12 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-/**
- * Internal dependencies
- */
-import type { HelloWorldAttributes } from './widget';
 import styles from './style.module.css';
+import type { HelloWorldAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 type HelloWorldRenderProps = WidgetRenderProps< HelloWorldAttributes >;
 
@@ -18,9 +15,7 @@ type HelloWorldRenderProps = WidgetRenderProps< HelloWorldAttributes >;
  * @param {HelloWorldRenderProps} props - Component props
  * @return {React.ReactNode} The rendered widget.
  */
-export default function HelloWorld( {
-	attributes = {},
-}: HelloWorldRenderProps ): React.ReactNode {
+export default function HelloWorld( { attributes = {} }: HelloWorldRenderProps ): React.ReactNode {
 	return (
 		<Stack align="center" justify="center" className={ styles.root }>
 			<Text variant="heading-2xl" render={ <h2 /> }>

--- a/projects/packages/premium-analytics/widgets/hello-world/widget.ts
+++ b/projects/packages/premium-analytics/widgets/hello-world/widget.ts
@@ -1,26 +1,33 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
+
+/**
+ * Widget attributes shape.
+ */
+export type HelloWorldAttributes = {
+	message?: string;
+};
 
 /**
  * Widget type definition.
  */
 export default {
 	name: 'jpa/hello-world',
-	title: 'Hello World',
+	title: __( 'Hello World', 'jetpack-premium-analytics' ),
 	icon: wordpress,
-	presentation: 'full-bleed',
 	attributes: [
 		{
 			id: 'message',
-			label: 'Message',
+			label: __( 'Message', 'jetpack-premium-analytics' ),
 			type: 'text',
 		},
 	],
 	example: {
 		attributes: {
-			message: 'Hello World',
+			message: __( 'Hello World', 'jetpack-premium-analytics' ),
 		},
 	},
 };


### PR DESCRIPTION
## What?

- Bring the `hello-world` example widget in line with the `@wordpress/widget-primitives` render contract.
- Add reusable widget tooling: a shared `widgets` rule auto-linked into the package's `widgets/` folder, plus a `/widget-audit` command.

## Why?

`hello-world` is the example other widgets get copied from, so it should model the contract. The audit found it diverged: a hand-rolled render-props type, an undefended `attributes`, a duplicated attribute shape, no i18n, and a non-semantic heading. The tooling encodes those invariants once so any `widgets/` folder gets the guardrails by convention.

## How?

Widget (`widgets/hello-world/`):
- Type render props with `WidgetRenderProps< HelloWorldAttributes >` instead of a local shape.
- Default `attributes = {}` — the host's render path can pass it empty.
- Declare `HelloWorldAttributes` once in `widget.ts`, reuse it in `render.tsx`.
- Wrap user-visible strings in `__( …, 'jetpack-premium-analytics' )`.
- Render the full-bleed hero as a semantic `<h2>`.

Tooling: shared rule in `.agents/rules/widgets.md`, linked per folder via `widgets/{CLAUDE,AGENTS}.md`; `/widget-audit` content in `.agents/skills/`, wrapper in `.claude/commands/`.

## Testing

- `/widget-audit hello-world` → all PASS.
- `typecheck`, `lint`, `jetpack build packages/premium-analytics`.

Full-bleed depends on `@wordpress/build` ≥ 0.16.1 forwarding `presentation` from `widget.json`; on the pinned `0.14.0` the tile falls back to `framed` until that bump.

## Follow-ups

- [ ] Bump `@wordpress/build` to ≥ 0.16.1 so `presentation` propagates from `widget.json`.
- [ ] Link the widget API declaration in the shared rule (TODO).
- [ ] Run `/widget-audit` on `top-posts`.
