### PR TITLE
RTC: Track unique sessions via a session_id on jetpack_rtc_* events

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-17703-track-unique-sessions
+++ b/projects/packages/rtc/changelog/dotcom-17703-track-unique-sessions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+RTC: Add a session_id (derived from the awareness clientID) to the jetpack_rtc_* Tracks events so unique collaboration sessions can be measured.

--- a/projects/packages/rtc/src/js/tracking/awareness.ts
+++ b/projects/packages/rtc/src/js/tracking/awareness.ts
@@ -41,6 +41,28 @@ export function getContributorIds(
 }
 
 /**
+ * A stable identifier for the local client's collaboration session in a room.
+ *
+ * Derived from the Yjs awareness `clientID`, which is generated fresh for each
+ * Y.Doc instance — i.e. each time a client connects to a room (a page load /
+ * provider creation) — and stays constant for that connection's lifetime. So
+ * every event a client emits during one editing session (join, then any later
+ * connection error) shares the same `session_id`, while a reload, a second tab,
+ * or a different user each get a distinct one.
+ *
+ * Returned as a string because it is an opaque token, not a quantity. Like
+ * `contributors`, `clientID` is only unique within a room, so count distinct
+ * sessions scoped to a single `blog_id`/`post_id` (both attached to every
+ * event) rather than globally — see `getContributorIds` for the id-space notes.
+ *
+ * @param awareness - The Yjs awareness instance for the room.
+ * @return The local client's session id.
+ */
+export function getSessionId( awareness: Awareness ): string {
+	return String( awareness.clientID );
+}
+
+/**
  * The local client's WordPress user id, read from the local awareness state's
  * `collaboratorInfo.id` (same id-space as `contributors` — see
  * `getContributorIds`). Undefined until core-data populates it, shortly after

--- a/projects/packages/rtc/src/js/tracking/test/awareness.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/awareness.test.ts
@@ -1,4 +1,4 @@
-import { getContributorIds, getLocalUserId } from '../awareness';
+import { getContributorIds, getLocalUserId, getSessionId } from '../awareness';
 
 type StateSpec = Record< number, number | null >;
 
@@ -46,5 +46,19 @@ describe( 'getLocalUserId', () => {
 	it( 'returns undefined when the local client is not present', () => {
 		const awareness = fakeAwareness( { 2: 9 }, 1 );
 		expect( getLocalUserId( awareness as never ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'getSessionId', () => {
+	it( 'returns the local clientID as a string', () => {
+		const awareness = fakeAwareness( { 1: 7 }, 4242 );
+		expect( getSessionId( awareness as never ) ).toBe( '4242' );
+	} );
+
+	it( 'does not depend on the collaborator id being populated', () => {
+		// clientID is set the moment the Y.Doc exists, before core-data fills in
+		// collaboratorInfo — so a session id is available even with no states.
+		const awareness = fakeAwareness( {}, 99 );
+		expect( getSessionId( awareness as never ) ).toBe( '99' );
 	} );
 } );

--- a/projects/packages/rtc/src/js/tracking/test/track-blocked.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-blocked.test.ts
@@ -51,6 +51,7 @@ describe( 'recordBlocked', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_blocked', {
 			contributor_count: 2,
 			contributors: [ 7, 8 ],
+			session_id: '3',
 			is_admin: false,
 			is_plan_owner: true,
 		} );

--- a/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-connection-error.test.ts
@@ -45,6 +45,8 @@ const entityRoom = {
 	objectType: 'postType',
 	objectId: 'post-42',
 	ydoc: {} as never,
+	// Only clientID is read (via getSessionId); the rest of awareness is unused here.
+	awareness: { clientID: 777 } as never,
 };
 
 describe( 'withConnectionErrorTracking', () => {
@@ -64,6 +66,7 @@ describe( 'withConnectionErrorTracking', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledTimes( 1 );
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
 			error_code: undefined,
+			session_id: '777',
 		} );
 	} );
 
@@ -77,6 +80,23 @@ describe( 'withConnectionErrorTracking', () => {
 
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
 			error_code: 'authentication-failed',
+			session_id: '777',
+		} );
+	} );
+
+	it( 'omits the session id when awareness is not provided', async () => {
+		const provider = makeProvider();
+		const creator = jest.fn().mockResolvedValue( provider );
+		const wrapped = withConnectionErrorTracking( creator as never );
+
+		// No awareness on the room (the session id ties to clientID, which lives
+		// on awareness); recordRtcEvent drops the undefined before it reaches Tracks.
+		await wrapped( { ...entityRoom, awareness: undefined } as never );
+		provider.emitStatus( { status: 'disconnected' } );
+
+		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_connection_error', {
+			error_code: undefined,
+			session_id: undefined,
 		} );
 	} );
 

--- a/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
+++ b/projects/packages/rtc/src/js/tracking/test/track-join.test.ts
@@ -89,6 +89,7 @@ describe( 'withJoinTracking', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 3,
 			contributors: [ 7, 7, 9 ],
+			session_id: '1',
 		} );
 	} );
 
@@ -108,6 +109,7 @@ describe( 'withJoinTracking', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 2,
 			contributors: [ 7, 9 ],
+			session_id: '1',
 		} );
 	} );
 
@@ -133,6 +135,7 @@ describe( 'withJoinTracking', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 1,
 			contributors: [ 7 ],
+			session_id: '1',
 		} );
 	} );
 
@@ -204,6 +207,7 @@ describe( 'withJoinTracking', () => {
 		expect( recordRtcEventMock ).toHaveBeenCalledWith( 'jetpack_rtc_join', {
 			contributor_count: 2,
 			contributors: [ 7, 9 ],
+			session_id: '1',
 		} );
 	} );
 

--- a/projects/packages/rtc/src/js/tracking/track-blocked.ts
+++ b/projects/packages/rtc/src/js/tracking/track-blocked.ts
@@ -1,4 +1,4 @@
-import { getContributorIds } from './awareness';
+import { getContributorIds, getSessionId } from './awareness';
 import { recordRtcEvent } from './tracks';
 import type { Awareness } from '@wordpress/sync';
 
@@ -26,6 +26,7 @@ export function recordBlocked( awareness: Awareness ): void {
 	recordRtcEvent( BLOCKED_EVENT, {
 		contributor_count: contributors.length,
 		contributors,
+		session_id: getSessionId( awareness ),
 		is_admin: config?.isAdmin ?? false,
 		is_plan_owner: config?.isPlanOwner ?? false,
 	} );

--- a/projects/packages/rtc/src/js/tracking/track-connection-error.ts
+++ b/projects/packages/rtc/src/js/tracking/track-connection-error.ts
@@ -1,5 +1,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { isRoomLimitBreached } from '../notices/room-limit';
+import { getSessionId } from './awareness';
 import { recordRtcEvent } from './tracks';
 import type { ConnectionStatus, ProviderCreator } from '@wordpress/sync';
 
@@ -41,7 +42,9 @@ function isRoomLimitDisconnect( status: ConnectionStatus ): boolean {
  * room-limit and join-tracking wrappers.
  *
  * `transport`, `post_id`, `post_type`, and `wp_user_id` are added by
- * `recordRtcEvent`; this only supplies the error code.
+ * `recordRtcEvent`; this only supplies the error code and the session id.
+ * `session_id` (the client's `clientID`) ties this error to the same client's
+ * `jetpack_rtc_join`; it is omitted when awareness has not been provided.
  *
  * @param creator - The provider creator to wrap.
  * @return The wrapped provider creator.
@@ -53,6 +56,7 @@ export function withConnectionErrorTracking( creator: ProviderCreator ): Provide
 			return result;
 		}
 
+		const sessionId = options.awareness ? getSessionId( options.awareness ) : undefined;
 		let recorded = false;
 		let tearingDown = false;
 
@@ -66,6 +70,7 @@ export function withConnectionErrorTracking( creator: ProviderCreator ): Provide
 			recorded = true;
 			recordRtcEvent( CONNECTION_ERROR_EVENT, {
 				error_code: status.error?.code,
+				session_id: sessionId,
 			} );
 		} );
 

--- a/projects/packages/rtc/src/js/tracking/track-join.ts
+++ b/projects/packages/rtc/src/js/tracking/track-join.ts
@@ -1,6 +1,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { isRoomLimitBreached } from '../notices/room-limit';
-import { getContributorIds, getLocalUserId } from './awareness';
+import { getContributorIds, getLocalUserId, getSessionId } from './awareness';
 import { recordRtcEvent } from './tracks';
 import type { Awareness, ProviderCreator } from '@wordpress/sync';
 
@@ -28,7 +28,7 @@ function isLocalClientPresent( awareness: Awareness ): boolean {
  * Record the join event with a snapshot of the contributors currently present.
  *
  * `transport`, `post_id`, `post_type`, and `wp_user_id` are added by
- * `recordRtcEvent`; this only supplies the room roster.
+ * `recordRtcEvent`; this only supplies the room roster and the session id.
  *
  * @param awareness - The Yjs awareness instance for the room.
  */
@@ -37,6 +37,7 @@ function recordJoin( awareness: Awareness ): void {
 	recordRtcEvent( JOIN_EVENT, {
 		contributor_count: contributors.length,
 		contributors,
+		session_id: getSessionId( awareness ),
 	} );
 }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17703

## Proposed changes
* Add a `session_id` property to the `jetpack_rtc_join`, `jetpack_rtc_blocked`, and `jetpack_rtc_connection_error` Tracks events so unique collaboration sessions can be measured separately from unique users and posts.
* The id is derived from the Yjs awareness `clientID` via a new `getSessionId()` helper. `clientID` is generated fresh for each `Y.Doc` instance — i.e. each time a client connects to a room (page load / provider creation) — and is stable for that connection's lifetime. So every event a single client emits during one editing session shares one `session_id`, while a reload, a second tab, or a different user each get a distinct one.
* Like the existing `contributors` roster, `clientID` is only unique within a room, so distinct sessions should be counted scoped to a single `blog_id`/`post_id` (both already attached to every event).
* For `connection_error`, the `session_id` is read from `options.awareness` at provider-wrap time and omitted (dropped by `recordRtcEvent`) when awareness isn't available.
* Updated and added unit tests; added a changelog entry.

## Related product discussion/links
* https://linear.app/a8c/issue/DOTCOM-17703

## Does this pull request change what data or activity we track or use?
Yes. It adds a `session_id` property to the existing `jetpack_rtc_join`, `jetpack_rtc_blocked`, and `jetpack_rtc_connection_error` Tracks events. The value is the Yjs awareness `clientID` (a random per-document integer), not a user identifier — it carries no additional PII and exists only to let distinct collaboration sessions be counted within a `blog_id`/`post_id`.

## Testing instructions
* Build the RTC package (or a plugin bundling it) and open a post in the block editor on a site with RTC enabled.
* Open the same post in a second browser/profile so two clients join the room.
* Watch the Tracks events (e.g. via the browser's network tab / Tracks debug, or the `jetpack_rtc_*` events server-side) and confirm:
  * `jetpack_rtc_join` now includes a `session_id`.
  * Each client reports a different `session_id`, and reloading a tab produces a new one.
  * Forcing the room limit produces `jetpack_rtc_blocked` with a `session_id`; a genuine disconnect produces `jetpack_rtc_connection_error` with the same `session_id` that client reported on join.
* Run the package unit tests: `cd projects/packages/rtc && pnpm test` (45 tests pass).
