### PR TITLE
Charts: fix Bar Chart comparison mode keyboard a11y and zero baseline [CHARTS-220]

### DIFF
--- a/projects/js-packages/charts/changelog/charts-220-bar-chart-comparison-mode-keyboard-a11y-zero-baseline-fixes
+++ b/projects/js-packages/charts/changelog/charts-220-bar-chart-comparison-mode-keyboard-a11y-zero-baseline-fixes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: fix Bar Chart comparison mode — pair the keyboard tooltip with the focused bar and keep the value axis zero-based.
+Charts: fix Bar Chart comparison mode — pair the keyboard tooltip with the focused bar, keep the value axis zero-based, and make the tooltip label/value separator translatable.

--- a/projects/js-packages/charts/changelog/charts-220-bar-chart-comparison-mode-keyboard-a11y-zero-baseline-fixes
+++ b/projects/js-packages/charts/changelog/charts-220-bar-chart-comparison-mode-keyboard-a11y-zero-baseline-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix Bar Chart comparison mode — pair the keyboard tooltip with the focused bar and keep the value axis zero-based.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -1,7 +1,7 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { PatternLines, PatternCircles, PatternWaves, PatternHexagons } from '@visx/pattern';
 import { Axis, BarSeries, BarGroup, Grid, XYChart } from '@visx/xychart';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useContext, useState, useRef, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -82,6 +82,19 @@ const validateData = ( data: SeriesData[] ) => {
 };
 
 const getPatternId = ( chartId: string, index: number ) => `bar-pattern-${ chartId }-${ index }`;
+
+// A "label: value" tooltip row. The join is a translated format string so the
+// separator (a colon + space here) can be adapted per locale.
+const renderTooltipRow = ( label: string | undefined, value: string ) => (
+	<div className={ styles[ 'bar-chart__tooltip-row' ] }>
+		{ sprintf(
+			/* translators: 1: data series, period, or category label. 2: its formatted value. */
+			__( '%1$s: %2$s', 'jetpack-charts' ),
+			label,
+			value
+		) }
+	</div>
+);
 
 const BarChartInternal: FC< BarChartProps > = ( {
 	data,
@@ -317,20 +330,11 @@ const BarChartInternal: FC< BarChartProps > = ( {
 				return (
 					<div className={ styles[ 'bar-chart__tooltip' ] }>
 						<div className={ styles[ 'bar-chart__tooltip-header' ] }>{ categoryLabel }</div>
-						<div className={ styles[ 'bar-chart__tooltip-row' ] }>
-							<span className={ styles[ 'bar-chart__tooltip-label' ] }>{ primaryKey }:</span>
-							<span className={ styles[ 'bar-chart__tooltip-value' ] }>
-								{ formatNumber( nearestDatum.value as number ) }
-							</span>
-						</div>
-						<div className={ styles[ 'bar-chart__tooltip-row' ] }>
-							<span className={ styles[ 'bar-chart__tooltip-label' ] }>
-								{ comparisonEntry.series.label }:
-							</span>
-							<span className={ styles[ 'bar-chart__tooltip-value' ] }>
-								{ formatNumber( comparisonDatum.value as number ) }
-							</span>
-						</div>
+						{ renderTooltipRow( primaryKey, formatNumber( nearestDatum.value as number ) ) }
+						{ renderTooltipRow(
+							comparisonEntry.series.label,
+							formatNumber( comparisonDatum.value as number )
+						) }
 					</div>
 				);
 			}
@@ -338,12 +342,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 			return (
 				<div className={ styles[ 'bar-chart__tooltip' ] }>
 					<div className={ styles[ 'bar-chart__tooltip-header' ] }>{ primaryKey }</div>
-					<div className={ styles[ 'bar-chart__tooltip-row' ] }>
-						<span className={ styles[ 'bar-chart__tooltip-label' ] }>{ categoryLabel }:</span>
-						<span className={ styles[ 'bar-chart__tooltip-value' ] }>
-							{ formatNumber( nearestDatum.value as number ) }
-						</span>
-					</div>
+					{ renderTooltipRow( categoryLabel, formatNumber( nearestDatum.value as number ) ) }
 				</div>
 			);
 		},

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -191,6 +191,14 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		[ primaryEntries ]
 	);
 
+	// The keyboard-navigation index space and the highlight CSS both stride over primary
+	// bars only; the accessible tooltip must use the same list, or its datum diverges from
+	// the highlighted bar once a comparison series shifts the indices.
+	const primarySeries = useMemo(
+		() => primaryEntries.map( ( { series } ) => series ),
+		[ primaryEntries ]
+	);
+
 	const comparisonEntries = useMemo( () => {
 		const primaryByGroup = new Map< string | undefined, { label: string; index: number } >(
 			primaryEntries.map( ( { series, index } ) => [
@@ -622,7 +630,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 												keyboardFocusedClassName={
 													styles[ 'bar-chart__tooltip--keyboard-focused' ]
 												}
-												series={ data }
+												series={ primarySeries }
 												mode="individual"
 											/>
 										) }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/comparison-bars.tsx
@@ -146,6 +146,7 @@ export const ComparisonBars: FC< {
 		<g
 			className="bar-chart__comparison-bars"
 			pointerEvents="none"
+			aria-hidden="true"
 			data-testid="bar-chart-comparison-bars"
 		>
 			{ rects }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -123,8 +123,11 @@ export function useBarChartOptions(
 					} );
 				} );
 				if ( allValues.length > 0 ) {
+					// Keep zero in the domain so bar length stays proportional to value — a
+					// non-zero baseline would exaggerate differences between periods. Math.max
+					// keeps zero on the far side too, so charts with negative values still span 0.
 					valueScaleDomainOverride = {
-						domain: [ Math.min( ...allValues ), Math.max( ...allValues ) ],
+						domain: [ Math.min( 0, ...allValues ), Math.max( 0, ...allValues ) ],
 					};
 				}
 			}

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -901,6 +901,57 @@ describe( 'BarChart', () => {
 			expect( bars.length ).toBeGreaterThanOrEqual( 2 );
 		} );
 
+		it( 'hides the comparison shadow group from assistive technology', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [ { label: 'Jan', value: 100 } ],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Jan', value: 80 } ],
+				},
+			];
+			render( <BarChart data={ data } width={ 400 } height={ 300 } /> );
+
+			// The shadow is decorative: no keyboard/hover target and its value is surfaced
+			// through the tooltip, so it must not be announced as a separate element.
+			expect( screen.getByTestId( 'bar-chart-comparison-bars' ) ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			);
+		} );
+
+		it( 'renders comparison shadows in horizontal orientation', () => {
+			const data = [
+				{
+					label: 'This year',
+					group: 'views',
+					data: [
+						{ label: 'Jan', value: 100 },
+						{ label: 'Feb', value: 120 },
+					],
+				},
+				{
+					label: 'Last year',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [
+						{ label: 'Jan', value: 80 },
+						{ label: 'Feb', value: 140 },
+					],
+				},
+			];
+			render( <BarChart data={ data } orientation="horizontal" width={ 400 } height={ 300 } /> );
+
+			const shadows = screen.getAllByTestId( /^bar-chart-comparison-\d+-\d+$/ );
+			expect( shadows ).toHaveLength( 2 );
+			expect( shadows[ 0 ] ).toHaveAttribute( 'opacity', '0.5' );
+		} );
+
 		it( 'expands value-axis domain to include comparison values exceeding the primary max', () => {
 			// Comparison value 150 exceeds primary max 100.
 			// Without domain expansion the value-axis scale config has no explicit domain,

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -322,6 +322,8 @@ describe( 'BarChart', () => {
 				await user.keyboard( '{ArrowRight}' );
 				expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveFocus();
 				expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'Series A' );
+				// The category/value row joins with a space after the colon.
+				expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'Jan 1: 10' );
 				expect( screen.queryByTestId( 'chart-tooltip-1' ) ).not.toBeInTheDocument();
 
 				// Second tab should focus on the second tooltip.
@@ -409,11 +411,9 @@ describe( 'BarChart', () => {
 
 				await user.keyboard( '{ArrowRight}' );
 				const tooltip = screen.getByTestId( 'chart-tooltip-0' );
-				// Both the current and previous period values are shown.
-				expect( tooltip ).toHaveTextContent( 'This period' );
-				expect( tooltip ).toHaveTextContent( '10' );
-				expect( tooltip ).toHaveTextContent( 'Previous period' );
-				expect( tooltip ).toHaveTextContent( '15' );
+				// Both periods are shown, each as "label: value" with a space after the colon.
+				expect( tooltip ).toHaveTextContent( 'This period: 10' );
+				expect( tooltip ).toHaveTextContent( 'Previous period: 15' );
 			} );
 
 			test( 'keyboard navigation past the first slot stays on the primary bar, not the comparison series', async () => {

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -415,6 +415,47 @@ describe( 'BarChart', () => {
 				expect( tooltip ).toHaveTextContent( 'Previous period' );
 				expect( tooltip ).toHaveTextContent( '15' );
 			} );
+
+			test( 'keyboard navigation past the first slot stays on the primary bar, not the comparison series', async () => {
+				const user = userEvent.setup();
+				renderWithTheme( {
+					withTooltips: true,
+					data: [
+						{
+							label: 'This period',
+							group: 'views',
+							data: [
+								{ label: 'Mon', value: 10 },
+								{ label: 'Tue', value: 20 },
+							],
+						},
+						{
+							label: 'Previous period',
+							group: 'views',
+							options: { type: 'comparison' as const },
+							data: [
+								{ label: 'Mon', value: 15 },
+								{ label: 'Tue', value: 25 },
+							],
+						},
+					],
+				} );
+
+				const chart = screen.getByRole( 'grid', { name: /bar chart/i } );
+				chart.focus();
+
+				// Slot 0 is the first primary bar (Mon); slot 1 must be the SECOND primary
+				// bar (Tue) — not the comparison series' first bar. The keyboard index space
+				// counts only primary bars, so the tooltip must too.
+				await user.keyboard( '{ArrowRight}' );
+				await user.keyboard( '{ArrowRight}' );
+				const tooltip = screen.getByTestId( 'chart-tooltip-1' );
+				expect( tooltip ).toHaveTextContent( 'Tue' );
+				expect( tooltip ).toHaveTextContent( 'This period' );
+				expect( tooltip ).toHaveTextContent( '20' );
+				expect( tooltip ).toHaveTextContent( 'Previous period' );
+				expect( tooltip ).toHaveTextContent( '25' );
+			} );
 		} );
 
 		describe( 'Tab Key Navigation', () => {

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -927,6 +927,52 @@ describe( 'BarChart', () => {
 			expect( ( yScale.domain as number[] )[ 1 ] ).toBeGreaterThanOrEqual( 150 );
 		} );
 
+		it( 'keeps the value-axis baseline at zero so comparison bars encode magnitude truthfully', () => {
+			// All values are well above zero; the domain must still start at 0 so a bar's
+			// length stays proportional to its value (a non-zero baseline exaggerates differences).
+			const data = [
+				{
+					label: 'This period',
+					group: 'views',
+					data: [ { label: 'Mon', value: 420 } ],
+				},
+				{
+					label: 'Previous period',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Mon', value: 510 } ],
+				},
+			];
+
+			const { result } = renderHook( () => useBarChartOptions( data, false, {} ) );
+			const yScale = result.current.yScale as { domain?: number[] };
+			expect( yScale.domain ).toBeDefined();
+			expect( ( yScale.domain as number[] )[ 0 ] ).toBe( 0 );
+		} );
+
+		it( 'zero-bases the value-axis domain in horizontal comparison charts', () => {
+			const data = [
+				{
+					label: 'This period',
+					group: 'views',
+					data: [ { label: 'Mon', value: 420 } ],
+				},
+				{
+					label: 'Previous period',
+					group: 'views',
+					options: { type: 'comparison' as const },
+					data: [ { label: 'Mon', value: 510 } ],
+				},
+			];
+
+			// In horizontal charts the value axis is x.
+			const { result } = renderHook( () => useBarChartOptions( data, true, {} ) );
+			const xScale = result.current.xScale as { domain?: number[] };
+			expect( xScale.domain ).toBeDefined();
+			expect( ( xScale.domain as number[] )[ 0 ] ).toBe( 0 );
+			expect( ( xScale.domain as number[] )[ 1 ] ).toBeGreaterThanOrEqual( 510 );
+		} );
+
 		it( 'counts only primary series for keyboard navigation when a comparison series is present', async () => {
 			const user = userEvent.setup();
 			// 2 primary + 1 comparison. totalPoints should be 2*2=4, not 3*2=6.


### PR DESCRIPTION
Fixes CHARTS-220

## Why

A post-merge review of #49676 (Bar Chart comparison mode) surfaced two defects that shipped behind passing tests:

1. **Keyboard navigation was broken in comparison mode.** `AccessibleTooltip` received the full `data` array, so its individual-mode index space strode over *all* series while keyboard nav and the highlight CSS strode over *primary bars only*. With a comparison series present, the focus ring and the tooltip diverged past the first slot — the highlighted bar and the announced value referred to different bars, and the tooltip could resolve a comparison datum that has no focusable bar. That's a real accessibility failure for keyboard and screen-reader users.
2. **Comparison mode abandoned the zero baseline.** The explicit value-axis domain used the data minimum as its lower bound, so the shortest bar rendered as a near-empty sliver and bar length stopped encoding magnitude — the one invariant a bar chart must preserve.

Both were caught only because the review exercised the feature in a real browser; the unit suite was green throughout.

## Proposed changes

* **Fix keyboard tooltip pairing** — pass the primary-only series list to `AccessibleTooltip` so its index space matches keyboard navigation and the highlight CSS. The paired comparison value is still shown via the existing `renderDefaultTooltip` augmentation, so the dual-period tooltip is preserved.
* **Zero-base the comparison value axis** — fold `0` into the computed domain bounds (`Math.min(0, …)` / `Math.max(0, …)`), so bars stay proportional and negative-valued charts still span the baseline.
* **Hide the comparison shadow from assistive tech** — add `aria-hidden="true"` to the decorative shadow group (it already has no hover/keyboard target; its value is surfaced through the tooltip).
* **Add the missing integration coverage** — a keyboard pass *past the first slot* with a comparison series (the exact case that let the bug ship green), the `aria-hidden` assertion, and a horizontal-orientation comparison render (previously only covered at the pure-geometry unit level).
* **Translate the tooltip label/value separator** — the rows joined `label:` + value with no space and a hardcoded `": "`, which isn't right for every locale. Each row now goes through a translated `%1$s: %2$s` format string (via a shared `renderTooltipRow` helper), fixing the missing space in both the comparison and standard tooltips.

### Screenshots

Captured live from Storybook with the branch's code.

**Keyboard navigation — focus ring vs. tooltip**

| Before (bug) | After (fix) |
|-|-|
| Focus ring on the **Tue** bar, tooltip shows **Mon / Previous period** — they disagree, and the stop is the invisible comparison shadow. | Focus ring on the **Thu** bar, tooltip shows **Thu / This period + Previous period** — highlighted bar and tooltip agree. |
| <img width="1400" height="900" alt="before-keyboard-focus-tooltip-mismatch" src="https://github.com/user-attachments/assets/e6fc7232-c44c-4df7-bbce-11e83ed9d66a" /> | <img width="1400" height="900" alt="after-keyboard-focus-tooltip-aligned" src="https://github.com/user-attachments/assets/99d0021e-18a0-4945-9c50-9834021a6d4c" /> |

**Value axis — zero baseline**

| Before (bug) | After (fix) |
|-|-|
| Axis starts at **300**; "Wed" (310) is a near-empty sliver — bar length no longer encodes magnitude. | Axis starts at **0**; "Wed" renders as a real bar proportional to its value. |
| <img width="1400" height="900" alt="before-axis-truncated-at-300" src="https://github.com/user-attachments/assets/a6897d73-de30-4334-8e89-4a03ec389826" /> | <img width="1400" height="900" alt="after-axis-zero-based" src="https://github.com/user-attachments/assets/5b232388-2ba5-4497-92c2-bd8e0ac7b46e" /> |

### Scope notes / divergence from the issue

CHARTS-220 also lists softer suggestions that remain **intentionally deferred**:

* 50%-opacity shadow contrast — a design call (the value is already conveyed via the tooltip, so not a WCAG failure).
* Doc note that primary series labels must be unique; comment on the rebuilt visx inner band scale as a maintenance hazard.

These remain tracked on CHARTS-220.

## Related product discussion/links

* Linear: CHARTS-220
* Follows up the post-merge review of #49676 (CHARTS-217)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

In `projects/js-packages/charts`, run Storybook (`pnpm run storybook`) and open **JS Packages → Charts Library → Charts → Bar Chart**:

* **Comparison** story — the value axis now starts at **0**; "Wed" (310) renders as a real bar rather than a sliver, and each translucent shadow still sits centred behind its primary.
* Focus the chart (Tab to it) and press **ArrowRight** repeatedly — each stop lands on a primary bar (Mon → Tue → Wed → …), the blue focus ring and the tooltip always agree, and the tooltip shows both the current and previous period. It no longer lands on a phantom "Previous period" stop.
* Toggle **orientation: horizontal** (story control) on the Comparison story — shadows render and centre correctly there too.
* **Default** and **Horizontal** (standard, non-comparison) stories render unchanged.

Automated (from `projects/js-packages/charts`):

* `pnpm test` → 918 tests pass (48 suites), including new cases for keyboard-past-slot-0, zero baseline (vertical + horizontal), `aria-hidden`, and horizontal comparison render.
* `pnpm run typecheck` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


