### PR TITLE
Premium Analytics: load widget manifest on REST requests, not just admin

### DIFF
--- a/projects/packages/premium-analytics/changelog/2026-06-25-07-47-18-730807
+++ b/projects/packages/premium-analytics/changelog/2026-06-25-07-47-18-730807
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix dashboard widgets rendering "Widget is no longer available" by loading the widget manifest on REST requests, not just admin page loads
+Fix dashboard widgets rendering "Widget is no longer available" by loading the widget manifest on REST requests, not just admin page loads.

--- a/projects/packages/premium-analytics/changelog/2026-06-25-07-47-18-730807
+++ b/projects/packages/premium-analytics/changelog/2026-06-25-07-47-18-730807
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix dashboard widgets rendering "Widget is no longer available" by loading the widget manifest on REST requests, not just admin page loads

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -78,7 +78,18 @@ class Analytics {
 		// injection and the REST route the "reset to default" action reads.
 		require_once __DIR__ . '/dashboard-layout.php';
 
-		// Below: admin-only render path (interceptor, assets, menu).
+		// Load wp-build output (interceptor, modules, routes, page render).
+		// Must stay above the is_admin() gate: build/widgets.php defines the
+		// manifest the widget registry reads, and the registry serves REST
+		// requests (e.g. /widget-modules) where is_admin() is false. The render
+		// pieces here self-gate on admin_init, so loading them globally is inert
+		// off the dashboard. Only the polyfill registration below is admin-scoped.
+		$build_entry = __DIR__ . '/../build/build.php';
+		if ( file_exists( $build_entry ) ) {
+			require_once $build_entry;
+		}
+
+		// Below: admin-only render path (assets, menu).
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -93,12 +104,6 @@ class Analytics {
 					WP_Build_Polyfills::MODULE_IDS
 				)
 			);
-		}
-
-		// Load wp-build output (interceptor, modules, routes, page render).
-		$build_entry = __DIR__ . '/../build/build.php';
-		if ( file_exists( $build_entry ) ) {
-			require_once $build_entry;
 		}
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -81,7 +81,7 @@ class Analytics {
 		// Load wp-build output (interceptor, modules, routes, page render).
 		// Must stay above the is_admin() gate: build/widgets.php defines the
 		// manifest the widget registry reads, and the registry serves REST
-		// requests (e.g. /widget-modules) where is_admin() is false. The render
+		// requests (e.g. /jetpack/v4/widget-modules) where is_admin() is false. The render
 		// pieces here self-gate on admin_init, so loading them globally is inert
 		// off the dashboard. Only the polyfill registration below is admin-scoped.
 		$build_entry = __DIR__ . '/../build/build.php';


### PR DESCRIPTION
Fixes # N/A

Regression from #49838 (merged Jun 24). That PR scoped the wp-build polyfill registration to dashboard pages by introducing an `if ( ! is_admin() ) return;` gate in `Analytics::init()` — but it also moved the `build/build.php` load *below* that gate. `build/build.php` defines `jpa_get_registered_widget_modules()` (via `build/widgets.php`), which is the manifest the widget type registry reads.

On the `/jetpack/v4/widget-modules` REST request, `is_admin()` is `false`, so the code returned before loading the manifest. The registry stayed empty, the endpoint returned `[]`, and the client's `useWidgetTypes()` had no widget types — so every dashboard widget rendered **"Widget is no longer available"**.

This contradicted #49838's own intent: its description said *"the menu, REST controllers, and build load stay global as before; only the core-handle force-replace is scoped,"* and the approving review noted REST/registry registrations should stay above the gate. The build load slipping below the gate was an unintended side effect.

## Proposed changes
* Move the `build/build.php` load above the `is_admin()` gate in `Analytics::init()`, restoring the pre-#49838 behavior so the widget manifest is available on REST requests (and cron/frontend), not just admin page loads.
* The wp-build polyfill registration — the only thing #49838 actually meant to scope — stays gated behind `is_admin()` + `is_dashboard_request()`, so the private-apis blast-radius fix is preserved.
* Add a comment explaining why the build load must stay above the gate, to prevent the regression being reintroduced.

## Related product discussion/links
* Regression from #49838 (Premium Analytics: scope wp-build polyfills to dashboard pages).
* Follows #49793 (Premium Analytics: dashboard on core Gutenberg packages).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Check out this branch and serve the `premium-analytics` plugin (build already present; no rebuild needed for the PHP change).
* Open **Premium Analytics** (`admin.php?page=jetpack-premium-analytics`).
* Confirm the **Traffic** tab renders the widgets (e.g. "Hello World") instead of **"Widget is no longer available"**.
* Verify the REST endpoint directly: `GET /wp-json/jetpack/v4/widget-modules` should return a non-empty array of widget types (`jpa/hello-world`, `jpa/average-items-per-order`, `jpa/locations`) rather than `[]`.
* Regression check for #49838: open a non-dashboard admin page (e.g. **Posts → Add New**) and confirm `wp-private-apis` is still **not** swapped to the polyfill build there — the polyfill remains scoped to the dashboard.
