### PR TITLE
Podcast: gate paid surfaces on the Growth plan for self-hosted sites

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-with-jetpack-pricing
+++ b/projects/packages/podcast/changelog/add-podcast-with-jetpack-pricing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Resolve the podcast premium gate over the Jetpack connection so self-hosted Growth sites unlock the paid surfaces while free sites keep the feed plus settings, and point the upsell at the Growth plan on self-hosted.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -134,12 +134,21 @@ class Admin_Page {
 			$data = array();
 		}
 
+		// Self-hosted upsells the Growth plan; WordPress.com keeps Premium.
+		// `product_slug` is fed straight to the checkout URL; `plan_name` is a
+		// product name shown in the locked-preview copy (not translated).
+		$is_wpcom = ( new Host() )->is_wpcom_platform();
+
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
 			// Settings only: categories rejects per_page=-1 server-side, stats is a live relay.
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
+			'upgrade'             => array(
+				'product_slug' => $is_wpcom ? 'premium' : 'jetpack_growth_yearly',
+				'plan_name'    => $is_wpcom ? 'Premium' : 'Growth',
+			),
 		);
 
 		return $data;

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -21,7 +21,8 @@ class Admin_Page {
 	/**
 	 * Query var the checkout return URL carries so the gate busts its cached
 	 * purchases lookup the instant a buyer lands back on the dashboard. Kept in
-	 * sync with `PURCHASE_RETURN_PARAM` in `src/dashboard/upgrade.ts`.
+	 * sync with the `podcast_purchased` literal in `withPurchaseReturnMarker()`
+	 * (`src/dashboard/upgrade.ts`).
 	 */
 	const PURCHASE_RETURN_QUERY_VAR = 'podcast_purchased';
 

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -19,6 +19,13 @@ class Admin_Page {
 	const ADMIN_PAGE_SLUG = 'jetpack-podcast';
 
 	/**
+	 * Query var the checkout return URL carries so the gate busts its cached
+	 * purchases lookup the instant a buyer lands back on the dashboard. Kept in
+	 * sync with `PURCHASE_RETURN_PARAM` in `src/dashboard/upgrade.ts`.
+	 */
+	const PURCHASE_RETURN_QUERY_VAR = 'podcast_purchased';
+
+	/**
 	 * Where the Podcast item sits in the Jetpack submenu on self-hosted.
 	 *
 	 * Placed after Subscribers (15) and Newsletter (10) to mirror the order
@@ -132,6 +139,14 @@ class Admin_Page {
 	public static function inject_podcast_script_data( $data ) {
 		if ( ! is_array( $data ) ) {
 			$data = array();
+		}
+
+		// A buyer returning from checkout carries the purchase marker; bust the
+		// cached purchases lookup so the gate re-reads `/upgrades` and unlocks
+		// the paid surfaces now instead of after the transient expires.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET[ self::PURCHASE_RETURN_QUERY_VAR ] ) ) {
+			Podcast_Gate::flush_purchases_cache();
 		}
 
 		// Self-hosted upsells the Growth plan; WordPress.com keeps Premium.

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -44,11 +44,19 @@ class Podcast_Gate {
 	const PAID_PLAN_SLUG_PREFIXES = array( 'jetpack_growth', 'jetpack_complete' );
 
 	/**
-	 * Transient holding the cached `/upgrades` response. Short-lived: long
-	 * enough to dedupe across a page load, short enough that a fresh Growth
-	 * purchase unlocks the surfaces without a long wait.
+	 * Transient holding the cached `/upgrades` response. Short-lived (see
+	 * `PURCHASES_TTL`): mainly dedupes the lookup across a single page load.
+	 * A buyer returning from checkout busts it outright via
+	 * `flush_purchases_cache()`, so the TTL only bounds the unlikely case where
+	 * that signal is missed.
 	 */
 	const PURCHASES_TRANSIENT = 'jetpack_podcast_site_purchases';
+
+	/**
+	 * How long the cached `/upgrades` response lives, in seconds. Kept short so
+	 * a plan change is reflected quickly even without the checkout-return bust.
+	 */
+	const PURCHASES_TTL = 30;
 
 	/**
 	 * Request-scoped memo of the purchases lookup (including failures, so a
@@ -78,6 +86,16 @@ class Podcast_Gate {
 		}
 
 		return (bool) Current_Plan::supports( self::FEATURE_SLUG );
+	}
+
+	/**
+	 * Drop the cached purchases lookup so the next access check re-reads
+	 * `/upgrades`. Called when a buyer returns from checkout so a fresh plan
+	 * unlocks the paid surfaces immediately rather than after the TTL.
+	 */
+	public static function flush_purchases_cache(): void {
+		delete_transient( self::PURCHASES_TRANSIENT );
+		self::$purchases_cache = null;
 	}
 
 	/**
@@ -139,7 +157,7 @@ class Podcast_Gate {
 			return self::$purchases_cache;
 		}
 
-		set_transient( self::PURCHASES_TRANSIENT, $decoded, 5 * MINUTE_IN_SECONDS );
+		set_transient( self::PURCHASES_TRANSIENT, $decoded, self::PURCHASES_TTL );
 		self::$purchases_cache = $decoded;
 		return self::$purchases_cache;
 	}

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -38,25 +38,12 @@ class Podcast_Gate {
 	const GRANDFATHER_CUTOFF_DATE = '2026-05-18';
 
 	/**
-	 * Product-slug prefixes that unlock the paid surfaces on self-hosted
-	 * Jetpack. Matched as prefixes so every billing term/tier counts.
-	 */
-	const PAID_PLAN_SLUG_PREFIXES = array( 'jetpack_growth', 'jetpack_complete' );
-
-	/**
-	 * Transient holding the cached `/upgrades` response. Short-lived (see
-	 * `PURCHASES_TTL`): mainly dedupes the lookup across a single page load.
-	 * A buyer returning from checkout busts it outright via
-	 * `flush_purchases_cache()`, so the TTL only bounds the unlikely case where
-	 * that signal is missed.
+	 * Transient holding the cached `/upgrades` response. Short-lived (30s, set
+	 * below): mainly dedupes the lookup across a single page load. A buyer
+	 * returning from checkout busts it outright via `flush_purchases_cache()`,
+	 * so the TTL only bounds the unlikely case where that signal is missed.
 	 */
 	const PURCHASES_TRANSIENT = 'jetpack_podcast_site_purchases';
-
-	/**
-	 * How long the cached `/upgrades` response lives, in seconds. Kept short so
-	 * a plan change is reflected quickly even without the checkout-return bust.
-	 */
-	const PURCHASES_TTL = 30;
 
 	/**
 	 * Request-scoped memo of the purchases lookup (including failures, so a
@@ -110,7 +97,9 @@ class Podcast_Gate {
 		foreach ( self::get_site_current_purchases() as $purchase ) {
 			$slug = is_array( $purchase ) && isset( $purchase['product_slug'] ) ? $purchase['product_slug'] : '';
 
-			foreach ( self::PAID_PLAN_SLUG_PREFIXES as $prefix ) {
+			// Growth and Complete bundles unlock the paid surfaces; matched as
+			// prefixes so every billing term/tier counts.
+			foreach ( array( 'jetpack_growth', 'jetpack_complete' ) as $prefix ) {
 				if ( is_string( $slug ) && 0 === strpos( $slug, $prefix ) ) {
 					return true;
 				}
@@ -157,7 +146,9 @@ class Podcast_Gate {
 			return self::$purchases_cache;
 		}
 
-		set_transient( self::PURCHASES_TRANSIENT, $decoded, self::PURCHASES_TTL );
+		// 30s: short enough that a plan change shows up quickly even if the
+		// checkout-return bust is missed, long enough to dedupe a page load.
+		set_transient( self::PURCHASES_TRANSIENT, $decoded, 30 );
 		self::$purchases_cache = $decoded;
 		return self::$purchases_cache;
 	}

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -124,7 +124,8 @@ class Podcast_Gate {
 
 		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/upgrades?site=%d', (int) Jetpack_Options::get_option( 'id' ) ),
-			'1.2'
+			'1.2',
+			array( 'method' => 'GET' )
 		);
 
 		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -90,9 +90,7 @@ class Podcast_Gate {
 	 */
 	private static function self_hosted_has_paid_plan(): bool {
 		foreach ( self::get_site_current_purchases() as $purchase ) {
-			$slug = is_object( $purchase )
-				? ( $purchase->product_slug ?? '' )
-				: ( $purchase['product_slug'] ?? '' );
+			$slug = is_array( $purchase ) && isset( $purchase['product_slug'] ) ? $purchase['product_slug'] : '';
 
 			foreach ( self::PAID_PLAN_SLUG_PREFIXES as $prefix ) {
 				if ( is_string( $slug ) && 0 === strpos( $slug, $prefix ) ) {

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -7,14 +7,24 @@
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status\Host;
+use Jetpack_Options;
 
 /**
  * Premium podcast feature gate.
  *
- * Operates on the current blog. `Current_Plan::supports` reads request-scoped
- * state, so callers that need to gate a different blog must `switch_to_blog`
- * first.
+ * Resolves the paid surfaces (episode dashboard, stats, episode block) two
+ * ways depending on the host:
+ *
+ * - WordPress.com (Simple/WoA): the `podcasting` plan feature via
+ *   `Current_Plan::supports`, plus the launch-day grandfather rule. Reads
+ *   request-scoped state, so callers gating a different blog must
+ *   `switch_to_blog` first.
+ * - Self-hosted Jetpack: the site's purchased plan over the Jetpack
+ *   connection. Per PODS-123, the Growth (and Complete) plans unlock the paid
+ *   surfaces; everything else is feed-only.
  */
 class Podcast_Gate {
 
@@ -23,16 +33,41 @@ class Podcast_Gate {
 	/**
 	 * Launch-day cutoff for the paying-blog grandfather rule. Paid blogs
 	 * registered before this date keep Premium podcast features without
-	 * needing the `podcasting` plan feature.
+	 * needing the `podcasting` plan feature. WordPress.com only.
 	 */
 	const GRANDFATHER_CUTOFF_DATE = '2026-05-18';
 
 	/**
-	 * Whether the current blog can use Premium podcast features.
+	 * Product-slug prefixes that unlock the paid surfaces on self-hosted
+	 * Jetpack. Matched as prefixes so every billing term/tier counts.
+	 */
+	const PAID_PLAN_SLUG_PREFIXES = array( 'jetpack_growth', 'jetpack_complete' );
+
+	/**
+	 * Transient holding the cached `/upgrades` response. Short-lived: long
+	 * enough to dedupe across a page load, short enough that a fresh Growth
+	 * purchase unlocks the surfaces without a long wait.
+	 */
+	const PURCHASES_TRANSIENT = 'jetpack_podcast_site_purchases';
+
+	/**
+	 * Request-scoped memo of the purchases lookup (including failures, so a
+	 * failed fetch isn't retried mid-request). Null until first resolved.
+	 *
+	 * @var array|null
+	 */
+	private static $purchases_cache = null;
+
+	/**
+	 * Whether the current site can use the paid podcast surfaces.
 	 *
 	 * @return bool
 	 */
 	public static function has_product_access(): bool {
+		if ( ! ( new Host() )->is_wpcom_platform() ) {
+			return self::self_hosted_has_paid_plan();
+		}
+
 		$blog_id = get_current_blog_id();
 		if ( $blog_id <= 0 ) {
 			return false;
@@ -43,6 +78,71 @@ class Podcast_Gate {
 		}
 
 		return (bool) Current_Plan::supports( self::FEATURE_SLUG );
+	}
+
+	/**
+	 * Whether a self-hosted Jetpack site owns a Growth (or Complete) plan.
+	 *
+	 * Mirrors the bundle-detection pattern used by My Jetpack's Growth/Security
+	 * products: match purchased product slugs rather than the `podcasting`
+	 * feature, which maps to all Jetpack sites on WordPress.com and so can't
+	 * distinguish free from paid here.
+	 */
+	private static function self_hosted_has_paid_plan(): bool {
+		foreach ( self::get_site_current_purchases() as $purchase ) {
+			$slug = is_object( $purchase )
+				? ( $purchase->product_slug ?? '' )
+				: ( $purchase['product_slug'] ?? '' );
+
+			foreach ( self::PAID_PLAN_SLUG_PREFIXES as $prefix ) {
+				if ( is_string( $slug ) && 0 === strpos( $slug, $prefix ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The site's current purchases from WordPress.com (`/upgrades`).
+	 *
+	 * Fails closed: an unreachable or malformed response returns no purchases
+	 * and isn't written to the transient, so the next request retries rather
+	 * than serving a stale empty result.
+	 *
+	 * @return array List of purchase entries (associative arrays); empty on failure.
+	 */
+	private static function get_site_current_purchases(): array {
+		if ( null !== self::$purchases_cache ) {
+			return self::$purchases_cache;
+		}
+
+		$cached = get_transient( self::PURCHASES_TRANSIENT );
+		if ( is_array( $cached ) ) {
+			self::$purchases_cache = $cached;
+			return self::$purchases_cache;
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/upgrades?site=%d', (int) Jetpack_Options::get_option( 'id' ) ),
+			'1.2'
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			self::$purchases_cache = array();
+			return self::$purchases_cache;
+		}
+
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $decoded ) ) {
+			self::$purchases_cache = array();
+			return self::$purchases_cache;
+		}
+
+		set_transient( self::PURCHASES_TRANSIENT, $decoded, 5 * MINUTE_IN_SECONDS );
+		self::$purchases_cache = $decoded;
+		return self::$purchases_cache;
 	}
 
 	/**

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -5,6 +5,10 @@ declare module '@automattic/jetpack-script-data' {
 			show_url_hosts?: Record< string, readonly string[] >;
 			show_url_max_length?: number;
 			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;
+			upgrade?: {
+				product_slug?: string;
+				plan_name?: string;
+			};
 		};
 	}
 }

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -60,10 +60,7 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 			  )
 			: sprintf(
 					/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
-					__(
-						'Upgrade to %s to see downloads by episode, app, and country.',
-						'jetpack-podcast'
-					),
+					__( 'Upgrade to %s to see downloads by episode, app, and country.', 'jetpack-podcast' ),
 					planName
 			  );
 

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -2,10 +2,10 @@
 // non-language skeleton of the gated content behind a centered upgrade card.
 
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getSiteData } from '@automattic/jetpack-script-data';
+import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useId } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 
 export type LockedPreviewVariant = 'episodes' | 'stats';
@@ -18,6 +18,11 @@ const Skeleton = () => <span className="podcast-locked-preview__cell-skeleton" /
 
 const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 	const siteSuffix = getSiteData()?.suffix ?? '';
+	// Self-hosted upsells Growth, WordPress.com Premium; the server picks the
+	// product slug + plan name to match the host.
+	const upgrade = getScriptData()?.podcast?.upgrade;
+	const productSlug = upgrade?.product_slug ?? 'premium';
+	const planName = upgrade?.plan_name ?? 'Premium';
 	const returnUrl = window.location.href;
 	const checkoutUrl = ( () => {
 		if ( ! siteSuffix ) {
@@ -25,7 +30,7 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 		}
 		// `getProductCheckoutUrl` sets `redirect_to`; the cart's close button
 		// reads `cancel_to`, so both need to point back to the dashboard.
-		const url = new URL( getProductCheckoutUrl( 'premium', siteSuffix, returnUrl, true ) );
+		const url = new URL( getProductCheckoutUrl( productSlug, siteSuffix, returnUrl, true ) );
 		url.searchParams.set( 'cancel_to', returnUrl );
 		return url.toString();
 	} )();
@@ -33,17 +38,33 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 	const titleId = useId();
 	const title =
 		variant === 'episodes'
-			? __( 'Episode dashboard included with Premium', 'jetpack-podcast' )
-			: __( 'Episode stats included with Premium', 'jetpack-podcast' );
+			? sprintf(
+					/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+					__( 'Episode dashboard included with %s', 'jetpack-podcast' ),
+					planName
+			  )
+			: sprintf(
+					/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+					__( 'Episode stats included with %s', 'jetpack-podcast' ),
+					planName
+			  );
 	const description =
 		variant === 'episodes'
-			? __(
-					'Upgrade to Premium to manage your podcast catalog from a unified dashboard.',
-					'jetpack-podcast'
+			? sprintf(
+					/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+					__(
+						'Upgrade to %s to manage your podcast catalog from a unified dashboard.',
+						'jetpack-podcast'
+					),
+					planName
 			  )
-			: __(
-					'Upgrade to Premium to see downloads by episode, app, and country.',
-					'jetpack-podcast'
+			: sprintf(
+					/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+					__(
+						'Upgrade to %s to see downloads by episode, app, and country.',
+						'jetpack-podcast'
+					),
+					planName
 			  );
 
 	return (
@@ -132,7 +153,11 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus
 					>
-						{ __( 'Upgrade to Premium', 'jetpack-podcast' ) }
+						{ sprintf(
+							/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+							__( 'Upgrade to %s', 'jetpack-podcast' ),
+							planName
+						) }
 					</Button>
 				</div>
 			</div>

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -5,7 +5,7 @@ import { getSiteData } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
+import { buildUpgradeCheckoutUrl, getUpgradePlanName, withPurchaseReturnMarker } from '../upgrade';
 import './style.scss';
 
 export type LockedPreviewVariant = 'episodes' | 'stats';
@@ -20,10 +20,12 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 	const planName = getUpgradePlanName();
 	const returnUrl = window.location.href;
 	// `getProductCheckoutUrl` sets `redirect_to`; the cart's close button reads
-	// `cancel_to`, so both point back to the current dashboard view.
+	// `cancel_to`. Both point back to the current dashboard view, but only the
+	// post-purchase `redirect_to` carries the marker — a cancel shouldn't bust
+	// the cache for an unchanged plan.
 	const checkoutUrl = buildUpgradeCheckoutUrl( {
 		siteSlug: getSiteData()?.suffix ?? '',
-		returnUrl,
+		returnUrl: withPurchaseReturnMarker( returnUrl ),
 		params: { cancel_to: returnUrl },
 		noSiteSlugUrl: 'https://wordpress.com/pricing',
 	} );

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -1,11 +1,11 @@
 // Locked-preview UX for Episodes + Stats on free plans. Renders a blurred,
 // non-language skeleton of the gated content behind a centered upgrade card.
 
-import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
+import { getSiteData } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
 export type LockedPreviewVariant = 'episodes' | 'stats';
@@ -17,23 +17,16 @@ interface LockedPreviewProps {
 const Skeleton = () => <span className="podcast-locked-preview__cell-skeleton" />;
 
 const LockedPreview = ( { variant }: LockedPreviewProps ) => {
-	const siteSuffix = getSiteData()?.suffix ?? '';
-	// Self-hosted upsells Growth, WordPress.com Premium; the server picks the
-	// product slug + plan name to match the host.
-	const upgrade = getScriptData()?.podcast?.upgrade;
-	const productSlug = upgrade?.product_slug ?? 'premium';
-	const planName = upgrade?.plan_name ?? 'Premium';
+	const planName = getUpgradePlanName();
 	const returnUrl = window.location.href;
-	const checkoutUrl = ( () => {
-		if ( ! siteSuffix ) {
-			return 'https://wordpress.com/pricing';
-		}
-		// `getProductCheckoutUrl` sets `redirect_to`; the cart's close button
-		// reads `cancel_to`, so both need to point back to the dashboard.
-		const url = new URL( getProductCheckoutUrl( productSlug, siteSuffix, returnUrl, true ) );
-		url.searchParams.set( 'cancel_to', returnUrl );
-		return url.toString();
-	} )();
+	// `getProductCheckoutUrl` sets `redirect_to`; the cart's close button reads
+	// `cancel_to`, so both point back to the current dashboard view.
+	const checkoutUrl = buildUpgradeCheckoutUrl( {
+		siteSlug: getSiteData()?.suffix ?? '',
+		returnUrl,
+		params: { cancel_to: returnUrl },
+		noSiteSlugUrl: 'https://wordpress.com/pricing',
+	} );
 
 	const titleId = useId();
 	const title =

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -32,6 +32,13 @@ interface UpgradeCheckoutUrlArgs {
 
 /**
  * Build the podcast upsell checkout URL for the injected upgrade product.
+ *
+ * @param {UpgradeCheckoutUrlArgs} args               - Checkout URL arguments.
+ * @param {string}                 args.siteSlug      - Calypso site fragment; empty falls back to `noSiteSlugUrl`.
+ * @param {string}                 args.returnUrl     - Where checkout returns after purchase (`redirect_to`).
+ * @param {object}                 [args.params]      - Extra query params to set on the checkout URL.
+ * @param {string}                 args.noSiteSlugUrl - URL to use when there's no site slug.
+ * @return {string} The checkout URL for the injected upgrade product.
  */
 export const buildUpgradeCheckoutUrl = ( {
 	siteSlug,
@@ -43,7 +50,9 @@ export const buildUpgradeCheckoutUrl = ( {
 		return noSiteSlugUrl;
 	}
 
-	const url = new URL( getProductCheckoutUrl( getUpgradeProductSlug(), siteSlug, returnUrl, true ) );
+	const url = new URL(
+		getProductCheckoutUrl( getUpgradeProductSlug(), siteSlug, returnUrl, true )
+	);
 	if ( params ) {
 		for ( const [ key, value ] of Object.entries( params ) ) {
 			url.searchParams.set( key, value );

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -19,6 +19,26 @@ export const getUpgradeProductSlug = (): string =>
 export const getUpgradePlanName = (): string =>
 	getScriptData()?.podcast?.upgrade?.plan_name ?? DEFAULT_PLAN_NAME;
 
+// Marker the server watches for (Admin_Page::PURCHASE_RETURN_QUERY_VAR) to bust
+// its cached purchases lookup the instant a buyer returns from checkout.
+export const PURCHASE_RETURN_PARAM = 'podcast_purchased';
+
+/**
+ * Append the post-checkout marker to a return URL so the server re-reads the
+ * site's plan on arrival and unlocks the paid surfaces without waiting on cache.
+ *
+ * @param {string} url - The checkout return URL; an empty string is passed through.
+ * @return {string} The URL carrying the purchase-return marker.
+ */
+export const withPurchaseReturnMarker = ( url: string ): string => {
+	if ( ! url ) {
+		return url;
+	}
+	const next = new URL( url );
+	next.searchParams.set( PURCHASE_RETURN_PARAM, '1' );
+	return next.toString();
+};
+
 interface UpgradeCheckoutUrlArgs {
 	/** Calypso site fragment (`site.suffix`); empty falls back to `noSiteSlugUrl`. */
 	siteSlug: string;

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -1,0 +1,53 @@
+// Shared upsell helpers for the podcast dashboard. `getProductCheckoutUrl` is
+// the canonical Calypso checkout-URL builder, so it stays the one place the URL
+// format lives; callers only vary the return target, extra params, and the
+// no-site-slug fallback.
+
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+import { getScriptData } from '@automattic/jetpack-script-data';
+
+// Self-hosted upsells Growth, WordPress.com Premium; the server injects the
+// matching slug + plan name (see Admin_Page::inject_podcast_script_data). The
+// defaults reproduce today's Premium/WordPress.com behavior for an old bundle
+// running against PHP that doesn't yet inject `upgrade`.
+const DEFAULT_PRODUCT_SLUG = 'premium';
+const DEFAULT_PLAN_NAME = 'Premium';
+
+export const getUpgradeProductSlug = (): string =>
+	getScriptData()?.podcast?.upgrade?.product_slug ?? DEFAULT_PRODUCT_SLUG;
+
+export const getUpgradePlanName = (): string =>
+	getScriptData()?.podcast?.upgrade?.plan_name ?? DEFAULT_PLAN_NAME;
+
+interface UpgradeCheckoutUrlArgs {
+	/** Calypso site fragment (`site.suffix`); empty falls back to `noSiteSlugUrl`. */
+	siteSlug: string;
+	/** Where checkout returns after purchase (`redirect_to`). */
+	returnUrl: string;
+	/** Extra query params to set on the checkout URL (e.g. `source`, `cancel_to`). */
+	params?: Record< string, string >;
+	/** URL to use when there's no site slug to build a per-site checkout from. */
+	noSiteSlugUrl: string;
+}
+
+/**
+ * Build the podcast upsell checkout URL for the injected upgrade product.
+ */
+export const buildUpgradeCheckoutUrl = ( {
+	siteSlug,
+	returnUrl,
+	params,
+	noSiteSlugUrl,
+}: UpgradeCheckoutUrlArgs ): string => {
+	if ( ! siteSlug ) {
+		return noSiteSlugUrl;
+	}
+
+	const url = new URL( getProductCheckoutUrl( getUpgradeProductSlug(), siteSlug, returnUrl, true ) );
+	if ( params ) {
+		for ( const [ key, value ] of Object.entries( params ) ) {
+			url.searchParams.set( key, value );
+		}
+	}
+	return url.toString();
+};

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -8,24 +8,20 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 
 // Self-hosted upsells Growth, WordPress.com Premium; the server injects the
 // matching slug + plan name (see Admin_Page::inject_podcast_script_data). The
-// defaults reproduce today's Premium/WordPress.com behavior for an old bundle
-// running against PHP that doesn't yet inject `upgrade`.
-const DEFAULT_PRODUCT_SLUG = 'premium';
-const DEFAULT_PLAN_NAME = 'Premium';
-
+// `'premium'` / `'Premium'` fallbacks reproduce today's Premium/WordPress.com
+// behavior for an old bundle running against PHP that doesn't yet inject
+// `upgrade`.
 export const getUpgradeProductSlug = (): string =>
-	getScriptData()?.podcast?.upgrade?.product_slug ?? DEFAULT_PRODUCT_SLUG;
+	getScriptData()?.podcast?.upgrade?.product_slug ?? 'premium';
 
 export const getUpgradePlanName = (): string =>
-	getScriptData()?.podcast?.upgrade?.plan_name ?? DEFAULT_PLAN_NAME;
-
-// Marker the server watches for (Admin_Page::PURCHASE_RETURN_QUERY_VAR) to bust
-// its cached purchases lookup the instant a buyer returns from checkout.
-export const PURCHASE_RETURN_PARAM = 'podcast_purchased';
+	getScriptData()?.podcast?.upgrade?.plan_name ?? 'Premium';
 
 /**
  * Append the post-checkout marker to a return URL so the server re-reads the
  * site's plan on arrival and unlocks the paid surfaces without waiting on cache.
+ *
+ * The `podcast_purchased` literal must match `Admin_Page::PURCHASE_RETURN_QUERY_VAR`.
  *
  * @param {string} url - The checkout return URL; an empty string is passed through.
  * @return {string} The URL carrying the purchase-return marker.
@@ -35,7 +31,7 @@ export const withPurchaseReturnMarker = ( url: string ): string => {
 		return url;
 	}
 	const next = new URL( url );
-	next.searchParams.set( PURCHASE_RETURN_PARAM, '1' );
+	next.searchParams.set( 'podcast_purchased', '1' );
 	return next.toString();
 };
 

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,6 +1,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getSiteData } from '@automattic/jetpack-script-data';
+import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -13,7 +13,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
 import './style.scss';
 
@@ -23,9 +23,17 @@ interface WelcomeProps {
 
 const CHECKOUT_SOURCE = 'jetpack-podcast-welcome';
 
-const getPremiumCheckoutUrl = (): string => {
+// Self-hosted upsells Growth, WordPress.com Premium; the server injects the
+// matching product slug.
+const getUpgradeProductSlug = (): string =>
+	getScriptData()?.podcast?.upgrade?.product_slug ?? 'premium';
+
+const getUpgradePlanName = (): string => getScriptData()?.podcast?.upgrade?.plan_name ?? 'Premium';
+
+const getUpgradeCheckoutUrl = (): string => {
 	const data = getSiteData();
 	const adminUrl = data?.admin_url ?? '';
+	const productSlug = getUpgradeProductSlug();
 
 	// Prefer `site.suffix` since it preserves the full Calypso site fragment
 	// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
@@ -40,7 +48,7 @@ const getPremiumCheckoutUrl = (): string => {
 	}
 
 	if ( ! slug ) {
-		return 'https://wordpress.com/checkout/premium';
+		return `https://wordpress.com/checkout/${ productSlug }`;
 	}
 
 	// `tab=settings` bypasses the welcome gate so buyers continue configuring
@@ -48,7 +56,7 @@ const getPremiumCheckoutUrl = (): string => {
 	const returnTo = adminUrl
 		? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
 		: '';
-	const url = new URL( getProductCheckoutUrl( 'premium', slug, returnTo, true ) );
+	const url = new URL( getProductCheckoutUrl( productSlug, slug, returnTo, true ) );
 	// Calypso threads `source` through its downstream Tracks events.
 	url.searchParams.set( 'source', CHECKOUT_SOURCE );
 	return url.toString();
@@ -121,7 +129,8 @@ const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = 
 ];
 
 const Welcome = ( { onEnable }: WelcomeProps ) => {
-	const premiumCheckoutUrl = getPremiumCheckoutUrl();
+	const upgradeCheckoutUrl = getUpgradeCheckoutUrl();
+	const planName = getUpgradePlanName();
 
 	// Fire-and-forget Tracks; the anchor handles navigation so middle/cmd-click
 	// still opens checkout in a new tab and "copy link address" shows the URL.
@@ -195,7 +204,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 								<VStack spacing={ 2 }>
 									<HStack justify="space-between" alignment="center">
 										<Text size="title" weight={ 500 }>
-											{ __( 'Premium', 'jetpack-podcast' ) }
+											{ planName }
 										</Text>
 										<span className="podcast__welcome-plan-badge">
 											{ __( 'Popular', 'jetpack-podcast' ) }
@@ -208,8 +217,12 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 										) }
 									</Text>
 								</VStack>
-								<Button variant="primary" href={ premiumCheckoutUrl } onClick={ onPremiumClick }>
-									{ __( 'Start your premium podcast', 'jetpack-podcast' ) }
+								<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onPremiumClick }>
+									{ sprintf(
+										/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+										__( 'Start your %s podcast', 'jetpack-podcast' ),
+										planName
+									) }
 								</Button>
 								<ul className="podcast__welcome-plan-features">
 									{ PREMIUM_FEATURES.map( feature => (

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,6 +1,5 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getScriptData, getSiteData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { getAdminUrl, getSiteData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -15,6 +14,7 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
+import { buildUpgradeCheckoutUrl, getUpgradeProductSlug, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
 interface WelcomeProps {
@@ -23,17 +23,9 @@ interface WelcomeProps {
 
 const CHECKOUT_SOURCE = 'jetpack-podcast-welcome';
 
-// Self-hosted upsells Growth, WordPress.com Premium; the server injects the
-// matching product slug.
-const getUpgradeProductSlug = (): string =>
-	getScriptData()?.podcast?.upgrade?.product_slug ?? 'premium';
-
-const getUpgradePlanName = (): string => getScriptData()?.podcast?.upgrade?.plan_name ?? 'Premium';
-
 const getUpgradeCheckoutUrl = (): string => {
 	const data = getSiteData();
 	const adminUrl = data?.admin_url ?? '';
-	const productSlug = getUpgradeProductSlug();
 
 	// Prefer `site.suffix` since it preserves the full Calypso site fragment
 	// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
@@ -47,19 +39,17 @@ const getUpgradeCheckoutUrl = (): string => {
 		}
 	}
 
-	if ( ! slug ) {
-		return `https://wordpress.com/checkout/${ productSlug }`;
-	}
-
 	// `tab=settings` bypasses the welcome gate so buyers continue configuring
 	// the podcast instead of re-seeing this same pricing card after checkout.
-	const returnTo = adminUrl
-		? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
-		: '';
-	const url = new URL( getProductCheckoutUrl( productSlug, slug, returnTo, true ) );
-	// Calypso threads `source` through its downstream Tracks events.
-	url.searchParams.set( 'source', CHECKOUT_SOURCE );
-	return url.toString();
+	const returnTo = adminUrl ? getAdminUrl( 'admin.php?page=jetpack-podcast&tab=settings' ) : '';
+
+	return buildUpgradeCheckoutUrl( {
+		siteSlug: slug,
+		returnUrl: returnTo,
+		// Calypso threads `source` through its downstream Tracks events.
+		params: { source: CHECKOUT_SOURCE },
+		noSiteSlugUrl: `https://wordpress.com/checkout/${ getUpgradeProductSlug() }`,
+	} );
 };
 
 const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string } > = [

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,6 +1,10 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
+import {
+	getScriptData,
+	getSiteData,
+	isWpcomPlatformSite,
+} from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -89,18 +93,33 @@ const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string 
 	},
 ];
 
-const FREE_FEATURES: ReadonlyArray< string > = [
+// WordPress.com hosts the audio (and sells storage); self-hosted Jetpack sites
+// serve audio from their own media library, so the plan copy differs by host.
+const FREE_FEATURES_WPCOM: ReadonlyArray< string > = [
 	__( 'Publish a podcast with audio hosted on another site', 'jetpack-podcast' ),
 	__( 'Distribute to Apple, Spotify, and every major app', 'jetpack-podcast' ),
 	__( 'Submission-ready RSS feed for every directory', 'jetpack-podcast' ),
 ];
 
-const PREMIUM_FEATURES: ReadonlyArray< string > = [
+const FREE_FEATURES_SELF_HOSTED: ReadonlyArray< string > = [
+	__( 'Publish a podcast with audio from your own media library', 'jetpack-podcast' ),
+	__( 'Distribute to Apple, Spotify, and every major app', 'jetpack-podcast' ),
+	__( 'Submission-ready RSS feed for every directory', 'jetpack-podcast' ),
+];
+
+const PAID_FEATURES_WPCOM: ReadonlyArray< string > = [
 	__( 'Host your podcast on WordPress.com with 13 GB of storage', 'jetpack-podcast' ),
 	__( 'Distribute to Apple, Spotify, and every major app', 'jetpack-podcast' ),
 	__( 'Submission-ready RSS feed for every directory', 'jetpack-podcast' ),
 	__( 'Podcast stats including downloads by app and country', 'jetpack-podcast' ),
 	__( 'Episode dashboard', 'jetpack-podcast' ),
+	__( 'Episode player block for your posts', 'jetpack-podcast' ),
+];
+
+const PAID_FEATURES_SELF_HOSTED: ReadonlyArray< string > = [
+	__( 'Everything in the free plan', 'jetpack-podcast' ),
+	__( 'Podcast stats including downloads by app and country', 'jetpack-podcast' ),
+	__( 'Episode dashboard to manage your catalog', 'jetpack-podcast' ),
 	__( 'Episode player block for your posts', 'jetpack-podcast' ),
 ];
 
@@ -131,6 +150,19 @@ const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = 
 const Welcome = ( { onEnable }: WelcomeProps ) => {
 	const upgradeCheckoutUrl = getUpgradeCheckoutUrl();
 	const planName = getUpgradePlanName();
+	const isWpcom = isWpcomPlatformSite();
+
+	const freeFeatures = isWpcom ? FREE_FEATURES_WPCOM : FREE_FEATURES_SELF_HOSTED;
+	const paidFeatures = isWpcom ? PAID_FEATURES_WPCOM : PAID_FEATURES_SELF_HOSTED;
+	const paidDescription = isWpcom
+		? __(
+				'Host your podcast at WordPress.com and get all the advanced features.',
+				'jetpack-podcast'
+		  )
+		: __(
+				'Unlock podcast stats, the episode dashboard, and the episode block.',
+				'jetpack-podcast'
+		  );
 
 	// Fire-and-forget Tracks; the anchor handles navigation so middle/cmd-click
 	// still opens checkout in a new tab and "copy link address" shows the URL.
@@ -182,7 +214,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 									{ __( 'Start your podcast', 'jetpack-podcast' ) }
 								</Button>
 								<ul className="podcast__welcome-plan-features">
-									{ FREE_FEATURES.map( feature => (
+									{ freeFeatures.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">
 											<span aria-hidden="true">
 												<Icon icon={ check } size={ 20 } />
@@ -210,12 +242,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 											{ __( 'Popular', 'jetpack-podcast' ) }
 										</span>
 									</HStack>
-									<Text variant="muted">
-										{ __(
-											'Host your podcast at WordPress.com and get all the advanced features.',
-											'jetpack-podcast'
-										) }
-									</Text>
+									<Text variant="muted">{ paidDescription }</Text>
 								</VStack>
 								<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onPremiumClick }>
 									{ sprintf(
@@ -225,7 +252,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 									) }
 								</Button>
 								<ul className="podcast__welcome-plan-features">
-									{ PREMIUM_FEATURES.map( feature => (
+									{ paidFeatures.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">
 											<span aria-hidden="true">
 												<Icon icon={ check } size={ 20 } />

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -14,7 +14,12 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
-import { buildUpgradeCheckoutUrl, getUpgradeProductSlug, getUpgradePlanName } from '../upgrade';
+import {
+	buildUpgradeCheckoutUrl,
+	getUpgradeProductSlug,
+	getUpgradePlanName,
+	withPurchaseReturnMarker,
+} from '../upgrade';
 import './style.scss';
 
 interface WelcomeProps {
@@ -40,8 +45,12 @@ const getUpgradeCheckoutUrl = (): string => {
 	}
 
 	// `tab=settings` bypasses the welcome gate so buyers continue configuring
-	// the podcast instead of re-seeing this same pricing card after checkout.
-	const returnTo = adminUrl ? getAdminUrl( 'admin.php?page=jetpack-podcast&tab=settings' ) : '';
+	// the podcast instead of re-seeing this same pricing card after checkout;
+	// the purchase marker busts the server's cached plan so access flips on
+	// arrival.
+	const returnTo = adminUrl
+		? withPurchaseReturnMarker( getAdminUrl( 'admin.php?page=jetpack-podcast&tab=settings' ) )
+		: '';
 
 	return buildUpgradeCheckoutUrl( {
 		siteSlug: slug,

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -152,7 +152,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 
 	// Fire-and-forget Tracks; the anchor handles navigation so middle/cmd-click
 	// still opens checkout in a new tab and "copy link address" shows the URL.
-	const onPremiumClick = useCallback( () => {
+	const onUpgradeClick = useCallback( () => {
 		const currentPlan = getSiteData()?.plan?.product_slug;
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_premium_upgrade_clicked', {
 			current_plan: currentPlan ?? '',
@@ -230,7 +230,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 									</HStack>
 									<Text variant="muted">{ paidDescription }</Text>
 								</VStack>
-								<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onPremiumClick }>
+								<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onUpgradeClick }>
 									{ sprintf(
 										/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
 										__( 'Start your %s podcast', 'jetpack-podcast' ),

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,10 +1,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import {
-	getScriptData,
-	getSiteData,
-	isWpcomPlatformSite,
-} from '@automattic/jetpack-script-data';
+import { getScriptData, getSiteData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -34,23 +34,11 @@ class Admin_Page_Test extends BaseTestCase {
 		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
 		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
 		unset( $_GET[ Admin_Page::PURCHASE_RETURN_QUERY_VAR ] );
-		delete_transient( Podcast_Gate::PURCHASES_TRANSIENT );
-		self::reset_gate_purchases_cache();
+		// Drops the transient and the request-scoped memo so neither leaks into
+		// a sibling test.
+		Podcast_Gate::flush_purchases_cache();
 		wp_set_current_user( 0 );
 		parent::tearDown();
-	}
-
-	/**
-	 * Clear the gate's request-scoped purchases memo so a seeded transient is
-	 * read fresh (and never leaks into a sibling test).
-	 */
-	private static function reset_gate_purchases_cache(): void {
-		$property = ( new \ReflectionClass( Podcast_Gate::class ) )->getProperty( 'purchases_cache' );
-		// @todo Remove once we drop PHP < 8.1 support.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
-		$property->setValue( null, null );
 	}
 
 	/**
@@ -142,11 +130,12 @@ class Admin_Page_Test extends BaseTestCase {
 	 * `/upgrades` request).
 	 */
 	public function test_inject_script_data_targets_growth_on_self_hosted() {
+		// Clear the memo first, then seed, so the transient is read fresh.
+		Podcast_Gate::flush_purchases_cache();
 		set_transient(
 			Podcast_Gate::PURCHASES_TRANSIENT,
 			array( array( 'product_slug' => 'jetpack_growth_yearly' ) )
 		);
-		self::reset_gate_purchases_cache();
 
 		$data = Admin_Page::inject_podcast_script_data( array() );
 
@@ -166,8 +155,8 @@ class Admin_Page_Test extends BaseTestCase {
 	 */
 	public function test_inject_script_data_busts_stale_purchases_on_return() {
 		// Stale "free" lookup cached before the purchase completed.
+		Podcast_Gate::flush_purchases_cache();
 		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, array() );
-		self::reset_gate_purchases_cache();
 		$_GET[ Admin_Page::PURCHASE_RETURN_QUERY_VAR ] = '1';
 
 		Admin_Page::inject_podcast_script_data( array() );

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -33,6 +33,7 @@ class Admin_Page_Test extends BaseTestCase {
 		Constants::clear_constants();
 		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
 		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
+		unset( $_GET[ Admin_Page::PURCHASE_RETURN_QUERY_VAR ] );
 		delete_transient( Podcast_Gate::PURCHASES_TRANSIENT );
 		self::reset_gate_purchases_cache();
 		wp_set_current_user( 0 );
@@ -157,5 +158,23 @@ class Admin_Page_Test extends BaseTestCase {
 			$data['podcast']['upgrade']
 		);
 		$this->assertTrue( $data['podcast']['has_product_access'] );
+	}
+
+	/**
+	 * A buyer returning from checkout carries the purchase marker, which drops
+	 * the stale (pre-purchase) cached purchases so access is recomputed fresh.
+	 */
+	public function test_inject_script_data_busts_stale_purchases_on_return() {
+		// Stale "free" lookup cached before the purchase completed.
+		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, array() );
+		self::reset_gate_purchases_cache();
+		$_GET[ Admin_Page::PURCHASE_RETURN_QUERY_VAR ] = '1';
+
+		Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertFalse(
+			get_transient( Podcast_Gate::PURCHASES_TRANSIENT ),
+			'The purchase marker should drop the stale cached purchases.'
+		);
 	}
 }

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Podcast\Tests;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
+use Automattic\Jetpack\Podcast\Podcast_Gate;
 use Automattic\Jetpack\Podcast\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -32,8 +33,23 @@ class Admin_Page_Test extends BaseTestCase {
 		Constants::clear_constants();
 		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
 		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
+		delete_transient( Podcast_Gate::PURCHASES_TRANSIENT );
+		self::reset_gate_purchases_cache();
 		wp_set_current_user( 0 );
 		parent::tearDown();
+	}
+
+	/**
+	 * Clear the gate's request-scoped purchases memo so a seeded transient is
+	 * read fresh (and never leaks into a sibling test).
+	 */
+	private static function reset_gate_purchases_cache(): void {
+		$property = ( new \ReflectionClass( Podcast_Gate::class ) )->getProperty( 'purchases_cache' );
+		// @todo Remove once we drop PHP < 8.1 support.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
 	}
 
 	/**
@@ -100,5 +116,46 @@ class Admin_Page_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'preload', $data['podcast'] );
 		$this->assertIsArray( $data['podcast']['preload'] );
+	}
+
+	/**
+	 * WPCOM (Simple/Atomic): the injected upsell points at Premium + WordPress.com checkout.
+	 */
+	public function test_inject_script_data_targets_premium_on_wpcom() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertSame(
+			array(
+				'product_slug' => 'premium',
+				'plan_name'    => 'Premium',
+			),
+			$data['podcast']['upgrade']
+		);
+	}
+
+	/**
+	 * Self-hosted Jetpack: the injected upsell points at the Growth plan. The
+	 * gate's purchases lookup is seeded so this stays a hermetic unit test (no
+	 * `/upgrades` request).
+	 */
+	public function test_inject_script_data_targets_growth_on_self_hosted() {
+		set_transient(
+			Podcast_Gate::PURCHASES_TRANSIENT,
+			array( array( 'product_slug' => 'jetpack_growth_yearly' ) )
+		);
+		self::reset_gate_purchases_cache();
+
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertSame(
+			array(
+				'product_slug' => 'jetpack_growth_yearly',
+				'plan_name'    => 'Growth',
+			),
+			$data['podcast']['upgrade']
+		);
+		$this->assertTrue( $data['podcast']['has_product_access'] );
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -290,4 +290,17 @@ class Podcast_Gate_Test extends BaseTestCase {
 		$this->assertFalse( Podcast_Gate::has_product_access() );
 		$this->assertFalse( get_transient( Podcast_Gate::PURCHASES_TRANSIENT ) );
 	}
+
+	public function test_flush_purchases_cache_drops_transient_and_memo(): void {
+		self::as_self_hosted();
+		self::seed_purchases( array( 'jetpack_growth_yearly' ) );
+		// Prime the request-scoped memo.
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+
+		Podcast_Gate::flush_purchases_cache();
+
+		$this->assertFalse( get_transient( Podcast_Gate::PURCHASES_TRANSIENT ) );
+		// Memo cleared too: the uncached lookup now fails closed (no connection).
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -52,10 +52,10 @@ class Podcast_Gate_Test extends BaseTestCase {
 	 * @param array $slugs Product slugs to present as current purchases.
 	 */
 	private static function seed_purchases( array $slugs ): void {
-		$purchases = array_map(
-			static fn ( $slug ) => array( 'product_slug' => $slug ),
-			$slugs
-		);
+		$purchases = array();
+		foreach ( $slugs as $slug ) {
+			$purchases[] = array( 'product_slug' => $slug );
+		}
 		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, $purchases );
 		self::reset_purchases_cache();
 	}

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -73,7 +73,7 @@ class Podcast_Gate_Test extends BaseTestCase {
 		}
 		return static function () use ( $purchases ) {
 			return array(
-				'body'     => wp_json_encode( $purchases ),
+				'body'     => wp_json_encode( $purchases, JSON_UNESCAPED_SLASHES ),
 				'response' => array(
 					'code'    => 200,
 					'message' => 'OK',

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -7,9 +7,11 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Podcast\Podcast_Gate;
+use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -32,6 +34,7 @@ class Podcast_Gate_Test extends BaseTestCase {
 
 	protected function tearDown(): void {
 		unset( $GLOBALS['jetpack_podcast_test_blog_details'] );
+		remove_all_filters( 'pre_http_request' );
 		Constants::clear_constants();
 		WorDBless_Options::init()->clear_options();
 		self::reset_active_plan_cache();
@@ -44,6 +47,39 @@ class Podcast_Gate_Test extends BaseTestCase {
 	 */
 	private static function as_self_hosted(): void {
 		Constants::clear_single_constant( 'IS_WPCOM' );
+	}
+
+	/**
+	 * Self-hosted path with a connected blog, so the gate's uncached lookup
+	 * actually issues the `/upgrades` request (intercepted via `pre_http_request`).
+	 */
+	private static function as_connected_self_hosted(): void {
+		self::as_self_hosted();
+		( new Tokens() )->update_blog_token( 'test.test' );
+		Jetpack_Options::update_option( 'id', 123 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+	}
+
+	/**
+	 * A 200 `/upgrades` response carrying the given purchase slugs.
+	 *
+	 * @param string[] $slugs Product slugs to return as current purchases.
+	 * @return callable A `pre_http_request` filter.
+	 */
+	private static function upgrades_response( array $slugs ): callable {
+		$purchases = array();
+		foreach ( $slugs as $slug ) {
+			$purchases[] = array( 'product_slug' => $slug );
+		}
+		return static function () use ( $purchases ) {
+			return array(
+				'body'     => wp_json_encode( $purchases ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		};
 	}
 
 	/**
@@ -202,5 +238,56 @@ class Podcast_Gate_Test extends BaseTestCase {
 		self::seed_purchases( array() );
 
 		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_self_hosted_fetches_growth_over_connection_grants_access(): void {
+		self::as_connected_self_hosted();
+		add_filter( 'pre_http_request', self::upgrades_response( array( 'jetpack_growth_yearly' ) ) );
+
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+		// A successful fetch is cached for reuse within the page load.
+		$this->assertSame(
+			array( array( 'product_slug' => 'jetpack_growth_yearly' ) ),
+			get_transient( Podcast_Gate::PURCHASES_TRANSIENT )
+		);
+	}
+
+	public function test_self_hosted_fetch_http_error_denies_and_does_not_cache(): void {
+		self::as_connected_self_hosted();
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return array(
+					'body'     => '',
+					'response' => array(
+						'code'    => 500,
+						'message' => 'Internal Server Error',
+					),
+				);
+			}
+		);
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+		// Fails closed without caching, so the next request retries.
+		$this->assertFalse( get_transient( Podcast_Gate::PURCHASES_TRANSIENT ) );
+	}
+
+	public function test_self_hosted_fetch_malformed_body_denies_access(): void {
+		self::as_connected_self_hosted();
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return array(
+					'body'     => 'not-json',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+				);
+			}
+		);
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+		$this->assertFalse( get_transient( Podcast_Gate::PURCHASES_TRANSIENT ) );
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -29,7 +29,7 @@ class Podcast_Gate_Test extends BaseTestCase {
 		// self-hosted cases clear it explicitly via `as_self_hosted()`.
 		Constants::set_constant( 'IS_WPCOM', true );
 		self::reset_active_plan_cache();
-		self::reset_purchases_cache();
+		Podcast_Gate::flush_purchases_cache();
 	}
 
 	protected function tearDown(): void {
@@ -38,7 +38,7 @@ class Podcast_Gate_Test extends BaseTestCase {
 		Constants::clear_constants();
 		WorDBless_Options::init()->clear_options();
 		self::reset_active_plan_cache();
-		self::reset_purchases_cache();
+		Podcast_Gate::flush_purchases_cache();
 		parent::tearDown();
 	}
 
@@ -88,12 +88,14 @@ class Podcast_Gate_Test extends BaseTestCase {
 	 * @param array $slugs Product slugs to present as current purchases.
 	 */
 	private static function seed_purchases( array $slugs ): void {
+		// Clear the memo (and any stale transient) first, then seed, so the
+		// gate reads the seeded value fresh.
+		Podcast_Gate::flush_purchases_cache();
 		$purchases = array();
 		foreach ( $slugs as $slug ) {
 			$purchases[] = array( 'product_slug' => $slug );
 		}
 		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, $purchases );
-		self::reset_purchases_cache();
 	}
 
 	/**
@@ -101,19 +103,8 @@ class Podcast_Gate_Test extends BaseTestCase {
 	 */
 	private static function reset_active_plan_cache(): void {
 		$property = ( new \ReflectionClass( Current_Plan::class ) )->getProperty( 'active_plan_cache' );
-		// @todo Remove once we drop PHP < 8.1 support.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
-		$property->setValue( null, null );
-	}
-
-	/**
-	 * The gate memoizes purchases per request; clear it between tests.
-	 */
-	private static function reset_purchases_cache(): void {
-		$property = ( new \ReflectionClass( Podcast_Gate::class ) )->getProperty( 'purchases_cache' );
-		// @todo Remove once we drop PHP < 8.1 support.
+		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
+		// deprecated in 8.5 (a no-op since 8.1), so only call it where it's needed.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Podcast\Podcast_Gate;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -22,14 +23,41 @@ class Podcast_Gate_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$GLOBALS['jetpack_podcast_test_blog_details'] = array();
+		// Default these tests to the WordPress.com (feature + grandfather) path;
+		// self-hosted cases clear it explicitly via `as_self_hosted()`.
+		Constants::set_constant( 'IS_WPCOM', true );
 		self::reset_active_plan_cache();
+		self::reset_purchases_cache();
 	}
 
 	protected function tearDown(): void {
 		unset( $GLOBALS['jetpack_podcast_test_blog_details'] );
+		Constants::clear_constants();
 		WorDBless_Options::init()->clear_options();
 		self::reset_active_plan_cache();
+		self::reset_purchases_cache();
 		parent::tearDown();
+	}
+
+	/**
+	 * Switch the gate onto the self-hosted Jetpack path (no WordPress.com host).
+	 */
+	private static function as_self_hosted(): void {
+		Constants::clear_single_constant( 'IS_WPCOM' );
+	}
+
+	/**
+	 * Seed the cached `/upgrades` response the self-hosted path reads.
+	 *
+	 * @param array $slugs Product slugs to present as current purchases.
+	 */
+	private static function seed_purchases( array $slugs ): void {
+		$purchases = array_map(
+			static fn ( $slug ) => array( 'product_slug' => $slug ),
+			$slugs
+		);
+		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, $purchases );
+		self::reset_purchases_cache();
 	}
 
 	/**
@@ -37,6 +65,18 @@ class Podcast_Gate_Test extends BaseTestCase {
 	 */
 	private static function reset_active_plan_cache(): void {
 		$property = ( new \ReflectionClass( Current_Plan::class ) )->getProperty( 'active_plan_cache' );
+		// @todo Remove once we drop PHP < 8.1 support.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * The gate memoizes purchases per request; clear it between tests.
+	 */
+	private static function reset_purchases_cache(): void {
+		$property = ( new \ReflectionClass( Podcast_Gate::class ) )->getProperty( 'purchases_cache' );
 		// @todo Remove once we drop PHP < 8.1 support.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
@@ -117,6 +157,49 @@ class Podcast_Gate_Test extends BaseTestCase {
 		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
 			'registered' => '2027-01-01 00:00:00',
 		);
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_self_hosted_growth_purchase_grants_access(): void {
+		self::as_self_hosted();
+		self::seed_purchases( array( 'jetpack_growth_yearly' ) );
+
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_self_hosted_complete_purchase_grants_access(): void {
+		self::as_self_hosted();
+		self::seed_purchases( array( 'jetpack_complete' ) );
+
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_self_hosted_non_qualifying_purchase_denies_access(): void {
+		self::as_self_hosted();
+		self::seed_purchases( array( 'jetpack_security_t1_yearly' ) );
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_self_hosted_no_purchases_denies_access(): void {
+		self::as_self_hosted();
+		self::seed_purchases( array() );
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	/**
+	 * The `podcasting` plan feature maps to all Jetpack sites on WordPress.com,
+	 * so it can't gate on self-hosted: a free site can report it active. The
+	 * self-hosted path must ignore the feature and require a Growth purchase.
+	 */
+	public function test_self_hosted_ignores_podcasting_feature_without_purchase(): void {
+		self::as_self_hosted();
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( Podcast_Gate::FEATURE_SLUG );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		self::seed_purchases( array() );
 
 		$this->assertFalse( Podcast_Gate::has_product_access() );
 	}


### PR DESCRIPTION
Fixes PODS-181

## Proposed changes

Now that Podcasting ships in the Jetpack plugin for self-hosted sites, the premium gate needs to resolve paid access over the Jetpack connection. This mirrors the WordPress.com gate, with **Growth** as the paid plan instead of Premium: free sites get the feed plus the Settings and Distribution surfaces, and Growth (or Complete) unlocks Stats, the episode dashboard, and the episode block.

* Resolve `Podcast_Gate::has_product_access()` by host. WordPress.com (Simple/Atomic) is unchanged — `Current_Plan::supports( 'podcasting' )` plus the launch-day grandfather rule. Self-hosted now checks the site's purchased plan slugs (`/upgrades`) for `jetpack_growth*` / `jetpack_complete*`, transient-cached and fail-closed.
* Deliberately ignore the `podcasting` plan feature on self-hosted: it maps to all Jetpack sites on WordPress.com, so a free site could report it active. Slug-based detection avoids that leak (covered by a regression test).
* Inject a host-aware upsell target (`product_slug` + `plan_name`) into `window.JetpackScriptData.podcast`. The locked Stats/Episodes previews and the Welcome plan cards now show Premium + WordPress.com checkout on Simple/Atomic, and Growth + Growth checkout on self-hosted.
* Make the Welcome plan-card copy host-aware (WordPress.com audio hosting/storage vs. self-hosted media library), using the shared `isWpcomPlatformSite()` helper.
* Add self-hosted gate tests (Growth/Complete granted; free and the `podcasting`-feature-without-purchase case denied).

Deploy ordering is safe both ways: the dashboard reads `upgrade?.product_slug ?? 'premium'` and `isWpcomPlatformSite()`, so an old bundle against new PHP (or vice-versa) falls back to today's Premium/WordPress.com behavior — no fatal.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a **self-hosted Jetpack site** (e.g. Jurassic Ninja) with the Podcast module enabled:

* **Free / connected:** the Podcast menu appears. Settings and Distribution are usable — set a category, title, and cover art and confirm a working feed. The Stats and Episodes tabs show the locked preview with **Growth** copy and a Growth checkout link. The Welcome card shows the Growth plan with self-hosted (media-library) copy, not WordPress.com hosting.
* **Growth (or Complete) plan:** Stats, Episodes, and the new-episode block prefill are all unlocked.
* Confirm there are no PHP warnings in the log on the free site.

On **WordPress.com (Simple/Atomic):** behavior is unchanged — Premium gating, "Premium" copy, and WordPress.com checkout.