### PR TITLE
Podcast: handle Jetpack disconnected

### DIFF
--- a/projects/packages/podcast/changelog/pods-182-handle-disconnected
+++ b/projects/packages/podcast/changelog/pods-182-handle-disconnected
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Degrade gracefully when Jetpack is installed but not connected: the free feed and setup still work, the dashboard mirrors the connected blog ID so stats address correctly on self-hosted, and the stats, episodes, and Pocket Casts surfaces show a connect prompt instead of the paid upsell or an error.
+Podcast: show a "Connect Jetpack" prompt on Stats and Episodes when the site isn't connected, instead of an upsell or an error.

--- a/projects/packages/podcast/changelog/pods-182-handle-disconnected
+++ b/projects/packages/podcast/changelog/pods-182-handle-disconnected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Degrade gracefully when Jetpack is installed but not connected: the free feed and setup still work, the dashboard mirrors the connected blog ID so stats address correctly on self-hosted, and the stats, episodes, and Pocket Casts surfaces show a connect prompt instead of the paid upsell or an error.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -143,7 +143,9 @@ class Admin_Page {
 			$data = array();
 		}
 
-		if ( ! ( new Host() )->is_wpcom_platform() && empty( $data['site']['wpcom']['blog_id'] ) ) {
+		$is_wpcom = ( new Host() )->is_wpcom_platform();
+
+		if ( ! $is_wpcom && empty( $data['site']['wpcom']['blog_id'] ) ) {
 			$blog_id = (int) Connection_Manager::get_site_id( true );
 			if ( $blog_id > 0 ) {
 				$data['site']['wpcom']['blog_id'] = $blog_id;
@@ -161,8 +163,6 @@ class Admin_Page {
 		// Self-hosted upsells the Growth plan; WordPress.com keeps Premium.
 		// `product_slug` is fed straight to the checkout URL; `plan_name` is a
 		// product name shown in the locked-preview copy (not translated).
-		$is_wpcom = ( new Host() )->is_wpcom_platform();
-
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
 			'is_connected'        => ( new Connection_Manager( 'jetpack' ) )->is_connected(),

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -142,6 +142,21 @@ class Admin_Page {
 			$data = array();
 		}
 
+		// jetpack-mu-wpcom populates `site.wpcom.blog_id` on Simple/Atomic, but it
+		// doesn't run on self-hosted. The dashboard reads that value both as the
+		// "connected" signal and to address the stats proxy, so mirror the
+		// connected blog ID here. It stays 0 while disconnected, which the SPA
+		// renders as a connect prompt rather than the paid upsell.
+		if ( ! ( new Host() )->is_wpcom_platform()
+			&& empty( $data['site']['wpcom']['blog_id'] )
+			&& class_exists( '\\Jetpack_Options' )
+		) {
+			$blog_id = (int) \Jetpack_Options::get_option( 'id' );
+			if ( $blog_id > 0 ) {
+				$data['site']['wpcom']['blog_id'] = $blog_id;
+			}
+		}
+
 		// A buyer returning from checkout carries the purchase marker; bust the
 		// cached purchases lookup so the gate re-reads `/upgrades` and unlocks
 		// the paid surfaces now instead of after the transient expires.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Podcast;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
@@ -143,15 +144,11 @@ class Admin_Page {
 		}
 
 		// jetpack-mu-wpcom populates `site.wpcom.blog_id` on Simple/Atomic, but it
-		// doesn't run on self-hosted. The dashboard reads that value both as the
-		// "connected" signal and to address the stats proxy, so mirror the
-		// connected blog ID here. It stays 0 while disconnected, which the SPA
-		// renders as a connect prompt rather than the paid upsell.
-		if ( ! ( new Host() )->is_wpcom_platform()
-			&& empty( $data['site']['wpcom']['blog_id'] )
-			&& class_exists( '\\Jetpack_Options' )
-		) {
-			$blog_id = (int) \Jetpack_Options::get_option( 'id' );
+		// doesn't run on self-hosted. The dashboard addresses the stats proxy with
+		// that value, so mirror the connected blog ID here via the canonical
+		// resolver (returns 0 while disconnected).
+		if ( ! ( new Host() )->is_wpcom_platform() && empty( $data['site']['wpcom']['blog_id'] ) ) {
+			$blog_id = (int) Connection_Manager::get_site_id( true );
 			if ( $blog_id > 0 ) {
 				$data['site']['wpcom']['blog_id'] = $blog_id;
 			}
@@ -172,6 +169,10 @@ class Admin_Page {
 
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
+			// Canonical connection check. The dashboard gates its WPCOM-proxied
+			// surfaces (stats, episodes, Pocket Casts) on this rather than
+			// inferring connection from the presence of a blog ID.
+			'is_connected'        => ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
 			// Settings only: categories rejects per_page=-1 server-side, stats is a live relay.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -143,10 +143,6 @@ class Admin_Page {
 			$data = array();
 		}
 
-		// jetpack-mu-wpcom populates `site.wpcom.blog_id` on Simple/Atomic, but it
-		// doesn't run on self-hosted. The dashboard addresses the stats proxy with
-		// that value, so mirror the connected blog ID here via the canonical
-		// resolver (returns 0 while disconnected).
 		if ( ! ( new Host() )->is_wpcom_platform() && empty( $data['site']['wpcom']['blog_id'] ) ) {
 			$blog_id = (int) Connection_Manager::get_site_id( true );
 			if ( $blog_id > 0 ) {
@@ -169,9 +165,6 @@ class Admin_Page {
 
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
-			// Canonical connection check. The dashboard gates its WPCOM-proxied
-			// surfaces (stats, episodes, Pocket Casts) on this rather than
-			// inferring connection from the presence of a blog ID.
 			'is_connected'        => ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -41,7 +41,11 @@ const ConnectPrompt = ( { variant }: { variant: ConnectPromptVariant } ) => {
 							{ description }
 						</Text>
 					</Stack>
-					<Button variant="solid" render={ <a href={ getConnectUrl() } /> }>
+					<Button
+						variant="solid"
+						className="podcast-connect-prompt__cta"
+						render={ <a href={ getConnectUrl() } /> }
+					>
 						{ __( 'Connect Jetpack', 'jetpack-podcast' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -1,14 +1,6 @@
-import {
-	Button,
-	Card,
-	CardBody,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, link } from '@wordpress/icons';
+import { Button, Card, Stack, Text } from '@wordpress/ui';
 import { getConnectUrl } from '../connection';
 import './style.scss';
 
@@ -35,24 +27,24 @@ const ConnectPrompt = ( { variant }: { variant: ConnectPromptVariant } ) => {
 	const { title, description } = COPY[ variant ];
 
 	return (
-		<Card className="podcast-connect-prompt">
-			<CardBody>
-				<VStack spacing={ 4 } alignment="center" className="podcast-connect-prompt__inner">
+		<Card.Root className="podcast-connect-prompt">
+			<Card.Content>
+				<Stack direction="column" gap="md" align="center" className="podcast-connect-prompt__inner">
 					<span className="podcast-connect-prompt__icon" aria-hidden="true">
 						<Icon icon={ link } />
 					</span>
-					<VStack spacing={ 2 } alignment="center">
+					<Stack direction="column" gap="sm" align="center">
 						<h2 className="podcast-connect-prompt__title">{ title }</h2>
-						<Text variant="muted" className="podcast-connect-prompt__description">
+						<Text variant="body-md" className="podcast-connect-prompt__description">
 							{ description }
 						</Text>
-					</VStack>
-					<Button variant="primary" href={ getConnectUrl() } __next40pxDefaultSize>
+					</Stack>
+					<Button variant="solid" render={ <a href={ getConnectUrl() } /> }>
 						{ __( 'Connect Jetpack', 'jetpack-podcast' ) }
 					</Button>
-				</VStack>
-			</CardBody>
-		</Card>
+				</Stack>
+			</Card.Content>
+		</Card.Root>
 	);
 };
 

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -1,0 +1,64 @@
+// Shown on the connection-dependent surfaces (Stats, Episodes) when the site
+// has Jetpack installed but not connected. The free podcast feed and the
+// Settings/Welcome setup work without a connection, so this replaces only the
+// paid upsell — connecting comes before any plan can be read or purchased.
+
+import {
+	Button,
+	Card,
+	CardBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, link } from '@wordpress/icons';
+import { getConnectUrl } from '../connection';
+import './style.scss';
+
+export type ConnectPromptVariant = 'stats' | 'episodes';
+
+const COPY: Record< ConnectPromptVariant, { title: string; description: string } > = {
+	stats: {
+		title: __( 'Connect Jetpack to see your podcast stats', 'jetpack-podcast' ),
+		description: __(
+			'Your podcast feed already works. Connect this site to WordPress.com to track downloads by episode, app, and country.',
+			'jetpack-podcast'
+		),
+	},
+	episodes: {
+		title: __( 'Connect Jetpack to manage your episodes', 'jetpack-podcast' ),
+		description: __(
+			'Your podcast feed already works. Connect this site to WordPress.com to manage your catalog and plays from one dashboard.',
+			'jetpack-podcast'
+		),
+	},
+};
+
+const ConnectPrompt = ( { variant }: { variant: ConnectPromptVariant } ) => {
+	const { title, description } = COPY[ variant ];
+
+	return (
+		<Card className="podcast-connect-prompt">
+			<CardBody>
+				<VStack spacing={ 4 } alignment="center" className="podcast-connect-prompt__inner">
+					<span className="podcast-connect-prompt__icon" aria-hidden="true">
+						<Icon icon={ link } />
+					</span>
+					<VStack spacing={ 2 } alignment="center">
+						<h2 className="podcast-connect-prompt__title">{ title }</h2>
+						<Text variant="muted" className="podcast-connect-prompt__description">
+							{ description }
+						</Text>
+					</VStack>
+					<Button variant="primary" href={ getConnectUrl() } __next40pxDefaultSize>
+						{ __( 'Connect Jetpack', 'jetpack-podcast' ) }
+					</Button>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default ConnectPrompt;

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -31,10 +31,12 @@ const ConnectPrompt = ( { variant }: { variant: ConnectPromptVariant } ) => {
 			<Card.Content>
 				<Stack direction="column" gap="md" align="center" className="podcast-connect-prompt__inner">
 					<span className="podcast-connect-prompt__icon" aria-hidden="true">
-						<Icon icon={ link } />
+						<Icon icon={ link } size={ 28 } />
 					</span>
 					<Stack direction="column" gap="sm" align="center">
-						<h2 className="podcast-connect-prompt__title">{ title }</h2>
+						<Text variant="heading-xl" render={ <h2 /> }>
+							{ title }
+						</Text>
 						<Text variant="body-md" className="podcast-connect-prompt__description">
 							{ description }
 						</Text>

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -1,8 +1,3 @@
-// Shown on the connection-dependent surfaces (Stats, Episodes) when the site
-// has Jetpack installed but not connected. The free podcast feed and the
-// Settings/Welcome setup work without a connection, so this replaces only the
-// paid upsell — connecting comes before any plan can be read or purchased.
-
 import {
 	Button,
 	Card,

--- a/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
@@ -1,7 +1,6 @@
 .podcast-connect-prompt {
 
 	&__inner {
-		padding: 24px 16px;
 		text-align: center;
 	}
 
@@ -14,17 +13,6 @@
 		border-radius: 50%;
 		background: var(--jp-gray-0, #f6f7f7);
 		color: var(--jp-black, #1e1e1e);
-
-		svg {
-			width: 28px;
-			height: 28px;
-		}
-	}
-
-	&__title {
-		margin: 0;
-		font-size: 20px;
-		font-weight: 500;
 	}
 
 	&__description {

--- a/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
@@ -1,0 +1,33 @@
+.podcast-connect-prompt {
+
+	&__inner {
+		padding: 24px 16px;
+		text-align: center;
+	}
+
+	&__icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 48px;
+		height: 48px;
+		border-radius: 50%;
+		background: var(--jp-gray-0, #f6f7f7);
+		color: var(--jp-black, #1e1e1e);
+
+		svg {
+			width: 28px;
+			height: 28px;
+		}
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 20px;
+		font-weight: 500;
+	}
+
+	&__description {
+		max-width: 420px;
+	}
+}

--- a/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
@@ -29,5 +29,6 @@
 
 	&__description {
 		max-width: 420px;
+		color: var(--jp-gray-50, #646970);
 	}
 }

--- a/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
@@ -19,4 +19,15 @@
 		max-width: 420px;
 		color: var(--jp-gray-50, #646970);
 	}
+
+	a#{&}__cta {
+
+		&,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--wp-ui-button-foreground-color);
+			-webkit-text-fill-color: var(--wp-ui-button-foreground-color);
+		}
+	}
 }

--- a/projects/packages/podcast/src/dashboard/connection.ts
+++ b/projects/packages/podcast/src/dashboard/connection.ts
@@ -1,0 +1,21 @@
+// Connection helpers for the podcast dashboard. The WP.com blog ID is only
+// present once the site is connected to WordPress.com (0 when installed but not
+// connected), and it's the same signal the stats/distribution proxies gate on
+// server-side — so the dashboard treats it as the connection check.
+
+import { getMyJetpackUrl, getSiteData } from '@automattic/jetpack-script-data';
+
+/**
+ * Whether the site is connected to WordPress.com.
+ *
+ * @return {boolean} True once a WP.com blog ID is present.
+ */
+export const isSiteConnected = (): boolean => Number( getSiteData()?.wpcom?.blog_id ?? 0 ) > 0;
+
+/**
+ * URL of the My Jetpack connection screen, where a disconnected site links its
+ * Jetpack account.
+ *
+ * @return {string} The connect URL.
+ */
+export const getConnectUrl = (): string => getMyJetpackUrl( '#/connection' );

--- a/projects/packages/podcast/src/dashboard/connection.ts
+++ b/projects/packages/podcast/src/dashboard/connection.ts
@@ -1,16 +1,16 @@
-// Connection helpers for the podcast dashboard. The WP.com blog ID is only
-// present once the site is connected to WordPress.com (0 when installed but not
-// connected), and it's the same signal the stats/distribution proxies gate on
-// server-side — so the dashboard treats it as the connection check.
+// Connection helpers for the podcast dashboard. `podcast.is_connected` is the
+// canonical server-side signal (Connection_Manager::is_connected()); the
+// WPCOM-proxied surfaces gate on it rather than inferring connection from the
+// blog ID (which is set at registration, before a token exists).
 
-import { getMyJetpackUrl, getSiteData } from '@automattic/jetpack-script-data';
+import { getMyJetpackUrl, getScriptData } from '@automattic/jetpack-script-data';
 
 /**
  * Whether the site is connected to WordPress.com.
  *
- * @return {boolean} True once a WP.com blog ID is present.
+ * @return {boolean} True when the site has a usable WP.com connection.
  */
-export const isSiteConnected = (): boolean => Number( getSiteData()?.wpcom?.blog_id ?? 0 ) > 0;
+export const isSiteConnected = (): boolean => getScriptData()?.podcast?.is_connected ?? false;
 
 /**
  * URL of the My Jetpack connection screen, where a disconnected site links its

--- a/projects/packages/podcast/src/dashboard/connection.ts
+++ b/projects/packages/podcast/src/dashboard/connection.ts
@@ -1,8 +1,3 @@
-// Connection helpers for the podcast dashboard. `podcast.is_connected` is the
-// canonical server-side signal (Connection_Manager::is_connected()); the
-// WPCOM-proxied surfaces gate on it rather than inferring connection from the
-// blog ID (which is set at registration, before a token exists).
-
 import { getMyJetpackUrl, getScriptData } from '@automattic/jetpack-script-data';
 
 /**

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -2,6 +2,7 @@ declare module '@automattic/jetpack-script-data' {
 	interface JetpackScriptData {
 		podcast?: {
 			has_product_access?: boolean;
+			is_connected?: boolean;
 			show_url_hosts?: Record< string, readonly string[] >;
 			show_url_max_length?: number;
 			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -64,8 +64,6 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 	const { submit, isSubmitting, result, errorMessage } = usePocketCastsSubmit();
 	const celebratedRef = useRef( false );
 
-	// Pocket Casts submits through the WordPress.com relay, so it needs a
-	// connection. Surface that up front rather than letting the request fail.
 	const connected = isSiteConnected();
 
 	// Live result wins over the persisted state until the modal is reopened.

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -17,6 +17,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
+import { getConnectUrl, isSiteConnected } from '../../../connection';
 import { usePodcastSettings } from '../../../hooks/use-podcast-settings';
 import './style.scss';
 import { extractRejectionReasons, usePocketCastsSubmit } from './use-submit';
@@ -62,6 +63,10 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 
 	const { submit, isSubmitting, result, errorMessage } = usePocketCastsSubmit();
 	const celebratedRef = useRef( false );
+
+	// Pocket Casts submits through the WordPress.com relay, so it needs a
+	// connection. Surface that up front rather than letting the request fail.
+	const connected = isSiteConnected();
 
 	// Live result wins over the persisted state until the modal is reopened.
 	const liveState = result ? liveStateFromResult( result.state ) : null;
@@ -134,6 +139,18 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 					</Text>
 				) }
 
+				{ ! connected && (
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'Connect this site to WordPress.com to submit your podcast to Pocket Casts.',
+							'jetpack-podcast'
+						) }{ ' ' }
+						<ExternalLink href={ getConnectUrl() }>
+							{ __( 'Connect Jetpack', 'jetpack-podcast' ) }
+						</ExternalLink>
+					</Notice>
+				) }
+
 				{ result?.state === 'rejected' && (
 					<Notice status="error" isDismissible={ false }>
 						{ rejectedMessage ??
@@ -162,7 +179,7 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 					iconPosition="left"
 					onClick={ handleSubmit }
 					isBusy={ isSubmitting }
-					disabled={ ! feedUrl || isSubmitting || isDone }
+					disabled={ ! connected || ! feedUrl || isSubmitting || isDone }
 					accessibleWhenDisabled
 				>
 					{ isSubmitting && ! effectiveState

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -7,10 +7,12 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordp
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Button, Tabs } from '@wordpress/ui';
+import { isSiteConnected } from './connection';
 import ErrorBoundary from './error-boundary';
 import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
 import type { TabName } from './types';
+import type { ReactNode } from 'react';
 
 const Welcome = lazy( () => import( './welcome' ) );
 const CategorySetupModal = lazy( () => import( './welcome/category-setup-modal' ) );
@@ -19,6 +21,7 @@ const EpisodesTab = lazy( () => import( './episodes' ) );
 const DistributionTab = lazy( () => import( './distribution' ) );
 const StatsTab = lazy( () => import( './stats' ) );
 const LockedPreview = lazy( () => import( './locked-preview' ) );
+const ConnectPrompt = lazy( () => import( './connect-prompt' ) );
 
 // Fail-open: a missing flag means access-granted, so a deploy race never locks
 // grandfathered users out of the Episodes tab.
@@ -29,6 +32,30 @@ const TabFallback = () => (
 		<Spinner />
 	</div>
 );
+
+// A paid surface (Stats, Episodes) gates in two steps: connect first (no plan
+// can be read or bought while disconnected), then the product-access upsell.
+// `children` is only mounted once both pass — the element is created eagerly but
+// React doesn't load its lazy chunk until it actually renders.
+const GatedTab = ( {
+	connected,
+	hasAccess,
+	variant,
+	children,
+}: {
+	connected: boolean;
+	hasAccess: boolean;
+	variant: 'stats' | 'episodes';
+	children: ReactNode;
+} ) => {
+	if ( ! connected ) {
+		return <ConnectPrompt variant={ variant } />;
+	}
+	if ( ! hasAccess ) {
+		return <LockedPreview variant={ variant } />;
+	}
+	return <>{ children }</>;
+};
 
 const VALID_TABS: readonly TabName[] = [ 'settings', 'episodes', 'distribution', 'stats' ];
 
@@ -47,6 +74,9 @@ const App = () => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const isSetUp = !! settings && settings.podcasting_category_id > 0;
 	const hasAccess = hasProductAccess();
+	// Connecting precedes any plan: a disconnected site can't read or buy one, so
+	// the connection-dependent surfaces prompt to connect rather than to upgrade.
+	const connected = isSiteConnected();
 
 	// `?tab=` owns the active tab; absent `?tab=` falls back to `defaultTab`.
 	const search = useSearch( { from: '/' as unknown as never, strict: false } ) as StageSearch;
@@ -210,7 +240,9 @@ const App = () => {
 					<div className="podcast__tab-content podcast__tab-content--xwide">
 						<ErrorBoundary>
 							<Suspense fallback={ <TabFallback /> }>
-								{ hasAccess ? <StatsTab /> : <LockedPreview variant="stats" /> }
+								<GatedTab connected={ connected } hasAccess={ hasAccess } variant="stats">
+									<StatsTab />
+								</GatedTab>
 							</Suspense>
 						</ErrorBoundary>
 					</div>
@@ -219,7 +251,9 @@ const App = () => {
 					<div className="podcast__tab-content">
 						<ErrorBoundary>
 							<Suspense fallback={ <TabFallback /> }>
-								{ hasAccess ? <EpisodesTab /> : <LockedPreview variant="episodes" /> }
+								<GatedTab connected={ connected } hasAccess={ hasAccess } variant="episodes">
+									<EpisodesTab />
+								</GatedTab>
 							</Suspense>
 						</ErrorBoundary>
 					</div>

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -33,10 +33,6 @@ const TabFallback = () => (
 	</div>
 );
 
-// A paid surface (Stats, Episodes) gates in two steps: connect first (no plan
-// can be read or bought while disconnected), then the product-access upsell.
-// `children` is only mounted once both pass — the element is created eagerly but
-// React doesn't load its lazy chunk until it actually renders.
 const GatedTab = ( {
 	connected,
 	hasAccess,
@@ -74,8 +70,6 @@ const App = () => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const isSetUp = !! settings && settings.podcasting_category_id > 0;
 	const hasAccess = hasProductAccess();
-	// Connecting precedes any plan: a disconnected site can't read or buy one, so
-	// the connection-dependent surfaces prompt to connect rather than to upgrade.
 	const connected = isSiteConnected();
 
 	// `?tab=` owns the active tab; absent `?tab=` falls back to `defaultTab`.

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -11,8 +11,10 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
 use Automattic\Jetpack\Podcast\Podcast_Gate;
 use Automattic\Jetpack\Podcast\Settings;
+use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
+use WorDBless\Options as WorDBless_Options;
 
 /**
  * @covers \Automattic\Jetpack\Podcast\Admin_Page
@@ -37,6 +39,7 @@ class Admin_Page_Test extends BaseTestCase {
 		// Drops the transient and the request-scoped memo so neither leaks into
 		// a sibling test.
 		Podcast_Gate::flush_purchases_cache();
+		WorDBless_Options::init()->clear_options();
 		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
@@ -147,6 +150,46 @@ class Admin_Page_Test extends BaseTestCase {
 			$data['podcast']['upgrade']
 		);
 		$this->assertTrue( $data['podcast']['has_product_access'] );
+	}
+
+	/**
+	 * Self-hosted connected: the connected blog ID is mirrored into
+	 * `site.wpcom.blog_id` (nothing else populates it off WordPress.com), giving
+	 * the dashboard its connection signal. Purchases are seeded empty to keep
+	 * the gate's access check hermetic.
+	 */
+	public function test_inject_script_data_sets_blog_id_when_connected_on_self_hosted() {
+		Podcast_Gate::flush_purchases_cache();
+		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, array() );
+		Jetpack_Options::update_option( 'id', 456 );
+
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertSame( 456, $data['site']['wpcom']['blog_id'] );
+	}
+
+	/**
+	 * Self-hosted disconnected: no blog ID to mirror, so the dashboard reads a
+	 * falsy value and renders a connect prompt instead of the paid upsell.
+	 */
+	public function test_inject_script_data_leaves_blog_id_unset_when_disconnected() {
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertEmpty( $data['site']['wpcom']['blog_id'] ?? null );
+	}
+
+	/**
+	 * WordPress.com platforms already get `site.wpcom.blog_id` from
+	 * jetpack-mu-wpcom, so the podcast injection must not overwrite it.
+	 */
+	public function test_inject_script_data_preserves_existing_blog_id() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$data = Admin_Page::inject_podcast_script_data(
+			array( 'site' => array( 'wpcom' => array( 'blog_id' => 789 ) ) )
+		);
+
+		$this->assertSame( 789, $data['site']['wpcom']['blog_id'] );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -160,7 +160,7 @@ class Admin_Page_Test extends BaseTestCase {
 	 * stats proxy. Purchases are seeded empty to keep the gate's access check
 	 * hermetic.
 	 */
-	public function test_inject_script_data_sets_blog_id_when_connected_on_self_hosted() {
+	public function test_inject_script_data_sets_blog_id_from_option_on_self_hosted() {
 		Podcast_Gate::flush_purchases_cache();
 		set_transient( Podcast_Gate::PURCHASES_TRANSIENT, array() );
 		Jetpack_Options::update_option( 'id', 456 );

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -40,8 +40,6 @@ class Admin_Page_Test extends BaseTestCase {
 		// Drops the transient and the request-scoped memo so neither leaks into
 		// a sibling test.
 		Podcast_Gate::flush_purchases_cache();
-		// `is_connected()` memoizes in a static; reset it so a connection state
-		// computed here doesn't leak into a sibling test.
 		( new Connection_Manager() )->reset_connection_status();
 		WorDBless_Options::init()->clear_options();
 		wp_set_current_user( 0 );

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
 use Automattic\Jetpack\Podcast\Podcast_Gate;
@@ -39,6 +40,9 @@ class Admin_Page_Test extends BaseTestCase {
 		// Drops the transient and the request-scoped memo so neither leaks into
 		// a sibling test.
 		Podcast_Gate::flush_purchases_cache();
+		// `is_connected()` memoizes in a static; reset it so a connection state
+		// computed here doesn't leak into a sibling test.
+		( new Connection_Manager() )->reset_connection_status();
 		WorDBless_Options::init()->clear_options();
 		wp_set_current_user( 0 );
 		parent::tearDown();
@@ -153,10 +157,10 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Self-hosted connected: the connected blog ID is mirrored into
-	 * `site.wpcom.blog_id` (nothing else populates it off WordPress.com), giving
-	 * the dashboard its connection signal. Purchases are seeded empty to keep
-	 * the gate's access check hermetic.
+	 * Self-hosted: the blog ID is mirrored into `site.wpcom.blog_id` (nothing
+	 * else populates it off WordPress.com) so the dashboard can address the
+	 * stats proxy. Purchases are seeded empty to keep the gate's access check
+	 * hermetic.
 	 */
 	public function test_inject_script_data_sets_blog_id_when_connected_on_self_hosted() {
 		Podcast_Gate::flush_purchases_cache();
@@ -169,12 +173,14 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Self-hosted disconnected: no blog ID to mirror, so the dashboard reads a
-	 * falsy value and renders a connect prompt instead of the paid upsell.
+	 * Self-hosted disconnected: no token, so `podcast.is_connected` is false and
+	 * there's no blog ID to mirror. The dashboard reads the falsy connection flag
+	 * and renders a connect prompt instead of the paid upsell.
 	 */
 	public function test_inject_script_data_leaves_blog_id_unset_when_disconnected() {
 		$data = Admin_Page::inject_podcast_script_data( array() );
 
+		$this->assertFalse( $data['podcast']['is_connected'] );
 		$this->assertEmpty( $data['site']['wpcom']['blog_id'] ?? null );
 	}
 

--- a/projects/plugins/jetpack/changelog/pods-182-podcast-bootstrap-without-connection
+++ b/projects/plugins/jetpack/changelog/pods-182-podcast-bootstrap-without-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: load the package outside Jetpack's connection-gated module loader so the podcast feed and dashboard keep working when the site is disconnected.

--- a/projects/plugins/jetpack/changelog/pods-182-podcast-bootstrap-without-connection
+++ b/projects/plugins/jetpack/changelog/pods-182-podcast-bootstrap-without-connection
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: bugfix
 
 Podcast: load the package outside Jetpack's connection-gated module loader so the podcast feed and dashboard keep working when the site is disconnected.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -885,14 +885,7 @@ class Jetpack {
 		Activity_Log_Init::initialize();
 		Scan_Page_Init::initialize();
 		Jetpack_SEO_Initializer::init();
-
-		// The Podcast package's feed customization and dashboard shell work without
-		// a WordPress.com connection, but Jetpack's module loader skips every module
-		// on a disconnected site (Jetpack::load_modules() bails before the loop).
-		// Bootstrap the package here — outside that loader — so the podcast feed and
-		// the "connect" prompt survive a disconnect. Self-gates on host + the
-		// `jetpack_podcast_for_the_world` filter and is idempotent, so the connected
-		// module path (modules/podcast.php) is a harmless no-op once this has run.
+		// Loaded here, outside the connection-gated module loader, so the podcast feed and dashboard survive a disconnect.
 		\Automattic\Jetpack\Podcast\Podcast::init();
 
 		/*

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -885,7 +885,6 @@ class Jetpack {
 		Activity_Log_Init::initialize();
 		Scan_Page_Init::initialize();
 		Jetpack_SEO_Initializer::init();
-		// Loaded here, outside the connection-gated module loader, so the podcast feed and dashboard survive a disconnect.
 		\Automattic\Jetpack\Podcast\Podcast::init();
 
 		/*

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -886,6 +886,15 @@ class Jetpack {
 		Scan_Page_Init::initialize();
 		Jetpack_SEO_Initializer::init();
 
+		// The Podcast package's feed customization and dashboard shell work without
+		// a WordPress.com connection, but Jetpack's module loader skips every module
+		// on a disconnected site (Jetpack::load_modules() bails before the loop).
+		// Bootstrap the package here — outside that loader — so the podcast feed and
+		// the "connect" prompt survive a disconnect. Self-gates on host + the
+		// `jetpack_podcast_for_the_world` filter and is idempotent, so the connected
+		// module path (modules/podcast.php) is a harmless no-op once this has run.
+		\Automattic\Jetpack\Podcast\Podcast::init();
+
 		/*
 		 * Initialize Boost Speed Score. It only does work on REST requests (the
 		 * dashboard speed-score endpoints) and on a few Jetpack Boost lifecycle

--- a/projects/plugins/jetpack/modules/podcast.php
+++ b/projects/plugins/jetpack/modules/podcast.php
@@ -21,4 +21,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 // The package self-gates on the `jetpack_podcast_for_the_world` filter for
 // self-hosted sites, and the module itself is only listed when that filter is
 // true (see Jetpack::filter_available_modules_podcast()).
+//
+// Jetpack::late_initialization() already calls Podcast::init() on every request
+// so the feed + dashboard load even while disconnected (the module loader skips
+// all modules on a disconnected site). This call is the idempotent no-op for the
+// connected module path; init() guards against running twice.
 Podcast::init();

--- a/projects/plugins/jetpack/modules/podcast.php
+++ b/projects/plugins/jetpack/modules/podcast.php
@@ -20,10 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // The package self-gates on the `jetpack_podcast_for_the_world` filter for
 // self-hosted sites, and the module itself is only listed when that filter is
-// true (see Jetpack::filter_available_modules_podcast()).
-//
-// Jetpack::late_initialization() already calls Podcast::init() on every request
-// so the feed + dashboard load even while disconnected (the module loader skips
-// all modules on a disconnected site). This call is the idempotent no-op for the
-// connected module path; init() guards against running twice.
+// true (see Jetpack::filter_available_modules_podcast()). Jetpack::late_initialization()
+// also calls this on every request (idempotent) so it loads while disconnected.
 Podcast::init();


### PR DESCRIPTION
Fixes PODS-182

## Proposed changes

When Jetpack is installed but **not** connected to WordPress.com, the Podcast dashboard used to either show a "buy a plan" upsell or just break — even though you can't buy a plan until you're connected. This makes it behave sensibly: it asks you to connect first.

What still works without connecting: the podcast feed itself, plus the Settings and Welcome setup screens.

What changed:

* **How we check "is this site connected?"** — added a small helper plus a server-side `is_connected` flag using Jetpack's standard connection check (`Connection_Manager::is_connected()`). The dashboard reads that one true/false instead of guessing from other data.
* **Stats & Episodes tabs** — when you're not connected they now show a friendly "Connect Jetpack" card instead of the paid upsell or an error. Once connected, the usual flow returns (connect → maybe upgrade → use it).
* **Pocket Casts submit** — submitting goes through WordPress.com, so when disconnected the modal shows a connect notice and disables the submit button instead of letting the request fail.
* **Blog ID for stats** — on self-hosted sites the dashboard needs the WordPress.com blog ID to fetch stats. We now fill that in using Jetpack's standard helper (`Connection_Manager::get_site_id()`). WordPress.com sites already have it, so they're left untouched.
* The new "Connect Jetpack" card is built with `@wordpress/ui` components (matching the rest of the dashboard shell).
* Added tests and a changelog entry.

This is behind the `jetpack_podcast_for_the_world` feature flag.

**Behavior change worth noting:** a disconnected self-hosted site that *fail-opens* the plan check previously rendered the Stats/Episodes tabs (which fail with no blog ID to address the stats proxy). It now shows the connect prompt first.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a self-hosted site with the Podcast feature flag enabled, **disconnect** Jetpack.
* Go to **Jetpack → Podcast**. Confirm the feed, Settings, and Welcome screens still work.
* Open the **Stats** and **Episodes** tabs — confirm each shows a "Connect Jetpack" card (not the paid upsell or an error).
* Open the **Pocket Casts** submit modal under Distribution — confirm the connect notice shows and the submit button is disabled.
* **Connect** Jetpack, reload, and confirm the prompts are gone and the normal upsell/paid gating returns.
