### PR TITLE
AI Editorial Review: remove the per-feature enablement filter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-aer-remove-proprietary-filter
+++ b/projects/plugins/jetpack/changelog/update-aer-remove-proprietary-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Editorial Review: gate the sidebar suggestion on Big Sky availability and AI features instead of the jetpack_ai_editorial_review_enabled filter, which is removed.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -274,16 +274,14 @@ class Jetpack_AI_Sidebar {
 	 * UI feature flag for AI Editorial Review.
 	 *
 	 * Server-side permission checks still gate execution. This site-side flag
-	 * controls whether the sidebar suggestion is exposed, while keeping a
-	 * feature-specific filter available as a kill switch.
+	 * exposes the suggestion whenever the Big Sky sidebar is enabled and Jetpack
+	 * AI features are available — condition-based gating like the other sidebar
+	 * suggestions, with no per-feature filter override.
 	 *
 	 * @return bool
 	 */
 	private static function is_ai_editorial_review_enabled(): bool {
-		return (bool) apply_filters(
-			'jetpack_ai_editorial_review_enabled',
-			true
-		);
+		return self::is_jetpack_ai_sidebar_preview_enabled() && self::has_ai_features();
 	}
 
 	/**
@@ -402,8 +400,8 @@ class Jetpack_AI_Sidebar {
 
 		// Set our fields in place, leaving the rest of $data (including agentProviders)
 		// untouched so the client-side gate can drop Jetpack AI Sidebar while keeping
-		// fallbacks such as the Big Sky provider. Hosts that need intentional overrides
-		// should use the AI Editorial Review and preview filters.
+		// fallbacks such as the Big Sky provider. Hosts that need to force the
+		// sidebar on or off should use the jetpack_ai_sidebar_enabled filter.
 		foreach ( self::get_sidebar_am_fields() as $key => $value ) {
 			$data[ $key ] = $value;
 		}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -103,7 +103,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
-		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -323,23 +322,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the preview surface can initialize without AI Editorial Review.
-	 */
-	public function test_init_registers_hooks_when_preview_is_enabled_without_ai_editorial_review() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		Jetpack_AI_Sidebar::init();
-
-		$this->assertNotFalse(
-			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should be hooked when the preview gate is true.'
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
-			'maybe_enqueue_abilities_script should be hooked when the preview gate is true.'
-		);
-	}
-
-	/**
 	 * Test that init() registers hooks when the feature filter is true.
 	 */
 	public function test_init_registers_hooks_when_enabled() {
@@ -482,23 +464,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that the Agents Manager block-editor gate preserves existing true values.
 	 */
 	public function test_enable_agents_manager_in_post_editor_preserves_existing_true() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_page_block_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( true ) );
-	}
-
-	/**
-	 * The AI Editorial Review filter is decoupled from this Agents Manager entrypoint.
-	 *
-	 * The preview gate is wpcom/Big Sky-based, so turning AI Editorial Review off
-	 * does not close the gate (AI Editorial Review only affects the exposed data).
-	 */
-	public function test_enable_agents_manager_in_post_editor_ignores_ai_editorial_review_filter() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		$this->set_block_editor_screen();
-
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	/**
@@ -520,7 +488,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
 		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -615,22 +582,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Preview and AI Editorial Review have separate gates.
-	 */
-	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
-		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-
-		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-	}
-
-	/**
 	 * Platform-emitted preview data is scoped to the post editor.
 	 */
 	public function test_add_agents_manager_data_skips_page_editor() {
@@ -639,6 +590,20 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
+	}
+
+	/**
+	 * No preview fields are emitted when Jetpack AI features are unavailable, so
+	 * AI Editorial Review tracks the surface gate rather than a per-feature filter.
+	 */
+	public function test_add_agents_manager_data_skips_when_ai_disabled() {
+		$this->set_block_editor_screen();
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the `jetpack_ai_editorial_review_enabled` filter and gate the AI Editorial Review sidebar suggestion on the same condition as its sibling suggestions — the Big Sky sidebar being available and Jetpack AI features being present (`is_jetpack_ai_sidebar_preview_enabled() && has_ai_features()`).
* This drops AI Editorial Review's per-feature kill switch so no sidebar suggestion carries a bespoke enablement filter. The surface-level `jetpack_ai_sidebar_enabled` override still gates the whole sidebar.
* Update PHPUnit coverage: remove the cases that toggled the removed filter, and add coverage for the AI-features-off path.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* WPCOM companion — symmetric backend change that removes Generate Feedback's `wpcom_generate_feedback_enabled` filter, so neither feature keeps a per-feature enablement filter: 224903-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

