### PR TITLE
Heartbeat: move connection-related stats to Connection package

### DIFF
--- a/projects/packages/connection/changelog/update-heartbeat-connection-stats-to-package
+++ b/projects/packages/connection/changelog/update-heartbeat-connection-stats-to-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move the missing connection owner and XML-RPC error heartbeat stats to the Connection package.

--- a/projects/packages/connection/changelog/update-heartbeat-connection-stats-to-package
+++ b/projects/packages/connection/changelog/update-heartbeat-connection-stats-to-package
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Move the missing connection owner and XML-RPC error heartbeat stats to the Connection package.
+Heartbeat: Report the missing connection owner and XML-RPC error stats for all connected sites.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -158,6 +158,7 @@ class Manager {
 
 		Heartbeat::init();
 		add_filter( 'jetpack_heartbeat_stats_array', array( $manager, 'add_stats_to_heartbeat' ) );
+		add_action( 'jetpack_verify_signature_error', array( $manager, 'track_xmlrpc_error' ) );
 
 		Webhooks::init( $manager );
 
@@ -2810,6 +2811,34 @@ class Manager {
 		}
 
 		return $stats;
+	}
+
+	/**
+	 * Records a failed XML-RPC signature verification so it can be reported in the heartbeat.
+	 *
+	 * We don't want to expose a detailed error message about why a request failed
+	 * signature verification, as doing so could leak information. Instead, we track
+	 * that the error occurred via a Jetpack option and send that data back in the
+	 * heartbeat. All this does is record the error code, but it's enough to find trends.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \WP_Error $xmlrpc_error The error produced during signature validation.
+	 * @return void
+	 */
+	public function track_xmlrpc_error( $xmlrpc_error ) {
+		$code = is_wp_error( $xmlrpc_error )
+			? $xmlrpc_error->get_error_code()
+			: 'should-not-happen';
+
+		$xmlrpc_errors = \Jetpack_Options::get_option( 'xmlrpc_errors', array() );
+		if ( isset( $xmlrpc_errors[ $code ] ) && $xmlrpc_errors[ $code ] ) {
+			// No need to update the option if we already have this code stored.
+			return;
+		}
+		$xmlrpc_errors[ $code ] = true;
+
+		\Jetpack_Options::update_option( 'xmlrpc_errors', $xmlrpc_errors, false );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2777,6 +2777,7 @@ class Manager {
 	 * If the site-level connection is active, add the list of plugins using connection to the heartbeat (except Jetpack itself)
 	 *
 	 * @since 6.11.0 Add the list of Jetpack package versions to the heartbeat.
+	 * @since $$next-version$$ Add the missing connection owner and XML-RPC error stats to the heartbeat.
 	 *
 	 * @param array $stats The Heartbeat stats array.
 	 * @return array $stats
@@ -2798,6 +2799,15 @@ class Manager {
 		$stats['jetpack_package_versions'] = apply_filters( 'jetpack_package_versions', array() );
 
 		$stats['identitycrisis'] = Identity_Crisis::check_identity_crisis() ? 'yes' : 'no';
+
+		// Missing the connection owner?
+		$stats['missing-owner'] = $this->is_missing_connection_owner();
+
+		$xmlrpc_errors = \Jetpack_Options::get_option( 'xmlrpc_errors', array() );
+		if ( $xmlrpc_errors ) {
+			$stats['xmlrpc-errors'] = implode( ',', array_keys( $xmlrpc_errors ) );
+			\Jetpack_Options::delete_option( 'xmlrpc_errors' );
+		}
 
 		return $stats;
 	}

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -196,6 +196,80 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * `add_stats_to_heartbeat()` reports the missing connection owner stat when connected.
+	 */
+	public function test_add_stats_to_heartbeat_reports_missing_owner() {
+		$manager = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'is_connected', 'is_missing_connection_owner' ) )
+			->getMock();
+		$manager->method( 'is_connected' )->willReturn( true );
+		$manager->method( 'is_missing_connection_owner' )->willReturn( true );
+
+		// `add_stats_to_heartbeat()` reads the connected plugins list, which requires Plugin_Storage to be configured.
+		Plugin_Storage::configure();
+
+		$stats = $manager->add_stats_to_heartbeat( array() );
+
+		$this->assertArrayHasKey( 'missing-owner', $stats );
+		$this->assertTrue( $stats['missing-owner'] );
+	}
+
+	/**
+	 * `add_stats_to_heartbeat()` does not add any stats when the site is not connected.
+	 */
+	public function test_add_stats_to_heartbeat_skips_when_not_connected() {
+		$manager = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'is_connected' ) )
+			->getMock();
+		$manager->method( 'is_connected' )->willReturn( false );
+
+		$this->assertSame( array(), $manager->add_stats_to_heartbeat( array() ) );
+	}
+
+	/**
+	 * `add_stats_to_heartbeat()` reports the stored XML-RPC errors and clears the option afterwards.
+	 */
+	public function test_add_stats_to_heartbeat_reports_and_clears_xmlrpc_errors() {
+		$manager = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'is_connected', 'is_missing_connection_owner' ) )
+			->getMock();
+		$manager->method( 'is_connected' )->willReturn( true );
+		$manager->method( 'is_missing_connection_owner' )->willReturn( false );
+
+		// `add_stats_to_heartbeat()` reads the connected plugins list, which requires Plugin_Storage to be configured.
+		Plugin_Storage::configure();
+
+		Jetpack_Options::update_option( 'xmlrpc_errors', array( 'malformed_token' => true ) );
+
+		$stats = $manager->add_stats_to_heartbeat( array() );
+
+		$this->assertSame( 'malformed_token', $stats['xmlrpc-errors'] );
+		$this->assertFalse( Jetpack_Options::get_option( 'xmlrpc_errors' ), 'The xmlrpc_errors option should be cleared after reporting.' );
+	}
+
+	/**
+	 * `track_xmlrpc_error()` stores the error code in the `xmlrpc_errors` option.
+	 */
+	public function test_track_xmlrpc_error_records_error_code() {
+		Jetpack_Options::delete_option( 'xmlrpc_errors' );
+
+		$this->manager->track_xmlrpc_error( new WP_Error( 'malformed_token', 'Malformed token.' ) );
+
+		$this->assertSame( array( 'malformed_token' => true ), Jetpack_Options::get_option( 'xmlrpc_errors' ) );
+	}
+
+	/**
+	 * `track_xmlrpc_error()` does not duplicate an already-recorded error code.
+	 */
+	public function test_track_xmlrpc_error_does_not_duplicate_existing_code() {
+		Jetpack_Options::update_option( 'xmlrpc_errors', array( 'malformed_token' => true ) );
+
+		$this->manager->track_xmlrpc_error( new WP_Error( 'malformed_token', 'Malformed token.' ) );
+
+		$this->assertSame( array( 'malformed_token' => true ), Jetpack_Options::get_option( 'xmlrpc_errors' ) );
+	}
+
+	/**
 	 * Test the `has_connected_owner` functionality when connected.
 	 */
 	public function test_has_connected_owner_when_connected() {

--- a/projects/plugins/jetpack/changelog/update-heartbeat-connection-stats-to-package
+++ b/projects/plugins/jetpack/changelog/update-heartbeat-connection-stats-to-package
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Move connection-related heartbeat stats to the Connection package.
+Heartbeat: Connection owner and XML-RPC error stats are now provided by the Connection package.

--- a/projects/plugins/jetpack/changelog/update-heartbeat-connection-stats-to-package
+++ b/projects/plugins/jetpack/changelog/update-heartbeat-connection-stats-to-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Move connection-related heartbeat stats to the Connection package.

--- a/projects/plugins/jetpack/class.jetpack-heartbeat.php
+++ b/projects/plugins/jetpack/class.jetpack-heartbeat.php
@@ -5,7 +5,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Heartbeat;
 
 /**
@@ -91,16 +90,6 @@ class Jetpack_Heartbeat {
 		}
 
 		$return[ "{$prefix}space-used" ] = $space_used;
-
-		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );
-		if ( $xmlrpc_errors ) {
-			$return[ "{$prefix}xmlrpc-errors" ] = implode( ',', array_keys( $xmlrpc_errors ) );
-			Jetpack_Options::delete_option( 'xmlrpc_errors' );
-		}
-
-		// Missing the connection owner?
-		$connection_manager                 = new Manager();
-		$return[ "{$prefix}missing-owner" ] = $connection_manager->is_missing_connection_owner();
 
 		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`.
 		$return[ "{$prefix}is-multi-network" ] = 'single-site';

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -635,8 +635,6 @@ class Jetpack {
 		add_action( 'mu_plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
-		add_action( 'jetpack_verify_signature_error', array( $this, 'track_xmlrpc_error' ) );
-
 		/**
 		 * Prepare Gutenberg Editor functionality
 		 *
@@ -4218,35 +4216,6 @@ p {
 </div>
 			<?php
 endif;
-	}
-
-	/**
-	 * We can't always respond to a signed XML-RPC request with a
-	 * helpful error message. In some circumstances, doing so could
-	 * leak information.
-	 *
-	 * Instead, track that the error occurred via a Jetpack_Option,
-	 * and send that data back in the heartbeat.
-	 * All this does is increment a number, but it's enough to find
-	 * trends.
-	 *
-	 * @param WP_Error $xmlrpc_error The error produced during
-	 *                               signature validation.
-	 */
-	public function track_xmlrpc_error( $xmlrpc_error ) {
-		$code = is_wp_error( $xmlrpc_error )
-			? $xmlrpc_error->get_error_code()
-			: 'should-not-happen';
-
-		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );
-		if ( isset( $xmlrpc_errors[ $code ] ) && $xmlrpc_errors[ $code ] ) {
-			// No need to update the option if we already have
-			// this code stored.
-			return;
-		}
-		$xmlrpc_errors[ $code ] = true;
-
-		Jetpack_Options::update_option( 'xmlrpc_errors', $xmlrpc_errors, false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes CONNECT-167

## Proposed changes
Follow-up to #46967 (which moved the IDC heartbeat stat to the Connection package). This audits the remaining stats in `Jetpack_Heartbeat::generate_stats_array()` and moves the ones that are pure connection concerns into the Connection package's `Manager::add_stats_to_heartbeat()`:

* Move the `missing-owner` stat to the Connection package. It now uses `$this->is_missing_connection_owner()` directly, so the plugin no longer needs to instantiate `Manager`.
* Move the `xmlrpc-errors` stat **and its data source** to the Connection package. `Manager::track_xmlrpc_error()` (hooked to `jetpack_verify_signature_error` in `configure()`) now records the `xmlrpc_errors` option, and `add_stats_to_heartbeat()` reports + clears it. Previously the tracking lived only in the Jetpack plugin (`Jetpack::track_xmlrpc_error()`), so standalone-connection sites never populated the stat — now they do.
* Remove the now-unused `Manager` import from `class.jetpack-heartbeat.php` and the `track_xmlrpc_error()` method + hook from `class.jetpack.php`.
* Add `Manager` unit tests covering both heartbeat stats and the XML-RPC error tracking.

`ssl` (`Jetpack::permit_ssl()`) is also a connection-transport concern, but it depends on logic in `class.jetpack.php`, so it is intentionally left for a separate PR. Generic environment stats (`wp-version`, `php-version`, `public`, `language`, etc.) are deferred to a separate decision.

## Related product discussion/links
* CONNECT-167
* Follow-up to #46967

## Does this pull request change what data or activity we track or use?
No new data is collected. The same `missing-owner` and `xmlrpc-errors` stats are still sent; they now originate from the Connection heartbeat instead of the Jetpack plugin heartbeat. As a side effect, standalone-connection sites (a connection but no Jetpack plugin) will now report both stats — including `xmlrpc-errors`, since the signature-error tracking moved into the package too. Both still only run when the site is connected.

## Testing instructions
* Code review.
* On a connected site, trigger `jetpack_v2_heartbeat` (e.g. via the Crontrol plugin) and confirm `missing-owner` and `xmlrpc-errors` (when present) are part of the heartbeat received on WPCOM, matching the previous behavior.
* `jetpack test php packages/connection` passes (includes new `ManagerTest` coverage).