### PR TITLE
[Step 1] Custom colors: stop serving discontinued COLOURLovers backgrounds

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-1758-stop-colourlovers-backgrounds
+++ b/projects/plugins/wpcomsh/changelog/dotcom-1758-stop-colourlovers-backgrounds
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Stop serving COLOURLovers background images now that COLOURLovers support has been discontinued.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -141,6 +141,16 @@ class Colors_Manager_Common {
 	 * Initialize the object.
 	 */
 	public static function init() {
+		// COLOURLovers support has been discontinued, so we must stop requesting
+		// COLOURLovers-hosted assets. Atomic sites store background images on
+		// COLOURLovers' S3 bucket and emit those URLs straight into the page, so
+		// every visitor's browser requests them directly. Blank them at render time.
+		// Attached unconditionally (before the enable_custom_customizer guard) so the
+		// requests stop even where the rest of the custom-colors tool is disabled.
+		// No fallback: broken backgrounds are acceptable.
+		add_filter( 'theme_mod_background_image', array( __CLASS__, 'remove_colourlovers_background' ) );
+		add_filter( 'theme_mod_background_image_thumb', array( __CLASS__, 'remove_colourlovers_background' ) );
+
 		if ( ! apply_filters( 'enable_custom_customizer', true ) ) {
 			return;
 		}
@@ -632,6 +642,31 @@ class Colors_Manager_Common {
 		header( 'Content-Type: text/javascript' );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- It takes null, but its phpdoc only says int.
 		wp_send_json( $response, null, JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * Stop serving COLOURLovers background images.
+	 *
+	 * COLOURLovers support has been discontinued, so we must no longer make
+	 * requests to COLOURLovers-hosted infrastructure. Atomic sites store
+	 * background images on the legacy `colourlovers.com.s3.amazonaws.com` bucket
+	 * (and historically the `colourlovers-static-replica` bucket) and emit those
+	 * URLs straight into the page, so every visitor's browser requests them
+	 * directly. Blank any such value at render time. We intentionally provide no
+	 * fallback: broken backgrounds are acceptable.
+	 *
+	 * @param mixed $url The stored background image URL.
+	 * @return mixed Empty string for COLOURLovers-hosted images, otherwise the original value.
+	 */
+	public static function remove_colourlovers_background( $url ) {
+		if ( is_string( $url ) && (
+			false !== stripos( $url, 'colourlovers.com.s3.amazonaws.com' )
+			|| false !== stripos( $url, 'colourlovers-static-replica.s3.amazonaws.com' )
+		) ) {
+			return '';
+		}
+
+		return $url;
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -659,6 +659,11 @@ class Colors_Manager_Common {
 	 * @return mixed Empty string for COLOURLovers-hosted images, otherwise the original value.
 	 */
 	public static function remove_colourlovers_background( $url ) {
+		// Match on the bucket host as a substring rather than parsing the URL host or
+		// reusing COLOURLOVERS_HOST: this also catches imgpress/Photon-proxied and
+		// http/https variants where the bucket appears in a `url=` param or path, which
+		// host parsing would miss. Over-blanking is the safe direction here — a missed
+		// match means we keep requesting COLOURLovers.
 		if ( is_string( $url ) && (
 			false !== stripos( $url, 'colourlovers.com.s3.amazonaws.com' )
 			|| false !== stripos( $url, 'colourlovers-static-replica.s3.amazonaws.com' )


### PR DESCRIPTION
## Proposed changes
* COLOURLovers support has been discontinued. On Atomic sites, a background image set from a COLOURLovers pattern is stored on the COLOURLovers S3 bucket (`colourlovers.com.s3.amazonaws.com`) and emitted straight into the page, so every visitor's browser requests it on each load. This adds a `theme_mod_background_image` / `theme_mod_background_image_thumb` render filter (`Colors_Manager_Common::remove_colourlovers_background()`) that blanks any `colourlovers.com.s3.amazonaws.com` or `colourlovers-static-replica.s3.amazonaws.com` URL, so those requests stop.
* No fallback is provided — empty/broken backgrounds are acceptable. The stored theme_mod is left untouched and only blanked at render time, so a site shows no background until its owner picks a new one.
* The filter is attached before the `enable_custom_customizer` guard, so the requests stop even where the rest of the custom-colors tool is disabled.

## Related product discussion/links
* Related to DOTCOM-1758

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an Atomic site, switch to a classic theme that supports custom backgrounds (e.g. Twenty Fifteen).
* Give it a COLOURLovers background image, e.g.:
  * `wp theme mod set background_image "https://colourlovers-static-replica.s3.amazonaws.com/images/patterns/5814/5814723.png"`
  * `wp theme mod set background_image_thumb "https://colourlovers-static-replica.s3.amazonaws.com/images/patterns/5814/5814723.png"`
* **Before** this change: load the front end → the `#custom-background-css` block contains that URL and the browser requests it (visible in DevTools → Network).
* **After** this change: reload → the `custom-background` block is gone, `get_theme_mod( 'background_image' )` returns empty, and no request is made to either COLOURLovers host.
