### PR TITLE
My Jetpack: guard SEO opt-in card with method_exists to prevent fatal

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-seo-optin-fatal
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-seo-optin-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal error when an older bundled SEO package is loaded: guard the SEO opt-in card with method_exists instead of class_exists.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -472,12 +472,11 @@ class Initializer {
 	 * @return array{showCard: bool, redirect: string}
 	 */
 	public static function get_seo_opt_in_state() {
-		// Single source of truth lives on the SEO package's public API. Guarded with
-		// class_exists because both packages ship inside the Jetpack plugin but SEO isn't a
-		// composer dependency here (and the surface is feature-flagged).
-		$seo_loaded = class_exists( 'Automattic\\Jetpack\\SEO\\Initializer' );
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- guarded by the $seo_loaded check.
-		$show_card = $seo_loaded && \Automattic\Jetpack\SEO\Initializer::is_optin_available();
+		// Guard with method_exists rather than class_exists: an older bundled SEO package can ship
+		// the Initializer class without this method, and class_exists alone would still fatal.
+		$seo_initializer = 'Automattic\Jetpack\SEO\Initializer';
+		// @phan-suppress-next-line PhanUndeclaredClassReference -- optional SEO package, guarded by method_exists.
+		$show_card = method_exists( $seo_initializer, 'is_optin_available' ) && $seo_initializer::is_optin_available();
 
 		return array(
 			'showCard' => $show_card,


### PR DESCRIPTION
Fixes SOCIAL-515

## Proposed changes

* Guard the My Jetpack SEO opt-in card against a fatal on standalone installs. `get_seo_opt_in_state()` checked `class_exists( SEO\Initializer )` and then called `::is_optin_available()`. When a standalone plugin (e.g. Social, Boost) runs alongside an *older* Jetpack — or no Jetpack at all — the loaded `SEO\Initializer` predates that method, so `class_exists()` passes but the call fatals with `Call to undefined method`.
* Switch the guard to `method_exists( SEO\Initializer, 'is_optin_available' )`, matching the existing cross-package convention in this package (e.g. `VideoPress\Initializer` usage). This is the only occurrence of the pattern in my-jetpack.

## Related product discussion/links

* SOCIAL-515
* p1782456815017909-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a JN site with Beta tester plugin active
* Enable Jetpack on the stable version - `v15.9` or `v15.9.1`
* Enable Social or Boost on bleeding edge
* Go to My Jetpack and confirm the fatal error
* Now enable Social or Boost from this branch - `fix/my-jetpack-seo-optin-fatal`
* Go to My Jetpack
* Confirm that there is no fatal error