### PR TITLE
Social: limit modernized dashboard to connection management for non-admins

### DIFF
--- a/projects/packages/publicize/_inc/components/overview-tab/index.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/index.tsx
@@ -1,6 +1,7 @@
 import useConnectionErrorNotice, {
 	ConnectionError,
 } from '@automattic/jetpack-connection/use-connection-error-notice';
+import { currentUserCan } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
@@ -65,6 +66,13 @@ export default function OverviewTab(): JSX.Element {
 		[]
 	);
 
+	// Social traffic is read from the WPCOM stats endpoint, which requires
+	// `view_stats` — a capability non-admins lack, so the fetch 403s and the
+	// card falls into its error state. Admins are the only role we expose
+	// client-side, so gate the whole chart on `manage_options`: non-admins
+	// only get the connection-management UI below.
+	const canManageOptions = currentUserCan( 'manage_options' );
+
 	return (
 		<div className="jetpack-social-overview">
 			{ hasConnectionError && (
@@ -82,13 +90,14 @@ export default function OverviewTab(): JSX.Element {
 			 */ }
 			{ ! hasConnections && <ThemedConnectionsModal /> }
 			{ /*
-			 * Traffic chart only renders when at least one connection
-			 * exists, so the no-connections state focuses the user on
-			 * the onboarding CTA in the accounts card. Once a single
-			 * account is connected, the chart appears above with the
+			 * Traffic chart only renders for admins with at least one
+			 * connection. The no-connections state focuses the user on
+			 * the onboarding CTA in the accounts card; non-admins never
+			 * see the chart at all (they can't read stats). Once an admin
+			 * connects a single account, the chart appears above with the
 			 * paid/free/empty branches taking over from there.
 			 */ }
-			{ hasConnections && <TrafficChartCard /> }
+			{ hasConnections && canManageOptions && <TrafficChartCard /> }
 			<Card.Root>
 				{ hasConnections && (
 					<Card.Header className="jetpack-social-overview__accounts-card-header">

--- a/projects/packages/publicize/_inc/components/overview-tab/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/test/index.test.tsx
@@ -1,0 +1,76 @@
+import { currentUserCan } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import OverviewTab from '..';
+
+// Avoid pulling the real social store (and its @wordpress/editor imports)
+// into the test.
+jest.mock( '../../../social-store', () => ( { store: 'jetpack-social' } ) );
+
+// Stub the heavy children so this test isolates OverviewTab's gating — what
+// renders for admins vs non-admins.
+jest.mock( '../traffic-chart-card', () => () => <div data-testid="traffic-chart-card" /> );
+jest.mock( '../../connection-management', () => () => <div data-testid="connection-management" /> );
+jest.mock( '../../manage-connections-modal', () => ( {
+	ThemedConnectionsModal: () => <div data-testid="connections-modal" />,
+} ) );
+
+jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
+	__esModule: true,
+	default: () => ( { hasConnectionError: false } ),
+	ConnectionError: () => <div data-testid="connection-error" />,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: () => ( { openConnectionsModal: jest.fn() } ),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	currentUserCan: jest.fn(),
+} ) );
+
+const mockUseSelect = useSelect as jest.Mock;
+const mockCurrentUserCan = currentUserCan as jest.Mock;
+
+/**
+ * Configure the Overview tab's inputs.
+ *
+ * @param overrides                - State overrides.
+ * @param overrides.hasConnections - Whether the site has any social connections.
+ * @param overrides.manageOptions  - Whether the current user has manage_options.
+ */
+function setup( { hasConnections = true, manageOptions = true } = {} ) {
+	mockUseSelect.mockImplementation( ( mapSelect: ( select: unknown ) => unknown ) =>
+		mapSelect( () => ( {
+			getConnections: () => ( hasConnections ? [ { connection_id: '1' } ] : [] ),
+		} ) )
+	);
+	mockCurrentUserCan.mockImplementation( cap =>
+		cap === 'manage_options' ? manageOptions : false
+	);
+}
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'OverviewTab', () => {
+	it( 'shows the traffic chart to admins that have connections', () => {
+		setup( { hasConnections: true, manageOptions: true } );
+
+		render( <OverviewTab /> );
+
+		expect( screen.getByTestId( 'traffic-chart-card' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'connection-management' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the traffic chart from non-admins but keeps connection management', () => {
+		setup( { hasConnections: true, manageOptions: false } );
+
+		render( <OverviewTab /> );
+
+		expect( screen.queryByTestId( 'traffic-chart-card' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'connection-management' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -1,5 +1,5 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
-import { getSiteData } from '@automattic/jetpack-script-data';
+import { currentUserCan, getSiteData } from '@automattic/jetpack-script-data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
@@ -56,6 +56,12 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 	const { gate, dismissPricing } = useSocialGate();
 	const headerActions = gate === null ? actions : null;
 
+	// Both the Settings tab and the Overview stats chart require admin-only
+	// capabilities (`manage_options` / stats reads), so non-admins have nothing
+	// to switch between — drop the tab chrome entirely and show the lone
+	// connection-management surface the Overview route hands us.
+	const canManageOptions = currentUserCan( 'manage_options' );
+
 	// Keep the route at `/` and toggle tabs via a `?tab=` search param so the
 	// `Tabs.Root` mounts once and the active-tab indicator can animate.
 	const onTabChange = useCallback(
@@ -83,25 +89,31 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 					actions={ headerActions }
 				>
 					<SocialGate gate={ gate } onDismissPricing={ dismissPricing }>
-						<Tabs.Root
-							className="jetpack-social-tabs"
-							value={ activeTab }
-							onValueChange={ onTabChange }
-						>
-							<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
-								<Tabs.List variant="minimal">
-									<Tabs.Tab value="overview">
-										{ __( 'Overview', 'jetpack-publicize-pkg' ) }
-									</Tabs.Tab>
-									<Tabs.Tab value="settings">
-										{ __( 'Settings', 'jetpack-publicize-pkg' ) }
-									</Tabs.Tab>
-								</Tabs.List>
-							</div>
+						{ canManageOptions ? (
+							<Tabs.Root
+								className="jetpack-social-tabs"
+								value={ activeTab }
+								onValueChange={ onTabChange }
+							>
+								<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
+									<Tabs.List variant="minimal">
+										<Tabs.Tab value="overview">
+											{ __( 'Overview', 'jetpack-publicize-pkg' ) }
+										</Tabs.Tab>
+										<Tabs.Tab value="settings">
+											{ __( 'Settings', 'jetpack-publicize-pkg' ) }
+										</Tabs.Tab>
+									</Tabs.List>
+								</div>
+								<div className="jetpack-social-page__content jetpack-social-page__content--padded">
+									{ children }
+								</div>
+							</Tabs.Root>
+						) : (
 							<div className="jetpack-social-page__content jetpack-social-page__content--padded">
 								{ children }
 							</div>
-						</Tabs.Root>
+						) }
 					</SocialGate>
 				</AdminPage>
 			</Tooltip.Provider>

--- a/projects/packages/publicize/_inc/components/test/social-page.test.tsx
+++ b/projects/packages/publicize/_inc/components/test/social-page.test.tsx
@@ -1,0 +1,78 @@
+import { currentUserCan } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import { Tabs } from '@wordpress/ui';
+import SocialPage from '../social-page';
+
+// AdminPage pulls in the full jetpack-components chrome (and its build
+// artifact); stub it down to a passthrough so this test isolates the tab nav.
+jest.mock( '@automattic/jetpack-components/admin-page', () => ( {
+	__esModule: true,
+	default: ( { children, actions }: { children: React.ReactNode; actions?: React.ReactNode } ) => (
+		<div>
+			{ actions }
+			{ children }
+		</div>
+	),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteData: () => ( {} ),
+	currentUserCan: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useNavigate: () => jest.fn(),
+} ) );
+
+// The gate decision is exercised elsewhere; force the happy path (no gate)
+// so SocialGate just renders the tab block.
+jest.mock( '../social-gate', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+jest.mock( '../social-gate/use-social-gate', () => ( {
+	__esModule: true,
+	default: () => ( { gate: null, dismissPricing: jest.fn() } ),
+} ) );
+
+const mockCurrentUserCan = currentUserCan as jest.Mock;
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'SocialPage', () => {
+	it( 'renders the Overview and Settings tabs for admins', () => {
+		mockCurrentUserCan.mockReturnValue( true );
+
+		render(
+			<SocialPage activeTab="overview">
+				<Tabs.Panel value="overview">
+					<div data-testid="overview-content" />
+				</Tabs.Panel>
+				<Tabs.Panel value="settings">
+					<div data-testid="settings-content" />
+				</Tabs.Panel>
+			</SocialPage>
+		);
+
+		const tabs = screen.getAllByRole( 'tab' );
+		expect( tabs ).toHaveLength( 2 );
+		expect( screen.getByRole( 'tab', { name: 'Overview' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: 'Settings' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders no tab chrome for non-admins, only the content', () => {
+		mockCurrentUserCan.mockReturnValue( false );
+
+		render(
+			<SocialPage activeTab="overview">
+				<div data-testid="overview-content" />
+			</SocialPage>
+		);
+
+		expect( screen.queryAllByRole( 'tab' ) ).toHaveLength( 0 );
+		expect( screen.queryByRole( 'tab', { name: 'Settings' } ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'overview-content' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/changelog/fix-social-modernized-non-admins
+++ b/projects/packages/publicize/changelog/fix-social-modernized-non-admins
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Social modernized dashboard (behind rsm_jetpack_ui_modernization_social): hide the Overview stats chart and the Settings tab from non-admins, leaving only the connection-management UI.
+
+

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -1,5 +1,5 @@
 import analytics from '@automattic/jetpack-analytics';
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { currentUserCan, getScriptData } from '@automattic/jetpack-script-data';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -56,7 +56,13 @@ const Stage = () => {
 		strict: false,
 	} ) as StageSearch;
 
-	const activeTab: SocialTab = search.tab === 'settings' ? 'settings' : 'overview';
+	// Non-admins can't read stats or change settings, so the page collapses to
+	// the Overview (connection-management) surface — `SocialPage` drops the tab
+	// chrome for them, and we ignore any stale `?tab=settings` left in the URL.
+	const canManageOptions = currentUserCan( 'manage_options' );
+
+	const activeTab: SocialTab =
+		canManageOptions && search.tab === 'settings' ? 'settings' : 'overview';
 
 	const actions = activeTab === 'overview' ? <AddAccountAction /> : null;
 
@@ -87,12 +93,18 @@ const Stage = () => {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<SocialPage activeTab={ activeTab } actions={ actions }>
-				<Tabs.Panel value="overview">
-					{ activeTab === 'overview' ? <OverviewTab /> : null }
-				</Tabs.Panel>
-				<Tabs.Panel value="settings">
-					{ activeTab === 'settings' ? <SettingsTab /> : null }
-				</Tabs.Panel>
+				{ canManageOptions ? (
+					<>
+						<Tabs.Panel value="overview">
+							{ activeTab === 'overview' ? <OverviewTab /> : null }
+						</Tabs.Panel>
+						<Tabs.Panel value="settings">
+							{ activeTab === 'settings' ? <SettingsTab /> : null }
+						</Tabs.Panel>
+					</>
+				) : (
+					<OverviewTab />
+				) }
 			</SocialPage>
 		</QueryClientProvider>
 	);


### PR DESCRIPTION
Fixes #

## Proposed changes

The modernized Social dashboard (behind the `rsm_jetpack_ui_modernization_social` filter) exposed the Overview stats chart and the Settings tab to non-admins, who can't act on either:

* Gate the Overview "Traffic from social media" chart behind `manage_options`. Non-admins lack `view_stats`, so the stats fetch 403'd and the card fell into its error state ("Couldn't load traffic data"). They no longer see the chart at all.
* Hide the Settings tab — and the entire tab chrome — for non-admins. The modernized dashboard collapses to the connection-management surface, which is the only thing they can use.
* Ignore a stale `?tab=settings` in the URL for non-admins, so the Settings panel can't be reached directly.
* Add unit tests: the Overview chart gating (admins vs non-admins) and the tab visibility on the page shell.

`manage_options` is the gate because it's the only admin capability exposed client-side (`class-script-data.php`), and it matches the legacy admin page and the existing message-templates card.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Internal report from the Social modernization rollout.

## Does this pull request change what data or activity we track or use?

No new tracking. The existing `jetpack_social_tab_view` event is unchanged; non-admins now only ever record `tab: overview` since that's the only surface they see.

## Testing instructions

1. Enable the modernized Social dashboard by adding a mu-plugin (e.g. `wp-content/mu-plugins/social-modern.php`):
   ```php
   <?php
   add_filter( 'rsm_jetpack_ui_modernization_social', '__return_true' );
   ```
2. As an **admin**, go to **Jetpack → Social**. Confirm:
   * Both **Overview** and **Settings** tabs appear.
   * The **Traffic from social media** chart renders on Overview (or its paid/free/empty state).
   * The **Settings** tab shows the settings cards.
3. Log in as a **non-admin** (Editor or Author) and open the same Social page. Confirm:
   * There is **no tab bar** (no Overview/Settings tabs).
   * There is **no traffic chart** and **no "Couldn't load traffic data" error**.
   * The connected-accounts / connection-management card **is** present.
4. Still as the non-admin, append `?tab=settings` to the URL and reload — confirm it still shows the connection-management view, not the Settings cards.
