### PR TITLE
Charts: tokenize shadow & animation values with WPDS elevation/motion tokens [CHARTS-200]

### DIFF
--- a/projects/js-packages/charts/changelog/charts-200-shadowanimation-tokenization
+++ b/projects/js-packages/charts/changelog/charts-200-shadowanimation-tokenization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: tokenize box-shadow, transition, and animation values with WPDS elevation and motion tokens. Shadows now use --wpds-elevation-sm and motion uses --wpds-motion-duration/easing tokens, making elevation and motion themeable; chart entrance animations move to the design system's motion scale (400ms).

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.module.scss
@@ -6,7 +6,8 @@
 		path {
 			transform-origin: 0 95%;
 			transform: scaleY(0);
-			animation: rise 1s ease-out forwards;
+			animation: rise var(--wpds-motion-duration-xl, 400ms)
+				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 	}
 

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.module.scss
@@ -6,7 +6,8 @@
 		path {
 			transform-origin: 0 95%;
 			transform: scaleY(0);
-			animation: rise var(--wpds-motion-duration-xl, 400ms)
+			animation:
+				rise var(--wpds-motion-duration-xl, 400ms)
 				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 	}

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -8,7 +8,8 @@
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);
-		animation: rise var(--wpds-motion-duration-xl, 400ms)
+		animation:
+			rise var(--wpds-motion-duration-xl, 400ms)
 			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 
@@ -23,7 +24,8 @@
 		transform-origin: left;
 		transform-box: fill-box;
 		transform: scaleX(0);
-		animation: stretch var(--wpds-motion-duration-xl, 400ms)
+		animation:
+			stretch var(--wpds-motion-duration-xl, 400ms)
 			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.module.scss
@@ -8,7 +8,8 @@
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);
-		animation: rise 1s ease-out forwards;
+		animation: rise var(--wpds-motion-duration-xl, 400ms)
+			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 
 	@keyframes rise {
@@ -22,7 +23,8 @@
 		transform-origin: left;
 		transform-box: fill-box;
 		transform: scaleX(0);
-		animation: stretch 1s ease-out forwards;
+		animation: stretch var(--wpds-motion-duration-xl, 400ms)
+			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 
 	@keyframes stretch {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -85,7 +85,8 @@
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);
-		animation: stretch 1s ease-out forwards;
+		animation: stretch var(--wpds-motion-duration-xl, 400ms)
+			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 
 	@keyframes stretch {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -43,7 +43,8 @@
 	height: 100%;
 
 	&--animated {
-		transition: opacity 0.3s ease;
+		transition: opacity var(--wpds-motion-duration-lg, 300ms)
+			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
 	&--blurred {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -101,7 +101,13 @@
 	// Override .visx-tooltip inline styles.
 	border-radius: var(--wpds-border-radius-md, 4px) !important;
 	padding: var(--wpds-dimension-padding-md, 12px) !important;
-	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.15), 0 3px 9px 0 rgba(0, 0, 0, 0.12) !important;
+	box-shadow: var(
+		--wpds-elevation-sm,
+		0 1px 2px 0 #0000000d,
+		0 2px 3px 0 #0000000a,
+		0 6px 6px 0 #00000008,
+		0 8px 8px 0 #00000005
+	) !important;
 
 }
 

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -43,7 +43,8 @@
 	height: 100%;
 
 	&--animated {
-		transition: opacity var(--wpds-motion-duration-lg, 300ms)
+		transition:
+			opacity var(--wpds-motion-duration-lg, 300ms)
 			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
@@ -85,7 +86,8 @@
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);
-		animation: stretch var(--wpds-motion-duration-xl, 400ms)
+		animation:
+			stretch var(--wpds-motion-duration-xl, 400ms)
 			var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 	}
 
@@ -103,13 +105,7 @@
 	// Override .visx-tooltip inline styles.
 	border-radius: var(--wpds-border-radius-md, 4px) !important;
 	padding: var(--wpds-dimension-padding-md, 12px) !important;
-	box-shadow: var(
-		--wpds-elevation-sm,
-		0 1px 2px 0 #0000000d,
-		0 2px 3px 0 #0000000a,
-		0 6px 6px 0 #00000008,
-		0 8px 8px 0 #00000005
-	) !important;
+	box-shadow: var(--wpds-elevation-sm, 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005) !important;
 
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -1,5 +1,6 @@
 .leaderboardChart {
-	transition: opacity 0.3s ease-in-out;
+	transition: opacity var(--wpds-motion-duration-lg, 300ms)
+		var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 
 	&--responsive {
 		height: 100%;
@@ -118,11 +119,15 @@
 	// a grid item aligned to the inline start, so its inset mirrors in RTL; the
 	// value slide is given an RTL override below. No row background.
 	.bar {
-		transition: opacity 0.15s ease, width 0.15s ease;
+		transition: opacity var(--wpds-motion-duration-sm, 100ms)
+				var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1)),
+			width var(--wpds-motion-duration-sm, 100ms)
+				var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
 	.valueContainer {
-		transition: transform 0.15s ease;
+		transition: transform var(--wpds-motion-duration-sm, 100ms)
+			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
 	&:hover,
@@ -172,7 +177,8 @@
 	margin-block: auto;
 	opacity: 0;
 	color: var(--wpds-color-fg-content-neutral-weak, #707070);
-	transition: opacity 0.15s ease;
+	transition: opacity var(--wpds-motion-duration-sm, 100ms)
+		var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	pointer-events: none;
 
 	// The glyph points toward the inline end, so flip it to point left in RTL.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -1,5 +1,6 @@
 .leaderboardChart {
-	transition: opacity var(--wpds-motion-duration-lg, 300ms)
+	transition:
+		opacity var(--wpds-motion-duration-lg, 300ms)
 		var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 
 	&--responsive {
@@ -57,7 +58,8 @@
 			transform-origin: left;
 			transform-box: fill-box;
 			transform: scaleX(0);
-			animation: stretch var(--wpds-motion-duration-xl, 400ms)
+			animation:
+				stretch var(--wpds-motion-duration-xl, 400ms)
 				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 
@@ -120,14 +122,16 @@
 	// a grid item aligned to the inline start, so its inset mirrors in RTL; the
 	// value slide is given an RTL override below. No row background.
 	.bar {
-		transition: opacity var(--wpds-motion-duration-sm, 100ms)
-				var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1)),
+		transition:
+			opacity var(--wpds-motion-duration-sm, 100ms)
+			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1)),
 			width var(--wpds-motion-duration-sm, 100ms)
-				var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
+			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
 	.valueContainer {
-		transition: transform var(--wpds-motion-duration-sm, 100ms)
+		transition:
+			transform var(--wpds-motion-duration-sm, 100ms)
 			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	}
 
@@ -178,7 +182,8 @@
 	margin-block: auto;
 	opacity: 0;
 	color: var(--wpds-color-fg-content-neutral-weak, #707070);
-	transition: opacity var(--wpds-motion-duration-sm, 100ms)
+	transition:
+		opacity var(--wpds-motion-duration-sm, 100ms)
 		var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 	pointer-events: none;
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -57,7 +57,8 @@
 			transform-origin: left;
 			transform-box: fill-box;
 			transform: scaleX(0);
-			animation: stretch 1s ease-out forwards;
+			animation: stretch var(--wpds-motion-duration-xl, 400ms)
+				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 
 		@keyframes stretch {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -6,7 +6,8 @@
 		path {
 			transform-origin: 0 95%;
 			transform: scaleY(0);
-			animation: rise 1s ease-out forwards;
+			animation: rise var(--wpds-motion-duration-xl, 400ms)
+				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 	}
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -6,7 +6,8 @@
 		path {
 			transform-origin: 0 95%;
 			transform: scaleY(0);
-			animation: rise var(--wpds-motion-duration-xl, 400ms)
+			animation:
+				rise var(--wpds-motion-duration-xl, 400ms)
 				var(--wpds-motion-easing-expressive, cubic-bezier(0.25, 0, 0, 1)) forwards;
 		}
 	}
@@ -64,13 +65,7 @@
 		border: none;
 		border-radius: var(--wpds-border-radius-md, 4px);
 		font-size: var(--wpds-typography-font-size-md, 13px);
-		box-shadow: var(
-			--wpds-elevation-sm,
-			0 1px 2px 0 #0000000d,
-			0 2px 3px 0 #0000000a,
-			0 6px 6px 0 #00000008,
-			0 8px 8px 0 #00000005
-		);
+		box-shadow: var(--wpds-elevation-sm, 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005);
 		position: fixed;
 		// Without margin set, the popover has margin:auto which upsets the
 		// positioning relative to the trigger button. A gap token is appropriate

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -63,7 +63,13 @@
 		border: none;
 		border-radius: var(--wpds-border-radius-md, 4px);
 		font-size: var(--wpds-typography-font-size-md, 13px);
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+		box-shadow: var(
+			--wpds-elevation-sm,
+			0 1px 2px 0 #0000000d,
+			0 2px 3px 0 #0000000a,
+			0 6px 6px 0 #00000008,
+			0 8px 8px 0 #00000005
+		);
 		position: fixed;
 		// Without margin set, the popover has margin:auto which upsets the
 		// positioning relative to the trigger button. A gap token is appropriate

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -28,13 +28,7 @@
 			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
 		border-radius: var(--wpds-border-radius-md, 4px);
 		cursor: pointer;
-		box-shadow: var(
-			--wpds-elevation-sm,
-			0 1px 2px 0 #0000000d,
-			0 2px 3px 0 #0000000a,
-			0 6px 6px 0 #00000008,
-			0 8px 8px 0 #00000005
-		);
+		box-shadow: var(--wpds-elevation-sm, 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005);
 
 		&:hover {
 			background: var(--charts-zoom-reset-bg-hover, rgba(255, 255, 255, 1));

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -28,7 +28,13 @@
 			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
 		border-radius: var(--wpds-border-radius-md, 4px);
 		cursor: pointer;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+		box-shadow: var(
+			--wpds-elevation-sm,
+			0 1px 2px 0 #0000000d,
+			0 2px 3px 0 #0000000a,
+			0 6px 6px 0 #00000008,
+			0 8px 8px 0 #00000005
+		);
 
 		&:hover {
 			background: var(--charts-zoom-reset-bg-hover, rgba(255, 255, 255, 1));

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -28,7 +28,7 @@
 			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
 		border-radius: var(--wpds-border-radius-md, 4px);
 		cursor: pointer;
-		box-shadow: var(--wpds-elevation-sm, 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005);
+		box-shadow: var(--wpds-elevation-xs, 0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003);
 
 		&:hover {
 			background: var(--charts-zoom-reset-bg-hover, rgba(255, 255, 255, 1));

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -8,7 +8,8 @@
 	&--interactive {
 		cursor: pointer;
 		user-select: none;
-		transition: opacity 0.2s ease;
+		transition: opacity var(--wpds-motion-duration-md, 200ms)
+			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 
 		&:hover {
 			opacity: 0.8;

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -8,7 +8,8 @@
 	&--interactive {
 		cursor: pointer;
 		user-select: none;
-		transition: opacity var(--wpds-motion-duration-md, 200ms)
+		transition:
+			opacity var(--wpds-motion-duration-md, 200ms)
 			var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));
 
 		&:hover {

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -7,7 +7,13 @@
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);
 	font-size: var(--wpds-typography-font-size-md, 13px);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	box-shadow: var(
+		--wpds-elevation-sm,
+		0 1px 2px 0 #0000000d,
+		0 2px 3px 0 #0000000a,
+		0 6px 6px 0 #00000008,
+		0 8px 8px 0 #00000005
+	);
 	position: absolute;
 	pointer-events: none;
 	transform: translate(-50%, -100%);

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -7,13 +7,7 @@
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);
 	font-size: var(--wpds-typography-font-size-md, 13px);
-	box-shadow: var(
-		--wpds-elevation-sm,
-		0 1px 2px 0 #0000000d,
-		0 2px 3px 0 #0000000a,
-		0 6px 6px 0 #00000008,
-		0 8px 8px 0 #00000005
-	);
+	box-shadow: var(--wpds-elevation-sm, 0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005);
 	position: absolute;
 	pointer-events: none;
 	transform: translate(-50%, -100%);


### PR DESCRIPTION
## Why

The charts package is migrating to WordPress UI + Theme (WPDS), and shadows/motion were the last fully-hardcoded style category — 0% tokenized. Box-shadows were hand-rolled `rgba()` values and transitions/animations used literal timings (`0.15s`/`0.2s`/`0.3s`, `1s ease-out`), so neither could follow the design system or be themed. WPDS now ships both `--wpds-elevation-*` and `--wpds-motion-*` tokens, so these can finally be routed through the design system the same way the package's spacing, typography, and border values already are.

## Proposed changes

* **Box-shadows → `--wpds-elevation-sm`** — base tooltip, line-chart annotation popover, and conversion-funnel tooltip. All three are floating contextual surfaces, which map to `elevation-sm` ("Tooltips, Snackbar").
* **Box-shadow → `--wpds-elevation-xs`** — zoom-reset button. It's a stationary control rendered inside the chart's bounding box, not a floating overlay, so `elevation-xs` is the correct semantic tier and stays closest to its original subtle `rgba(0,0,0,0.08)` shadow.
* **Transitions → `--wpds-motion-duration-sm/md/lg` + `--wpds-motion-easing-subtle`** — leaderboard, conversion-funnel, and legend hover/state transitions. The `prefers-reduced-motion` override that disables these is left intact.
* **Reveal animations → `--wpds-motion-duration-xl` (400ms) + `--wpds-motion-easing-expressive`** — bar/area/line `rise` and bar/leaderboard/funnel `stretch` entrance animations.

Per the package's fallback-matches-spec rule (`AGENTS.md`), every fallback uses the exact WPDS spec value, so this **adopts** the design-system values rather than preserving the old pixels. Intentional visible consequences:

* Tooltip shadows become the softer, layered WPDS `elevation-sm` shadow instead of the old single `rgba(0,0,0,0.1)`. The zoom-reset button uses `elevation-xs` instead — it's a stationary control, not a floating tooltip, and xs stays closest to its original subtle `0.08` shadow.
* **Fallback-mode timing/easing shifts** (i.e. when WPDS tokens aren't loaded, the fallbacks — which equal the WPDS spec — apply): leaderboard hover transitions go `0.15s → 100ms`; the loading-state fade goes `0.3s → 300ms`; and `ease`/`ease-in-out` are unified to `easing-subtle` (`cubic-bezier(0.15, 0, 0.15, 1)`). These are intentional consequences of adopting the DS motion scale, not regressions.
* Chart entrance animations shorten from `1s` to `400ms` — WPDS motion caps at 400ms, so the reveals move onto the design system's motion scale (a ~2.5× speed-up). This was a deliberate call rather than introducing charts-scoped motion tokens.

Commits are split by concern (shadows / transitions / animations / formatting / changelog) for easy review.

### Scope note: which tooltips actually render `elevation-sm`

This PR tokenizes the *authored* tooltip shadow rules. In live charts, `elevation-sm` currently renders on the **conversion-funnel tooltip** (which overrides visx's default container with `!important`) and the **line-chart annotation popover**. The plain hover tooltips on line/bar/area render inside visx's default container, and pie/semi render their `BaseTooltip` with `renderContainer={ false }` — so those don't route through the `elevation-sm` rule yet. Unifying every tooltip onto one WPDS-tokenized container (matched to the Gutenberg Popover) is a deliberate, separate step tracked in **CHARTS-235** — out of scope here, which is a mechanical hardcoded-value → token swap.

### Screenshots

Rendered from the package's real compiled CSS with the WPDS tokens loaded, showing the tokenized **styles** directly (not a live chart-hover capture): the `--wpds-elevation-sm` tooltip shadow rule, and the `--wpds-motion-duration-xl` (400ms) + `easing-expressive` bar reveal. See the scope note above for where this shadow rule does/doesn't render during real chart use.

<img src="https://github.com/user-attachments/assets/29f7f90e-bc35-43eb-9267-eb97a1b82f3f">

## Related product discussion/links

* Linear: CHARTS-200 (includes the design-analysis P2 and the full hardcoded-instance inventory)
* Follow-up: CHARTS-235 (unify tooltip elevation across the library, matched to the Gutenberg Popover)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package to confirm the SCSS compiles: `pnpm --filter @automattic/charts build` (or `jetpack build js-packages/charts`).
* Unit tests: `pnpm --filter @automattic/charts test` (913 tests).
* In Storybook:
  * **Conversion Funnel** (hover a step) — the tooltip renders the layered WPDS `elevation-sm` shadow. For the same shadow on an annotation surface, open the popover in **Line Chart → Annotations → Custom** (or **Alert**) — the plain annotation labels in the other annotation stories intentionally have no shadow. (The plain line/bar/area hover tooltip still uses visx's default container shadow — routing those onto `elevation-sm` is tracked in CHARTS-235.)
  * **Line Chart** with `zoomable` on — zoom in, then the zoom-reset button renders the subtler WPDS `elevation-xs` shadow.
  * **Bar Chart** — reload to replay the entrance animation: bars rise over ~400ms with the `expressive` easing (snappier than before).
* Theming check: with a `@wordpress/theme` `ThemeProvider` the shadow/motion follow the theme; without one, the fallbacks (which equal the WPDS spec values) render identically.
