### PR TITLE
fix: clear stale wpcom_user_id in logged-out Write editor to prevent anon post loss

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-anon-clear-stale-user-id
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-anon-clear-stale-user-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: clear a stale wpcom_user_id from localStorage on the logged-out editor so the Publish handoff to signup no longer mistakes the visitor for a logged-in user and drops the anonymous draft.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -116,12 +116,51 @@ function clearAnonDraft() {
 	}
 }
 
+/**
+ * Remove a stale `wpcom_user_id` left in localStorage by a previous Calypso
+ * session.
+ *
+ * The anon editor only renders for logged-out visitors, so any `wpcom_user_id`
+ * persisted under this origin is stale. Calypso bootstraps "is this visitor
+ * logged in?" from that key, and the `/setup/write-on` signup flow blocks entry
+ * and bails to My Home when it thinks the visitor is already authenticated — so
+ * a stale id (e.g. a logout that didn't clear it) silently drops the anon draft
+ * handed off on Publish. Clearing it keeps the persisted auth state in sync with
+ * the real, logged-out session. See READ-574.
+ *
+ * Scoped to the single key on purpose: clearing the whole store would also wipe
+ * the `wpcom-write-anon-draft` snapshot the editor just persisted.
+ *
+ * @return {boolean} True if a stale id was present and removed.
+ */
+function clearStaleWpcomUserId() {
+	try {
+		const hadStaleId = window.localStorage.getItem( 'wpcom_user_id' ) !== null;
+		window.localStorage.removeItem( 'wpcom_user_id' );
+		return hadStaleId;
+	} catch {
+		// localStorage unavailable/blocked — nothing to clear.
+		return false;
+	}
+}
+
 // Mark the page as anonymous so style.css can hide UI that has no anon
 // equivalent (back button, more-menu, the standalone Save-draft button,
 // unsupported-content "Open in editor" buttons). Set as early as the
 // module loads so the initial render doesn't flash the hidden surfaces.
 if ( isAnon() && typeof document !== 'undefined' && document.documentElement ) {
 	document.documentElement.classList.add( 'bw-anon' );
+}
+
+// Drop a stale `wpcom_user_id` from a prior Calypso session so the Publish
+// handoff to `/setup/write-on` doesn't mistake this logged-out visitor for an
+// authenticated one and discard their draft. See READ-574.
+if ( isAnon() ) {
+	const hadStaleId = clearStaleWpcomUserId();
+	if ( hadStaleId ) {
+		window._tkq = window._tkq || [];
+		window._tkq.push( [ 'recordEvent', 'wpcom_write_editor_anon_stale_user_cleared' ] );
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes READ-574

## Proposed changes
* The anonymous (logged-out) Write editor and the Calypso `/setup/write-on` signup flow share the `wordpress.com` origin and its `localStorage`. Calypso bootstraps whether a visitor is logged in from the `wpcom_user_id` key, and the `write-on` flow blocks entry and redirects to My Home when it believes the visitor is already authenticated — so it never transfers the draft that Publish hands off.
* When a prior session's logout fails to clear `wpcom_user_id`, a genuinely logged-out visitor is treated as authenticated and their anonymous post is silently dropped.
* This PR clears the stale `wpcom_user_id` when the logged-out editor loads, so the persisted auth state matches the real (logged-out) session before the Publish handoff. The clear is scoped to that single key on purpose — clearing the whole store would also wipe the `wpcom-write-anon-draft` snapshot the editor just persisted. It is gated on the existing `isAnon()` flag, so the logged-in editor is unaffected.

## Related product discussion/links
* READ-574

## Does this pull request change what data or activity we track or use?
Yes — adds one Tracks event, `wpcom_write_editor_anon_stale_user_cleared`, fired only when a stale `wpcom_user_id` was actually found and removed on the anonymous editor. No new personal data is collected.

## Testing instructions
Because the full reproduction spans the wpcom (Atlas) anonymous route and the Calypso `/setup/write-on` flow, the end-to-end path is exercised on wordpress.com rather than a vanilla local WordPress. The editor-side behavior was verified locally by loading the served `view.js` in a real browser with the anon flag set and a seeded `localStorage`:

* With `window.wpcomWriteIsAnon = true` and a pre-seeded `wpcom_user_id`, the key is removed on load, the `wpcom-write-anon-draft` snapshot is preserved, and the `wpcom_write_editor_anon_stale_user_cleared` Tracks event fires.
* With the anon flag off (logged-in editor), `wpcom_user_id` is left untouched and no event fires.

Full-flow check on wordpress.com:
* While logged out, write a post in Write and click **Publish**; create a new account.
* Confirm you land back in the Write editor with the post intact (not on My Home).
* Log out, then repeat — even when a `wpcom_user_id` lingered in `localStorage` from the previous run, the post should survive signup.