### PR TITLE
fix: [Search] Replace zero-width space in .legend::after with min-height

### DIFF
--- a/projects/js-packages/components/changelog/fix-search-pricing-legend-min-height
+++ b/projects/js-packages/components/changelog/fix-search-pricing-legend-min-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bug
+
+Replace zero-width space in `.legend::after` pseudo-element with `min-height` to prevent junk text rendering in Chrome.

--- a/projects/js-packages/components/changelog/fix-search-pricing-legend-min-height
+++ b/projects/js-packages/components/changelog/fix-search-pricing-legend-min-height
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bug
+Type: fixed
 
 Replace zero-width space in `.legend::after` pseudo-element with `min-height` to prevent junk text rendering in Chrome.

--- a/projects/js-packages/components/components/product-price/style.module.scss
+++ b/projects/js-packages/components/components/product-price/style.module.scss
@@ -56,7 +56,7 @@
 	color: var(--jp-gray-40);
 	font-size: var(--font-body-small);
 	line-height: 20px;
-	min-height: 20px;
+	min-height: 20px; // Reserve a line of height even when the legend is empty
 }
 
 .promo-label {

--- a/projects/js-packages/components/components/product-price/style.module.scss
+++ b/projects/js-packages/components/components/product-price/style.module.scss
@@ -56,10 +56,7 @@
 	color: var(--jp-gray-40);
 	font-size: var(--font-body-small);
 	line-height: 20px;
-
-	&::after {
-		content: "\200B"; // Pseudo element to keep height
-	}
+	min-height: 20px;
 }
 
 .promo-label {


### PR DESCRIPTION
## What does this PR do?

Replaces the zero-width space character (`\200B`) in the `.legend::after` pseudo-element with a `min-height` property. The zero-width space was intermittently rendering as visible junk text in Chrome. Using `min-height: 20px` achieves the same layout goal (preventing the element from collapsing when empty) without putting any invisible characters in the DOM.

Fixes #27034

## Testing instructions

1. Install the Jetpack Search plugin
2. Navigate to the Search pricing page (wp-admin → Jetpack → Search)
3. View the page in Chrome
4. Confirm no junk text appears under the Free plan price

## Changelog

- Added changelog entry for `@automattic/jetpack-components`