### PR TITLE
Forms: disable device visibility on fields/inputs, honor per-viewport hiding on labels

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Disable the block visibility ("Hide on…") control on form fields and inputs, where it had no effect on the frontend. Labels keep their visibility support.

--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Disable the block visibility control on form fields and inputs, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support.
+Forms: Disable the block visibility control on form fields and inputs, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too.

--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Disable the block visibility ("Hide on…") control on form fields and inputs, where it had no effect on the frontend. Labels keep their visibility support.
+Forms: Disable the block visibility control on form fields and inputs, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support.

--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Disable the block visibility control on form field, input, and choice/option blocks, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too.
+Forms: Disable the block visibility control on form field, input, and choice/option blocks, where the per-viewport "Hide on…" option was not honored on the frontend. Fields still honor a saved "Hide everywhere" (removing the field entirely, which keeps required fields safe) regardless of WordPress version. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too, and grouped fields whose legend label is hidden keep an accessible name.

--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Disable the block visibility control on form field, input, and choice/option blocks, where the per-viewport "Hide on…" option was not honored on the frontend. Fields still honor a saved "Hide everywhere" (removing the field entirely, which keeps required fields safe) regardless of WordPress version. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too, and grouped fields whose legend label is hidden keep an accessible name.
+Disable the block visibility control on form field, input, and choice/option blocks, where the per-viewport "Hide on…" option was not honored on the frontend. Fields still honor a saved "Hide everywhere" (removing the field entirely, which keeps required fields safe) regardless of WordPress version. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too, and fields whose label is hidden keep an accessible name.

--- a/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
+++ b/projects/packages/forms/changelog/fix-forms-disable-field-visibility-control
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Disable the block visibility control on form fields and inputs, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too.
+Forms: Disable the block visibility control on form field, input, and choice/option blocks, where the per-viewport "Hide on…" option was not honored on the frontend. Labels keep their visibility support and now honor the per-viewport "Hide on…" option too.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -112,8 +112,11 @@ class Contact_Form_Block {
 	public static function disable_field_visibility_support( $args, $block_name ) {
 		// TODO: refactor into an array_merge'd shared supports array mirroring the JS defaultSettings, instead of this filter.
 		$is_field = strpos( $block_name, 'jetpack/field-' ) === 0 && strpos( $block_name, 'jetpack/field-option-' ) !== 0;
+		// All input variants: jetpack/input, input-range, input-rating,
+		// input-image-option, plus the differently-named phone-input and dropzone.
+		$is_input = strpos( $block_name, 'jetpack/input' ) === 0 || in_array( $block_name, array( 'jetpack/phone-input', 'jetpack/dropzone' ), true );
 
-		if ( 'jetpack/input' === $block_name || $is_field ) {
+		if ( $is_input || $is_field ) {
 			if ( ! isset( $args['supports'] ) || ! is_array( $args['supports'] ) ) {
 				$args['supports'] = array();
 			}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -131,6 +131,39 @@ class Contact_Form_Block {
 	}
 
 	/**
+	 * Drop a field that has been hidden everywhere via block visibility.
+	 *
+	 * FORMS-694. "Hide everywhere" (metadata.blockVisibility === false) must keep
+	 * working on fields even though we disable the visibility *support* on them
+	 * (see disable_field_visibility_support). We can't rely on core's render_block
+	 * visibility filter for this: on released WP it gates the full-hide branch
+	 * behind the support check, so once support is false the field would reappear
+	 * (the fix that reorders those — WordPress/gutenberg#78780 — is unreleased).
+	 *
+	 * Dropping the field's rendered output ('') before Contact_Form::parse() sees
+	 * it removes the [contact-field] shortcode entirely, so the field is never
+	 * parsed, rendered, or validated — which is what makes this required-safe (a
+	 * required hidden-everywhere field simply isn't in the form). This is a full
+	 * removal, not a CSS hide; the per-viewport "Hide on…" mode (which leaves the
+	 * field in place and only display:none's it) is intentionally not honored on
+	 * fields for exactly that reason.
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Parsed block.
+	 * @return string
+	 */
+	public static function drop_field_hidden_everywhere( $block_content, $block ) {
+		$block_name       = $block['blockName'] ?? '';
+		$block_visibility = $block['attrs']['metadata']['blockVisibility'] ?? null;
+
+		if ( false === $block_visibility && strpos( $block_name, 'jetpack/field-' ) === 0 ) {
+			return '';
+		}
+
+		return $block_content;
+	}
+
+	/**
 	 * Register the contact form block feature flag.
 	 *
 	 * @param array $features - the features array.
@@ -216,6 +249,10 @@ class Contact_Form_Block {
 		// src/blocks/input/index.js), which disables it on fields and inputs.
 		add_filter( 'register_block_type_args', array( __CLASS__, 'disable_field_visibility_support' ), 10, 2 );
 
+		// Honor "hide everywhere" on fields ourselves, independent of core's
+		// version-dependent visibility filter. See drop_field_hidden_everywhere().
+		add_filter( 'render_block', array( __CLASS__, 'drop_field_hidden_everywhere' ), 10, 2 );
+
 		// Field inner block types.
 		Blocks::jetpack_register_block(
 			'jetpack/input',
@@ -254,12 +291,12 @@ class Contact_Form_Block {
 			'jetpack/label',
 			array(
 				'supports'     => array(
-					'color'           => array(
+					'color'      => array(
 						'text'       => true,
 						'background' => false,
 						'gradients'  => false,
 					),
-					'typography'      => array(
+					'typography' => array(
 						'fontSize'                     => true,
 						'lineHeight'                   => true,
 						'__experimentalFontFamily'     => true,
@@ -269,7 +306,10 @@ class Contact_Form_Block {
 						'__experimentalTextDecoration' => true,
 						'__experimentalLetterSpacing'  => true,
 					),
-					'blockVisibility' => true,
+					// The real support key is `visibility`, not `blockVisibility`
+					// (that's the per-instance saved attribute). The label is the
+					// only forms block that keeps the control — see FORMS-694.
+					'visibility' => true,
 				),
 				'uses_context' => array(
 					'jetpack/field-required',

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -107,6 +107,7 @@ class Contact_Form_Block {
 	 * @return array
 	 */
 	public static function disable_field_visibility_support( $args, $block_name ) {
+		// TODO: refactor into an array_merge'd shared supports array mirroring the JS defaultSettings, instead of this filter.
 		$is_field = strpos( $block_name, 'jetpack/field-' ) === 0 && strpos( $block_name, 'jetpack/field-option-' ) !== 0;
 
 		if ( 'jetpack/input' === $block_name || $is_field ) {

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -99,11 +99,12 @@ class Contact_Form_Block {
 	 * render_block class injection — and on a required field it cannot be made
 	 * safe (server- and client-side validation are both viewport-blind). "Hide
 	 * everywhere" does work for fields, but the control bundles both modes under
-	 * one boolean, so we disable it wholesale on fields and inputs as an interim.
-	 * This mirrors the JS registration (shared/settings/index.js and
-	 * input/index.js). Labels keep visibility support (full-hide wired via
-	 * labelhiddenbyblockvisibility), and the internal field-option-* blocks are
-	 * left untouched to match JS. Full field visibility is a separate decision.
+	 * one boolean, so we disable it wholesale on fields, inputs, and choice/option
+	 * blocks as an interim. This mirrors the JS registration. The label is the
+	 * only block that keeps visibility support — it honors hiding (full-hide via
+	 * labelhiddenbyblockvisibility, per-viewport via wp-block-hidden-* classes)
+	 * and never affects validation or submission. Full field visibility is a
+	 * separate decision.
 	 *
 	 * @param array  $args       Block type registration args.
 	 * @param string $block_name Block name being registered.
@@ -111,12 +112,15 @@ class Contact_Form_Block {
 	 */
 	public static function disable_field_visibility_support( $args, $block_name ) {
 		// TODO: refactor into an array_merge'd shared supports array mirroring the JS defaultSettings, instead of this filter.
-		$is_field = strpos( $block_name, 'jetpack/field-' ) === 0 && strpos( $block_name, 'jetpack/field-option-' ) !== 0;
+		// Fields, incl. the deprecated field-option-* choice blocks.
+		$is_field = strpos( $block_name, 'jetpack/field-' ) === 0;
 		// All input variants: jetpack/input, input-range, input-rating,
 		// input-image-option, plus the differently-named phone-input and dropzone.
 		$is_input = strpos( $block_name, 'jetpack/input' ) === 0 || in_array( $block_name, array( 'jetpack/phone-input', 'jetpack/dropzone' ), true );
+		// Choice/option containers.
+		$is_option = in_array( $block_name, array( 'jetpack/option', 'jetpack/options', 'jetpack/fieldset-image-options' ), true );
 
-		if ( $is_input || $is_field ) {
+		if ( $is_input || $is_field || $is_option ) {
 			if ( ! isset( $args['supports'] ) || ! is_array( $args['supports'] ) ) {
 				$args['supports'] = array();
 			}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -94,13 +94,16 @@ class Contact_Form_Block {
 	/**
 	 * Disable the block "visibility" support on form field and input blocks.
 	 *
-	 * Device/viewport visibility ("Hide on…") is not honored on the field
-	 * wrapper at render time — the field render pipeline bypasses core's
-	 * render_block visibility filter — so the control would do nothing. We
-	 * disable the support so it does not appear. This mirrors the JS
-	 * registration (shared/settings/index.js and input/index.js). Labels keep
-	 * visibility support (handled separately via labelhiddenbyblockvisibility),
-	 * and the internal field-option-* blocks are left untouched to match JS.
+	 * FORMS-694 (interim). The per-viewport "Hide on…" option is not honored in
+	 * the forms render pipeline — fields flatten to a shortcode and bypass core's
+	 * render_block class injection — and on a required field it cannot be made
+	 * safe (server- and client-side validation are both viewport-blind). "Hide
+	 * everywhere" does work for fields, but the control bundles both modes under
+	 * one boolean, so we disable it wholesale on fields and inputs as an interim.
+	 * This mirrors the JS registration (shared/settings/index.js and
+	 * input/index.js). Labels keep visibility support (full-hide wired via
+	 * labelhiddenbyblockvisibility), and the internal field-option-* blocks are
+	 * left untouched to match JS. Full field visibility is a separate decision.
 	 *
 	 * @param array  $args       Block type registration args.
 	 * @param string $block_name Block name being registered.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -90,6 +90,35 @@ class Contact_Form_Block {
 		// Load AI integration after Jetpack_Gutenberg registers extensions (priority 10)
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'maybe_load_ai_integration' ), 11 );
 	}
+
+	/**
+	 * Disable the block "visibility" support on form field and input blocks.
+	 *
+	 * Device/viewport visibility ("Hide on…") is not honored on the field
+	 * wrapper at render time — the field render pipeline bypasses core's
+	 * render_block visibility filter — so the control would do nothing. We
+	 * disable the support so it does not appear. This mirrors the JS
+	 * registration (shared/settings/index.js and input/index.js). Labels keep
+	 * visibility support (handled separately via labelhiddenbyblockvisibility),
+	 * and the internal field-option-* blocks are left untouched to match JS.
+	 *
+	 * @param array  $args       Block type registration args.
+	 * @param string $block_name Block name being registered.
+	 * @return array
+	 */
+	public static function disable_field_visibility_support( $args, $block_name ) {
+		$is_field = strpos( $block_name, 'jetpack/field-' ) === 0 && strpos( $block_name, 'jetpack/field-option-' ) !== 0;
+
+		if ( 'jetpack/input' === $block_name || $is_field ) {
+			if ( ! isset( $args['supports'] ) || ! is_array( $args['supports'] ) ) {
+				$args['supports'] = array();
+			}
+			$args['supports']['visibility'] = false;
+		}
+
+		return $args;
+	}
+
 	/**
 	 * Register the contact form block feature flag.
 	 *
@@ -170,6 +199,11 @@ class Contact_Form_Block {
 		if ( ! self::can_manage_block() ) {
 			return;
 		}
+
+		// Keep the PHP-registered "visibility" support in sync with the JS
+		// registration (src/blocks/shared/settings/index.js and
+		// src/blocks/input/index.js), which disables it on fields and inputs.
+		add_filter( 'register_block_type_args', array( __CLASS__, 'disable_field_visibility_support' ), 10, 2 );
 
 		// Field inner block types.
 		Blocks::jetpack_register_block(

--- a/projects/packages/forms/src/blocks/deprecated/field-option-checkbox/index.js
+++ b/projects/packages/forms/src/blocks/deprecated/field-option-checkbox/index.js
@@ -15,6 +15,9 @@ const settings = {
 		},
 	},
 	supports: {
+		// FORMS-694: choice/option blocks flatten through the field shortcode
+		// like inputs — visibility is inert; disable the control.
+		visibility: false,
 		html: false,
 		inserter: false,
 		reusable: false,

--- a/projects/packages/forms/src/blocks/deprecated/field-option-radio/index.js
+++ b/projects/packages/forms/src/blocks/deprecated/field-option-radio/index.js
@@ -15,6 +15,9 @@ const settings = {
 		},
 	},
 	supports: {
+		// FORMS-694: choice/option blocks flatten through the field shortcode
+		// like inputs — visibility is inert; disable the control.
+		visibility: false,
 		html: false,
 		inserter: false,
 		reusable: false,

--- a/projects/packages/forms/src/blocks/dropzone/index.js
+++ b/projects/packages/forms/src/blocks/dropzone/index.js
@@ -42,6 +42,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// FORMS-694: the dropzone is the file field's input — inert for visibility
+		// (output discarded by the field renderer); disable the control.
+		visibility: false,
 		// Mimic the layout settings of the core Group block.
 		layout: {
 			type: 'flex',

--- a/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
@@ -18,6 +18,11 @@ const settings = {
 	icon,
 	parent: [ 'jetpack/field-image-select' ],
 	allowedBlocks: [ 'jetpack/input-image-option' ],
+	supports: {
+		// FORMS-694: choice/option blocks flatten through the field shortcode
+		// like inputs — visibility is inert; disable the control.
+		visibility: false,
+	},
 	edit,
 	save,
 };

--- a/projects/packages/forms/src/blocks/input-image-option/index.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/index.tsx
@@ -29,6 +29,9 @@ const settings = {
 		fixedHeight: 'fixedHeight',
 	},
 	supports: {
+		// FORMS-694: inputs are inert for visibility (output discarded by the
+		// field renderer); disable the control like the standard input block.
+		visibility: false,
 		color: {
 			background: true,
 			text: true,

--- a/projects/packages/forms/src/blocks/input-phone/index.js
+++ b/projects/packages/forms/src/blocks/input-phone/index.js
@@ -28,6 +28,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// FORMS-694: inputs are inert for visibility (output discarded by the
+		// field renderer); disable the control like the standard input block.
+		visibility: false,
 		color: {
 			text: true,
 			background: true,

--- a/projects/packages/forms/src/blocks/input-range/index.js
+++ b/projects/packages/forms/src/blocks/input-range/index.js
@@ -29,6 +29,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// FORMS-694: inputs are inert for visibility (output discarded by the
+		// field renderer); disable the control like the standard input block.
+		visibility: false,
 		color: {
 			text: true,
 			background: false,

--- a/projects/packages/forms/src/blocks/input-rating/index.js
+++ b/projects/packages/forms/src/blocks/input-rating/index.js
@@ -36,6 +36,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// FORMS-694: inputs are inert for visibility (output discarded by the
+		// field renderer); disable the control like the standard input block.
+		visibility: false,
 		color: {
 			text: true,
 			background: false,

--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -32,6 +32,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// See FORMS-694: device/viewport visibility isn't honored on the field
+		// wrapper at render, so disable the control on the input too.
+		visibility: false,
 		color: {
 			text: true,
 			background: true,

--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -32,8 +32,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
-		// See FORMS-694: device/viewport visibility isn't honored on the field
-		// wrapper at render, so disable the control on the input too.
+		// FORMS-694 (interim): disabled on the input for the same reason as the
+		// field — see shared/settings/index.js. The input is inert in every
+		// visibility mode (its rendered output is discarded by the field renderer).
 		visibility: false,
 		color: {
 			text: true,

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -53,7 +53,9 @@ const settings = {
 				fontSize: true,
 			},
 		},
-		blockVisibility: true,
+		// The real support key is `visibility`, not `blockVisibility` (that's the
+		// per-instance saved attribute); mirrors the PHP registration. FORMS-694.
+		visibility: true,
 	},
 	attributes: {
 		label: {

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -20,6 +20,9 @@ const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		// FORMS-694: choice/option blocks flatten through the field shortcode
+		// like inputs — visibility is inert; disable the control.
+		visibility: false,
 		splitting: true,
 		color: {
 			text: true,

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -29,6 +29,9 @@ const settings = {
 	},
 	usesContext: [ 'jetpack/field-share-attributes' ],
 	supports: {
+		// FORMS-694: choice/option blocks flatten through the field shortcode
+		// like inputs — visibility is inert; disable the control.
+		visibility: false,
 		spacing: {
 			blockGap: false,
 		},

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -30,10 +30,13 @@ export default {
 	supports: {
 		reusable: false,
 		html: false,
-		// Device/viewport visibility ("Hide on…") is not honored on the field
-		// wrapper at render time, so disable the control on fields to avoid an
-		// option that does nothing. Labels keep visibility support (handled
-		// separately via labelhiddenbyblockvisibility). See FORMS-694.
+		// FORMS-694 (interim): the per-viewport "Hide on…" option isn't honored
+		// in the forms render pipeline — fields flatten to a shortcode and bypass
+		// core's render_block class injection — and on a required field it can't
+		// be made safe (server/client validation are viewport-blind). "Hide
+		// everywhere" does work, but the control bundles both under one boolean,
+		// so we disable it wholesale here. Labels keep it (full-hide wired via
+		// labelhiddenbyblockvisibility). Full field visibility is a separate call.
 		visibility: false,
 		__experimentalExposeControlsToChildren: true,
 	},

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -30,6 +30,11 @@ export default {
 	supports: {
 		reusable: false,
 		html: false,
+		// Device/viewport visibility ("Hide on…") is not honored on the field
+		// wrapper at render time, so disable the control on fields to avoid an
+		// option that does nothing. Labels keep visibility support (handled
+		// separately via labelhiddenbyblockvisibility). See FORMS-694.
+		visibility: false,
 		__experimentalExposeControlsToChildren: true,
 	},
 	transforms,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -861,6 +861,27 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Return an aria-label attribute string for a grouped field's <fieldset>
+	 * when its legend label is fully hidden by block visibility.
+	 *
+	 * The render_legend_as_label() method returns '' on full-hide, which strips
+	 * the group's accessible name (a display:none/removed <legend> is dropped from
+	 * the a11y tree). This mirrors the single-input aria-label fallback in render_field()
+	 * so radio / checkbox-multiple / image-select / rating groups keep a name.
+	 * Returns '' (no attribute) when the legend is visible. See FORMS-694.
+	 *
+	 * @param string $label The field label.
+	 * @return string An ` aria-label='…' ` attribute, or '' when not hidden.
+	 */
+	private function get_hidden_legend_aria_label_attr( $label ) {
+		if ( ! $this->get_attribute( 'labelhiddenbyblockvisibility' ) ) {
+			return '';
+		}
+
+		return " aria-label='" . esc_attr( Contact_Form_Plugin::strip_tags( $label ) ) . "'";
+	}
+
+	/**
 	 * Return the HTML for a legend that shares the same style as a label.
 	 *
 	 * @param string $type - the field type.
@@ -1295,7 +1316,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$options_styles    = $this->get_attribute( 'optionsstyles' );
 		$form_style        = $this->get_form_style();
 		$is_outlined_style = 'outlined' === $form_style;
-		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'";
+		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -1784,7 +1805,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * any of the radio buttons in the group is selected, adding a required attribute directly to
 		 * a checkbox means that this specific checkbox must be checked.
 		 */
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -2119,7 +2140,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field = "<div class='jetpack-field jetpack-field-image-select'>";
 
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
 
 		$field .= "<fieldset {$fieldset_id} data-wp-bind--aria-invalid='state.fieldAriaInvalid' >";
 
@@ -2966,7 +2987,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$style_attr .= ' ' . implode( ';', $remaining_styles ) . '"';
 
 		return sprintf(
-			'<fieldset id="%4$s-label" class="jetpack-field-multiple__fieldset jetpack-field-rating" %1$s>
+			'<fieldset id="%4$s-label" class="jetpack-field-multiple__fieldset jetpack-field-rating" %1$s%6$s>
 				%5$s
 				<div class="jetpack-field-rating__options %3$s">%2$s</div>
 			</fieldset>',
@@ -2974,7 +2995,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$options,
 			esc_attr( $this->field_classes ),
 			esc_attr( $id ),
-			$label_html
+			$label_html,
+			$this->get_hidden_legend_aria_label_attr( $label )
 		) . $this->get_error_div( $id, 'rating' );
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2554,7 +2554,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		return '
 			<label
 				for="' . esc_attr( $id ) . '"
-				class="below-label__label ' . ( $this->is_error() ? ' form-error' : '' ) . '"
+				class="below-label__label ' . ( $this->is_error() ? ' form-error' : '' ) . ( $this->label_classes ? ' ' . esc_attr( $this->label_classes ) : '' ) . '"
 			>'
 			. esc_html( $label )
 			. ( $required && $required_indicator ? '<span>' . $required_field_text . '</span>' : '' ) .

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -874,6 +874,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_legend_as_label( $type, $id, $legend, $required, $required_field_text, $extra_attrs = array(), $required_indicator = true ) {
+		// Full-hide via blockVisibility, mirroring render_label(). Grouped fields
+		// (radio, checkbox-multiple, image-select, rating) render their label as a
+		// legend, so they need the same guard. Per-viewport hiding still works via
+		// the label_classes applied below.
+		if ( $this->attributes['labelhiddenbyblockvisibility'] ) {
+			return '';
+		}
 		if ( ! empty( $this->label_styles ) ) {
 			$extra_attrs['style'] = $this->label_styles;
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -861,24 +861,60 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Whether the field's label is hidden by block visibility in any mode.
+	 *
+	 * Two modes hide a label: "hide everywhere" (labelhiddenbyblockvisibility,
+	 * the label is not rendered at all) and per-viewport (the label is rendered
+	 * but carries a wp-block-hidden-{viewport} class that display:none's it on
+	 * that viewport). Either way the label is absent from the accessibility tree
+	 * where hidden, so the field needs an aria-label fallback to keep a name.
+	 *
+	 * The visibility control now only survives on the label block (see
+	 * FORMS-694), so this is the single place that decides "is the label hidden?"
+	 *
+	 * @return bool
+	 */
+	private function is_label_hidden_by_block_visibility() {
+		if ( $this->get_attribute( 'labelhiddenbyblockvisibility' ) ) {
+			return true;
+		}
+
+		return strpos( (string) $this->get_attribute( 'labelclasses' ), 'wp-block-hidden-' ) !== false;
+	}
+
+	/**
+	 * The accessible name to fall back to when the label is hidden by block
+	 * visibility. Prefers the label text (it matches what sighted users see on
+	 * viewports where the label is visible, for the per-viewport case) and only
+	 * falls back to the placeholder when there is no label. See FORMS-694.
+	 *
+	 * @param string $placeholder Optional placeholder to use when there is no label.
+	 * @return string
+	 */
+	private function get_block_visibility_aria_label( $placeholder = '' ) {
+		$label = Contact_Form_Plugin::strip_tags( (string) $this->get_attribute( 'label' ) );
+
+		return '' !== $label ? $label : (string) $placeholder;
+	}
+
+	/**
 	 * Return an aria-label attribute string for a grouped field's <fieldset>
-	 * when its legend label is fully hidden by block visibility.
+	 * when its legend label is hidden by block visibility (full or per-viewport).
 	 *
-	 * The render_legend_as_label() method returns '' on full-hide, which strips
-	 * the group's accessible name (a display:none/removed <legend> is dropped from
-	 * the a11y tree). This mirrors the single-input aria-label fallback in render_field()
-	 * so radio / checkbox-multiple / image-select / rating groups keep a name.
-	 * Returns '' (no attribute) when the legend is visible. See FORMS-694.
+	 * The render_legend_as_label() method drops the legend from the a11y tree
+	 * where hidden (returns '' on full-hide; display:none on the hidden viewport
+	 * otherwise), so the group would lose its name. This mirrors the single-input
+	 * aria-label fallback in render_field() for radio / checkbox-multiple /
+	 * image-select / rating. Returns '' (no attribute) when the legend is shown.
 	 *
-	 * @param string $label The field label.
 	 * @return string An ` aria-label='…' ` attribute, or '' when not hidden.
 	 */
-	private function get_hidden_legend_aria_label_attr( $label ) {
-		if ( ! $this->get_attribute( 'labelhiddenbyblockvisibility' ) ) {
+	private function get_hidden_legend_aria_label_attr() {
+		if ( ! $this->is_label_hidden_by_block_visibility() ) {
 			return '';
 		}
 
-		return " aria-label='" . esc_attr( Contact_Form_Plugin::strip_tags( $label ) ) . "'";
+		return " aria-label='" . esc_attr( $this->get_block_visibility_aria_label() ) . "'";
 	}
 
 	/**
@@ -963,9 +999,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$extra_attrs_string .= " data-wp-on--keypress='actions.handleNumberKeyPress' ";
 		}
 
-		if ( $this->get_attribute( 'labelhiddenbyblockvisibility' ) ) {
-			$aria_label          = ! empty( $placeholder ) ? $placeholder : Contact_Form_Plugin::strip_tags( $this->get_attribute( 'label' ) );
-			$extra_attrs_string .= " aria-label='" . esc_attr( $aria_label ) . "' ";
+		if ( $this->is_label_hidden_by_block_visibility() ) {
+			$extra_attrs_string .= " aria-label='" . esc_attr( $this->get_block_visibility_aria_label( $placeholder ) ) . "' ";
 		}
 
 		return "<input
@@ -1215,8 +1250,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-class--has-value='context.phoneNumber'
 					data-wp-init="callbacks.registerPhoneInput"
 					data-wp-init--phone-field-custom-combobox="callbacks.initializePhoneFieldCustomComboBox"
-					<?php if ( $this->get_attribute( 'labelhiddenbyblockvisibility' ) ) { ?>
-						aria-label="<?php echo esc_attr( $this->get_attribute( 'label' ) ); ?>"
+					<?php if ( $this->is_label_hidden_by_block_visibility() ) { ?>
+						aria-label="<?php echo esc_attr( $this->get_block_visibility_aria_label() ); ?>"
 					<?php } ?>
 					/>
 				<input type="hidden"
@@ -1273,7 +1308,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		$field      = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text, array(), false, $required_indicator );
-		$aria_label = ! empty( $placeholder ) ? $placeholder : Contact_Form_Plugin::strip_tags( $this->get_attribute( 'label' ) );
+		$aria_label = $this->get_block_visibility_aria_label( $placeholder );
 		$field     .= "<textarea
 		                style='" . $this->field_styles . "'
 		                name='" . esc_attr( $id ) . "'
@@ -1286,7 +1321,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						aria-describedby='" . esc_attr( $id ) . "-textarea-error-message'
 						data-wp-bind--aria-invalid='state.fieldAriaInvalid'
 						"
-						. ( $this->get_attribute( 'labelhiddenbyblockvisibility' )
+						. ( $this->is_label_hidden_by_block_visibility()
 							? "aria-label='" . esc_attr( $aria_label ) . "'"
 							: '' )
 						. $class
@@ -1316,7 +1351,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$options_styles    = $this->get_attribute( 'optionsstyles' );
 		$form_style        = $this->get_form_style();
 		$is_outlined_style = 'outlined' === $form_style;
-		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
+		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -1805,7 +1840,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * any of the radio buttons in the group is selected, adding a required attribute directly to
 		 * a checkbox means that this specific checkbox must be checked.
 		 */
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -1945,7 +1980,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$aria_label = ! empty( $this->get_attribute( 'togglelabel' ) )
 			? Contact_Form_Plugin::strip_tags( $this->get_attribute( 'togglelabel' ) )
 			: __( 'Select an option', 'jetpack-forms' ); // selects don't have a default label
-		$field     .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . " data-wp-on--change='actions.onFieldChange' data-wp-bind--aria-invalid='state.fieldAriaInvalid' " . ( $this->get_attribute( 'labelhiddenbyblockvisibility' ) ? "aria-label='" . esc_attr( $aria_label ) . "'" : '' ) . ">\n";
+		$field     .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . " data-wp-on--change='actions.onFieldChange' data-wp-bind--aria-invalid='state.fieldAriaInvalid' " . ( $this->is_label_hidden_by_block_visibility() ? "aria-label='" . esc_attr( $this->get_block_visibility_aria_label( $aria_label ) ) . "'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
@@ -2140,7 +2175,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field = "<div class='jetpack-field jetpack-field-image-select'>";
 
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr( $label );
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
 
 		$field .= "<fieldset {$fieldset_id} data-wp-bind--aria-invalid='state.fieldAriaInvalid' >";
 
@@ -2996,7 +3031,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			esc_attr( $this->field_classes ),
 			esc_attr( $id ),
 			$label_html,
-			$this->get_hidden_legend_aria_label_attr( $label )
+			$this->get_hidden_legend_aria_label_attr()
 		) . $this->get_error_div( $id, 'rating' );
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -886,35 +886,51 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * The accessible name to fall back to when the label is hidden by block
 	 * visibility. Prefers the label text (it matches what sighted users see on
 	 * viewports where the label is visible, for the per-viewport case) and only
-	 * falls back to the placeholder when there is no label. See FORMS-694.
+	 * falls back to a secondary name when there is no label. See FORMS-694.
 	 *
-	 * @param string $placeholder Optional placeholder to use when there is no label.
+	 * @param string|null $fallback Secondary name to use when there is no label.
+	 *                              Must be a raw string, not a built attribute
+	 *                              fragment. Defaults to the raw placeholder.
 	 * @return string
 	 */
-	private function get_block_visibility_aria_label( $placeholder = '' ) {
+	private function get_block_visibility_aria_label( $fallback = null ) {
 		$label = Contact_Form_Plugin::strip_tags( (string) $this->get_attribute( 'label' ) );
+		if ( '' !== $label ) {
+			return $label;
+		}
 
-		return '' !== $label ? $label : (string) $placeholder;
+		if ( null === $fallback ) {
+			$fallback = $this->get_attribute( 'placeholder' );
+		}
+
+		return Contact_Form_Plugin::strip_tags( (string) $fallback );
 	}
 
 	/**
-	 * Return an aria-label attribute string for a grouped field's <fieldset>
-	 * when its legend label is hidden by block visibility (full or per-viewport).
+	 * Return an ` aria-label='…'` attribute string when the field's label is
+	 * hidden by block visibility (full or per-viewport), or '' otherwise.
 	 *
-	 * The render_legend_as_label() method drops the legend from the a11y tree
-	 * where hidden (returns '' on full-hide; display:none on the hidden viewport
-	 * otherwise), so the group would lose its name. This mirrors the single-input
-	 * aria-label fallback in render_field() for radio / checkbox-multiple /
-	 * image-select / rating. Returns '' (no attribute) when the legend is shown.
+	 * A hidden label (removed on full-hide, display:none per-viewport) is absent
+	 * from the a11y tree, so every field that renders its own label — single
+	 * inputs and the grouped <fieldset> legend alike — needs this fallback to
+	 * keep an accessible name. Shared by all paths so none get missed. The
+	 * attribute is skipped when there is no name to give. See FORMS-694.
 	 *
-	 * @return string An ` aria-label='…' ` attribute, or '' when not hidden.
+	 * @param string|null $fallback Secondary name when there is no label (raw
+	 *                              string, not a built attribute fragment).
+	 * @return string
 	 */
-	private function get_hidden_legend_aria_label_attr() {
+	private function get_hidden_label_aria_label_attr( $fallback = null ) {
 		if ( ! $this->is_label_hidden_by_block_visibility() ) {
 			return '';
 		}
 
-		return " aria-label='" . esc_attr( $this->get_block_visibility_aria_label() ) . "'";
+		$name = $this->get_block_visibility_aria_label( $fallback );
+		if ( '' === $name ) {
+			return '';
+		}
+
+		return " aria-label='" . esc_attr( $name ) . "'";
 	}
 
 	/**
@@ -999,9 +1015,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$extra_attrs_string .= " data-wp-on--keypress='actions.handleNumberKeyPress' ";
 		}
 
-		if ( $this->is_label_hidden_by_block_visibility() ) {
-			$extra_attrs_string .= " aria-label='" . esc_attr( $this->get_block_visibility_aria_label( $placeholder ) ) . "' ";
-		}
+		$extra_attrs_string .= $this->get_hidden_label_aria_label_attr();
 
 		return "<input
 					type='" . esc_attr( $type ) . "'
@@ -1250,9 +1264,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-class--has-value='context.phoneNumber'
 					data-wp-init="callbacks.registerPhoneInput"
 					data-wp-init--phone-field-custom-combobox="callbacks.initializePhoneFieldCustomComboBox"
-					<?php if ( $this->is_label_hidden_by_block_visibility() ) { ?>
-						aria-label="<?php echo esc_attr( $this->get_block_visibility_aria_label() ); ?>"
-					<?php } ?>
+					<?php echo $this->get_hidden_label_aria_label_attr(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- attribute value is escaped in the helper. ?>
 					/>
 				<input type="hidden"
 					id="<?php echo esc_attr( $id ); ?>"
@@ -1307,9 +1319,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$value = '';
 		}
 
-		$field      = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text, array(), false, $required_indicator );
-		$aria_label = $this->get_block_visibility_aria_label( $placeholder );
-		$field     .= "<textarea
+		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text, array(), false, $required_indicator );
+		$field .= "<textarea
 		                style='" . $this->field_styles . "'
 		                name='" . esc_attr( $id ) . "'
 		                id='contact-form-comment-" . esc_attr( $id ) . "'
@@ -1321,9 +1332,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						aria-describedby='" . esc_attr( $id ) . "-textarea-error-message'
 						data-wp-bind--aria-invalid='state.fieldAriaInvalid'
 						"
-						. ( $this->is_label_hidden_by_block_visibility()
-							? "aria-label='" . esc_attr( $aria_label ) . "'"
-							: '' )
+						. $this->get_hidden_label_aria_label_attr()
 						. $class
 						. $placeholder
 						. ' ' . ( $required ? "required aria-required='true'" : '' ) .
@@ -1351,7 +1360,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$options_styles    = $this->get_attribute( 'optionsstyles' );
 		$form_style        = $this->get_form_style();
 		$is_outlined_style = 'outlined' === $form_style;
-		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
+		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_label_aria_label_attr();
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -1840,7 +1849,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * any of the radio buttons in the group is selected, adding a required attribute directly to
 		 * a checkbox means that this specific checkbox must be checked.
 		 */
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_label_aria_label_attr();
 
 		if ( $is_outlined_style ) {
 			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
@@ -1980,7 +1989,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$aria_label = ! empty( $this->get_attribute( 'togglelabel' ) )
 			? Contact_Form_Plugin::strip_tags( $this->get_attribute( 'togglelabel' ) )
 			: __( 'Select an option', 'jetpack-forms' ); // selects don't have a default label
-		$field     .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . " data-wp-on--change='actions.onFieldChange' data-wp-bind--aria-invalid='state.fieldAriaInvalid' " . ( $this->is_label_hidden_by_block_visibility() ? "aria-label='" . esc_attr( $this->get_block_visibility_aria_label( $aria_label ) ) . "'" : '' ) . ">\n";
+		$field     .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . " data-wp-on--change='actions.onFieldChange' data-wp-bind--aria-invalid='state.fieldAriaInvalid' " . $this->get_hidden_label_aria_label_attr( $aria_label ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
@@ -2175,7 +2184,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field = "<div class='jetpack-field jetpack-field-image-select'>";
 
-		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_legend_aria_label_attr();
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'" . $this->get_hidden_label_aria_label_attr();
 
 		$field .= "<fieldset {$fieldset_id} data-wp-bind--aria-invalid='state.fieldAriaInvalid' >";
 
@@ -3031,7 +3040,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			esc_attr( $this->field_classes ),
 			esc_attr( $id ),
 			$label_html,
-			$this->get_hidden_legend_aria_label_attr()
+			$this->get_hidden_label_aria_label_attr()
 		) . $this->get_error_div( $id, 'rating' );
 	}
 
@@ -3110,6 +3119,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-bind--value="state.getSliderValue"
 					data-wp-on--input="actions.onSliderChange"
 					data-wp-bind--aria-invalid="state.fieldAriaInvalid"
+					<?php echo $this->get_hidden_label_aria_label_attr(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- attribute value is escaped in the helper. ?>
 				/>
 				<div
 					class="jetpack-field-slider__value-indicator"

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -934,6 +934,38 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Accessible name for the file field's dropzone <div role="button">.
+	 *
+	 * The dropzone is the field's interactive control, but its name is otherwise
+	 * the generic "Select a file to upload.", so two hidden-label upload fields
+	 * would be announced identically. When the label is hidden (full or
+	 * per-viewport), prefix the field name — the same fallback the other single
+	 * inputs use. Falls back to the plain instruction when the label is visible
+	 * or there is no name to give. See FORMS-694.
+	 *
+	 * @return string
+	 */
+	private function get_file_dropzone_aria_label() {
+		$select_file_text = __( 'Select a file to upload.', 'jetpack-forms' );
+
+		if ( ! $this->is_label_hidden_by_block_visibility() ) {
+			return $select_file_text;
+		}
+
+		$hidden_name = $this->get_block_visibility_aria_label();
+		if ( '' === $hidden_name ) {
+			return $select_file_text;
+		}
+
+		return sprintf(
+			/* translators: 1: the form field's label, 2: the "Select a file to upload." instruction. */
+			_x( '%1$s: %2$s', 'file upload field accessible name', 'jetpack-forms' ),
+			$hidden_name,
+			$select_file_text
+		);
+	}
+
+	/**
 	 * Return the HTML for a legend that shares the same style as a label.
 	 *
 	 * @param string $type - the field type.
@@ -1704,6 +1736,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field = $this->render_label( 'file', $id, $label, $required, $required_field_text, array(), true, $required_indicator );
 
+		$dropzone_aria_label = $this->get_file_dropzone_aria_label();
+
 		ob_start();
 		?>
 		<div
@@ -1721,7 +1755,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			data-is-required="<?php echo esc_attr( $required ); ?>"
 		>
 			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.hasMaxFiles">
-				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker" data-wp-on--keydown="actions.handleKeyDown" tabindex="0" role="button" aria-label="<?php esc_attr_e( 'Select a file to upload.', 'jetpack-forms' ); ?>"></div>
+				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker" data-wp-on--keydown="actions.handleKeyDown" tabindex="0" role="button" aria-label="<?php echo esc_attr( $dropzone_aria_label ); ?>"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is intentionally unescaped as it contains block content that was previously escaped ?>
 				<?php echo html_entity_decode( $this->content, ENT_COMPAT, 'UTF-8' ); ?>
 				<input

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -584,8 +584,22 @@ class Contact_Form_Plugin {
 					$atts['labelstyles']                      = $label_attrs['style'] ?? null;
 					$add_block_style_classes_to_field_wrapper = true;
 
-					// check if the block has been hidden by blockVisibility support
-					$atts['labelhiddenbyblockvisibility'] = isset( $inner_block['attrs']['metadata']['blockVisibility'] ) && false === $inner_block['attrs']['metadata']['blockVisibility'];
+					// Honor blockVisibility support on the label. Full-hide
+					// (blockVisibility === false) skips the label render; per-viewport
+					// hide gets the same wp-block-hidden-{mobile,tablet,desktop} classes
+					// Gutenberg would add — the matching media-query CSS is already
+					// registered by core's render_block visibility filter (the label
+					// keeps visibility support). See FORMS-694.
+					$block_visibility                     = $inner_block['attrs']['metadata']['blockVisibility'] ?? null;
+					$atts['labelhiddenbyblockvisibility'] = false === $block_visibility;
+
+					if ( is_array( $block_visibility ) && isset( $block_visibility['viewport'] ) && is_array( $block_visibility['viewport'] ) ) {
+						foreach ( array( 'mobile', 'tablet', 'desktop' ) as $viewport_size ) {
+							if ( isset( $block_visibility['viewport'][ $viewport_size ] ) && false === $block_visibility['viewport'][ $viewport_size ] ) {
+								$atts['labelclasses'] .= ' wp-block-hidden-' . $viewport_size;
+							}
+						}
+					}
 
 					continue;
 				}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -547,4 +547,50 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		// Cleanup
 		wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Test that ::disable_field_visibility_support turns off the visibility
+	 * support on every field, input, and choice/option block, and leaves the
+	 * label and non-forms blocks untouched. See FORMS-694.
+	 *
+	 * @dataProvider data_disable_field_visibility_support
+	 *
+	 * @param string $block_name     The block name being registered.
+	 * @param bool   $should_disable Whether visibility should be disabled for it.
+	 */
+	#[DataProvider( 'data_disable_field_visibility_support' )]
+	public function test_disable_field_visibility_support( $block_name, $should_disable ) {
+		$result = Contact_Form_Block::disable_field_visibility_support( array(), $block_name );
+
+		if ( $should_disable ) {
+			$this->assertArrayHasKey( 'supports', $result );
+			$this->assertFalse( $result['supports']['visibility'] );
+		} else {
+			$this->assertArrayNotHasKey( 'supports', $result );
+		}
+	}
+
+	/**
+	 * Data provider for test_disable_field_visibility_support.
+	 *
+	 * @return array
+	 */
+	public static function data_disable_field_visibility_support() {
+		return array(
+			'field'                  => array( 'jetpack/field-name', true ),
+			'field (file)'           => array( 'jetpack/field-file', true ),
+			'deprecated option'      => array( 'jetpack/field-option-radio', true ),
+			'standard input'         => array( 'jetpack/input', true ),
+			'range input'            => array( 'jetpack/input-range', true ),
+			'rating input'           => array( 'jetpack/input-rating', true ),
+			'image-option input'     => array( 'jetpack/input-image-option', true ),
+			'phone input'            => array( 'jetpack/phone-input', true ),
+			'dropzone'               => array( 'jetpack/dropzone', true ),
+			'option'                 => array( 'jetpack/option', true ),
+			'options'                => array( 'jetpack/options', true ),
+			'fieldset-image-options' => array( 'jetpack/fieldset-image-options', true ),
+			'label (kept)'           => array( 'jetpack/label', false ),
+			'non-forms block'        => array( 'core/paragraph', false ),
+		);
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -93,12 +93,12 @@ class Contact_Form_Block_Test extends BaseTestCase {
 			'jetpack/label'   => array(
 				'jetpack/label',
 				array(
-					'color'           => array(
+					'color'      => array(
 						'text'       => true,
 						'background' => false,
 						'gradients'  => false,
 					),
-					'typography'      => array(
+					'typography' => array(
 						'fontSize'                     => true,
 						'lineHeight'                   => true,
 						'__experimentalFontFamily'     => true,
@@ -108,7 +108,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'__experimentalTextDecoration' => true,
 						'__experimentalLetterSpacing'  => true,
 					),
-					'blockVisibility' => true,
+					'visibility' => true,
 				),
 			),
 			'jetpack/options' => array(
@@ -592,5 +592,82 @@ class Contact_Form_Block_Test extends BaseTestCase {
 			'label (kept)'           => array( 'jetpack/label', false ),
 			'non-forms block'        => array( 'core/paragraph', false ),
 		);
+	}
+
+	/**
+	 * Test that ::drop_field_hidden_everywhere removes a field's rendered output
+	 * when it has been hidden everywhere (metadata.blockVisibility === false), and
+	 * leaves it untouched for the per-viewport hide, no visibility, non-field
+	 * blocks, and non-boolean values. See FORMS-694.
+	 *
+	 * @dataProvider data_drop_field_hidden_everywhere
+	 *
+	 * @param array $block        The parsed block passed to the render_block filter.
+	 * @param bool  $should_drop  Whether the field output should be dropped.
+	 */
+	#[DataProvider( 'data_drop_field_hidden_everywhere' )]
+	public function test_drop_field_hidden_everywhere( $block, $should_drop ) {
+		$content = '[contact-field type="text" label="Name"/]';
+		$result  = Contact_Form_Block::drop_field_hidden_everywhere( $content, $block );
+
+		$this->assertSame( $should_drop ? '' : $content, $result );
+	}
+
+	/**
+	 * Data provider for test_drop_field_hidden_everywhere.
+	 *
+	 * @return array
+	 */
+	public static function data_drop_field_hidden_everywhere() {
+		$field = static function ( $block_visibility ) {
+			$attrs = array();
+			if ( null !== $block_visibility ) {
+				$attrs['metadata'] = array( 'blockVisibility' => $block_visibility );
+			}
+			return array(
+				'blockName' => 'jetpack/field-name',
+				'attrs'     => $attrs,
+			);
+		};
+
+		return array(
+			'field hidden everywhere'     => array( $field( false ), true ),
+			'field per-viewport hide'     => array( $field( array( 'viewport' => array( 'mobile' => false ) ) ), false ),
+			'field no visibility set'     => array( $field( null ), false ),
+			'field visibility true'       => array( $field( true ), false ),
+			'non-field hidden everywhere' => array(
+				array(
+					'blockName' => 'core/paragraph',
+					'attrs'     => array( 'metadata' => array( 'blockVisibility' => false ) ),
+				),
+				false,
+			),
+			'block without a name'        => array( array( 'attrs' => array() ), false ),
+		);
+	}
+
+	/**
+	 * Integration: confirm the render_block filter is actually wired by
+	 * register_child_blocks() and drops a hidden-everywhere field in the real
+	 * do_blocks() pipeline (independent of core's visibility filter), while a
+	 * normal field still renders its [contact-field] shortcode. Dropping the
+	 * shortcode before it reaches Contact_Form::parse() is what keeps a required
+	 * hidden field from ever being validated. See FORMS-694.
+	 */
+	public function test_hidden_everywhere_field_is_dropped_in_do_blocks() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$hidden = '<!-- wp:jetpack/field-text {"label":"Hide me","required":true,"metadata":{"blockVisibility":false}} /-->';
+		$shown  = '<!-- wp:jetpack/field-text {"label":"Keep me","required":true} /-->';
+
+		// The hidden-everywhere required field produces no output — so it never
+		// becomes a [contact-field] shortcode, is never parsed, and is never
+		// validated (a required field that isn't in the form can't block submit).
+		$this->assertSame( '', trim( do_blocks( $hidden ) ) );
+
+		// A normal field still flattens to its shortcode.
+		$this->assertStringContainsString( 'contact-field', do_blocks( $shown ) );
+		$this->assertStringContainsString( 'Keep me', do_blocks( $shown ) );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -87,6 +87,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'__experimentalTextDecoration' => true,
 						'__experimentalLetterSpacing'  => true,
 					),
+					'visibility'           => false,
 				),
 			),
 			'jetpack/label'   => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -127,6 +127,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'spacing'              => array(
 						'blockGap' => false,
 					),
+					'visibility'           => false,
 				),
 			),
 			'jetpack/option'  => array(
@@ -147,6 +148,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'__experimentalTextDecoration' => true,
 						'__experimentalLetterSpacing'  => true,
 					),
+					'visibility' => false,
 				),
 			),
 		);

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -414,4 +414,57 @@ class Contact_Form_Field_Test extends BaseTestCase {
 
 		$this->assertStringNotContainsString( 'aria-label', $html );
 	}
+
+	/**
+	 * The file field's dropzone button gets a distinct accessible name when its
+	 * label is hidden (field label prefixed to the instruction) so two
+	 * hidden-label upload fields aren't announced identically, and falls back to
+	 * the plain instruction otherwise. Tested directly because the full file
+	 * render short-circuits without an active Jetpack. See FORMS-694.
+	 *
+	 * @dataProvider data_file_dropzone_aria_label
+	 *
+	 * @param array  $atts     Field attributes.
+	 * @param string $expected Expected dropzone accessible name.
+	 */
+	#[DataProvider( 'data_file_dropzone_aria_label' )]
+	public function test_file_dropzone_aria_label( $atts, $expected ) {
+		$field  = $this->get_new_field_instance( array_merge( array( 'type' => 'file' ), $atts ) );
+		$method = new \ReflectionMethod( $field, 'get_file_dropzone_aria_label' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $field ) );
+	}
+
+	/**
+	 * Data provider for test_file_dropzone_aria_label.
+	 *
+	 * @return array
+	 */
+	public static function data_file_dropzone_aria_label() {
+		return array(
+			'visible label'          => array( array( 'label' => 'Resume' ), 'Select a file to upload.' ),
+			'full-hidden label'      => array(
+				array(
+					'label'                        => 'Resume',
+					'labelhiddenbyblockvisibility' => true,
+				),
+				'Resume: Select a file to upload.',
+			),
+			'per-viewport hidden'    => array(
+				array(
+					'label'        => 'Resume',
+					'labelclasses' => 'wp-block-hidden-mobile',
+				),
+				'Resume: Select a file to upload.',
+			),
+			'hidden but empty label' => array(
+				array(
+					'label'                        => '',
+					'labelhiddenbyblockvisibility' => true,
+				),
+				'Select a file to upload.',
+			),
+		);
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -323,4 +323,54 @@ class Contact_Form_Field_Test extends BaseTestCase {
 			'rating'            => array( 'rating', array() ),
 		);
 	}
+
+	/**
+	 * Per-viewport hide: a grouped field whose legend label carries a
+	 * wp-block-hidden-{viewport} class is still rendered (display:none only on
+	 * that viewport), but the <fieldset> also gets an aria-label so the group
+	 * keeps an accessible name where the legend is hidden. See FORMS-694.
+	 */
+	public function test_render_grouped_field_per_viewport_hidden_legend_keeps_accessible_name() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'         => 'radio',
+				'id'           => 'test_group',
+				'label'        => 'Pick one',
+				'options'      => array( 'A', 'B' ),
+				'labelclasses' => 'wp-block-hidden-mobile',
+			)
+		);
+
+		$html = $field->render();
+
+		// The legend is still rendered (per-viewport is display:none, not removed)...
+		$this->assertStringContainsString( '<legend', $html );
+		$this->assertStringContainsString( 'wp-block-hidden-mobile', $html );
+		// ...and the accessible name is also on the fieldset for the hidden viewport.
+		$this->assertStringContainsString( "aria-label='Pick one'", $html );
+	}
+
+	/**
+	 * Per-viewport hide: a single input whose label carries a
+	 * wp-block-hidden-{viewport} class gets an aria-label (the label text, not the
+	 * placeholder) so it keeps an accessible name where the label is hidden. See
+	 * FORMS-694.
+	 */
+	public function test_render_input_per_viewport_hidden_label_keeps_accessible_name() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'         => 'text',
+				'id'           => 'test_text',
+				'label'        => 'Your name',
+				'placeholder'  => 'e.g. Jane',
+				'labelclasses' => 'wp-block-hidden-tablet',
+			)
+		);
+
+		$html = $field->render();
+
+		// The accessible name falls back to the label, matching the visible label.
+		$this->assertStringContainsString( "aria-label='Your name'", $html );
+		$this->assertStringNotContainsString( "aria-label='e.g. Jane'", $html );
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
@@ -242,5 +243,84 @@ class Contact_Form_Field_Test extends BaseTestCase {
 		// Should default to implicit (hidden field)
 		$this->assertStringContainsString( 'type=\'hidden\'', $html );
 		$this->assertStringContainsString( 'consent-implicit', $html );
+	}
+
+	/**
+	 * A grouped field whose legend label is fully hidden via block visibility
+	 * must render no <legend>, but must move the label onto the <fieldset> as an
+	 * aria-label so the group keeps an accessible name. Covers both fieldset code
+	 * paths — radio/checkbox-multiple/image-select (via $fieldset_id) and rating
+	 * (via sprintf). See FORMS-694.
+	 *
+	 * @dataProvider data_grouped_field_types
+	 *
+	 * @param string $type       The grouped field type.
+	 * @param array  $extra_atts Extra attributes needed to make the field renderable.
+	 */
+	#[DataProvider( 'data_grouped_field_types' )]
+	public function test_render_grouped_field_hidden_legend_keeps_accessible_name( $type, $extra_atts ) {
+		$field = $this->get_new_field_instance(
+			array_merge(
+				array(
+					'type'                         => $type,
+					'id'                           => 'test_group',
+					'label'                        => 'Pick one',
+					'labelhiddenbyblockvisibility' => true,
+				),
+				$extra_atts
+			)
+		);
+
+		$html = $field->render();
+
+		// The legend is dropped (no visible group label)...
+		$this->assertStringNotContainsString( '<legend', $html );
+		// ...but the accessible name is preserved on the fieldset.
+		$this->assertStringContainsString( "aria-label='Pick one'", $html );
+	}
+
+	/**
+	 * When the legend label is NOT hidden, the grouped field renders a normal
+	 * <legend> and does not add the aria-label fallback to the fieldset. Guards
+	 * the render-level behavior above against regressions. See FORMS-694.
+	 *
+	 * @dataProvider data_grouped_field_types
+	 *
+	 * @param string $type       The grouped field type.
+	 * @param array  $extra_atts Extra attributes needed to make the field renderable.
+	 */
+	#[DataProvider( 'data_grouped_field_types' )]
+	public function test_render_grouped_field_visible_legend_has_no_aria_label( $type, $extra_atts ) {
+		$field = $this->get_new_field_instance(
+			array_merge(
+				array(
+					'type'  => $type,
+					'id'    => 'test_group',
+					'label' => 'Pick one',
+				),
+				$extra_atts
+			)
+		);
+
+		$html = $field->render();
+
+		$this->assertStringContainsString( '<legend', $html );
+		$this->assertStringContainsString( 'Pick one', $html );
+		$this->assertStringNotContainsString( "aria-label='Pick one'", $html );
+	}
+
+	/**
+	 * Grouped field types keyed by the two distinct <fieldset> code paths.
+	 *
+	 * @return array
+	 */
+	public static function data_grouped_field_types() {
+		return array(
+			// $fieldset_id path (shared by radio, checkbox-multiple, image-select).
+			'radio'             => array( 'radio', array( 'options' => array( 'A', 'B' ) ) ),
+			'checkbox-multiple' => array( 'checkbox-multiple', array( 'options' => array( 'A', 'B' ) ) ),
+			// sprintf path.
+			'rating'            => array( 'rating', array() ),
+		);
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -373,4 +373,45 @@ class Contact_Form_Field_Test extends BaseTestCase {
 		$this->assertStringContainsString( "aria-label='Your name'", $html );
 		$this->assertStringNotContainsString( "aria-label='e.g. Jane'", $html );
 	}
+
+	/**
+	 * The slider's <input type="range"> gets the hidden-label aria-label fallback
+	 * too — it renders a bare range input with no other accessible name. See
+	 * FORMS-694.
+	 */
+	public function test_render_slider_hidden_label_keeps_accessible_name() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'                         => 'slider',
+				'id'                           => 'test_slider',
+				'label'                        => 'Rate us',
+				'labelhiddenbyblockvisibility' => true,
+			)
+		);
+
+		$html = $field->render();
+
+		$this->assertStringContainsString( 'type="range"', $html );
+		$this->assertStringContainsString( "aria-label='Rate us'", $html );
+	}
+
+	/**
+	 * When the label is hidden but empty and there is no placeholder, no
+	 * aria-label attribute is emitted (rather than an empty or fragment value).
+	 * See FORMS-694.
+	 */
+	public function test_render_input_hidden_empty_label_emits_no_aria_label() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'                         => 'text',
+				'id'                           => 'test_text',
+				'label'                        => '',
+				'labelhiddenbyblockvisibility' => true,
+			)
+		);
+
+		$html = $field->render();
+
+		$this->assertStringNotContainsString( 'aria-label', $html );
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -431,7 +431,9 @@ class Contact_Form_Field_Test extends BaseTestCase {
 	public function test_file_dropzone_aria_label( $atts, $expected ) {
 		$field  = $this->get_new_field_instance( array_merge( array( 'type' => 'file' ), $atts ) );
 		$method = new \ReflectionMethod( $field, 'get_file_dropzone_aria_label' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$this->assertSame( $expected, $method->invoke( $field ) );
 	}
@@ -464,6 +466,50 @@ class Contact_Form_Field_Test extends BaseTestCase {
 					'labelhiddenbyblockvisibility' => true,
 				),
 				'Select a file to upload.',
+			),
+		);
+	}
+
+	/**
+	 * The hidden-label aria-label fallback reaches the other single-input render
+	 * paths too — textarea, select and the country-selector phone input each move
+	 * the label onto the control when it's hidden. See FORMS-694.
+	 *
+	 * @dataProvider data_single_input_render_paths
+	 *
+	 * @param array $atts Field attributes (type plus anything needed to render).
+	 */
+	#[DataProvider( 'data_single_input_render_paths' )]
+	public function test_render_single_input_hidden_label_keeps_accessible_name( $atts ) {
+		$hidden = $this->get_new_field_instance(
+			array_merge( array( 'label' => 'Your name' ), $atts, array( 'labelhiddenbyblockvisibility' => true ) )
+		);
+		$this->assertStringContainsString( "aria-label='Your name'", $hidden->render() );
+
+		// And no stray aria-label when the label is visible.
+		$shown = $this->get_new_field_instance( array_merge( array( 'label' => 'Your name' ), $atts ) );
+		$this->assertStringNotContainsString( "aria-label='Your name'", $shown->render() );
+	}
+
+	/**
+	 * Data provider for test_render_single_input_hidden_label_keeps_accessible_name.
+	 *
+	 * @return array
+	 */
+	public static function data_single_input_render_paths() {
+		return array(
+			'textarea'          => array( array( 'type' => 'textarea' ) ),
+			'select'            => array(
+				array(
+					'type'    => 'select',
+					'options' => array( 'A', 'B' ),
+				),
+			),
+			'phone w/ selector' => array(
+				array(
+					'type'                => 'phone',
+					'showcountryselector' => true,
+				),
 			),
 		);
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -2109,4 +2109,79 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			wp_set_current_user( 0 );
 		}
 	}
+
+	/**
+	 * Test that ::block_attributes_to_shortcode_attributes honors the label's
+	 * blockVisibility support: full-hide (blockVisibility === false) sets
+	 * labelhiddenbyblockvisibility, and per-viewport hide adds the matching
+	 * wp-block-hidden-{mobile,tablet,desktop} classes to the label. See FORMS-694.
+	 *
+	 * @dataProvider data_provider_label_block_visibility
+	 *
+	 * @param mixed $block_visibility   The label's metadata.blockVisibility value (null to omit).
+	 * @param bool  $expected_full_hide Whether labelhiddenbyblockvisibility should be truthy.
+	 * @param array $expected_hidden    The viewports expected to add a wp-block-hidden-* class.
+	 */
+	#[DataProvider( 'data_provider_label_block_visibility' )]
+	public function test_block_attributes_to_shortcode_attributes_label_block_visibility( $block_visibility, $expected_full_hide, $expected_hidden ) {
+		$label_attrs = array( 'label' => 'Name' );
+		if ( null !== $block_visibility ) {
+			$label_attrs['metadata'] = array( 'blockVisibility' => $block_visibility );
+		}
+		$block = array(
+			'blockName'   => 'jetpack/field-name',
+			'attrs'       => array( 'required' => false ),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => $label_attrs,
+				),
+			),
+		);
+		$atts  = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), 'text', new WP_Block( $block ) );
+
+		$this->assertSame( $expected_full_hide, (bool) $atts['labelhiddenbyblockvisibility'] );
+
+		foreach ( array( 'mobile', 'tablet', 'desktop' ) as $viewport ) {
+			$class = 'wp-block-hidden-' . $viewport;
+			if ( in_array( $viewport, $expected_hidden, true ) ) {
+				$this->assertStringContainsString( $class, $atts['labelclasses'] );
+			} else {
+				$this->assertStringNotContainsString( $class, $atts['labelclasses'] );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for test_block_attributes_to_shortcode_attributes_label_block_visibility.
+	 *
+	 * @return array
+	 */
+	public static function data_provider_label_block_visibility() {
+		return array(
+			'no visibility set'       => array( null, false, array() ),
+			'full hide (false)'       => array( false, true, array() ),
+			'hide on mobile'          => array( array( 'viewport' => array( 'mobile' => false ) ), false, array( 'mobile' ) ),
+			'hide on mobile + tablet' => array(
+				array(
+					'viewport' => array(
+						'mobile' => false,
+						'tablet' => false,
+					),
+				),
+				false,
+				array( 'mobile', 'tablet' ),
+			),
+			'viewport all visible'    => array(
+				array(
+					'viewport' => array(
+						'mobile' => true,
+						'tablet' => true,
+					),
+				),
+				false,
+				array(),
+			),
+		);
+	}
 }


### PR DESCRIPTION
## Proposed changes

Interim measure for FORMS-694 while we decide whether to fully support per-field device visibility.

**What the GB control actually does.** The block "visibility" support exposes two modes behind a single `supports.visibility` boolean: *Hide everywhere* (writes `blockVisibility = false`) and *per-viewport* "Hide on mobile/tablet/desktop" (writes `{ viewport: … }`).

**How they behave on our (dynamic) form blocks:**

* **Per-viewport "Hide on…" is not honored** — fields flatten into a shortcode-style array and bypass core's `render_block` class injection, so `wp-block-hidden-*` + the media-query CSS never reach the field. Worse, it *can't* be made safe on a required field: both server (`validate()`) and client (`isFormValid`) validation are viewport-blind, so a required field hidden on mobile stays required but unfillable → dead form.
* **"Hide everywhere" does work on fields** (the field's shortcode is dropped before parse, so it's never validated/submitted — `required`-safe), but the single boolean bundles it with the broken per-viewport mode and we can't split them.
* **Inputs and choice/option blocks are inert in every mode** (the field renderer reads their attrs directly and discards their rendered output).

So this disables `visibility` on every **field**, **input**, and **choice/option** block (the only one that keeps it is the label — see below).

**Labels keep their support — and now honor per-viewport hiding too.** Label hiding never touches input/validation/submission (it's pure presentation), so the viewport pitfall doesn't apply. Full-hide was already wired via `labelhiddenbyblockvisibility`; this adds the per-viewport case: the block→shortcode bridge reads `blockVisibility.viewport` and adds the same `wp-block-hidden-{mobile,tablet,desktop}` classes Gutenberg would to the label the field renderer emits. The matching media-query CSS is already registered by core's `render_block` visibility filter (the label keeps `visibility` support, so the filter runs on it — it just couldn't attach the class because that output is discarded). Applied across the default, outlined, animated, and below label styles.

Applied consistently on **both** registrations:
* JS — `shared/settings/index.js` (all field blocks), plus per-block `visibility: false` on the input variants (`input`, `input-range`, `input-rating`, `input-image-option`, `phone-input`, `dropzone`) and choice/option blocks (`option`, `options`, `fieldset-image-options`, deprecated `field-option-*`).
* PHP — a `register_block_type_args` filter matching all `jetpack/field-*`, `jetpack/input*`, `phone-input`, `dropzone`, and the option containers, mirroring the JS.

> **Note:** this currently means a per-block opt-out duplicated across ~15 blocks. The cleaner end state — a shared supports array `array_merge`'d into each declaration, mirroring the JS `defaultSettings` — is tracked as a follow-up (TODO in the PHP filter).

## Related

* FORMS-694

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* In the block editor, add a Form block and select any field, its input, or a choice/option — the visibility control is gone. Select a field's **label** — it's still there (the only forms block that keeps it). Select a non-form block (e.g. a paragraph) — unaffected.
* Set a field's **label** to "Hide on mobile" and view the form on the frontend: the `<label>` gets `wp-block-hidden-mobile` and the `@media (width <= 480px){…display:none}` rule is emitted, so it hides on mobile. Full-hide on a label still removes it entirely.
* Verified registration parity both sides: editor `wp.blocks.hasBlockSupport('jetpack/field-name','visibility',true) === false` for fields/input and `true` for labels/options; server `WP_Block_Type_Registry` reports the same. PHP `Contact_Form_Block_Test` passes.

## Deferred (separate decision, FORMS-694)

Fully **supporting** per-field device visibility would require honoring viewport hiding inside the forms render pipeline *and* a viewport flag on the submission so required/validation can be skipped for the hidden viewport on **both** client and server — plus token handling. Likely not worth it; tracked in FORMS-694.
