### PR TITLE
Search Blocks: render results and filter buckets on a deep link (?s=)

### DIFF
--- a/projects/packages/search/changelog/fix-search-blocks-deeplink-overlay-double-hydration
+++ b/projects/packages/search/changelog/fix-search-blocks-deeplink-overlay-double-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Fix deep-link searches (?s=) rendering no results or filter buckets by hydrating the overlay once, after the Interactivity runtime's initial walk.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -385,15 +385,10 @@ if ( overlayEl ) {
 }
 
 /**
- * Honor the URL on initial paint: if the page loaded with `?s=`/`?q=`, open the
- * overlay (same as `popstate` on back/forward; matches legacy deep-link and
- * core-search-form behavior).
- *
- * Deferred to a later frame so `ensureHydrated()` clones the overlay regions
- * into the DOM after the Interactivity runtime's DOMContentLoaded hydration
- * walk, not during it. Opening synchronously (this deferred module evaluates
- * pre-DOMContentLoaded) lets the walk and `apis.render()` hydrate the same
- * regions twice, which detaches their `data-wp-each` bindings.
+ * Open the overlay on initial paint when the URL carries `?s=`/`?q=`, deferred
+ * to an animation frame so `ensureHydrated()` clones the regions after the
+ * Interactivity runtime's hydration walk — opening during it double-hydrates
+ * the regions and detaches their `data-wp-each` bindings.
  */
 function openOverlayFromInitialUrl() {
 	requestAnimationFrame( handlePopState );

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -398,8 +398,8 @@ if ( overlayEl ) {
 function openOverlayFromInitialUrl() {
 	requestAnimationFrame( handlePopState );
 }
-if ( document.readyState === 'complete' ) {
-	openOverlayFromInitialUrl();
-} else {
+if ( document.readyState === 'loading' ) {
 	document.addEventListener( 'DOMContentLoaded', openOverlayFromInitialUrl, { once: true } );
+} else {
+	openOverlayFromInitialUrl();
 }

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -384,12 +384,22 @@ if ( overlayEl ) {
 	overlayEl.addEventListener( 'click', handleOverlayClick );
 }
 
-// Honor the URL on initial paint the same way `popstate` does on back/forward:
-// if the page loaded with `?s=` or `?q=`, open the overlay. This matches the
-// legacy instant-search behavior where deep links and core-search-form GET
-// submissions surface results in the overlay without a click.
-if ( document.readyState === 'loading' ) {
-	document.addEventListener( 'DOMContentLoaded', handlePopState, { once: true } );
+/**
+ * Honor the URL on initial paint: if the page loaded with `?s=`/`?q=`, open the
+ * overlay (same as `popstate` on back/forward; matches legacy deep-link and
+ * core-search-form behavior).
+ *
+ * Deferred to a later frame so `ensureHydrated()` clones the overlay regions
+ * into the DOM after the Interactivity runtime's DOMContentLoaded hydration
+ * walk, not during it. Opening synchronously (this deferred module evaluates
+ * pre-DOMContentLoaded) lets the walk and `apis.render()` hydrate the same
+ * regions twice, which detaches their `data-wp-each` bindings.
+ */
+function openOverlayFromInitialUrl() {
+	requestAnimationFrame( handlePopState );
+}
+if ( document.readyState === 'complete' ) {
+	openOverlayFromInitialUrl();
 } else {
-	handlePopState();
+	document.addEventListener( 'DOMContentLoaded', openOverlayFromInitialUrl, { once: true } );
 }

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -65,14 +65,32 @@ function setReadyState( value ) {
 	} );
 }
 
+// Queue rAF callbacks rather than running them, so a test can observe the
+// pre-frame state (the open is deferred) and then advance the frame explicitly.
+// jsdom's real rAF fires on a ~16ms timer the `setTimeout(0)` flush doesn't
+// await, and a stray late callback would leak into the next test.
+let rafQueue = [];
+
 /**
- * Import the bootstrap fresh and let the fire-and-forget `openOverlay` settle.
+ * Run and clear every queued animation-frame callback.
+ */
+function flushAnimationFrames() {
+	const callbacks = rafQueue;
+	rafQueue = [];
+	callbacks.forEach( cb => cb( 0 ) );
+}
+
+/**
+ * Import the bootstrap fresh, run the deferred initial-load open, and let the
+ * fire-and-forget `openOverlay` settle.
  */
 async function loadBootstrap() {
 	jest.resetModules();
 	await import( '../index.js' );
-	// `handlePopState` → `openOverlay` awaits hydration before toggling `hidden`;
-	// flush the microtask queue so the attribute change has landed.
+	// The initial-load open is queued on `requestAnimationFrame`; run it, then
+	// flush the microtask queue so `openOverlay`'s post-hydration `hidden`
+	// toggle has landed.
+	flushAnimationFrames();
 	await new Promise( resolve => setTimeout( resolve, 0 ) );
 }
 
@@ -87,19 +105,16 @@ const isOpen = () => ! document.getElementById( OVERLAY_ID ).hasAttribute( 'hidd
 
 let rafSpy;
 beforeEach( () => {
-	// The initial-load open is deferred to `requestAnimationFrame` (so it lands
-	// after the Interactivity runtime's hydration walk). jsdom's real rAF fires
-	// on a ~16ms timer, which the `setTimeout(0)` flush in `loadBootstrap()`
-	// doesn't await — and a stray late callback would leak into the next test.
-	// Run rAF synchronously so the deferral is deterministic here.
+	rafQueue = [];
 	rafSpy = jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( cb => {
-		cb( 0 );
-		return 0;
+		rafQueue.push( cb );
+		return rafQueue.length;
 	} );
 } );
 
 afterEach( () => {
 	rafSpy.mockRestore();
+	rafQueue = [];
 	setReadyState( 'complete' );
 	setUrl( '/' );
 	document.body.innerHTML = '';
@@ -160,6 +175,30 @@ describe( 'overlay-bootstrap initial-load URL trigger', () => {
 		expect( isOpen() ).toBe( false );
 
 		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		flushAnimationFrames();
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'defers the initial-load open to an animation frame rather than opening synchronously', async () => {
+		// The deferral is the fix: it keeps the cloned overlay regions out of the
+		// Interactivity runtime's DOMContentLoaded hydration walk (a synchronous
+		// open double-hydrates them and detaches the result/filter bindings). So
+		// after the module evaluates the overlay must still be closed — it only
+		// opens once the queued animation frame runs.
+		setReadyState( 'complete' );
+		renderOverlayShell();
+		setUrl( '/?s=hello' );
+
+		jest.resetModules();
+		await import( '../index.js' );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( window.requestAnimationFrame ).toHaveBeenCalled();
+		expect( isOpen() ).toBe( false );
+
+		flushAnimationFrames();
 		await new Promise( resolve => setTimeout( resolve, 0 ) );
 
 		expect( isOpen() ).toBe( true );

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -85,7 +85,21 @@ const isOpen = () => ! document.getElementById( OVERLAY_ID ).hasAttribute( 'hidd
 // `expect( console ).toHaveErrored()` as evidence the call fired — that doubles
 // as the declaration that satisfies the jest-console strict guard.
 
+let rafSpy;
+beforeEach( () => {
+	// The initial-load open is deferred to `requestAnimationFrame` (so it lands
+	// after the Interactivity runtime's hydration walk). jsdom's real rAF fires
+	// on a ~16ms timer, which the `setTimeout(0)` flush in `loadBootstrap()`
+	// doesn't await — and a stray late callback would leak into the next test.
+	// Run rAF synchronously so the deferral is deterministic here.
+	rafSpy = jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( cb => {
+		cb( 0 );
+		return 0;
+	} );
+} );
+
 afterEach( () => {
+	rafSpy.mockRestore();
 	setReadyState( 'complete' );
 	setUrl( '/' );
 	document.body.innerHTML = '';
@@ -120,6 +134,20 @@ describe( 'overlay-bootstrap initial-load URL trigger', () => {
 		await loadBootstrap();
 
 		expect( isOpen() ).toBe( false );
+	} );
+
+	it( 'opens immediately when the document is interactive (DOMContentLoaded already fired)', async () => {
+		// readyState stays `interactive` from DOMContentLoaded until `load`, so a
+		// late-evaluating module can land here after DCL has already fired —
+		// waiting on a fresh DOMContentLoaded would hang. The non-loading branch
+		// must open without depending on another DOMContentLoaded.
+		setReadyState( 'interactive' );
+		renderOverlayShell();
+		setUrl( '/?s=hello' );
+
+		await loadBootstrap();
+
+		expect( isOpen() ).toBe( true );
 	} );
 
 	it( 'waits for DOMContentLoaded when the document is still loading', async () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-302

## Why

Opening a Search Blocks deep link — e.g. `https://FG...com?s=hello`, a shared search link, or a theme search-form submission — showed the overlay with the result count and AI Answer but **no result rows and no filter buckets**. Visitors landing on a search URL directly saw what looked like an empty, broken search; only typing a fresh query and pressing Enter worked, which made the failure seem random. This restores results on the very first paint of a deep link.

## Proposed changes

* Defer the deep-link overlay auto-open in `overlay-bootstrap` to a `requestAnimationFrame` after `DOMContentLoaded`, so the overlay regions are cloned into the DOM and hydrated exactly once (via `apis.render()`), after the Interactivity runtime's hydration walk — instead of being double-hydrated by the walk *and* `apis.render()`, which detached the `data-wp-each` result/filter bindings.

Root cause: the bootstrap is a deferred module, so on a deep link it auto-opened the overlay at readyState `interactive` (before `DOMContentLoaded`). `ensureHydrated()` synchronously cloned the overlay `<template>` content into the live DOM while the runtime's hydration walk was still pending; the walk then hydrated those regions and `apis.render()` hydrated them again. The double pass left the `data-wp-each` lists inert, so `state.results` / `state.aggregations` never painted (permanently — even a later search stayed empty). The click-open path clones long after the walk, so it hydrates once and works. PR #49876 fixed the interactive path's array re-render but not this deep-link path.

## Screenshots

Live verification against `fg.a88.com/?s=hello` (the fix logic applied to the deployed bundle):

### Before — deep link renders count + AI answer but no results or filter buckets
<img width="900" src="https://github.com/user-attachments/assets/6d489cfc-c726-4106-9cc7-3dd1d212a3d0" />

### After — result rows and filter buckets render on first paint
<img width="1400" height="1500" alt="Search Blocks PR 49944" src="https://github.com/user-attachments/assets/bac732cc-77e5-41a2-b55f-af73f472590c" />

## Related product discussion/links

* SEARCH-302: https://linear.app/a8c/issue/SEARCH-302
* Prior, partial fix: #49876 (jetpack-production `000de52`)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria (from SEARCH-302):

* [ ] Load a Search Blocks deep link such as `/?s=hello` (and `/?q=hello`) → result rows render on first paint.
* [ ] Filter aggregation buckets (e.g. CATEGORY, PAGE CONDITIONS) render on the deep-link first paint.
* [ ] From a no-query page, click the search field, type a query, press Enter → results still render (no regression).
* [ ] Browser back/forward (`popstate`) still opens/closes the overlay and renders correctly.
* [ ] The overlay's regions are hydrated exactly once on the deep-link path (no double hydration).

