### PR TITLE
Charts: tokenize surface/foreground colors (CHARTS-205)

### DIFF
--- a/projects/js-packages/charts/changelog/charts-205-surfaceforeground-color-tokenization
+++ b/projects/js-packages/charts/changelog/charts-205-surfaceforeground-color-tokenization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: replace hardcoded surface, foreground, and UI colors with WPDS design tokens.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -27,7 +27,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
-import { attachSubComponents } from '../../utils';
+import { attachSubComponents, resolveCssVariable } from '../../utils';
 import { renderDefaultTooltip } from '../line-chart';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
@@ -461,7 +461,10 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 														stacked={ stacked }
 														stackOffset={ stackOffset }
 														getElementStyles={ getElementStyles }
-														strokeColor={ providerTheme.backgroundColor }
+														strokeColor={
+															resolveCssVariable( providerTheme.backgroundColor ) ??
+															providerTheme.backgroundColor
+														}
 													/>
 												</>
 											) }

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -96,7 +96,6 @@
 }
 
 .tooltip-wrapper {
-	border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral, #dbdbdb);
 	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	// Override .visx-tooltip inline styles.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -12,7 +12,7 @@
 
 .main-rate {
 	overflow: hidden;
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	text-overflow: ellipsis;
 	font-size: var(--wpds-typography-font-size-xl, 18px);
 	font-style: normal;
@@ -52,7 +52,7 @@
 }
 
 .step-label {
-	color: #757575;
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 	font-weight: var(--wpds-typography-font-weight-regular, 400);
 	line-height: var(--wpds-typography-line-height-xs, 16px);
@@ -62,7 +62,7 @@
 }
 
 .step-rate {
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
 	line-height: var(--wpds-typography-line-height-xs, 16px);
@@ -96,8 +96,8 @@
 }
 
 .tooltip-wrapper {
-	border-bottom: var(--wpds-border-width-xs, 1px) solid var(--Gray-Gray-5, #dcdcde);
-	background: var(--black-white-white, #fff);
+	border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral, #dbdbdb);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	// Override .visx-tooltip inline styles.
 	border-radius: var(--wpds-border-radius-md, 4px) !important;
@@ -107,7 +107,7 @@
 }
 
 .tooltip-title {
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 	font-style: normal;
 	font-weight: var(--wpds-typography-font-weight-regular, 400);
@@ -115,7 +115,7 @@
 }
 
 .tooltip-content {
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-style: normal;
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
@@ -124,6 +124,6 @@
 
 .empty-state {
 	text-align: center;
-	color: #6b7280;
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	font-size: var(--wpds-typography-font-size-lg, 16px);
 }

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
@@ -70,7 +70,7 @@ The following properties can be customized via the theme system:
 | -------- | ---- | ------- | ----------- |
 | `colors[0]` | `string` | `'#98C8DF'` | Primary color used for data visualization (color axis range) |
 | `backgroundColor` | `string` | `'#FFFFFF'` | Background color of the map |
-| `geoChart.featureFillColor` | `string` | `'var(--jp-white, #ffffff)'` | Fill color for countries without data values |
+| `geoChart.featureFillColor` | `string` | `'var(--wpds-color-bg-surface-neutral-weak, #f4f4f4)'` | Fill color for countries without data values |
 
 ## Country Identification
 

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
@@ -69,7 +69,7 @@ The following properties can be customized via the theme system:
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `colors[0]` | `string` | `'#98C8DF'` | Primary color used for data visualization (color axis range) |
-| `backgroundColor` | `string` | `'#FFFFFF'` | Background color of the map |
+| `backgroundColor` | `string` | `'var(--wpds-color-bg-surface-neutral-strong, #fff)'` | Background color of the map |
 | `geoChart.featureFillColor` | `string` | `'var(--wpds-color-bg-surface-neutral-weak, #f4f4f4)'` | Fill color for countries without data values |
 
 ## Country Identification

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -79,7 +79,7 @@
 .emptyState {
 	padding: var(--wpds-dimension-padding-3xl, 32px) var(--wpds-dimension-padding-lg, 16px);
 	text-align: center;
-	color: #666;
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-style: italic;
 }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -16,7 +16,7 @@
 
 	&__tooltip,
 	&__annotation-label-popover {
-		background: #fff;
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 		padding: var(--wpds-dimension-padding-sm, 8px);
 	}
 
@@ -59,7 +59,7 @@
 
 	&__annotation-label-popover {
 		min-width: 125px;
-		background: #fff;
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 		border: none;
 		border-radius: var(--wpds-border-radius-md, 4px);
 		font-size: var(--wpds-typography-font-size-md, 13px);

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -60,7 +60,6 @@
 
 	&__annotation-label-popover {
 		min-width: 125px;
-		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 		border: none;
 		border-radius: var(--wpds-border-radius-md, 4px);
 		font-size: var(--wpds-typography-font-size-md, 13px);

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -17,6 +17,7 @@
 	&__tooltip,
 	&__annotation-label-popover {
 		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+		color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 		padding: var(--wpds-dimension-padding-sm, 8px);
 	}
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -29,7 +29,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
-import { attachSubComponents } from '../../utils';
+import { attachSubComponents, resolveCssVariable } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
 import { DefaultGlyph } from '../private/default-glyph';
@@ -190,6 +190,10 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const legendPosition = legend.position ?? 'bottom';
 
 		const providerTheme = useGlobalChartsTheme();
+		// Gradient stops apply this as an SVG attribute, where CSS var() cannot
+		// resolve, so resolve the WPDS token to a concrete value first.
+		const resolvedBackgroundColor =
+			resolveCssVariable( providerTheme.backgroundColor ) ?? providerTheme.backgroundColor;
 		const theme = useXYChartTheme( data );
 		const chartId = useChartId( providedChartId );
 		const chartRef = useRef< HTMLDivElement >( null );
@@ -485,7 +489,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 																		from={ color }
 																		fromOpacity={ 0.4 }
 																		toOpacity={ 0.1 }
-																		to={ providerTheme.backgroundColor }
+																		to={ resolvedBackgroundColor }
 																		{ ...seriesData.options?.gradient }
 																		data-testid="line-gradient"
 																	>

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation.tsx
@@ -10,7 +10,7 @@ import { DataContext } from '@visx/xychart';
 import merge from 'deepmerge';
 import { useContext, useRef, useEffect, useState, useMemo } from 'react';
 import { useGlobalChartsTheme } from '../../../providers';
-import { isSafari } from '../../../utils';
+import { isSafari, resolveCssVariable } from '../../../utils';
 import LineChartAnnotationLabelWithPopover, {
 	POPOVER_BUTTON_SIZE,
 } from './line-chart-annotation-label-popover';
@@ -159,6 +159,11 @@ const LineChartAnnotation: FC< LineChartAnnotationProps > = ( {
 	// Deep merge styles to preserve nested object properties
 	const styles = merge( providerTheme.annotationStyles ?? {}, datumStyles ?? {} );
 
+	// visx annotation parts apply these colors as SVG presentation attributes,
+	// where CSS var() cannot resolve. Resolve WPDS tokens to concrete values first.
+	const resolveColor = ( value?: string ): string | undefined =>
+		value ? resolveCssVariable( value ) ?? value : value;
+
 	// Measure the label height once after initial render
 	useEffect( () => {
 		if ( labelRef.current?.getBBox ) {
@@ -264,8 +269,14 @@ const LineChartAnnotation: FC< LineChartAnnotationProps > = ( {
 	return (
 		<g data-testid={ testId }>
 			<Annotation x={ x } y={ y } dx={ dx } dy={ dy }>
-				<Connector { ...styles?.connector } />
-				{ subjectType === 'circle' && <CircleSubject { ...styles?.circleSubject } /> }
+				<Connector { ...styles?.connector } stroke={ resolveColor( styles?.connector?.stroke ) } />
+				{ subjectType === 'circle' && (
+					<CircleSubject
+						{ ...styles?.circleSubject }
+						fill={ resolveColor( styles?.circleSubject?.fill ) }
+						stroke={ resolveColor( styles?.circleSubject?.stroke ) }
+					/>
+				) }
 				{ subjectType === 'line-vertical' && (
 					<LineSubject
 						min={ yMax }
@@ -301,6 +312,8 @@ const LineChartAnnotation: FC< LineChartAnnotationProps > = ( {
 							title={ title }
 							subtitle={ subtitle }
 							{ ...styles?.label }
+							anchorLineStroke={ resolveColor( styles?.label?.anchorLineStroke ) }
+							backgroundFill={ resolveColor( styles?.label?.backgroundFill ) }
 							{ ...labelPosition }
 							horizontalAnchor={ getHorizontalAnchor( subjectType, isFlippedHorizontally ) }
 							verticalAnchor={ getVerticalAnchor(

--- a/projects/js-packages/charts/src/charts/private/grid-control/grid-control.module.scss
+++ b/projects/js-packages/charts/src/charts/private/grid-control/grid-control.module.scss
@@ -1,10 +1,7 @@
-// Variables
-$grid-line-color: #d7d6d6;
-
 .grid-control {
 
 	:global(.visx-line) {
-		stroke: $grid-line-color;
+		stroke: var(--wpds-color-stroke-surface-neutral, #dbdbdb);
 		stroke-width: 1px;
 		shape-rendering: crispEdges;
 	}

--- a/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
+++ b/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
@@ -1,5 +1,5 @@
 .svg-empty-state {
 	text-align: center;
 	font-size: var(--wpds-typography-font-size-md, 13px);
-	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
+	color: var(--wpds-color-fg-content-neutral-weak, #707070);
 }

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -1,5 +1,8 @@
 .x-zoom {
 
+	// The translucent rgba overlay colors (selection fill/stroke, reset
+	// background/border) have no WPDS equivalent and stay as-is; only the
+	// opaque foreground and focus colors are tokenized.
 	&__selection {
 		fill: var(--charts-zoom-selection-fill, rgba(56, 88, 233, 0.16));
 		stroke: var(--charts-zoom-selection-stroke, rgba(56, 88, 233, 0.65));
@@ -19,7 +22,7 @@
 		height: 28px;
 		padding: 0;
 		background: var(--charts-zoom-reset-bg, rgba(255, 255, 255, 0.92));
-		color: var(--charts-zoom-reset-fg, #1e1e1e);
+		color: var(--charts-zoom-reset-fg, var(--wpds-color-fg-content-neutral, #1e1e1e));
 		border:
 			var(--wpds-border-width-xs, 1px) solid
 			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
@@ -32,7 +35,7 @@
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--charts-zoom-reset-focus, #3858e9);
+			outline: 2px solid var(--charts-zoom-reset-focus, var(--wpds-color-stroke-focus-brand, #3858e9));
 			outline-offset: 1px;
 		}
 	}

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -2,7 +2,7 @@
 	padding: var(--wpds-dimension-padding-sm, 8px);
 	// No WPDS token fits a translucent dark tooltip surface:
 	// bg-interactive-neutral-strong is opaque, and there is no
-	// white-on-dark content foreground token. Left as-is.
+	// white-on-dark content foreground token.
 	background-color: rgba(0, 0, 0, 0.85);
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -1,7 +1,8 @@
 .tooltip {
 	padding: var(--wpds-dimension-padding-sm, 8px);
-	// No WPDS token fits a translucent dark tooltip surface: bg-interactive-neutral-strong
-	// is opaque #2d2d2d, and there is no white-on-dark content foreground token. Left as-is.
+	// No WPDS token fits a translucent dark tooltip surface:
+	// bg-interactive-neutral-strong is opaque, and there is no
+	// white-on-dark content foreground token. Left as-is.
 	background-color: rgba(0, 0, 0, 0.85);
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -1,5 +1,7 @@
 .tooltip {
 	padding: var(--wpds-dimension-padding-sm, 8px);
+	// No WPDS token fits a translucent dark tooltip surface: bg-interactive-neutral-strong
+	// is opaque #2d2d2d, and there is no white-on-dark content foreground token. Left as-is.
 	background-color: rgba(0, 0, 0, 0.85);
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
@@ -73,13 +73,14 @@ The component uses CSS Modules with the following class structure:
 
 ## CSS Custom Properties
 
-The component exposes CSS custom properties for theming:
+The component exposes CSS custom properties for theming. When unset, each one
+resolves to the accessible WPDS semantic token shown below:
 
-| Property | Default | Description |
-|----------|---------|-------------|
-| `--charts-trend-up-color` | `#1a8917` | Color for upward trends (green) |
-| `--charts-trend-down-color` | `#d63638` | Color for downward trends (red) |
-| `--charts-trend-neutral-color` | `#646970` | Color for neutral trends (gray) |
+| Property | Default (WPDS token) | Description |
+|----------|----------------------|-------------|
+| `--charts-trend-up-color` | `--wpds-color-fg-content-success-weak` (`#008030`) | Color for upward trends (green) |
+| `--charts-trend-down-color` | `--wpds-color-fg-content-error-weak` (`#cc1818`) | Color for downward trends (red) |
+| `--charts-trend-neutral-color` | `--wpds-color-fg-content-neutral-weak` (`#707070`) | Color for neutral trends (gray) |
 
 ## Accessibility Attributes
 

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
@@ -131,9 +131,9 @@ them:
 	language="css"
 	code={`:root {
 	/* Defaults shown — these resolve to the WPDS tokens below: */
-	--charts-trend-up-color: var(--wpds-color-fg-content-success-weak); /* #008030 */
-	--charts-trend-down-color: var(--wpds-color-fg-content-error-weak); /* #cc1818 */
-	--charts-trend-neutral-color: var(--wpds-color-fg-content-neutral-weak); /* #707070 */
+	--charts-trend-up-color: var(--wpds-color-fg-content-success-weak, #008030);
+	--charts-trend-down-color: var(--wpds-color-fg-content-error-weak, #cc1818);
+	--charts-trend-neutral-color: var(--wpds-color-fg-content-neutral-weak, #707070);
 }`}
 />
 

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
@@ -123,18 +123,22 @@ Apply custom styles using the `className` or `style` props:
 
 ## Theming Integration
 
-The component uses CSS custom properties for colors, making it easy to customize:
+By default the trend colors resolve to accessible WordPress Design System
+tokens. The component also exposes CSS custom properties so you can override
+them:
 
 <Source
 	language="css"
 	code={`:root {
-	--charts-trend-up-color: #1a8917;    /* Green for positive */
-	--charts-trend-down-color: #d63638;  /* Red for negative */
-	--charts-trend-neutral-color: #646970; /* Gray for neutral */
+	/* Defaults shown — these resolve to the WPDS tokens below: */
+	--charts-trend-up-color: var(--wpds-color-fg-content-success-weak); /* #008030 */
+	--charts-trend-down-color: var(--wpds-color-fg-content-error-weak); /* #cc1818 */
+	--charts-trend-neutral-color: var(--wpds-color-fg-content-neutral-weak); /* #707070 */
 }`}
 />
 
-Override these variables in your stylesheet to match your design system.
+Override these variables to match your design system. Make sure any custom
+colors meet contrast requirements.
 
 ## Common Use Cases
 

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -7,8 +7,7 @@
 	line-height: 1;
 
 	// Trend colors use the documented --charts-trend-* override API, falling
-	// back to the accessible WPDS semantic tokens (the original chart green/red
-	// did not meet contrast requirements).
+	// back to the accessible WPDS semantic tokens.
 	&--up {
 		color: var(--charts-trend-up-color, var(--wpds-color-fg-content-success-weak, #008030));
 	}

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -6,20 +6,19 @@
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
 	line-height: 1;
 
-	// Trend colors resolve via the documented --charts-trend-* override,
-	// then the WPDS semantic token, then the chart's original palette.
-	// The deep fallback intentionally keeps the original values (not the
-	// WPDS spec) so the trend colors stay visually backward-compatible.
+	// Trend colors use the documented --charts-trend-* override API, falling
+	// back to the accessible WPDS semantic tokens (the original chart green/red
+	// did not meet contrast requirements).
 	&--up {
-		color: var(--charts-trend-up-color, var(--wpds-color-fg-content-success-weak, #1a8917));
+		color: var(--charts-trend-up-color, var(--wpds-color-fg-content-success-weak, #008030));
 	}
 
 	&--down {
-		color: var(--charts-trend-down-color, var(--wpds-color-fg-content-error-weak, #d63638));
+		color: var(--charts-trend-down-color, var(--wpds-color-fg-content-error-weak, #cc1818));
 	}
 
 	&--neutral {
-		color: var(--charts-trend-neutral-color, var(--wpds-color-fg-content-neutral-weak, #646970));
+		color: var(--charts-trend-neutral-color, var(--wpds-color-fg-content-neutral-weak, #707070));
 	}
 
 	&__icon {

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -6,16 +6,20 @@
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
 	line-height: 1;
 
+	// Trend colors resolve via the documented --charts-trend-* override,
+	// then the WPDS semantic token, then the chart's original palette.
+	// The deep fallback intentionally keeps the original values (not the
+	// WPDS spec) so the trend colors stay visually backward-compatible.
 	&--up {
-		color: var(--charts-trend-up-color, #1a8917);
+		color: var(--charts-trend-up-color, var(--wpds-color-fg-content-success-weak, #1a8917));
 	}
 
 	&--down {
-		color: var(--charts-trend-down-color, #d63638);
+		color: var(--charts-trend-down-color, var(--wpds-color-fg-content-error-weak, #d63638));
 	}
 
 	&--neutral {
-		color: var(--charts-trend-neutral-color, #646970);
+		color: var(--charts-trend-neutral-color, var(--wpds-color-fg-content-neutral-weak, #646970));
 	}
 
 	&__icon {

--- a/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
+++ b/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
@@ -1,7 +1,14 @@
 import { buildChartTheme } from '@visx/xychart';
 import { useMemo } from 'react';
 import { useGlobalChartsTheme } from '../providers';
+import { resolveCssVariable } from '../utils';
 import type { SeriesData } from '../types';
+
+// visx applies grid, axis, and tick-label colors as SVG presentation attributes,
+// where CSS var() cannot resolve. Resolve WPDS tokens to concrete values (or their
+// fallbacks) before handing the theme to buildChartTheme.
+const resolveColor = ( value?: string ): string | undefined =>
+	value ? resolveCssVariable( value ) ?? value : value;
 
 export const useXYChartTheme = ( data: SeriesData[] ) => {
 	const theme = useGlobalChartsTheme();
@@ -14,6 +21,22 @@ export const useXYChartTheme = ( data: SeriesData[] ) => {
 		return buildChartTheme( {
 			...theme,
 			colors: [ ...seriesColors, ...( theme.colors ?? [] ) ],
+			gridStyles: theme.gridStyles && {
+				...theme.gridStyles,
+				stroke: resolveColor( theme.gridStyles.stroke ),
+			},
+			xAxisLineStyles: theme.xAxisLineStyles && {
+				...theme.xAxisLineStyles,
+				stroke: resolveColor( theme.xAxisLineStyles.stroke ),
+			},
+			xTickLineStyles: theme.xTickLineStyles && {
+				...theme.xTickLineStyles,
+				stroke: resolveColor( theme.xTickLineStyles.stroke ),
+			},
+			svgLabelSmall: theme.svgLabelSmall && {
+				...theme.svgLabelSmall,
+				fill: resolveColor( theme.svgLabelSmall.fill ),
+			},
 		} );
 	}, [ theme, data ] );
 };

--- a/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
+++ b/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
@@ -21,6 +21,7 @@ export const useXYChartTheme = ( data: SeriesData[] ) => {
 		return buildChartTheme( {
 			...theme,
 			colors: [ ...seriesColors, ...( theme.colors ?? [] ) ],
+			backgroundColor: resolveColor( theme.backgroundColor ),
 			gridStyles: theme.gridStyles && {
 				...theme.gridStyles,
 				stroke: resolveColor( theme.gridStyles.stroke ),

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -112,8 +112,7 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 		// Core colors used for data visualization
 		colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 
-		// Chart background and labels. Colors resolve to WPDS tokens by default,
-		// with a spec-value fallback for hosts that don't load @wordpress/boot.
+    	// Chart background and labels
 		backgroundColor: 'var(--wpds-color-bg-surface-neutral-strong, #fff)',
 		labelBackgroundColor: 'transparent',
 		labelTextColor: '#FFFFFF',

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -112,22 +112,23 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 		// Core colors used for data visualization
 		colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 
-		// Chart background and labels
-		backgroundColor: '#FFFFFF',
+		// Chart background and labels. Colors resolve to WPDS tokens by default,
+		// with a spec-value fallback for hosts that don't load @wordpress/boot.
+		backgroundColor: 'var(--wpds-color-bg-surface-neutral-strong, #fff)',
 		labelBackgroundColor: 'transparent',
 		labelTextColor: '#FFFFFF',
 
 		// Grid and axis styling
 		gridStyles: {
-			stroke: '#DCDCDE',
+			stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)',
 			strokeWidth: 1,
 		},
-		xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
+		xAxisLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
 
 		// Legend appearance
 		legend: {
 			labelStyles: {
-				color: 'var(--jp-gray-80, #2c3338)',
+				color: 'var(--wpds-color-fg-content-neutral, #1e1e1e)',
 			},
 		},
 
@@ -135,12 +136,17 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 		leaderboardChart: {
 			primaryColor: '#006DAB',
 			secondaryColor: '#98C8DF',
-			deltaColors: [ '#FF8C8F', '#757575', '#1F9828' ], // [negative, neutral, positive]
+			// [negative, neutral, positive]
+			deltaColors: [
+				'var(--wpds-color-fg-content-error-weak, #cc1818)',
+				'var(--wpds-color-fg-content-neutral-weak, #707070)',
+				'var(--wpds-color-fg-content-success-weak, #008030)',
+			],
 		},
 
 		conversionFunnelChart: {
 			primaryColor: '#006DAB',
-			backgroundColor: '#F3F4F6',
+			backgroundColor: 'var(--wpds-color-bg-surface-neutral-weak, #f4f4f4)',
 		}
 	};
 

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -17,7 +17,7 @@ const defaultTheme: CompleteChartTheme = {
 	tickLength: 4,
 	gridColor: '',
 	gridColorDark: '',
-	xTickLineStyles: { stroke: 'var(--wpds-color-fg-content-neutral, #1e1e1e)' },
+	xTickLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
 	xAxisLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
 	legend: {
 		labelStyles: {

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -4,9 +4,6 @@ import type { CompleteChartTheme } from '../../types';
  * Default theme configuration
  */
 const defaultTheme: CompleteChartTheme = {
-	// Applied as an SVG presentation attribute in several components (chart
-	// background, glyph outline, gradient stops), where CSS var() cannot resolve —
-	// consumers resolve it to a concrete value before use.
 	backgroundColor: 'var(--wpds-color-bg-surface-neutral-strong, #fff)',
 	labelBackgroundColor: 'transparent', // label background color (transparent by default)
 	// White label text sits on top of arbitrary series colors, so it has no WPDS
@@ -59,8 +56,7 @@ const defaultTheme: CompleteChartTheme = {
 		rowGap: 12,
 		columnGap: 4,
 		labelSpacing: 'xs',
-		// [negative, neutral, positive] — accessible WPDS trend tokens (the original
-		// chart red/grey/green did not meet contrast requirements).
+		// [negative, neutral, positive]
 		deltaColors: [
 			'var(--wpds-color-fg-content-error-weak, #cc1818)',
 			'var(--wpds-color-fg-content-neutral-weak, #707070)',

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -4,22 +4,27 @@ import type { CompleteChartTheme } from '../../types';
  * Default theme configuration
  */
 const defaultTheme: CompleteChartTheme = {
-	backgroundColor: '#FFFFFF', // chart background color
+	// Read raw as an SVG presentation attribute in several components (chart
+	// background, glyph outline, gradient stops), where CSS var() cannot resolve.
+	// Kept literal; it already equals the WPDS `bg-surface-neutral-strong` value.
+	backgroundColor: '#FFFFFF',
 	labelBackgroundColor: 'transparent', // label background color (transparent by default)
-	labelTextColor: '#FFFFFF', // label text color (white to match original behavior)
+	// White label text sits on top of arbitrary series colors, so it has no WPDS
+	// content-foreground equivalent and stays hardcoded (tokenization outlier).
+	labelTextColor: '#FFFFFF',
 	colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 	gridStyles: {
-		stroke: '#DCDCDE',
+		stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)',
 		strokeWidth: 1,
 	},
 	tickLength: 4,
 	gridColor: '',
 	gridColorDark: '',
-	xTickLineStyles: { stroke: 'black' },
-	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
+	xTickLineStyles: { stroke: 'var(--wpds-color-fg-content-neutral, #1e1e1e)' },
+	xAxisLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
 	legend: {
 		labelStyles: {
-			color: 'var(--jp-gray-80, #2c3338)',
+			color: 'var(--wpds-color-fg-content-neutral, #1e1e1e)',
 		},
 		containerStyles: {},
 		shapeStyles: [],
@@ -31,35 +36,41 @@ const defaultTheme: CompleteChartTheme = {
 	// that `buildChartTheme` injects as an inline style on SVG `<text>`
 	// elements for axis labels and ticks. Setting `inherit` lets SVG text
 	// pick up the host application's font-family via normal CSS inheritance.
-	svgLabelSmall: { fill: 'var(--jp-gray-80, #2c3338)', fontFamily: 'inherit' },
+	svgLabelSmall: { fill: 'var(--wpds-color-fg-content-neutral, #1e1e1e)', fontFamily: 'inherit' },
 	svgLabelBig: { fontFamily: 'inherit' },
 	annotationStyles: {
 		label: {
-			anchorLineStroke: 'var(--jp-gray-80, #2c3338)',
-			backgroundFill: '#fff',
+			anchorLineStroke: 'var(--wpds-color-fg-content-neutral, #1e1e1e)',
+			backgroundFill: 'var(--wpds-color-bg-surface-neutral-strong, #fff)',
 		},
 		connector: {
-			stroke: 'var(--jp-gray-80, #2c3338)',
+			stroke: 'var(--wpds-color-fg-content-neutral, #1e1e1e)',
 		},
 		circleSubject: {
 			stroke: 'transparent',
-			fill: 'var(--jp-gray-80, #2c3338)',
+			fill: 'var(--wpds-color-fg-content-neutral, #1e1e1e)',
 			radius: 5,
 		},
 	},
 	geoChart: {
-		featureFillColor: 'var(--jp-gray-0, #f6f7f7)',
+		featureFillColor: 'var(--wpds-color-bg-surface-neutral-weak, #f4f4f4)',
 	},
 	leaderboardChart: {
 		rowGap: 12,
 		columnGap: 4,
 		labelSpacing: 'xs',
-		deltaColors: [ '#FF8C8F', '#757575', '#1F9828' ], // [negative, neutral, positive]
+		// [negative, neutral, positive] — accessible WPDS trend tokens (the original
+		// chart red/grey/green did not meet contrast requirements).
+		deltaColors: [
+			'var(--wpds-color-fg-content-error-weak, #cc1818)',
+			'var(--wpds-color-fg-content-neutral-weak, #707070)',
+			'var(--wpds-color-fg-content-success-weak, #008030)',
+		],
 	},
 	conversionFunnelChart: {
-		backgroundColor: '#F3F4F6',
-		positiveChangeColor: '#1F9828',
-		negativeChangeColor: '#FF8C8F',
+		backgroundColor: 'var(--wpds-color-bg-surface-neutral-weak, #f4f4f4)',
+		positiveChangeColor: 'var(--wpds-color-fg-content-success-weak, #008030)',
+		negativeChangeColor: 'var(--wpds-color-fg-content-error-weak, #cc1818)',
 	},
 	lineChart: {
 		lineStyles: {

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -4,10 +4,10 @@ import type { CompleteChartTheme } from '../../types';
  * Default theme configuration
  */
 const defaultTheme: CompleteChartTheme = {
-	// Read raw as an SVG presentation attribute in several components (chart
-	// background, glyph outline, gradient stops), where CSS var() cannot resolve.
-	// Kept literal; it already equals the WPDS `bg-surface-neutral-strong` value.
-	backgroundColor: '#FFFFFF',
+	// Applied as an SVG presentation attribute in several components (chart
+	// background, glyph outline, gradient stops), where CSS var() cannot resolve —
+	// consumers resolve it to a concrete value before use.
+	backgroundColor: 'var(--wpds-color-bg-surface-neutral-strong, #fff)',
 	labelBackgroundColor: 'transparent', // label background color (transparent by default)
 	// White label text sits on top of arbitrary series colors, so it has no WPDS
 	// content-foreground equivalent and stays hardcoded (tokenization outlier).


### PR DESCRIPTION
Fixes CHARTS-205

## Why

The charts package is migrating to WordPress UI + Theme as its defaults, with styling driven by WPDS design tokens (`var(--wpds-*, <fallback>)`) instead of hardcoded values. Several SCSS modules and the JS/TS `defaultTheme` still hardcoded surface, foreground, and UI colors (tooltip/container backgrounds, body text, borders, grid lines, axis/tick colors, annotations, trend and delta colors), so those elements could not follow a host theme and drifted from the design system. This is the surface/foreground counterpart to the palette work in CHARTS-202, and it brings these colors in line with the pattern already used by `svg-empty-state`.

## Proposed changes

Replace hardcoded surface, foreground, and UI colors with WPDS tokens across the charts package, in both SCSS modules and the JS/TS default theme. Fallbacks use the WPDS spec value for each token (per the package's `AGENTS.md`), so the design-system value applies whether or not the host loads `@wordpress/boot`.

### SCSS modules

* **Foreground/text** → `fg-content-neutral` (#1e1e1e) and `fg-content-neutral-weak` (#707070): conversion funnel (`main-rate`, `step-label`, `step-rate`, tooltip title/content, empty-state), leaderboard empty-state, and the x-zoom reset button text.
* **Focus outline** → `stroke-focus-brand` (#3858e9): x-zoom reset button (nested in its `--charts-zoom-reset-focus` override, matching the leaderboard pattern).
* **Surface backgrounds** → `bg-surface-neutral-strong` (#fff): line chart tooltip + annotation popover, conversion funnel tooltip wrapper (also migrates the non-standard `--black-white-white` variable).
* **Borders / grid lines** → `stroke-surface-neutral` (#dbdbdb): the grid control line stroke (removes the single-use `$grid-line-color` SCSS variable). _Note: the conversion funnel tooltip's bottom border (originally `--Gray-Gray-5`) was tokenized here too, then removed — it was redundant since the tooltip already has a box-shadow. So `stroke-surface-neutral` now applies only to the grid line._
* **Trend indicators** → nest `fg-content-success-weak` / `fg-content-error-weak` / `fg-content-neutral-weak` inside the documented `--charts-trend-*` override API. Fallbacks use the accessible WPDS spec values (`#008030` / `#cc1818` / `#707070`) — the original chart green/red/grey did not meet contrast requirements. The `.api.mdx` / `.docs.mdx` docs are updated to show the WPDS defaults.

### Default theme (`themes.ts`)

The JS/TS `defaultTheme` still carried `--jp-*` and literal-hex colors. Tokenize them and drop the `--jp-*` variables:

* **Text / strokes** → `fg-content-neutral` (#1e1e1e): axis tick line, legend label, `svgLabelSmall` (axis-label fill), and the annotation `anchorLineStroke` / `connector` / `circleSubject` fill.
* **Grid & axis lines** → `stroke-surface-neutral` (#dbdbdb): `gridStyles` and `xAxisLineStyles` strokes.
* **Weak surfaces** → `bg-surface-neutral-weak` (#f4f4f4): geo feature fill and conversion-funnel background.
* **Strong surface** → `bg-surface-neutral-strong` (#fff): `backgroundColor` and the annotation `backgroundFill`.
* **Delta / change colors** → `fg-content-error-weak` / `fg-content-neutral-weak` / `fg-content-success-weak` (#cc1818 / #707070 / #008030): leaderboard `deltaColors` and the conversion-funnel positive/negative change colors.

**visx SVG-attribute resolution.** visx applies many of these (grid, axis, tick labels, annotation parts, the line-chart gradient stop, the area-chart hover-glyph stroke) as **SVG presentation attributes**, where CSS `var()` cannot resolve — a naive hex→`var()` swap would break rendering. Tokens that reach visx are resolved to concrete values (or their fallbacks) via `resolveCssVariable` (the existing `geoChart` pattern) in `useXYChartTheme`, the line-chart annotation, the line-chart gradient stop, and the area-chart hover-glyph stroke, before they hit visx. Inline-style / HTML fields (legend, `deltaColors`, funnel) consume the token via `var()` directly.

### Intentional outliers

* **Base tooltip** (`base-tooltip.module.scss`) keeps its translucent dark surface `rgba(0,0,0,0.85)` + white text. WPDS 0.15.1 has no translucent/dark *surface* token and no white-on-dark *content* foreground token, so it is left as-is with a comment explaining why.
* **x-zoom translucent overlays** (`x-zoom.module.scss`) — the selection fill/stroke and reset button background/border use translucent `rgba()` values with no WPDS equivalent, so they stay as-is (comment added). Only the opaque foreground/focus colors there are tokenized.
* **`defaultTheme.labelTextColor`** stays hardcoded `#FFFFFF`. It is white label text drawn on top of arbitrary series colors, so it has no WPDS content-foreground equivalent (comment added).

### Note on token names

The installed `@wordpress/boot@0.15.1` defines the short token names (`--wpds-color-fg-*`, `--wpds-color-bg-*`, `--wpds-color-stroke-focus-brand`). The WordPress Design System MCP documents the newer long names (`--wpds-color-foreground-*`, …) that are not present in this pinned version, so this PR uses the short names that actually resolve in-repo.


### Screenshots

**Trend indicator** — up resolves to the WPDS `success-weak` token (#008030), down to `error-weak` (#cc1818):

![trend up](https://github.com/user-attachments/assets/04a1e5a1-b93f-45bc-ac80-ab784900c09b) ![trend down](https://github.com/user-attachments/assets/0f3407ed-443d-4e68-a605-004fb11f79f6)

**Conversion funnel** (Default) — text uses `fg-content-neutral` (#1e1e1e) and `fg-content-neutral-weak` (#707070):

![conversion funnel](https://github.com/user-attachments/assets/56847843-2e46-4882-b3c6-118042a5cbf9)

**Base tooltip** (Default) — intentional outlier, unchanged translucent dark surface + white text:

![dark tooltip](https://github.com/user-attachments/assets/4524e167-48c6-41bf-9de4-61f18257e8a0)

**Grid lines** (GridControl / Both Axes) — stroke uses `stroke-surface-neutral` (#dbdbdb):

![grid lines](https://github.com/user-attachments/assets/20427e7e-d6d6-4b64-bdbd-9822c8c3e0f3)
## Related product discussion/links

* Linear: [CHARTS-205](https://linear.app/a8c/issue/CHARTS-205/surfaceforeground-color-tokenization)
* Related: [CHARTS-202](https://linear.app/a8c/issue/CHARTS-202/color-palette-tokenization) (palette), [CHARTS-200](https://linear.app/a8c/issue/CHARTS-200/shadowanimation-tokenization) (shadows)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Verified in Storybook (`pnpm --filter ./projects/js-packages/storybook storybook:dev`), computed colors confirmed via devtools:

* **Trend Indicator** → up resolves to `rgb(0,128,48)` (#008030), down to #cc1818 — the WPDS success/error-weak tokens.
* **Conversion Funnel** (Default) → step labels `rgb(112,112,112)` (#707070), rates `rgb(30,30,30)` (#1e1e1e); funnel and tooltip render unchanged.
* **Tooltip** (Default) → dark translucent base tooltip with white text renders unchanged (outlier).
* **GridControl** (Both Axes) → grid lines stroke `rgb(219,219,219)` (#dbdbdb).
* **Line / Area / Geo charts** → grid, axis, tick labels, annotations, gradients and geo fill render unchanged (WPDS tokens resolve to their spec-value fallbacks via `resolveCssVariable`).
* `pnpm --filter @automattic/charts build` succeeds; stylelint passes on all touched files.
