### PR TITLE
Forms: fix IDOR info-leak in jetpack-forms status-counts endpoint (FORMS-661)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-661-idor
+++ b/projects/packages/forms/changelog/fix-forms-661-idor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Restrict form status counts to a user's own forms when they cannot edit others' forms.
+Status counts: Restrict counts to a user's own forms when they cannot edit others' forms.

--- a/projects/packages/forms/changelog/fix-forms-661-idor
+++ b/projects/packages/forms/changelog/fix-forms-661-idor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Restrict form status counts to a user's own forms when they cannot edit others' forms.

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -74,19 +74,28 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Retrieves per-status counts for the jetpack_form post type.
 	 *
-	 * Uses wp_count_posts() which returns all status counts in a single query.
+	 * Users who can edit others' forms (e.g. admins and editors) receive
+	 * site-wide counts via wp_count_posts(). Users who cannot (e.g. authors)
+	 * receive counts scoped to the forms they authored, so aggregate counts of
+	 * other users' forms are not leaked.
 	 *
 	 * @return \WP_REST_Response Response object with status counts.
 	 */
 	public function get_status_counts() {
-		$counts = wp_count_posts( Contact_Form::POST_TYPE );
+		$post_type_object = get_post_type_object( $this->post_type );
 
-		$publish = (int) ( $counts->publish ?? 0 );
-		$draft   = (int) ( $counts->draft ?? 0 );
-		$pending = (int) ( $counts->pending ?? 0 );
-		$future  = (int) ( $counts->future ?? 0 );
-		$private = (int) ( $counts->{'private'} ?? 0 );
-		$trash   = (int) ( $counts->trash ?? 0 );
+		if ( $post_type_object && current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+			$counts = (array) wp_count_posts( Contact_Form::POST_TYPE );
+		} else {
+			$counts = $this->get_status_counts_for_author( get_current_user_id() );
+		}
+
+		$publish = (int) ( $counts['publish'] ?? 0 );
+		$draft   = (int) ( $counts['draft'] ?? 0 );
+		$pending = (int) ( $counts['pending'] ?? 0 );
+		$future  = (int) ( $counts['future'] ?? 0 );
+		$private = (int) ( $counts['private'] ?? 0 );
+		$trash   = (int) ( $counts['trash'] ?? 0 );
 
 		return rest_ensure_response(
 			array(
@@ -99,6 +108,45 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'trash'   => $trash,
 			)
 		);
+	}
+
+	/**
+	 * Count forms authored by a specific user, grouped by post status.
+	 *
+	 * wp_count_posts() cannot be scoped by author (its second argument is a
+	 * permission level, not query args), so a direct query is used to mirror its
+	 * shape while restricting results to a single author. The result is
+	 * user-scoped and computed by a single grouped aggregate run once per request
+	 * (the dashboard preloads this endpoint), so it is intentionally not cached --
+	 * unlike get_entries_count_by_form_id(), whose lookup is shared across forms
+	 * and benefits from a short-lived cache.
+	 *
+	 * @param int $author_id User ID to scope the counts to.
+	 * @return array<string,int> Map of post_status => count.
+	 */
+	private function get_status_counts_for_author( int $author_id ): array {
+		global $wpdb;
+
+		// Intentionally uncached: the result is user-scoped and computed once per request.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_status, COUNT(1) AS num_posts
+				FROM {$wpdb->posts}
+				WHERE post_type = %s
+				  AND post_author = %d
+				GROUP BY post_status",
+				Contact_Form::POST_TYPE,
+				$author_id
+			)
+		);
+
+		$counts = array();
+		foreach ( (array) $rows as $row ) {
+			$counts[ $row->post_status ] = (int) $row->num_posts;
+		}
+
+		return $counts;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -113,7 +113,7 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Count forms authored by a specific user, grouped by post status.
 	 *
-	 * wp_count_posts() cannot be scoped by author (its second argument is a
+	 * The wp_count_posts() function cannot be scoped by author (its second argument is a
 	 * permission level, not query args), so a direct query is used to mirror its
 	 * shape while restricting results to a single author. The result is
 	 * user-scoped and computed by a single grouped aggregate run once per request

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -436,16 +436,23 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	 * endpoint runs so we can assert how it is scoped, and (b) return controlled rows so
 	 * the response shape can be asserted.
 	 *
-	 * @param array $captured_queries Reference that receives each matching query string.
-	 * @param array $rows             Map of post_status => count to return for the query.
+	 * @param array $captured_queries  Reference that receives each matching query string.
+	 * @param array $rows              Map of post_status => count to return for the query.
+	 * @param array $required_fragments Query fragments that must be present before returning stubbed rows.
 	 */
-	private function stub_status_count_query( array &$captured_queries, array $rows ): void {
-		$this->status_count_filter = function ( $results, $query ) use ( &$captured_queries, $rows ) {
+	private function stub_status_count_query( array &$captured_queries, array $rows, array $required_fragments = array() ): void {
+		$this->status_count_filter = function ( $results, $query ) use ( &$captured_queries, $rows, $required_fragments ) {
 			if ( false === strpos( $query, 'GROUP BY post_status' ) ) {
 				return $results;
 			}
 
 			$captured_queries[] = $query;
+
+			foreach ( $required_fragments as $fragment ) {
+				if ( false === strpos( $query, $fragment ) ) {
+					return $results;
+				}
+			}
 
 			$stubbed = array();
 			foreach ( $rows as $status => $count ) {
@@ -499,6 +506,10 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 				'draft'   => 2,
 				'pending' => 4,
 				'trash'   => 8,
+			),
+			array(
+				"post_type = 'jetpack_form'",
+				'post_author = ' . $author_id,
 			)
 		);
 
@@ -506,14 +517,23 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 
 		// The query must be scoped to the current author's own forms.
 		$this->assertNotEmpty( $captured_queries, 'Author should trigger a direct, author-scoped status query' );
+		$this->assertStringContainsString( "post_type = 'jetpack_form'", $captured_queries[0], 'Author query must filter to jetpack_form posts' );
 		$this->assertStringContainsString( 'post_author = ' . $author_id, $captured_queries[0], 'Author query must filter by the current author ID' );
 
 		// The response reflects only the author's own counts.
-		$this->assertSame( 1, $data['publish'], 'Author should only see their own published forms' );
-		$this->assertSame( 2, $data['draft'], 'Author should only see their own draft forms' );
-		$this->assertSame( 4, $data['pending'], 'Author should only see their own pending forms' );
-		$this->assertSame( 8, $data['trash'], 'Author should see their own trash count' );
-		$this->assertSame( 7, $data['all'], 'Author "all" count sums publish+draft+pending+future+private and excludes trash' );
+		$this->assertSame(
+			array(
+				'all'     => 7,
+				'publish' => 1,
+				'draft'   => 2,
+				'pending' => 4,
+				'future'  => 0,
+				'private' => 0,
+				'trash'   => 8,
+			),
+			$data,
+			'Author response should preserve all status-count keys, default missing statuses to zero, and exclude trash from all'
+		);
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * Unit Tests for Jetpack_Form.
-register* @package automattic/jetpack-forms
+ *
+ * @package automattic/jetpack-forms
  */
 
 namespace Automattic\Jetpack\Forms\ContactForm;
@@ -36,6 +37,13 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	private static $user_id;
 
 	/**
+	 * The status-count query stub filter currently registered, if any.
+	 *
+	 * @var callable|null
+	 */
+	private $status_count_filter = null;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
@@ -64,6 +72,11 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
+
+		if ( null !== $this->status_count_filter ) {
+			remove_filter( 'wordbless_wpdb_query_results', $this->status_count_filter, 10 );
+			$this->status_count_filter = null;
+		}
 
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
@@ -413,6 +426,140 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 
 		$this->assertStringContainsString( $existing_where, $clauses['where'] );
 		$this->assertStringContainsString( 'EXISTS', $clauses['where'] );
+	}
+
+	/**
+	 * Capture and stub the grouped status-count SQL query.
+	 *
+	 * The forms package runs tests against WorDBless' "dbless" engine, which does not
+	 * execute real aggregate SQL. We hook its query filter to (a) record the query the
+	 * endpoint runs so we can assert how it is scoped, and (b) return controlled rows so
+	 * the response shape can be asserted.
+	 *
+	 * @param array $captured_queries Reference that receives each matching query string.
+	 * @param array $rows             Map of post_status => count to return for the query.
+	 */
+	private function stub_status_count_query( array &$captured_queries, array $rows ): void {
+		$this->status_count_filter = function ( $results, $query ) use ( &$captured_queries, $rows ) {
+			if ( false === strpos( $query, 'GROUP BY post_status' ) ) {
+				return $results;
+			}
+
+			$captured_queries[] = $query;
+
+			$stubbed = array();
+			foreach ( $rows as $status => $count ) {
+				$stubbed[] = (object) array(
+					'post_status' => $status,
+					'num_posts'   => $count,
+				);
+			}
+			return $stubbed;
+		};
+
+		add_filter( 'wordbless_wpdb_query_results', $this->status_count_filter, 10, 2 );
+	}
+
+	/**
+	 * Dispatch the status-counts endpoint and return the response data.
+	 *
+	 * @return array The status counts response data.
+	 */
+	private function dispatch_status_counts(): array {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/status-counts' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status(), 'status-counts request should return 200' );
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Test that a user who cannot edit others' forms only sees counts for their own forms.
+	 */
+	public function test_status_counts_scoped_to_author_for_non_editor() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		// An author can edit_posts but not edit_others_posts.
+		$author_id = wp_insert_user(
+			array(
+				'user_login' => 'test_author',
+				'user_pass'  => '123',
+				'role'       => 'author',
+			)
+		);
+		wp_set_current_user( $author_id );
+
+		$captured_queries = array();
+		$this->stub_status_count_query(
+			$captured_queries,
+			array(
+				'publish' => 1,
+				'draft'   => 2,
+				'pending' => 4,
+				'trash'   => 8,
+			)
+		);
+
+		$data = $this->dispatch_status_counts();
+
+		// The query must be scoped to the current author's own forms.
+		$this->assertNotEmpty( $captured_queries, 'Author should trigger a direct, author-scoped status query' );
+		$this->assertStringContainsString( 'post_author = ' . $author_id, $captured_queries[0], 'Author query must filter by the current author ID' );
+
+		// The response reflects only the author's own counts.
+		$this->assertSame( 1, $data['publish'], 'Author should only see their own published forms' );
+		$this->assertSame( 2, $data['draft'], 'Author should only see their own draft forms' );
+		$this->assertSame( 4, $data['pending'], 'Author should only see their own pending forms' );
+		$this->assertSame( 8, $data['trash'], 'Author should see their own trash count' );
+		$this->assertSame( 7, $data['all'], 'Author "all" count sums publish+draft+pending+future+private and excludes trash' );
+	}
+
+	/**
+	 * Test that a user who can edit others' forms still sees site-wide status counts.
+	 */
+	public function test_status_counts_global_for_editor() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		// Current user is the administrator from setUp(), who can edit_others_posts.
+		$captured_queries = array();
+		$this->stub_status_count_query(
+			$captured_queries,
+			array(
+				'publish' => 3,
+				'draft'   => 2,
+			)
+		);
+
+		$data = $this->dispatch_status_counts();
+
+		// Admins/editors get site-wide counts via wp_count_posts(), which is not author-scoped.
+		$this->assertNotEmpty( $captured_queries, 'Admin should trigger the site-wide status query' );
+		$this->assertStringNotContainsString( 'post_author', $captured_queries[0], 'Admin query must not be scoped by author' );
+
+		$this->assertSame( 3, $data['publish'], 'Admin should see every user\'s published forms' );
+		$this->assertSame( 2, $data['draft'], 'Admin should see every user\'s draft forms' );
+		$this->assertSame( 5, $data['all'], 'Admin "all" count should include every user\'s forms' );
+	}
+
+	/**
+	 * Test that the status-counts route denies users who cannot edit forms.
+	 *
+	 * This guards the permission gate on the route so the author-scoped branch is
+	 * never reached for a logged-out user (post_author = 0).
+	 */
+	public function test_status_counts_denied_for_logged_out_user() {
+		Contact_Form::register_post_type();
+		do_action( 'rest_api_init' );
+
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/jetpack-forms/status-counts' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertContains( $response->get_status(), array( 401, 403 ), 'Logged-out users must not access status-counts' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORMS-661.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix an authorization (IDOR) information leak in the Jetpack Forms package. The `GET /wp/v2/jetpack-forms/status-counts` route is gated only by `current_user_can( edit_posts )`, but its handler returned site-wide `jetpack_form` status counts via `wp_count_posts()`. An Author (who cannot edit others' posts) could therefore read aggregate `publish`/`draft`/`pending`/`future`/`private`/`trash` counts for **every** user's forms.
* When the current user cannot edit others' forms, the endpoint now scopes the counts to their own authorship using a prepared, author-filtered query (`SELECT post_status, COUNT(1) … WHERE post_type = %s AND post_author = %d GROUP BY post_status`).
* Users who **can** edit others' forms (administrators, editors) still receive the site-wide counts. The dashboard preloads this endpoint for those roles, so their experience is unchanged.
* The "can see others" capability is read from the post type object's `cap->edit_others_posts`, consistent with how the controller reads capabilities elsewhere.
* The response shape is unchanged (`all`, `publish`, `draft`, `pending`, `future`, `private`, `trash`; `all` = publish + draft + pending + future + private).
* Adds PHPUnit coverage proving an Author sees only their own counts, an admin still sees site-wide counts, the `all` aggregate excludes trash, and the route denies logged-out users.

This PR intentionally touches only the `jetpack_form` status-counts endpoint. The sibling forms-list scoping concern (JETPACK-1446 / FIND-07) is tracked separately and is out of scope here.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: FORMS-661 (Jetpack Codex Security Review project; parent JETPACK-1439).

## Does this pull request change what data or activity we track or use?
No. This restricts which aggregate counts an existing endpoint returns to a user; it does not add or change any tracking.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

Set up a site with the Jetpack Forms package active (the `jetpack_form` CPT registered and the dashboard available), then create some block-editor Forms owned by different users and in different statuses — e.g. a couple of published/draft forms authored by an **Administrator**, and one or two authored by an **Author**.

The endpoint requires authentication (logged-in cookie + REST nonce). The simplest way to call it as a given user is from that user's browser dev-tools console while logged in:

```js
wp.apiFetch( { path: '/wp/v2/jetpack-forms/status-counts' } ).then( console.log );
```

Or with curl, reusing a logged-in session's cookies and nonce:

```bash
curl 'https://<your-site>/wp-json/wp/v2/jetpack-forms/status-counts' \
  -H 'X-WP-Nonce: <wpApiSettings.nonce for the logged-in user>' \
  --cookie '<the logged-in user's cookies>'
```

* **As an Administrator (or Editor):** call the endpoint. You should see site-wide counts that include every user's forms (this is unchanged by the PR). For example, with the seeded data above, `all`/`publish`/`draft` reflect both the admin's and the author's forms.
* **As an Author:**
  * **Before this PR:** the same call returns the same **site-wide** counts — the Author can see aggregate counts of the admin's (and everyone else's) forms. This is the leak.
  * **After this PR:** the call returns counts scoped to **only the Author's own** forms. Counts of other users' forms are no longer exposed.
* **Logged out:** the route returns `401`/`403` (the `edit_posts` permission gate), so the author-scoped branch is never reached with an empty user.
* Run the package test suite: from `projects/packages/forms`, `jp test php packages/forms -- --filter Jetpack_Form_Endpoint_Test` (or the full `jp test php packages/forms`). All tests pass.
