### PR TITLE
Premium Analytics: add UTM stats data hook

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-utm-endpoint
+++ b/projects/packages/premium-analytics/changelog/add-stats-utm-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add UTM endpoint data hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -21,6 +21,7 @@ const statsHookNames = [
 	'useStatsStreak',
 	'useStatsVisits',
 	'useStatsInsights',
+	'useStatsUtm',
 ] as const satisfies ReadonlyArray< keyof typeof dataPackage >;
 
 describe( 'Stats public hook names', () => {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -43,6 +43,7 @@ export type {
 	StatsInsightsResponse,
 	StatsInsightsYear,
 } from './use-stats-insights';
+export { useStatsUtm, type StatsUtmParams, type StatsUtmResponse } from './use-stats-utm';
 export type { UseStatsOptions } from './use-stats-report';
 
 /**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-utm.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { statsUtmQuery } from '../queries/stats-utm-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsUtmParams, StatsUtmResponse } from '../queries/stats-utm-query';
+
+export type { StatsUtmParams, StatsUtmResponse } from '../queries/stats-utm-query';
+
+export function useStatsUtm( params: StatsUtmParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsUtmParams, StatsUtmResponse >(
+		statsUtmQuery,
+		params,
+		[ 'stats', 'utm', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -52,6 +52,8 @@ export type {
 	StatsInsightsResponse,
 	StatsInsightsYear,
 } from './hooks/use-stats-insights';
+export { useStatsUtm } from './hooks/use-stats-utm';
+export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
 export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
@@ -103,6 +105,9 @@ export type {
 	StatsTimeSeriesReport,
 	StatsTopAuthorsItem,
 	StatsTopPostsItem,
+	StatsUtmItem,
+	StatsUtmParam,
+	StatsUtmTopPostItem,
 	StatsVideoPlaysItem,
 } from './processing/stats';
 export type { StatsReportParams } from './queries/stats-query';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/utm.ts
@@ -1,0 +1,23 @@
+export const utmFixture = {
+	top_utm_values: {
+		'["google","cpc"]': 11,
+		'["newsletter","email"]': '24',
+	},
+};
+
+export const utmWithTopPostsFixture = {
+	top_utm_values: {
+		'["spring-sale","newsletter","email"]': 18,
+		direct: 7,
+	},
+	top_posts: {
+		'["spring-sale","newsletter","email"]': [
+			{
+				id: 41,
+				title: 'Spring sale landing page',
+				views: 12,
+				href: 'https://example.com/spring-sale/',
+			},
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -100,4 +100,27 @@ describe( 'Stats UTM normalizer', () => {
 			},
 		] );
 	} );
+
+	it( 'treats disabled top post queries as already resolved', () => {
+		const result = sanitizeStatsUtmResponse(
+			{
+				top_utm_values: {
+					'["newsletter","email"]': 24,
+				},
+			},
+			{
+				date: '2026-06-16',
+				query_top_posts: false,
+				utm_param: 'utm_source,utm_medium',
+			}
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			{
+				label: 'newsletter / email',
+				value: 24,
+				children: null,
+			},
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -80,4 +80,24 @@ describe( 'Stats UTM normalizer', () => {
 			data: [],
 		} );
 	} );
+
+	it( 'treats an empty top posts object as already resolved', () => {
+		const result = sanitizeStatsUtmResponse(
+			{
+				top_utm_values: {
+					direct: 7,
+				},
+				top_posts: {},
+			},
+			{ date: '2026-06-16' }
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			{
+				label: 'direct',
+				value: 7,
+				children: null,
+			},
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -101,6 +101,27 @@ describe( 'Stats UTM normalizer', () => {
 		] );
 	} );
 
+	it( 'keeps param values when top posts are null', () => {
+		const result = sanitizeStatsUtmResponse(
+			{
+				top_utm_values: {
+					direct: 7,
+				},
+				top_posts: null,
+			},
+			{ date: '2026-06-16' }
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			{
+				label: 'direct',
+				value: 7,
+				paramValues: 'direct',
+				children: null,
+			},
+		] );
+	} );
+
 	it( 'treats disabled top post queries as already resolved', () => {
 		const result = sanitizeStatsUtmResponse(
 			{

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -1,0 +1,83 @@
+import { sanitizeStatsUtmResponse } from '..';
+import { utmFixture, utmWithTopPostsFixture } from '../__fixtures__/utm';
+
+describe( 'Stats UTM normalizer', () => {
+	it( 'normalizes raw UTM top values into sorted report items', () => {
+		const result = sanitizeStatsUtmResponse( utmFixture, {
+			date: '2026-06-16',
+			utm_param: 'utm_source,utm_medium',
+		} );
+
+		expect( result.summary ).toEqual( { total: 35 } );
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-16',
+				date_start: '2026-06-16T00:00:00+00:00',
+				date_end: '2026-06-16T23:59:59+00:00',
+				items: [
+					{
+						label: 'newsletter / email',
+						value: 24,
+						paramValues: '["newsletter","email"]',
+						children: null,
+					},
+					{
+						label: 'google / cpc',
+						value: 11,
+						paramValues: '["google","cpc"]',
+						children: null,
+					},
+				],
+			} )
+		);
+	} );
+
+	it( 'normalizes top posts included with UTM values', () => {
+		const result = sanitizeStatsUtmResponse( utmWithTopPostsFixture, {
+			date: '2026-06-16',
+			utm_param: 'utm_campaign,utm_source,utm_medium',
+		} );
+
+		expect( result.summary ).toEqual( { total: 25 } );
+		expect( result.data[ 0 ].items ).toEqual( [
+			{
+				label: 'spring-sale / newsletter / email',
+				value: 18,
+				children: [
+					{
+						id: 41,
+						label: 'Spring sale landing page',
+						value: 12,
+						href: 'https://example.com/spring-sale/',
+						page: '/stats/post/41',
+						actions: [
+							{ type: 'link', data: 'https://example.com/spring-sale/' },
+							{
+								type: 'url-builder',
+								data: {
+									url: 'https://example.com/spring-sale/',
+									utm_campaign: 'spring-sale',
+									utm_source: 'newsletter',
+									utm_medium: 'email',
+								},
+							},
+						],
+						children: null,
+					},
+				],
+			},
+			{
+				label: 'direct',
+				value: 7,
+				children: null,
+			},
+		] );
+	} );
+
+	it( 'returns an empty report when top UTM values are missing', () => {
+		expect( sanitizeStatsUtmResponse( {}, { date: '2026-06-16' } ) ).toEqual( {
+			summary: { total: 0 },
+			data: [],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -14,6 +14,7 @@ export { sanitizeStatsVideoPlaysResponse } from './video-plays';
 export { isStatsTimeSeriesPayload, sanitizeStatsTimeSeriesResponse } from './time-series';
 export { sanitizeStatsVisitsResponse } from './visits';
 export { sanitizeStatsInsightsResponse } from './insights';
+export { sanitizeStatsUtmResponse } from './utm';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
 export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
@@ -31,6 +32,7 @@ export type {
 	StatsInsightsResponse,
 	StatsInsightsYear,
 } from './insights';
+export type { StatsUtmItem, StatsUtmParam, StatsUtmTopPostItem } from './utm';
 export type { StatsEmailSummaryItem } from './email-summary';
 export type { StatsEmailBreakdownItem } from './email-breakdown';
 export type { StatsArchivesItem } from './archives';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts
@@ -8,6 +8,7 @@ import type { StatsReferrersItem } from './referrers';
 import type { StatsSearchTermsItem } from './search-terms';
 import type { StatsTopAuthorsItem } from './top-authors';
 import type { StatsTopPostsItem } from './top-posts';
+import type { StatsUtmItem } from './utm';
 import type { StatsVideoPlaysItem } from './video-plays';
 
 export type StatsNormalizedItemBase< TChild = unknown > = {
@@ -29,6 +30,7 @@ export type StatsNormalizedItem =
 	| StatsTopAuthorsItem
 	| StatsLocationsItem
 	| StatsVideoPlaysItem
+	| StatsUtmItem
 	| StatsEmailSummaryItem
 	| StatsEmailBreakdownItem
 	| StatsArchivesItem;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -79,9 +79,9 @@ export function sanitizeStatsUtmResponse(
 	const payload = coerceStatsRecord( response );
 	const topUtmValues = coerceStatsRecord( payload.top_utm_values );
 	const topPosts = coerceStatsRecord( payload.top_posts );
-	// Calypso treats the presence of top_posts, even an empty object, as the signal
-	// that top-post fetching has already been resolved for this response.
-	const hasTopPosts = payload.top_posts !== undefined;
+	// Calypso treats top_posts presence, even an empty object, or an explicit
+	// query_top_posts=false request as the signal that top-post fetching is resolved.
+	const hasTopPosts = payload.top_posts !== undefined || query?.query_top_posts === false;
 	const utmParam = query?.utm_param;
 	const items = Object.entries( topUtmValues )
 		.sort( ( [ , valueA ], [ , valueB ] ) => safeParseFloat( valueB ) - safeParseFloat( valueA ) )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -79,6 +79,8 @@ export function sanitizeStatsUtmResponse(
 	const payload = coerceStatsRecord( response );
 	const topUtmValues = coerceStatsRecord( payload.top_utm_values );
 	const topPosts = coerceStatsRecord( payload.top_posts );
+	// Calypso treats the presence of top_posts, even an empty object, as the signal
+	// that top-post fetching has already been resolved for this response.
 	const hasTopPosts = payload.top_posts !== undefined;
 	const utmParam = query?.utm_param;
 	const items = Object.entries( topUtmValues )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -1,0 +1,106 @@
+import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
+import type { StatsItemAction, StatsNormalizedItemBase, StatsNormalizedReport } from './types';
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+export type StatsUtmParam =
+	| 'utm_source,utm_medium'
+	| 'utm_campaign,utm_source,utm_medium'
+	| 'utm_source'
+	| 'utm_medium'
+	| 'utm_campaign';
+
+export type StatsUtmTopPostItem = StatsNormalizedItemBase & {
+	id: number;
+	value: number;
+	href: string | null;
+	page: string | null;
+	actions: StatsItemAction[];
+	children: null;
+};
+
+export interface StatsUtmItem extends StatsNormalizedItemBase< StatsUtmTopPostItem > {
+	value: number;
+	paramValues?: string;
+}
+
+function parseUtmLabelParts( key: string ): string[] {
+	try {
+		const parsed = JSON.parse( key );
+
+		return Array.isArray( parsed ) ? parsed.map( String ) : [ key ];
+	} catch {
+		return [ key ];
+	}
+}
+
+function getUtmData( utmParam: unknown, parts: string[] ) {
+	if ( typeof utmParam !== 'string' ) {
+		return {};
+	}
+
+	return Object.fromEntries(
+		utmParam
+			.split( ',' )
+			.map( ( key, index ) => [ key, parts[ index ] ] )
+			.filter( ( entry ): entry is [ string, string ] => entry[ 1 ] !== undefined )
+	) as Record< string, string >;
+}
+
+function normalizeUtmTopPost(
+	post: unknown,
+	utmData: Record< string, string >
+): StatsUtmTopPostItem {
+	const payload = coerceStatsRecord( post );
+	const href = typeof payload.href === 'string' ? payload.href : null;
+	const id = safeParseInt( payload.id );
+	const actions = href
+		? [
+				{ type: 'link', data: href },
+				{ type: 'url-builder', data: { url: href, ...utmData } },
+		  ]
+		: [];
+
+	return {
+		id,
+		label: payload.title ?? '',
+		value: safeParseFloat( payload.views ),
+		href,
+		page: id ? `/stats/post/${ id }` : null,
+		actions,
+		children: null,
+	};
+}
+
+export function sanitizeStatsUtmResponse(
+	response: unknown,
+	query?: StatsQueryParams
+): StatsNormalizedReport< StatsUtmItem > {
+	const payload = coerceStatsRecord( response );
+	const topUtmValues = coerceStatsRecord( payload.top_utm_values );
+	const topPosts = coerceStatsRecord( payload.top_posts );
+	const hasTopPosts = payload.top_posts !== undefined;
+	const utmParam = query?.utm_param;
+	const items = Object.entries( topUtmValues )
+		.sort( ( [ , valueA ], [ , valueB ] ) => safeParseFloat( valueB ) - safeParseFloat( valueA ) )
+		.map( ( [ paramValues, value ] ) => {
+			const labelParts = parseUtmLabelParts( paramValues );
+			const children = coerceStatsArray( topPosts[ paramValues ] ).map( post =>
+				normalizeUtmTopPost( post, getUtmData( utmParam, labelParts ) )
+			);
+
+			return {
+				label: labelParts.join( ' / ' ),
+				value: safeParseFloat( value ),
+				...( hasTopPosts ? {} : { paramValues } ),
+				children: children.length ? children : null,
+			};
+		} );
+
+	return {
+		summary: {
+			total: items.reduce( ( total, item ) => total + item.value, 0 ),
+		},
+		data: items.length ? [ createStatsListDataPoint( response, query, items ) ] : [],
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -81,7 +81,7 @@ export function sanitizeStatsUtmResponse(
 	const topPosts = coerceStatsRecord( payload.top_posts );
 	// Calypso treats the presence of top_posts, even an empty object, or an explicit
 	// top-post opt-out as the signal that top-post fetching has already been resolved.
-	const hasResolvedTopPosts = payload.top_posts !== undefined || query?.query_top_posts === false;
+	const hasResolvedTopPosts = payload.top_posts != null || query?.query_top_posts === false;
 	const utmParam = query?.utm_param;
 	const items = Object.entries( topUtmValues )
 		.sort( ( [ , valueA ], [ , valueB ] ) => safeParseFloat( valueB ) - safeParseFloat( valueA ) )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -79,9 +79,9 @@ export function sanitizeStatsUtmResponse(
 	const payload = coerceStatsRecord( response );
 	const topUtmValues = coerceStatsRecord( payload.top_utm_values );
 	const topPosts = coerceStatsRecord( payload.top_posts );
-	// Calypso treats top_posts presence, even an empty object, or an explicit
-	// query_top_posts=false request as the signal that top-post fetching is resolved.
-	const hasTopPosts = payload.top_posts !== undefined || query?.query_top_posts === false;
+	// Calypso treats the presence of top_posts, even an empty object, or an explicit
+	// top-post opt-out as the signal that top-post fetching has already been resolved.
+	const hasResolvedTopPosts = payload.top_posts !== undefined || query?.query_top_posts === false;
 	const utmParam = query?.utm_param;
 	const items = Object.entries( topUtmValues )
 		.sort( ( [ , valueA ], [ , valueB ] ) => safeParseFloat( valueB ) - safeParseFloat( valueA ) )
@@ -94,7 +94,7 @@ export function sanitizeStatsUtmResponse(
 			return {
 				label: labelParts.join( ' / ' ),
 				value: safeParseFloat( value ),
-				...( hasTopPosts ? {} : { paramValues } ),
+				...( hasResolvedTopPosts ? {} : { paramValues } ),
 				children: children.length ? children : null,
 			};
 		} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -7,6 +7,7 @@ import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsStreakQuery } from '../stats-streak-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
+import { statsUtmQuery } from '../stats-utm-query';
 import { statsVisitsQuery } from '../stats-visits-query';
 import type { StatsReportParams } from '../stats-query';
 
@@ -175,6 +176,54 @@ describe( 'Stats query factories', () => {
 					date: '2026-06-07',
 					start_date: '2026-06-01',
 					quantity: 7,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'builds UTM query keys from the selected UTM parameter', () => {
+		const query = statsUtmQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+			utmParam: 'utm_campaign,utm_source,utm_medium',
+		} );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'utm',
+			'1.1',
+			'stats/utm/utm_campaign,utm_source,utm_medium',
+			'GET',
+			{
+				max: 10,
+				date: '2026-06-07',
+				days: 7,
+				start_date: '2026-06-01',
+				post_id: '',
+				query_top_posts: true,
+			},
+			undefined,
+			'utm',
+			{ utm_param: 'utm_campaign,utm_source,utm_medium' },
+		] );
+		expect( query.enabled ).toBe( true );
+	} );
+
+	it( 'disables UTM top posts when querying a post detail', () => {
+		const query = statsUtmQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+			post_id: 41,
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				'stats/utm/utm_source,utm_medium',
+				expect.objectContaining( {
+					post_id: 41,
+					query_top_posts: false,
 				} ),
 			] )
 		);

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -229,6 +229,23 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
+	it( 'preserves explicit UTM top posts boolean params', () => {
+		const query = statsUtmQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+			query_top_posts: false,
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					query_top_posts: false,
+				} ),
+			] )
+		);
+	} );
+
 	it( 'omits visits quantity for non-day ranges', () => {
 		const query = statsVisitsQuery( {
 			from: '2026-06-01',

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -229,6 +229,24 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
+	it( 'treats zero UTM post IDs as omitted', () => {
+		const query = statsUtmQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+			post_id: 0,
+		} );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					post_id: '',
+					query_top_posts: true,
+				} ),
+			] )
+		);
+	} );
+
 	it( 'preserves explicit UTM top posts boolean params', () => {
 		const query = statsUtmQuery( {
 			from: '2026-06-01',

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -27,3 +27,4 @@ export { statsArchivesQuery } from './stats-archives-query';
 export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
 export { statsInsightsQuery } from './stats-insights-query';
+export { statsUtmQuery } from './stats-utm-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -18,6 +18,7 @@ import {
 	sanitizeStatsSiteResponse,
 	sanitizeStatsTopAuthorsResponse,
 	sanitizeStatsTopPostsResponse,
+	sanitizeStatsUtmResponse,
 	sanitizeStatsVideoPlaysResponse,
 } from '../processing/stats';
 import {
@@ -45,6 +46,7 @@ const statsSanitizers = {
 	archives: sanitizeStatsArchivesResponse,
 	insights: sanitizeStatsInsightsResponse,
 	streak: sanitizeStatsStreakResponse,
+	utm: sanitizeStatsUtmResponse,
 	visits: sanitizeStatsVisitsResponse,
 } satisfies Record< string, StatsSanitizer >;
 
@@ -63,6 +65,7 @@ export type StatsQueryConfig< TSanitizer extends StatsSanitizerKey = StatsSaniti
 	method?: StatsProxyMethod;
 	body?: unknown;
 	sanitizer?: TSanitizer;
+	sanitizerParams?: StatsQueryParams;
 	enabled?: boolean;
 };
 
@@ -73,12 +76,31 @@ export function statsProxyQuery(
 	config: StatsQueryConfig
 ): StatsReportQueryOptions< 'passthrough' >;
 export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOptions {
-	const { name, version, endpoint, params, method = 'GET', body, enabled = true } = config;
+	const {
+		name,
+		version,
+		endpoint,
+		params,
+		method = 'GET',
+		body,
+		sanitizerParams,
+		enabled = true,
+	} = config;
 	const sanitizer = config.sanitizer ?? 'passthrough';
 	const apiParams = statsQueryParamsToApiParams( params );
 
 	return {
-		queryKey: [ 'stats', name, version, endpoint, method, apiParams, body, sanitizer ],
+		queryKey: [
+			'stats',
+			name,
+			version,
+			endpoint,
+			method,
+			apiParams,
+			body,
+			sanitizer,
+			...( sanitizerParams ? [ sanitizerParams ] : [] ),
+		],
 		queryFn: async () => {
 			const response = await fetchStatsProxy( {
 				version,
@@ -87,7 +109,10 @@ export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOpt
 				method,
 				body,
 			} );
-			return statsSanitizers[ sanitizer ]( response, apiParams );
+			return statsSanitizers[ sanitizer ]( response, {
+				...apiParams,
+				...sanitizerParams,
+			} );
 		},
 		enabled,
 		placeholderData: previousData => previousData,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
@@ -29,6 +29,8 @@ export const statsUtmQuery = ( params: StatsUtmParams ): StatsReportQueryOptions
 		max: apiParams.max ?? 10,
 		date: apiParams.date,
 		days: apiParams.days,
+		// Match Calypso's UTM request shape; the endpoint accepts empty values for
+		// missing optional filters.
 		start_date: apiParams.start_date ?? '',
 		post_id: params.post_id ?? '',
 		query_top_posts: queryTopPosts,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
@@ -33,6 +33,7 @@ export const statsUtmQuery = ( params: StatsUtmParams ): StatsReportQueryOptions
 		// missing optional filters.
 		start_date: apiParams.start_date ?? '',
 		post_id: params.post_id ?? '',
+		// Calypso sends booleans for this endpoint; keep parity with that request shape.
 		query_top_posts: queryTopPosts,
 	};
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
@@ -24,7 +24,8 @@ export const statsUtmQuery = ( params: StatsUtmParams ): StatsReportQueryOptions
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
 	const utmParam = params.utmParam ?? DEFAULT_UTM_PARAM;
-	const queryTopPosts = params.post_id ? false : params.query_top_posts ?? true;
+	const postId = params.post_id || '';
+	const queryTopPosts = postId ? false : params.query_top_posts ?? true;
 	const utmParams: StatsProxyParams = {
 		max: apiParams.max ?? 10,
 		date: apiParams.date,
@@ -32,7 +33,7 @@ export const statsUtmQuery = ( params: StatsUtmParams ): StatsReportQueryOptions
 		// Match Calypso's UTM request shape; the endpoint accepts empty values for
 		// missing optional filters.
 		start_date: apiParams.start_date ?? '',
-		post_id: params.post_id ?? '',
+		post_id: postId,
 		// Calypso sends booleans for this endpoint; keep parity with that request shape.
 		query_top_posts: queryTopPosts,
 	};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
+import type { StatsProxyParams } from '../api';
+import type { StatsUtmItem, StatsUtmParam, StatsNormalizedReport } from '../processing/stats';
+
+const DEFAULT_UTM_PARAM: StatsUtmParam = 'utm_source,utm_medium';
+
+export type StatsUtmParams = StatsReportParams & {
+	utmParam?: StatsUtmParam;
+	post_id?: number;
+	query_top_posts?: boolean;
+};
+
+export type StatsUtmResponse = StatsNormalizedReport< StatsUtmItem >;
+
+export const statsUtmQuery = ( params: StatsUtmParams ): StatsReportQueryOptions< 'utm' > => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const utmParam = params.utmParam ?? DEFAULT_UTM_PARAM;
+	const queryTopPosts = params.post_id ? false : params.query_top_posts ?? true;
+	const utmParams: StatsProxyParams = {
+		max: apiParams.max ?? 10,
+		date: apiParams.date,
+		days: apiParams.days,
+		start_date: apiParams.start_date ?? '',
+		post_id: params.post_id ?? '',
+		query_top_posts: queryTopPosts,
+	};
+
+	return statsProxyQuery( {
+		name: 'utm',
+		version: '1.1',
+		endpoint: `stats/utm/${ utmParam }`,
+		params: utmParams,
+		sanitizer: 'utm',
+		sanitizerParams: { utm_param: utmParam },
+		enabled: !! apiParams.date,
+	} );
+};


### PR DESCRIPTION
Fixes #

## Why
The Premium Analytics data package has Stats hooks for the split endpoint work, but the UTM surface was stranded in closed PR #49773 and was not included in #49780, #49781, or #49782. This adds the missing UTM query, hook, and normalizer so consumers can request campaign performance data through the same typed data package patterns as the other Stats reports.

## Proposed changes
* Add `statsUtmQuery` for `stats/utm/{utmParam}` with Calypso-aligned request params.
* Add `useStatsUtm` and public exports for the hook and response/item types.
* Add a UTM sanitizer that normalizes raw `top_utm_values` and optional `top_posts` payloads into the existing normalized Stats report shape.
* Add raw API-shaped fixtures plus query, normalizer, and export coverage.

## Verification
Focused tests, lint, typecheck, and whitespace checks passed locally.

<details>
<summary>Output</summary>

```text
$ pnpm --dir projects/packages/premium-analytics test -- packages/data/src/processing/stats/__tests__/utm.test.ts packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand
Test Suites: 3 passed, 3 total
Tests:       34 passed, 34 total

$ pnpm exec eslint --max-warnings=0 <touched files>
Passed with no output.

$ pnpm --dir projects/packages/premium-analytics run typecheck
$ tsgo --noEmit

$ git diff --check
Passed with no output.
```

</details>

## Related product discussion/links
* https://github.com/Automattic/jetpack/pull/49773
* https://github.com/Automattic/jetpack/pull/49780
* https://github.com/Automattic/jetpack/pull/49781
* https://github.com/Automattic/jetpack/pull/49782

## Does this pull request change what data or activity we track or use?
No. This adds a typed client data hook/query/normalizer for an existing Stats endpoint and does not change what data is tracked or used.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test -- packages/data/src/processing/stats/__tests__/utm.test.ts packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand`.
* Run `pnpm exec eslint --max-warnings=0 projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts projects/packages/premium-analytics/packages/data/src/hooks/index.ts projects/packages/premium-analytics/packages/data/src/hooks/use-stats-utm.ts projects/packages/premium-analytics/packages/data/src/index.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/utm.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts projects/packages/premium-analytics/packages/data/src/processing/stats/types.ts projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts projects/packages/premium-analytics/packages/data/src/queries/index.ts projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts projects/packages/premium-analytics/packages/data/src/queries/stats-utm-query.ts`.
* Run `pnpm --dir projects/packages/premium-analytics run typecheck`.
* Run `git diff --check`.
