### PR TITLE
cli: Trust uncommitted composer.lock by default in `jetpack build`

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -70,6 +70,11 @@ export function builder( yargs ) {
 		.option( 'timing', {
 			type: 'boolean',
 			description: 'Output timing information.',
+		} )
+		.option( 'use-uncommitted-composer-lock', { type: 'boolean', hidden: true } )
+		.option( 'no-use-uncommitted-composer-lock', {
+			type: 'boolean',
+			description: "Don't use uncommitted composer.lock files.",
 		} );
 }
 
@@ -87,6 +92,8 @@ export async function handler( argv ) {
 		console.error( e.message );
 		process.exit( 1 );
 	}
+
+	argv.useUncommittedComposerLock = argv.useUncommittedComposerLock !== false;
 
 	let dependencies = await getDependencies( process.cwd(), 'build' );
 	const listr = new Listr( [], {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
To speed up repeat local builds, run `composer install` rather than `composer update` when there is an uncommitted composer.lock file present. A `--no-use-uncommitted-composer-lock` option is added to turn this behavior off, matching the option of the same name already present in `jetpack test` and `jetpack phan`.

This should have minimal to no effect on CI builds, because (1) they won't have any uncommitted lockfiles and (2) there's already logic for those to skip `composer` entirely if there's no build step configured.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1782414437302549/1782412159.121369-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `jetpack build -v --timing` for some project a few times. The re-runs should take much less time in the "install" portion.
* Should be no changes to built artifacts.