### PR TITLE
Add JSDoc audit dimension to widget-audit command

### DIFF
--- a/.agents/rules/widgets.md
+++ b/.agents/rules/widgets.md
@@ -11,6 +11,10 @@ The render component is bound by `WidgetRenderProps<Item>` from
 `@wordpress/widget-primitives`: it receives only `{ attributes, setAttributes }`.
 `attributes` may arrive empty — default it (`= {}`).
 
+The attribute shape (`Item`) is declared and exported once from `widget.ts`,
+alongside the `attributes`/`example` schema it describes; `render.tsx` imports it
+rather than redeclaring it, so the schema and the render props cannot drift.
+
 The host owns all chrome. The widget renders body only — never a `Card`, header,
 title, or remove control. `presentation` in `widget.json` declares how the widget
 wants to be framed; the host decides how.

--- a/.agents/skills/widget-audit.md
+++ b/.agents/skills/widget-audit.md
@@ -52,6 +52,16 @@ assume: namespace, text domain, and the dependency versions the package resolves
   Modules, never global CSS.
 - User-visible strings go through `__( …, '<text-domain>' )`.
 
+**Docs (JSDoc)**
+- Props are a named `type`/`interface` with each field documented on the type,
+  not echoed in `@param`. A component takes one typed tag
+  (`@param {Props} props - The component props.`) — never `@param props.<field>`
+  blocks; plain functions keep positional `@param`s.
+- Descriptions track the code: referenced symbols still exist, terminology is
+  consistent (`widget.json` ↔ `widget.ts` ↔ rendered strings), `@return` is accurate.
+- Verify, don't guess: `jsdoc/require-param` is satisfied by that single typed
+  `props` tag — confirm with `eslint <widget>/render.tsx` instead of dropping it.
+
 ## How to verify tokens
 
 ```bash


### PR DESCRIPTION
## What?

Adds a **Docs (JSDoc)** section to the `widget-audit` command so an audit also covers documentation, both format and content.

Until now, the command checked shape, contract, chrome, and style/i18n, but not the widget's documentation.

## Why?

Widgets drift in their JSDoc: per-field `@param props.<field>` blocks that duplicate the props type, descriptions that reference renamed symbols, and inconsistent terminology across `widget.json`, `widget.ts`, and the strings the body renders.

Codifying the convention in the command ensures audits catch this consistently, rather than relying on memory.

## How?
Three checklist bullets, in the command's existing one-line-per-item style:
- Props are a named `type`/`interface` with each field documented on the type; a component takes a single typed `@param {Props} props`, never `@param props.<field>` blocks (plain functions keep positional `@param`s).
- Descriptions track the code (referenced symbols exist, terminology consistent,`@return` accurate).
- Verify with `eslint <widget>/render.tsx` rather than guessing — `jsdoc/require-param` is satisfied by that single typed `props` tag.

## Testing
Command/docs change only; no runtime impact.
- Run `/widget-audit <widget>` and confirm the audit now reports JSDoc findings under the new section.