### PR TITLE
Donations block: add render_email_callback for email rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Donations Block: render the static fallback content with email-friendly CTA buttons in the block email renderer.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 Donations Block: render the static fallback content with email-friendly CTA buttons in the block email renderer.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-donations-block
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Donations Block: render the static fallback content with email-friendly CTA buttons in the block email renderer.
+Donations Block: add an email renderer that builds the block from its attributes with email-friendly CTA buttons, preserving per-interval customization.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -370,54 +370,180 @@ function render_block( $attr, $content ) {
 /**
  * WooCommerce Email Editor render callback for the Donations block.
  *
- * Reuses the block's static fallback HTML (headings, supporting text and
- * separators) and swaps each fallback donation link for an email-friendly CTA
- * button rendered by the Button block's own email renderer.
+ * Builds a dedicated email version of the block from its attributes (rather than
+ * post-processing the interactive frontend markup) so customizations — per
+ * interval heading, supporting text and button label — are preserved. Each
+ * interval is rendered as an email-safe table section with a CTA button drawn by
+ * the Button block's own email renderer.
  *
- * @param string $block_content     The rendered (fallback) block content.
+ * @param string $block_content     The rendered block content (unused; we rebuild from attributes).
  * @param array  $parsed_block      The parsed block data.
  * @param object $rendering_context The email rendering context.
  *
  * @return string
  */
 function render_email( $block_content, array $parsed_block, $rendering_context ) {
-	if ( ! is_string( $block_content ) || '' === trim( $block_content )
+	if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] )
 		|| ! function_exists( '\Automattic\Jetpack\Extensions\Button\render_email' )
-		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Button' ) ) {
-		return $block_content;
+		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Button' )
+		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
+		return '';
 	}
 
-	$email_attrs = $parsed_block['email_attrs'] ?? array();
+	$attr          = $parsed_block['attrs'];
+	$default_texts = get_default_texts();
+	$intervals     = get_email_intervals( $attr, $default_texts );
+	if ( empty( $intervals ) ) {
+		return '';
+	}
 
-	$rendered = preg_replace_callback(
-		'#<a\b[^>]*\bclass="[^"]*\bjetpack-donations-fallback-link\b[^"]*"[^>]*>(.*?)</a>#is',
-		static function ( $matches ) use ( $rendering_context, $email_attrs ) {
-			$text = trim( wp_strip_all_tags( $matches[1] ) );
-			$url  = '#';
-			if ( preg_match( '/\bhref="([^"]*)"/i', $matches[0], $href ) ) {
-				$url = html_entity_decode( $href[1], ENT_QUOTES );
-			}
+	// In email there's no interactive form, so every CTA points to the post that
+	// hosts the full Donations block, mirroring the static fallback link.
+	$url = get_permalink();
+	if ( ! is_string( $url ) || '' === $url ) {
+		$url = is_string( $attr['fallbackLinkUrl'] ?? null ) && '' !== $attr['fallbackLinkUrl'] ? $attr['fallbackLinkUrl'] : '#';
+	}
 
-			$button_parsed_block = array(
-				'attrs'       => array(
-					'text'    => '' !== $text ? $text : __( 'Donate', 'jetpack' ),
-					'url'     => $url,
-					'element' => 'a',
-				),
-				'email_attrs' => $email_attrs,
+	$target_width = get_email_target_width( $rendering_context );
+	$alignment    = in_array( $attr['contentAlignment'] ?? '', array( 'left', 'center', 'right' ), true ) ? $attr['contentAlignment'] : 'left';
+	$email_attrs  = $parsed_block['email_attrs'] ?? array();
+
+	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', $target_width );
+
+	$sections   = '';
+	$first_key  = array_key_first( $intervals );
+	foreach ( $intervals as $key => $interval ) {
+		$content = '';
+
+		$heading = wp_kses_post( $interval['heading'] );
+		if ( '' !== trim( wp_strip_all_tags( $heading ) ) ) {
+			$content .= sprintf(
+				'<p style="margin:0 0 4px;font-size:18px;font-weight:700;line-height:1.3;text-align:%s;">%s</p>',
+				esc_attr( $alignment ),
+				$heading
 			);
+		}
 
-			$button = \Automattic\Jetpack\Extensions\Button\render_email( '', $button_parsed_block, $rendering_context );
+		$extra_text = wp_kses_post( $interval['extraText'] );
+		if ( '' !== trim( wp_strip_all_tags( $extra_text ) ) ) {
+			$content .= sprintf(
+				'<p style="margin:0 0 14px;font-size:15px;line-height:1.5;text-align:%s;">%s</p>',
+				esc_attr( $alignment ),
+				$extra_text
+			);
+		}
 
-			// The email renderer strips the block's margins, so add padding around the
-			// CTA button to keep the donation intervals from rendering cramped together.
-			return '<div style="padding-top:12px;padding-bottom:28px;">' . $button . '</div>';
-		},
-		$block_content
+		$content .= render_email_donate_button( $interval['buttonText'], $url, $attr, $rendering_context, $email_attrs );
+
+		// Vertical padding spaces the intervals out; a top border on subsequent
+		// sections mimics the block's interval separator.
+		$is_first   = $key === $first_key;
+		$cell_style = sprintf(
+			'text-align:%1$s;padding:%2$s;%3$s',
+			esc_attr( $alignment ),
+			$is_first ? '0 0 24px' : '24px 0',
+			$is_first ? '' : 'border-top:1px solid #e0e0e0;'
+		);
+
+		$sections .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+			$content,
+			array( 'style' => $table_style ),
+			array( 'style' => $cell_style )
+		);
+	}
+
+	return $sections;
+}
+
+/**
+ * Build the ordered list of donation intervals to render in email, preserving
+ * any per-interval heading / button text / supporting text the user customized.
+ *
+ * @param array $attr          Block attributes.
+ * @param array $default_texts Default texts from get_default_texts().
+ * @return array List of intervals, each with 'heading', 'buttonText' and 'extraText'.
+ */
+function get_email_intervals( $attr, $default_texts ) {
+	$config = array(
+		'oneTimeDonation' => true,  // Legacy blocks default one-time to shown.
+		'monthlyDonation' => false,
+		'annualDonation'  => false,
 	);
 
-	// preg_replace_callback returns null on PCRE failure (e.g. backtrack limit); keep the fallback content intact.
-	return null === $rendered ? $block_content : $rendered;
+	$intervals = array();
+	foreach ( $config as $attr_key => $default_show ) {
+		if ( false === ( $attr[ $attr_key ]['show'] ?? $default_show ) ) {
+			continue;
+		}
+		$intervals[] = array(
+			'heading'    => $attr[ $attr_key ]['heading'] ?? $default_texts[ $attr_key ]['heading'],
+			'buttonText' => $attr[ $attr_key ]['buttonText'] ?? $default_texts[ $attr_key ]['buttonText'],
+			'extraText'  => $attr[ $attr_key ]['extraText'] ?? $default_texts['extraText'],
+		);
+	}
+
+	return $intervals;
+}
+
+/**
+ * Render a single donation CTA as an email-safe button via the Button block's
+ * email renderer, carrying over the donation block's button styling.
+ *
+ * @param string $text              Button label.
+ * @param string $url               Button destination.
+ * @param array  $attr              Donations block attributes.
+ * @param object $rendering_context The email rendering context.
+ * @param array  $email_attrs       Email-specific attributes passed through to the button.
+ * @return string
+ */
+function render_email_donate_button( $text, $url, $attr, $rendering_context, $email_attrs ) {
+	$text = trim( wp_strip_all_tags( (string) $text ) );
+
+	$button_attrs = array(
+		'text'    => '' !== $text ? $text : __( 'Donate', 'jetpack' ),
+		'url'     => $url,
+		'element' => 'a',
+	);
+
+	if ( ! empty( $attr['buttonFontSize'] ) && is_string( $attr['buttonFontSize'] ) ) {
+		$button_attrs['customFontSize'] = $attr['buttonFontSize'];
+	}
+	if ( isset( $attr['buttonBorderRadius'] ) && is_string( $attr['buttonBorderRadius'] ) ) {
+		$radius = (int) $attr['buttonBorderRadius'];
+		if ( $radius > 0 ) {
+			$button_attrs['borderRadius'] = $radius;
+		}
+	}
+
+	return \Automattic\Jetpack\Extensions\Button\render_email(
+		'',
+		array(
+			'attrs'       => $button_attrs,
+			'email_attrs' => $email_attrs,
+		),
+		$rendering_context
+	);
+}
+
+/**
+ * Resolve the target content width (in px) from the email rendering context,
+ * falling back to a sensible default.
+ *
+ * @param object $rendering_context The email rendering context.
+ * @return int Width in pixels.
+ */
+function get_email_target_width( $rendering_context ) {
+	$target_width = 600;
+	if ( is_object( $rendering_context ) && method_exists( $rendering_context, 'get_layout_width_without_padding' ) ) {
+		$width = $rendering_context->get_layout_width_without_padding();
+		if ( is_string( $width ) && preg_match( '/(\d+)/', $width, $matches ) ) {
+			$parsed = (int) $matches[1];
+			if ( $parsed > 0 ) {
+				$target_width = $parsed;
+			}
+		}
+	}
+	return $target_width;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -399,7 +399,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	}
 
 	$alignment   = in_array( $attr['contentAlignment'] ?? '', array( 'left', 'center', 'right' ), true ) ? $attr['contentAlignment'] : 'left';
-	$email_attrs = $parsed_block['email_attrs'] ?? array();
 	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', get_email_target_width( $rendering_context ) );
 
 	$sections = '';
@@ -431,7 +430,7 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 				$extra
 			);
 		}
-		$content .= render_email_donate_button( $interval['buttonText'] ?? $default_texts[ $key ]['buttonText'], $url, $attr, $rendering_context, $email_attrs );
+		$content .= render_email_donate_button( $interval['buttonText'] ?? $default_texts[ $key ]['buttonText'], $url, $attr, $rendering_context );
 
 		$is_first   = '' === $sections;
 		$cell_style = sprintf(
@@ -458,16 +457,14 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
  * @param string $url               Button destination.
  * @param array  $attr              Donations block attributes.
  * @param object $rendering_context The email rendering context.
- * @param array  $email_attrs       Email-specific attributes passed through to the button.
  * @return string
  */
-function render_email_donate_button( $text, $url, $attr, $rendering_context, $email_attrs ) {
+function render_email_donate_button( $text, $url, $attr, $rendering_context ) {
 	$text = trim( wp_strip_all_tags( (string) $text ) );
 
 	$button_attrs = array(
-		'text'    => '' !== $text ? $text : __( 'Donate', 'jetpack' ),
-		'url'     => $url,
-		'element' => 'a',
+		'text' => '' !== $text ? $text : __( 'Donate', 'jetpack' ),
+		'url'  => $url,
 	);
 
 	if ( ! empty( $attr['buttonFontSize'] ) && is_string( $attr['buttonFontSize'] ) ) {
@@ -482,10 +479,7 @@ function render_email_donate_button( $text, $url, $attr, $rendering_context, $em
 
 	return \Automattic\Jetpack\Extensions\Button\render_email(
 		'',
-		array(
-			'attrs'       => $button_attrs,
-			'email_attrs' => $email_attrs,
-		),
+		array( 'attrs' => $button_attrs ),
 		$rendering_context
 	);
 }
@@ -501,7 +495,7 @@ function get_email_target_width( $rendering_context ) {
 	$target_width = 600;
 	if ( is_object( $rendering_context ) && method_exists( $rendering_context, 'get_layout_width_without_padding' ) ) {
 		$width = $rendering_context->get_layout_width_without_padding();
-		if ( is_string( $width ) && preg_match( '/(\d+)/', $width, $matches ) ) {
+		if ( is_string( $width ) && preg_match( '/(\d+)px/', $width, $matches ) ) {
 			$parsed = (int) $matches[1];
 			if ( $parsed > 0 ) {
 				$target_width = $parsed;

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -33,8 +33,9 @@ function register_block() {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array(
-				'render_callback' => __NAMESPACE__ . '\render_block',
-				'plan_check'      => true,
+				'render_callback'       => __NAMESPACE__ . '\render_block',
+				'render_email_callback' => __NAMESPACE__ . '\render_email',
+				'plan_check'            => true,
 			)
 		);
 	}
@@ -364,6 +365,55 @@ function render_block( $attr, $content ) {
 		$custom_styles ? '<style>' . $custom_styles . '</style>' : '',
 		esc_attr( $tab_content_class )
 	);
+}
+
+/**
+ * WooCommerce Email Editor render callback for the Donations block.
+ *
+ * Reuses the block's static fallback HTML (headings, supporting text and
+ * separators) and swaps each fallback donation link for an email-friendly CTA
+ * button rendered by the Button block's own email renderer.
+ *
+ * @param string $block_content     The rendered (fallback) block content.
+ * @param array  $parsed_block      The parsed block data.
+ * @param object $rendering_context The email rendering context.
+ *
+ * @return string
+ */
+function render_email( $block_content, array $parsed_block, $rendering_context ) {
+	if ( ! is_string( $block_content ) || '' === trim( $block_content )
+		|| ! function_exists( '\Automattic\Jetpack\Extensions\Button\render_email' )
+		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Button' ) ) {
+		return $block_content;
+	}
+
+	$email_attrs = $parsed_block['email_attrs'] ?? array();
+
+	$rendered = preg_replace_callback(
+		'#<a\b[^>]*\bclass="[^"]*\bjetpack-donations-fallback-link\b[^"]*"[^>]*>(.*?)</a>#is',
+		static function ( $matches ) use ( $rendering_context, $email_attrs ) {
+			$text = trim( wp_strip_all_tags( $matches[1] ) );
+			$url  = '#';
+			if ( preg_match( '/\bhref="([^"]*)"/i', $matches[0], $href ) ) {
+				$url = html_entity_decode( $href[1], ENT_QUOTES );
+			}
+
+			$button_parsed_block = array(
+				'attrs'       => array(
+					'text'    => '' !== $text ? $text : __( 'Donate', 'jetpack' ),
+					'url'     => $url,
+					'element' => 'a',
+				),
+				'email_attrs' => $email_attrs,
+			);
+
+			return \Automattic\Jetpack\Extensions\Button\render_email( '', $button_parsed_block, $rendering_context );
+		},
+		$block_content
+	);
+
+	// preg_replace_callback returns null on PCRE failure (e.g. backtrack limit); keep the fallback content intact.
+	return null === $rendered ? $block_content : $rendered;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -393,8 +393,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	$attr          = $parsed_block['attrs'];
 	$default_texts = get_default_texts();
 
-	// In email there's no interactive form, so every CTA points to the post that
-	// hosts the full Donations block, mirroring the static fallback link.
 	$url = get_permalink();
 	if ( ! is_string( $url ) || '' === $url ) {
 		$url = is_string( $attr['fallbackLinkUrl'] ?? null ) && '' !== $attr['fallbackLinkUrl'] ? $attr['fallbackLinkUrl'] : '#';
@@ -404,7 +402,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	$email_attrs = $parsed_block['email_attrs'] ?? array();
 	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', get_email_target_width( $rendering_context ) );
 
-	// Intervals in priority order; one-time defaults to shown for legacy blocks.
 	$sections = '';
 	foreach ( array(
 		'oneTimeDonation' => true,
@@ -436,7 +433,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		}
 		$content .= render_email_donate_button( $interval['buttonText'] ?? $default_texts[ $key ]['buttonText'], $url, $attr, $rendering_context, $email_attrs );
 
-		// First section sits flush; later ones get a top border + spacing as a separator.
 		$is_first   = '' === $sections;
 		$cell_style = sprintf(
 			'text-align:%1$s;padding:%2$s;%3$s',

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -410,8 +410,8 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 
 	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', $target_width );
 
-	$sections   = '';
-	$first_key  = array_key_first( $intervals );
+	$sections  = '';
+	$first_key = array_key_first( $intervals );
 	foreach ( $intervals as $key => $interval ) {
 		$content = '';
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -392,10 +392,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 
 	$attr          = $parsed_block['attrs'];
 	$default_texts = get_default_texts();
-	$intervals     = get_email_intervals( $attr, $default_texts );
-	if ( empty( $intervals ) ) {
-		return '';
-	}
 
 	// In email there's no interactive form, so every CTA points to the post that
 	// hosts the full Donations block, mirroring the static fallback link.
@@ -404,18 +400,26 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		$url = is_string( $attr['fallbackLinkUrl'] ?? null ) && '' !== $attr['fallbackLinkUrl'] ? $attr['fallbackLinkUrl'] : '#';
 	}
 
-	$target_width = get_email_target_width( $rendering_context );
-	$alignment    = in_array( $attr['contentAlignment'] ?? '', array( 'left', 'center', 'right' ), true ) ? $attr['contentAlignment'] : 'left';
-	$email_attrs  = $parsed_block['email_attrs'] ?? array();
+	$alignment   = in_array( $attr['contentAlignment'] ?? '', array( 'left', 'center', 'right' ), true ) ? $attr['contentAlignment'] : 'left';
+	$email_attrs = $parsed_block['email_attrs'] ?? array();
+	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', get_email_target_width( $rendering_context ) );
 
-	$table_style = sprintf( 'width:100%%;max-width:%dpx;border-collapse:collapse;', $target_width );
+	// Intervals in priority order; one-time defaults to shown for legacy blocks.
+	$sections = '';
+	foreach ( array(
+		'oneTimeDonation' => true,
+		'monthlyDonation' => false,
+		'annualDonation'  => false,
+	) as $key => $default_show ) {
+		if ( false === ( $attr[ $key ]['show'] ?? $default_show ) ) {
+			continue;
+		}
 
-	$sections  = '';
-	$first_key = array_key_first( $intervals );
-	foreach ( $intervals as $key => $interval ) {
+		$interval = is_array( $attr[ $key ] ?? null ) ? $attr[ $key ] : array();
+		$heading  = wp_kses_post( $interval['heading'] ?? $default_texts[ $key ]['heading'] );
+		$extra    = wp_kses_post( $interval['extraText'] ?? $default_texts['extraText'] );
+
 		$content = '';
-
-		$heading = wp_kses_post( $interval['heading'] );
 		if ( '' !== trim( wp_strip_all_tags( $heading ) ) ) {
 			$content .= sprintf(
 				'<p style="margin:0 0 4px;font-size:18px;font-weight:700;line-height:1.3;text-align:%s;">%s</p>',
@@ -423,29 +427,24 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 				$heading
 			);
 		}
-
-		$extra_text = wp_kses_post( $interval['extraText'] );
-		if ( '' !== trim( wp_strip_all_tags( $extra_text ) ) ) {
+		if ( '' !== trim( wp_strip_all_tags( $extra ) ) ) {
 			$content .= sprintf(
 				'<p style="margin:0 0 14px;font-size:15px;line-height:1.5;text-align:%s;">%s</p>',
 				esc_attr( $alignment ),
-				$extra_text
+				$extra
 			);
 		}
+		$content .= render_email_donate_button( $interval['buttonText'] ?? $default_texts[ $key ]['buttonText'], $url, $attr, $rendering_context, $email_attrs );
 
-		$content .= render_email_donate_button( $interval['buttonText'], $url, $attr, $rendering_context, $email_attrs );
-
-		// Vertical padding spaces the intervals out; a top border on subsequent
-		// sections mimics the block's interval separator.
-		$is_first   = $key === $first_key;
+		// First section sits flush; later ones get a top border + spacing as a separator.
+		$is_first   = '' === $sections;
 		$cell_style = sprintf(
 			'text-align:%1$s;padding:%2$s;%3$s',
 			esc_attr( $alignment ),
 			$is_first ? '0 0 24px' : '24px 0',
 			$is_first ? '' : 'border-top:1px solid #e0e0e0;'
 		);
-
-		$sections .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+		$sections  .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
 			$content,
 			array( 'style' => $table_style ),
 			array( 'style' => $cell_style )
@@ -453,36 +452,6 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	}
 
 	return $sections;
-}
-
-/**
- * Build the ordered list of donation intervals to render in email, preserving
- * any per-interval heading / button text / supporting text the user customized.
- *
- * @param array $attr          Block attributes.
- * @param array $default_texts Default texts from get_default_texts().
- * @return array List of intervals, each with 'heading', 'buttonText' and 'extraText'.
- */
-function get_email_intervals( $attr, $default_texts ) {
-	$config = array(
-		'oneTimeDonation' => true,  // Legacy blocks default one-time to shown.
-		'monthlyDonation' => false,
-		'annualDonation'  => false,
-	);
-
-	$intervals = array();
-	foreach ( $config as $attr_key => $default_show ) {
-		if ( false === ( $attr[ $attr_key ]['show'] ?? $default_show ) ) {
-			continue;
-		}
-		$intervals[] = array(
-			'heading'    => $attr[ $attr_key ]['heading'] ?? $default_texts[ $attr_key ]['heading'],
-			'buttonText' => $attr[ $attr_key ]['buttonText'] ?? $default_texts[ $attr_key ]['buttonText'],
-			'extraText'  => $attr[ $attr_key ]['extraText'] ?? $default_texts['extraText'],
-		);
-	}
-
-	return $intervals;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -385,7 +385,6 @@ function render_block( $attr, $content ) {
 function render_email( $block_content, array $parsed_block, $rendering_context ) {
 	if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] )
 		|| ! function_exists( '\Automattic\Jetpack\Extensions\Button\render_email' )
-		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Button' )
 		|| ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
 		return '';
 	}
@@ -407,12 +406,12 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		'monthlyDonation' => false,
 		'annualDonation'  => false,
 	) as $key => $default_show ) {
-		if ( false === ( $attr[ $key ]['show'] ?? $default_show ) ) {
+		$interval = is_array( $attr[ $key ] ?? null ) ? $attr[ $key ] : array();
+		if ( false === ( $interval['show'] ?? $default_show ) ) {
 			continue;
 		}
 
-		$interval = is_array( $attr[ $key ] ?? null ) ? $attr[ $key ] : array();
-		$heading  = wp_kses_post( $interval['heading'] ?? $default_texts[ $key ]['heading'] );
+		$heading = wp_kses_post( $interval['heading'] ?? $default_texts[ $key ]['heading'] );
 		$extra    = wp_kses_post( $interval['extraText'] ?? $default_texts['extraText'] );
 
 		$content = '';

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -412,7 +412,7 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		}
 
 		$heading = wp_kses_post( $interval['heading'] ?? $default_texts[ $key ]['heading'] );
-		$extra    = wp_kses_post( $interval['extraText'] ?? $default_texts['extraText'] );
+		$extra   = wp_kses_post( $interval['extraText'] ?? $default_texts['extraText'] );
 
 		$content = '';
 		if ( '' !== trim( wp_strip_all_tags( $heading ) ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -407,7 +407,11 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 				'email_attrs' => $email_attrs,
 			);
 
-			return \Automattic\Jetpack\Extensions\Button\render_email( '', $button_parsed_block, $rendering_context );
+			$button = \Automattic\Jetpack\Extensions\Button\render_email( '', $button_parsed_block, $rendering_context );
+
+			// The email renderer strips the block's margins, so add padding around the
+			// CTA button to keep the donation intervals from rendering cramped together.
+			return '<div style="padding-top:12px;padding-bottom:28px;">' . $button . '</div>';
 		},
 		$block_content
 	);

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
@@ -8,7 +8,6 @@
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
 
-// Ensure the functions are available.
 if ( ! function_exists( 'Automattic\Jetpack\Extensions\Donations\render_email' ) ) {
 	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
 }
@@ -16,7 +15,6 @@ if ( ! function_exists( 'Automattic\Jetpack\Extensions\Button\render_email' ) ) 
 	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
 }
 
-// Include mock classes for WooCommerce Email Editor helpers.
 require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
 require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
 require_once __DIR__ . '/mocks/class-mock-woocommerce-button-renderer.php';
@@ -100,20 +98,16 @@ class Donations_Block_Email_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '<table', $result );
 
-		// Custom headings.
 		$this->assertStringContainsString( 'Give once', $result );
 		$this->assertStringContainsString( 'Give monthly', $result );
 		$this->assertStringContainsString( 'Give yearly', $result );
 
-		// Custom button labels.
 		$this->assertStringContainsString( 'Give now', $result );
 		$this->assertStringContainsString( 'Subscribe monthly', $result );
 		$this->assertStringContainsString( 'Subscribe yearly', $result );
 
-		// Custom supporting text.
 		$this->assertStringContainsString( 'One-time thanks.', $result );
 
-		// CTA destination.
 		$this->assertStringContainsString( 'https://example.com/donate-post', $result );
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
@@ -94,6 +94,9 @@ class Donations_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Donate', $result );
 		$this->assertStringContainsString( 'Donate monthly', $result );
 		$this->assertStringContainsString( 'https://example.com/my-post', $result );
+
+		// Each button is wrapped with spacing so intervals aren't cramped.
+		$this->assertStringContainsString( 'padding-bottom:28px', $result );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Donations Block Email Rendering tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
+
+// Ensure the functions are available.
+if ( ! function_exists( 'Automattic\Jetpack\Extensions\Donations\render_email' ) ) {
+	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
+}
+if ( ! function_exists( 'Automattic\Jetpack\Extensions\Button\render_email' ) ) {
+	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
+}
+
+// Include mock classes for WooCommerce Email Editor helpers.
+require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
+require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
+require_once __DIR__ . '/mocks/class-mock-woocommerce-button-renderer.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Donations Block Email Rendering tests.
+ *
+ * Verifies that render_email reuses the block's static fallback HTML and swaps
+ * each fallback donation link for an email-friendly CTA button.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Donations\render_email
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Donations\render_email' )]
+class Donations_Block_Email_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Build fallback block content matching the block's saved/static output.
+	 *
+	 * @param string $url      Fallback link URL.
+	 * @param array  $buttons  Button texts to render as fallback links.
+	 * @return string
+	 */
+	private function build_fallback_content( $url = 'https://example.com/my-post', $buttons = array( 'Donate', 'Donate monthly' ) ) {
+		$content = '<div class="wp-block-jetpack-donations">';
+		foreach ( $buttons as $index => $text ) {
+			if ( $index > 0 ) {
+				$content .= '<hr class="donations__separator" />';
+			}
+			$content .= '<h4>Make a donation</h4>';
+			$content .= '<p>Your contribution is appreciated.</p>';
+			$content .= sprintf(
+				'<a class="jetpack-donations-fallback-link" href="%s" rel="noopener noreferrer noamphtml" target="_blank">%s</a>',
+				esc_url( $url ),
+				esc_html( $text )
+			);
+		}
+		return $content . '</div>';
+	}
+
+	/**
+	 * Helper to create a rendering context mock.
+	 *
+	 * @param string $width The width to return from get_layout_width_without_padding.
+	 * @return object Mock rendering context.
+	 */
+	private function create_rendering_context_mock( $width = '600px' ) {
+		return new class( $width ) {
+			private $width;
+
+			public function __construct( $width ) {
+				$this->width = $width;
+			}
+
+			public function get_layout_width_without_padding() {
+				return $this->width;
+			}
+		};
+	}
+
+	/**
+	 * Each fallback link is replaced with a CTA button.
+	 */
+	public function test_render_email_replaces_links_with_buttons() {
+		$content = $this->build_fallback_content();
+		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+
+		// Fallback links are gone, replaced by table-based buttons.
+		$this->assertStringNotContainsString( 'jetpack-donations-fallback-link', $result );
+		$this->assertStringContainsString( '<table', $result );
+
+		// Both button texts and the destination URL survive.
+		$this->assertStringContainsString( 'Donate', $result );
+		$this->assertStringContainsString( 'Donate monthly', $result );
+		$this->assertStringContainsString( 'https://example.com/my-post', $result );
+	}
+
+	/**
+	 * Headings, supporting text and separators from the fallback are preserved.
+	 */
+	public function test_render_email_preserves_surrounding_content() {
+		$content = $this->build_fallback_content();
+		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+
+		$this->assertStringContainsString( '<h4>Make a donation</h4>', $result );
+		$this->assertStringContainsString( 'Your contribution is appreciated.', $result );
+		$this->assertStringContainsString( 'donations__separator', $result );
+	}
+
+	/**
+	 * HTML inside the button text is stripped before rendering.
+	 */
+	public function test_render_email_strips_html_in_button_text() {
+		$content = $this->build_fallback_content( 'https://example.com/my-post', array( '<strong>Give now</strong>' ) );
+		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+
+		$this->assertStringContainsString( 'Give now', $result );
+		$this->assertStringNotContainsString( '<strong>Give now', $result );
+	}
+
+	/**
+	 * Content without fallback links is returned unchanged.
+	 */
+	public function test_render_email_without_links_returns_content_unchanged() {
+		$content = '<div class="wp-block-jetpack-donations"><h4>Make a donation</h4></div>';
+		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * Empty content is returned unchanged.
+	 */
+	public function test_render_email_with_empty_content() {
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+		$this->assertSame( '', $result );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
@@ -26,8 +26,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 /**
  * Donations Block Email Rendering tests.
  *
- * Verifies that render_email reuses the block's static fallback HTML and swaps
- * each fallback donation link for an email-friendly CTA button.
+ * Verifies that render_email builds a dedicated email version of the block from
+ * its attributes, preserving per-interval customization and rendering CTA buttons.
  *
  * @covers ::Automattic\Jetpack\Extensions\Donations\render_email
  */
@@ -36,27 +36,40 @@ class Donations_Block_Email_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
-	 * Build fallback block content matching the block's saved/static output.
+	 * Build a parsed block with the given attributes.
 	 *
-	 * @param string $url      Fallback link URL.
-	 * @param array  $buttons  Button texts to render as fallback links.
-	 * @return string
+	 * @param array $attrs Block attributes.
+	 * @return array
 	 */
-	private function build_fallback_content( $url = 'https://example.com/my-post', $buttons = array( 'Donate', 'Donate monthly' ) ) {
-		$content = '<div class="wp-block-jetpack-donations">';
-		foreach ( $buttons as $index => $text ) {
-			if ( $index > 0 ) {
-				$content .= '<hr class="donations__separator" />';
-			}
-			$content .= '<h4>Make a donation</h4>';
-			$content .= '<p>Your contribution is appreciated.</p>';
-			$content .= sprintf(
-				'<a class="jetpack-donations-fallback-link" href="%s" rel="noopener noreferrer noamphtml" target="_blank">%s</a>',
-				esc_url( $url ),
-				esc_html( $text )
-			);
-		}
-		return $content . '</div>';
+	private function parsed_block( $attrs = array() ) {
+		return array( 'attrs' => $attrs );
+	}
+
+	/**
+	 * Default attributes showing all three intervals with custom text.
+	 *
+	 * @return array
+	 */
+	private function customized_attrs() {
+		return array(
+			'fallbackLinkUrl' => 'https://example.com/donate-post',
+			'oneTimeDonation' => array(
+				'show'       => true,
+				'heading'    => 'Give once',
+				'buttonText' => 'Give now',
+				'extraText'  => 'One-time thanks.',
+			),
+			'monthlyDonation' => array(
+				'show'       => true,
+				'heading'    => 'Give monthly',
+				'buttonText' => 'Subscribe monthly',
+			),
+			'annualDonation'  => array(
+				'show'       => true,
+				'heading'    => 'Give yearly',
+				'buttonText' => 'Subscribe yearly',
+			),
+		);
 	}
 
 	/**
@@ -80,63 +93,108 @@ class Donations_Block_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Each fallback link is replaced with a CTA button.
+	 * Custom per-interval headings, button labels and supporting text are preserved.
 	 */
-	public function test_render_email_replaces_links_with_buttons() {
-		$content = $this->build_fallback_content();
-		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+	public function test_render_email_preserves_customization() {
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', $this->parsed_block( $this->customized_attrs() ), $this->create_rendering_context_mock() );
 
-		// Fallback links are gone, replaced by table-based buttons.
-		$this->assertStringNotContainsString( 'jetpack-donations-fallback-link', $result );
 		$this->assertStringContainsString( '<table', $result );
 
-		// Both button texts and the destination URL survive.
-		$this->assertStringContainsString( 'Donate', $result );
-		$this->assertStringContainsString( 'Donate monthly', $result );
-		$this->assertStringContainsString( 'https://example.com/my-post', $result );
+		// Custom headings.
+		$this->assertStringContainsString( 'Give once', $result );
+		$this->assertStringContainsString( 'Give monthly', $result );
+		$this->assertStringContainsString( 'Give yearly', $result );
 
-		// Each button is wrapped with spacing so intervals aren't cramped.
-		$this->assertStringContainsString( 'padding-bottom:28px', $result );
+		// Custom button labels.
+		$this->assertStringContainsString( 'Give now', $result );
+		$this->assertStringContainsString( 'Subscribe monthly', $result );
+		$this->assertStringContainsString( 'Subscribe yearly', $result );
+
+		// Custom supporting text.
+		$this->assertStringContainsString( 'One-time thanks.', $result );
+
+		// CTA destination.
+		$this->assertStringContainsString( 'https://example.com/donate-post', $result );
 	}
 
 	/**
-	 * Headings, supporting text and separators from the fallback are preserved.
+	 * Hidden intervals are not rendered.
 	 */
-	public function test_render_email_preserves_surrounding_content() {
-		$content = $this->build_fallback_content();
-		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+	public function test_render_email_respects_hidden_intervals() {
+		$attrs = array(
+			'fallbackLinkUrl' => 'https://example.com/donate-post',
+			'oneTimeDonation' => array(
+				'show'       => true,
+				'heading'    => 'Give once',
+				'buttonText' => 'Give now',
+			),
+			'monthlyDonation' => array( 'show' => false ),
+			'annualDonation'  => array( 'show' => false ),
+		);
 
-		$this->assertStringContainsString( '<h4>Make a donation</h4>', $result );
-		$this->assertStringContainsString( 'Your contribution is appreciated.', $result );
-		$this->assertStringContainsString( 'donations__separator', $result );
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', $this->parsed_block( $attrs ), $this->create_rendering_context_mock() );
+
+		$this->assertStringContainsString( 'Give once', $result );
+		$this->assertStringNotContainsString( 'monthly', $result );
+		$this->assertStringNotContainsString( 'yearly', $result );
 	}
 
 	/**
-	 * HTML inside the button text is stripped before rendering.
+	 * Falls back to default texts when nothing is customized.
+	 */
+	public function test_render_email_uses_default_texts() {
+		$attrs = array(
+			'fallbackLinkUrl' => 'https://example.com/donate-post',
+			'oneTimeDonation' => array( 'show' => true ),
+			'monthlyDonation' => array( 'show' => false ),
+			'annualDonation'  => array( 'show' => false ),
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', $this->parsed_block( $attrs ), $this->create_rendering_context_mock() );
+
+		$this->assertStringContainsString( 'Make a one-time donation', $result );
+		$this->assertStringContainsString( 'Donate', $result );
+	}
+
+	/**
+	 * Returns empty string when no intervals are shown.
+	 */
+	public function test_render_email_returns_empty_when_no_intervals() {
+		$attrs = array(
+			'oneTimeDonation' => array( 'show' => false ),
+			'monthlyDonation' => array( 'show' => false ),
+			'annualDonation'  => array( 'show' => false ),
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', $this->parsed_block( $attrs ), $this->create_rendering_context_mock() );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Returns empty string when attrs are missing.
+	 */
+	public function test_render_email_returns_empty_with_missing_attrs() {
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', array( 'not-attrs' => array() ), $this->create_rendering_context_mock() );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * HTML inside a custom button label is stripped.
 	 */
 	public function test_render_email_strips_html_in_button_text() {
-		$content = $this->build_fallback_content( 'https://example.com/my-post', array( '<strong>Give now</strong>' ) );
-		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
+		$attrs = array(
+			'fallbackLinkUrl' => 'https://example.com/donate-post',
+			'oneTimeDonation' => array(
+				'show'       => true,
+				'buttonText' => '<strong>Give now</strong>',
+			),
+			'monthlyDonation' => array( 'show' => false ),
+			'annualDonation'  => array( 'show' => false ),
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', $this->parsed_block( $attrs ), $this->create_rendering_context_mock() );
 
 		$this->assertStringContainsString( 'Give now', $result );
 		$this->assertStringNotContainsString( '<strong>Give now', $result );
-	}
-
-	/**
-	 * Content without fallback links is returned unchanged.
-	 */
-	public function test_render_email_without_links_returns_content_unchanged() {
-		$content = '<div class="wp-block-jetpack-donations"><h4>Make a donation</h4></div>';
-		$result  = \Automattic\Jetpack\Extensions\Donations\render_email( $content, array( 'attrs' => array() ), $this->create_rendering_context_mock() );
-
-		$this->assertSame( $content, $result );
-	}
-
-	/**
-	 * Empty content is returned unchanged.
-	 */
-	public function test_render_email_with_empty_content() {
-		$result = \Automattic\Jetpack\Extensions\Donations\render_email( '', array( 'attrs' => array() ), $this->create_rendering_context_mock() );
-		$this->assertSame( '', $result );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Block_Email_Test.php
@@ -8,14 +8,6 @@
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
 
-if ( ! function_exists( 'Automattic\Jetpack\Extensions\Donations\render_email' ) ) {
-	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/donations/donations.php';
-}
-if ( ! function_exists( 'Automattic\Jetpack\Extensions\Button\render_email' ) ) {
-	require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/button/button.php';
-}
-
-require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
 require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
 require_once __DIR__ . '/mocks/class-mock-woocommerce-button-renderer.php';
 
@@ -28,8 +20,12 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * its attributes, preserving per-interval customization and rendering CTA buttons.
  *
  * @covers ::Automattic\Jetpack\Extensions\Donations\render_email
+ * @covers ::Automattic\Jetpack\Extensions\Donations\render_email_donate_button
+ * @covers ::Automattic\Jetpack\Extensions\Donations\get_email_target_width
  */
 #[CoversFunction( 'Automattic\Jetpack\Extensions\Donations\render_email' )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Donations\render_email_donate_button' )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Donations\get_email_target_width' )]
 class Donations_Block_Email_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 


### PR DESCRIPTION
Fixes NL-708

<img width="689" height="961" alt="Screenshot on 2026-06-25 at 04-18-27" src="https://github.com/user-attachments/assets/dec283cf-5f85-4071-8afb-755a485355ca" />

## Summary

The Donations block didn't know how to draw itself inside an email (newsletter). So it showed up broken. This adds an email version of the block.

Instead of trying to cram the interactive donation form into an email, we rebuild a simple, email-safe version from the block's settings: for each donation option (one-time / monthly / yearly) we show its heading, its supporting text, and a button. Every button just links back to the post, where people can actually donate.

Because we build it from the block's settings, any text the user customized (headings, button labels, supporting text) carries over into the email. Buttons are drawn with the same email button code other blocks use, and laid out with email-safe tables so they render consistently across mail clients.

## Testing instructions

1. On a site with newsletter email sending, publish a post with a **Donations** block (Stripe connected, at least one interval enabled).
2. Customize a heading and a button label.
3. Preview the post as an email.
4. Confirm each enabled interval shows its heading, text, and a **button** (not a plain link), the custom text carries through, and buttons link to the post.

Bonus: after publishing the post use the PHP sending script to send the email and verify it looks good in the mail client.

## Does this pull request change what data or activity we track or use?

No.
