### PR TITLE
Forms: Add ability output schemas

### DIFF
--- a/projects/packages/forms/changelog/abilities-output-schemas
+++ b/projects/packages/forms/changelog/abilities-output-schemas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Agent Access: Improve response contracts for form and response abilities.

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -152,6 +152,21 @@ class Forms_Abilities extends Registrar {
 				),
 				'additionalProperties' => false,
 			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'            => array( 'type' => 'integer' ),
+						'title'         => array( 'type' => 'string' ),
+						'status'        => array( 'type' => 'string' ),
+						'entries_count' => array( 'type' => 'integer' ),
+						'edit_url'      => array( 'type' => 'string' ),
+						'date'          => array( 'type' => 'string' ),
+						'modified'      => array( 'type' => 'string' ),
+					),
+				),
+			),
 			'execute_callback'    => array( __CLASS__, 'list_forms' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
 			'meta'                => array(
@@ -186,6 +201,18 @@ class Forms_Abilities extends Registrar {
 					),
 				),
 				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'       => array( 'type' => 'integer' ),
+					'title'    => array( 'type' => 'string' ),
+					'status'   => array( 'type' => 'string' ),
+					'fields'   => self::form_fields_schema(),
+					'date'     => array( 'type' => 'string' ),
+					'modified' => array( 'type' => 'string' ),
+					'edit_url' => array( 'type' => 'string' ),
+				),
 			),
 			'execute_callback'    => array( __CLASS__, 'get_form' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
@@ -232,6 +259,15 @@ class Forms_Abilities extends Registrar {
 				),
 				'additionalProperties' => false,
 			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'       => array( 'type' => 'integer' ),
+					'title'    => array( 'type' => 'string' ),
+					'status'   => array( 'type' => 'string' ),
+					'edit_url' => array( 'type' => 'string' ),
+				),
+			),
 			'execute_callback'    => array( __CLASS__, 'create_form' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
 			'meta'                => array(
@@ -266,6 +302,14 @@ class Forms_Abilities extends Registrar {
 					),
 				),
 				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'      => array( 'type' => 'integer' ),
+					'deleted' => array( 'type' => 'boolean' ),
+					'status'  => array( 'type' => 'string' ),
+				),
 			),
 			'execute_callback'    => array( __CLASS__, 'delete_form' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
@@ -344,6 +388,12 @@ class Forms_Abilities extends Registrar {
 				),
 				'additionalProperties' => false,
 			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type' => 'object',
+				),
+			),
 			'execute_callback'    => array( __CLASS__, 'get_form_responses' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
 			'meta'                => array(
@@ -371,6 +421,10 @@ class Forms_Abilities extends Registrar {
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
+				'anyOf'                => array(
+					array( 'required' => array( 'status' ) ),
+					array( 'required' => array( 'is_unread' ) ),
+				),
 				'properties'           => array(
 					'id'        => array(
 						'type'        => 'integer',
@@ -387,6 +441,15 @@ class Forms_Abilities extends Registrar {
 					),
 				),
 				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'        => array( 'type' => 'integer' ),
+					'status'    => array( 'type' => 'string' ),
+					'is_unread' => array( 'type' => 'boolean' ),
+					'count'     => array( 'type' => 'integer' ),
+				),
 			),
 			'execute_callback'    => array( __CLASS__, 'update_form_response' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
@@ -429,6 +492,27 @@ class Forms_Abilities extends Registrar {
 					),
 				),
 				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action'    => array( 'type' => 'string' ),
+					'succeeded' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'integer' ),
+					),
+					'failed'    => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'      => array( 'type' => 'integer' ),
+								'code'    => array( 'type' => 'string' ),
+								'message' => array( 'type' => 'string' ),
+							),
+						),
+					),
+				),
 			),
 			'execute_callback'    => array( __CLASS__, 'bulk_update_responses' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
@@ -483,6 +567,14 @@ class Forms_Abilities extends Registrar {
 				),
 				'additionalProperties' => false,
 			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'inbox' => array( 'type' => 'integer' ),
+					'spam'  => array( 'type' => 'integer' ),
+					'trash' => array( 'type' => 'integer' ),
+				),
+			),
 			'execute_callback'    => array( __CLASS__, 'get_status_counts' ),
 			'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
 			'meta'                => array(
@@ -495,6 +587,27 @@ class Forms_Abilities extends Registrar {
 				'mcp'          => array(
 					'public' => true,
 					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
+			),
+		);
+	}
+
+	/**
+	 * Output schema for extracted form fields.
+	 *
+	 * @return array
+	 */
+	private static function form_fields_schema(): array {
+		return array(
+			'type'  => 'array',
+			'items' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'label'       => array( 'type' => 'string' ),
+					'type'        => array( 'type' => 'string' ),
+					'required'    => array( 'type' => 'boolean' ),
+					'options'     => array( 'type' => 'array' ),
+					'placeholder' => array( 'type' => 'string' ),
 				),
 			),
 		);
@@ -587,6 +700,7 @@ class Forms_Abilities extends Registrar {
 		}
 
 		$raw_content = $data['content']['raw'] ?? '';
+		$edit_url    = get_edit_post_link( $data['id'], 'raw' );
 
 		return array(
 			'id'       => $data['id'],
@@ -595,7 +709,7 @@ class Forms_Abilities extends Registrar {
 			'fields'   => self::extract_fields_from_content( $raw_content ),
 			'date'     => $data['date'],
 			'modified' => $data['modified'],
-			'edit_url' => $data['link'] ?? get_edit_post_link( $data['id'], 'raw' ),
+			'edit_url' => $edit_url ? $edit_url : '',
 		);
 	}
 
@@ -689,6 +803,10 @@ class Forms_Abilities extends Registrar {
 	public static function update_form_response( $args ) {
 		if ( ! isset( $args['id'] ) ) {
 			return new \WP_Error( 'missing_id', __( 'Response ID is required.', 'jetpack-forms' ) );
+		}
+
+		if ( ! isset( $args['status'] ) && ! isset( $args['is_unread'] ) ) {
+			return new \WP_Error( 'missing_update', __( 'Provide a status or read state to update.', 'jetpack-forms' ) );
 		}
 
 		$id     = absint( $args['id'] );

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -297,6 +297,13 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertEquals( 'missing_id', $result->get_error_code() );
 	}
 
+	public function test_update_form_response_requires_mutation_field() {
+		$result = Forms_Abilities::update_form_response( array( 'id' => 123 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result, 'Should return WP_Error when no update field is provided' );
+		$this->assertEquals( 'missing_update', $result->get_error_code() );
+	}
+
 	/**
 	 * Test that abilities handle Abilities API not being available gracefully.
 	 */
@@ -416,6 +423,7 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'Name', $result['fields'][0]['label'] );
 		$this->assertSame( 'text', $result['fields'][0]['type'] );
 		$this->assertTrue( $result['fields'][0]['required'] );
+		$this->assertSame( get_edit_post_link( $post_id, 'raw' ), $result['edit_url'] );
 	}
 
 	/**
@@ -638,11 +646,167 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertSame( array( $id ), $result['succeeded'], 'Duplicate IDs in input should collapse to one succeeded entry.' );
 	}
 
-	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
-		foreach ( Forms_Abilities::get_abilities() as $slug => $spec ) {
+	public function test_ability_metadata_matches_public_contract(): void {
+		foreach ( self::expected_ability_contracts() as $slug => $expected ) {
+			$spec = Forms_Abilities::get_abilities()[ $slug ];
+
+			$this->assertArrayHasKey( 'meta', $spec, "{$slug} must publish meta." );
+			$this->assertSame( true, $spec['meta']['show_in_rest'] ?? null, "{$slug} must be available through the REST abilities endpoint." );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'], "{$slug} must publish meta.annotations." );
+			$this->assertSame( $expected['annotations'], $spec['meta']['annotations'], "{$slug} annotations must match its current behavior." );
 			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
-			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
-			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+			$this->assertSame( true, $spec['meta']['mcp']['public'] ?? null, "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'] ?? null, "{$slug} must be exposed as an MCP tool." );
 		}
+	}
+
+	public function test_every_ability_declares_output_schema_for_current_return_shape(): void {
+		foreach ( self::expected_ability_contracts() as $slug => $expected ) {
+			$spec = Forms_Abilities::get_abilities()[ $slug ];
+
+			$this->assertArrayHasKey( 'output_schema', $spec, "{$slug} must document its output_schema." );
+			$this->assertSame( $expected['output_type'], $spec['output_schema']['type'] ?? null, "{$slug} output_schema type must match current return shape." );
+
+			if ( 'array' === $expected['output_type'] ) {
+				$this->assertSame( 'object', $spec['output_schema']['items']['type'] ?? null, "{$slug} array items must be objects." );
+				$this->assertSchemaProperties( $expected['properties'], $spec['output_schema']['items']['properties'] ?? array(), "{$slug} item" );
+			} else {
+				$this->assertSchemaProperties( $expected['properties'], $spec['output_schema']['properties'] ?? array(), $slug );
+			}
+		}
+	}
+
+	/**
+	 * Assert that the documented schema includes the expected property types.
+	 *
+	 * @param array  $expected Expected property => type map.
+	 * @param array  $actual   Actual schema properties.
+	 * @param string $context  Assertion context.
+	 */
+	private function assertSchemaProperties( array $expected, array $actual, string $context ): void {
+		foreach ( $expected as $property => $type ) {
+			$this->assertArrayHasKey( $property, $actual, "{$context} schema must include {$property}." );
+			$this->assertSame( $type, $actual[ $property ]['type'] ?? null, "{$context}.{$property} type must match current return shape." );
+		}
+	}
+
+	/**
+	 * Expected public contract for the eight Forms abilities.
+	 *
+	 * @return array
+	 */
+	private static function expected_ability_contracts(): array {
+		return array(
+			'jetpack-forms/list-forms'            => array(
+				'annotations' => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'array',
+				'properties'  => array(
+					'id'            => 'integer',
+					'title'         => 'string',
+					'status'        => 'string',
+					'entries_count' => 'integer',
+					'edit_url'      => 'string',
+					'date'          => 'string',
+					'modified'      => 'string',
+				),
+			),
+			'jetpack-forms/get-form'              => array(
+				'annotations' => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'id'       => 'integer',
+					'title'    => 'string',
+					'status'   => 'string',
+					'fields'   => 'array',
+					'date'     => 'string',
+					'modified' => 'string',
+					'edit_url' => 'string',
+				),
+			),
+			'jetpack-forms/create-form'           => array(
+				'annotations' => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'id'       => 'integer',
+					'title'    => 'string',
+					'status'   => 'string',
+					'edit_url' => 'string',
+				),
+			),
+			'jetpack-forms/delete-form'           => array(
+				'annotations' => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'id'      => 'integer',
+					'deleted' => 'boolean',
+					'status'  => 'string',
+				),
+			),
+			'jetpack-forms/get-responses'         => array(
+				'annotations' => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'array',
+				'properties'  => array(),
+			),
+			'jetpack-forms/update-response'       => array(
+				'annotations' => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'id'        => 'integer',
+					'status'    => 'string',
+					'is_unread' => 'boolean',
+					'count'     => 'integer',
+				),
+			),
+			'jetpack-forms/bulk-update-responses' => array(
+				'annotations' => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'action'    => 'string',
+					'succeeded' => 'array',
+					'failed'    => 'array',
+				),
+			),
+			'jetpack-forms/get-status-counts'     => array(
+				'annotations' => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'output_type' => 'object',
+				'properties'  => array(
+					'inbox' => 'integer',
+					'spam'  => 'integer',
+					'trash' => 'integer',
+				),
+			),
+		);
 	}
 }


### PR DESCRIPTION
Fixes #

This PR is open because Forms is already the strongest Jetpack Abilities API integration, and agents need dependable response shapes to use it safely. It keeps the change limited to output contracts and a small no-op guard so the broader rollout can stay reviewable.

## Proposed changes
* Add explicit output schemas for the Jetpack Forms abilities so agent clients can reason about response shapes.
* Tighten `jetpack-forms/update-response` so calls must include a mutation field, matching the declared object output contract.
* Return the admin edit URL from `jetpack-forms/get-form` instead of the public permalink.
* Strengthen Forms ability tests for public metadata, output schemas, no-op update handling, and edit URL behavior.

## Related product discussion/links
* JETPACK-1769: https://linear.app/a8c/issue/JETPACK-1769/track-targeted-jetpack-abilities-api-rollout-prs

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* From `projects/packages/forms`, run:
  * `php vendor/bin/phpunit-select-config phpunit.#.xml.dist --colors=always tests/php/abilities/Forms_Abilities_Test.php`
* Confirm the test passes with `30 tests, 227 assertions`.
* Optional broader check: `CI=true jp test php packages/forms -v` currently reaches PHPUnit but fails in existing webhook localhost tests unrelated to these Forms abilities changes.