### PR TITLE
Cookie Consent: honor Global Privacy Control (GPC) in the GDPR path

### DIFF
--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-gpc-gdpr
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-gpc-gdpr
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Cookie Consent: honor a Global Privacy Control signal as an opt-out in GDPR regions, force-denying non-essential cookies. Gated by the `gdpr_honors_gpc` config flag (default on).
+GDPR: Honor Global Privacy Control (GPC) as an opt-out signal, denying non-essential cookies (configurable via `gdpr_honors_gpc`).

--- a/projects/packages/cookie-consent/changelog/add-cookie-consent-gpc-gdpr
+++ b/projects/packages/cookie-consent/changelog/add-cookie-consent-gpc-gdpr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Cookie Consent: honor a Global Privacy Control signal as an opt-out in GDPR regions, force-denying non-essential cookies. Gated by the `gdpr_honors_gpc` config flag (default on).

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -702,7 +702,7 @@ class Cookie_Consent {
 				'cookiePolicyUrl'   => $config['cookie_policy_url'],
 				'gdprCountries'     => $config['gdpr_countries'],
 				'ccpaRegions'       => $config['ccpa_regions'],
-				'gdprHonorsGpc'     => $config['gdpr_honors_gpc'],
+				'gdprHonorsGpc'     => $config['gdpr_honors_gpc'] ?? true,
 				'showOnError'       => $config['show_on_error'],
 				'forcePreview'      => $force_preview,
 			)

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -607,6 +607,7 @@ class Cookie_Consent {
 				'delaware',
 			),
 			'show_on_error'       => true, // Show banner if geolocation fails.
+			'gdpr_honors_gpc'     => true, // Honor a Global Privacy Control signal as an opt-out in GDPR regions.
 			'event_prefix'        => 'jetpack', // Tracks event name prefix; set to 'woocommerceanalytics' for Unified Analytics continuity.
 		);
 
@@ -701,6 +702,7 @@ class Cookie_Consent {
 				'cookiePolicyUrl'   => $config['cookie_policy_url'],
 				'gdprCountries'     => $config['gdpr_countries'],
 				'ccpaRegions'       => $config['ccpa_regions'],
+				'gdprHonorsGpc'     => $config['gdpr_honors_gpc'],
 				'showOnError'       => $config['show_on_error'],
 				'forcePreview'      => $force_preview,
 			)

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
@@ -10,6 +10,9 @@ export const UNKNOWN_COUNTRY_CODE = 'UNKNOWN';
 interface Config {
 	gdprCountries: string[];
 	ccpaRegions: string[];
+	// Whether a Global Privacy Control signal force-denies non-essential cookies in GDPR
+	// regions. Conservative default (honor GPC) applies when the flag is omitted.
+	gdprHonorsGpc?: boolean;
 }
 
 interface Context {
@@ -123,9 +126,26 @@ export function handleConsentByRegion(
 ): void {
 	if ( isGdprCountry( countryCode, config ) ) {
 		// GDPR: Opt-in model - show banner for explicit consent
-		context.showBanner = true;
 		setConsentType( 'optin' );
 
+		// A Global Privacy Control signal is a clear opt-out request, so honor it as a
+		// rejection: force-deny non-essential categories and skip the banner. The shopper
+		// can still grant consent later via the "Manage Privacy Preferences" footer link.
+		// Gated by a config flag so the legal decision is a value, not a code change;
+		// the conservative default (honor GPC) applies when the flag is omitted.
+		if ( config.gdprHonorsGpc !== false && hasOptedOutViaGlobalPrivacyControl() ) {
+			context.showBanner = false;
+			saveConsentChoices(
+				{
+					analytics: false,
+					advertising: false,
+				},
+				'opt-out'
+			);
+			return;
+		}
+
+		context.showBanner = true;
 		trackPrivacyBannerView();
 		return;
 	}

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -59,6 +59,7 @@ interface StoreConfig {
 	cookiePolicyUrl: string;
 	gdprCountries: string[];
 	ccpaRegions: string[];
+	gdprHonorsGpc: boolean;
 	showOnError: boolean;
 	forcePreview: boolean;
 }

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -4,7 +4,7 @@
  * @jest-environment-options {"url": "https://shop.example.co.uk/"}
  */
 
-import { getCookie, setCookie } from '../src/modules/cookie-consent/utils';
+import { getCookie, setCookie, handleConsentByRegion } from '../src/modules/cookie-consent/utils';
 
 describe( 'setCookie', () => {
 	let writes: string[];
@@ -105,5 +105,92 @@ describe( 'getCookie', () => {
 		stubCookies( 'wp_consent_functional=; x=1' );
 
 		expect( getCookie( 'wp_consent_functional' ) ).toBeNull();
+	} );
+} );
+
+describe( 'handleConsentByRegion (GDPR + GPC)', () => {
+	const baseConfig = {
+		gdprCountries: [ 'FR' ],
+		ccpaRegions: [ 'california' ],
+		gdprHonorsGpc: true,
+	};
+
+	let consentCalls: Array< [ string, string ] >;
+	let originalGpc: PropertyDescriptor | undefined;
+
+	const setGpc = ( value: boolean | undefined ) => {
+		Object.defineProperty( window.navigator, 'globalPrivacyControl', {
+			configurable: true,
+			value,
+		} );
+	};
+
+	beforeEach( () => {
+		consentCalls = [];
+		window.wp_set_consent = ( category: string, state: string ) => {
+			consentCalls.push( [ category, state ] );
+		};
+		originalGpc = Object.getOwnPropertyDescriptor( window.navigator, 'globalPrivacyControl' );
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { wp_set_consent?: unknown } ).wp_set_consent;
+		if ( originalGpc ) {
+			Object.defineProperty( window.navigator, 'globalPrivacyControl', originalGpc );
+		} else {
+			delete ( window.navigator as unknown as { globalPrivacyControl?: unknown } )
+				.globalPrivacyControl;
+		}
+	} );
+
+	const wasDenied = ( category: string ) =>
+		consentCalls.some( ( [ cat, state ] ) => cat === category && state === 'deny' );
+
+	it( 'force-denies non-essential categories and hides the banner when GPC is present in a GDPR region', () => {
+		setGpc( true );
+		const context = { showBanner: false };
+
+		handleConsentByRegion( 'FR', '', baseConfig, context );
+
+		expect( context.showBanner ).toBe( false );
+		expect( wasDenied( 'statistics' ) ).toBe( true );
+		expect( wasDenied( 'marketing' ) ).toBe( true );
+		// Functional/required cookies are always allowed.
+		expect( consentCalls ).toContainEqual( [ 'functional', 'allow' ] );
+	} );
+
+	it( 'shows the opt-in banner when GPC is absent in a GDPR region', () => {
+		setGpc( undefined );
+		const context = { showBanner: false };
+
+		handleConsentByRegion( 'FR', '', baseConfig, context );
+
+		expect( context.showBanner ).toBe( true );
+		expect( wasDenied( 'statistics' ) ).toBe( false );
+	} );
+
+	it( 'ignores GPC in a GDPR region when honoring is disabled by config', () => {
+		setGpc( true );
+		const context = { showBanner: false };
+
+		handleConsentByRegion( 'FR', '', { ...baseConfig, gdprHonorsGpc: false }, context );
+
+		expect( context.showBanner ).toBe( true );
+		expect( wasDenied( 'statistics' ) ).toBe( false );
+	} );
+
+	it( 'honors GPC by default when the config flag is omitted', () => {
+		setGpc( true );
+		const context = { showBanner: false };
+
+		handleConsentByRegion(
+			'FR',
+			'',
+			{ gdprCountries: [ 'FR' ], ccpaRegions: [ 'california' ] },
+			context
+		);
+
+		expect( context.showBanner ).toBe( false );
+		expect( wasDenied( 'statistics' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes # WOOA7S-1609

## Proposed changes

**Why:** `hasOptedOutViaGlobalPrivacyControl()` was only consulted on the CCPA path. In the GDPR branch of `handleConsentByRegion()` the Global Privacy Control (GPC) signal was ignored, so a GDPR visitor whose browser sends GPC was still shown the opt-in banner and had no opt-out honored. GPC is a recognized opt-out signal, so it should also force-deny non-essential cookies in GDPR regions.

**How:** Wire the existing GPC check into the GDPR branch. When GPC is present, treat it as a rejection: force-deny the non-essential categories (analytics/advertising) via the WP Consent API and skip the banner. Because this also sets the functional consent cookie, the footer "Manage Privacy Preferences" link appears, so the visitor can still grant consent later. The behavior is gated behind a `gdpr_honors_gpc` config flag (exposed to the frontend as `gdprHonorsGpc`) so the pending Product/Legal decision is a config value, not a code change. The conservative default is **on** (honor GPC), including when the flag is omitted (`!== false`).

**What:**
* `utils.ts` — `handleConsentByRegion()` GDPR branch now force-denies non-essential cookies and hides the banner when GPC is present and honoring is enabled; added `gdprHonorsGpc?` to the `Config` type.
* `view.ts` — added `gdprHonorsGpc` to `StoreConfig`.
* `class-cookie-consent.php` — added `gdpr_honors_gpc => true` to the default config (filterable via `jetpack_cookie_consent_config`) and passed it through `wp_interactivity_config`.
* `tests/utils.test.ts` — added coverage for: GPC present (deny + hide banner), GPC absent (opt-in banner shown), flag disabled (GPC ignored), flag omitted (conservative default honors GPC).

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?

Yes, in a privacy-strengthening direction. In GDPR regions, when the visitor's browser sends a GPC signal, non-essential cookies (analytics/advertising) are now force-denied and the opt-in banner is not shown — so we collect *less* in that case. No new data is collected. Gated by the `gdpr_honors_gpc` flag (default on).

## Testing instructions

* Set up the cookie consent banner (premium-analytics + WP Consent API plugin, GDPR region or `?preview_cookie_consent=1`).
* In a browser/profile that sends GPC (e.g. Firefox with "Tell websites not to sell or share my data" enabled, or a `Sec-GPC: 1`-equivalent `navigator.globalPrivacyControl === true`), visit a frontend page from a GDPR region.
  * Expected: the opt-in banner does **not** appear; `wp_consent_statistics` / `wp_consent_marketing` are set to `deny`, `wp_consent_functional` is `allow`; the footer "Manage Privacy Preferences" link is available.
* Repeat without GPC from a GDPR region.
  * Expected: the opt-in banner appears as before; no consent is auto-set.
* To verify the kill switch, add a filter setting `gdpr_honors_gpc => false` and confirm GPC is ignored (banner shown) in GDPR regions.
* Confirm the CCPA path is unchanged.
* Unit tests: `cd projects/packages/cookie-consent && pnpm test`.
