### PR TITLE
Archives shortcode: cap unbounded postbypost to prevent OOM

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-archives-shortcode-postbypost-oom
+++ b/projects/plugins/jetpack/changelog/fix-archives-shortcode-postbypost-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Archives shortcode: Cap the unbounded postbypost type with a sane, filterable default limit to prevent memory exhaustion on large sites.

--- a/projects/plugins/jetpack/modules/shortcodes/archives.php
+++ b/projects/plugins/jetpack/modules/shortcodes/archives.php
@@ -52,6 +52,33 @@ function archives_shortcode( $atts ) {
 		$limit = '';
 	}
 
+	/*
+	 * The `postbypost` type (also the default) lists one entry per published
+	 * post. Left unbounded, wp_get_archives() materializes the entire post table
+	 * in a single request, which can exhaust PHP memory and fatal on large sites.
+	 * Apply a sane, filterable default cap when no explicit limit was supplied.
+	 */
+	if ( 'postbypost' === $attr['type'] && '' === $limit ) {
+		/**
+		 * Filter the default number of entries listed by the [archives] shortcode
+		 * when using the unbounded `postbypost` type with no explicit `limit`.
+		 *
+		 * Set to 0 to restore the previous (unlimited) behavior, though this is
+		 * not recommended on sites with a large number of posts.
+		 *
+		 * @module shortcodes
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $limit Default maximum number of posts to list. Default 100.
+		 */
+		$default_limit = (int) apply_filters( 'jetpack_archives_shortcode_default_limit', 100 );
+
+		if ( $default_limit > 0 ) {
+			$limit = $default_limit;
+		}
+	}
+
 	$showcount = false !== $attr['showcount'] && 'false' !== $attr['showcount'];
 	$before    = wp_kses( $attr['before'], $allowedposttags );
 	$after     = wp_kses( $attr['after'], $allowedposttags );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Archives_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Archives_Test.php
@@ -222,6 +222,168 @@ class Jetpack_Shortcodes_Archives_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The default `postbypost` type with no limit must be capped to avoid
+	 * materializing every published post (which can OOM on large sites).
+	 */
+	public function test_shortcodes_archives_postbypost_default_is_capped() {
+		add_filter(
+			'jetpack_archives_shortcode_default_limit',
+			static function () {
+				return 2;
+			}
+		);
+
+		self::factory()->post->create_many( 5 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'postbypost',
+			)
+		);
+
+		$this->assertSame( 2, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * With no filter attached, the shipped default cap of 100 must apply. This
+	 * pins the literal default value that the OOM fix relies on, since every
+	 * other cap test overrides it via the filter.
+	 */
+	public function test_shortcodes_archives_postbypost_default_limit_is_100() {
+		$this->assertSame( 100, apply_filters( 'jetpack_archives_shortcode_default_limit', 100 ) );
+
+		self::factory()->post->create_many( 101 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'postbypost',
+			)
+		);
+
+		$this->assertSame( 100, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * An invalid type falls back to `postbypost` and must also be capped, since
+	 * that is the most likely real-world trigger (typos, legacy shortcodes).
+	 */
+	public function test_shortcodes_archives_invalid_type_is_capped() {
+		add_filter(
+			'jetpack_archives_shortcode_default_limit',
+			static function () {
+				return 2;
+			}
+		);
+
+		self::factory()->post->create_many( 5 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'not-a-real-type',
+			)
+		);
+
+		$this->assertSame( 2, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * Filtering the limit to 0 restores the previous unlimited behavior for
+	 * `postbypost` (the documented escape hatch / `$default_limit > 0` branch).
+	 */
+	public function test_shortcodes_archives_postbypost_filter_zero_is_unlimited() {
+		add_filter( 'jetpack_archives_shortcode_default_limit', '__return_zero' );
+
+		self::factory()->post->create_many( 3 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'postbypost',
+			)
+		);
+
+		$this->assertSame( 3, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * An explicit limit must still be honored over the default cap. A lower cap
+	 * is filtered in so the test fails if the cap ever overrides an explicit limit.
+	 */
+	public function test_shortcodes_archives_explicit_limit_overrides_default() {
+		add_filter(
+			'jetpack_archives_shortcode_default_limit',
+			static function () {
+				return 1;
+			}
+		);
+
+		self::factory()->post->create_many( 3 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'postbypost',
+				'limit'  => '3',
+			)
+		);
+
+		$this->assertSame( 3, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * An explicit `limit=0` normalizes to "no limit", which for `postbypost` is
+	 * the same unbounded OOM vector as omitting it — so it must also be capped.
+	 */
+	public function test_shortcodes_archives_limit_zero_is_capped() {
+		add_filter(
+			'jetpack_archives_shortcode_default_limit',
+			static function () {
+				return 1;
+			}
+		);
+
+		self::factory()->post->create_many( 3 );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'postbypost',
+				'limit'  => '0',
+			)
+		);
+
+		$this->assertSame( 1, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
+	 * The cap only applies to `postbypost`; date-bucketed types stay unbounded.
+	 * A low cap is filtered in to prove `yearly` ignores it entirely.
+	 */
+	public function test_shortcodes_archives_yearly_not_capped() {
+		add_filter(
+			'jetpack_archives_shortcode_default_limit',
+			static function () {
+				return 1;
+			}
+		);
+
+		self::factory()->post->create( array( 'post_date' => '2013-01-01 01:00:00' ) );
+		self::factory()->post->create( array( 'post_date' => '2014-01-01 01:00:00' ) );
+
+		$archives = archives_shortcode(
+			array(
+				'format' => 'html',
+				'type'   => 'yearly',
+			)
+		);
+
+		$this->assertSame( 2, substr_count( $archives, '<li>' ) );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @since 3.2
 	 */


### PR DESCRIPTION
Fixes JETPACK-1711

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* The `[archives]` shortcode defaults to `type=postbypost` with no limit, so `wp_get_archives()` materializes one entry per published post. On large sites this exhausts PHP memory and triggers OOM fatals (~98 MB single allocations tripping the 384 MB request cap, observed steadily in wpcom fatal-tracking).
* Clamp **only** the unbounded `postbypost` + no-limit case to a sane, filterable default of **100** via a new `jetpack_archives_shortcode_default_limit` filter.
* Explicit limits and date-bucketed types (`yearly`/`monthly`/`weekly`/`daily`) are untouched. `limit=0` normalizes to "no limit", which is the same unbounded vector, so it is capped too. Set the filter to `0` to restore the previous unlimited behavior.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: [JETPACK-1711](https://linear.app/a8c/issue/JETPACK-1711)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
* On a test site with several published posts, add a page/post whose content contains `[archives]` (or `[archives type="postbypost"]`) and view it.
* **With the fix:** the rendered list is capped at 100 entries (before, it rendered one link per published post, unbounded — the OOM vector on large sites).
* Verify date-bucketed types are unaffected: `[archives type="monthly"]` and `[archives type="yearly"]` still list every period.
* Verify an explicit limit is still honored: `[archives limit="5"]` shows 5 entries.
* Verify the escape hatch: with `add_filter( 'jetpack_archives_shortcode_default_limit', '__return_zero' );`, `postbypost` is unlimited again.
* Automated: run the Archives shortcode PHPUnit suite (`jetpack docker phpunit jetpack -- --filter Archives`) — 25 tests pass.
