### PR TITLE
Cookie Consent: Add lifecycle cleanup APIs

### DIFF
--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -30,9 +30,11 @@ function my_plugin_uninstall() {
 `deactivate()` unschedules the daily consent-log cleanup cron while keeping the
 CCPA page, options, and consent logs intact.
 
-`uninstall()` unschedules cron, deletes the auto-created CCPA page, and clears
-the `jetpack_cookie_consent_ccpa_page_id` and
-`jetpack_cookie_consent_ccpa_page_created` options. Consent logs are retained by
+`uninstall()` unschedules cron, deletes the package-created CCPA page, and
+clears the `jetpack_cookie_consent_ccpa_page_id` and
+`jetpack_cookie_consent_ccpa_page_created` options. If the stored CCPA page ID
+points to a manually configured page or a page adopted by slug, the page is left
+intact and only the package options are cleared. Consent logs are retained by
 default because they may be compliance records. To drop the consent-log table and
 clear `jetpack_cookie_consent_consent_log_db_version`, call:
 

--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -12,6 +12,34 @@ Build the frontend module before use:
 
 `pnpm --filter @automattic/jetpack-cookie-consent build`
 
+## Lifecycle
+
+Cookie Consent is a package, not a plugin, so consumers must wire lifecycle hooks
+from their own plugin entry point:
+
+```php
+add_action( 'plugins_loaded', array( \Automattic\Jetpack\CookieConsent\Cookie_Consent::class, 'init' ) );
+register_deactivation_hook( __FILE__, array( \Automattic\Jetpack\CookieConsent\Cookie_Consent::class, 'deactivate' ) );
+
+register_uninstall_hook( __FILE__, 'my_plugin_uninstall' );
+function my_plugin_uninstall() {
+	\Automattic\Jetpack\CookieConsent\Cookie_Consent::uninstall();
+}
+```
+
+`deactivate()` unschedules the daily consent-log cleanup cron while keeping the
+CCPA page, options, and consent logs intact.
+
+`uninstall()` unschedules cron, deletes the auto-created CCPA page, and clears
+the `jetpack_cookie_consent_ccpa_page_id` and
+`jetpack_cookie_consent_ccpa_page_created` options. Consent logs are retained by
+default because they may be compliance records. To drop the consent-log table and
+clear `jetpack_cookie_consent_consent_log_db_version`, call:
+
+```php
+\Automattic\Jetpack\CookieConsent\Cookie_Consent::uninstall( true );
+```
+
 ## Configuration
 
 Filter `jetpack_cookie_consent_config` to override defaults (geo API URL, GDPR/CCPA region lists, cookie policy URL, and the Tracks `event_prefix`). The Tracks event prefix defaults to `jetpack`; set it to `woocommerceanalytics` to keep continuity with the WooCommerce/Unified Analytics Tracks stream.

--- a/projects/packages/cookie-consent/changelog/add-lifecycle-cleanup-api
+++ b/projects/packages/cookie-consent/changelog/add-lifecycle-cleanup-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Lifecycle: Add consumer-callable cleanup APIs for deactivation and uninstall.

--- a/projects/packages/cookie-consent/src/class-consent-log-controller.php
+++ b/projects/packages/cookie-consent/src/class-consent-log-controller.php
@@ -111,9 +111,47 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 *
 	 * @return string
 	 */
-	private function get_table_name() {
+	private static function get_table_name() {
 		global $wpdb;
 		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Remove scheduled events and optionally delete persisted consent logs.
+	 *
+	 * Consumers should call this from their uninstall hook. Consent logs are
+	 * retained by default because they may be compliance records; pass true only
+	 * when the consuming plugin has decided uninstall should delete them.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $delete_consent_logs Whether to drop the consent-log table.
+	 */
+	public static function uninstall( $delete_consent_logs = false ) {
+		self::deactivate();
+
+		if ( $delete_consent_logs ) {
+			self::drop_table();
+		}
+	}
+
+	/**
+	 * Remove scheduled consent-log cleanup hooks.
+	 *
+	 * Consumers should call this from their deactivation hook when they want to
+	 * stop background cleanup while retaining consent-log data.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function deactivate() {
+		self::unschedule_cleanup();
+
+		if ( null === self::$instance ) {
+			return;
+		}
+
+		remove_action( 'rest_api_init', array( self::$instance, 'register_routes' ) );
+		remove_action( self::CLEANUP_HOOK, array( self::$instance, 'cleanup_expired_logs' ) );
 	}
 
 	/**
@@ -133,7 +171,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 */
 	private function create_table() {
 		global $wpdb;
-		$table_name      = $this->get_table_name();
+		$table_name      = self::get_table_name();
 		$charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE {$table_name} (
@@ -362,7 +400,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 		);
 
 		$result = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$this->get_table_name(),
+			self::get_table_name(),
 			$data,
 			array( '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s' )
 		);
@@ -386,7 +424,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 */
 	public function get_consent_logs( WP_REST_Request $request ) {
 		global $wpdb;
-		$table_name = $this->get_table_name();
+		$table_name = self::get_table_name();
 
 		// Build WHERE clause.
 		$where  = array( '1=1' );
@@ -584,7 +622,7 @@ class Consent_Log_Controller extends WP_REST_Controller {
 		$cutoff_timestamp = time() - ( $retention_days * DAY_IN_SECONDS );
 		$cutoff_date      = gmdate( 'Y-m-d H:i:s', $cutoff_timestamp );
 
-		$table_name = $this->get_table_name();
+		$table_name = self::get_table_name();
 		$batch_size = 1000;
 
 		// Delete in batches until all expired records are removed.
@@ -619,10 +657,18 @@ class Consent_Log_Controller extends WP_REST_Controller {
 	 * Unschedule cleanup event.
 	 * This method can be called on plugin deactivation.
 	 */
-	public function unschedule_cleanup() {
-		$timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
-		if ( $timestamp ) {
-			wp_unschedule_event( $timestamp, self::CLEANUP_HOOK );
-		}
+	public static function unschedule_cleanup() {
+		wp_clear_scheduled_hook( self::CLEANUP_HOOK );
+	}
+
+	/**
+	 * Drop the consent logs table and clear its schema-version option.
+	 */
+	private static function drop_table() {
+		global $wpdb;
+		$table_name = self::get_table_name();
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+		delete_option( self::DB_VERSION_OPTION );
 	}
 }

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -28,6 +28,27 @@ class Cookie_Consent {
 	const PACKAGE_VERSION = '0.1.0-alpha';
 
 	/**
+	 * CCPA page ID option name.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_ID_OPTION = 'jetpack_cookie_consent_ccpa_page_id';
+
+	/**
+	 * CCPA page created-once option name.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_CREATED_OPTION = 'jetpack_cookie_consent_ccpa_page_created';
+
+	/**
+	 * CCPA opt-out page slug.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_SLUG = 'your-privacy-choices';
+
+	/**
 	 * Whether the class has been initialized.
 	 *
 	 * @var bool
@@ -81,6 +102,73 @@ class Cookie_Consent {
 	}
 
 	/**
+	 * Deactivate Cookie Consent runtime hooks and scheduled events.
+	 *
+	 * Consumers should call this from their plugin deactivation hook. This keeps
+	 * stored consent logs, CCPA page content, and options intact so a later
+	 * reactivation can resume without data loss.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function deactivate() {
+		remove_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+		remove_action( 'wp_footer', array( __CLASS__, 'render_banner' ), 999 );
+		remove_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );
+
+		remove_filter( 'hooked_block_types', array( __CLASS__, 'register_footer_navigation_links' ), 10 );
+		remove_filter( 'hooked_block_core/navigation-link', array( __CLASS__, 'set_footer_navigation_link_attributes' ), 10 );
+		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_ccpa_interactivity_directives' ), 10 );
+		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'maybe_suppress_privacy_policy_link' ), 10 );
+		remove_filter( 'render_block_core/navigation-link', array( __CLASS__, 'add_gdpr_manage_preferences_directives' ), 10 );
+		remove_filter( 'render_block_core/button', array( __CLASS__, 'add_ccpa_button_directive' ), 10 );
+		remove_filter( 'render_block_core/group', array( __CLASS__, 'add_ccpa_group_directives' ), 10 );
+		remove_filter( 'get_pages', array( __CLASS__, 'exclude_ccpa_from_get_pages' ), 10 );
+		remove_action( 'rest_api_init', array( __CLASS__, 'register_ccpa_page_setting' ) );
+		remove_filter( 'jetpack_boost_ignore_cookies', array( __CLASS__, 'ignore_geo_cookies_in_page_cache' ), 10 );
+
+		if ( function_exists( 'unregister_setting' ) ) {
+			unregister_setting( 'general', self::CCPA_PAGE_ID_OPTION );
+		}
+
+		Consent_Log_Controller::deactivate();
+		self::$initialized = false;
+	}
+
+	/**
+	 * Delete Cookie Consent artifacts owned by this package.
+	 *
+	 * Consumers should call this from their plugin uninstall hook. Consent logs
+	 * are retained by default because they may be compliance records; pass true
+	 * only when the consuming plugin has decided uninstall should delete them.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $delete_consent_logs Whether to drop the consent-log table.
+	 */
+	public static function uninstall( $delete_consent_logs = false ) {
+		self::deactivate();
+		self::delete_ccpa_page();
+		Consent_Log_Controller::uninstall( $delete_consent_logs );
+	}
+
+	/**
+	 * Delete the configured CCPA page and clear the CCPA options.
+	 */
+	private static function delete_ccpa_page() {
+		$page_id = (int) get_option( self::CCPA_PAGE_ID_OPTION );
+
+		if ( $page_id ) {
+			$page = get_post( $page_id );
+			if ( $page && 'page' === $page->post_type ) {
+				wp_delete_post( $page_id, true );
+			}
+		}
+
+		delete_option( self::CCPA_PAGE_ID_OPTION );
+		delete_option( self::CCPA_PAGE_CREATED_OPTION );
+	}
+
+	/**
 	 * Create the CCPA opt-out page at most once per site.
 	 *
 	 * Once the created-once flag is set, the page is never recreated — even if
@@ -89,28 +177,28 @@ class Cookie_Consent {
 	public static function maybe_create_ccpa_page() {
 		// Create the page at most once per site. Once we have created or adopted
 		// a page, never recreate it — even if the owner later deletes it.
-		if ( get_option( 'jetpack_cookie_consent_ccpa_page_created' ) ) {
+		if ( get_option( self::CCPA_PAGE_CREATED_OPTION ) ) {
 			return;
 		}
 
 		// A page already exists for the stored ID: record that and stop.
-		$page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$page_id = get_option( self::CCPA_PAGE_ID_OPTION );
 		if ( $page_id && get_post( $page_id ) ) {
-			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
+			update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
 			return;
 		}
 
 		// Stale ID (option set but post gone): clear it before trying the slug.
 		if ( $page_id && ! get_post( $page_id ) ) {
-			delete_option( 'jetpack_cookie_consent_ccpa_page_id' );
+			delete_option( self::CCPA_PAGE_ID_OPTION );
 		}
 
 		// Fallback: adopt an existing page by slug (backwards compatibility).
-		$page_slug = 'your-privacy-choices';
+		$page_slug = self::CCPA_PAGE_SLUG;
 		$page      = get_page_by_path( $page_slug );
 		if ( $page ) {
-			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page->ID );
-			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
+			update_option( self::CCPA_PAGE_ID_OPTION, $page->ID );
+			update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
 			return;
 		}
 
@@ -135,8 +223,8 @@ class Cookie_Consent {
 
 		// Store the page ID and mark as created.
 		if ( $page_id && ! is_wp_error( $page_id ) ) {
-			update_option( 'jetpack_cookie_consent_ccpa_page_id', $page_id );
-			update_option( 'jetpack_cookie_consent_ccpa_page_created', 1 );
+			update_option( self::CCPA_PAGE_ID_OPTION, $page_id );
+			update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
 		}
 	}
 
@@ -146,7 +234,7 @@ class Cookie_Consent {
 	public static function register_ccpa_page_setting() {
 		register_setting(
 			'general',
-			'jetpack_cookie_consent_ccpa_page_id',
+			self::CCPA_PAGE_ID_OPTION,
 			array(
 				'show_in_rest' => true,
 				'type'         => 'integer',
@@ -186,7 +274,7 @@ class Cookie_Consent {
 	 * @return bool
 	 */
 	private static function ccpa_page_is_published() {
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$ccpa_page_id = get_option( self::CCPA_PAGE_ID_OPTION );
 		if ( ! $ccpa_page_id ) {
 			return false;
 		}
@@ -240,7 +328,7 @@ class Cookie_Consent {
 			return $pages;
 		}
 
-		$ccpa_page_id = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$ccpa_page_id = get_option( self::CCPA_PAGE_ID_OPTION );
 
 		if ( ! $ccpa_page_id || empty( $pages ) ) {
 			return $pages;
@@ -335,7 +423,7 @@ class Cookie_Consent {
 		$privacy_policy_exists  = self::privacy_policy_is_published();
 
 		$ccpa_page_exists = self::ccpa_page_is_published();
-		$ccpa_page_id     = get_option( 'jetpack_cookie_consent_ccpa_page_id' );
+		$ccpa_page_id     = get_option( self::CCPA_PAGE_ID_OPTION );
 
 		// Process Privacy Policy first (if it exists and hasn't been processed).
 		if ( $privacy_policy_exists && ! $privacy_policy_processed ) {

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -49,6 +49,13 @@ class Cookie_Consent {
 	private const CCPA_PAGE_SLUG = 'your-privacy-choices';
 
 	/**
+	 * Post meta marker for CCPA pages created by this package.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_CREATED_META = '_jetpack_cookie_consent_created_ccpa_page';
+
+	/**
 	 * Whether the class has been initialized.
 	 *
 	 * @var bool
@@ -159,7 +166,11 @@ class Cookie_Consent {
 
 		if ( $page_id ) {
 			$page = get_post( $page_id );
-			if ( $page && 'page' === $page->post_type ) {
+			if (
+				$page
+				&& 'page' === $page->post_type
+				&& get_post_meta( $page_id, self::CCPA_PAGE_CREATED_META, true )
+			) {
 				wp_delete_post( $page_id, true );
 			}
 		}
@@ -223,6 +234,7 @@ class Cookie_Consent {
 
 		// Store the page ID and mark as created.
 		if ( $page_id && ! is_wp_error( $page_id ) ) {
+			update_post_meta( $page_id, self::CCPA_PAGE_CREATED_META, 1 );
 			update_option( self::CCPA_PAGE_ID_OPTION, $page_id );
 			update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
 		}

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -118,6 +118,12 @@ class Cookie_Consent {
 	 * @since $$next-version$$
 	 */
 	public static function deactivate() {
+		// These mirror init()'s front-end registrations and matter only when a
+		// consumer deactivates within the same request (e.g. a runtime toggle).
+		// The standard register_deactivation_hook path runs in a separate admin
+		// request where these hooks never fire, so the durable cleanup is the
+		// cron unschedule and setting unregister below. Keep this list in sync
+		// with init() whenever a hook is added there.
 		remove_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		remove_action( 'wp_footer', array( __CLASS__, 'render_banner' ), 999 );
 		remove_action( 'init', array( __CLASS__, 'maybe_create_ccpa_page' ) );

--- a/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
@@ -76,6 +76,8 @@ class Lifecycle_Test extends TestCase {
 		Cookie_Consent::deactivate();
 
 		$this->assertFalse( wp_next_scheduled( self::CLEANUP_HOOK ) );
+
+		// Idempotent: a second call must not error or drop retained artifacts.
 		Cookie_Consent::deactivate();
 
 		$this->assertSame( 123, get_option( self::CCPA_PAGE_ID_OPTION ) );
@@ -97,6 +99,8 @@ class Lifecycle_Test extends TestCase {
 		Cookie_Consent::uninstall();
 
 		$this->assertNull( get_post( $page_id ) );
+
+		// Idempotent: a second call must not error after the page is already gone.
 		Cookie_Consent::uninstall();
 
 		$this->assertFalse( get_option( self::CCPA_PAGE_ID_OPTION ) );

--- a/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for Cookie Consent lifecycle cleanup APIs.
+ *
+ * @package automattic/jetpack-cookie-consent
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for consumer-callable lifecycle cleanup.
+ *
+ * @covers \Automattic\Jetpack\CookieConsent\Cookie_Consent
+ * @covers \Automattic\Jetpack\CookieConsent\Consent_Log_Controller
+ */
+#[CoversClass( Cookie_Consent::class )]
+#[CoversClass( Consent_Log_Controller::class )]
+class Lifecycle_Test extends TestCase {
+
+	/**
+	 * The CCPA page ID option.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_ID_OPTION = 'jetpack_cookie_consent_ccpa_page_id';
+
+	/**
+	 * The CCPA page created-once option.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_CREATED_OPTION = 'jetpack_cookie_consent_ccpa_page_created';
+
+	/**
+	 * The consent-log DB version option.
+	 *
+	 * @var string
+	 */
+	private const DB_VERSION_OPTION = 'jetpack_cookie_consent_consent_log_db_version';
+
+	/**
+	 * The consent-log cleanup cron hook.
+	 *
+	 * @var string
+	 */
+	private const CLEANUP_HOOK = 'jetpack_cookie_consent_cleanup_consent_logs';
+
+	/**
+	 * Clean lifecycle hooks after each test.
+	 */
+	public function tearDown(): void {
+		Cookie_Consent::deactivate();
+		wp_clear_scheduled_hook( self::CLEANUP_HOOK );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Deactivation unschedules cleanup without deleting retained artifacts.
+	 */
+	public function test_deactivate_unschedules_cleanup_and_keeps_options() {
+		wp_schedule_event( time(), 'daily', self::CLEANUP_HOOK );
+		update_option( self::CCPA_PAGE_ID_OPTION, 123 );
+		update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
+		update_option( self::DB_VERSION_OPTION, '0.0.1' );
+
+		Cookie_Consent::deactivate();
+
+		$this->assertFalse( wp_next_scheduled( self::CLEANUP_HOOK ) );
+		Cookie_Consent::deactivate();
+
+		$this->assertSame( 123, get_option( self::CCPA_PAGE_ID_OPTION ) );
+		$this->assertSame( 1, get_option( self::CCPA_PAGE_CREATED_OPTION ) );
+		$this->assertSame( '0.0.1', get_option( self::DB_VERSION_OPTION ) );
+	}
+
+	/**
+	 * Uninstall removes the package-owned CCPA page and options.
+	 */
+	public function test_uninstall_deletes_ccpa_page_and_options() {
+		Cookie_Consent::maybe_create_ccpa_page();
+		$page_id = (int) get_option( self::CCPA_PAGE_ID_OPTION );
+
+		$this->assertGreaterThan( 0, $page_id );
+		$this->assertNotNull( get_post( $page_id ) );
+
+		Cookie_Consent::uninstall();
+
+		$this->assertNull( get_post( $page_id ) );
+		Cookie_Consent::uninstall();
+
+		$this->assertFalse( get_option( self::CCPA_PAGE_ID_OPTION ) );
+		$this->assertFalse( get_option( self::CCPA_PAGE_CREATED_OPTION ) );
+	}
+
+	/**
+	 * Uninstall keeps consent-log metadata by default.
+	 */
+	public function test_uninstall_keeps_consent_log_metadata_by_default() {
+		update_option( self::DB_VERSION_OPTION, '0.0.1' );
+
+		Cookie_Consent::uninstall();
+
+		$this->assertSame( '0.0.1', get_option( self::DB_VERSION_OPTION ) );
+	}
+
+	/**
+	 * Uninstall can opt into deleting consent-log metadata.
+	 */
+	public function test_uninstall_deletes_consent_log_metadata_when_requested() {
+		update_option( self::DB_VERSION_OPTION, '0.0.1' );
+
+		Cookie_Consent::uninstall( true );
+
+		$this->assertFalse( get_option( self::DB_VERSION_OPTION ) );
+	}
+}

--- a/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Lifecycle_Test.php
@@ -34,6 +34,13 @@ class Lifecycle_Test extends TestCase {
 	private const CCPA_PAGE_CREATED_OPTION = 'jetpack_cookie_consent_ccpa_page_created';
 
 	/**
+	 * The post meta marker for package-created CCPA pages.
+	 *
+	 * @var string
+	 */
+	private const CCPA_PAGE_CREATED_META = '_jetpack_cookie_consent_created_ccpa_page';
+
+	/**
 	 * The consent-log DB version option.
 	 *
 	 * @var string
@@ -85,12 +92,58 @@ class Lifecycle_Test extends TestCase {
 
 		$this->assertGreaterThan( 0, $page_id );
 		$this->assertNotNull( get_post( $page_id ) );
+		$this->assertSame( 1, get_post_meta( $page_id, self::CCPA_PAGE_CREATED_META, true ) );
 
 		Cookie_Consent::uninstall();
 
 		$this->assertNull( get_post( $page_id ) );
 		Cookie_Consent::uninstall();
 
+		$this->assertFalse( get_option( self::CCPA_PAGE_ID_OPTION ) );
+		$this->assertFalse( get_option( self::CCPA_PAGE_CREATED_OPTION ) );
+	}
+
+	/**
+	 * Uninstall clears options but keeps a manually configured CCPA page.
+	 */
+	public function test_uninstall_keeps_manually_configured_ccpa_page() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Manual Privacy Choices',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+		update_option( self::CCPA_PAGE_ID_OPTION, $page_id );
+
+		Cookie_Consent::uninstall();
+
+		$this->assertNotNull( get_post( $page_id ) );
+		$this->assertFalse( get_option( self::CCPA_PAGE_ID_OPTION ) );
+		$this->assertFalse( get_option( self::CCPA_PAGE_CREATED_OPTION ) );
+	}
+
+	/**
+	 * Uninstall clears options but keeps a page adopted by the CCPA slug fallback.
+	 */
+	public function test_uninstall_keeps_slug_adopted_ccpa_page() {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Your Privacy Choices',
+				'post_name'   => 'your-privacy-choices',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+
+		update_option( self::CCPA_PAGE_ID_OPTION, $page_id );
+		update_option( self::CCPA_PAGE_CREATED_OPTION, 1 );
+
+		$this->assertSame( '', get_post_meta( $page_id, self::CCPA_PAGE_CREATED_META, true ) );
+
+		Cookie_Consent::uninstall();
+
+		$this->assertNotNull( get_post( $page_id ) );
 		$this->assertFalse( get_option( self::CCPA_PAGE_ID_OPTION ) );
 		$this->assertFalse( get_option( self::CCPA_PAGE_CREATED_OPTION ) );
 	}


### PR DESCRIPTION
Fixes WOOA7S-1602

## Proposed changes
* Add `Cookie_Consent::deactivate()` and `Cookie_Consent::uninstall()` for package consumers to wire into their plugin lifecycle hooks.
* Add consent-log lifecycle cleanup helpers that unschedule cron and optionally drop the consent-log table plus DB-version option.
* Delete only package-created CCPA pages on uninstall by tracking ownership with private post meta; manually configured or slug-adopted pages are preserved while package options are cleared.
* Retain consent logs by default unless the consumer explicitly opts into dropping them.
* Document lifecycle usage and add focused PHP coverage for deactivation/uninstall cleanup behavior.

## Related product discussion/links
* Linear: WOOA7S-1602

## Does this pull request change what data or activity we track or use?
No. This adds cleanup APIs for existing Cookie Consent artifacts and does not add or change tracking events.

## Testing instructions
* `php -l projects/packages/cookie-consent/src/class-cookie-consent.php && php -l projects/packages/cookie-consent/tests/php/Lifecycle_Test.php`.
* `git diff --check`.
* Pre-commit PHP lint/PHPCS for changed PHP files.
* `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" node "$HOME/.nvm/versions/node/v24.15.0/lib/node_modules/pnpm/bin/pnpm.mjs" jetpack test php packages/cookie-consent -v` passed: 23 tests, 46 assertions.
* `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" node "$HOME/.nvm/versions/node/v24.15.0/lib/node_modules/pnpm/bin/pnpm.mjs" jetpack test js packages/cookie-consent` skipped as expected because the package has no `test-js` script.
* `pnpm jetpack phan packages/cookie-consent` was blocked locally by missing PHP `ast` extension.
* `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" node "$HOME/.nvm/versions/node/v24.15.0/lib/node_modules/pnpm/bin/pnpm.mjs" jetpack phan --allow-polyfill-parser packages/cookie-consent` ran but failed on existing package PHPUnit/stub reports.