### PR TITLE
Renovate: update bundled wp package rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,6 +124,8 @@
 		//
 		// @wordpress/build is still heavily developed; its dashboards share the same bundled
 		// packages and test surface, so exercising build alongside the rest is practical.
+		//
+		// Bundled @wordpress/grid is missing here as its updates with "Widgets Dashboard" grouping separately.
 		{
 			groupName: 'Bundled @wordpress/* monorepo',
 			matchPackageNames: [
@@ -131,7 +133,6 @@
 				'@wordpress/build',
 				'@wordpress/dataviews',
 				'@wordpress/fields',
-				'@wordpress/grid',
 				'@wordpress/icons',
 				'@wordpress/interface',
 				'@wordpress/style-runtime',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,21 +111,35 @@
 			additionalReviewers: [ 'team:qualityops' ],
 		},
 
-		// Bundled, WordPress dependencies are separated from 'monorepo:wordpress' while
+		// Bundled WordPress dependencies are separated from 'monorepo:wordpress' while
 		// they're still considered unstable and can have significant breaking changes.
 		// Since they're not externalized to WP, they have higher chance of impacting functionality.
+		// See the list at https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
+		//
+		// @wordpress/theme is grouped here because many bundled packages (notably @wordpress/ui)
+		// rely on its design tokens (--wpds-*).
+		//
+		// @wordpress/stylelint-config is grouped with theme because its WPDS rules lint against
+		// the token set shipped in @wordpress/theme — the two should be updated in lockstep.
+		//
+		// @wordpress/build is still heavily developed; its dashboards share the same bundled
+		// packages and test surface, so exercising build alongside the rest is practical.
 		{
 			groupName: 'Bundled @wordpress/* monorepo',
-			// See the list at https://github.com/WordPress/gutenberg/blob/580d8bd24b9d1647a66fecc3115edf9b7dce64b1/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
 			matchPackageNames: [
 				'@wordpress/admin-ui',
+				'@wordpress/build',
 				'@wordpress/dataviews',
+				'@wordpress/fields',
+				'@wordpress/grid',
 				'@wordpress/icons',
 				'@wordpress/interface',
-				'@wordpress/undo-manager',
-				'@wordpress/fields',
-				'@wordpress/views',
+				'@wordpress/style-runtime',
+				'@wordpress/stylelint-config',
+				'@wordpress/theme',
 				'@wordpress/ui',
+				'@wordpress/undo-manager',
+				'@wordpress/views',
 			],
 			separateMajorMinor: false,
 			// Teams that can help test the update
@@ -133,19 +147,6 @@
 				'team:triforce', // Monorepo overall, Publicize, My Jetpack
 				'team:loop', // Newsletter dashboard & subscriber management
 				'team:zap', // Forms, much of the recent componentry work.
-				'team:red', // Premium Analytics
-				'team:ventures', // Premium Analytics
-			],
-		},
-
-		// Separate Build from 'monorepo:wordpress' as build is still heavily developed, to manually test changes.
-		{
-			groupName: '@wordpress/build',
-			matchPackageNames: [ '@wordpress/build' ],
-			separateMajorMinor: false,
-			// Teams using Build in their projects
-			additionalReviewers: [
-				'team:zap', // Forms
 				'team:red', // Premium Analytics
 				'team:ventures', // Premium Analytics
 			],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -135,6 +135,10 @@
 				// @wordpress/build is still heavily developed; its dashboards share the same bundled
 				// packages and test surface, so exercising build alongside the rest is practical.
 				'@wordpress/build',
+				// Widgets Dashboard packages used by Premium Analytics
+				'@wordpress/grid',
+				'@wordpress/widget-dashboard',
+				'@wordpress/widget-primitives',
 			],
 			separateMajorMinor: false,
 			// Teams that can help test the update
@@ -142,21 +146,6 @@
 				'team:triforce', // Monorepo overall, Publicize, My Jetpack
 				'team:loop', // Newsletter dashboard & subscriber management
 				'team:zap', // Forms, much of the recent componentry work.
-				'team:red', // Premium Analytics
-				'team:ventures', // Premium Analytics
-			],
-		},
-
-		// Widgets Dashboard packages are still experimental/development-focused, so group them for targeted review.
-		{
-			groupName: 'Widgets Dashboard',
-			matchPackageNames: [
-				'@wordpress/widget-dashboard',
-				'@wordpress/widget-primitives',
-				'@wordpress/grid',
-			],
-			separateMajorMinor: false,
-			additionalReviewers: [
 				'team:red', // Premium Analytics
 				'team:ventures', // Premium Analytics
 			],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -132,9 +132,6 @@
 				// @wordpress/theme is grouped here because many bundled packages (notably @wordpress/ui)
 				// rely on its design tokens (--wpds-*).
 				'@wordpress/theme',
-				// @wordpress/stylelint-config is grouped with theme because its WPDS rules lint against
-				// the token set shipped in @wordpress/theme — the two should be updated in lockstep.
-				'@wordpress/stylelint-config',
 				// @wordpress/build is still heavily developed; its dashboards share the same bundled
 				// packages and test surface, so exercising build alongside the rest is practical.
 				'@wordpress/build',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,33 +114,30 @@
 		// Bundled WordPress dependencies are separated from 'monorepo:wordpress' while
 		// they're still considered unstable and can have significant breaking changes.
 		// Since they're not externalized to WP, they have higher chance of impacting functionality.
-		// See the list at https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
 		//
-		// @wordpress/theme is grouped here because many bundled packages (notably @wordpress/ui)
-		// rely on its design tokens (--wpds-*).
-		//
-		// @wordpress/stylelint-config is grouped with theme because its WPDS rules lint against
-		// the token set shipped in @wordpress/theme — the two should be updated in lockstep.
-		//
-		// @wordpress/build is still heavily developed; its dashboards share the same bundled
-		// packages and test surface, so exercising build alongside the rest is practical.
-		//
-		// Bundled @wordpress/grid is missing here as its updates with "Widgets Dashboard" grouping separately.
+		// Some related packages are included here too.
 		{
 			groupName: 'Bundled @wordpress/* monorepo',
 			matchPackageNames: [
+				// Bundled packages, from the list at https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
 				'@wordpress/admin-ui',
-				'@wordpress/build',
 				'@wordpress/dataviews',
 				'@wordpress/fields',
 				'@wordpress/icons',
 				'@wordpress/interface',
 				'@wordpress/style-runtime',
-				'@wordpress/stylelint-config',
-				'@wordpress/theme',
 				'@wordpress/ui',
 				'@wordpress/undo-manager',
 				'@wordpress/views',
+				// @wordpress/theme is grouped here because many bundled packages (notably @wordpress/ui)
+				// rely on its design tokens (--wpds-*).
+				'@wordpress/theme',
+				// @wordpress/stylelint-config is grouped with theme because its WPDS rules lint against
+				// the token set shipped in @wordpress/theme — the two should be updated in lockstep.
+				'@wordpress/stylelint-config',
+				// @wordpress/build is still heavily developed; its dashboards share the same bundled
+				// packages and test surface, so exercising build alongside the rest is practical.
+				'@wordpress/build',
 			],
 			separateMajorMinor: false,
 			// Teams that can help test the update

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -186,6 +186,15 @@ async function fixDeps( pkg ) {
 		pkg.peerDependencies.stylelint = pkg.peerDependencies.stylelint.replace( /^(?:\^|>=)?/, '>=' );
 	}
 
+	// Make sure @wordpress/stylelint-config gets whatever @wordpress/theme is installed.
+	if (
+		pkg.name === '@wordpress/stylelint-config' &&
+		pkg.dependencies[ '@wordpress/theme' ]?.startsWith( '^' )
+	) {
+		pkg.dependencies[ '@wordpress/theme' ] =
+			'>=' + pkg.dependencies[ '@wordpress/theme' ].substring( 1 );
+	}
+
 	// Update localtunnel axios dep to avoid CVE
 	// https://github.com/localtunnel/localtunnel/issues/632
 	if ( pkg.name === 'localtunnel' && pkg.dependencies.axios === '0.21.4' ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-DkELBMMoq2PwHOAUtmqQ7Kzgrjhkrww1drUmcqHQ8sE=
+pnpmfileChecksum: sha256-PzkdBGEN7/Zz4Qb42N9B8uXzkny4nJaMly/Hokov//Y=
 
 patchedDependencies:
   react-autosize-textarea: 5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/49272#pullrequestreview-4578753347

Latest bundled WP packages update revealed a few gaps.

~Best to have https://github.com/Automattic/jetpack/pull/49272 merged first before this so that Renovate doesn't close it.~ [We can](https://github.com/Automattic/jetpack/pull/50007#issuecomment-4810731529) merge this before the bundle update.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
- Includes `@wordpress/theme` to avoid mismatching versions of bundled deps (notably `@wordpress/ui`, `@wordpress/dataviews`, `@wordpress/admin-ui` and others) using style tokens from different version than Jetpack is shipping.
- Since we use `@wordpress/stylelint-config` to lint invalid design tokens, we need to bump that together with `@wordpress/theme`.
- Moves WP Build from its own section into Bundled WP section; this could be updated independently but for practical reasons testing steps and teams are basically the same as with the rest of the list, so worth combining. It can still be manually updated separately ahead of time when needed. 
- Adds `@wordpress/style-runtime` from the latest [bundled deps list](https://github.com/WordPress/gutenberg/blob/8bc5bfcf43f1c95513659d2b45e767da62873299/packages/dependency-extraction-webpack-plugin/lib/util.js#L10)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* See https://github.com/Automattic/jetpack/pull/49272

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* N/A