### PR TITLE
Jetpack: backport 15.9.1 changelog entry to trunk

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -49,6 +49,10 @@
 - Notifications: Let users opt into the v3 notifications panel via the `notifications=v3` query parameter. [#49514]
 - Update package dependencies. [#49273] [#49448] [#49492]
 
+## 15.9.1 - 2026-06-24
+### Bug fixes
+- Fix the Social admin page rendering blank, and restore the editor sharing panel, on WordPress 6.9. [#49859]
+
 ## 15.9 - 2026-06-09
 ### Enhancements
 - Abilities API: Register Shortlinks support for the WP.me Shortlinks module on WordPress 6.9+. [#48334]

--- a/projects/plugins/jetpack/changelog/fix-social-wp69-theme-shim
+++ b/projects/plugins/jetpack/changelog/fix-social-wp69-theme-shim
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix the Social admin page rendering blank, and restore the editor sharing panel, on WordPress 6.9.


### PR DESCRIPTION
Records the **15.9.1** point release (Social WP 6.9.x fix, #49859) in trunk's changelog.

- Adds the `## 15.9.1` entry to `projects/plugins/jetpack/CHANGELOG.md` (version-sorted, between `16.0-a.1` and `15.9`).
- Removes the `fix-social-wp69-theme-shim` changelog fragment so the fix is documented under **15.9.1 only** (not re-listed under 16.0), per the release lead's call.

No version files, no `composer` changes, and the `jetpack-publicize 0.81.3.1` four-point deliberately stays out of trunk.