### PR TITLE
Forms: fix multistep nav buttons floating/cramping when a button width is set

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-multistep-nav-button-width
+++ b/projects/packages/forms/changelog/fix-forms-multistep-nav-button-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Multistep forms: fix navigation buttons floating and the button gap collapsing on the frontend when a button width is set.

--- a/projects/packages/forms/changelog/fix-forms-multistep-nav-button-width
+++ b/projects/packages/forms/changelog/fix-forms-multistep-nav-button-width
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Multistep forms: fix navigation buttons floating and the button gap collapsing on the frontend when a button width is set.
+Multistep forms: Fix navigation buttons floating and the button gap collapsing on the frontend when a button width is set.

--- a/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
@@ -17,23 +17,6 @@
 	}
 }
 
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]),
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-button[style*="width:"]) {
-	gap: var(--wp--style--block-gap, 1.5rem) 0;
-}
-
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link,
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"] .wp-block-button__link {
-	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
-}
-
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit,
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-next,
-.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-submit {
-	float: right;
-}
-
 .wp-block-jetpack-form-step-navigation__wrapper {
 	width: 100%;
 }

--- a/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/editor.scss
@@ -17,6 +17,22 @@
 	}
 }
 
+// Legacy jetpack/button nav buttons only — see style.scss. The core/button
+// equivalents were removed (FORMS-576); these are kept so existing
+// jetpack/button forms render unchanged in the editor.
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]) {
+	gap: var(--wp--style--block-gap, 1.5rem) 0;
+}
+
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link {
+	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
+}
+
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
+.editor-styles-wrapper .wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit {
+	float: right;
+}
+
 .wp-block-jetpack-form-step-navigation__wrapper {
 	width: 100%;
 }

--- a/projects/packages/forms/src/blocks/form-step-navigation/style.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/style.scss
@@ -9,24 +9,6 @@
 	flex-wrap: inherit;
 }
 
-.wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]),
-.wp-block-jetpack-form-step-navigation:has(.wp-block-button[style*="width:"]) {
-	gap: 0;
-}
-
-.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link,
-.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"] .wp-block-button__link {
-	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
-	white-space: nowrap;
-}
-
-.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
-.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit,
-.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-next,
-.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"].is-submit {
-	float: right;
-}
-
 .contact-form .wp-block-jetpack-form-step-navigation .wp-block-button__link {
 	width: 100%;
 }

--- a/projects/packages/forms/src/blocks/form-step-navigation/style.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/style.scss
@@ -9,6 +9,24 @@
 	flex-wrap: inherit;
 }
 
+// Legacy jetpack/button nav buttons only. The equivalent core/button rules were
+// removed (FORMS-576) because the float + zeroed gap made width-driven wrapping
+// overlap. These are kept untouched so existing jetpack/button forms (which
+// migrate to core/button on next edit) render exactly as before.
+.wp-block-jetpack-form-step-navigation:has(.wp-block-jetpack-button[style*="width:"]) {
+	gap: 0;
+}
+
+.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .wp-block-button__link {
+	width: calc(100% - var(--wp--style--block-gap, 1.5rem) / 2);
+	white-space: nowrap;
+}
+
+.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-next,
+.wp-block-jetpack-form-step-navigation .wp-block-jetpack-button[style*="width:"] .is-submit {
+	float: right;
+}
+
 .contact-form .wp-block-jetpack-form-step-navigation .wp-block-button__link {
 	width: 100%;
 }

--- a/projects/packages/forms/src/blocks/form-step-navigation/style.scss
+++ b/projects/packages/forms/src/blocks/form-step-navigation/style.scss
@@ -27,6 +27,12 @@
 	float: right;
 }
 
+// Keep #44926 (no inner-text wrap) for width-set core/button nav buttons,
+// without the float / gap:0 / width-calc that caused the overlap (FORMS-576).
+.wp-block-jetpack-form-step-navigation .wp-block-button[style*="width:"] .wp-block-button__link {
+	white-space: nowrap;
+}
+
 .contact-form .wp-block-jetpack-form-step-navigation .wp-block-button__link {
 	width: 100%;
 }


### PR DESCRIPTION
## Proposed changes

* Multistep form navigation buttons (Back / Next / Submit) rendered incorrectly on the **frontend** when a button width was set: the affected button got `float: right` and the navigation container's `gap` collapsed to `0`, so width‑driven wrapping produced cramped / overlapping buttons.
* **Root cause:** a `[style*="width:"]`‑keyed CSS bundle in `form-step-navigation` (`gap: 0` + `width: calc(100% - gap/2)` + `float: right`) originally written for the `jetpack/button` multistep nav and later carried over to `core/button`. It was a compensation for the flex `gap` + percentage‑width overflow case (two 50% buttons + gap > 100% → wrap), but it fires whenever *any* nav button has a width and breaks the wrap case. The editor stylesheet kept a row‑gap while the frontend zeroed it entirely, which is why this only showed on the frontend.
* **Fix:** remove the bundle from both `style.scss` and `editor.scss`. Native flexbox now handles button widths, wrapping, and spacing. Button widths themselves are unaffected — they come from the separate `wp-block-button__width-*` class path.

Width compensation:

| Before | After |
|--------|--------|
| <img width="900" height="1200" alt="576ab-twentytwentyfive-before" src="https://github.com/user-attachments/assets/e7b47eb3-a2cc-4689-a197-18134a2d3cbe" /> | <img width="900" height="1200" alt="576ab-twentytwentyfive-after" src="https://github.com/user-attachments/assets/e823e38e-dfdb-46b8-94ff-decf26b84c0f" /> | 


Gap on wrap:

| Before | After |
|--------|--------|
| <img width="900" height="1100" alt="576ab-twentytwentyfive-last-before" src="https://github.com/user-attachments/assets/5f0192af-41fe-4a19-8560-cd2eac57da37" /> | <img width="900" height="1100" alt="576ab-twentytwentyfive-last-after" src="https://github.com/user-attachments/assets/a019a799-9160-4f70-b7a4-3a174aefe0f7" /> | 



## Related product discussion/links

* FORMS-576

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable the multistep form feature, add a **Form** block, and pick the **Multistep Form** variation.
* Select a navigation button (Back / Next / Submit) → **Styles → Dimensions → Width**, and set a width (e.g. Next or Submit to 50%, or any button to 100%).
* Publish and view the form on the frontend; advance to a step that shows two nav buttons (e.g. the last step with **Back + Submit**).
* **Before** this change: the floated button overlaps/crowds its sibling and the gap between buttons collapses to `0`.
* **After:** buttons keep the theme's normal gap, no floating, and the widths still apply. Verified across Twenty Twenty‑Five, Twenty Seventeen, and Astra.


