### PR TITLE
Agents Manager: expose AI & Help entry points in the editor omnibar

### DIFF
--- a/projects/packages/agents-manager/changelog/add-editor-omnibar-entry-points
+++ b/projects/packages/agents-manager/changelog/add-editor-omnibar-entry-points
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Ask AI and Help entry points to the block editor omnibar.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -78,6 +78,42 @@ class Agents_Manager {
 	}
 
 	/**
+	 * Add the Agents Manager Help "?" node (`agents-manager`) to the admin bar, replacing the
+	 * legacy Help Center node (`help-center`).
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar     The WP_Admin_Bar instance.
+	 * @param bool          $use_disconnected Disconnected variants link straight to the Help Center instead of opening the dropdown.
+	 */
+	public function add_help_menu( $wp_admin_bar, $use_disconnected ) {
+		$wp_admin_bar->remove_node( 'help-center' );
+
+		$menu_args = array(
+			'id'     => 'agents-manager',
+			'title'  => '<span title="' . esc_attr__( 'Help Center', 'jetpack-agents-manager' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+							<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
+						</svg></span>',
+			'parent' => 'top-secondary',
+		);
+
+		if ( $use_disconnected ) {
+			$menu_args['href'] = self::HELP_CENTER_URL;
+			$menu_args['meta'] = array(
+				'target' => '_blank',
+				'rel'    => 'noopener noreferrer',
+			);
+		} else {
+			$menu_args['meta'] = array(
+				'html'   => '<div id="agents-manager-masterbar"></div>',
+				'class'  => 'menupop',
+				'target' => '_blank',
+				'rel'    => 'noopener noreferrer',
+			);
+		}
+
+		$wp_admin_bar->add_menu( $menu_args );
+	}
+
+	/**
 	 * Add the agents manager menu panel to the admin bar.
 	 *
 	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
@@ -208,44 +244,15 @@ class Agents_Manager {
 			wp_dequeue_style( 'help-center-style' );
 		}
 
-		// For non-Gutenberg, non-CIAB environments, add to admin bar.
-		// Gutenberg doesn't have an admin bar, so JS will handle UI insertion.
-		// CIAB hides the classic admin bar and uses its own Site Hub — the JS variant handles UI there.
+		// For non-Gutenberg, non-CIAB environments, add to the admin bar. The fullscreen Gutenberg
+		// editor has no admin bar, so JS handles UI insertion — except under the omnibar, which is
+		// handled below. CIAB hides the admin bar and uses its own Site Hub.
 		$is_ciab = $this->is_ciab_environment();
 		if ( ! $is_gutenberg && ! $is_ciab ) {
 			add_action(
 				'admin_bar_menu',
 				function ( $wp_admin_bar ) use ( $use_disconnected ) {
-					// Remove the help-center menu item
-					$wp_admin_bar->remove_node( 'help-center' );
-
-					$menu_args = array(
-						'id'     => 'agents-manager',
-						'title'  => '<span title="' . __( 'Help Center', 'jetpack-agents-manager' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-										<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
-									</svg></span>',
-						'parent' => 'top-secondary',
-					);
-
-					// For disconnected variants, link directly to help center instead of showing dropdown
-					if ( $use_disconnected ) {
-						$menu_args['href'] = self::HELP_CENTER_URL;
-						$menu_args['meta'] = array(
-							'target' => '_blank',
-							'rel'    => 'noopener noreferrer',
-						);
-					} else {
-						// For full variants, show the dropdown menu panel
-						$menu_args['meta'] = array(
-							'html'   => '<div id="agents-manager-masterbar" />',
-							'class'  => 'menupop',
-							'target' => '_blank',
-							'rel'    => 'noopener noreferrer',
-						);
-					}
-
-					// Add the main agents manager menu node
-					$wp_admin_bar->add_menu( $menu_args );
+					$this->add_help_menu( $wp_admin_bar, $use_disconnected );
 				},
 				// Add the agents manager icon to the admin bar after the help center is added, so we can remove it.
 				100
@@ -258,6 +265,30 @@ class Agents_Manager {
 
 			// Standalone AI chat button, shown only in the unified experience.
 			if ( ! $use_disconnected && self::is_unified_experience() ) {
+				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
+			}
+		}
+
+		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, expose the entry
+		// points in that editor admin bar (CIAB is excluded — it has its own Site Hub UI). The Help
+		// "?" dropdown shows only in the full unified experience (mirroring wp-admin); the Ask AI
+		// button shows in any dev/internal context while the feature is in development. The
+		// wp-calypso admin-bar integration wires both, so no frontend change is needed.
+		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
+			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
+			if ( self::is_unified_experience() ) {
+				add_action(
+					'admin_bar_menu',
+					function ( $wp_admin_bar ) {
+						$this->add_help_menu( $wp_admin_bar, false );
+					},
+					100
+				);
+				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			}
+
+			// Ask AI button — dev/internal contexts only while the feature is in development.
+			if ( self::is_dev_mode() ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}
@@ -851,6 +882,22 @@ class Agents_Manager {
 		$current_screen = get_current_screen();
 		// The widgets screen has the block editor but no Gutenberg top bar.
 		return $current_screen && $current_screen->is_block_editor() && $current_screen->id !== 'widgets';
+	}
+
+	/**
+	 * Returns true when Gutenberg's "admin bar in editor" (omnibar) experiment is active.
+	 *
+	 * Mirrors Gutenberg core's gate in `lib/experimental/admin-bar-in-editor/load.php`, and fails
+	 * safe when `gutenberg_is_experiment_enabled()` is unavailable.
+	 *
+	 * @return bool
+	 */
+	private static function is_admin_bar_in_editor() {
+		return self::is_block_editor()
+			&& is_admin_bar_showing()
+			&& function_exists( 'gutenberg_is_experiment_enabled' )
+			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
+			&& \gutenberg_is_experiment_enabled( 'gutenberg-admin-bar-in-editor' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -639,6 +639,127 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Puts the current request into a block-editor screen with Agents Manager enabled
+	 * (block-editor-only, no unified experience), so the editor omnibar branch is reachable.
+	 */
+	private function set_up_block_editor_request() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'post' );
+		$screen     = get_current_screen();
+		$reflection = new \ReflectionClass( $screen );
+		$property   = $reflection->getProperty( 'is_block_editor' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $screen, true );
+
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Ask AI button is added to the editor admin bar when the omnibar experiment
+	 * is active in a dev/internal context (here, a proxied request).
+	 */
+	public function test_ai_chat_button_registered_in_editor_omnibar() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Ask AI button is not added to the editor admin bar when the omnibar
+	 * experiment is inactive, even in a dev/internal context.
+	 */
+	public function test_ai_chat_button_not_registered_in_editor_without_omnibar() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( false );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Ask AI button is not added to the editor admin bar outside dev/internal
+	 * contexts, even when the omnibar experiment is active.
+	 */
+	public function test_ai_chat_button_not_registered_in_editor_outside_dev_mode() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( false );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Help "?" dropdown (its menu panel) is added to the editor admin bar when the
+	 * omnibar experiment is active in the unified experience.
+	 */
+	public function test_help_menu_registered_in_editor_omnibar_when_unified() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) )
+		);
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Help "?" dropdown is not added to the editor admin bar when the omnibar
+	 * experiment is active but the unified experience is disabled (Ask AI only).
+	 */
+	public function test_help_menu_not_registered_in_editor_omnibar_without_unified() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
 	 * Tests that should_display_menu_panel returns false by default.
 	 */
 	public function test_should_display_menu_panel_returns_false_by_default() {

--- a/projects/packages/agents-manager/tests/php/bootstrap.php
+++ b/projects/packages/agents-manager/tests/php/bootstrap.php
@@ -10,5 +10,9 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+// Load Patchwork before WordPress so Brain Monkey can redefine WP core functions that the test
+// suite mocks (e.g. `is_admin_bar_showing()`); otherwise they're defined too early to intercept.
+require_once __DIR__ . '/../../vendor/antecedent/patchwork/Patchwork.php';
+
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();


### PR DESCRIPTION
Part of AI-1016

## Proposed changes

Registers the Agents Manager admin-bar entry points inside Gutenberg’s admin-bar-in-editor (omnibar) experiment, so the block editor exposes the same AI and Help affordances as `/wp-admin`:

* **Ask AI** sparkle node, gated to dev mode.
* **Help “?”** menu (and its panel), gated to the unified AI experience; the legacy Help Center node is removed in this mode.
* Adds `is_admin_bar_in_editor()` detection (block editor + `is_admin_bar_showing()` + the `gutenberg-admin-bar-in-editor` experiment) and extracts the shared Help menu wiring into `add_help_menu()`.

The existing non-Gutenberg admin bar and CIAB paths are unchanged.

## Related product discussion/links

* AI-1016

## Does this pull request change what data or activity we track or use?

No new data is collected. The Tracks events for these entry points are fired from the Calypso frontend; see the companion PR.

## Testing instructions

Refer to the Calypso PR: https://github.com/Automattic/wp-calypso/pull/111999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
