### PR TITLE
Content Guidelines: use Jetpack Notice component for AI upgrade notice

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/upgrade-notice.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/upgrade-notice.jsx
@@ -1,12 +1,14 @@
 import { useAICheckout, useAiFeature } from '@automattic/jetpack-ai-client';
-import { Button, Notice } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { Notice } from '@automattic/jetpack-components';
+import { Button } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { recordAiEvent } from '../lib/tracks';
 
 export default function UpgradeNotice() {
 	const { hasFeature } = useAiFeature();
 	const { checkoutUrl } = useAICheckout();
+	const [ isDismissed, setIsDismissed ] = useState( false );
 
 	const handleUpgradeClick = useCallback( () => {
 		recordAiEvent( 'jetpack_ai_upgrade_button', {
@@ -14,32 +16,36 @@ export default function UpgradeNotice() {
 		} );
 	}, [] );
 
-	if ( hasFeature ) {
+	const handleClose = useCallback( () => {
+		setIsDismissed( true );
+	}, [] );
+
+	if ( hasFeature || isDismissed ) {
 		return null;
 	}
 
-	return (
-		<Notice
-			status="success"
-			isDismissible
-			className="jetpack-content-guidelines-ai__upgrade-notice"
-		>
-			<p>
-				{ __(
-					'Not sure where to start? Jetpack can read your site and suggest guidelines tailored to your content. Upgrade to get started.',
-					'jetpack'
-				) }
-			</p>
-			{ checkoutUrl && (
+	const actions = checkoutUrl
+		? [
 				<Button
+					key="upgrade"
 					variant="primary"
 					href={ checkoutUrl }
 					target="_blank"
 					onClick={ handleUpgradeClick }
 				>
 					{ __( 'Upgrade', 'jetpack' ) }
-				</Button>
-			) }
-		</Notice>
+				</Button>,
+		  ]
+		: undefined;
+
+	return (
+		<div className="jetpack-content-guidelines-ai__upgrade-notice">
+			<Notice level="success" onClose={ handleClose } actions={ actions }>
+				{ __(
+					'Not sure where to start? Jetpack can read your site and suggest guidelines tailored to your content. Upgrade to get started.',
+					'jetpack'
+				) }
+			</Notice>
+		</div>
 	);
 }

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-notice-component
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-notice-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Guidelines: use the Jetpack design-system Notice component for the AI upgrade notice.


### PR DESCRIPTION
## Proposed changes

Switches the Content Guidelines **AI upgrade notice** from the `@wordpress/components` `Notice` (green-tinted box) to the Jetpack design-system `Notice` from `@automattic/jetpack-components` (white card with a green left-accent bar), to match the design mockup.

* `status="success"` → `level="success"` (the Jetpack `Notice` prop).
* CTA moved into the component's `actions={[…]}` array; the existing `Upgrade` button, `checkoutUrl`, `target="_blank"`, and `jetpack_ai_upgrade_button` tracking are unchanged.
* `isDismissible` → a real `onClose` handler backed by `useState`, so the dismiss button now actually hides the notice (previously the `Notice` had no `onRemove`, so the X did nothing).
* The layout class (`width`/`margin`) moved onto a wrapper `<div>` because the Jetpack `Notice` doesn't accept `className`. No SCSS changes were needed.

### Notes for reviewers / design

* The Jetpack `Notice` **always renders a status icon** (a green check on the left) and a plain X — neither is configurable via props. The mockup didn't show the left check icon, so the result is ~95% of the mockup with that icon present. Flagging for design sign-off.
* Convention check: across the monorepo `@wordpress/components` `Notice` is used in ~47 places (including the rest of this settings page), while the `@automattic/jetpack-components` `Notice` box is used in only one other place — My Jetpack's SEO opt-in promo card. This change is consistent with that one upsell-card precedent, but it does introduce the design-system look into an otherwise wp-admin-native settings page. Opening as **draft** for that reason.

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_ai_upgrade_button` event is preserved as-is.

## Testing instructions

* On a site **without** a paid Jetpack AI plan, open the Content Guidelines settings where the upgrade notice renders.
* Confirm the notice now appears as a white card with a green left-accent bar, a green check icon, the body copy, and an `Upgrade` button.
* Click **Upgrade** → opens the checkout URL in a new tab (tracking event fires).
* Click the **X** → the notice dismisses.
* ⚠️ The JS bundle (`_inc/build/content-guidelines-ai.min.js`) was **not** rebuilt in this branch (local build was blocked by environment tooling). Run `jetpack build plugins/jetpack` before testing locally / before marking ready for review.

<sub>Before/after of the component swap (CSS-faithful mock — green-tinted WP `Notice` vs. white-card Jetpack `Notice`):</sub>
