### PR TITLE
CODEOWNERS: Add VideoPress team as owner of the videopress package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@
 /projects/packages/sync/src @Automattic/jetpack-vulcan
 /projects/packages/connection/src/class-package-version.php
 /projects/packages/sync/src/class-package-version.php
+/projects/packages/videopress @Automattic/VideoPress
 
 # Plugins
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,7 @@
 /projects/packages/connection/src/class-package-version.php
 /projects/packages/sync/src/class-package-version.php
 /projects/packages/videopress/src @Automattic/VideoPress
-/projects/packages/videopress/src/class-package-version.php
+/projects/packages/videopress/src/class-package-version.php # No owner - too noisy
 
 # Plugins
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,6 +62,7 @@
 /projects/packages/connection/src/class-package-version.php
 /projects/packages/sync/src/class-package-version.php
 /projects/packages/videopress @Automattic/VideoPress
+/projects/packages/videopress/src/class-package-version.php
 
 # Plugins
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,7 +61,7 @@
 /projects/packages/sync/src @Automattic/jetpack-vulcan
 /projects/packages/connection/src/class-package-version.php
 /projects/packages/sync/src/class-package-version.php
-/projects/packages/videopress @Automattic/VideoPress
+/projects/packages/videopress/src @Automattic/VideoPress
 /projects/packages/videopress/src/class-package-version.php
 
 # Plugins


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add `@Automattic/VideoPress` as the code owner for `projects/packages/videopress/src`, so the team is automatically requested for review on changes to the package source.
* Scope ownership to `src/` (matching the connection and sync packages) so the team is not pinged on `composer.lock` dependency bumps, `CHANGELOG.md`/`changelog/` release updates, or other non-source churn.
* Exclude `projects/packages/videopress/src/class-package-version.php` from ownership (no-owner override), so the team is not pinged on automated package-version bumps.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* This is a metadata-only change to `.github/CODEOWNERS`; there is nothing to test functionally.
* Confirm the `# Packages` section ends with:
  ```
  /projects/packages/videopress/src @Automattic/VideoPress
  /projects/packages/videopress/src/class-package-version.php
  ```
* After merge, a PR touching files under `projects/packages/videopress/src/` should auto-request review from the VideoPress team, while a PR that only bumps `class-package-version.php`, `composer.lock`, or `CHANGELOG.md` should not.
