### PR TITLE
wpcomsh: Suppress Crowdsignal Forms activation redirect on WoA

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-crowdsignal-activation-redirect
+++ b/projects/plugins/wpcomsh/changelog/fix-crowdsignal-activation-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent Crowdsignal Forms from redirecting to its settings page on WoA sites after the Atomic transfer or a managed plugin version bump.

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Crowdsignal Forms tweaks for WoA sites.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Prevent Crowdsignal Forms from hijacking wp-admin with its onboarding redirect.
+ *
+ * On activation Crowdsignal sets the `crowdsignal_forms_do_activation_redirect` option
+ * and, on the next admin_init, redirects to its settings page unless a Crowdsignal
+ * account is already connected. That connection lives in WordPress.com-managed state and
+ * isn't present in the site's options on Atomic, so the plugin's own guard misses and the
+ * redirect fires on every activation a WoA site sees: the Simple-to-Atomic transfer (which
+ * installs and activates the plugin) and every later managed version-bump reactivation.
+ * None of those should send the admin to Crowdsignal's settings page.
+ *
+ * wpcomsh only loads on Atomic, so clearing the flag here is inherently WoA-scoped. Running
+ * at priority 1 ensures the option is gone before Crowdsignal's own admin_init handler
+ * (priority 10) reads it, regardless of how the activation was triggered.
+ */
+function wpcomsh_suppress_crowdsignal_activation_redirect() {
+	if ( get_option( 'crowdsignal_forms_do_activation_redirect' ) ) {
+		delete_option( 'crowdsignal_forms_do_activation_redirect' );
+	}
+}
+add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -135,6 +135,7 @@ require_once __DIR__ . '/feature-plugins/additional-css.php';
 require_once __DIR__ . '/feature-plugins/autosave-revision.php';
 require_once __DIR__ . '/feature-plugins/blaze.php';
 require_once __DIR__ . '/feature-plugins/coblocks-mods.php';
+require_once __DIR__ . '/feature-plugins/crowdsignal.php';
 require_once __DIR__ . '/feature-plugins/full-site-editing.php';
 require_once __DIR__ . '/feature-plugins/google-fonts.php';
 require_once __DIR__ . '/feature-plugins/gutenberg-mods.php';


### PR DESCRIPTION
### Problem

On Atomic (WoA) sites, Crowdsignal Forms redirects the next wp-admin page load to its settings page when it shouldn't. The plugin arms a one-time onboarding redirect on every activation and only skips it when a Crowdsignal account is already connected, but that connection state isn't present in the site's options on Atomic — so the guard misses.

This fires in two situations a WoA site routinely hits:

- The Simple→Atomic transfer, which installs and activates the plugin.
- Every later managed version-bump reactivation.

In both cases the admin is sent to Crowdsignal's settings page instead of where they were going.

### Fix

Clear the redirect flag early on `admin_init`, before Crowdsignal's own handler reads it. wpcomsh only loads on Atomic, so this is inherently scoped to WoA sites. Mirrors the existing approach used for WooCommerce's first-run redirect.

**Scope:** this suppresses Crowdsignal's onboarding redirect for **all** activations on WoA, not only the transfer and version-bump cases. On Atomic, Crowdsignal is platform-provisioned and account connection is handled through WordPress.com rather than the plugin's own settings screen, so that redirect is never the right destination on these sites — the two flows above are simply the ones users actually hit it through. Clearing the flag at read time (rather than gating on the activation context) is deliberate: it's self-healing, so whatever arms the flag, the next admin load clears it regardless of how the activation was triggered.

This is the immediate mitigation; the durable fix belongs upstream in Crowdsignal Forms (only arm the redirect for interactive, user-initiated activations), and this can be removed once that lands.

### Testing instructions

- On a WoA site, trigger a Crowdsignal Forms reactivation (e.g. a plugin version bump) and confirm the next wp-admin page load is **not** redirected to the Crowdsignal settings page.
- Confirm normal navigation to other admin pages is unaffected.
