### PR TITLE
codeowners: Set Zap as owner of tools/performance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,10 @@
 /tools @Automattic/jetpack-monorepo
 /tools/e2e-commons # No owner assigned
 
+# Tools owned by specific teams
+
+/tools/performance @Automattic/Zap
+
 # Actions
 
 /projects/github-actions/repo-gardening/ @jeherve
@@ -59,8 +63,8 @@
 /projects/packages/connection/src @Automattic/jetpack-vulcan
 /projects/packages/connection/legacy @Automattic/jetpack-vulcan
 /projects/packages/sync/src @Automattic/jetpack-vulcan
-/projects/packages/connection/src/class-package-version.php
-/projects/packages/sync/src/class-package-version.php
+/projects/packages/connection/src/class-package-version.php # No owner - too noisy
+/projects/packages/sync/src/class-package-version.php # No owner - too noisy
 /projects/packages/videopress/src @Automattic/VideoPress
 /projects/packages/videopress/src/class-package-version.php # No owner - too noisy
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is the team that seems to own the tool (following pc9hqz-40R-p2), they should get pinged for reviews of this.

Also, take the opportuity to explicitly flag the remaining "no owner" lines.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None really. The ping for @Automattic/jetpack-monorepo on #49966 didn't seem useful, so I propose this adjustment.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Make sense?
* Visiting https://github.com/Automattic/jetpack/blob/update/codeowners-for-tools-performance/.github/CODEOWNERS and looking for GitHub to say "This CODEOWNERS file is valid" is also a good check.