### PR TITLE
RTC: Fix PingHub room chunking regression for payloads over 1024 bytes

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17708-fix-pinghub-room-chunking-regression-in-production
+++ b/projects/packages/rtc/changelog/dotcom-17708-fix-pinghub-room-chunking-regression-in-production
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC: Fix PingHub WebSocket chunking so messages larger than 1024 bytes reassemble correctly. Each chunk now carries the room tag, instead of tagging the whole message once before chunking which left later chunks untagged and dropped on receive.

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -617,8 +617,9 @@ export class PingHubBridge {
 	/**
 	 * Send binary data to peers in the given room.
 	 *
-	 * The payload is tagged with the room name before chunking and sending,
-	 * so all peers on the shared channel can demultiplex by room.
+	 * Small messages are sent as a single room-tagged frame. Larger messages
+	 * are split into chunks, with each chunk individually room-tagged so the
+	 * receiver can demultiplex every chunk independently before reassembly.
 	 *
 	 * @param room - Room name.
 	 * @param data - Payload to send.
@@ -636,15 +637,21 @@ export class PingHubBridge {
 			return;
 		}
 
+		// Each chunk is demultiplexed independently on receive by reading its
+		// room tag, so every chunk must carry one. Chunk the RAW payload and
+		// re-tag each slice as room\0<slice>; tagging once and slicing the
+		// tagged buffer would leave later chunks without a room prefix, so the
+		// receiver would drop them and the message would never reassemble.
+		const roomTagLength = textEncoder.encode( room ).length + 1; // room bytes + separator
+		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN - roomTagLength;
 		// eslint-disable-next-line no-bitwise
 		const msgId = this.chunkMsgId & 0xffff;
 		this.chunkMsgId++;
-		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN;
-		const totalChunks = Math.ceil( tagged.length / chunkSize );
+		const totalChunks = Math.ceil( data.length / chunkSize );
 		for ( let i = 0; i < totalChunks; i++ ) {
 			const start = i * chunkSize;
-			const payload = tagged.subarray( start, Math.min( start + chunkSize, tagged.length ) );
-			sendOne( buildChunk( msgId, totalChunks, i, payload ) );
+			const slice = data.subarray( start, Math.min( start + chunkSize, data.length ) );
+			sendOne( buildChunk( msgId, totalChunks, i, tagPayload( room, slice ) ) );
 		}
 	}
 }

--- a/projects/packages/rtc/src/js/providers/pinghub/test/pinghub-bridge.test.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/test/pinghub-bridge.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the PingHub bridge chunking round-trip.
+ *
+ * Regression guard for DOTCOM-17708: messages larger than the single-frame
+ * threshold must survive the send -> chunk -> receive -> reassemble round-trip.
+ * The regression tagged the whole message with the room name once and then
+ * chunked the tagged buffer, so only the first chunk carried the room tag and
+ * every later chunk was dropped on receive, meaning payloads over ~1024 bytes
+ * never reassembled.
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
+	default: jest.fn( () => Promise.resolve( { token: 'test-jwt' } ) ),
+} ) );
+
+const { PingHubBridge } = await import( '../pinghub-bridge' );
+
+// Mirror of the (module-private) wire constants in pinghub-bridge.ts.
+const CHUNK_MAGIC = 0xfe;
+const MAX_PAYLOAD_BEFORE_CHUNK = 1024;
+
+type FakeEvent = Record< string, unknown >;
+
+/**
+ * Minimal WebSocket stand-in (jsdom does not implement WebSocket). Records the
+ * frames passed to send() and lets tests fire lifecycle/message events at the
+ * listeners the bridge registers.
+ */
+class MockWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: MockWebSocket[] = [];
+
+	url: string;
+	binaryType = 'blob';
+	readyState: number = MockWebSocket.CONNECTING;
+	sent: string[] = [];
+	private listeners: Record< string, Array< ( event: FakeEvent ) => void > > = {};
+
+	/**
+	 * Track the created socket so tests can drive it.
+	 *
+	 * @param url - The socket URL the bridge connected to.
+	 */
+	constructor( url: string ) {
+		this.url = url;
+		MockWebSocket.instances.push( this );
+	}
+
+	/**
+	 * Register a listener for a socket event.
+	 *
+	 * @param type - Event name.
+	 * @param cb   - Listener callback.
+	 */
+	addEventListener( type: string, cb: ( event: FakeEvent ) => void ): void {
+		( this.listeners[ type ] ||= [] ).push( cb );
+	}
+
+	/**
+	 * Remove a previously registered listener.
+	 *
+	 * @param type - Event name.
+	 * @param cb   - Listener callback to remove.
+	 */
+	removeEventListener( type: string, cb: ( event: FakeEvent ) => void ): void {
+		this.listeners[ type ] = ( this.listeners[ type ] || [] ).filter( fn => fn !== cb );
+	}
+
+	/**
+	 * Capture a frame the bridge sent.
+	 *
+	 * @param data - Base64-encoded frame the bridge is sending.
+	 */
+	send( data: string ): void {
+		this.sent.push( data );
+	}
+
+	/** Close the socket and notify listeners. */
+	close(): void {
+		this.readyState = MockWebSocket.CLOSED;
+		this.emit( 'close', { code: 1000, reason: 'test', wasClean: true } );
+	}
+
+	/**
+	 * Dispatch an event to the bridge's registered listeners.
+	 *
+	 * @param type  - Event name.
+	 * @param event - Event payload.
+	 */
+	emit( type: string, event: FakeEvent = {} ): void {
+		( this.listeners[ type ] || [] ).forEach( cb => cb( event ) );
+	}
+
+	/** Transition to OPEN and notify the bridge. */
+	fireOpen(): void {
+		this.readyState = MockWebSocket.OPEN;
+		this.emit( 'open', {} );
+	}
+}
+
+/**
+ * Decode a base64 frame back into bytes (mirrors the bridge's wire format).
+ *
+ * @param base64 - Base64-encoded frame.
+ * @return Decoded bytes.
+ */
+function decodeFrame( base64: string ): Uint8Array {
+	const binary = atob( base64 );
+	const u8 = new Uint8Array( binary.length );
+	for ( let i = 0; i < binary.length; i++ ) {
+		u8[ i ] = binary.charCodeAt( i );
+	}
+	return u8;
+}
+
+/**
+ * Flush pending microtasks/timers so the async connect can settle.
+ *
+ * @return A promise that resolves on the next macrotask.
+ */
+function flush(): Promise< void > {
+	return new Promise( resolve => setTimeout( resolve, 0 ) );
+}
+
+describe( 'PingHubBridge chunking', () => {
+	const room = 'post-42';
+	let bridge: InstanceType< typeof PingHubBridge >;
+
+	beforeEach( () => {
+		MockWebSocket.instances = [];
+		( globalThis as Record< string, unknown > ).WebSocket = MockWebSocket;
+		( window as Record< string, unknown > )._currentSiteId = 123;
+		( window as Record< string, unknown > ).jetpackRTC = {
+			currentPostType: 'post',
+			currentPostId: 1,
+		};
+		bridge = new PingHubBridge();
+	} );
+
+	afterEach( () => {
+		delete ( globalThis as Record< string, unknown > ).WebSocket;
+		delete ( window as Record< string, unknown > )._currentSiteId;
+		delete ( window as Record< string, unknown > ).jetpackRTC;
+	} );
+
+	/**
+	 * Open the shared socket and return the underlying mock once it is OPEN.
+	 *
+	 * @return The mock WebSocket backing the bridge.
+	 */
+	async function connect(): Promise< MockWebSocket > {
+		const connected = bridge.connect( room );
+		await flush();
+		const ws = MockWebSocket.instances[ MockWebSocket.instances.length - 1 ];
+		ws.fireOpen();
+		await connected;
+		ws.sent = []; // Drop any handshake frames; capture only the test's sends.
+		return ws;
+	}
+
+	/**
+	 * Echo every frame the bridge sent back into its own message handler, as the
+	 * PingHub server would broadcast it to peers in the room.
+	 *
+	 * @param ws - The mock socket whose sent frames should be echoed back.
+	 */
+	function echo( ws: MockWebSocket ): void {
+		ws.sent.forEach( frame => ws.emit( 'message', { data: frame } ) );
+	}
+
+	it( 'round-trips a message larger than the chunk threshold', async () => {
+		const ws = await connect();
+		const received: Uint8Array[] = [];
+		bridge.on( room, 'message', data => {
+			received.push( data );
+		} );
+
+		// 5000 bytes forces multiple chunks and includes 0x00 bytes, which the
+		// pre-fix code mis-parsed as room separators inside untagged chunks.
+		const payload = new Uint8Array( 5000 );
+		for ( let i = 0; i < payload.length; i++ ) {
+			payload[ i ] = i % 256;
+		}
+
+		bridge.send( room, payload );
+		expect( ws.sent.length ).toBeGreaterThan( 1 ); // Actually chunked.
+
+		echo( ws );
+
+		expect( received ).toHaveLength( 1 );
+		expect( Array.from( received[ 0 ] ) ).toEqual( Array.from( payload ) );
+	} );
+
+	it( 'tags every chunk and keeps each frame within the single-frame limit', async () => {
+		const ws = await connect();
+		const payload = new Uint8Array( 5000 ).fill( 65 );
+		const roomTag = new TextEncoder().encode( room );
+
+		bridge.send( room, payload );
+
+		expect( ws.sent.length ).toBeGreaterThan( 1 );
+		ws.sent.forEach( frame => {
+			const bytes = decodeFrame( frame );
+			expect( bytes.length ).toBeLessThanOrEqual( MAX_PAYLOAD_BEFORE_CHUNK );
+			expect( bytes[ 0 ] ).toBe( CHUNK_MAGIC );
+			// After the 5-byte chunk header, every chunk must start with room\0.
+			const tagged = bytes.subarray( 5 );
+			expect( Array.from( tagged.subarray( 0, roomTag.length ) ) ).toEqual( Array.from( roomTag ) );
+			expect( tagged[ roomTag.length ] ).toBe( 0 );
+		} );
+	} );
+
+	it( 'round-trips a small single-frame message', async () => {
+		const ws = await connect();
+		const received: Uint8Array[] = [];
+		bridge.on( room, 'message', data => {
+			received.push( data );
+		} );
+
+		const payload = new Uint8Array( [ 1, 2, 3, 4, 5 ] );
+		bridge.send( room, payload );
+
+		expect( ws.sent ).toHaveLength( 1 ); // Single frame, not chunked.
+		echo( ws );
+
+		expect( received ).toHaveLength( 1 );
+		expect( Array.from( received[ 0 ] ) ).toEqual( Array.from( payload ) );
+	} );
+} );


### PR DESCRIPTION
DOTCOM-17708

## Proposed changes

* Fixes a regression in the PingHub WebSocket transport where real-time collaboration edits stopped syncing for payloads larger than 1024 bytes.
* The multiplex refactor (#47994) moved the room tag into the payload and applied it **once before chunking**, so only the first chunk kept the `room\0` prefix. The receiver demultiplexes every chunk by reading its room tag, so chunks after the first were dropped and messages over 1024 bytes never reassembled. Awareness/cursor traffic is small and single-frame, so it kept working — which is why the failure was silent ("cursors work, edits don't").
* `send()` now chunks the **raw** payload and re-tags **every** chunk as `room\0<slice>`, matching what the receiver already expects. `chunkSize` now accounts for the per-chunk room tag so each frame stays within the 1024-byte limit. The receive/reassembly path is unchanged.
* Adds a regression test (mock WebSocket) covering a >1024-byte send→receive round-trip, the per-chunk room-tag + frame-size invariant, and a small single-frame round-trip. Confirmed the round-trip test fails on the pre-fix code and passes after.

## Related product discussion/links

* DOTCOM-17708

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Automated: run the RTC package tests and confirm the new `pinghub-bridge` suite passes:
  * `pnpm --filter @automattic/jetpack-rtc test`
* Manual (optional): on a Simple WordPress.com site with RTC over the WebSocket transport, open the same post in two browsers as two collaborators, paste several paragraphs (>1 KB) of content in one window, and confirm the edits appear in the other in real time. Before this fix, large edits would silently fail to sync while cursors/presence still worked. (you'll need to sandbox your site and public-api.wordpress.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
