### PR TITLE
Cookie Consent: Make consent copy configurable

### DIFF
--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -46,6 +46,20 @@ clear `jetpack_cookie_consent_consent_log_db_version`, call:
 
 Filter `jetpack_cookie_consent_config` to override defaults (geo API URL, GDPR/CCPA region lists, cookie policy URL, and the Tracks `event_prefix`). The Tracks event prefix defaults to `jetpack`; set it to `woocommerceanalytics` to keep continuity with the WooCommerce/Unified Analytics Tracks stream.
 
+User-facing banner, preferences modal, footer link, CCPA page, and CCPA snackbar strings are configured through the `copy` group. Package defaults are translated with the `jetpack-cookie-consent` text domain. Consumers that override strings should translate those overrides before returning them from the filter, using their own text domain:
+
+```php
+add_filter(
+	'jetpack_cookie_consent_config',
+	function ( $config ) {
+		$config['copy']['banner_title'] = __( 'Your privacy settings', 'my-plugin' );
+		$config['copy']['ccpa_opt_out_button'] = __( 'Do Not Sell or Share My Personal Information', 'my-plugin' );
+
+		return $config;
+	}
+);
+```
+
 ## Requirements
 
 - PHP >= 7.2

--- a/projects/packages/cookie-consent/changelog/wooa7s-1601-configurable-copy
+++ b/projects/packages/cookie-consent/changelog/wooa7s-1601-configurable-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make banner and CCPA copy configurable.

--- a/projects/packages/cookie-consent/src/ccpa-content.php
+++ b/projects/packages/cookie-consent/src/ccpa-content.php
@@ -11,11 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // $config is supplied by Cookie_Consent::get_ccpa_page_content() when this template is included.
 $config = isset( $config ) && is_array( $config ) ? $config : array();
-if ( isset( $config['copy'] ) && is_array( $config['copy'] ) ) {
-	$copy = $config['copy'];
-} else {
-	$copy = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_default_copy();
-}
+$copy   = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_copy( $config );
 ?>
 
 <!-- wp:paragraph -->

--- a/projects/packages/cookie-consent/src/ccpa-content.php
+++ b/projects/packages/cookie-consent/src/ccpa-content.php
@@ -8,34 +8,42 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+// $config is supplied by Cookie_Consent::get_ccpa_page_content() when this template is included.
+$config = isset( $config ) && is_array( $config ) ? $config : array();
+if ( isset( $config['copy'] ) && is_array( $config['copy'] ) ) {
+	$copy = $config['copy'];
+} else {
+	$copy = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_default_copy();
+}
 ?>
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'We value your privacy and want you to feel in control of your personal information. Like most websites, we use cookies and similar tools to improve your shopping experience and show you relevant ads. Sometimes we share this information with trusted partners to do so.', 'jetpack-cookie-consent' ); ?></p>
+<p><?php echo esc_html( $copy['ccpa_intro'] ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Some U.S. state laws consider this kind of data sharing a sale or sharing of personal information. Depending on where you live, you may have the right to opt out.', 'jetpack-cookie-consent' ); ?></p>
+<p><?php echo esc_html( $copy['ccpa_laws_notice'] ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading"><?php echo esc_html__( 'How to Opt Out', 'jetpack-cookie-consent' ); ?></h2>
+<h2 class="wp-block-heading"><?php echo esc_html( $copy['ccpa_heading'] ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:list -->
 <ul class="wp-block-list">
-<li><?php echo esc_html__( 'Browser Opt-Out: Click the Opt Out button below to stop your browser from sharing this data.', 'jetpack-cookie-consent' ); ?></li>
-<li><?php echo esc_html__( 'Account Opt-Out: To apply this choice to your customer account, check the box and enter your email.', 'jetpack-cookie-consent' ); ?></li>
-<li><?php echo esc_html__( 'Automatic Opt-Out: If you use a browser with Global Privacy Control (GPC) turned on, we will recognize it and respect your choice automatically.', 'jetpack-cookie-consent' ); ?></li>
+<li><?php echo esc_html( $copy['ccpa_browser_opt_out'] ); ?></li>
+<li><?php echo esc_html( $copy['ccpa_account_opt_out'] ); ?></li>
+<li><?php echo esc_html( $copy['ccpa_gpc_opt_out'] ); ?></li>
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Your preferences will only affect how we use your information for personalized ads and similar activities. It will not affect how we use your information for other purposes, like security or site functionality.', 'jetpack-cookie-consent' ); ?></p>
+<p><?php echo esc_html( $copy['ccpa_preferences_notice'] ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php echo esc_html__( 'Click the Opt Out button to stop this browser from sharing personal data.', 'jetpack-cookie-consent' ); ?></p>
+<p><?php echo esc_html( $copy['ccpa_button_instruction'] ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"lock":{"move":false,"remove":true},"className":"jetpack-cookie-consent-ccpa-opt-out-section"} -->
@@ -43,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- wp:buttons {"lock":{"move":false,"remove":true}} -->
 	<div class="wp-block-buttons">
 		<!-- wp:button {"tagName":"button","lock":{"move":false,"remove":true},"className":"jetpack-cookie-consent-ccpa-opt-out-button"} -->
-		<div class="wp-block-button jetpack-cookie-consent-ccpa-opt-out-button"><button type="button" class="wp-block-button__link wp-element-button"><?php echo esc_html__( 'Opt Out', 'jetpack-cookie-consent' ); ?></button></div>
+		<div class="wp-block-button jetpack-cookie-consent-ccpa-opt-out-button"><button type="button" class="wp-block-button__link wp-element-button"><?php echo esc_html( $copy['ccpa_opt_out_button'] ); ?></button></div>
 		<!-- /wp:button -->
 	</div>
 	<!-- /wp:buttons -->

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -221,6 +221,8 @@ class Cookie_Consent {
 
 		// Build the page content with blocks.
 		$content = self::get_ccpa_page_content();
+		$config  = self::get_config();
+		$copy    = $config['copy'];
 
 		// Create the page in a single call so the created-once flag is only set
 		// once the full page (with content) has actually persisted. A two-step
@@ -228,7 +230,7 @@ class Cookie_Consent {
 		// failed update would leave a permanently published, empty page.
 		$page_id = wp_insert_post(
 			array(
-				'post_title'     => __( 'Your Privacy Choices', 'jetpack-cookie-consent' ),
+				'post_title'     => $copy['ccpa_page_title'],
 				'post_name'      => $page_slug,
 				'post_status'    => 'publish',
 				'post_type'      => 'page',
@@ -330,6 +332,7 @@ class Cookie_Consent {
 		}
 
 		ob_start();
+		$config = self::get_config(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		include $template_path;
 		return ob_get_clean();
 	}
@@ -469,8 +472,9 @@ class Cookie_Consent {
 
 		// Process GDPR "Manage Privacy Preferences" link last.
 		if ( ! $manage_preferences_processed ) {
+			$config                            = self::get_config();
 			$hooked_block['attrs']['url']      = '#manage-preferences';
-			$hooked_block['attrs']['label']    = __( 'Manage Privacy Preferences', 'jetpack-cookie-consent' );
+			$hooked_block['attrs']['label']    = $config['copy']['manage_preferences_link'];
 			$hooked_block['attrs']['kind']     = 'custom';
 			$hooked_block['attrs']['metadata'] = array(
 				'name' => 'jetpack-cookie-consent-gdpr-manage-preferences-link',
@@ -627,6 +631,9 @@ class Cookie_Consent {
 			$block_content = $tags->get_updated_html();
 		}
 
+		$config = self::get_config();
+		$copy   = $config['copy'];
+
 		// Build the snackbar HTML.
 		$snackbar_html = sprintf(
 			'<div class="jetpack-cookie-consent-ccpa-snackbar" data-wp-bind--hidden="!state.showSnackbar">
@@ -635,8 +642,8 @@ class Cookie_Consent {
 					<button type="button" class="jetpack-cookie-consent-ccpa-snackbar__dismiss" data-wp-on--click="actions.dismissSnackbar" aria-label="%s">×</button>
 				</div>
 			</div>',
-			esc_html__( 'Your browser has been successfully opted out from sharing personal data.', 'jetpack-cookie-consent' ),
-			esc_attr__( 'Dismiss', 'jetpack-cookie-consent' )
+			esc_html( $copy['ccpa_snackbar_success'] ),
+			esc_attr( $copy['ccpa_snackbar_dismiss_label'] )
 		);
 
 		// Insert the snackbar inside the group block (before the closing </div>).
@@ -649,11 +656,84 @@ class Cookie_Consent {
 	}
 
 	/**
+	 * Get default UI copy.
+	 *
+	 * Defaults are translated in the package text domain. Consumers can override
+	 * any key through the `copy` config group and translate those overrides in
+	 * their own text domain before returning them from the config filter.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array Default copy keyed by semantic UI location.
+	 */
+	public static function get_default_copy() {
+		return array(
+			'banner_title'                     => __( 'Use of your personal data', 'jetpack-cookie-consent' ),
+			'banner_description'               => __( 'We and our partners process your personal data, such as browsing data, IP addresses, cookie information, and other unique identifiers, based on your consent and/or our legitimate interest to improve our website, marketing activities, and your user experience.', 'jetpack-cookie-consent' ),
+			'banner_accept_button'             => __( 'Accept', 'jetpack-cookie-consent' ),
+			'banner_reject_button'             => __( 'Reject', 'jetpack-cookie-consent' ),
+			'banner_customize_button'          => __( 'Customize', 'jetpack-cookie-consent' ),
+			'modal_title'                      => __( 'Customize preferences', 'jetpack-cookie-consent' ),
+			'modal_close_label'                => __( 'Close modal', 'jetpack-cookie-consent' ),
+			'modal_description'                => __( 'Your privacy is important to us. We and our partners use, store, and process your personal data to improve our website, such as by improving security or conducting analytics, marketing activities to help deliver relevant marketing or content, and your user experience, such as by remembering your account name or language settings where applicable. You can customize your cookie settings below. Learn more in our', 'jetpack-cookie-consent' ),
+			'privacy_policy_link'              => __( 'Privacy Policy', 'jetpack-cookie-consent' ),
+			'modal_links_conjunction'          => __( 'and', 'jetpack-cookie-consent' ),
+			'cookie_policy_link'               => __( 'Cookie Policy', 'jetpack-cookie-consent' ),
+			'category_toggle_label'            => __( 'Toggle category description', 'jetpack-cookie-consent' ),
+			'required_category_label'          => __( 'Required', 'jetpack-cookie-consent' ),
+			'always_active_label'              => __( 'Always active', 'jetpack-cookie-consent' ),
+			'required_category_description'    => __( 'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.', 'jetpack-cookie-consent' ),
+			'analytics_category_label'         => __( 'Analytics', 'jetpack-cookie-consent' ),
+			'analytics_category_description'   => __( 'These cookies allow us to improve performance by collecting information on how users interact with our websites.', 'jetpack-cookie-consent' ),
+			'advertising_category_label'       => __( 'Advertising', 'jetpack-cookie-consent' ),
+			'advertising_category_description' => __( 'These cookies are set by us and our advertising partners to provide you with relevant content and to understand that content\'s effectiveness.', 'jetpack-cookie-consent' ),
+			'save_preferences_button'          => __( 'Save preferences', 'jetpack-cookie-consent' ),
+			'accept_all_button'                => __( 'Accept all', 'jetpack-cookie-consent' ),
+			'reject_all_button'                => __( 'Reject all', 'jetpack-cookie-consent' ),
+			'manage_preferences_link'          => __( 'Manage Privacy Preferences', 'jetpack-cookie-consent' ),
+			'ccpa_page_title'                  => __( 'Your Privacy Choices', 'jetpack-cookie-consent' ),
+			'ccpa_intro'                       => __( 'We value your privacy and want you to feel in control of your personal information. Like most websites, we use cookies and similar tools to improve your website experience and show you relevant ads. Sometimes we share this information with trusted partners to do so.', 'jetpack-cookie-consent' ),
+			'ccpa_laws_notice'                 => __( 'Some U.S. state laws consider this kind of data sharing a sale or sharing of personal information. Depending on where you live, you may have the right to opt out.', 'jetpack-cookie-consent' ),
+			'ccpa_heading'                     => __( 'How to Opt Out', 'jetpack-cookie-consent' ),
+			'ccpa_browser_opt_out'             => __( 'Browser Opt-Out: Click the Opt Out button below to stop your browser from sharing this data.', 'jetpack-cookie-consent' ),
+			'ccpa_account_opt_out'             => __( 'Account Opt-Out: To apply this choice to your account, check the box and enter your email.', 'jetpack-cookie-consent' ),
+			'ccpa_gpc_opt_out'                 => __( 'Automatic Opt-Out: If you use a browser with Global Privacy Control (GPC) turned on, we will recognize it and respect your choice automatically.', 'jetpack-cookie-consent' ),
+			'ccpa_preferences_notice'          => __( 'Your preferences will only affect how we use your information for personalized ads and similar activities. It will not affect how we use your information for other purposes, like security or site functionality.', 'jetpack-cookie-consent' ),
+			'ccpa_button_instruction'          => __( 'Click the Opt Out button to stop this browser from sharing personal data.', 'jetpack-cookie-consent' ),
+			'ccpa_opt_out_button'              => __( 'Opt Out', 'jetpack-cookie-consent' ),
+			'ccpa_snackbar_success'            => __( 'Your browser has been successfully opted out from sharing personal data.', 'jetpack-cookie-consent' ),
+			'ccpa_snackbar_dismiss_label'      => __( 'Dismiss', 'jetpack-cookie-consent' ),
+		);
+	}
+
+	/**
+	 * Normalize configured copy by merging consumer overrides with defaults.
+	 *
+	 * @param array $copy     Copy values supplied by configuration.
+	 * @param array $defaults Default copy values.
+	 * @return array Normalized copy.
+	 */
+	private static function normalize_copy( $copy, $defaults ) {
+		if ( ! is_array( $copy ) ) {
+			return $defaults;
+		}
+
+		foreach ( $copy as $key => $value ) {
+			if ( is_string( $key ) && is_scalar( $value ) ) {
+				$defaults[ $key ] = (string) $value;
+			}
+		}
+
+		return $defaults;
+	}
+
+	/**
 	 * Get configuration with filters
 	 *
 	 * @return array Configuration array
 	 */
 	private static function get_config() {
+		$default_copy   = self::get_default_copy();
 		$default_config = array(
 			'geo_api_url'         => 'https://public-api.wordpress.com/geo/',
 			'geo_cookie_duration' => 6 * HOUR_IN_SECONDS, // 6 hours.
@@ -715,6 +795,7 @@ class Cookie_Consent {
 			'show_on_error'       => true, // Show banner if geolocation fails.
 			'gdpr_honors_gpc'     => true, // Honor a Global Privacy Control signal as an opt-out in GDPR regions.
 			'event_prefix'        => 'jetpack', // Tracks event name prefix; set to 'woocommerceanalytics' for Unified Analytics continuity.
+			'copy'                => $default_copy,
 		);
 
 		/**
@@ -722,7 +803,14 @@ class Cookie_Consent {
 		 *
 		 * @param array $config Configuration array
 		 */
-		return apply_filters( 'jetpack_cookie_consent_config', $default_config );
+		$config = apply_filters( 'jetpack_cookie_consent_config', $default_config );
+		if ( ! is_array( $config ) ) {
+			$config = $default_config;
+		}
+
+		$config['copy'] = self::normalize_copy( $config['copy'] ?? array(), $default_copy );
+
+		return $config;
 	}
 
 	/**

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -332,6 +332,7 @@ class Cookie_Consent {
 		}
 
 		ob_start();
+		// Get config for template (consumed by ccpa-content.php via include scope).
 		$config = self::get_config(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		include $template_path;
 		return ob_get_clean();
@@ -707,6 +708,24 @@ class Cookie_Consent {
 	}
 
 	/**
+	 * Resolve UI copy for a template, backfilling any missing keys with defaults.
+	 *
+	 * Templates normally receive a fully normalized `copy` group from get_config(),
+	 * but they can also be included directly (tests, Storybook). Routing through this
+	 * helper guarantees every key is present so a partial or absent `copy` array can't
+	 * cause undefined-index access.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $config Configuration array, which may lack a normalized `copy` group.
+	 * @return array Copy with every key present.
+	 */
+	public static function get_copy( $config = array() ) {
+		$copy = is_array( $config ) && isset( $config['copy'] ) ? $config['copy'] : array();
+		return self::normalize_copy( $copy, self::get_default_copy() );
+	}
+
+	/**
 	 * Normalize configured copy by merging consumer overrides with defaults.
 	 *
 	 * @param array $copy     Copy values supplied by configuration.
@@ -719,9 +738,24 @@ class Cookie_Consent {
 		}
 
 		foreach ( $copy as $key => $value ) {
-			if ( is_string( $key ) && is_scalar( $value ) ) {
-				$defaults[ $key ] = (string) $value;
+			if ( ! is_string( $key ) ) {
+				continue;
 			}
+
+			if ( is_scalar( $value ) ) {
+				$defaults[ $key ] = (string) $value;
+				continue;
+			}
+
+			// A non-scalar override can't render, so the default is kept. Surface it
+			// so an integrating developer notices the override was dropped instead of
+			// silently shipping the default copy.
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s is the copy configuration key. */
+				esc_html( sprintf( __( 'Cookie consent copy override for "%s" was ignored because it is not a scalar value.', 'jetpack-cookie-consent' ), $key ) ),
+				''
+			);
 		}
 
 		return $defaults;

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -11,11 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // $config is supplied by Cookie_Consent::render_banner() when this template is included.
 $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_policy_url' => '' );
-if ( isset( $config['copy'] ) && is_array( $config['copy'] ) ) {
-	$copy = $config['copy'];
-} else {
-	$copy = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_default_copy();
-}
+$copy   = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_copy( $config );
 ?>
 
 <div

--- a/projects/packages/cookie-consent/src/cookie-banner-content.php
+++ b/projects/packages/cookie-consent/src/cookie-banner-content.php
@@ -11,6 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // $config is supplied by Cookie_Consent::render_banner() when this template is included.
 $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_policy_url' => '' );
+if ( isset( $config['copy'] ) && is_array( $config['copy'] ) ) {
+	$copy = $config['copy'];
+} else {
+	$copy = \Automattic\Jetpack\CookieConsent\Cookie_Consent::get_default_copy();
+}
 ?>
 
 <div
@@ -40,15 +45,10 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 
 			<div class="jetpack-cookie-consent__banner-content">
 				<h2 id="cookie-consent-title" class="jetpack-cookie-consent__banner-title">
-					<?php echo esc_html__( 'Use of your personal data', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['banner_title'] ); ?>
 				</h2>
 				<p id="cookie-consent-description" class="jetpack-cookie-consent__banner-description">
-					<?php
-					echo esc_html__(
-						'We and our partners process your personal data (such as browsing data, IP Addresses, cookie information, and other unique identifiers) based on your consent and/or our legitimate interest to optimize our website, marketing activities, and your user experience.',
-						'jetpack-cookie-consent'
-					);
-					?>
+					<?php echo esc_html( $copy['banner_description'] ); ?>
 				</p>
 			</div>
 			<div class="jetpack-cookie-consent__banner-actions">
@@ -57,21 +57,21 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.acceptAll"
 				>
-					<?php echo esc_html__( 'Accept', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['banner_accept_button'] ); ?>
 				</button>
 				<button
 					type="button"
 					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.rejectAll"
 				>
-					<?php echo esc_html__( 'Reject', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['banner_reject_button'] ); ?>
 				</button>
 				<button
 					type="button"
 					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.openModal"
 				>
-					<?php echo esc_html__( 'Customize', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['banner_customize_button'] ); ?>
 				</button>
 			</div>
 		</div>
@@ -95,13 +95,13 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 	>
 		<div class="jetpack-cookie-consent__modal-header">
 			<h3 id="cookie-consent-modal-title" class="jetpack-cookie-consent__modal-title">
-				<?php echo esc_html__( 'Customize preferences', 'jetpack-cookie-consent' ); ?>
+				<?php echo esc_html( $copy['modal_title'] ); ?>
 			</h3>
 			<button
 				type="button"
 				class="jetpack-cookie-consent__modal-close"
 				data-wp-on--click="actions.closeModal"
-				aria-label="<?php echo esc_attr__( 'Close modal', 'jetpack-cookie-consent' ); ?>"
+				aria-label="<?php echo esc_attr( $copy['modal_close_label'] ); ?>"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 					<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
@@ -111,18 +111,13 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 		<div class="jetpack-cookie-consent__modal-content">
 			<div class="jetpack-cookie-consent__modal-body">
 				<p class="jetpack-cookie-consent__modal-description">
-					<?php
-					echo esc_html__(
-						'Your privacy is critically important to us. We and our partners use, store, and process your personal data to optimize our website such as by improving security or conducting analytics, marketing activities to help deliver relevant marketing or content, and your user experience such as by remembering your account name, language settings, or cart information, where applicable. You can customize your cookie settings below. Learn more in our',
-						'jetpack-cookie-consent'
-					);
-					?>
+					<?php echo esc_html( $copy['modal_description'] ); ?>
 					<a href="<?php echo esc_url( get_privacy_policy_url() ); ?>" class="jetpack-cookie-consent__link">
-						<?php echo esc_html__( 'Privacy Policy', 'jetpack-cookie-consent' ); ?>
+						<?php echo esc_html( $copy['privacy_policy_link'] ); ?>
 					</a>
-					<?php echo esc_html__( 'and', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['modal_links_conjunction'] ); ?>
 					<a href="<?php echo esc_url( $config['cookie_policy_url'] ); ?>" class="jetpack-cookie-consent__link">
-						<?php echo esc_html__( 'Cookie Policy', 'jetpack-cookie-consent' ); ?>
+						<?php echo esc_html( $copy['cookie_policy_link'] ); ?>
 					</a>.
 				</p>
 
@@ -132,7 +127,7 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 						class="jetpack-cookie-consent__description-toggle"
 						data-wp-class--jetpack-cookie-consent__description-toggle--expanded="context.textExpanded"
 						data-wp-on--click="actions.toggleDescription"
-						aria-label="<?php echo esc_attr__( 'Toggle category description', 'jetpack-cookie-consent' ); ?>"
+						aria-label="<?php echo esc_attr( $copy['category_toggle_label'] ); ?>"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 25 25" fill="none">
 							<path d="M18 12.5319L12.5 16.9319L7 12.5319L7.9 11.3319L12.5 14.9319L17 11.3319L18 12.5319Z" fill="#1E1E1E"/>
@@ -152,9 +147,9 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 								<label for="cookie-required">
 									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
 									<span class="jetpack-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Required', 'jetpack-cookie-consent' ); ?>
+										<?php echo esc_html( $copy['required_category_label'] ); ?>
 										<span class="jetpack-cookie-consent__category-badge">
-											<?php echo esc_html__( 'Always active', 'jetpack-cookie-consent' ); ?>
+											<?php echo esc_html( $copy['always_active_label'] ); ?>
 										</span>
 									</span>
 								</label>
@@ -165,22 +160,14 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 								<?php
 								echo esc_html(
 									wp_trim_words(
-										__(
-											'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
-											'jetpack-cookie-consent'
-										),
+										$copy['required_category_description'],
 										25
 									)
 								);
 								?>
 							</p>
 							<p data-wp-bind--hidden="!context.textExpanded" class="jetpack-cookie-consent__category-text">
-								<?php
-								echo esc_html__(
-									'These cookies are essential for our websites and services to perform basic functions and are necessary for us to operate certain features. Examples include your IP address, browser type, requested URLs, response codes, and operating system data.',
-									'jetpack-cookie-consent'
-								);
-								?>
+								<?php echo esc_html( $copy['required_category_description'] ); ?>
 							</p>
 						</div>
 					</div>
@@ -198,19 +185,14 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 								<label for="cookie-analytics">
 									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
 									<span class="jetpack-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Analytics', 'jetpack-cookie-consent' ); ?>
+										<?php echo esc_html( $copy['analytics_category_label'] ); ?>
 									</span>
 								</label>
 							</div>
 						</div>
 						<div class="jetpack-cookie-consent__category-content">
 							<p class="jetpack-cookie-consent__category-text">
-								<?php
-								echo esc_html__(
-									'These cookies allow us to optimize performance by collecting information on how users interact with our websites.',
-									'jetpack-cookie-consent'
-								);
-								?>
+								<?php echo esc_html( $copy['analytics_category_description'] ); ?>
 							</p>
 						</div>
 					</div>
@@ -228,19 +210,14 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 								<label for="cookie-advertising">
 									<span class="jetpack-cookie-consent__category-checkbox-icon"></span>
 									<span class="jetpack-cookie-consent__category-label-text">
-										<?php echo esc_html__( 'Advertising', 'jetpack-cookie-consent' ); ?>
+										<?php echo esc_html( $copy['advertising_category_label'] ); ?>
 									</span>
 								</label>
 							</div>
 						</div>
 						<div class="jetpack-cookie-consent__category-content">
 							<p class="jetpack-cookie-consent__category-text">
-								<?php
-								echo esc_html__(
-									'These cookies are set by us and our advertising partners to provide you with relevant content and to understand that content\'s effectiveness.',
-									'jetpack-cookie-consent'
-								);
-								?>
+								<?php echo esc_html( $copy['advertising_category_description'] ); ?>
 							</p>
 						</div>
 					</div>
@@ -252,21 +229,21 @@ $config = isset( $config ) && is_array( $config ) ? $config : array( 'cookie_pol
 					class="wp-element-button jetpack-cookie-consent__button jetpack-cookie-consent__button--primary"
 					data-wp-on--click="actions.savePreferences"
 				>
-					<?php echo esc_html__( 'Save preferences', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['save_preferences_button'] ); ?>
 				</button>
 				<button
 					type="button"
 					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.acceptAll"
 				>
-					<?php echo esc_html__( 'Accept all', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['accept_all_button'] ); ?>
 				</button>
 				<button
 					type="button"
 					class="jetpack-cookie-consent__button jetpack-cookie-consent__button--secondary"
 					data-wp-on--click="actions.rejectAll"
 				>
-					<?php echo esc_html__( 'Reject all', 'jetpack-cookie-consent' ); ?>
+					<?php echo esc_html( $copy['reject_all_button'] ); ?>
 				</button>
 			</div>
 		</div>

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/index.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/index.ts
@@ -1,5 +1,5 @@
 /**
- * Shoppers Privacy Module Entry Point
+ * Cookie Consent Module Entry Point
  *
  * This module handles GDPR cookie consent and CCPA opt-out functionality.
  */

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/logger.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/logger.ts
@@ -1,7 +1,7 @@
 /**
- * Shoppers Privacy Controls Logger Integration
+ * Cookie Consent Controls Logger Integration
  *
- * Listens to consent events from the shoppers privacy controls and logs them via REST API.
+ * Listens to consent events from the cookie consent controls and logs them via REST API.
  * This file should only be loaded when consent logging is enabled.
  *
  */

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -1,5 +1,5 @@
 /**
- * Shoppers Privacy Tracking
+ * Cookie Consent Tracking
  *
  * Privacy-specific tracking wrappers for Tracks.
  */
@@ -10,7 +10,7 @@ import type { ConsentPreferences } from './types';
 /**
  * Track privacy banner view
  *
- * Fired when the cookie consent banner is displayed to the shopper.
+ * Fired when the cookie consent banner is displayed to the visitor.
  */
 export function trackPrivacyBannerView(): void {
 	recordEvent( 'privacy_banner_view', getCommonProperties() );
@@ -33,7 +33,7 @@ export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): voi
 /**
  * Track privacy banner reject button click
  *
- * Fired when shopper clicks "Reject All" in customize modal.
+ * Fired when the visitor clicks "Reject All" in customize modal.
  */
 export function trackPrivacyBannerReject(): void {
 	recordEvent( 'privacy_banner_button_reject', getCommonProperties() );
@@ -42,7 +42,7 @@ export function trackPrivacyBannerReject(): void {
 /**
  * Track privacy banner customize button click
  *
- * Fired when shopper clicks "Customize" to open the preferences modal.
+ * Fired when the visitor clicks "Customize" to open the preferences modal.
  */
 export function trackPrivacyBannerCustomize(): void {
 	recordEvent( 'privacy_banner_button_customize', getCommonProperties() );
@@ -51,7 +51,7 @@ export function trackPrivacyBannerCustomize(): void {
 /**
  * Track "Manage Privacy Preferences" link click
  *
- * Fired when shopper opens preferences modal from the footer link.
+ * Fired when the visitor opens preferences modal from the footer link.
  */
 export function trackPrivacyManageOpen(): void {
 	recordEvent( 'privacy_manage_open', getCommonProperties() );
@@ -60,7 +60,7 @@ export function trackPrivacyManageOpen(): void {
 /**
  * Track CCPA opt-out button click
  *
- * Fired when shopper submits the CCPA "Do Not Sell/Share" opt-out.
+ * Fired when the visitor submits the CCPA "Do Not Sell/Share" opt-out.
  */
 export function trackPrivacyPolicyOptOut(): void {
 	recordEvent( 'privacy_policy_page_button_opt_out', getCommonProperties() );

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
@@ -129,7 +129,7 @@ export function handleConsentByRegion(
 		setConsentType( 'optin' );
 
 		// A Global Privacy Control signal is a clear opt-out request, so honor it as a
-		// rejection: force-deny non-essential categories and skip the banner. The shopper
+		// rejection: force-deny non-essential categories and skip the banner. The visitor
 		// can still grant consent later via the "Manage Privacy Preferences" footer link.
 		// Gated by a config flag so the legal decision is a value, not a code change;
 		// the conservative default (honor GPC) applies when the flag is omitted.

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -1,5 +1,5 @@
 /**
- * Shoppers Privacy Controls Interactivity
+ * Cookie Consent Controls Interactivity
  *
  * Single store handling both GDPR cookie banner and CCPA opt-out functionality.
  * Uses separate contexts for each UI component while sharing actions and initialization.
@@ -547,7 +547,7 @@ const { actions } = store( 'jetpack/cookie-consent', {
 			if ( 'isGdprManageLink' in context ) {
 				gdprManageLinkContexts.add( context );
 
-				// Keep the footer link visibility in sync after the shopper saves consent.
+				// Keep the footer link visibility in sync after the visitor saves consent.
 				// Without this, the link stays hidden until a full page reload.
 				const config = getConfig() as unknown as StoreConfig;
 				if ( ! manageLinkConsentListenerRegistered ) {


### PR DESCRIPTION
Fixes WOOA7S-1601

## Proposed changes
* Add a normalized `copy` config group for Cookie Consent banner, modal, footer link, CCPA page, and snackbar strings.
* Keep package defaults translatable in the `jetpack-cookie-consent` text domain while allowing consumers to provide translated overrides from their own text domain.
* Replace commerce-flavored default wording with generic visitor/site wording.
* Make template fallback copy self-healing when `copy` is missing or non-array, and avoid recomputing default copy during config normalization.

## Related product discussion/links
* WOOA7S-1601

## Does this pull request change what data or activity we track or use?
No. This changes configurable UI copy and generic code comments only; it does not add tracking events or change tracked data.

## Testing instructions
* Confirm PHP syntax passed for:
  * `projects/packages/cookie-consent/src/class-cookie-consent.php`
  * `projects/packages/cookie-consent/src/cookie-banner-content.php`
  * `projects/packages/cookie-consent/src/ccpa-content.php`
* Confirm template fallback smoke coverage: rendering the banner and CCPA templates with missing `copy` uses package defaults without undefined-key warnings.
* Confirm config normalization smoke coverage: partial copy overrides are preserved, non-scalar copy values are ignored, and default copy is translated once per config build.
* Confirm lint/test/build validation passed:
  * `composer phpcs:lint -- projects/packages/cookie-consent/src/class-cookie-consent.php projects/packages/cookie-consent/src/cookie-banner-content.php projects/packages/cookie-consent/src/ccpa-content.php`
  * `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-cookie-consent test`
  * `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-cookie-consent typecheck`
  * `mise x node@24.15.0 -- pnpm --filter @automattic/jetpack-cookie-consent build`
* Confirm `rg -n "shopping|shopper|cart|customer account|Shoppers" projects/packages/cookie-consent` returns no matches.

Known validation note: `mise x node@24.15.0 -- pnpm jetpack phan --allow-polyfill-parser packages/cookie-consent` still reports existing package-wide issues in `class-consent-log-controller.php` and PHP test stubs, not in the changed files.