### PR TITLE
Podcast: centralize show-URL host allowlist + preload mount-time REST data

### DIFF
--- a/projects/packages/podcast/changelog/centralize-show-url-hosts-and-preload
+++ b/projects/packages/podcast/changelog/centralize-show-url-hosts-and-preload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Centralize podcatcher host allowlist in PHP script data and preload mount-time REST responses to drop first-render round-trips

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -135,10 +135,43 @@ class Admin_Page {
 		}
 
 		$data['podcast'] = array(
-			'has_product_access' => Podcast_Gate::has_product_access(),
+			'has_product_access'  => Podcast_Gate::has_product_access(),
+			// Authoritative directory→host allowlist; the dashboard derives its
+			// podcatcher list and client-side URL validation from this so PHP stays
+			// the single source of truth (see Settings::SHOW_URL_HOSTS).
+			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
+			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
+			// Seed apiFetch's cache with the two responses the dashboard resolves at
+			// mount (core-data settings + categories), removing those round-trips
+			// from first render. Paths must match the requests apiFetch issues.
+			'preload'             => self::build_preload(),
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Server-render the REST responses the dashboard fetches on first paint so
+	 * apiFetch's preloading middleware can serve them without a network hit.
+	 *
+	 * Each path mirrors exactly what `@wordpress/core-data` requests: the bare
+	 * settings route, and the `category` taxonomy entity (which core-data fetches
+	 * with `context=edit`). Misses are silent — a mismatch just falls back to the
+	 * live request.
+	 *
+	 * @return array<string, array{body: mixed, headers: array<string, string>}>
+	 */
+	private static function build_preload() {
+		$preload = array();
+
+		foreach ( array(
+			'/wpcom/v2/podcast/settings',
+			'/wp/v2/categories?context=edit&per_page=-1',
+		) as $path ) {
+			$preload = rest_preload_api_request( $preload, $path );
+		}
+
+		return $preload;
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -139,65 +139,13 @@ class Admin_Page {
 			// Source of truth for the dashboard's directory list + URL validation.
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
-			// Lets the dashboard skip its mount-time REST fetches.
-			'preload'             => self::build_preload(),
+			// Seed the settings response so the dashboard skips its mount-time fetch.
+			// Only settings: categories rejects per_page=-1 server-side, and stats
+			// is a live wpcom relay we don't want to block page render on.
+			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
 		);
 
 		return $data;
-	}
-
-	/**
-	 * Pre-fetch the settings + categories REST responses so the dashboard reads
-	 * them from cache instead of hitting the network on first render. Keys must
-	 * match what core-data requests, or the cache silently misses.
-	 *
-	 * @return array<string, array{body: mixed, headers: array<string, string>}>
-	 */
-	private static function build_preload() {
-		$preload = rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' );
-
-		$preload = self::add_categories_preload( $preload );
-
-		return $preload;
-	}
-
-	/**
-	 * Add the category list to the preload map.
-	 *
-	 * The dashboard asks core-data for every category (`per_page=-1`), but the
-	 * terms endpoint rejects `-1`, so core-data paginates at `per_page=100`. We
-	 * fetch page one — a request the server accepts — and store it under the
-	 * `per_page=-1` key the dashboard's first request matches on. Skipped when the
-	 * list spans more than one page, or we'd truncate the picker (preloading
-	 * short-circuits the pagination that would fetch the rest).
-	 *
-	 * @param array $preload Preload map so far.
-	 * @return array
-	 */
-	private static function add_categories_preload( $preload ) {
-		$page_path = '/wp/v2/categories?context=edit&per_page=100';
-		$fetched   = rest_preload_api_request( array(), $page_path );
-
-		if ( ! isset( $fetched[ $page_path ] ) ) {
-			return $preload;
-		}
-
-		$entry   = $fetched[ $page_path ];
-		$headers = isset( $entry['headers'] ) && is_array( $entry['headers'] ) ? $entry['headers'] : array();
-
-		$total_pages = 1;
-		foreach ( $headers as $name => $value ) {
-			if ( 'x-wp-totalpages' === strtolower( (string) $name ) ) {
-				$total_pages = (int) $value;
-				break;
-			}
-		}
-
-		if ( $total_pages <= 1 ) {
-			$preload['/wp/v2/categories?context=edit&per_page=-1'] = $entry;
-		}
-
-		return $preload;
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -136,14 +136,10 @@ class Admin_Page {
 
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
-			// Authoritative directory→host allowlist; the dashboard derives its
-			// podcatcher list and client-side URL validation from this so PHP stays
-			// the single source of truth (see Settings::SHOW_URL_HOSTS).
+			// Source of truth for the dashboard's directory list + URL validation.
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
-			// Seed apiFetch's cache with the two responses the dashboard resolves at
-			// mount (core-data settings + categories), removing those round-trips
-			// from first render. Paths must match the requests apiFetch issues.
+			// Lets the dashboard skip its mount-time REST fetches.
 			'preload'             => self::build_preload(),
 		);
 
@@ -151,13 +147,9 @@ class Admin_Page {
 	}
 
 	/**
-	 * Server-render the REST responses the dashboard fetches on first paint so
-	 * apiFetch's preloading middleware can serve them without a network hit.
-	 *
-	 * Each path mirrors exactly what `@wordpress/core-data` requests: the bare
-	 * settings route, and the `category` taxonomy entity (which core-data fetches
-	 * with `context=edit`). Misses are silent — a mismatch just falls back to the
-	 * live request.
+	 * Pre-fetch the settings + categories REST responses so the dashboard reads
+	 * them from cache instead of hitting the network on first render. Paths must
+	 * match what core-data requests, or the cache silently misses.
 	 *
 	 * @return array<string, array{body: mixed, headers: array<string, string>}>
 	 */

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -148,19 +148,53 @@ class Admin_Page {
 
 	/**
 	 * Pre-fetch the settings + categories REST responses so the dashboard reads
-	 * them from cache instead of hitting the network on first render. Paths must
+	 * them from cache instead of hitting the network on first render. Keys must
 	 * match what core-data requests, or the cache silently misses.
 	 *
 	 * @return array<string, array{body: mixed, headers: array<string, string>}>
 	 */
 	private static function build_preload() {
-		$preload = array();
+		$preload = rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' );
 
-		foreach ( array(
-			'/wpcom/v2/podcast/settings',
-			'/wp/v2/categories?context=edit&per_page=-1',
-		) as $path ) {
-			$preload = rest_preload_api_request( $preload, $path );
+		$preload = self::add_categories_preload( $preload );
+
+		return $preload;
+	}
+
+	/**
+	 * Add the category list to the preload map.
+	 *
+	 * The dashboard asks core-data for every category (`per_page=-1`), but the
+	 * terms endpoint rejects `-1`, so core-data paginates at `per_page=100`. We
+	 * fetch page one — a request the server accepts — and store it under the
+	 * `per_page=-1` key the dashboard's first request matches on. Skipped when the
+	 * list spans more than one page, or we'd truncate the picker (preloading
+	 * short-circuits the pagination that would fetch the rest).
+	 *
+	 * @param array $preload Preload map so far.
+	 * @return array
+	 */
+	private static function add_categories_preload( $preload ) {
+		$page_path = '/wp/v2/categories?context=edit&per_page=100';
+		$fetched   = rest_preload_api_request( array(), $page_path );
+
+		if ( ! isset( $fetched[ $page_path ] ) ) {
+			return $preload;
+		}
+
+		$entry   = $fetched[ $page_path ];
+		$headers = isset( $entry['headers'] ) && is_array( $entry['headers'] ) ? $entry['headers'] : array();
+
+		$total_pages = 1;
+		foreach ( $headers as $name => $value ) {
+			if ( 'x-wp-totalpages' === strtolower( (string) $name ) ) {
+				$total_pages = (int) $value;
+				break;
+			}
+		}
+
+		if ( $total_pages <= 1 ) {
+			$preload['/wp/v2/categories?context=edit&per_page=-1'] = $entry;
 		}
 
 		return $preload;

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -136,12 +136,9 @@ class Admin_Page {
 
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
-			// Source of truth for the dashboard's directory list + URL validation.
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
-			// Seed the settings response so the dashboard skips its mount-time fetch.
-			// Only settings: categories rejects per_page=-1 server-side, and stats
-			// is a live wpcom relay we don't want to block page render on.
+			// Settings only: categories rejects per_page=-1 server-side, stats is a live relay.
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
 		);
 

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -2,6 +2,9 @@ declare module '@automattic/jetpack-script-data' {
 	interface JetpackScriptData {
 		podcast?: {
 			has_product_access?: boolean;
+			show_url_hosts?: Record< string, readonly string[] >;
+			show_url_max_length?: number;
+			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;
 		};
 	}
 }

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/amazon.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/amazon.tsx
@@ -33,14 +33,4 @@ export const amazon: PodcastApp = {
 	name: 'Amazon Music',
 	Logo: AmazonLogo,
 	submitUrl: 'https://podcasters.amazon.com',
-	showHosts: [
-		'music.amazon.com',
-		'music.amazon.co.uk',
-		'music.amazon.de',
-		'music.amazon.co.jp',
-		'music.amazon.com.au',
-		'music.amazon.fr',
-		'music.amazon.ca',
-		'music.amazon.es',
-	],
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/apple.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/apple.tsx
@@ -53,5 +53,4 @@ export const apple: PodcastApp = {
 	Logo: AppleLogo,
 	submitUrl: 'https://podcastsconnect.apple.com/',
 	learnMoreUrl: 'https://podcasters.apple.com/support/897-submit-a-show',
-	showHosts: [ 'podcasts.apple.com' ],
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/index.tsx
@@ -26,6 +26,5 @@ export const pocketcasts: PodcastApp = {
 	Logo: PocketCastsLogo,
 	submitUrl: 'https://pocketcasts.com/submit',
 	learnMoreUrl: 'https://support.pocketcasts.com/knowledge-base/submitting-podcasts/',
-	showHosts: [ 'pca.st', 'pocketcasts.com' ],
 	Modal: PocketCastsSubmitModal,
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/podcastindex.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/podcastindex.tsx
@@ -22,5 +22,4 @@ export const podcastindex: PodcastApp = {
 	name: 'Podcast Index',
 	Logo: PodcastIndexLogo,
 	submitUrl: 'https://podcastindex.org/add',
-	showHosts: [ 'podcastindex.org' ],
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/spotify.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/spotify.tsx
@@ -24,5 +24,4 @@ export const spotify: PodcastApp = {
 	submitUrl: 'https://creators.spotify.com/',
 	learnMoreUrl:
 		'https://support.spotify.com/creators/article/claiming-your-podcast-on-spotify-for-creators/',
-	showHosts: [ 'open.spotify.com' ],
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/types.ts
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/types.ts
@@ -7,8 +7,6 @@ export interface PodcastApp {
 	Logo: ComponentType;
 	submitUrl: string;
 	learnMoreUrl?: string;
-	// Lowercase, no `www.`. Mirrors SHOW_URL_HOSTS in src/class-settings.php.
-	showHosts: readonly string[];
 	// Full replacement for the default 3-step submit modal.
 	Modal?: ComponentType< PodcastAppModalProps >;
 }

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/youtube.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/youtube.tsx
@@ -24,5 +24,4 @@ export const youtube: PodcastApp = {
 	Logo: YouTubeMusicLogo,
 	submitUrl: 'https://studio.youtube.com',
 	learnMoreUrl: 'https://support.google.com/youtube/answer/13973017',
-	showHosts: [ 'youtube.com', 'm.youtube.com', 'youtu.be', 'music.youtube.com' ],
 };

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -49,8 +49,7 @@ const isValidShowUrl = ( url: string, allowedHosts: readonly string[] ): boolean
 	if ( parsed.protocol !== 'https:' ) {
 		return false;
 	}
-	// No injected host list (stale bundle vs. new PHP) → skip the allowlist and
-	// let the server's authoritative check be the backstop.
+	// No host list injected → skip the check; the server validates anyway.
 	if ( allowedHosts.length === 0 ) {
 		return true;
 	}

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -23,12 +23,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, external, link } from '@wordpress/icons';
 import { prependHTTPS } from '@wordpress/url';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
+import { getShowHostsFor, getShowUrlMaxLength } from '../podcatchers';
 import type { PodcastSettingsUpdate } from '../types';
 import type { PodcastAppModalProps } from './podcast-apps';
 import type { FormEvent } from 'react';
-
-// Mirrors `SHOW_URL_MAX_LENGTH` in src/class-settings.php.
-const SHOW_URL_MAX_LENGTH = 2048;
 
 // `prependHTTPS` leaves an existing `http://` alone, but the backend rejects
 // non-https — upgrade ourselves.
@@ -39,7 +37,7 @@ const isValidShowUrl = ( url: string, allowedHosts: readonly string[] ): boolean
 	if ( ! url ) {
 		return false;
 	}
-	if ( url.length > SHOW_URL_MAX_LENGTH ) {
+	if ( url.length > getShowUrlMaxLength() ) {
 		return false;
 	}
 	let parsed: URL;
@@ -50,6 +48,11 @@ const isValidShowUrl = ( url: string, allowedHosts: readonly string[] ): boolean
 	}
 	if ( parsed.protocol !== 'https:' ) {
 		return false;
+	}
+	// No injected host list (stale bundle vs. new PHP) → skip the allowlist and
+	// let the server's authoritative check be the backstop.
+	if ( allowedHosts.length === 0 ) {
+		return true;
 	}
 	const host = parsed.hostname.toLowerCase().replace( /^www\./, '' );
 	return allowedHosts.includes( host );
@@ -131,9 +134,9 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 	const handleSave = useCallback(
 		( event: FormEvent< HTMLFormElement > ) => {
 			event.preventDefault();
-			if ( ! isValidShowUrl( normalizedDraft, app.showHosts ) ) {
+			if ( ! isValidShowUrl( normalizedDraft, getShowHostsFor( app.id ) ) ) {
 				setSaveError(
-					normalizedDraft.length > SHOW_URL_MAX_LENGTH
+					normalizedDraft.length > getShowUrlMaxLength()
 						? sprintf(
 								/* translators: %s: podcast directory name (e.g. "Apple Podcasts"). */
 								__( 'Your %s URL is too long.', 'jetpack-podcast' ),
@@ -200,7 +203,6 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 		},
 		[
 			normalizedDraft,
-			app.showHosts,
 			app.id,
 			app.name,
 			saveSettings,

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -54,8 +54,8 @@ const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_show_states',
 ];
 
-// Podcatcher ids come from the server-injected host map; union in whatever keys
-// the (server-padded) record carries so a missing map never drops stored values.
+// Ids from the injected map, plus the record's own keys, so a missing map never
+// drops stored values.
 const podcatcherIds = ( source: Record< string, unknown > ): readonly PodcatcherId[] =>
 	[ ...new Set( [ ...getPodcatcherIds(), ...Object.keys( source ) ] ) ] as PodcatcherId[];
 

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -9,6 +9,7 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { getPodcatcherIds } from '../podcatchers';
 import type {
 	PodcastSettings,
 	PodcastSettingsUpdate,
@@ -53,20 +54,15 @@ const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_show_states',
 ];
 
-// Keep in sync with `SHOW_URL_HOSTS` in src/class-settings.php.
-const PODCATCHER_IDS: readonly PodcatcherId[] = [
-	'pocketcasts',
-	'apple',
-	'spotify',
-	'youtube',
-	'amazon',
-	'podcastindex',
-] as const;
+// Podcatcher ids come from the server-injected host map; union in whatever keys
+// the (server-padded) record carries so a missing map never drops stored values.
+const podcatcherIds = ( source: Record< string, unknown > ): readonly PodcatcherId[] =>
+	[ ...new Set( [ ...getPodcatcherIds(), ...Object.keys( source ) ] ) ] as PodcatcherId[];
 
 const normalizeShowUrls = ( raw: unknown ): PodcastShowUrls => {
 	const source = ( raw && typeof raw === 'object' ? raw : {} ) as Record< string, unknown >;
 	const out = {} as PodcastShowUrls;
-	for ( const id of PODCATCHER_IDS ) {
+	for ( const id of podcatcherIds( source ) ) {
 		const value = source[ id ];
 		out[ id ] = typeof value === 'string' ? value : '';
 	}
@@ -78,7 +74,7 @@ const SHOW_STATES: readonly PodcastShowState[] = [ '', 'pending', 'active' ] as 
 const normalizeShowStates = ( raw: unknown ): PodcastShowStates => {
 	const source = ( raw && typeof raw === 'object' ? raw : {} ) as Record< string, unknown >;
 	const out = {} as PodcastShowStates;
-	for ( const id of PODCATCHER_IDS ) {
+	for ( const id of podcatcherIds( source ) ) {
 		const value = source[ id ];
 		out[ id ] =
 			typeof value === 'string' && ( SHOW_STATES as readonly string[] ).includes( value )

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,3 +1,6 @@
+// Side-effect import: registers the apiFetch preloading middleware before any
+// hook can fire a mount-time REST request. Must stay first.
+import './preload';
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 import { Spinner } from '@wordpress/components';

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,4 +1,4 @@
-// Registers the apiFetch preload middleware; must stay first (runs before any fetch).
+// Side-effect import: registers the apiFetch preload middleware.
 import './preload';
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,5 +1,4 @@
-// Side-effect import: registers the apiFetch preloading middleware before any
-// hook can fire a mount-time REST request. Must stay first.
+// Registers the apiFetch preload middleware; must stay first (runs before any fetch).
 import './preload';
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';

--- a/projects/packages/podcast/src/dashboard/podcatchers.ts
+++ b/projects/packages/podcast/src/dashboard/podcatchers.ts
@@ -1,39 +1,38 @@
 import { getScriptData } from '@automattic/jetpack-script-data';
 import type { PodcatcherId } from './types';
 
-// Server-injected mirror of Settings::SHOW_URL_HOSTS / SHOW_URL_MAX_LENGTH. PHP
-// is authoritative; the dashboard reads these instead of hand-copying the values.
+// PHP owns these values and injects them; we just read them.
 const DEFAULT_MAX_LENGTH = 2048;
 
 /**
- * Directory→allowed-host map, lowercase and `www.`-stripped.
+ * The directory→allowed-hosts map PHP sent us.
  *
- * @return The injected host map, or `{}` when absent.
+ * @return The map, or `{}` if missing.
  */
 export const getShowUrlHosts = (): Partial< Record< PodcatcherId, readonly string[] > > =>
 	getScriptData()?.podcast?.show_url_hosts ?? {};
 
 /**
- * Hosts allowed for a single directory.
+ * Hosts allowed for one directory.
  *
- * @param id - Podcatcher id.
- * @return Allowed hosts, or `[]` when the map is absent.
+ * @param id - Which directory.
+ * @return Its hosts, or `[]` if missing.
  */
 export const getShowHostsFor = ( id: PodcatcherId ): readonly string[] =>
 	getShowUrlHosts()[ id ] ?? [];
 
 /**
- * Known podcatcher ids, derived from the injected host map.
+ * The directories PHP knows about.
  *
- * @return The list of podcatcher ids.
+ * @return Their ids.
  */
 export const getPodcatcherIds = (): readonly PodcatcherId[] =>
 	Object.keys( getShowUrlHosts() ) as PodcatcherId[];
 
 /**
- * Max accepted show-URL length.
+ * Longest show URL we accept.
  *
- * @return The injected max length, or the default.
+ * @return The limit.
  */
 export const getShowUrlMaxLength = (): number =>
 	getScriptData()?.podcast?.show_url_max_length ?? DEFAULT_MAX_LENGTH;

--- a/projects/packages/podcast/src/dashboard/podcatchers.ts
+++ b/projects/packages/podcast/src/dashboard/podcatchers.ts
@@ -1,0 +1,39 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import type { PodcatcherId } from './types';
+
+// Server-injected mirror of Settings::SHOW_URL_HOSTS / SHOW_URL_MAX_LENGTH. PHP
+// is authoritative; the dashboard reads these instead of hand-copying the values.
+const DEFAULT_MAX_LENGTH = 2048;
+
+/**
+ * Directory→allowed-host map, lowercase and `www.`-stripped.
+ *
+ * @return The injected host map, or `{}` when absent.
+ */
+export const getShowUrlHosts = (): Partial< Record< PodcatcherId, readonly string[] > > =>
+	getScriptData()?.podcast?.show_url_hosts ?? {};
+
+/**
+ * Hosts allowed for a single directory.
+ *
+ * @param id - Podcatcher id.
+ * @return Allowed hosts, or `[]` when the map is absent.
+ */
+export const getShowHostsFor = ( id: PodcatcherId ): readonly string[] =>
+	getShowUrlHosts()[ id ] ?? [];
+
+/**
+ * Known podcatcher ids, derived from the injected host map.
+ *
+ * @return The list of podcatcher ids.
+ */
+export const getPodcatcherIds = (): readonly PodcatcherId[] =>
+	Object.keys( getShowUrlHosts() ) as PodcatcherId[];
+
+/**
+ * Max accepted show-URL length.
+ *
+ * @return The injected max length, or the default.
+ */
+export const getShowUrlMaxLength = (): number =>
+	getScriptData()?.podcast?.show_url_max_length ?? DEFAULT_MAX_LENGTH;

--- a/projects/packages/podcast/src/dashboard/podcatchers.ts
+++ b/projects/packages/podcast/src/dashboard/podcatchers.ts
@@ -1,7 +1,6 @@
 import { getScriptData } from '@automattic/jetpack-script-data';
 import type { PodcatcherId } from './types';
 
-// PHP owns these values and injects them; we just read them.
 const DEFAULT_MAX_LENGTH = 2048;
 
 /**

--- a/projects/packages/podcast/src/dashboard/preload.ts
+++ b/projects/packages/podcast/src/dashboard/preload.ts
@@ -1,11 +1,8 @@
 import { getScriptData } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 
-// Seed apiFetch with the settings + categories responses PHP rendered into script
-// data, so the first dashboard render serves them from cache instead of issuing
-// mount-time REST round-trips. Each path is served once (the bootstrap GET); saves
-// and refetches fall through to the network as before. Imported first in index.tsx
-// so the middleware is registered before any hook can fire a request.
+// Serve the first settings + categories fetches from PHP-rendered data instead of
+// the network. Imported first in index.tsx so it runs before any hook fetches.
 const preload = getScriptData()?.podcast?.preload;
 
 if ( preload ) {

--- a/projects/packages/podcast/src/dashboard/preload.ts
+++ b/projects/packages/podcast/src/dashboard/preload.ts
@@ -1,8 +1,6 @@
 import { getScriptData } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 
-// Serve the first settings + categories fetches from PHP-rendered data instead of
-// the network. Imported first in index.tsx so it runs before any hook fetches.
 const preload = getScriptData()?.podcast?.preload;
 
 if ( preload ) {

--- a/projects/packages/podcast/src/dashboard/preload.ts
+++ b/projects/packages/podcast/src/dashboard/preload.ts
@@ -1,0 +1,13 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import apiFetch from '@wordpress/api-fetch';
+
+// Seed apiFetch with the settings + categories responses PHP rendered into script
+// data, so the first dashboard render serves them from cache instead of issuing
+// mount-time REST round-trips. Each path is served once (the bootstrap GET); saves
+// and refetches fall through to the network as before. Imported first in index.tsx
+// so the middleware is registered before any hook can fire a request.
+const preload = getScriptData()?.podcast?.preload;
+
+if ( preload ) {
+	apiFetch.use( apiFetch.createPreloadingMiddleware( preload ) );
+}

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Podcast\Tests;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
+use Automattic\Jetpack\Podcast\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -79,5 +80,27 @@ class Admin_Page_Test extends BaseTestCase {
 			$slugs,
 			'WPCOM should register the Podcast page directly under the Jetpack menu'
 		);
+	}
+
+	/**
+	 * The host allowlist and max length ride to the dashboard verbatim so PHP
+	 * stays the single source of truth for client-side URL validation.
+	 */
+	public function test_inject_script_data_exposes_show_url_hosts() {
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertSame( Settings::SHOW_URL_HOSTS, $data['podcast']['show_url_hosts'] );
+		$this->assertSame( Settings::SHOW_URL_MAX_LENGTH, $data['podcast']['show_url_max_length'] );
+	}
+
+	/**
+	 * The mount-time REST responses are preloaded into script data so the first
+	 * render serves them from cache instead of the network.
+	 */
+	public function test_inject_script_data_includes_preload_map() {
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertArrayHasKey( 'preload', $data['podcast'] );
+		$this->assertIsArray( $data['podcast']['preload'] );
 	}
 }

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -83,8 +83,7 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The host allowlist and max length ride to the dashboard verbatim so PHP
-	 * stays the single source of truth for client-side URL validation.
+	 * The host allowlist + max length reach the dashboard verbatim.
 	 */
 	public function test_inject_script_data_exposes_show_url_hosts() {
 		$data = Admin_Page::inject_podcast_script_data( array() );
@@ -94,8 +93,7 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The mount-time REST responses are preloaded into script data so the first
-	 * render serves them from cache instead of the network.
+	 * The preload map is present in script data.
 	 */
 	public function test_inject_script_data_includes_preload_map() {
 		$data = Admin_Page::inject_podcast_script_data( array() );


### PR DESCRIPTION
## Proposed changes

Two small, independent Podcast dashboard cleanups. No user-facing change.

**A — One source of truth for the directory host list.**
The list of allowed hosts per podcast directory (Apple, Spotify, …) lived in PHP *and* a hand-copied JS copy with "keep in sync" comments. If they drifted, the server would accept a URL the browser rejected. Now PHP sends the list to the page and the dashboard reads it — so adding a host is a one-line PHP change, no JS edit.

**B — Skip one network request on load.**
The dashboard fetches its settings on first render. PHP now ships that response inside the page, so the dashboard reads it from there instead of making the request. Saving still works the same way.

Only settings is preloaded. Categories can't be (the wpcom endpoint rejects the "give me all" request), and stats is intentionally left alone (it's a live, always-changing feed).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open **Jetpack → Podcast**.
* **Preload:** in DevTools → Network, hard-reload — there should be **no** request for `/wpcom/v2/podcast/settings` on first paint. Saving settings still hits the network normally.
* **Host list:** on the **Distribution** tab, open a directory's submit modal — a valid URL saves, a wrong-host URL is rejected.
* Add a host to `Settings::SHOW_URL_HOSTS` in PHP only; the browser should accept a URL on that host with no JS change.
* `cd projects/packages/podcast && composer phpunit` green; JS lint/types clean.
