### PR TITLE
Add Premium Analytics post stats data hook

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-premium-analytics-post-stats
+++ b/projects/packages/premium-analytics/changelog/add-premium-analytics-post-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: Add post stats data hook.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -5,6 +5,7 @@ import * as dataPackage from '../../index';
 
 const statsHookNames = [
 	'useStatsSite',
+	'useStatsPost',
 	'useStatsTopPosts',
 	'useStatsReferrers',
 	'useStatsClicks',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -6,6 +6,12 @@ export { useReportCustomers } from './use-report-customers';
 export { useReportConversionRate } from './use-report-conversion-rate';
 export { useReportBookings } from './use-report-bookings';
 export { useStatsSite } from './use-stats-site';
+export {
+	useStatsPost,
+	type StatsPostField,
+	type StatsPostParams,
+	type StatsPostResponse,
+} from './use-stats-post';
 export { useStatsTopPosts } from './use-stats-top-posts';
 export { useStatsReferrers } from './use-stats-referrers';
 export { useStatsClicks } from './use-stats-clicks';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-post.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { statsPostQuery } from '../queries/stats-post-query';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsPostParams, StatsPostResponse } from '../queries/stats-post-query';
+
+export type {
+	StatsPostField,
+	StatsPostParams,
+	StatsPostResponse,
+} from '../queries/stats-post-query';
+
+export function useStatsPost( params: StatsPostParams, options?: UseStatsOptions ) {
+	return useStatsQuery< StatsPostResponse >( statsPostQuery( params ), options );
+}

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -107,6 +107,7 @@ export type {
 	StatsNormalizedReport,
 	StatsNormalizedSummary,
 	StatsPostMonthValues,
+	StatsPostRawResponse,
 	StatsPostWeek,
 	StatsPostWeekDay,
 	StatsPostYear,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -107,7 +107,6 @@ export type {
 	StatsNormalizedReport,
 	StatsNormalizedSummary,
 	StatsPostMonthValues,
-	StatsPostRawResponse,
 	StatsPostWeek,
 	StatsPostWeekDay,
 	StatsPostYear,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -15,6 +15,8 @@ export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-loca
 export { useReportBookings } from './hooks/use-report-bookings';
 export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
 export { useStatsSite } from './hooks/use-stats-site';
+export { useStatsPost } from './hooks/use-stats-post';
+export type { StatsPostField, StatsPostParams, StatsPostResponse } from './hooks/use-stats-post';
 export { useStatsTopPosts } from './hooks/use-stats-top-posts';
 export { useStatsReferrers } from './hooks/use-stats-referrers';
 export { useStatsClicks } from './hooks/use-stats-clicks';
@@ -104,6 +106,11 @@ export type {
 	StatsNormalizedItemBase,
 	StatsNormalizedReport,
 	StatsNormalizedSummary,
+	StatsPostMonthValues,
+	StatsPostRawResponse,
+	StatsPostWeek,
+	StatsPostWeekDay,
+	StatsPostYear,
 	StatsReferrersItem,
 	StatsSearchTermsItem,
 	StatsStreakRawResponse,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
@@ -2,48 +2,48 @@ import type { StatsPostRawResponse } from '../post';
 
 export const postStatsFixture: StatsPostRawResponse = {
 	date: '2026-06-22',
-	views: '128',
+	views: 128,
 	years: {
 		'2026': {
-			total: '128',
+			total: 128,
 			months: {
-				'1': '0',
-				'2': '0',
-				'3': '0',
-				'4': '0',
-				'5': '43',
-				'6': '85',
+				'1': 0,
+				'2': 0,
+				'3': 0,
+				'4': 0,
+				'5': 43,
+				'6': 85,
 			},
 		},
 	},
 	averages: {
 		'2026': {
-			overall: '4.13',
+			overall: 4.13,
 			months: {
-				'5': '1.39',
-				'6': '3.86',
+				'5': 1.39,
+				'6': 3.86,
 			},
 		},
 	},
 	weeks: [
 		{
 			days: [
-				{ day: '2026-06-15', count: '12' },
-				{ day: '2026-06-16', count: '0' },
-				{ day: '2026-06-17', count: '8' },
-				{ day: '2026-06-18', count: '14' },
-				{ day: '2026-06-19', count: '16' },
-				{ day: '2026-06-20', count: '11' },
-				{ day: '2026-06-21', count: '24' },
+				{ day: '2026-06-15', count: 12 },
+				{ day: '2026-06-16', count: 0 },
+				{ day: '2026-06-17', count: 8 },
+				{ day: '2026-06-18', count: 14 },
+				{ day: '2026-06-19', count: 16 },
+				{ day: '2026-06-20', count: 11 },
+				{ day: '2026-06-21', count: 24 },
 			],
-			total: '85',
-			average: '12.14',
-			change: '15.25',
+			total: 85,
+			average: 12.14,
+			change: 15.25,
 		},
 	],
-	highest_month: '85',
-	highest_day_average: '12.14',
-	highest_week_average: '85',
+	highest_month: 85,
+	highest_day_average: 12.14,
+	highest_week_average: 85,
 	post: {
 		ID: 41,
 		title: 'Hello world',
@@ -52,5 +52,5 @@ export const postStatsFixture: StatsPostRawResponse = {
 };
 
 export const postStatsViewsFixture: StatsPostRawResponse = {
-	views: '128',
+	views: 128,
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
@@ -1,4 +1,6 @@
-export const postStatsFixture = {
+import type { StatsPostRawResponse } from '../post';
+
+export const postStatsFixture: StatsPostRawResponse = {
 	date: '2026-06-22',
 	views: 128,
 	years: {
@@ -49,6 +51,6 @@ export const postStatsFixture = {
 	},
 };
 
-export const postStatsViewsFixture = {
+export const postStatsViewsFixture: StatsPostRawResponse = {
 	views: 128,
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
@@ -1,6 +1,4 @@
-import type { StatsPostRawResponse } from '../post';
-
-export const postStatsFixture: StatsPostRawResponse = {
+export const postStatsFixture = {
 	date: '2026-06-22',
 	views: 128,
 	years: {
@@ -51,6 +49,6 @@ export const postStatsFixture: StatsPostRawResponse = {
 	},
 };
 
-export const postStatsViewsFixture: StatsPostRawResponse = {
+export const postStatsViewsFixture = {
 	views: 128,
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
@@ -1,0 +1,56 @@
+import type { StatsPostRawResponse } from '../post';
+
+export const postStatsFixture: StatsPostRawResponse = {
+	date: '2026-06-22',
+	views: '128',
+	years: {
+		'2026': {
+			total: '128',
+			months: {
+				'1': '0',
+				'2': '0',
+				'3': '0',
+				'4': '0',
+				'5': '43',
+				'6': '85',
+			},
+		},
+	},
+	averages: {
+		'2026': {
+			overall: '4.13',
+			months: {
+				'5': '1.39',
+				'6': '3.86',
+			},
+		},
+	},
+	weeks: [
+		{
+			days: [
+				{ day: '2026-06-15', count: '12' },
+				{ day: '2026-06-16', count: '0' },
+				{ day: '2026-06-17', count: '8' },
+				{ day: '2026-06-18', count: '14' },
+				{ day: '2026-06-19', count: '16' },
+				{ day: '2026-06-20', count: '11' },
+				{ day: '2026-06-21', count: '24' },
+			],
+			total: '85',
+			average: '12.14',
+			change: '15.25',
+		},
+	],
+	highest_month: '85',
+	highest_day_average: '12.14',
+	highest_week_average: '85',
+	post: {
+		ID: 41,
+		title: 'Hello world',
+		type: 'post',
+	},
+};
+
+export const postStatsViewsFixture: StatsPostRawResponse = {
+	views: '128',
+};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
@@ -63,6 +63,28 @@ describe( 'Stats post normalizer', () => {
 		} );
 	} );
 
+	it( 'coerces stringified numeric values defensively', () => {
+		expect(
+			sanitizeStatsPostResponse( {
+				views: '128',
+				years: {
+					'2026': {
+						total: '128',
+						months: { '6': '85' },
+					},
+				},
+			} )
+		).toEqual( {
+			views: 128,
+			years: {
+				'2026': {
+					total: 128,
+					months: { '6': 85 },
+				},
+			},
+		} );
+	} );
+
 	it( 'returns an empty object for missing or invalid payloads', () => {
 		expect( sanitizeStatsPostResponse( null ) ).toEqual( {} );
 		expect( sanitizeStatsPostResponse( [] ) ).toEqual( {} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
@@ -1,0 +1,70 @@
+import { sanitizeStatsPostResponse } from '..';
+import { postStatsFixture, postStatsViewsFixture } from '../__fixtures__/post';
+
+describe( 'Stats post normalizer', () => {
+	it( 'normalizes a raw post stats payload without dropping detail fields', () => {
+		const result = sanitizeStatsPostResponse( postStatsFixture );
+
+		expect( result ).toEqual( {
+			date: '2026-06-22',
+			views: 128,
+			years: {
+				'2026': {
+					total: 128,
+					months: {
+						'1': 0,
+						'2': 0,
+						'3': 0,
+						'4': 0,
+						'5': 43,
+						'6': 85,
+					},
+				},
+			},
+			averages: {
+				'2026': {
+					overall: 4.13,
+					months: {
+						'5': 1.39,
+						'6': 3.86,
+					},
+				},
+			},
+			weeks: [
+				{
+					days: [
+						{ day: '2026-06-15', count: 12 },
+						{ day: '2026-06-16', count: 0 },
+						{ day: '2026-06-17', count: 8 },
+						{ day: '2026-06-18', count: 14 },
+						{ day: '2026-06-19', count: 16 },
+						{ day: '2026-06-20', count: 11 },
+						{ day: '2026-06-21', count: 24 },
+					],
+					total: 85,
+					average: 12.14,
+					change: 15.25,
+				},
+			],
+			highest_month: 85,
+			highest_day_average: 12.14,
+			highest_week_average: 85,
+			post: {
+				ID: 41,
+				title: 'Hello world',
+				type: 'post',
+			},
+		} );
+	} );
+
+	it( 'normalizes a fields=views response', () => {
+		expect( sanitizeStatsPostResponse( postStatsViewsFixture ) ).toEqual( {
+			views: 128,
+		} );
+	} );
+
+	it( 'returns an empty object for missing or invalid payloads', () => {
+		expect( sanitizeStatsPostResponse( null ) ).toEqual( {} );
+		expect( sanitizeStatsPostResponse( [] ) ).toEqual( {} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -23,7 +23,6 @@ export { sanitizeStatsStreakResponse } from './streak';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
 	StatsPostMonthValues,
-	StatsPostRawResponse,
 	StatsPostResponse,
 	StatsPostWeek,
 	StatsPostWeekDay,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -4,6 +4,7 @@ export {
 	sanitizeStatsSiteResponse,
 } from './utils';
 export { sanitizeStatsTopPostsResponse } from './top-posts';
+export { sanitizeStatsPostResponse } from './post';
 export { sanitizeStatsReferrersResponse } from './referrers';
 export { sanitizeStatsClicksResponse } from './clicks';
 export { sanitizeStatsSearchTermsResponse } from './search-terms';
@@ -20,6 +21,14 @@ export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
 export { sanitizeStatsStreakResponse } from './streak';
 export type { StatsTopPostsItem } from './top-posts';
+export type {
+	StatsPostMonthValues,
+	StatsPostRawResponse,
+	StatsPostResponse,
+	StatsPostWeek,
+	StatsPostWeekDay,
+	StatsPostYear,
+} from './post';
 export type { StatsReferrersItem } from './referrers';
 export type { StatsClicksItem } from './clicks';
 export type { StatsSearchTermsItem } from './search-terms';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -23,6 +23,7 @@ export { sanitizeStatsStreakResponse } from './streak';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
 	StatsPostMonthValues,
+	StatsPostRawResponse,
 	StatsPostResponse,
 	StatsPostWeek,
 	StatsPostWeekDay,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -1,0 +1,115 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
+
+export type StatsPostMonthValues = Record< string, number >;
+
+export type StatsPostYear = {
+	total?: number;
+	overall?: number;
+	months: StatsPostMonthValues;
+};
+
+export type StatsPostWeekDay = {
+	day?: string;
+	count: number;
+};
+
+export type StatsPostWeek = {
+	days: StatsPostWeekDay[];
+	total?: number;
+	average?: number;
+	change?: number;
+};
+
+export type StatsPostRawResponse = {
+	date?: string;
+	views?: unknown;
+	years?: unknown;
+	averages?: unknown;
+	weeks?: unknown;
+	highest_month?: unknown;
+	highest_day_average?: unknown;
+	highest_week_average?: unknown;
+	post?: unknown;
+};
+
+export type StatsPostResponse = {
+	date?: string;
+	views?: number;
+	years?: Record< string, StatsPostYear >;
+	averages?: Record< string, StatsPostYear >;
+	weeks?: StatsPostWeek[];
+	highest_month?: number;
+	highest_day_average?: number;
+	highest_week_average?: number;
+	post?: unknown;
+};
+
+function normalizeStatsPostYear( value: unknown ): StatsPostYear {
+	const year = coerceStatsRecord( value );
+	const months = coerceStatsRecord( year.months );
+
+	return {
+		...( year.total !== undefined ? { total: safeParseFloat( year.total ) } : {} ),
+		...( year.overall !== undefined ? { overall: safeParseFloat( year.overall ) } : {} ),
+		months: Object.fromEntries(
+			Object.entries( months ).map( ( [ month, count ] ) => [ month, safeParseFloat( count ) ] )
+		),
+	};
+}
+
+function normalizeStatsPostYears( value: unknown ) {
+	const years = coerceStatsRecord( value );
+
+	return Object.fromEntries(
+		Object.entries( years ).map( ( [ year, stats ] ) => [ year, normalizeStatsPostYear( stats ) ] )
+	);
+}
+
+function normalizeStatsPostWeek( value: unknown ): StatsPostWeek {
+	const week = coerceStatsRecord( value );
+
+	return {
+		days: coerceStatsArray( week.days ).map( day => {
+			const item = coerceStatsRecord( day );
+
+			return {
+				...( typeof item.day === 'string' ? { day: item.day } : {} ),
+				count: safeParseFloat( item.count ),
+			};
+		} ),
+		...( week.total !== undefined ? { total: safeParseFloat( week.total ) } : {} ),
+		...( week.average !== undefined ? { average: safeParseFloat( week.average ) } : {} ),
+		...( week.change !== undefined ? { change: safeParseFloat( week.change ) } : {} ),
+	};
+}
+
+export function sanitizeStatsPostResponse( response: unknown ): StatsPostResponse {
+	if ( ! isStatsRecord( response ) ) {
+		return {};
+	}
+
+	const payload = coerceStatsRecord( response );
+
+	return {
+		...( typeof payload.date === 'string' ? { date: payload.date } : {} ),
+		...( payload.views !== undefined ? { views: safeParseFloat( payload.views ) } : {} ),
+		...( payload.years !== undefined ? { years: normalizeStatsPostYears( payload.years ) } : {} ),
+		...( payload.averages !== undefined
+			? { averages: normalizeStatsPostYears( payload.averages ) }
+			: {} ),
+		...( payload.weeks !== undefined
+			? { weeks: coerceStatsArray( payload.weeks ).map( normalizeStatsPostWeek ) }
+			: {} ),
+		...( payload.highest_month !== undefined
+			? { highest_month: safeParseFloat( payload.highest_month ) }
+			: {} ),
+		...( payload.highest_day_average !== undefined
+			? { highest_day_average: safeParseFloat( payload.highest_day_average ) }
+			: {} ),
+		...( payload.highest_week_average !== undefined
+			? { highest_week_average: safeParseFloat( payload.highest_week_average ) }
+			: {} ),
+		...( payload.post !== undefined ? { post: payload.post } : {} ),
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -41,7 +41,7 @@ type StatsPostRawWeek = {
 	change?: StatsPostRawNumeric;
 };
 
-export type StatsPostRawResponse = {
+type StatsPostRawResponse = {
 	date?: string;
 	views?: StatsPostRawNumeric;
 	years?: Record< string, StatsPostRawYear >;
@@ -109,7 +109,7 @@ export function sanitizeStatsPostResponse( response: unknown ): StatsPostRespons
 		return {};
 	}
 
-	const payload = coerceStatsRecord( response );
+	const payload = response as StatsPostRawResponse;
 
 	return {
 		...( typeof payload.date === 'string' ? { date: payload.date } : {} ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -21,15 +21,35 @@ export type StatsPostWeek = {
 	change?: number;
 };
 
+type StatsPostRawNumeric = number | string;
+
+type StatsPostRawYear = {
+	total?: StatsPostRawNumeric;
+	overall?: StatsPostRawNumeric;
+	months?: Record< string, StatsPostRawNumeric >;
+};
+
+type StatsPostRawWeekDay = {
+	day?: string;
+	count?: StatsPostRawNumeric;
+};
+
+type StatsPostRawWeek = {
+	days?: StatsPostRawWeekDay[];
+	total?: StatsPostRawNumeric;
+	average?: StatsPostRawNumeric;
+	change?: StatsPostRawNumeric;
+};
+
 export type StatsPostRawResponse = {
 	date?: string;
-	views?: unknown;
-	years?: unknown;
-	averages?: unknown;
-	weeks?: unknown;
-	highest_month?: unknown;
-	highest_day_average?: unknown;
-	highest_week_average?: unknown;
+	views?: StatsPostRawNumeric;
+	years?: Record< string, StatsPostRawYear >;
+	averages?: Record< string, StatsPostRawYear >;
+	weeks?: StatsPostRawWeek[];
+	highest_month?: StatsPostRawNumeric;
+	highest_day_average?: StatsPostRawNumeric;
+	highest_week_average?: StatsPostRawNumeric;
 	post?: unknown;
 };
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -41,7 +41,7 @@ type StatsPostRawWeek = {
 	change?: StatsPostRawNumeric;
 };
 
-type StatsPostRawResponse = {
+export type StatsPostRawResponse = {
 	date?: string;
 	views?: StatsPostRawNumeric;
 	years?: Record< string, StatsPostRawYear >;
@@ -109,7 +109,7 @@ export function sanitizeStatsPostResponse( response: unknown ): StatsPostRespons
 		return {};
 	}
 
-	const payload = response as StatsPostRawResponse;
+	const payload = coerceStatsRecord( response );
 
 	return {
 		...( typeof payload.date === 'string' ? { date: payload.date } : {} ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -5,6 +5,7 @@ import { statsAppProxyQuery } from '../stats-app-query';
 import { statsArchivesQuery } from '../stats-archives-query';
 import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
+import { statsPostQuery } from '../stats-post-query';
 import { statsStreakQuery } from '../stats-streak-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
@@ -14,6 +15,44 @@ import type { StatsReportParams } from '../stats-query';
 describe( 'Stats query factories', () => {
 	it( 'disables report queries until a date range is available', () => {
 		expect( statsTopPostsQuery( {} as StatsReportParams ).enabled ).toBe( false );
+	} );
+
+	it( 'builds post stats query keys with fields', () => {
+		const query = statsPostQuery( {
+			postId: 41,
+			fields: [ 'views', 'years' ],
+		} );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'post',
+			'1.1',
+			'stats/post/41',
+			'GET',
+			{
+				fields: 'views,years',
+			},
+			undefined,
+			'post',
+		] );
+	} );
+
+	it( 'matches Calypso post stats requests when fields are omitted', () => {
+		const query = statsPostQuery( { postId: 41 } );
+
+		expect( query.queryKey ).toEqual(
+			expect.arrayContaining( [
+				'stats/post/41',
+				{
+					fields: '',
+				},
+			] )
+		);
+	} );
+
+	it( 'disables post stats queries until a valid post ID is available', () => {
+		expect( statsPostQuery( { postId: -1 } ).enabled ).toBe( false );
 	} );
 
 	it( 'includes filter_by_country in query params when provided', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -51,8 +51,9 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
-	it( 'disables post stats queries until a valid post ID is available', () => {
+	it( 'disables post stats queries until a positive post ID is available', () => {
 		expect( statsPostQuery( { postId: -1 } ).enabled ).toBe( false );
+		expect( statsPostQuery( { postId: 0 } ).enabled ).toBe( false );
 	} );
 
 	it( 'includes filter_by_country in query params when provided', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -13,6 +13,7 @@ export { reportBookingsQuery } from './report-bookings-query';
 export { statsProxyQuery, statsReportQuery } from './stats-query';
 export type { StatsQueryConfig, StatsReportParams, StatsSanitizerKey } from './stats-query';
 export { statsSiteQuery } from './stats-site-query';
+export { statsPostQuery } from './stats-post-query';
 export { statsTopPostsQuery } from './stats-top-posts-query';
 export { statsReferrersQuery } from './stats-referrers-query';
 export { statsClicksQuery } from './stats-clicks-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-post-query.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { statsProxyQuery } from './stats-query';
-import type { StatsReportParams, StatsReportQueryOptions } from './stats-query';
+import type { StatsReportQueryOptions } from './stats-query';
 import type { StatsProxyParams } from '../api';
 import type { StatsPostResponse } from '../processing/stats';
 
@@ -17,7 +17,7 @@ export type StatsPostField =
 	| 'highest_week_average'
 	| 'post';
 
-export type StatsPostParams = Partial< StatsReportParams > & {
+export type StatsPostParams = {
 	postId: number;
 	fields?: StatsPostField[];
 };
@@ -35,6 +35,6 @@ export const statsPostQuery = ( params: StatsPostParams ): StatsReportQueryOptio
 		endpoint: `stats/post/${ params.postId }`,
 		params: postParams,
 		sanitizer: 'post',
-		enabled: Number.isInteger( params.postId ) && params.postId > -1,
+		enabled: Number.isInteger( params.postId ) && params.postId > 0,
 	} );
 };

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-post-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-post-query.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { statsProxyQuery } from './stats-query';
+import type { StatsReportParams, StatsReportQueryOptions } from './stats-query';
+import type { StatsProxyParams } from '../api';
+import type { StatsPostResponse } from '../processing/stats';
+
+export type StatsPostField =
+	| 'date'
+	| 'views'
+	| 'years'
+	| 'averages'
+	| 'weeks'
+	| 'highest_month'
+	| 'highest_day_average'
+	| 'highest_week_average'
+	| 'post';
+
+export type StatsPostParams = Partial< StatsReportParams > & {
+	postId: number;
+	fields?: StatsPostField[];
+};
+
+export type { StatsPostResponse };
+
+export const statsPostQuery = ( params: StatsPostParams ): StatsReportQueryOptions< 'post' > => {
+	const postParams: StatsProxyParams = {
+		fields: params.fields?.join( ',' ) ?? '',
+	};
+
+	return statsProxyQuery( {
+		name: 'post',
+		version: '1.1',
+		endpoint: `stats/post/${ params.postId }`,
+		params: postParams,
+		sanitizer: 'post',
+		enabled: Number.isInteger( params.postId ) && params.postId > -1,
+	} );
+};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -13,6 +13,7 @@ import {
 	sanitizeStatsStreakResponse,
 	sanitizeStatsVisitsResponse,
 	sanitizeStatsPassthroughResponse,
+	sanitizeStatsPostResponse,
 	sanitizeStatsReferrersResponse,
 	sanitizeStatsSearchTermsResponse,
 	sanitizeStatsSiteResponse,
@@ -34,6 +35,7 @@ type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQuer
 
 const statsSanitizers = {
 	passthrough: sanitizeStatsPassthroughResponse,
+	post: sanitizeStatsPostResponse,
 	site: sanitizeStatsSiteResponse,
 	topPosts: sanitizeStatsTopPostsResponse,
 	referrers: sanitizeStatsReferrersResponse,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a typed Premium Analytics data hook for the WPCOM `stats/post/{postId}` endpoint.
* Normalize the raw post stats payload while preserving endpoint-specific fields like views, years, averages, weeks, and post fallback data.
* Register the new sanitizer/query/hook exports and add focused query and normalizer tests.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No. This adds a typed client-side data wrapper for an existing stats endpoint.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics test -- packages/data/src/queries/__tests__/stats-queries.test.ts packages/data/src/processing/stats/__tests__/post.test.ts packages/data/src/hooks/__tests__/stats-exports.test.ts --runInBand`.
* Run `pnpm exec eslint --max-warnings=0 projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts projects/packages/premium-analytics/packages/data/src/hooks/index.ts projects/packages/premium-analytics/packages/data/src/hooks/use-stats-post.ts projects/packages/premium-analytics/packages/data/src/index.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts projects/packages/premium-analytics/packages/data/src/queries/index.ts projects/packages/premium-analytics/packages/data/src/queries/stats-post-query.ts projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts`.
* Run `pnpm --dir projects/packages/premium-analytics run typecheck`.
* Run `git diff --check`.
