### PR TITLE
Render Premium Analytics inside the wp-admin shell

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-analytics-wp-admin-shell
+++ b/projects/packages/premium-analytics/changelog/update-analytics-wp-admin-shell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Render the Premium Analytics admin page inside the native wp-admin shell (sidebar and header) instead of taking over the full screen.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -143,16 +143,10 @@ class Analytics {
 	/**
 	 * Register the admin menu page.
 	 *
-	 * Uses the wp-build "wp-admin integrated" page variant (the `-wp-admin`
-	 * slug) so the dashboard renders inside the native wp-admin shell,
-	 * keeping the sidebar and header intact, rather than the full-page
-	 * variant (the bare slug) that intercepts admin_init and takes over the
-	 * whole screen.
-	 *
-	 * The render callback is provided by the generated build
-	 * (build/pages/jetpack-premium-analytics/page-wp-admin.php, loaded by
-	 * build.php at init), so it is referenced by name and falls back to a
-	 * no-op when the build is absent.
+	 * Uses the wp-build "wp-admin integrated" variant (`-wp-admin` slug) so the
+	 * dashboard renders inside the native wp-admin shell, not the full-page
+	 * variant that takes over the screen via admin_init. The render callback
+	 * comes from the generated build, with a no-op fallback when it is absent.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -143,19 +143,30 @@ class Analytics {
 	/**
 	 * Register the admin menu page.
 	 *
-	 * The callback is __return_null because the wp-build interceptor
-	 * renders the full-page app on admin_init and calls exit() before
-	 * WordPress can invoke this callback.
+	 * Uses the wp-build "wp-admin integrated" page variant (the `-wp-admin`
+	 * slug) so the dashboard renders inside the native wp-admin shell,
+	 * keeping the sidebar and header intact, rather than the full-page
+	 * variant (the bare slug) that intercepts admin_init and takes over the
+	 * whole screen.
+	 *
+	 * The render callback is provided by the generated build
+	 * (build/pages/jetpack-premium-analytics/page-wp-admin.php, loaded by
+	 * build.php at init), so it is referenced by name and falls back to a
+	 * no-op when the build is absent.
 	 *
 	 * @return void
 	 */
 	public static function register_admin_menu() {
+		$render_callback = function_exists( 'jpa_jetpack_premium_analytics_wp_admin_render_page' )
+			? 'jpa_jetpack_premium_analytics_wp_admin_render_page'
+			: '__return_null';
+
 		add_menu_page(
 			esc_html( self::$menu_title ),
 			esc_html( self::$menu_title ),
 			'manage_options',
-			'jetpack-premium-analytics',
-			'__return_null',
+			'jetpack-premium-analytics-wp-admin',
+			$render_callback,
 			'dashicons-chart-bar',
 			30
 		);


### PR DESCRIPTION
## Proposed changes

* Register the Premium Analytics admin menu against the wp-build "wp-admin integrated" page variant (`jetpack-premium-analytics-wp-admin`) instead of the full-page slug. The page now renders inside the native wp-admin shell (sidebar + header) rather than the app taking over the whole screen via the `admin_init` interceptor.
* The menu callback points at the generated `jpa_jetpack_premium_analytics_wp_admin_render_page()` (from `build/pages/jetpack-premium-analytics/page-wp-admin.php`), guarded by `function_exists()` with a `__return_null` fallback when the build is absent.
* The full-page variant stays reachable directly at `?page=jetpack-premium-analytics`; only the menu entry switches to the in-shell variant.

Closes WOOA7S-1572

## Related product discussion/links

* WOOA7S-1572

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package if needed: `jetpack build packages/premium-analytics`.
* In wp-admin, open the **Analytics** menu entry.
* Confirm the dashboard renders inside the standard wp-admin chrome: the admin sidebar and header stay visible and the page no longer takes over the full screen.
* Confirm deep links still work, e.g. `?page=jetpack-premium-analytics-wp-admin&p=/` loads the dashboard route.

<img width="1728" height="1000" alt="image" src="https://github.com/user-attachments/assets/e524e1b1-25f7-4943-9e3b-db6621b14a9c" />

