### PR TITLE
Premium Analytics: drop unsupported Tabs.Panel focusable prop (@wordpress/ui 0.15)

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wp-ui-015-tabs-focusable
+++ b/projects/packages/premium-analytics/changelog/fix-wp-ui-015-tabs-focusable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Drop the unsupported `focusable` prop on `@wordpress/ui` `Tabs.Panel` (not a valid prop; was a no-op). Aligns with the `@wordpress/ui` 0.15 API. Panels already gate their content on the active section.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -71,12 +71,7 @@ function Dashboard(): JSX.Element {
 					onChange={ setActiveSection }
 				>
 					{ sections.map( section => (
-						<Tabs.Panel
-							key={ section.id }
-							value={ section.id }
-							focusable={ false }
-							className={ styles.content }
-						>
+						<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
 							{ activeSection === section.id ? (
 								<>
 									<WidgetDashboard.NoWidgetsState />

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -130,12 +130,7 @@ function DashboardSectionsGridStory() {
 				onChange={ setActiveSection }
 			>
 				{ sections.map( section => (
-					<Tabs.Panel
-						key={ section.id }
-						value={ section.id }
-						focusable={ false }
-						className={ styles.content }
-					>
+					<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
 						{ activeSection === section.id ? (
 							<WidgetDashboard
 								widgetTypes={ widgetTypes }


### PR DESCRIPTION
## Proposed changes

Part of the bundled `@wordpress/*` monorepo bump (#49272) cleanup — the same family as the merged #49795 (Backup) and #49796 (Scan).

`@wordpress/ui`'s `Tabs.Panel` has no `focusable` prop. Under 0.13's broken `.d.ts` (which degraded to `any` under `skipLibCheck`) it was silently ignored, but the 0.15 type exports surface it as a type error. This is the **last remaining Premium Analytics type error** under the bump.

* Drop `focusable={ false }` from `Tabs.Panel` in the dashboard route (`routes/dashboard/stage.tsx`) and its Storybook story (`widgets/hello-world/stories/dashboard-sections-grid.stories.tsx` — `widgets/**` is in the package `tsconfig` `include`, so stories are type-checked).
* Behavior-preserving: the prop was a no-op, and the panels already gate their content on the active section (`activeSection === section.id ? … : null`), matching the pattern in #49796 / #49629.

## Related product discussion/links

* Part of the bundled monorepo bump #49272; companion to #49795 and #49796
* Jetpack UI modernization #48160

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run typecheck` in `projects/packages/premium-analytics` is clean (valid on both `@wordpress/ui@0.13` and `0.15`).
* No visual change — `focusable` was inert. Optionally load the Premium Analytics dashboard and switch tabs to confirm panels still render their active section.
