### PR TITLE
[FORNO-326] Add Jetpack AI abilities to Page/Site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: enhancement
 
-AI Sidebar: Gate provider exposure to proxied preview requests.
+AI Sidebar: Add Jetpack AI abilities in page and site editors.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Sidebar: Gate provider exposure to proxied preview requests.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-provider-proxied-gate
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Sidebar: Add Jetpack AI abilities in page and site editors.
+AI Sidebar: Add Jetpack AI abilities in the page and site editors.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -59,8 +59,7 @@ class Jetpack_AI_Sidebar {
 
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
-		// Ask the Agents Manager package to mount in the post editor on Jetpack
-		// AI Sidebar Preview surfaces.
+		// Ask the Agents Manager package to mount on Jetpack AI provider surfaces.
 		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Enqueue the IIFE bundle in the preview post editor — it registers
@@ -595,7 +594,7 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Enable Agents Manager in the post editor when Jetpack AI Sidebar Preview is available.
+	 * Enable Agents Manager when the Jetpack AI provider can be exposed.
 	 *
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
@@ -605,7 +604,7 @@ class Jetpack_AI_Sidebar {
 			return true;
 		}
 
-		return self::should_expose_sidebar();
+		return self::should_expose_provider();
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -690,7 +690,7 @@ class Jetpack_AI_Sidebar {
 	 * Check whether AI features are available.
 	 *
 	 * - wpcom simple: available when Jetpack AI is enabled.
-	 * - Atomic/self-hosted: requires a connected owner with AI not disabled.
+	 * - Atomic/self-hosted: requires Jetpack AI enabled, a connected owner, and non-offline mode.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -431,16 +431,16 @@ class Jetpack_AI_Sidebar {
 	 * Whether the Jetpack AI provider bundle should be exposed for this request.
 	 *
 	 * This is scoped to the supported editor surfaces: post editor, page editor,
-	 * and site editor. It stays behind the same internal rollout gate as Generate
-	 * Feedback: preview enabled, internal testing environment, and AI features
-	 * available.
+	 * and site editor. The existing post editor surface remains available when
+	 * preview and AI feature gates pass, while the new page and site editor
+	 * surfaces require an internal testing environment.
 	 *
 	 * @return bool
 	 */
 	private static function should_expose_provider(): bool {
 		return self::is_jetpack_ai_sidebar_preview_enabled()
 			&& self::is_supported_provider_surface()
-			&& jetpack_is_internal_testing_environment()
+			&& self::is_provider_rollout_enabled()
 			&& self::has_ai_features();
 	}
 
@@ -684,6 +684,26 @@ class Jetpack_AI_Sidebar {
 		return self::is_block_editor()
 			&& 'post' === $screen->base
 			&& in_array( $screen->post_type, array( 'post', 'page' ), true );
+	}
+
+	/**
+	 * Keep the existing post editor rollout while gating newly supported surfaces.
+	 *
+	 * @return bool
+	 */
+	private static function is_provider_rollout_enabled(): bool {
+		if ( jetpack_is_internal_testing_environment() ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return $screen instanceof \WP_Screen
+			&& 'post' === $screen->base
+			&& 'post' === $screen->post_type;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -656,9 +656,7 @@ class Jetpack_AI_Sidebar {
 		}
 
 		// Build the assignments from the same field source as the data filter so the
-		// two emit paths cannot drift. agentProviders is left untouched so client-side
-		// gating can fall back to other providers (such as Big Sky) when Jetpack AI
-		// Sidebar is unavailable.
+		// two emit paths cannot drift.
 		$fields = self::get_agents_manager_data_fields();
 		if ( ! $fields ) {
 			return;
@@ -670,11 +668,27 @@ class Jetpack_AI_Sidebar {
 				. wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 		}
 
+		if ( self::get_ai_sidebar_asset_data() ) {
+			$assignments .= self::get_agent_provider_upsert_script();
+		}
+
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {' . $assignments . ' }',
 			'before'
 		);
+	}
+
+	/**
+	 * Build the inline script that upserts Jetpack AI Sidebar into agentProviders.
+	 *
+	 * @return string Inline JavaScript.
+	 */
+	private static function get_agent_provider_upsert_script(): string {
+		$provider_url = wp_json_encode( AI_SIDEBAR_PROVIDER_URL, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+
+		return ' agentsManagerData.agentProviders = Array.isArray( agentsManagerData.agentProviders ) ? agentsManagerData.agentProviders : [];'
+			. ' if ( agentsManagerData.agentProviders.indexOf( ' . $provider_url . ' ) === -1 ) { agentsManagerData.agentProviders.push( ' . $provider_url . ' ); }';
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -443,17 +443,16 @@ class Jetpack_AI_Sidebar {
 	 * This is intentionally broader than the sidebar data gate: page/site editor
 	 * can consume Jetpack AI tools through another host/agent, without Jetpack AI
 	 * setting the active Agents Manager agent ID. It still stays scoped to the same
-	 * internal rollout gate as Generate Feedback: preview enabled, proxied request,
-	 * Jetpack AI enabled, and AI features available.
+	 * internal rollout gate as Generate Feedback: preview enabled, internal
+	 * testing environment, and AI features available.
 	 *
 	 * @return bool
 	 */
 	private static function should_expose_provider(): bool {
 		return self::is_jetpack_ai_sidebar_preview_enabled()
 			&& self::is_supported_provider_surface()
-			&& self::is_proxied_request()
-			&& self::has_ai_features()
-			&& apply_filters( 'jetpack_ai_enabled', true );
+			&& jetpack_is_internal_testing_environment()
+			&& self::has_ai_features();
 	}
 
 	/**
@@ -579,18 +578,6 @@ class Jetpack_AI_Sidebar {
 		return array(
 			'jetpackAiSidebar' => self::get_jetpack_ai_sidebar_preview_config(),
 		);
-	}
-
-	/**
-	 * Whether the request is proxied through WordPress.com.
-	 *
-	 * @return bool
-	 */
-	private static function is_proxied_request(): bool {
-		$is_server_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
-			&& (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) );
-
-		return $is_server_proxied || ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST );
 	}
 
 	/**
@@ -748,12 +735,16 @@ class Jetpack_AI_Sidebar {
 	/**
 	 * Check whether AI features are available.
 	 *
-	 * - wpcom simple: always available.
+	 * - wpcom simple: available when Jetpack AI is enabled.
 	 * - Atomic/self-hosted: requires a connected owner with AI not disabled.
 	 *
 	 * @return bool
 	 */
 	private static function has_ai_features(): bool {
+		if ( ! apply_filters( 'jetpack_ai_enabled', true ) ) {
+			return false;
+		}
+
 		$host = new Host();
 
 		if ( $host->is_wpcom_simple() ) {
@@ -761,7 +752,6 @@ class Jetpack_AI_Sidebar {
 		}
 
 		return ( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
-			&& ! ( new Status() )->is_offline_mode()
-			&& apply_filters( 'jetpack_ai_enabled', true );
+			&& ! ( new Status() )->is_offline_mode();
 	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -552,18 +552,15 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Fields Jetpack contributes to `agentsManagerData`. Single source shared by the
-	 * data filter and the external-AM inline fallback so the two cannot drift.
+	 * Fields Jetpack contributes when Jetpack AI Sidebar owns the post editor.
 	 *
 	 * @return array
 	 */
 	private static function get_sidebar_am_fields(): array {
-		$config = self::get_jetpack_ai_sidebar_preview_config();
+		$fields            = self::get_provider_am_fields();
+		$fields['agentId'] = AI_SIDEBAR_AGENT_ID;
 
-		return array(
-			'agentId'          => AI_SIDEBAR_AGENT_ID,
-			'jetpackAiSidebar' => $config,
-		);
+		return $fields;
 	}
 
 	/**
@@ -586,15 +583,15 @@ class Jetpack_AI_Sidebar {
 	 * @return array
 	 */
 	private static function get_agents_manager_data_fields(): array {
+		if ( ! self::should_expose_provider() ) {
+			return array();
+		}
+
 		if ( self::should_expose_sidebar() ) {
 			return self::get_sidebar_am_fields();
 		}
 
-		if ( self::should_expose_provider() ) {
-			return self::get_provider_am_fields();
-		}
-
-		return array();
+		return self::get_provider_am_fields();
 	}
 
 	/**
@@ -651,8 +648,9 @@ class Jetpack_AI_Sidebar {
 
 		$assignments = '';
 		foreach ( $fields as $key => $value ) {
-			$assignments .= ' agentsManagerData.' . $key . ' = '
-				. wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
+			$assignment_value = wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+
+			$assignments .= ' agentsManagerData.' . $key . ' = ' . $assignment_value . ';';
 		}
 
 		if ( self::get_ai_sidebar_asset_data() ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -595,9 +595,7 @@ class Jetpack_AI_Sidebar {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::should_expose_provider() ) {
-			return;
-		}
+
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
 		// registered handle and serializes correctly regardless of when the
 		// enqueue lands in the dependency graph.
@@ -605,14 +603,15 @@ class Jetpack_AI_Sidebar {
 			return;
 		}
 
-		// Build the assignments from the same field source as the data filter so the
-		// two emit paths cannot drift. agentId is guarded client-side because the
-		// externally emitted payload may already define the active agent.
+		// The fields getter carries the provider exposure gate.
 		$fields = self::get_agents_manager_data_fields();
 		if ( ! $fields ) {
 			return;
 		}
 
+		// Build the assignments from the same field source as the data filter so the
+		// two emit paths cannot drift. agentId is guarded client-side because the
+		// externally emitted payload may already define the active agent.
 		$assignments = '';
 		foreach ( $fields as $key => $value ) {
 			$assignment_value = wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
@@ -668,11 +667,7 @@ class Jetpack_AI_Sidebar {
 	 * @return bool
 	 */
 	private static function is_supported_provider_surface(): bool {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		if ( ! $screen instanceof \WP_Screen ) {
 			return false;
 		}
@@ -696,11 +691,7 @@ class Jetpack_AI_Sidebar {
 			return true;
 		}
 
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		return $screen instanceof \WP_Screen
 			&& 'post' === $screen->base
 			&& 'post' === $screen->post_type;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -60,9 +60,9 @@ class Jetpack_AI_Sidebar {
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
 		// Ask the Agents Manager package to mount on Jetpack AI provider surfaces.
-		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
+		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_on_provider_surfaces' ) );
 
-		// Enqueue the IIFE bundle in the preview post editor — it registers
+		// Enqueue the IIFE bundle on supported editor surfaces — it registers
 		// Jetpack AI abilities via @wordpress/abilities, which Big Sky or the
 		// Agents Manager can discover regardless of which provider system is active.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_abilities_script' ), 201 );
@@ -428,22 +428,12 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Whether the sidebar surface should be exposed for this request.
-	 *
-	 * @return bool
-	 */
-	private static function should_expose_sidebar(): bool {
-		return self::is_post_editor() && self::should_expose_provider();
-	}
-
-	/**
 	 * Whether the Jetpack AI provider bundle should be exposed for this request.
 	 *
-	 * This is intentionally broader than the sidebar data gate: page/site editor
-	 * can consume Jetpack AI tools through another host/agent, without Jetpack AI
-	 * setting the active Agents Manager agent ID. It still stays scoped to the same
-	 * internal rollout gate as Generate Feedback: preview enabled, internal
-	 * testing environment, and AI features available.
+	 * This is scoped to the supported editor surfaces: post editor, page editor,
+	 * and site editor. It stays behind the same internal rollout gate as Generate
+	 * Feedback: preview enabled, internal testing environment, and AI features
+	 * available.
 	 *
 	 * @return bool
 	 */
@@ -503,7 +493,7 @@ class Jetpack_AI_Sidebar {
 	public static function is_toolbar_button_enabled(): bool {
 		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
 
-		return self::should_expose_sidebar()
+		return self::should_expose_provider()
 			&& true === ( $preview_config['features']['blockToolbarButton'] ?? false );
 	}
 
@@ -535,7 +525,7 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		$fields = self::get_agents_manager_data_fields();
+		$fields = self::get_agents_manager_data_fields( $data );
 		if ( ! $fields ) {
 			return $data;
 		}
@@ -551,46 +541,23 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Fields Jetpack contributes when Jetpack AI Sidebar owns the post editor.
-	 *
-	 * @return array
-	 */
-	private static function get_sidebar_am_fields(): array {
-		$fields            = self::get_provider_am_fields();
-		$fields['agentId'] = AI_SIDEBAR_AGENT_ID;
-
-		return $fields;
-	}
-
-	/**
-	 * Fields Jetpack contributes when another host owns Agents Manager.
-	 *
-	 * The page/site editor can consume Jetpack provider suggestions and tools, but
-	 * must keep the host-selected agent ID (for example Dolly).
-	 *
-	 * @return array
-	 */
-	private static function get_provider_am_fields(): array {
-		return array(
-			'jetpackAiSidebar' => self::get_jetpack_ai_sidebar_preview_config(),
-		);
-	}
-
-	/**
 	 * Fields Jetpack should add to `agentsManagerData` for the current screen.
 	 *
+	 * @param array $data Existing Agents Manager data.
 	 * @return array
 	 */
-	private static function get_agents_manager_data_fields(): array {
+	private static function get_agents_manager_data_fields( array $data = array() ): array {
 		if ( ! self::should_expose_provider() ) {
 			return array();
 		}
 
-		if ( self::should_expose_sidebar() ) {
-			return self::get_sidebar_am_fields();
+		$fields = array();
+		if ( empty( $data['agentId'] ) ) {
+			$fields['agentId'] = AI_SIDEBAR_AGENT_ID;
 		}
+		$fields['jetpackAiSidebar'] = self::get_jetpack_ai_sidebar_preview_config();
 
-		return self::get_provider_am_fields();
+		return $fields;
 	}
 
 	/**
@@ -599,7 +566,7 @@ class Jetpack_AI_Sidebar {
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
 	 */
-	public static function enable_agents_manager_in_post_editor( $enabled ): bool {
+	public static function enable_agents_manager_on_provider_surfaces( $enabled ): bool {
 		if ( $enabled ) {
 			return true;
 		}
@@ -639,7 +606,8 @@ class Jetpack_AI_Sidebar {
 		}
 
 		// Build the assignments from the same field source as the data filter so the
-		// two emit paths cannot drift.
+		// two emit paths cannot drift. agentId is guarded client-side because the
+		// externally emitted payload may already define the active agent.
 		$fields = self::get_agents_manager_data_fields();
 		if ( ! $fields ) {
 			return;
@@ -648,6 +616,11 @@ class Jetpack_AI_Sidebar {
 		$assignments = '';
 		foreach ( $fields as $key => $value ) {
 			$assignment_value = wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+
+			if ( 'agentId' === $key ) {
+				$assignments .= ' if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = ' . $assignment_value . '; }';
+				continue;
+			}
 
 			$assignments .= ' agentsManagerData.' . $key . ' = ' . $assignment_value . ';';
 		}
@@ -687,22 +660,6 @@ class Jetpack_AI_Sidebar {
 
 		$screen = get_current_screen();
 		return $screen && $screen->is_block_editor();
-	}
-
-	/**
-	 * Check if the current screen is the post block editor.
-	 *
-	 * @return bool
-	 */
-	private static function is_post_editor(): bool {
-		if ( ! self::is_block_editor() ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
-		return $screen instanceof \WP_Screen
-			&& 'post' === $screen->base
-			&& 'post' === $screen->post_type;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -92,7 +92,7 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function maybe_enqueue_abilities_script(): void {
-		if ( ! self::should_expose_sidebar() ) {
+		if ( ! self::should_expose_provider() ) {
 			return;
 		}
 
@@ -208,10 +208,10 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
-		// The provider IIFE is only enqueued in the post editor. Avoid registering
-		// the ESM wrapper on other block-editor surfaces, where AM may import it
-		// before window.__JetpackAIProvider exists.
-		if ( ! self::should_expose_sidebar() ) {
+		// The provider IIFE is enqueued on the same surfaces where the ESM
+		// wrapper is registered. Avoid registering the wrapper when AM may
+		// import it before window.__JetpackAIProvider exists.
+		if ( ! self::should_expose_provider() ) {
 			return $providers;
 		}
 
@@ -429,13 +429,31 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Whether the sidebar surface should be exposed for this request: the sidebar
-	 * gate is open, we are in the post editor, and AI features are available.
+	 * Whether the sidebar surface should be exposed for this request.
 	 *
 	 * @return bool
 	 */
 	private static function should_expose_sidebar(): bool {
-		return self::is_jetpack_ai_sidebar_preview_enabled() && self::is_post_editor() && self::has_ai_features();
+		return self::is_post_editor() && self::should_expose_provider();
+	}
+
+	/**
+	 * Whether the Jetpack AI provider bundle should be exposed for this request.
+	 *
+	 * This is intentionally broader than the sidebar data gate: page/site editor
+	 * can consume Jetpack AI tools through another host/agent, without Jetpack AI
+	 * setting the active Agents Manager agent ID. It still stays scoped to the same
+	 * internal rollout gate as Generate Feedback: preview enabled, proxied request,
+	 * Jetpack AI enabled, and AI features available.
+	 *
+	 * @return bool
+	 */
+	private static function should_expose_provider(): bool {
+		return self::is_jetpack_ai_sidebar_preview_enabled()
+			&& self::is_supported_provider_surface()
+			&& self::is_proxied_request()
+			&& self::has_ai_features()
+			&& apply_filters( 'jetpack_ai_enabled', true );
 	}
 
 	/**
@@ -519,7 +537,8 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		if ( ! self::should_expose_sidebar() ) {
+		$fields = self::get_agents_manager_data_fields();
+		if ( ! $fields ) {
 			return $data;
 		}
 
@@ -527,7 +546,7 @@ class Jetpack_AI_Sidebar {
 		// untouched so the client-side gate can drop Jetpack AI Sidebar while keeping
 		// fallbacks such as the Big Sky provider. Hosts that need intentional overrides
 		// should use the AI Editorial Review and preview filters.
-		foreach ( self::get_sidebar_am_fields() as $key => $value ) {
+		foreach ( $fields as $key => $value ) {
 			$data[ $key ] = $value;
 		}
 		return $data;
@@ -546,6 +565,49 @@ class Jetpack_AI_Sidebar {
 			'agentId'          => AI_SIDEBAR_AGENT_ID,
 			'jetpackAiSidebar' => $config,
 		);
+	}
+
+	/**
+	 * Fields Jetpack contributes when another host owns Agents Manager.
+	 *
+	 * The page/site editor can consume Jetpack provider suggestions and tools, but
+	 * must keep the host-selected agent ID (for example Dolly).
+	 *
+	 * @return array
+	 */
+	private static function get_provider_am_fields(): array {
+		return array(
+			'jetpackAiSidebar' => self::get_jetpack_ai_sidebar_preview_config(),
+		);
+	}
+
+	/**
+	 * Whether the request is proxied through WordPress.com.
+	 *
+	 * @return bool
+	 */
+	private static function is_proxied_request(): bool {
+		$is_server_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
+			&& (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) );
+
+		return $is_server_proxied || ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST );
+	}
+
+	/**
+	 * Fields Jetpack should add to `agentsManagerData` for the current screen.
+	 *
+	 * @return array
+	 */
+	private static function get_agents_manager_data_fields(): array {
+		if ( self::should_expose_sidebar() ) {
+			return self::get_sidebar_am_fields();
+		}
+
+		if ( self::should_expose_provider() ) {
+			return self::get_provider_am_fields();
+		}
+
+		return array();
 	}
 
 	/**
@@ -583,7 +645,7 @@ class Jetpack_AI_Sidebar {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::should_expose_sidebar() ) {
+		if ( ! self::should_expose_provider() ) {
 			return;
 		}
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
@@ -597,8 +659,13 @@ class Jetpack_AI_Sidebar {
 		// two emit paths cannot drift. agentProviders is left untouched so client-side
 		// gating can fall back to other providers (such as Big Sky) when Jetpack AI
 		// Sidebar is unavailable.
+		$fields = self::get_agents_manager_data_fields();
+		if ( ! $fields ) {
+			return;
+		}
+
 		$assignments = '';
-		foreach ( self::get_sidebar_am_fields() as $key => $value ) {
+		foreach ( $fields as $key => $value ) {
 			$assignments .= ' agentsManagerData.' . $key . ' = '
 				. wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 		}
@@ -638,6 +705,30 @@ class Jetpack_AI_Sidebar {
 		return $screen instanceof \WP_Screen
 			&& 'post' === $screen->base
 			&& 'post' === $screen->post_type;
+	}
+
+	/**
+	 * Check if the current screen can consume the Jetpack AI provider bundle.
+	 *
+	 * @return bool
+	 */
+	private static function is_supported_provider_surface(): bool {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen instanceof \WP_Screen ) {
+			return false;
+		}
+
+		if ( 'site-editor' === $screen->base ) {
+			return true;
+		}
+
+		return self::is_block_editor()
+			&& 'post' === $screen->base
+			&& in_array( $screen->post_type, array( 'post', 'page' ), true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -695,6 +695,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the provider remains disabled when no editor screen is available.
+	 */
+	public function test_enable_agents_manager_on_provider_surfaces_skips_without_current_screen() {
+		$GLOBALS['current_screen']      = null;
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
+	}
+
+	/**
 	 * Test that the Agents Manager block-editor gate opens in the page editor provider surface.
 	 */
 	public function test_enable_agents_manager_on_provider_surfaces_enables_page_editor_provider_surface() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -674,13 +674,24 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that the Agents Manager block-editor gate opens in the post editor.
+	 * Test that the existing Simple post editor remains available outside internal testing.
 	 */
-	public function test_enable_agents_manager_on_provider_surfaces_enables_post_editor() {
+	public function test_enable_agents_manager_on_provider_surfaces_enables_simple_post_editor_outside_internal_testing() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->simulate_wpcom_simple();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
+	}
+
+	/**
+	 * Test that newly supported editor surfaces remain limited to internal testing.
+	 */
+	public function test_enable_agents_manager_on_provider_surfaces_gates_new_surfaces_outside_internal_testing() {
+		$this->set_page_block_editor_screen();
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
+
+		$this->set_site_editor_screen();
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
@@ -804,11 +815,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A non-internal testing environment does not emit sidebar data, even if the
-	 * generic feature filter tries to enable in-development suggestions.
+	 * The public post editor keeps AI Editorial Review while in-development suggestions
+	 * remain disabled outside internal testing, even when the generic filter enables them.
 	 */
-	public function test_add_agents_manager_data_preview_features_filter_cannot_bypass_internal_testing_gate() {
+	public function test_add_agents_manager_data_keeps_aer_and_gates_in_development_features_outside_internal_testing() {
 		$this->set_block_editor_screen();
+		$this->simulate_wpcom_simple();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
@@ -823,8 +835,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertArrayNotHasKey( 'agentId', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertTrue( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['generateFeedback'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['proofreadContent'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 	}
 
 	/**
@@ -1274,10 +1291,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued outside internal testing environments.
+	 * Test that abilities script is not enqueued in the page editor outside internal testing.
 	 */
-	public function test_abilities_script_skips_outside_internal_testing_environment() {
-		$this->set_block_editor_screen();
+	public function test_abilities_script_skips_page_editor_outside_internal_testing_environment() {
+		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
@@ -1286,12 +1303,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is enqueued in the post block editor.
+	 * Test that abilities script remains enqueued in the post editor outside internal testing.
 	 */
-	public function test_abilities_script_enqueues_in_block_editor() {
+	public function test_abilities_script_enqueues_in_post_editor_outside_internal_testing() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->simulate_wpcom_simple();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
@@ -1422,10 +1439,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers outside internal testing environments.
+	 * Test that register_provider returns existing providers on new surfaces outside internal testing.
 	 */
-	public function test_register_provider_skips_outside_internal_testing_environment() {
-		$this->set_block_editor_screen();
+	public function test_register_provider_skips_page_editor_outside_internal_testing_environment() {
+		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -936,6 +936,24 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Jetpack AI Sidebar owns the post editor agent.
+	 */
+	public function test_add_agents_manager_data_overrides_existing_post_editor_agent_id() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName' => 'gutenberg',
+				'agentId'     => 'dolly',
+			)
+		);
+
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+	}
+
+	/**
 	 * Platform-emitted provider data is exposed in the Simple internal-testing
 	 * page editor without changing the agent.
 	 */
@@ -1020,6 +1038,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$inline_script = $this->get_agents_manager_inline_script();
 
+		$this->assertStringNotContainsString(
+			'if ( ! agentsManagerData.agentId )',
+			$inline_script
+		);
 		$this->assertStringContainsString(
 			'agentsManagerData.agentId = "wp-orchestrator"',
 			$inline_script
@@ -1107,6 +1129,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$inline_script = $this->get_agents_manager_inline_script();
 
+		$this->assertStringNotContainsString(
+			'if ( ! agentsManagerData.agentId )',
+			$inline_script
+		);
 		$this->assertStringContainsString(
 			'agentsManagerData.agentId = "wp-orchestrator"',
 			$inline_script

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -179,6 +179,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set the current screen to the site editor.
+	 */
+	private function set_site_editor_screen() {
+		set_current_screen( 'site-editor' );
+	}
+
+	/**
 	 * Enable the AI sidebar feature via filter.
 	 */
 	private function enable_sidebar() {
@@ -687,6 +694,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -742,10 +750,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The generic preview features filter cannot expose in-development suggestions
-	 * outside an internal testing environment.
+	 * An unproxied request does not emit sidebar data, even if the generic feature
+	 * filter tries to enable in-development suggestions.
 	 */
-	public function test_add_agents_manager_data_preview_features_filter_cannot_enable_in_development_features() {
+	public function test_add_agents_manager_data_preview_features_filter_cannot_bypass_unproxied_gate() {
 		$this->set_block_editor_screen();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
@@ -761,11 +769,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}
 
 	/**
@@ -902,6 +907,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -914,14 +920,51 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted preview data is scoped to the post editor.
+	 * Platform-emitted provider data is exposed in the Simple proxied page editor without changing the agent.
 	 */
-	public function test_add_agents_manager_data_skips_page_editor() {
+	public function test_add_agents_manager_data_adds_simple_proxied_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
+		$this->simulate_wpcom_simple();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
+	}
+
+	/**
+	 * Platform-emitted provider data is exposed in the Simple proxied site editor without changing the agent.
+	 */
+	public function test_add_agents_manager_data_adds_simple_proxied_provider_config_in_site_editor_without_overriding_agent() {
+		$this->set_site_editor_screen();
+		$this->simulate_wpcom_simple();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'site-editor' ) );
+
+		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
+	}
+
+	/**
+	 * Page editor provider data is limited to proxied requests with Jetpack AI enabled.
+	 */
+	public function test_add_agents_manager_data_gates_page_editor_provider_data() {
+		$this->set_page_block_editor_screen();
+		$this->simulate_wpcom_simple();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
+
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
 	}
 
@@ -983,10 +1026,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch is limited to the post editor.
+	 * The external AM payload patch adds Simple proxied provider config in the page editor without changing the agent.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_skips_page_editor() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_adds_simple_proxied_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
+		$this->simulate_wpcom_simple();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
@@ -997,8 +1041,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'agentsManagerData.agentId',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
-			'agentsManagerData.jetpackAiSidebar',
+		$this->assertStringContainsString(
+			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'"generateFeedback":true',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'"optimizeTitleSuggestion":true',
 			$this->get_agents_manager_inline_script()
 		);
 	}
@@ -1041,15 +1093,29 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued outside the post editor.
+	 * Test that abilities script is enqueued in the page editor.
 	 */
-	public function test_abilities_script_skips_page_editor() {
+	public function test_abilities_script_enqueues_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
-		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that abilities script is enqueued in the site editor.
+	 */
+	public function test_abilities_script_enqueues_in_site_editor() {
+		$this->set_site_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 	}
 
 	/**
@@ -1058,7 +1124,20 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_skips_when_preview_disabled() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that abilities script is not enqueued for unproxied requests.
+	 */
+	public function test_abilities_script_skips_when_unproxied() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
@@ -1071,6 +1150,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_enqueues_in_block_editor() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
@@ -1083,6 +1163,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_skips_when_ai_disabled() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_enabled', '__return_false' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
@@ -1100,6 +1181,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_adds_url() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
 
@@ -1115,6 +1197,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_provider_returns_unchanged_when_no_asset_data() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
@@ -1139,6 +1222,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_preserves_existing_providers() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$existing  = array( 'https://example.com/provider-a.mjs', 'https://example.com/provider-b.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1150,16 +1234,35 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers unchanged outside the post editor.
+	 * Test that register_provider adds the provider URL in the page editor.
 	 */
-	public function test_register_provider_skips_page_editor() {
+	public function test_register_provider_adds_url_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
 
-		$this->assertSame( $existing, $providers );
+		$this->assertCount( 2, $providers );
+		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
+	}
+
+	/**
+	 * Test that register_provider adds the provider URL in the site editor.
+	 */
+	public function test_register_provider_adds_url_in_site_editor() {
+		$this->set_site_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$existing  = array( 'https://example.com/provider-a.mjs' );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertCount( 2, $providers );
+		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
 	}
 
 	/**
@@ -1168,7 +1271,21 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_skips_when_preview_disabled() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+
+		$existing  = array( 'https://example.com/provider-a.mjs' );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertSame( $existing, $providers );
+	}
+
+	/**
+	 * Test that register_provider returns existing providers for unproxied requests.
+	 */
+	public function test_register_provider_skips_when_unproxied() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1189,6 +1306,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		}
 
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->cache_sidebar_asset_data(
 			array(
 				'version'      => 'cached-version',
@@ -1210,6 +1328,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_sidebar_asset_data_skips_enqueue_when_fetch_fails() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
@@ -1235,6 +1354,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_full_flow_with_default_enabled() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
 
@@ -1251,6 +1371,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_full_flow_injects_agents_manager_data() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		Jetpack_AI_Sidebar::init();
 
 		$data = apply_filters(

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -248,14 +248,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Whether the preview gate is open, observed through a public surface.
 	 *
 	 * Uses enable_agents_manager_in_post_editor(), which returns the preview gate
-	 * ANDed with the post-editor and AI-features checks — both satisfied by the
-	 * gate tests (set_up connects an owner; this sets the post editor screen) —
-	 * so it reflects is_jetpack_ai_sidebar_preview_enabled() without reflection.
+	 * ANDed with the post-editor, proxied-request, and AI-features checks — all
+	 * satisfied by the gate tests (set_up connects an owner; this sets the post
+	 * editor screen and proxied request) — so it reflects
+	 * is_jetpack_ai_sidebar_preview_enabled() without reflection.
 	 *
 	 * @return bool
 	 */
 	private function gate_open(): bool {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		return Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false );
 	}
 
@@ -533,6 +535,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_toolbar_button_enabled_by_preview_feature_flag() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
@@ -566,6 +569,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_toolbar_button_extension_marks_feature_available() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
@@ -639,6 +643,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_enable_agents_manager_in_post_editor_enables_post_editor() {
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
@@ -671,6 +676,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_enable_agents_manager_in_post_editor_ignores_ai_editorial_review_filter() {
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
@@ -1026,11 +1032,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch adds Simple proxied provider config in the page editor without changing the agent.
+	 * The external AM payload patch adds proxied provider config in the page editor without changing the agent.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_adds_simple_proxied_provider_config_in_page_editor_without_overriding_agent() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_adds_proxied_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
-		$this->simulate_wpcom_simple();
+		$this->simulate_wpcom_platform();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -248,9 +248,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Whether the preview gate is open, observed through a public surface.
 	 *
 	 * Uses enable_agents_manager_in_post_editor(), which returns the preview gate
-	 * ANDed with the post-editor, proxied-request, and AI-features checks — all
-	 * satisfied by the gate tests (set_up connects an owner; this sets the post
-	 * editor screen and proxied request) — so it reflects
+	 * ANDed with the post-editor, internal-testing-environment, and AI-features
+	 * checks — all satisfied by the gate tests (set_up connects an owner; this
+	 * sets the post editor screen and internal testing signal) — so it reflects
 	 * is_jetpack_ai_sidebar_preview_enabled() without reflection.
 	 *
 	 * @return bool
@@ -766,10 +766,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An unproxied request does not emit sidebar data, even if the generic feature
-	 * filter tries to enable in-development suggestions.
+	 * A non-internal testing environment does not emit sidebar data, even if the
+	 * generic feature filter tries to enable in-development suggestions.
 	 */
-	public function test_add_agents_manager_data_preview_features_filter_cannot_bypass_unproxied_gate() {
+	public function test_add_agents_manager_data_preview_features_filter_cannot_bypass_internal_testing_gate() {
 		$this->set_block_editor_screen();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
@@ -936,9 +936,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted provider data is exposed in the Simple proxied page editor without changing the agent.
+	 * Platform-emitted provider data is exposed in the Simple internal-testing
+	 * page editor without changing the agent.
 	 */
-	public function test_add_agents_manager_data_adds_simple_proxied_provider_config_in_page_editor_without_overriding_agent() {
+	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_simple();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
@@ -952,9 +953,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted provider data is exposed in the Simple proxied site editor without changing the agent.
+	 * Platform-emitted provider data is exposed in the Simple internal-testing
+	 * site editor without changing the agent.
 	 */
-	public function test_add_agents_manager_data_adds_simple_proxied_provider_config_in_site_editor_without_overriding_agent() {
+	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_site_editor_without_overriding_agent() {
 		$this->set_site_editor_screen();
 		$this->simulate_wpcom_simple();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
@@ -968,7 +970,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Page editor provider data is limited to proxied requests with Jetpack AI enabled.
+	 * Page editor provider data is limited to internal testing environments with
+	 * Jetpack AI enabled.
 	 */
 	public function test_add_agents_manager_data_gates_page_editor_provider_data() {
 		$this->set_page_block_editor_screen();
@@ -1048,9 +1051,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch adds proxied provider config in the page editor without changing the agent.
+	 * The external AM payload patch adds internal-testing provider config in the page editor without changing the agent.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_adds_proxied_provider_config_in_page_editor_without_overriding_agent() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_adds_internal_testing_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_platform();
 		$this->cache_sidebar_asset_data();
@@ -1196,9 +1199,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued for unproxied requests.
+	 * Test that abilities script is not enqueued outside internal testing environments.
 	 */
-	public function test_abilities_script_skips_when_unproxied() {
+	public function test_abilities_script_skips_outside_internal_testing_environment() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
@@ -1344,9 +1347,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers for unproxied requests.
+	 * Test that register_provider returns existing providers outside internal testing environments.
 	 */
-	public function test_register_provider_skips_when_unproxied() {
+	public function test_register_provider_skips_outside_internal_testing_environment() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -278,6 +278,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Assert that a provider URL identifies Jetpack AI Sidebar.
+	 *
+	 * @param mixed $provider Provider URL to inspect.
+	 */
+	private function assert_jetpack_provider_url( $provider ) {
+		$this->assertIsString( $provider );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $provider );
+	}
+
+	/**
 	 * Mock a CDN asset manifest response for tests that run with SCRIPT_DEBUG.
 	 *
 	 * @param string $filename Asset manifest filename.
@@ -992,6 +1002,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Simulate an external host having enqueued AM and declared upstream
 		// data with both Jetpack AI Sidebar and Big Sky providers.
@@ -1004,18 +1015,23 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
-		// agentProviders is left untouched so the Big Sky provider survives as a fallback.
-		$this->assertStringNotContainsString(
-			'agentsManagerData.agentProviders',
-			$this->get_agents_manager_inline_script()
-		);
+		$inline_script = $this->get_agents_manager_inline_script();
+
 		$this->assertStringContainsString(
 			'agentsManagerData.agentId = "wp-orchestrator"',
-			$this->get_agents_manager_inline_script()
+			$inline_script
 		);
 		$this->assertStringContainsString(
 			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
-			$this->get_agents_manager_inline_script()
+			$inline_script
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders = Array.isArray',
+			$inline_script
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders.push( "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" )',
+			$inline_script
 		);
 	}
 
@@ -1037,27 +1053,68 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_patch_jetpack_ai_sidebar_preview_data_adds_proxied_provider_config_in_page_editor_without_overriding_agent() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_platform();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
+		$inline_script = $this->get_agents_manager_inline_script();
+
 		$this->assertStringNotContainsString(
 			'agentsManagerData.agentId',
-			$this->get_agents_manager_inline_script()
+			$inline_script
 		);
 		$this->assertStringContainsString(
 			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
-			$this->get_agents_manager_inline_script()
+			$inline_script
 		);
 		$this->assertStringContainsString(
 			'"generateFeedback":true',
-			$this->get_agents_manager_inline_script()
+			$inline_script
 		);
 		$this->assertStringContainsString(
 			'"optimizeTitleSuggestion":true',
-			$this->get_agents_manager_inline_script()
+			$inline_script
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders.push( "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" )',
+			$inline_script
+		);
+	}
+
+	/**
+	 * The external AM payload patch still sets fields when the provider URL is unavailable.
+	 */
+	public function test_patch_jetpack_ai_sidebar_preview_data_skips_provider_url_when_asset_data_fails() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'blocked', 'No HTTP.' );
+			}
+		);
+		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
+
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
+
+		$inline_script = $this->get_agents_manager_inline_script();
+
+		$this->assertStringContainsString(
+			'agentsManagerData.agentId = "wp-orchestrator"',
+			$inline_script
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.jetpackAiSidebar = {"enabled":true',
+			$inline_script
+		);
+		$this->assertStringNotContainsString(
+			'agentsManagerData.agentProviders = Array.isArray',
+			$inline_script
 		);
 	}
 
@@ -1192,7 +1249,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
 
 		$this->assertCount( 1, $providers );
-		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[0] );
+		$this->assert_jetpack_provider_url( $providers[0] );
 		// Asset enqueueing is handled by maybe_enqueue_abilities_script, not register_provider.
 		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 		$this->assertFalse( wp_style_is( 'jetpack-ai-provider', 'enqueued' ) );
@@ -1236,7 +1293,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertCount( 3, $providers );
 		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
 		$this->assertSame( 'https://example.com/provider-b.mjs', $providers[1] );
-		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[2] );
+		$this->assert_jetpack_provider_url( $providers[2] );
 	}
 
 	/**
@@ -1252,7 +1309,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $providers );
 		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
-		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
+		$this->assert_jetpack_provider_url( $providers[1] );
 	}
 
 	/**
@@ -1268,7 +1325,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $providers );
 		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
-		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
+		$this->assert_jetpack_provider_url( $providers[1] );
 	}
 
 	/**
@@ -1367,7 +1424,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$providers = apply_filters( 'agents_manager_agent_providers', array() );
 
 		$this->assertCount( 1, $providers );
-		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[0] );
+		$this->assert_jetpack_provider_url( $providers[0] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -720,12 +720,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
-		// generateFeedback, proofreadContent, optimizeTitleSuggestion, seoSuggestions and excerptSuggestion are in development: off outside testing environments.
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
+		// A8C_PROXIED_REQUEST marks an internal testing environment, which is the same gate that
+		// emits this payload at all, so the in-development Generate Feedback, Optimize Title,
+		// and Excerpt suggestions are exposed here. SEO suggestions stay off because the
+		// seo-tools module and plan gate are not satisfied in this test.
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['chatHistory'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['supportGuides'] );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -659,12 +659,23 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Agents Manager block-editor gate does not open in the page editor.
+	 * Test that the Agents Manager block-editor gate opens in the page editor provider surface.
 	 */
-	public function test_enable_agents_manager_in_post_editor_skips_page_editor() {
+	public function test_enable_agents_manager_in_post_editor_enables_page_editor_provider_surface() {
 		$this->set_page_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate opens in the site editor provider surface.
+	 */
+	public function test_enable_agents_manager_in_post_editor_enables_site_editor_provider_surface() {
+		$this->set_site_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -247,18 +247,18 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * Whether the preview gate is open, observed through a public surface.
 	 *
-	 * Uses enable_agents_manager_in_post_editor(), which returns the preview gate
-	 * ANDed with the post-editor, internal-testing-environment, and AI-features
+	 * Uses enable_agents_manager_on_provider_surfaces(), which returns the preview gate
+	 * ANDed with supported-surface, internal-testing-environment, and AI-features
 	 * checks — all satisfied by the gate tests (set_up connects an owner; this
-	 * sets the post editor screen and internal testing signal) — so it reflects
-	 * is_jetpack_ai_sidebar_preview_enabled() without reflection.
+	 * helper sets a supported editor screen and internal testing signal) — so it
+	 * reflects is_jetpack_ai_sidebar_preview_enabled() without reflection.
 	 *
 	 * @return bool
 	 */
 	private function gate_open(): bool {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		return Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false );
+		return Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false );
 	}
 
 	/**
@@ -333,8 +333,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'register_provider should be hooked by default.'
 		);
 		$this->assertNotFalse(
-			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
-			'enable_agents_manager_in_post_editor should be hooked by default.'
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should be hooked by default.'
 		);
 		$this->assertNotFalse(
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ) ),
@@ -358,8 +358,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'register_provider should not be hooked when filter is false.'
 		);
 		$this->assertFalse(
-			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
-			'enable_agents_manager_in_post_editor should not be hooked when filter is false.'
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should not be hooked when filter is false.'
 		);
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
@@ -380,8 +380,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'register_provider should not be hooked on a self-hosted site.'
 		);
 		$this->assertFalse(
-			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
-			'enable_agents_manager_in_post_editor should not be hooked on a self-hosted site.'
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should not be hooked on a self-hosted site.'
 		);
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
@@ -422,8 +422,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'add_agents_manager_data should be hooked when filter is true.'
 		);
 		$this->assertNotFalse(
-			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
-			'enable_agents_manager_in_post_editor should be hooked when filter is true.'
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should be hooked when filter is true.'
 		);
 		$this->assertNotFalse(
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
@@ -624,11 +624,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the toolbar button feature stays unavailable outside the post editor.
+	 * Test that the toolbar button feature is available in the page editor.
 	 */
-	public function test_register_toolbar_button_extension_skips_page_editor() {
+	public function test_register_toolbar_button_extension_marks_feature_available_in_page_editor() {
 		$this->set_page_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->make_legacy_block_toolbar_extensions_available();
+		$this->enable_sidebar_extension_availability_checks();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
@@ -639,7 +641,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
+	}
+
+	/**
+	 * Test that the toolbar button feature is available in the site editor.
+	 */
+	public function test_register_toolbar_button_extension_marks_feature_available_in_site_editor() {
+		$this->set_site_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->make_legacy_block_toolbar_extensions_available();
+		$this->enable_sidebar_extension_availability_checks();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockToolbarButton'] = true;
+				return $features;
+			}
+		);
+
+		Jetpack_AI_Sidebar::register_toolbar_button_extension();
+
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}
@@ -651,41 +676,41 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * Test that the Agents Manager block-editor gate opens in the post editor.
 	 */
-	public function test_enable_agents_manager_in_post_editor_enables_post_editor() {
+	public function test_enable_agents_manager_on_provider_surfaces_enables_post_editor() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
 	 * Test that the Agents Manager block-editor gate opens in the page editor provider surface.
 	 */
-	public function test_enable_agents_manager_in_post_editor_enables_page_editor_provider_surface() {
+	public function test_enable_agents_manager_on_provider_surfaces_enables_page_editor_provider_surface() {
 		$this->set_page_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
 	 * Test that the Agents Manager block-editor gate opens in the site editor provider surface.
 	 */
-	public function test_enable_agents_manager_in_post_editor_enables_site_editor_provider_surface() {
+	public function test_enable_agents_manager_on_provider_surfaces_enables_site_editor_provider_surface() {
 		$this->set_site_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
 	 * Test that the Agents Manager block-editor gate preserves existing true values.
 	 */
-	public function test_enable_agents_manager_in_post_editor_preserves_existing_true() {
+	public function test_enable_agents_manager_on_provider_surfaces_preserves_existing_true() {
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_page_block_editor_screen();
 
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( true ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( true ) );
 	}
 
 	/**
@@ -694,22 +719,22 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The preview gate is wpcom/Big Sky-based, so turning AI Editorial Review off
 	 * does not close the gate (AI Editorial Review only affects the exposed data).
 	 */
-	public function test_enable_agents_manager_in_post_editor_ignores_ai_editorial_review_filter() {
+	public function test_enable_agents_manager_on_provider_surfaces_ignores_ai_editorial_review_filter() {
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
 	 * Test that the Agents Manager block-editor gate does not open when AI features are disabled.
 	 */
-	public function test_enable_agents_manager_in_post_editor_skips_when_ai_disabled() {
+	public function test_enable_agents_manager_on_provider_surfaces_skips_when_ai_disabled() {
 		add_filter( 'jetpack_ai_enabled', '__return_false' );
 		$this->set_block_editor_screen();
 
-		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -949,9 +974,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Jetpack AI Sidebar owns the post editor agent.
+	 * Existing host agent IDs are preserved.
 	 */
-	public function test_add_agents_manager_data_overrides_existing_post_editor_agent_id() {
+	public function test_add_agents_manager_data_preserves_existing_agent_id() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
@@ -962,39 +987,58 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertSame( 'dolly', $data['agentId'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 	}
 
 	/**
 	 * Platform-emitted provider data is exposed in the Simple internal-testing
-	 * page editor without changing the agent.
+	 * page editor and sets the default agent when upstream has not selected one.
 	 */
-	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_page_editor_without_overriding_agent() {
+	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_simple();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 	}
 
 	/**
-	 * Platform-emitted provider data is exposed in the Simple internal-testing
-	 * site editor without changing the agent.
+	 * Platform-emitted page editor data keeps an existing host-selected agent.
 	 */
-	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_site_editor_without_overriding_agent() {
+	public function test_add_agents_manager_data_preserves_existing_agent_id_in_page_editor() {
+		$this->set_page_block_editor_screen();
+		$this->simulate_wpcom_simple();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName' => 'gutenberg',
+				'agentId'     => 'dolly',
+			)
+		);
+
+		$this->assertSame( 'dolly', $data['agentId'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
+	}
+
+	/**
+	 * Platform-emitted provider data is exposed in the Simple internal-testing
+	 * site editor and sets the default agent when upstream has not selected one.
+	 */
+	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_site_editor() {
 		$this->set_site_editor_screen();
 		$this->simulate_wpcom_simple();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'site-editor' ) );
 
-		$this->assertArrayNotHasKey( 'agentId', $data );
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
@@ -1051,12 +1095,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$inline_script = $this->get_agents_manager_inline_script();
 
-		$this->assertStringNotContainsString(
-			'if ( ! agentsManagerData.agentId )',
-			$inline_script
-		);
 		$this->assertStringContainsString(
-			'agentsManagerData.agentId = "wp-orchestrator"',
+			'if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$inline_script
 		);
 		$this->assertStringContainsString(
@@ -1086,22 +1126,22 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch adds internal-testing provider config in the page editor without changing the agent.
+	 * The external AM payload patch adds provider config in the page editor and guards the default agent assignment.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_adds_internal_testing_provider_config_in_page_editor_without_overriding_agent() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_adds_internal_testing_provider_config_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_platform();
 		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
-		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg", agentId: "dolly" };', 'before' );
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$inline_script = $this->get_agents_manager_inline_script();
 
-		$this->assertStringNotContainsString(
-			'agentsManagerData.agentId',
+		$this->assertStringContainsString(
+			'if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$inline_script
 		);
 		$this->assertStringContainsString(
@@ -1142,12 +1182,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$inline_script = $this->get_agents_manager_inline_script();
 
-		$this->assertStringNotContainsString(
-			'if ( ! agentsManagerData.agentId )',
-			$inline_script
-		);
 		$this->assertStringContainsString(
-			'agentsManagerData.agentId = "wp-orchestrator"',
+			'if ( ! agentsManagerData.agentId ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$inline_script
 		);
 		$this->assertStringContainsString(


### PR DESCRIPTION
Fixes #

## Proposed changes
* Allow the Jetpack AI provider bundle/data to load on supported page and site editor surfaces.
* Gate Jetpack AI provider exposure behind the same rollout checks used for the in-development sidebar suggestions: preview enabled, proxied request, Jetpack AI enabled, and AI features available.
* Keep page/site editor provider data from overriding the host-selected `agentId`.
* Add tests for proxied page/site editor provider data, unproxied skips, disabled AI skips, and provider registration/enqueue behavior.

## Related product discussion/links
* FORNO-326

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
See WPCOM PR 227219
