### PR TITLE
Forms: fix file upload field collapsing to content width on the front end

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-file-upload-field-collapses-on-frontend
+++ b/projects/packages/forms/changelog/fix-forms-file-upload-field-collapses-on-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix the file upload field collapsing to its content width on the front end instead of filling the form like it does in the editor.

--- a/projects/packages/forms/changelog/fix-forms-file-upload-field-collapses-on-frontend
+++ b/projects/packages/forms/changelog/fix-forms-file-upload-field-collapses-on-frontend
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fix the file upload field collapsing to its content width on the front end instead of filling the form like it does in the editor.
+File upload: Fix the file upload field collapsing to its content width on the front end instead of filling the form like it does in the editor.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1371,15 +1371,7 @@ class Contact_Form_Plugin {
 	 */
 	public static function gutenblock_render_field_file( $atts, $content, $block ) {
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'file', $block );
-		// Create wrapper div for the file field
-		$output = '<div class="jetpack-form-file-field">';
-
-		// Render the file field
-		$output .= Contact_Form::parse_contact_field( $atts, $content );
-
-		$output .= '</div>';
-
-		return $output;
+		return Contact_Form::parse_contact_field( $atts, $content );
 	}
 	/**
 	 * Render the dropzone field.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -264,6 +264,38 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that gutenblock_render_field_file does not wrap its output in an extra element.
+	 *
+	 * The file field must render like every other gutenblock_render_field_* method - the
+	 * bare shortcode, with no extra wrapper. An extra wrapper demotes the field's own
+	 * `.grunion-field-wrap` shell from being the contact form's direct flex child, which
+	 * makes the field collapse to its content width on the front end instead of filling
+	 * the form.
+	 */
+	public function test_gutenblock_render_field_file_has_no_extra_wrapper() {
+		$block = array(
+			'blockName'   => 'jetpack/field-file',
+			'attrs'       => array(),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => array( 'label' => 'Upload a file' ),
+				),
+				array(
+					'blockName' => 'jetpack/dropzone',
+					'attrs'     => array(),
+				),
+			),
+		);
+
+		$output = Contact_Form_Plugin::gutenblock_render_field_file( array(), '', new WP_Block( $block ) );
+
+		$this->assertStringNotContainsString( '<div class="jetpack-form-file-field">', $output );
+		$this->assertStringStartsWith( '[contact-field', trim( $output ) );
+		$this->assertStringContainsString( 'type="file"', $output );
+	}
+
+	/**
 	 * Tests the render output of gutenblock_render_field_radio.
 	 */
 	public function test_gutenblock_gutenblock_render_field_radio() {


### PR DESCRIPTION
## Proposed changes

* The Forms **File upload** field collapsed to its content width on the front end instead of filling the form like every other field — and unlike how it renders in the block editor.
* **Root cause:** `gutenblock_render_field_file()` wrapped the field output in an extra `<div class="jetpack-form-file-field">`. That wrapper — rather than the field's own `.grunion-field-wrap` shell — became the contact form's direct flex child. The form is a flex column with `align-items: flex-start`, and the wrapper carries no width/flex rules, so it shrank to the dropzone's content width. The field-width attribute (25/50/75/100%) and horizontal form layouts both rely on those rules landing on `.grunion-field-wrap`.
* **Fix:** return the field directly, exactly like every other `gutenblock_render_field_*` method (this is how the field was originally scaffolded). With the redundant wrapper gone, `.grunion-field-wrap` is once again the form's direct flex child, so the field fills the form and respects width + orientation — with no new CSS.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a Form with a **File upload** field (or use a page that already has one).
* View the form on the front end.
* **Before:** the file upload dropzone is noticeably narrower than the Name/Email/Message fields. **After:** it spans the full form width, matching the editor.
* For good measure, set the file field's width to 50%/75% and/or switch the form to a horizontal layout — the file field should now size like the other fields.

### Before / After (captured live on Jurassic Ninja)

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-file-upload-field-collapses-on-frontend/before-file-upload.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-file-upload-field-collapses-on-frontend/after-file-upload.png) |
