### PR TITLE
Jetpack AI Sidebar: Cleanup - Remove redundant check for AI Editorial Review

### DIFF
--- a/projects/plugins/jetpack/changelog/update-decouple-aer-sidebar
+++ b/projects/plugins/jetpack/changelog/update-decouple-aer-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Sidebar: source the AI Editorial Review flag only from features.aiEditorialReview; drop the redundant top-level aiEditorialReviewEnabled field.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -454,9 +454,8 @@ class Jetpack_AI_Sidebar {
 		$config = self::get_jetpack_ai_sidebar_preview_config();
 
 		return array(
-			'agentId'                  => AI_SIDEBAR_AGENT_ID,
-			'aiEditorialReviewEnabled' => self::is_ai_editorial_review_enabled(),
-			'jetpackAiSidebar'         => $config,
+			'agentId'          => AI_SIDEBAR_AGENT_ID,
+			'jetpackAiSidebar' => $config,
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -689,7 +689,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
@@ -789,7 +788,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
@@ -805,7 +803,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
-		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}
 
@@ -849,10 +846,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'agentsManagerData.aiEditorialReviewEnabled = true',
-			$this->get_agents_manager_inline_script()
-		);
-		$this->assertStringContainsString(
 			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
 			$this->get_agents_manager_inline_script()
 		);
@@ -886,10 +879,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringNotContainsString(
-			'agentsManagerData.aiEditorialReviewEnabled',
-			$this->get_agents_manager_inline_script()
-		);
-		$this->assertStringNotContainsString(
 			'agentsManagerData.jetpackAiSidebar',
 			$this->get_agents_manager_inline_script()
 		);
@@ -908,10 +897,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString(
 			'agentsManagerData.agentId',
-			$this->get_agents_manager_inline_script()
-		);
-		$this->assertStringNotContainsString(
-			'agentsManagerData.aiEditorialReviewEnabled',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringNotContainsString(
@@ -1155,7 +1140,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 	}
 


### PR DESCRIPTION
## Proposed changes

The Jetpack AI Sidebar emits AI Editorial Review availability twice — as a flat top-level `agentsManagerData.aiEditorialReviewEnabled` and as nested `agentsManagerData.jetpackAiSidebar.features.aiEditorialReview`. The client reads the nested feature; the flat field has no consumer.

- Drop the flat `aiEditorialReviewEnabled` from `get_sidebar_am_fields()` so AER is sourced solely from `features.aiEditorialReview` (used by both the data filter and the external-AM inline fallback).
- Update PHPUnit assertions to the nested feature.

No behaviour change — the nested flag is unchanged.

## Testing instructions

See 225263-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No.
