### PR TITLE
docs: add cookie-consent AGENTS.md for AI coding agents

### DIFF
--- a/projects/packages/cookie-consent/AGENTS.md
+++ b/projects/packages/cookie-consent/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this package.
+
+## Overview
+
+Jetpack Cookie Consent renders a GDPR/CCPA cookie-consent banner and opt-out
+controls on the **site front end**, built on the WordPress Interactivity API.
+There is **no wp-admin page**: the package hooks `wp_footer` /
+`wp_enqueue_scripts` and the Block Hooks API (privacy-policy + CCPA navigation
+links, CCPA opt-out button/snackbar). A CCPA opt-out page is auto-created once
+(removable). A consent-log REST controller persists consents (own table, cron,
+route at `jetpack/v4/cookie-consent/consent-log`).
+
+- Composer package: `automattic/jetpack-cookie-consent`
+- PHP namespace: `Automattic\Jetpack\CookieConsent`
+- Consumer: the **premium-analytics plugin** (`projects/plugins/premium-analytics`)
+  bundles this package and calls `Cookie_Consent::init()`.
+
+## Structure
+
+```text
+src/class-cookie-consent.php            # entry: init(), front-end hooks, Block Hooks, CCPA page
+src/class-consent-log-controller.php    # consent-log REST route + table/cron
+src/cookie-banner-content.php           # banner markup
+src/ccpa-content.php                    # CCPA opt-out markup
+src/modules/cookie-consent/             # Interactivity API front end (TS): view, styles, tracks
+```
+
+## Development
+
+```bash
+composer phpunit                        # PHP tests
+pnpm run build / pnpm run test          # front-end build (webpack) / jest
+jetpack build packages/cookie-consent
+```
+
+## Verifying on a real site
+
+This is a **front-end** feature with conditional rendering — wp-admin shows
+nothing. Make the banner appear by satisfying its render preconditions first:
+
+- The **premium-analytics plugin** active (it boots this package) **and** the
+  **WP Consent API** plugin active.
+- A **GDPR/CCPA region**, or force rendering with `?preview_cookie_consent=1`.
+
+Then load a **front-end** URL (not wp-admin) and confirm a cache **MISS**
+(response header `cache;desc=MISS`) before trusting the HTML or a screenshot —
+JN/Atomic front-end pages are page-cached and a stale HIT shows pre-edit output.
+
+## Pitfalls
+
+- No admin page — there is no `?page=jetpack-cookie-consent`.
+- The banner/modal HTML is always server-rendered once at `wp_footer` (priority
+  999); visibility is controlled client-side via Interactivity API directives
+  (`showBanner` starts `false`), so the markup is present even when hidden.
+- Front-end output is cached — verify a cache MISS before asserting any change.

--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-agents-md
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-agents-md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add AGENTS.md with guidance for AI coding agents working in this package.


### PR DESCRIPTION
Fixes #

## Proposed changes

Adds an `AGENTS.md` to the `cookie-consent` package, giving AI coding agents (and new contributors) the package-specific context they need to work on it.

**Why:** `cookie-consent` had no `AGENTS.md`, so agent-driven workflows that gate on its presence couldn't act on the package, and its verification model is non-obvious

**What it documents:**
* Overview: front-end banner/CCPA controls on the WordPress Interactivity API; no admin page; consent-log REST controller.
* Identity: composer package `automattic/jetpack-cookie-consent`, namespace `Automattic\Jetpack\CookieConsent`, consumer = the premium-analytics plugin (calls `Cookie_Consent::init()`).
* Structure, development commands, and pitfalls.
* How to verify on a real site: render preconditions (premium-analytics plugin + WP Consent API plugin active, GDPR/CCPA region or `?preview_cookie_consent=1`) and the front-end page-cache `cache;desc=MISS` guard.

Docs only — no runtime code changes.

## Related product discussion/links
* N/A — internal developer documentation for the package.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a documentation-only change; there is nothing to exercise at runtime.

* Read `projects/packages/cookie-consent/AGENTS.md`.
* Confirm the claims match the package source — front-end hooks (`wp_footer` / `wp_enqueue_scripts`, Block Hooks), the REST route `jetpack/v4/cookie-consent/consent-log`, the consumer plugin (`premium-analytics` calling `Cookie_Consent::init()`), and the verification preconditions.
* Expected: no admin page is referenced, and the documented preconditions/cache guard are accurate.
