### PR TITLE
Newsletter settings - add support links to subscribe block custom modal messasge

### DIFF
--- a/projects/packages/newsletter/changelog/update-subscribe-modal-button-only-doc-link
+++ b/projects/packages/newsletter/changelog/update-subscribe-modal-button-only-doc-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter settings: Link the "Button only" style hint to platform-appropriate support documentation.

--- a/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteType, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
 import { DataForm, type Field } from '@wordpress/dataviews';
-import { useCallback, useMemo } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Link, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -68,6 +69,17 @@ export function SubscribeModalSection( {
 		onSave();
 	}, [ changedKeys, onSave, siteType ] );
 
+	const isWpcom = isWpcomPlatformSite();
+	const buttonOnlyStyleUrl = isWpcom
+		? 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/#change-the-subscription-box-appearance'
+		: 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/#use-the-button-only-style';
+
+	const ButtonOnlyStyleLink = isWpcom ? (
+		<WpcomSupportLink supportLink={ buttonOnlyStyleUrl } supportPostId={ 170164 } />
+	) : (
+		<Link openInNewTab href={ buttonOnlyStyleUrl } children={ null } />
+	);
+
 	const fields: Field< SubscribeModalFormData >[] = [
 		{
 			id: 'subscribe_modal_heading',
@@ -75,9 +87,14 @@ export function SubscribeModalSection( {
 			type: 'text' as const,
 			Edit: 'textarea' as const,
 			placeholder: __( 'Subscribe now to stay ahead and never miss a beat!', 'jetpack-newsletter' ),
-			description: __(
-				'Only affects Subscribe blocks using the "Button only" style. Leave blank to use the default heading.',
-				'jetpack-newsletter'
+			description: createInterpolateElement(
+				__(
+					'Only affects Subscribe blocks using the <link>"Button only" style</link>. Leave blank to use the default heading.',
+					'jetpack-newsletter'
+				),
+				{
+					link: ButtonOnlyStyleLink,
+				}
 			),
 		},
 	];

--- a/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
@@ -89,7 +89,7 @@ export function SubscribeModalSection( {
 			placeholder: __( 'Subscribe now to stay ahead and never miss a beat!', 'jetpack-newsletter' ),
 			description: createInterpolateElement(
 				__(
-					'Only affects Subscribe blocks using the <link>"Button only" style</link>. Leave blank to use the default heading.',
+					'Only affects Subscribe blocks using <link>the "Button only" style</link>. Leave blank to use the default heading.',
 					'jetpack-newsletter'
 				),
 				{

--- a/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
@@ -220,7 +220,7 @@ describe( 'SubscribeModalSection', () => {
 	it( 'links the Button only style hint to Jetpack support docs on self-hosted sites', () => {
 		renderSection();
 
-		const link = screen.getByRole( 'link', { name: '"Button only" style' } );
+		const link = screen.getByRole( 'link', { name: 'the "Button only" style' } );
 		expect( link ).toHaveAttribute(
 			'href',
 			'https://jetpack.com/support/jetpack-blocks/subscription-form-block/#use-the-button-only-style'
@@ -236,7 +236,7 @@ describe( 'SubscribeModalSection', () => {
 			'href',
 			'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/#change-the-subscription-box-appearance'
 		);
-		expect( link ).toHaveTextContent( '"Button only" style' );
+		expect( link ).toHaveTextContent( 'the "Button only" style' );
 	} );
 
 	it( 'renders the textarea with the default placeholder and the current heading value', () => {

--- a/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
@@ -40,6 +40,19 @@ jest.mock( '@wordpress/ui', () => ( {
 		),
 	},
 	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+	Link: ( {
+		children,
+		href,
+		openInNewTab,
+	}: {
+		children: React.ReactNode;
+		href: string;
+		openInNewTab?: boolean;
+	} ) => (
+		<a href={ href } target={ openInNewTab ? '_blank' : undefined } rel="noreferrer">
+			{ children }
+		</a>
+	),
 } ) );
 
 jest.mock( '@wordpress/dataviews', () => ( {
@@ -50,24 +63,47 @@ jest.mock( '@wordpress/dataviews', () => ( {
 		onChange,
 	}: {
 		data: Record< string, string >;
-		fields: Array< { id: string; label: string; placeholder?: string } >;
+		fields: Array< {
+			id: string;
+			label: string;
+			placeholder?: string;
+			description?: React.ReactNode;
+		} >;
 		onChange: ( updates: Record< string, string > ) => void;
 	} ) => {
 		const field = fields[ 0 ];
 		const handleChange = ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
 			onChange( { [ field.id ]: e.target.value } );
 		return (
-			<textarea
-				aria-label={ field.label }
-				placeholder={ field.placeholder }
-				value={ data[ field.id ] ?? '' }
-				// Test-only mock — the closure over `field.id` is intentional and
-				// the re-bind-per-render cost is irrelevant in a jest render.
-				// eslint-disable-next-line react/jsx-no-bind
-				onChange={ handleChange }
-			/>
+			<>
+				<textarea
+					aria-label={ field.label }
+					placeholder={ field.placeholder }
+					value={ data[ field.id ] ?? '' }
+					// Test-only mock — the closure over `field.id` is intentional and
+					// the re-bind-per-render cost is irrelevant in a jest render.
+					// eslint-disable-next-line react/jsx-no-bind
+					onChange={ handleChange }
+				/>
+				{ field.description && <p data-testid="field-description">{ field.description }</p> }
+			</>
 		);
 	},
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link', () => ( {
+	__esModule: true,
+	WpcomSupportLink: ( {
+		children,
+		supportLink,
+	}: {
+		children: React.ReactNode;
+		supportLink: string;
+	} ) => (
+		<a href={ supportLink } data-testid="wpcom-support-link">
+			{ children }
+		</a>
+	),
 } ) );
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
@@ -79,9 +115,11 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getSiteType: jest.fn( () => 'jetpack' ),
+	isWpcomPlatformSite: jest.fn( () => false ),
 } ) );
 
 import analytics from '@automattic/jetpack-analytics';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { render, screen } from '@testing-library/react';
 import { SubscribeModalSection } from '../src/settings/sections/subscribe-modal-section';
 import type { NewsletterSettings } from '../src/settings/types';
@@ -167,6 +205,7 @@ function setTextareaValue( textarea: HTMLTextAreaElement, value: string ) {
 describe( 'SubscribeModalSection', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		jest.mocked( isWpcomPlatformSite ).mockReturnValue( false );
 	} );
 
 	it( 'renders the card title and a description mentioning the Button only style', () => {
@@ -175,7 +214,29 @@ describe( 'SubscribeModalSection', () => {
 		expect(
 			screen.getByRole( 'heading', { name: 'Subscribe modal heading' } )
 		).toBeInTheDocument();
-		expect( screen.getByText( /"Button only" style/ ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'field-description' ) ).toHaveTextContent( /"Button only" style/ );
+	} );
+
+	it( 'links the Button only style hint to Jetpack support docs on self-hosted sites', () => {
+		renderSection();
+
+		const link = screen.getByRole( 'link', { name: '"Button only" style' } );
+		expect( link ).toHaveAttribute(
+			'href',
+			'https://jetpack.com/support/jetpack-blocks/subscription-form-block/#use-the-button-only-style'
+		);
+	} );
+
+	it( 'links the Button only style hint to WordPress.com support docs on platform sites', () => {
+		jest.mocked( isWpcomPlatformSite ).mockReturnValue( true );
+		renderSection();
+
+		const link = screen.getByTestId( 'wpcom-support-link' );
+		expect( link ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/#change-the-subscription-box-appearance'
+		);
+		expect( link ).toHaveTextContent( '"Button only" style' );
 	} );
 
 	it( 'renders the textarea with the default placeholder and the current heading value', () => {


### PR DESCRIPTION
Fixes # https://linear.app/a8c/issue/NL-710/subscribe-modal-heading-has-no-path-or-info-about-the-button-only

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds a linke to wpcom/jetpack support pages referencing the button only style.


<img width="704" height="395" alt="Screenshot 2026-06-26 at 10 48 19 AM" src="https://github.com/user-attachments/assets/a91029ce-6c9f-4398-b118-db0d3f5827ed" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to newsletter settings for the site this is applied to (try simple via wpcom and jetpack via beta tester plugin)
* Verify the link is present and opens to the correct version.
