### PR TITLE
VideoPress: Add capability check to Heartbeat processing-status handler

### DIFF
--- a/projects/packages/videopress/changelog/fix-vidp-231-heartbeat-ownership-check
+++ b/projects/packages/videopress/changelog/fix-vidp-231-heartbeat-ownership-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+VideoPress: Fix an issue where the media library Heartbeat handler exposed processing status for attachments the current user is not allowed to edit.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -368,7 +368,12 @@ class Attachment_Handler {
 
 		$statuses = array();
 		foreach ( $data['videopress_processing_ids'] as $id ) {
-			$id     = (int) $id;
+			$id = (int) $id;
+
+			if ( ! current_user_can( 'edit_post', $id ) ) {
+				continue;
+			}
+
 			$status = get_post_meta( $id, 'videopress_status', true );
 			if ( $status ) {
 				$statuses[ $id ] = $status;

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -26,15 +26,16 @@ class Attachment_Handler_Test extends BaseTestCase {
 	/**
 	 * Create a user with the given role and set as current user.
 	 *
-	 * @param string $role The user role.
+	 * @param string $role   The user role.
+	 * @param string $suffix Unique suffix for the login/email, so the same role can be created more than once.
 	 * @return int The new user ID.
 	 */
-	private function set_current_user_role( $role ) {
+	private function set_current_user_role( $role, $suffix = '_user' ) {
 		$user_id = wp_insert_user(
 			array(
-				'user_login' => $role . '_user',
+				'user_login' => $role . $suffix,
 				'user_pass'  => 'pass',
-				'user_email' => $role . '@test.com',
+				'user_email' => $role . $suffix . '@test.com',
 				'role'       => $role,
 			)
 		);
@@ -265,14 +266,7 @@ class Attachment_Handler_Test extends BaseTestCase {
 	 * to other users.
 	 */
 	public function test_heartbeat_received_skips_other_users_attachments() {
-		$owner_id = wp_insert_user(
-			array(
-				'user_login' => 'video_owner',
-				'user_pass'  => 'pass',
-				'user_email' => 'video_owner@test.com',
-				'role'       => 'author',
-			)
-		);
+		$owner_id = $this->set_current_user_role( 'author', '_owner' );
 
 		$post_id = wp_insert_post(
 			array(

--- a/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
+++ b/projects/packages/videopress/tests/php/Attachment_Handler_Test.php
@@ -18,8 +18,29 @@ class Attachment_Handler_Test extends BaseTestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		wp_set_current_user( 0 );
 		\WorDBless\Posts::init()->clear_all_posts();
 		parent::tear_down();
+	}
+
+	/**
+	 * Create a user with the given role and set as current user.
+	 *
+	 * @param string $role The user role.
+	 * @return int The new user ID.
+	 */
+	private function set_current_user_role( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $role . '_user',
+				'user_pass'  => 'pass',
+				'user_email' => $role . '@test.com',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		return $user_id;
 	}
 
 	/**
@@ -122,6 +143,7 @@ class Attachment_Handler_Test extends BaseTestCase {
 	 * Test that heartbeat_received returns statuses for requested IDs.
 	 */
 	public function test_heartbeat_received_returns_statuses() {
+		$this->set_current_user_role( 'author' );
 		$post_id = wp_insert_post(
 			array(
 				'post_type'      => 'attachment',
@@ -166,6 +188,7 @@ class Attachment_Handler_Test extends BaseTestCase {
 	 * Test that heartbeat_received casts IDs to integers.
 	 */
 	public function test_heartbeat_received_casts_ids_to_int() {
+		$this->set_current_user_role( 'author' );
 		$post_id = wp_insert_post(
 			array(
 				'post_type'      => 'attachment',
@@ -188,6 +211,7 @@ class Attachment_Handler_Test extends BaseTestCase {
 	 * Test that heartbeat_received omits IDs with no status meta.
 	 */
 	public function test_heartbeat_received_omits_ids_without_status() {
+		$this->set_current_user_role( 'author' );
 		$post_id = wp_insert_post(
 			array(
 				'post_type'      => 'attachment',
@@ -195,6 +219,95 @@ class Attachment_Handler_Test extends BaseTestCase {
 				'post_title'     => 'Test video',
 			)
 		);
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( $post_id ) )
+		);
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+	}
+
+	/**
+	 * Test that heartbeat_received does not expose status to a user who cannot
+	 * edit the attachment.
+	 *
+	 * Without a capability check any logged-in user (e.g. a subscriber) could
+	 * enumerate the processing status of arbitrary attachments by supplying
+	 * their IDs.
+	 */
+	public function test_heartbeat_received_skips_attachments_user_cannot_edit() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_status', 'processing' );
+
+		$this->set_current_user_role( 'subscriber' );
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( $post_id ) )
+		);
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+	}
+
+	/**
+	 * Test that heartbeat_received does not expose another user's attachment
+	 * status to an author who cannot edit it.
+	 *
+	 * This is the core IDOR guard: a logged-in author with upload permissions
+	 * must not be able to read the processing status of attachments belonging
+	 * to other users.
+	 */
+	public function test_heartbeat_received_skips_other_users_attachments() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'video_owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'video_owner@test.com',
+				'role'       => 'author',
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => "Owner's video",
+				'post_author'    => $owner_id,
+			)
+		);
+		add_post_meta( $post_id, 'videopress_status', 'processing' );
+
+		$this->set_current_user_role( 'author' );
+
+		$result = Attachment_Handler::heartbeat_received(
+			array(),
+			array( 'videopress_processing_ids' => array( $post_id ) )
+		);
+
+		$this->assertArrayNotHasKey( 'videopress_processing_status', $result );
+	}
+
+	/**
+	 * Test that heartbeat_received returns no status for a logged-out user.
+	 */
+	public function test_heartbeat_received_requires_logged_in_user() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+		add_post_meta( $post_id, 'videopress_status', 'processing' );
+
+		wp_set_current_user( 0 );
 
 		$result = Attachment_Handler::heartbeat_received(
 			array(),


### PR DESCRIPTION
Fixes VIDP-231

## Proposed changes
* The VideoPress media-library Heartbeat handler (`Attachment_Handler::heartbeat_received`) read caller-supplied `videopress_processing_ids` and returned the `videopress_status` post meta for each ID with **no capability check**. Any logged-in user — including a subscriber — could enumerate the processing status of arbitrary attachments via `wp.heartbeat.enqueue( 'videopress_processing_ids', [1,2,3,…] )` (IDOR, FIND-08).
* Gate each ID on `current_user_can( 'edit_post', $id )` so status is only returned for attachments the current user can actually manage. This is per-object authorization (not a blanket capability), so it also blocks cross-user enumeration between media managers — not just subscribers. It matches the per-post `edit_post` check already used in `class-block-editor-content.php` for gating VideoPress content access.
* This doesn't restrict legitimate use: the polled IDs only ever come from attachments already shown in the user's own media library grid, which they can edit.
* Added PHPUnit coverage: a subscriber, a logged-out user, and an author requesting another user's attachment all receive no status, while a user editing their own media continues to get statuses. Existing positive tests were updated to run as an authenticated `author` (not admin), since media management is not admin-only.

## Related product discussion/links
* https://linear.app/a8c/issue/VIDP-231/find-08-heartbeat-videopress-status-endpoint-lacks-ownership-check

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Build and deploy the change to a test site (e.g. via Jurassic Ninja) with VideoPress active.
* As an **author/administrator**, go to **Media → Library** and upload a video so it shows as "processing". Confirm the grid updates the status automatically (Heartbeat poll), exactly as before.
* As a **subscriber** (or while logged out), open the browser console on any page and run:
  ```js
  wp.heartbeat.enqueue( 'videopress_processing_ids', [ 1, 2, 3, 4, 5, 6 ] );
  ```
  Inspect the next Heartbeat `admin-ajax.php` response. **Before** this change it contained a `videopress_processing_status` map; **after** this change it does not.
* Run the package tests:
  ```
  cd projects/packages/videopress && composer phpunit -- --filter Attachment_Handler_Test
  ```
  All tests should pass.
