### PR TITLE
Performance: make the CodeVitals fixture network-hermetic

### DIFF
--- a/tools/performance/docker/setup-wordpress.sh
+++ b/tools/performance/docker/setup-wordpress.sh
@@ -88,6 +88,15 @@ define( 'NONCE_SALT',       '$(generate_salt)' );
 
 define( 'WP_DEBUG', false );
 
+// Keep the fixture network-hermetic. Without this, the fresh-install dashboard
+// render makes synchronous calls to api.wordpress.org (browse-happy / version /
+// update checks); on CI agents without egress those hang to a ~10s timeout and
+// dominate the LCP measurement. Blocking external HTTP makes them fail fast.
+// The wpcom connection simulator (mu-plugins/simulate-wpcom-connection.php)
+// short-circuits via the pre_http_request filter, which WordPress runs before
+// this block check, so the simulated connection still resolves.
+define( 'WP_HTTP_BLOCK_EXTERNAL', true );
+
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/' );
 }


### PR DESCRIPTION
Fixes [FORMS-711: Make the performance-test WordPress fixture network-hermetic](https://linear.app/a8c/issue/FORMS-711/make-the-performance-test-wordpress-fixture-network-hermetic)

## Proposed changes
* The CodeVitals performance harness (`tools/performance`) isn't network-isolated. On a fresh-install dashboard render, WordPress core calls `api.wordpress.org` (browse-happy, version, and update checks). On CI agents with no egress those calls hang to a ~10s timeout and dominate the measured LCP, so the metric reported ~10.2s instead of ~200ms.
* Add `define( 'WP_HTTP_BLOCK_EXTERNAL', true )` to the fixture's generated `wp-config.php` (`docker/setup-wordpress.sh`) so those calls fail fast. The wpcom connection simulator short-circuits through the `pre_http_request` filter, which WordPress runs before the block check, so the simulated connection still resolves.

## Related product discussion/links
* FORMS-696 (the Jetpack performance-tracking effort this feeds)

## Does this pull request change what data or activity we track or use?
No. This touches only the local CI test fixture and changes nothing in shipped Jetpack code.

## Testing instructions
* From `tools/performance`, run `pnpm test -- --skip-codevitals`. The Jetpack-connected dashboard should report a low LCP (~120ms locally) over 5 iterations and still render as a connected site.