### PR TITLE
Cookie Consent: make banner/modal/toggles theme-agnostic via design tokens

### DIFF
--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -2,7 +2,7 @@
 
 Cookie Consent (`@automattic/jetpack-cookie-consent`) is a plugin-agnostic package intended to provide a GDPR cookie-consent banner, a CCPA "Do Not Sell/Share" opt-out flow, geolocation-based consent-model selection, WP Consent API integration, and consent logging.
 
-This package is currently scaffold-only (no runtime behavior yet) and includes a placeholder Interactivity module entry point so the build passes; feature code is introduced in follow-up PRs.
+It renders a fixed-position consent banner and a preferences modal on `wp_footer` (driven by the WordPress Interactivity API), auto-creates a CCPA "Your Privacy Choices" opt-out page, injects the required legal links into a footer `core/navigation` block on block themes (via Block Hooks), and provides a floating fallback control for those links on classic themes.
 
 ## Usage
 
@@ -59,6 +59,39 @@ add_filter(
 	}
 );
 ```
+
+## Theming and customization
+
+The banner, modal, category toggles, and footer-links fallback control are styled from namespaced CSS custom properties (design tokens) with self-contained defaults, so they render consistently regardless of the active theme. The tokens are deliberately **not** derived from theme presets (`--wp--preset--*`): a theme that defines those presets for its own layout (a small spacing scale, an inverted palette, etc.) cannot break or recolor the consent UI.
+
+Override the tokens to customize the look — via the Customizer/Site Editor **Additional CSS**, a child theme stylesheet, or inline styles. Define them on `.jetpack-cookie-consent` (banner/modal) and/or `.jetpack-cookie-consent-footer-links` (the classic-theme fallback control):
+
+```css
+.jetpack-cookie-consent,
+.jetpack-cookie-consent-footer-links {
+	--jp-cookie-consent--color-background: #102a43;
+	--jp-cookie-consent--color-text: #f0f4f8;
+	--jp-cookie-consent--color-text-muted: #9fb3c8;
+	--jp-cookie-consent--color-border: #334e68;
+	--jp-cookie-consent--spacing: 20px;
+	--jp-cookie-consent--font-size: 16px;
+	--jp-cookie-consent--z-index: 50000; /* the modal sits at this value + 1 */
+}
+```
+
+The token-defining rule uses `:where()` (zero specificity), so any of these mechanisms overrides it without needing `!important`. The banner is rendered on `wp_footer` and is not a block, so it cannot be customized through the block editor or Global Styles — Additional CSS / the tokens are the supported customization path.
+
+## Theme support
+
+| Required legal links                                                                                  | Banner + modal | Consistent styling |
+| ----------------------------------------------------------------------------------------------------- | -------------- | ------------------ |
+| **Block theme with a footer `core/navigation`** — injected into the footer navigation via Block Hooks | ✓              | ✓                  |
+| **Block theme without a footer nav** — floating fallback control                                      | ✓              | ✓                  |
+| **Classic theme** — floating fallback control                                                         | ✓              | ✓                  |
+
+Rendering assumes the theme calls `wp_footer()`, which is effectively universal. A theme that omits `wp_footer()` will simply not render the banner/controls — a graceful no-op, not an error.
+
+Manual test matrix: verify on a representative classic theme (Twenty Twenty-One) and a block theme (Twenty Twenty-Four), with and without a footer `core/navigation` block.
 
 ## Requirements
 

--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -73,6 +73,7 @@ Override the tokens to customize the look — via the Customizer/Site Editor **A
 	--jp-cookie-consent--color-text: #f0f4f8;
 	--jp-cookie-consent--color-text-muted: #9fb3c8;
 	--jp-cookie-consent--color-border: #334e68;
+	--jp-cookie-consent--color-surface-hover: #243b53;
 	--jp-cookie-consent--spacing: 20px;
 	--jp-cookie-consent--font-size: 16px;
 	--jp-cookie-consent--z-index: 50000; /* the modal sits at this value + 1 */

--- a/projects/packages/cookie-consent/changelog/fix-cross-theme-styling
+++ b/projects/packages/cookie-consent/changelog/fix-cross-theme-styling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Make the consent banner, modal, category toggles, and classic-theme footer-links fallback control render consistently across classic and block themes by driving spacing, color, and z-index from namespaced design tokens (--jp-cookie-consent--*) instead of theme presets, and by hardening the toggle against theme form styles. The tokens double as a customization surface via Additional CSS.
+Make the consent banner, modal, and controls render consistently across classic and block themes, and expose their colors, spacing, and stacking order as CSS custom properties so the appearance can be customized via Additional CSS.

--- a/projects/packages/cookie-consent/changelog/fix-cross-theme-styling
+++ b/projects/packages/cookie-consent/changelog/fix-cross-theme-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make the consent banner, modal, category toggles, and classic-theme footer-links fallback control render consistently across classic and block themes by driving spacing, color, and z-index from namespaced design tokens (--jp-cookie-consent--*) instead of theme presets, and by hardening the toggle against theme form styles. The tokens double as a customization surface via Additional CSS.

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -21,7 +21,7 @@
 	--jp-cookie-consent--color-border: #dcdcde;
 	--jp-cookie-consent--spacing: 16px;
 	--jp-cookie-consent--font-size: 16px;
-	--jp-cookie-consent--z-index: 50000;
+	--jp-cookie-consent--z-index: 999999;
 }
 
 /* Banner */
@@ -31,7 +31,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	z-index: var(--jp-cookie-consent--z-index, 50000);
+	z-index: var(--jp-cookie-consent--z-index, 999999);
 	pointer-events: auto;
 	align-items: flex-end;
 }
@@ -129,7 +129,7 @@
 	right: 0;
 	top: 0;
 	transition: opacity 0.3s;
-	z-index: var(--jp-cookie-consent--z-index, 50000);
+	z-index: var(--jp-cookie-consent--z-index, 999999);
 }
 
 :where(.jetpack-cookie-consent__modal-overlay[hidden]) {
@@ -163,7 +163,7 @@
 	position: fixed;
 	transform: translateY(50px);
 	width: 100%;
-	z-index: calc(var(--jp-cookie-consent--z-index, 50000) + 1);
+	z-index: calc(var(--jp-cookie-consent--z-index, 999999) + 1);
 }
 
 :where(.jetpack-cookie-consent__modal[hidden]) {
@@ -419,6 +419,11 @@
 	transition: all 0.2s ease;
 }
 
+/* The checkmark is iconographic, not directional, so keep it identical in RTL.
+   rtl:ignore stops rtlcss from mirroring the border/rotation into a backwards
+   check. */
+
+/* rtl:ignore */
 .jetpack-cookie-consent__category-checkbox-icon::after {
 	content: "";
 	position: absolute;
@@ -535,7 +540,7 @@ input[type="checkbox"]:focus-visible + label
 	position: fixed;
 	bottom: 20px;
 	left: 20px;
-	z-index: 50000;
+	z-index: var(--jp-cookie-consent--z-index, 999999);
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -669,7 +674,7 @@ input[type="checkbox"]:focus-visible + label
 	position: fixed;
 	bottom: 20px;
 	left: 20px;
-	z-index: var(--jp-cookie-consent--z-index, 50000);
+	z-index: var(--jp-cookie-consent--z-index, 999999);
 	max-width: calc(100% - 100px);
 }
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -637,7 +637,7 @@ input[type="checkbox"]:focus-visible + label
 /* Reduced Motion */
 @media ( prefers-reduced-motion: reduce ) {
 
-	.jetpack-cookie-consent-footer-links__toggle {
+	#jetpack-cookie-consent-footer-links-toggle {
 		transition: none;
 	}
 }
@@ -675,7 +675,7 @@ input[type="checkbox"]:focus-visible + label
 	position: fixed;
 	bottom: 20px;
 	left: 20px;
-	z-index: var(--jp-cookie-consent--z-index, 999999);
+	z-index: 999999;
 	max-width: calc(100% - 100px);
 }
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -19,6 +19,7 @@
 	--jp-cookie-consent--color-text: #1e1e1e;
 	--jp-cookie-consent--color-text-muted: #686868;
 	--jp-cookie-consent--color-border: #dcdcde;
+	--jp-cookie-consent--color-surface-hover: #f0f0f0;
 	--jp-cookie-consent--spacing: 16px;
 	--jp-cookie-consent--font-size: 16px;
 	--jp-cookie-consent--z-index: 999999;
@@ -115,7 +116,7 @@
 }
 
 .jetpack-cookie-consent__button--tertiary:hover {
-	background: var(--jp-cookie-consent--color-border, #f0f0f0) !important;
+	background: var(--jp-cookie-consent--color-surface-hover, #f0f0f0) !important;
 }
 
 /* Modal Overlay - Aligned with WooCommerce Bookings modal pattern */
@@ -557,7 +558,7 @@ input[type="checkbox"]:focus-visible + label
 }
 
 /* The toggle is a <button>; classic themes ship high-specificity button resets
-   (e.g. Twenty Twenty-One's `button:not(:hover):not(:active)`, 0,3,1) that
+   (e.g. Twenty Twenty-One's `button:not(:hover):not(:active)`, 0,2,1) that
    out-specify a single class and recolor/repad it. Style the singleton control
    via its unique id so the token-driven appearance wins regardless of theme. */
 #jetpack-cookie-consent-footer-links-toggle {
@@ -577,7 +578,7 @@ input[type="checkbox"]:focus-visible + label
 }
 
 #jetpack-cookie-consent-footer-links-toggle:hover {
-	background: var(--jp-cookie-consent--color-border, #f0f0f0);
+	background: var(--jp-cookie-consent--color-surface-hover, #f0f0f0);
 }
 
 #jetpack-cookie-consent-footer-links-toggle:focus-visible {
@@ -625,7 +626,7 @@ input[type="checkbox"]:focus-visible + label
 
 .jetpack-cookie-consent-footer-links__link:hover {
 	text-decoration: underline;
-	background: var(--jp-cookie-consent--color-border, #f0f0f0);
+	background: var(--jp-cookie-consent--color-surface-hover, #f0f0f0);
 }
 
 .jetpack-cookie-consent-footer-links__link:focus-visible {
@@ -684,7 +685,7 @@ input[type="checkbox"]:focus-visible + label
 	align-items: center;
 	justify-content: space-between;
 	background-color: #f1f9f3;
-	color: var(--jp-cookie-consent--color-text, #1e1e1e);
+	color: #1e1e1e;
 	padding: 16px;
 	border-radius: 4px;
 	border: 1px solid #c3e8cd;

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -243,10 +243,13 @@
 	}
 }
 
-/* Desktop: Center modal like WooCommerce Bookings */
+/* Desktop: Center modal like WooCommerce Bookings.
+   Scoped under the root class (not :where()) so the structural sizing wins over
+   classic-theme resets such as `html, body, div, … { max-width: none }`, which
+   would otherwise stretch the modal to full width. */
 @media ( min-width: 782px ) {
 
-	:where(.jetpack-cookie-consent__modal) {
+	.jetpack-cookie-consent .jetpack-cookie-consent__modal {
 		bottom: auto;
 		height: auto;
 		left: 50%;
@@ -257,11 +260,11 @@
 		width: 100%;
 	}
 
-	:where(.jetpack-cookie-consent__modal--visible) {
+	.jetpack-cookie-consent .jetpack-cookie-consent__modal--visible {
 		transform: translate(-50%, -50%);
 	}
 
-	:where(.jetpack-cookie-consent__modal-content) {
+	.jetpack-cookie-consent .jetpack-cookie-consent__modal-content {
 		max-height: 630px;
 	}
 }
@@ -537,7 +540,11 @@ input[type="checkbox"]:focus-visible + label
 	display: none;
 }
 
-.jetpack-cookie-consent-footer-links__toggle {
+/* The toggle is a <button>; classic themes ship high-specificity button resets
+   (e.g. Twenty Twenty-One's `button:not(:hover):not(:active)`, 0,3,1) that
+   out-specify a single class and recolor/repad it. Style the singleton control
+   via its unique id so the token-driven appearance wins regardless of theme. */
+#jetpack-cookie-consent-footer-links-toggle {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
@@ -553,11 +560,11 @@ input[type="checkbox"]:focus-visible + label
 	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.12);
 }
 
-.jetpack-cookie-consent-footer-links__toggle:hover {
+#jetpack-cookie-consent-footer-links-toggle:hover {
 	background: var(--jp-cookie-consent--color-border, #f0f0f0);
 }
 
-.jetpack-cookie-consent-footer-links__toggle:focus-visible {
+#jetpack-cookie-consent-footer-links-toggle:focus-visible {
 	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: 2px;
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -95,10 +95,13 @@
 	outline-offset: 2px;
 }
 
+/* Secondary/tertiary buttons set their own surface; !important keeps a classic
+   theme's high-specificity `button` reset from recoloring them. Primary buttons
+   intentionally inherit the theme button styling, so are left alone. */
 .jetpack-cookie-consent__button--secondary {
-	background: var(--jp-cookie-consent--color-background, #fff);
-	color: var(--jp-cookie-consent--color-text, #1e1e1e);
-	border-color: var(--jp-cookie-consent--color-text, #1e1e1e);
+	background: var(--jp-cookie-consent--color-background, #fff) !important;
+	color: var(--jp-cookie-consent--color-text, #1e1e1e) !important;
+	border: 1px solid var(--jp-cookie-consent--color-text, #1e1e1e) !important;
 }
 
 .jetpack-cookie-consent__button--secondary:hover {
@@ -106,13 +109,13 @@
 }
 
 .jetpack-cookie-consent__button--tertiary {
-	background: transparent;
-	color: var(--jp-cookie-consent--color-text, #1e1e1e);
-	border-color: var(--jp-cookie-consent--color-border, #dcdcde);
+	background: transparent !important;
+	color: var(--jp-cookie-consent--color-text, #1e1e1e) !important;
+	border: 1px solid var(--jp-cookie-consent--color-border, #dcdcde) !important;
 }
 
 .jetpack-cookie-consent__button--tertiary:hover {
-	background: var(--jp-cookie-consent--color-border, #f0f0f0);
+	background: var(--jp-cookie-consent--color-border, #f0f0f0) !important;
 }
 
 /* Modal Overlay - Aligned with WooCommerce Bookings modal pattern */
@@ -197,8 +200,12 @@
 }
 
 :where(.jetpack-cookie-consent__modal-close) {
-	background: none;
-	border: none;
+
+	/* !important defeats classic-theme button fills (e.g. Twenty Twenty-One's
+	   `button:not(:hover):not(:active)`) that would otherwise paint this icon
+	   button with the theme color; specificity alone can't beat that selector. */
+	background: none !important;
+	border: none !important;
 	cursor: pointer;
 	padding: 5px;
 	display: flex;
@@ -310,8 +317,10 @@
 	right: 0;
 	top: 0;
 	position: absolute;
-	background: none;
-	border: none;
+
+	/* !important defeats classic-theme button fills (see modal-close above). */
+	background: none !important;
+	border: none !important;
 	cursor: pointer;
 	padding: 0;
 	margin-left: auto;
@@ -440,7 +449,9 @@ input[type="checkbox"]:focus-visible + label
 	opacity: 0.66;
 }
 
-.jetpack-cookie-consent__category-checkbox--disabled label {
+/* Root-scoped to match the (also root-scoped) label rule's specificity so the
+   disabled "Required" row shows not-allowed rather than the pointer cursor. */
+.jetpack-cookie-consent .jetpack-cookie-consent__category-checkbox--disabled label {
 	cursor: not-allowed;
 }
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/styles.scss
@@ -2,17 +2,36 @@
    Cookie Consent Styles
    Aligned with WooCommerce Bookings modal pattern for UI consistency.
    Uses :where() selectors for low specificity (theme-friendly).
-   Modal uses hard-coded spacing (like Bookings), banner uses theme variables.
+
+   Design tokens (--jp-cookie-consent--*) drive spacing, color, and z-index.
+   They are namespaced (not theme presets like --wp--preset--*) so themes
+   cannot override structural values, and the defaults stay legible and
+   consistent across classic and block themes. The tokens are also the
+   customization surface: override them via Additional CSS / inline styles,
+   e.g. `.jetpack-cookie-consent { --jp-cookie-consent--color-text: #111; }`.
    ========================================================================== */
 
-/* Banner - Uses theme variables for spacing */
+/* Design tokens, defined with :where() so specificity stays 0 — a plain
+   `.jetpack-cookie-consent {}` rule or inline style can override them. Covers
+   the footer-links fallback control (rendered outside the banner root). */
+:where(.jetpack-cookie-consent, .jetpack-cookie-consent-footer-links) {
+	--jp-cookie-consent--color-background: #fff;
+	--jp-cookie-consent--color-text: #1e1e1e;
+	--jp-cookie-consent--color-text-muted: #686868;
+	--jp-cookie-consent--color-border: #dcdcde;
+	--jp-cookie-consent--spacing: 16px;
+	--jp-cookie-consent--font-size: 16px;
+	--jp-cookie-consent--z-index: 50000;
+}
+
+/* Banner */
 .jetpack-cookie-consent__banner {
 	display: none; /* Hidden by default */
 	position: fixed;
 	bottom: 0;
 	left: 0;
 	right: 0;
-	z-index: 999999;
+	z-index: var(--jp-cookie-consent--z-index, 50000);
 	pointer-events: auto;
 	align-items: flex-end;
 }
@@ -26,11 +45,11 @@
 	display: flex;
 	align-items: center;
 	margin: 0;
-	padding: var(--wp--preset--spacing--20, 16px);
+	padding: var(--jp-cookie-consent--spacing, 16px);
 	width: 100%;
 	box-shadow: 0 -4px 16px 0 rgba(0, 0, 0, 0.08);
-	background: var(--wp--preset--color--base, #fff);
-	gap: var(--wp--preset--spacing--20, 16px);
+	background: var(--jp-cookie-consent--color-background, #fff);
+	gap: var(--jp-cookie-consent--spacing, 16px);
 }
 
 .jetpack-cookie-consent__banner-content {
@@ -38,23 +57,23 @@
 }
 
 .jetpack-cookie-consent__banner-title {
-	margin: 0 0 calc(var(--wp--preset--spacing--20, 10px) * 0.8) 0;
+	margin: 0 0 8px 0;
 	font-size: 16px;
 	font-weight: 600;
 	line-height: 1.5;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 }
 
 .jetpack-cookie-consent__banner-description {
 	margin: 0;
 	font-size: 14px;
 	line-height: 1.71;
-	color: var(--wp--preset--color--contrast-2, #686868);
+	color: var(--jp-cookie-consent--color-text-muted, #686868);
 }
 
 .jetpack-cookie-consent__banner-actions {
 	display: flex;
-	gap: var(--wp--preset--spacing--20, 16px);
+	gap: var(--jp-cookie-consent--spacing, 16px);
 	flex-shrink: 0;
 	align-items: center;
 }
@@ -62,7 +81,7 @@
 /* Buttons */
 .jetpack-cookie-consent__button {
 	padding: 12px 20px;
-	font-size: var(--wp--preset--font-size--normal, 16px);
+	font-size: var(--jp-cookie-consent--font-size, 16px);
 	font-weight: 400;
 	line-height: 1;
 	border: 1px solid transparent;
@@ -72,14 +91,14 @@
 }
 
 .jetpack-cookie-consent__button:focus-visible {
-	outline: 2px solid var(--wp--preset--color--contrast, #243dc8);
+	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: 2px;
 }
 
 .jetpack-cookie-consent__button--secondary {
-	background: var(--wp--preset--color--base, #fff);
-	color: var(--wp--preset--color--contrast, #1e1e1e);
-	border-color: var(--wp--preset--color--contrast, #1e1e1e);
+	background: var(--jp-cookie-consent--color-background, #fff);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
+	border-color: var(--jp-cookie-consent--color-text, #1e1e1e);
 }
 
 .jetpack-cookie-consent__button--secondary:hover {
@@ -88,12 +107,12 @@
 
 .jetpack-cookie-consent__button--tertiary {
 	background: transparent;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
-	border-color: var(--wp--preset--color--contrast-3, #dcdcde);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
+	border-color: var(--jp-cookie-consent--color-border, #dcdcde);
 }
 
 .jetpack-cookie-consent__button--tertiary:hover {
-	background: var(--wp--preset--color--contrast-3, #f0f0f0);
+	background: var(--jp-cookie-consent--color-border, #f0f0f0);
 }
 
 /* Modal Overlay - Aligned with WooCommerce Bookings modal pattern */
@@ -107,7 +126,7 @@
 	right: 0;
 	top: 0;
 	transition: opacity 0.3s;
-	z-index: 999999;
+	z-index: var(--jp-cookie-consent--z-index, 50000);
 }
 
 :where(.jetpack-cookie-consent__modal-overlay[hidden]) {
@@ -127,11 +146,11 @@
 
 /* Modal - Aligned with WooCommerce Bookings modal pattern */
 :where(.jetpack-cookie-consent__modal) {
-	background-color: var(--wp--preset--color--base, #fff);
+	background-color: var(--jp-cookie-consent--color-background, #fff);
 	border: 0;
 	bottom: 0;
 	box-sizing: border-box;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 	display: block;
 	left: 0;
 	right: 0;
@@ -141,7 +160,7 @@
 	position: fixed;
 	transform: translateY(50px);
 	width: 100%;
-	z-index: 1000000;
+	z-index: calc(var(--jp-cookie-consent--z-index, 50000) + 1);
 }
 
 :where(.jetpack-cookie-consent__modal[hidden]) {
@@ -174,7 +193,7 @@
 	font-size: 22px;
 	font-weight: 500;
 	line-height: 1.18;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 }
 
 :where(.jetpack-cookie-consent__modal-close) {
@@ -187,7 +206,7 @@
 	justify-content: center;
 
 	svg {
-		fill: var(--wp--preset--color--contrast, #1e1e1e);
+		fill: var(--jp-cookie-consent--color-text, #1e1e1e);
 	}
 }
 
@@ -196,7 +215,7 @@
 }
 
 .jetpack-cookie-consent__modal-close:focus-visible {
-	outline: 2px solid var(--wp--preset--color--accent-1, #243dc8);
+	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: 2px;
 }
 
@@ -253,11 +272,11 @@
 	font-style: normal;
 	font-weight: 400;
 	line-height: 1.71;
-	color: var(--wp--preset--color--contrast-2, #686868);
+	color: var(--jp-cookie-consent--color-text-muted, #686868);
 }
 
 .jetpack-cookie-consent__link {
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 	text-decoration: underline;
 }
 
@@ -296,7 +315,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 	transition: transform 0.2s ease;
 }
 
@@ -319,7 +338,7 @@
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 1.71;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 }
 
 .jetpack-cookie-consent__category-badge {
@@ -334,23 +353,39 @@
 	margin: 0;
 	font-size: 14px;
 	line-height: 1.71;
-	color: var(--wp--preset--color--contrast-2, #686868);
+	color: var(--jp-cookie-consent--color-text-muted, #686868);
 }
 
-/* Checkbox - uses regular selectors for higher specificity */
+/* Checkbox - uses regular selectors for higher specificity.
+   The native control is fully neutralized so theme form styles (e.g. classic
+   themes that render checkboxes as bordered boxes) can't leak in and break the
+   row; the visible control is the sibling icon span. */
 .jetpack-cookie-consent__category-checkbox {
 	position: relative;
 	flex-shrink: 0;
 }
 
-.jetpack-cookie-consent__category-checkbox input[type="checkbox"] {
+.jetpack-cookie-consent .jetpack-cookie-consent__category-checkbox input[type="checkbox"] {
+
+	/* Robustly hide the native checkbox: out of flow, zero-size, clipped, and
+	   stripped of native rendering so a theme can't paint a stray box. Clicks
+	   are handled by the associated label; keyboard focus still works. Scoped
+	   under the root class so theme form rules can't win on source order. */
 	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: 0;
+	padding: 0;
+	border: 0;
 	opacity: 0;
-	width: 0;
-	height: 0;
+	overflow: hidden;
+	clip-path: inset(50%);
+	-webkit-appearance: none;
+	appearance: none;
+	pointer-events: none;
 }
 
-.jetpack-cookie-consent__category-checkbox label {
+.jetpack-cookie-consent .jetpack-cookie-consent__category-checkbox label {
 	margin: 0;
 	display: flex;
 	align-items: center;
@@ -358,9 +393,12 @@
 	cursor: pointer;
 }
 
-.jetpack-cookie-consent__category-checkbox-icon {
+.jetpack-cookie-consent .jetpack-cookie-consent__category-checkbox-icon {
 	display: block;
+	box-sizing: border-box;
+	border: 0;
 	border-radius: 1px;
+	box-shadow: none;
 	width: 16.8px;
 	height: 16.8px;
 	background: #e2e2e2;
@@ -377,7 +415,7 @@
 	top: 3px;
 	width: 4px;
 	height: 7px;
-	border: solid var(--wp--preset--color--contrast, #1e1e1e);
+	border: solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	border-width: 0 2px 2px 0;
 	transform: rotate(45deg);
 }
@@ -391,7 +429,7 @@ input[type="checkbox"]:checked + label
 .jetpack-cookie-consent__category-checkbox
 input[type="checkbox"]:focus-visible + label
 .jetpack-cookie-consent__category-checkbox-icon {
-	outline: 2px solid var(--wp--preset--color--contrast, #1e1e1e);
+	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: 2px;
 }
 
@@ -428,12 +466,12 @@ input[type="checkbox"]:focus-visible + label
 	}
 
 	.jetpack-cookie-consent__banner-title {
-		font-size: var(--wp--preset--font-size--normal, 16px);
+		font-size: var(--jp-cookie-consent--font-size, 16px);
 	}
 
 	.jetpack-cookie-consent__banner-actions {
 		flex-direction: column;
-		gap: var(--wp--preset--spacing--20, 10px);
+		gap: var(--jp-cookie-consent--spacing, 16px);
 	}
 
 	.jetpack-cookie-consent__banner-actions .jetpack-cookie-consent__button {
@@ -508,19 +546,19 @@ input[type="checkbox"]:focus-visible + label
 	font-size: 14px;
 	line-height: 1.4;
 	cursor: pointer;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
-	background: var(--wp--preset--color--base, #fff);
-	border: 1px solid var(--wp--preset--color--contrast-3, #dcdcde);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
+	background: var(--jp-cookie-consent--color-background, #fff);
+	border: 1px solid var(--jp-cookie-consent--color-border, #dcdcde);
 	border-radius: 4px;
 	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.12);
 }
 
 .jetpack-cookie-consent-footer-links__toggle:hover {
-	background: var(--wp--preset--color--contrast-3, #f0f0f0);
+	background: var(--jp-cookie-consent--color-border, #f0f0f0);
 }
 
 .jetpack-cookie-consent-footer-links__toggle:focus-visible {
-	outline: 2px solid var(--wp--preset--color--accent-1, #243dc8);
+	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: 2px;
 }
 
@@ -537,8 +575,8 @@ input[type="checkbox"]:focus-visible + label
 	min-width: 220px;
 	max-width: calc(100vw - 40px);
 	padding: 8px 0;
-	background: var(--wp--preset--color--base, #fff);
-	border: 1px solid var(--wp--preset--color--contrast-3, #dcdcde);
+	background: var(--jp-cookie-consent--color-background, #fff);
+	border: 1px solid var(--jp-cookie-consent--color-border, #dcdcde);
 	border-radius: 4px;
 	box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.16);
 }
@@ -559,16 +597,16 @@ input[type="checkbox"]:focus-visible + label
 	font-size: 14px;
 	line-height: 1.5;
 	text-decoration: none;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 }
 
 .jetpack-cookie-consent-footer-links__link:hover {
 	text-decoration: underline;
-	background: var(--wp--preset--color--contrast-3, #f0f0f0);
+	background: var(--jp-cookie-consent--color-border, #f0f0f0);
 }
 
 .jetpack-cookie-consent-footer-links__link:focus-visible {
-	outline: 2px solid var(--wp--preset--color--accent-1, #243dc8);
+	outline: 2px solid var(--jp-cookie-consent--color-text, #1e1e1e);
 	outline-offset: -2px;
 }
 
@@ -613,7 +651,7 @@ input[type="checkbox"]:focus-visible + label
 	position: fixed;
 	bottom: 20px;
 	left: 20px;
-	z-index: 999999;
+	z-index: var(--jp-cookie-consent--z-index, 50000);
 	max-width: calc(100% - 100px);
 }
 
@@ -623,7 +661,7 @@ input[type="checkbox"]:focus-visible + label
 	align-items: center;
 	justify-content: space-between;
 	background-color: #f1f9f3;
-	color: var(--wp--preset--color--contrast, #1e1e1e);
+	color: var(--jp-cookie-consent--color-text, #1e1e1e);
 	padding: 16px;
 	border-radius: 4px;
 	border: 1px solid #c3e8cd;


### PR DESCRIPTION
Fixes WOOA7S-1545 (partial — cross-theme styling of the existing banner/modal/controls)

## Proposed changes

**Why:** The consent banner, modal, category toggles, and the classic-theme footer-links control render correctly on block themes but **degrade on classic themes** (and block themes with unusual palettes). Live cross-theme testing on Twenty Twenty-One found concrete breakage:

- **Banner padding collapsed to ~7px** — the CSS used `var(--wp--preset--spacing--20, 16px)`, but TT21 *defines* that preset as `0.44rem`, so the theme value won and the 16px fallback never applied.
- **Palette resolved inconsistently / inverted** — sibling elements reading `--wp--preset--color--{base,contrast}` resolved to different (and inverted) colors depending on the theme.
- **Buttons and form controls hijacked** — TT21's `button:not(:hover):not(:active)` reset (specificity 0,2,1) out-specified our rules, filling the close (X), the description-toggle chevron, and the secondary action buttons with the theme color; the native checkbox leaked in and broke the toggle row; the modal stretched full-width because TT21's `…{max-width:none}` reset beat our `:where()` sizing.

Root cause: the UI leaned on `--wp--preset--*` for **structural** spacing/color and used low-specificity selectors that classic themes out-specify.

**Why namespaced design tokens instead of `--wp--preset--*`:** theme presets belong to the active theme — their values differ per theme (or are undefined), so binding the consent UI's structural spacing and colors to them lets a theme collapse padding (e.g. a 0.44rem spacing scale) or invert the palette. Self-contained `--jp-cookie-consent--*` tokens make the appearance deterministic and legible on any theme, and double as a stable, documented customization surface. This follows what dedicated consent plugins do: CookieYes, Complianz, and Real Cookie Banner ship self-contained styles (their own CSS variables + a "Custom CSS" field) rather than inheriting host-theme design tokens, and WPConsent goes a step further with Shadow DOM + `::part()`. Shadow DOM isn't an option here because it's incompatible with this package's server-rendered Interactivity API hydration and its in-modal ARIA/form controls.

**How:**

- **Namespaced design tokens** drive all structural spacing, color, and z-index, defined once via `:where()` (specificity 0) on the banner/modal and footer-links roots. Themes never define them, so values are deterministic; because they're at specificity 0, site owners override them via **Additional CSS** (e.g. `.jetpack-cookie-consent { --jp-cookie-consent--color-text: #111; }`) or inline styles. (The banner isn't a block, so the block editor / Global Styles can't reach it — Additional CSS / the tokens are the supported path, and the hook a future settings UI would write to.)
- **Win the cascade against classic-theme resets** — structural sizing (modal) is scoped under the root class; the footer-links toggle is styled via its unique id; the icon buttons (close, chevron) and secondary/tertiary buttons use `!important` on the theme-attacked properties. Primary buttons intentionally keep inheriting theme button styling. The native checkbox is bulletproof-hidden so theme form CSS can't break the toggle row.
- **z-index** stays at `999999`/`1000000` (via the `--jp-cookie-consent--z-index` token) so the consent UI reliably sits above theme and site chrome — the convention dedicated consent plugins use for guaranteed visibility; still overridable via the token.
- **RTL** — the build emits `index.rtl.css` (rtlcss); the iconographic checkmark is marked `rtl:ignore` so it isn't mirrored into a backwards check.

**What:**

- `styles.scss`: introduce `--jp-cookie-consent--*` tokens; replace every `--wp--preset--*` usage; harden the toggle, icon/secondary buttons, modal sizing, and footer-links control against classic-theme CSS; keep z-index high; RTL checkmark fix.
- `README.md`: document the theming tokens, the customization path, and the theme-support contract.


| Before (TT21) | After |
|---|---|
| ![Screenshot 2026-06-25 at 4 54 02 PM](https://github.com/user-attachments/assets/3506b95d-556e-4e0d-ae64-74bf0ece4725) | ![Screenshot 2026-06-25 at 4 54 07 PM](https://github.com/user-attachments/assets/3c20fe2e-eae6-4a19-8e61-5eb50642a5b0) |

TT4
<img width="2560" height="1317" alt="Screenshot 2026-06-25 at 5 27 19 PM" src="https://github.com/user-attachments/assets/f55fdf5c-aa49-47c6-becc-6498fe6564b4" />

Astra
<img width="2560" height="1267" alt="Screenshot 2026-06-25 at 5 50 33 PM" src="https://github.com/user-attachments/assets/92e1b8ab-0b6c-494c-a96f-c4164aad025e" />

## Does this pull request change what data or activity we track or use?

No. CSS/docs-only change.


## Testing instructions

### Setup

- Use a site (e.g. a fresh JN/Atomic site) with **this branch** built into the **premium-analytics** plugin (it calls `Cookie_Consent::init()`), plus the **WP Consent API** plugin (`wp-consent-api`) active — the latter is required for the banner/modal to function (`window.wp_set_consent`); without it "Manage Privacy Preferences" can't open the modal.
- Set a published **Privacy Policy** page (Settings → Privacy). The CCPA "Your Privacy Choices" page is auto-created on init.
- Quick way to force the banner without region setup: append `?preview_cookie_consent=1` to a front-end URL.
- To simulate a region, set the geolocation cookies (when both are present the client skips the geo API; 6-hour TTL). In DevTools → Application → Cookies — on JN set them with `domain=.jurassic.ninja` so the geo API doesn't overwrite them — then **reload**:
  - **CCPA** → `country_code=US`, `region=California` (the matcher uses **full state names**, so `region=CA` does *not* trigger CCPA).
  - **GDPR** → `country_code=FR`, `region=` (any value).

### What to check

Test matrix: a **classic** theme (Twenty Twenty-One) + a **block** theme (Twenty Twenty-Four), plus an **RTL** site/locale.

On the **classic theme (TT21)** — where the bugs reproduced:

- **Banner:** ~16px padding (not collapsed), white background, dark legible text.
- **Modal:** centered and capped (~745px) on desktop; **close (X)** and the **chevron** render as plain icon buttons (no theme fill); **category toggles** are a single row with no stray native checkbox; the disabled "Required" row shows a `not-allowed` cursor.
- **Action buttons:** "Save preferences" (primary) stays theme-filled; "Accept all"/"Reject all"/"Customize" (secondary) are white with a dark border.
- **Footer-links fallback control** (bottom corner "Privacy"): white toggle/panel, dark text, light border — not inverted.
- **Customization:** Additional CSS like `.jetpack-cookie-consent { --jp-cookie-consent--color-background: #102a43; --jp-cookie-consent--color-text: #f0f4f8; }` recolors the banner and modal.

On the **block theme (TT24):** banner/modal look clean; footer-nav link injection works and the floating fallback is suppressed (no duplication).

(optionally) On an **RTL** locale: the modal stays centered, the close button moves to the left, the toggle/snackbar/footer-links hug the right edge, and the checkbox checkmark is **not** mirrored.


