### PR TITLE
Social: keep modernized connections modal within the content column

### DIFF
--- a/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
@@ -64,10 +64,17 @@ export const ModernManageConnectionsModal = () => {
 				 * disclosure row expands — pinning it makes the row scroll inside
 				 * the popup instead. The short confirmation view keeps its natural
 				 * height, and `full` already fills the viewport on mobile.
+				 *
+				 * Both non-`full` views also carry the admin-menu workaround so they
+				 * don't tuck under the wp-admin sidebar: `services-list` (its
+				 * horizontal half) and `menu-aware` (the confirmation view). See the
+				 * workaround section in style-modern.module.scss.
 				 */ }
 				<Dialog.Popup
 					size={ isSmall ? 'full' : 'large' }
-					className={ ! hasKeyringResult && ! isSmall ? styles[ 'services-list' ] : undefined }
+					className={
+						isSmall ? undefined : styles[ hasKeyringResult ? 'menu-aware' : 'services-list' ]
+					}
 				>
 					<Dialog.Header className={ styles[ 'modal-header' ] }>
 						<Dialog.Title>{ title }</Dialog.Title>

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
@@ -18,6 +18,80 @@
 	transform: translateX(-50%);
 }
 
+// ===== BEGIN admin-menu workaround — remove when fixed upstream =======
+// TODO (upstream): REMOVE THIS ENTIRE SECTION once the @wordpress/ui Dialog
+// is made wp-admin-aware in WordPress/gutenberg. The Dialog is viewport-fixed
+// and centers/sizes (`large` = 960px) against the whole window, ignoring
+// wp-admin's fixed admin menu — so on both Jetpack (160px sidebar) and WP.com
+// Simple (272px, body.is-nav-unification) the connections modal tucks under
+// the sidebar and overflows the viewport at narrow content widths. Until the
+// Dialog accounts for the menu itself, this section re-anchors the frame onto
+// the content column by mirroring the chassis sidebar-width matrix in
+// base-styles/admin-page-layout.scss (160 wp-admin / 272 nav-unification /
+// 36 folded / 0 off-canvas). Deleting everything between the BEGIN and END
+// markers reverts both views to the Dialog's centering; the `menu-aware`
+// class on the confirmation popup (index-modern.tsx) then becomes a no-op —
+// drop that branch too when convenient. The real fix belongs in @wordpress/ui;
+// file the issue and link it here.
+
+// Applies to both modal views: the services list (`services-list`, which also
+// gets the vertical pin above) and the post-connect confirmation
+// (`menu-aware`). `large` caps width at 960px via `max-inline-size`;
+// `max-width` is the same property, so `min()` keeps that ceiling while also
+// capping to the content column. `left: 50% + half-menu` shifts the anchor;
+// the popup's `translateX(-50%)` (explicit on `services-list`, inherited from
+// the Dialog's default transform on `menu-aware`) then centers it there.
+.services-list,
+.menu-aware {
+	--jetpack-social-admin-menu-width: 160px;
+
+	left: calc(50% + var(--jetpack-social-admin-menu-width) / 2);
+	max-width: min(960px, calc(100dvw - var(--jetpack-social-admin-menu-width) - 2 * var(--wpds-dimension-padding-2xl, 24px)));
+}
+
+// The sidebar width varies by environment and menu state; mirror the chassis
+// matrix exactly. Order matters — the ≤782px reset comes last so its `0`
+// outranks the equal-specificity folded/auto-fold rules above it.
+
+// "Collapse menu" preference narrows the sidebar to 36px at desktop widths.
+:global(body.folded) .services-list,
+:global(body.folded) .menu-aware {
+	--jetpack-social-admin-menu-width: 36px;
+}
+
+// Auto-fold (≤960px): the menu collapses to icons.
+@media screen and (max-width: 960px) {
+
+	:global(body.auto-fold) .services-list,
+	:global(body.auto-fold) .menu-aware {
+		--jetpack-social-admin-menu-width: 36px;
+	}
+}
+
+// WP.com wp-admin (`body.is-nav-unification`) renders a 272px sidebar at
+// expanded widths; `:not(.folded)` lets the collapse rule keep winning.
+@media screen and (min-width: 961px) {
+
+	:global(body.is-nav-unification:not(.folded)) .services-list,
+	:global(body.is-nav-unification:not(.folded)) .menu-aware {
+		--jetpack-social-admin-menu-width: 272px;
+	}
+}
+
+// Off-canvas (≤782px): the menu overlays content, which spans full width.
+@media screen and (max-width: 782px) {
+
+	.services-list,
+	.menu-aware,
+	:global(body.folded) .services-list,
+	:global(body.folded) .menu-aware,
+	:global(body.auto-fold) .services-list,
+	:global(body.auto-fold) .menu-aware {
+		--jetpack-social-admin-menu-width: 0px;
+	}
+}
+// ===== END admin-menu workaround =====================================
+
 // `Dialog.Content` owns the scroll, but `Dialog.Header` stays a shrinkable
 // flex child (`flex-shrink: 1`, `min-height: 32px`) even alongside it — WPDS
 // "pins" the header to the top (non-scrolling) but doesn't stop it

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
@@ -36,9 +36,11 @@
 
 // Applies to both modal views: the services list (`services-list`, which also
 // gets the vertical pin above) and the post-connect confirmation
-// (`menu-aware`). `large` caps width at 960px via `max-inline-size`;
-// `max-width` is the same property, so `min()` keeps that ceiling while also
-// capping to the content column. `left: 50% + half-menu` shifts the anchor;
+// (`menu-aware`). `large` caps width at 960px via `max-inline-size`. In
+// horizontal writing mode `max-width` and `max-inline-size` resolve to the
+// same physical constraint, so our `max-width` replaces (rather than adds
+// to) the Dialog's 960px ceiling — `min()` reinstates it while also capping
+// to the content column. `left: 50% + half-menu` shifts the anchor;
 // the popup's `translateX(-50%)` (explicit on `services-list`, inherited from
 // the Dialog's default transform on `menu-aware`) then centers it there.
 .services-list,

--- a/projects/packages/publicize/changelog/fix-social-modernized-viewport
+++ b/projects/packages/publicize/changelog/fix-social-modernized-viewport
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Social modernized dashboard (behind rsm_jetpack_ui_modernization_social): keep the connections modal within the content column so it no longer renders behind the wp-admin sidebar at some viewport widths (works on both wp-admin and WP.com nav-unification).
+
+


### PR DESCRIPTION
Fixes #

## Proposed changes

The modernized Social **connections modal** (the `*-modern` variants, behind the `rsm_jetpack_ui_modernization_social` flag) is built on the `@wordpress/ui` `Dialog`, which is viewport-fixed and centers/sizes (`large` = 960px) against the **whole window** — it has no awareness of wp-admin's fixed admin menu. As a result, at some viewport widths the modal rendered partly **behind the sidebar** and overflowed the viewport edge.

* Re-anchor and width-cap the modal frame to the **content column** by mirroring the existing chassis sidebar-width matrix in `@automattic/jetpack-base-styles/admin-page-layout` — so it's correct across environments: **160px** (Jetpack/self-hosted wp-admin), **272px** (WP.com Simple, `body.is-nav-unification`), **36px** (folded / auto-fold), **0** (off-canvas ≤782px).
  * Horizontal centering: `left: calc(50% + menu/2)`.
  * Width cap: `max-width: min(960px, content-column)` — `min()` is required because `max-width` is the same property as the Dialog's `large` 960px ceiling, so a bare override would remove it.
* Covers **both** modal views — the services list (`services-list`) and the post-connect confirmation step (`menu-aware`), via shared grouped selectors. The confirmation view keeps the Dialog's default vertical centering (it's short).
* The change is **quarantined** in a clearly-marked `BEGIN`/`END` workaround section (plus a `menu-aware` className branch) so it can be deleted wholesale once the underlying `@wordpress/ui` Dialog is made wp-admin-aware upstream. The real fix belongs in Gutenberg.

This is gated UI (the modernization flag defaults to `false`), so the changelog entry is a non-user-facing `Comment:`.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This UI is behind the modernization flag, so first enable it (e.g. in a mu-plugin or snippet):

```php
add_filter( 'rsm_jetpack_ui_modernization_social', '__return_true' );
```

1. Go to **Jetpack → Social** (`wp-admin/admin.php?page=jetpack-social`).
2. Click **Add account** to open the connections modal.
3. Resize the browser so the content column is narrower than ~960px (e.g. window width ~990px). **Before** this change the modal tucked under the wp-admin sidebar (title/labels clipped on the left) and overflowed the right edge; **after**, the modal stays fully within the content column, clears the sidebar, and stays inside the viewport.
4. Re-check across menu states: expanded sidebar (160px), **collapsed menu** (36px), **auto-fold** (≤960px viewport), and on a **WP.com Simple** site where the sidebar is 272px (`body.is-nav-unification`). The modal should clear the sidebar in every case, and stay at its `large` 960px width on wide screens.
5. **Confirmation sub-view:** verify the post-connect "Connection confirmation" step also stays within the content column. To preview it without a real OAuth connect, open the modal and run in the console:
   ```js
   wp.data.dispatch( 'jetpack-social-plugin' ).setKeyringResult( {
     ID: 1, service: 'mastodon', external_ID: 'x', external_name: 'x',
     external_display: 'Preview Account', external_profile_picture: '',
     additional_external_users: [], label: 'Mastodon', status: 'ok',
   } );
   ```
