### PR TITLE
ci: Update test-wpcom-filename-restrictions

### DIFF
--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -164,7 +164,7 @@ while IFS=$'\t' read -r _ MIRROR SLUG; do
 		echo "- $FILE"
 		check_underscores "$FILE"
 		check_invalid_chars "$FILE"
-		check_executable "$FILE"
+		#check_executable "$FILE"
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=A )
 
@@ -172,7 +172,7 @@ while IFS=$'\t' read -r _ MIRROR SLUG; do
 	echo 'Modified files:'
 	while IFS= read -r FILE; do
 		echo "- $FILE"
-		check_executable "$FILE"
+		#check_executable "$FILE"
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=MT )
 

--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -33,19 +33,6 @@ function check_invalid_chars {
 	fi
 }
 
-# Based on Automattic/pre-receive-hooks/blob/b3ca8ab/main-pre-receive-hooks.sh (130_stop_executables)
-function check_executable {
-	local FILE="$1"
-	local line old_mode new_mode
-	line=$( git diff --cached --raw "${FILE}" )
-	old_mode="$(echo "$line" | cut -d' ' -f1 | cut -c2-)"
-	new_mode="$(echo "$line" | cut -d' ' -f2)"
-	if [[ "100755" == "$new_mode" && "100755" != "$old_mode" ]]; then
-		echo '  ❌ File cannot be executable!'
-		failed "$SLUG: File \`$FILE\` may not be executable"
-	fi
-}
-
 # Based on Automattic/pre-receive-hooks/blob/b3ca8ab/main-pre-receive-hooks.sh (160_stop_symlinks)
 function check_symlink {
 	local FILE="$1"
@@ -164,7 +151,6 @@ while IFS=$'\t' read -r _ MIRROR SLUG; do
 		echo "- $FILE"
 		check_underscores "$FILE"
 		check_invalid_chars "$FILE"
-		#check_executable "$FILE"
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=A )
 
@@ -172,7 +158,6 @@ while IFS=$'\t' read -r _ MIRROR SLUG; do
 	echo 'Modified files:'
 	while IFS= read -r FILE; do
 		echo "- $FILE"
-		#check_executable "$FILE"
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=MT )
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
223-ghe-Automattic/pre-receive-hooks removed the stop_executables check for the wpcom repo.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Apparently the removal is related to pMz3w-olY-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷