### PR TITLE
Search Blocks: fix overlay deep-link hydration

### DIFF
--- a/projects/packages/search/changelog/fix-search-blocks-overlay-deeplink-hydration
+++ b/projects/packages/search/changelog/fix-search-blocks-overlay-deeplink-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Fix deep-linked overlay searches rendering empty result lists.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -72,6 +72,22 @@ function ensureHydrated() {
 		return hydrationPromise;
 	}
 	hydrationPromise = ( async () => {
+		// Hydration uses the WP Interactivity API's private surface. There is
+		// no public API for hydrating content inserted after DOMContentLoaded.
+		// If the privateApis contract changes, the catch leaves the overlay
+		// rendered-but-inert rather than crashing the page; the IA store
+		// reading from a static seed already covers initial display.
+		let ia = null;
+		let apis = null;
+		try {
+			ia = await import( '@wordpress/interactivity' );
+			apis = typeof ia.privateApis === 'function' ? ia.privateApis( PRIVATE_API_CONSENT ) : null;
+			await apis?.initialVdomPromise;
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[jetpack-search] overlay hydration failed', e );
+		}
+
 		const overlay = getOverlay();
 		const template = document.getElementById( TEMPLATE_ID );
 		const content = overlay?.querySelector( '.jetpack-search-block-overlay__content' );
@@ -80,18 +96,9 @@ function ensureHydrated() {
 		}
 		content.appendChild( template.content.cloneNode( true ) );
 
-		// Hydration uses the WP Interactivity API's private surface. There is
-		// no public API for hydrating content inserted after DOMContentLoaded.
-		// If the privateApis contract changes, the catch leaves the overlay
-		// rendered-but-inert rather than crashing the page; the IA store
-		// reading from a static seed already covers initial display.
 		try {
-			const ia = await import( '@wordpress/interactivity' );
-			if ( typeof ia.privateApis !== 'function' ) {
-				return;
-			}
-			const apis = ia.privateApis( PRIVATE_API_CONSENT );
 			if (
+				! apis ||
 				typeof apis.render !== 'function' ||
 				typeof apis.toVdom !== 'function' ||
 				typeof apis.getRegionRootFragment !== 'function'

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -6,9 +6,21 @@
  * `document.readyState`, then imports the module fresh via `jest.resetModules`.
  */
 
-// `ensureHydrated()` dynamically imports this; stub it so the hydration branch
-// no-ops instead of reaching for the real Interactivity runtime in jsdom.
-jest.mock( '@wordpress/interactivity', () => ( {} ), { virtual: true } );
+let mockActions;
+let mockApis;
+let mockResolveInitialVdom;
+
+// `ensureHydrated()` dynamically imports this; stub the private API shape so
+// bootstrap timing can be tested without reaching for the real Interactivity
+// runtime in jsdom.
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		privateApis: jest.fn( () => mockApis ),
+		store: jest.fn( () => ( { actions: mockActions } ) ),
+	} ),
+	{ virtual: true }
+);
 // The bootstrap statically depends on the shared store as a side-effect
 // import (so the runtime store registers before the bootstrap dispatches
 // `dispatchInitialSearchIfNeeded` after hydration). The store module itself
@@ -45,6 +57,24 @@ function renderOverlayShell( { full = false } = {} ) {
 }
 
 /**
+ * Reset the mocked Interactivity private API for a fresh bootstrap import.
+ */
+function resetInteractivityMock() {
+	mockActions = {
+		closeAllPopovers: jest.fn(),
+		dispatchInitialSearchIfNeeded: jest.fn(),
+	};
+	mockApis = {
+		getRegionRootFragment: jest.fn( region => region.parentElement ),
+		initialVdomPromise: new Promise( resolve => {
+			mockResolveInitialVdom = resolve;
+		} ),
+		render: jest.fn(),
+		toVdom: jest.fn( region => region ),
+	};
+}
+
+/**
  * Point `window.location` at the given path+query without a real navigation.
  *
  * @param {string} url - Path with optional query string, e.g. `/?s=foo`.
@@ -67,10 +97,16 @@ function setReadyState( value ) {
 
 /**
  * Import the bootstrap fresh and let the fire-and-forget `openOverlay` settle.
+ *
+ * @param {object}  [options]                         - Import options.
+ * @param {boolean} [options.resolveInitialHydration] - Whether to resolve the mocked initial hydration before flushing.
  */
-async function loadBootstrap() {
+async function loadBootstrap( { resolveInitialHydration = true } = {} ) {
 	jest.resetModules();
 	await import( '../index.js' );
+	if ( resolveInitialHydration ) {
+		mockResolveInitialVdom( new WeakMap() );
+	}
 	// `handlePopState` → `openOverlay` awaits hydration before toggling `hidden`;
 	// flush the microtask queue so the attribute change has landed.
 	await new Promise( resolve => setTimeout( resolve, 0 ) );
@@ -84,6 +120,10 @@ const isOpen = () => ! document.getElementById( OVERLAY_ID ).hasAttribute( 'hidd
 // another Document" `console.error`. Reload-path tests assert
 // `expect( console ).toHaveErrored()` as evidence the call fired — that doubles
 // as the declaration that satisfies the jest-console strict guard.
+
+beforeEach( () => {
+	resetInteractivityMock();
+} );
 
 afterEach( () => {
 	setReadyState( 'complete' );
@@ -135,6 +175,27 @@ describe( 'overlay-bootstrap initial-load URL trigger', () => {
 		await new Promise( resolve => setTimeout( resolve, 0 ) );
 
 		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'waits for the initial Interactivity hydration before cloning the overlay template', async () => {
+		setReadyState( 'complete' );
+		renderOverlayShell();
+		document.getElementById( 'jetpack-search-block-overlay-template' ).innerHTML =
+			'<div data-wp-interactive="jetpack-search" id="clone-marker"></div>';
+		setUrl( '/?s=hello' );
+
+		await loadBootstrap( { resolveInitialHydration: false } );
+
+		expect( isOpen() ).toBe( false );
+		expect( document.getElementById( 'clone-marker' ) ).toBeNull();
+
+		mockResolveInitialVdom( new WeakMap() );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( isOpen() ).toBe( true );
+		expect( document.getElementById( 'clone-marker' ) ).not.toBeNull();
+		expect( mockApis.render ).toHaveBeenCalled();
+		expect( mockActions.dispatchInitialSearchIfNeeded ).toHaveBeenCalled();
 	} );
 
 	it( 'is a no-op when the overlay shell is not rendered', async () => {


### PR DESCRIPTION
## Proposed changes:

* Wait for the Interactivity API initial hydration pass before cloning and privately hydrating the Search Blocks overlay.
* Prevent deep-linked overlay searches from consuming repeat templates before the cloned overlay owns its runtime subscriptions.
* Add unit coverage for the deferred clone timing.

## Testing instructions:

* `./node_modules/.bin/jest --passWithNoTests overlay-bootstrap`
* `./node_modules/.bin/jest --passWithNoTests tests/js/search-blocks/store.test.js`
* `./node_modules/.bin/eslint projects/packages/search/src/search-blocks/overlay-bootstrap/index.js projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js`
* `git diff --check`
* Verified a deep-linked Search Blocks overlay in a sandbox: results and filters rendered after initial load.