### PR TITLE
Tiled Gallery: fix infinite resize loop inside Row/Stack blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-firefox-size
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-firefox-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: keep the mosaic layout stable across browsers and reloads when the block is inside a Row or Stack, and split the row evenly between multiple galleries instead of letting them overflow.

--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-loop
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: fix an infinite resize loop when the block is placed inside a Row or Stack block.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -71,24 +71,31 @@ export default class Mosaic extends Component {
 	 * @return {number} The layout width in px.
 	 */
 	getLayoutWidth() {
+		// Re-resolve each pass rather than caching at mount: in the editor the flex
+		// ancestors may not be laid out yet on the first frame, and a stale null
+		// cache would strand the gallery at its own (circular) width — the very
+		// non-determinism this avoids.
 		const container = this.getFlexContainer();
-		if ( container ) {
-			const count = container.children.length;
-			if ( count <= 1 ) {
-				return container.clientWidth;
-			}
-			// Several flex items share the row. Give each an equal, deterministic
-			// share of the container's available width (minus the flex gap) instead
-			// of measuring the gallery's own width: that width is circularly defined
-			// by our own layout and settles to a different value on each reload in
-			// Firefox. Dividing the container width is content-independent, so the
-			// result is stable across browsers/reloads. See JETPACK-1726.
-			const view = container.ownerDocument?.defaultView || window;
-			const styles = view.getComputedStyle( container );
-			const gap = parseFloat( styles.columnGap || styles.gap || '' ) || 0;
-			return ( container.clientWidth - gap * ( count - 1 ) ) / count;
+		if ( ! container ) {
+			return this.gallery.current ? this.gallery.current.clientWidth : 0;
 		}
-		return this.gallery.current ? this.gallery.current.clientWidth : 0;
+		// children.length is a deliberate, pragmatic proxy for "number of flex
+		// items", and the division below assumes those items are equal width — it
+		// does not honor per-item flex-grow/flex-basis. That's enough for the common
+		// Row/Stack of galleries; non-uniform rows are left as a follow-up.
+		const count = container.children.length;
+		if ( count <= 1 ) {
+			return container.clientWidth;
+		}
+		// Several flex items share the row. Give each an equal, deterministic share
+		// of the container's available width (minus the flex gap) instead of
+		// measuring the gallery's own width: that width is circularly defined by our
+		// own layout and settles to a different value on each reload in Firefox.
+		// Dividing the container width is content-independent, so the result is
+		// stable across browsers/reloads. See JETPACK-1726.
+		const view = container.ownerDocument?.defaultView || window;
+		const gap = parseFloat( view.getComputedStyle( container ).columnGap ) || 0;
+		return ( container.clientWidth - gap * ( count - 1 ) ) / count;
 	}
 
 	handleGalleryResize = () => {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -6,9 +6,15 @@ import Row from '../row';
 import { imagesToRatios, ratiosToColumns, ratiosToMosaicRows } from './ratios';
 import { getGalleryRows, handleRowResize } from './resize';
 
+// Smallest width change (in px) that triggers a re-layout. Sub-pixel changes are
+// the signature of a ResizeObserver feedback loop, not a real resize, so ignoring
+// them keeps the observer from spiralling. See JETPACK-1726.
+const RESIZE_THRESHOLD = 1;
+
 export default class Mosaic extends Component {
 	gallery = createRef();
 	pendingRaf = null;
+	lastWidth = null; // width (px) of the most recent layout pass
 	ro = null; // resizeObserver instance
 
 	componentDidMount() {
@@ -35,6 +41,13 @@ export default class Mosaic extends Component {
 		this.pendingRaf = requestAnimationFrame( () => {
 			for ( const { contentRect, target } of entries ) {
 				const { width } = contentRect;
+				// Ignore sub-pixel width changes. When the block is a content-sized
+				// flex item (inside a Row/Stack), our own layout writes can feed back
+				// into the observed width; bailing here stops that feedback loop.
+				if ( null !== this.lastWidth && Math.abs( width - this.lastWidth ) < RESIZE_THRESHOLD ) {
+					continue;
+				}
+				this.lastWidth = width;
 				const colWidths = [];
 				getGalleryRows( target ).forEach( row => {
 					colWidths.push( handleRowResize( row, width ) );
@@ -48,6 +61,9 @@ export default class Mosaic extends Component {
 
 	triggerResize() {
 		if ( this.gallery.current ) {
+			// The images or layout changed, not necessarily the width, so force the
+			// next pass to run regardless of the resize threshold.
+			this.lastWidth = null;
 			this.handleGalleryResize( [
 				{
 					target: this.gallery.current,

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -33,28 +33,90 @@ export default class Mosaic extends Component {
 		}
 	}
 
-	handleGalleryResize = entries => {
+	/**
+	 * Nearest ancestor that lays the gallery out as a flex item, or null when the
+	 * gallery isn't inside a flex container. The returned element is the flex
+	 * container; its width is determined by the surrounding layout rather than by
+	 * the gallery's own content, so it is a stable target to lay out against.
+	 *
+	 * @return {?HTMLElement} The flex container, or null.
+	 */
+	getFlexContainer() {
+		const node = this.gallery.current;
+		if ( ! node ) {
+			return null;
+		}
+		const view = node.ownerDocument?.defaultView || window;
+		// Start above the gallery node itself (which is its own flex row container).
+		let el = node.parentElement;
+		while ( el && el.parentElement ) {
+			const parent = el.parentElement;
+			const display = view.getComputedStyle( parent ).display;
+			if ( 'flex' === display || 'inline-flex' === display ) {
+				return parent;
+			}
+			el = parent;
+		}
+		return null;
+	}
+
+	/**
+	 * Width (px) to lay the mosaic out against. Normally the gallery's own
+	 * content-box width, but when the gallery is a content-sized flex item (e.g.
+	 * selfStretch:"fit" inside a Row/Stack) that width is circularly defined by our
+	 * own layout and settles to a non-deterministic, browser-dependent value across
+	 * reloads. In that case anchor to the flex container's available width, which is
+	 * sized independently of the gallery's content. See JETPACK-1726.
+	 *
+	 * @return {number} The layout width in px.
+	 */
+	getLayoutWidth() {
+		const container = this.getFlexContainer();
+		if ( container ) {
+			const count = container.children.length;
+			if ( count <= 1 ) {
+				return container.clientWidth;
+			}
+			// Several flex items share the row. Give each an equal, deterministic
+			// share of the container's available width (minus the flex gap) instead
+			// of measuring the gallery's own width: that width is circularly defined
+			// by our own layout and settles to a different value on each reload in
+			// Firefox. Dividing the container width is content-independent, so the
+			// result is stable across browsers/reloads. See JETPACK-1726.
+			const view = container.ownerDocument?.defaultView || window;
+			const styles = view.getComputedStyle( container );
+			const gap = parseFloat( styles.columnGap || styles.gap || '' ) || 0;
+			return ( container.clientWidth - gap * ( count - 1 ) ) / count;
+		}
+		return this.gallery.current ? this.gallery.current.clientWidth : 0;
+	}
+
+	handleGalleryResize = () => {
 		if ( this.pendingRaf ) {
 			cancelAnimationFrame( this.pendingRaf );
 			this.pendingRaf = null;
 		}
 		this.pendingRaf = requestAnimationFrame( () => {
-			for ( const { contentRect, target } of entries ) {
-				const { width } = contentRect;
-				// Ignore sub-pixel width changes. When the block is a content-sized
-				// flex item (inside a Row/Stack), our own layout writes can feed back
-				// into the observed width; bailing here stops that feedback loop.
-				if ( null !== this.lastWidth && Math.abs( width - this.lastWidth ) < RESIZE_THRESHOLD ) {
-					continue;
-				}
-				this.lastWidth = width;
-				const colWidths = [];
-				getGalleryRows( target ).forEach( row => {
-					colWidths.push( handleRowResize( row, width ) );
-				} );
-				if ( 'undefined' !== typeof this.props.onResize ) {
-					this.props.onResize( colWidths );
-				}
+			const galleryNode = this.gallery.current;
+			if ( ! galleryNode ) {
+				return;
+			}
+			// Lay out against a stable width rather than the (possibly content-sized)
+			// observed width, so the result is deterministic across browsers/reloads.
+			const width = this.getLayoutWidth();
+			// Ignore sub-pixel width changes. When the block is a content-sized flex
+			// item (inside a Row/Stack), our own layout writes can feed back into the
+			// observed width; bailing here stops that feedback loop.
+			if ( null !== this.lastWidth && Math.abs( width - this.lastWidth ) < RESIZE_THRESHOLD ) {
+				return;
+			}
+			this.lastWidth = width;
+			const colWidths = [];
+			getGalleryRows( galleryNode ).forEach( row => {
+				colWidths.push( handleRowResize( row, width ) );
+			} );
+			if ( 'undefined' !== typeof this.props.onResize ) {
+				this.props.onResize( colWidths );
 			}
 		} );
 	};
@@ -64,12 +126,7 @@ export default class Mosaic extends Component {
 			// The images or layout changed, not necessarily the width, so force the
 			// next pass to run regardless of the resize threshold.
 			this.lastWidth = null;
-			this.handleGalleryResize( [
-				{
-					target: this.gallery.current,
-					contentRect: { width: this.gallery.current.clientWidth },
-				},
-			] );
+			this.handleGalleryResize();
 		}
 	}
 
@@ -78,6 +135,13 @@ export default class Mosaic extends Component {
 		this.ro = new ResizeObserver( this.handleGalleryResize );
 		if ( this.gallery.current ) {
 			this.ro.observe( this.gallery.current );
+			// Also watch the flex container: when the gallery lays out against the
+			// container's width, a container resize (e.g. window resize) won't
+			// necessarily change the gallery's own box, so observe it directly.
+			const container = this.getFlexContainer();
+			if ( container ) {
+				this.ro.observe( container );
+			}
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -63,8 +63,11 @@ function getImageRatio( img ) {
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	// Account for both JS and CSS gutters (they're the same value)
-	const totalGutterSpace = GUTTER_WIDTH * 2 * ( row.childElementCount - 1 );
+	// Reserve one gutter per gap between columns, matching the single gutter the
+	// DOM actually renders. Reserving more makes each layout pass narrower than
+	// the measured width, which spirals into an infinite resize loop when the
+	// block is a content-sized flex item (inside a Row/Stack). See JETPACK-1726.
+	const totalGutterSpace = GUTTER_WIDTH * ( row.childElementCount - 1 );
 	const availableWidth = width - totalGutterSpace;
 	const rawHeight = ( 1 / ratio ) * ( availableWidth - weightedRatio );
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
@@ -1,0 +1,85 @@
+import { render } from '@testing-library/react';
+import Mosaic from '../index';
+
+let observerCallback;
+
+jest.mock( 'resize-observer-polyfill', () => {
+	return class ResizeObserverMock {
+		constructor( cb ) {
+			observerCallback = cb;
+		}
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	};
+} );
+
+describe( 'Mosaic resize loop guard', () => {
+	let rafSpy;
+	let cafSpy;
+
+	beforeEach( () => {
+		observerCallback = undefined;
+		// Run the queued layout work synchronously so assertions are deterministic.
+		rafSpy = jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( cb => {
+			cb();
+			return 1;
+		} );
+		cafSpy = jest.spyOn( window, 'cancelAnimationFrame' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		rafSpy.mockRestore();
+		cafSpy.mockRestore();
+	} );
+
+	function mountMosaic( onResize ) {
+		const images = [
+			{ width: 100, height: 100 },
+			{ width: 100, height: 100 },
+			{ width: 100, height: 100 },
+		];
+		const renderedImages = images.map( ( img, i ) => (
+			<div className="tiled-gallery__item" key={ i }>
+				<img data-width="100" data-height="100" alt="" />
+			</div>
+		) );
+
+		render(
+			<Mosaic
+				align="center"
+				columns={ 3 }
+				images={ images }
+				layoutStyle="rectangular"
+				renderedImages={ renderedImages }
+				onResize={ onResize }
+			/>
+		);
+	}
+
+	function fireResize( width ) {
+		// The guard compares widths only; the observed target just needs to be a
+		// node the handler can query for rows (there are none here, which is fine).
+		observerCallback( [ { contentRect: { width }, target: document.createElement( 'div' ) } ] );
+	}
+
+	it( 'recomputes for a real width change but ignores a sub-pixel one', () => {
+		const onResize = jest.fn();
+		mountMosaic( onResize );
+
+		// Ignore the initial layout pass that runs on mount.
+		onResize.mockClear();
+
+		fireResize( 500 );
+		expect( onResize ).toHaveBeenCalledTimes( 1 );
+
+		// A sub-pixel change is the signature of the ResizeObserver feedback loop:
+		// it must not trigger another layout pass. See JETPACK-1726.
+		fireResize( 500.4 );
+		expect( onResize ).toHaveBeenCalledTimes( 1 );
+
+		// A genuine resize is still honored.
+		fireResize( 560 );
+		expect( onResize ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
@@ -17,20 +17,29 @@ jest.mock( 'resize-observer-polyfill', () => {
 describe( 'Mosaic resize loop guard', () => {
 	let rafSpy;
 	let cafSpy;
+	let clientWidthSpy;
+	let currentWidth;
 
 	beforeEach( () => {
 		observerCallback = undefined;
+		currentWidth = 0;
 		// Run the queued layout work synchronously so assertions are deterministic.
 		rafSpy = jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( cb => {
 			cb();
 			return 1;
 		} );
 		cafSpy = jest.spyOn( window, 'cancelAnimationFrame' ).mockImplementation( () => {} );
+		// The mosaic now lays out against a measured DOM width rather than the
+		// ResizeObserver's reported contentRect, so drive the width via clientWidth.
+		clientWidthSpy = jest
+			.spyOn( window.HTMLElement.prototype, 'clientWidth', 'get' )
+			.mockImplementation( () => currentWidth );
 	} );
 
 	afterEach( () => {
 		rafSpy.mockRestore();
 		cafSpy.mockRestore();
+		clientWidthSpy.mockRestore();
 	} );
 
 	function mountMosaic( onResize ) {
@@ -58,8 +67,9 @@ describe( 'Mosaic resize loop guard', () => {
 	}
 
 	function fireResize( width ) {
-		// The guard compares widths only; the observed target just needs to be a
-		// node the handler can query for rows (there are none here, which is fine).
+		// The mosaic reads its layout width from the DOM; the ResizeObserver entry is
+		// only a trigger, so the reported contentRect value is irrelevant here.
+		currentWidth = width;
 		observerCallback( [ { contentRect: { width }, target: document.createElement( 'div' ) } ] );
 	}
 
@@ -81,5 +91,93 @@ describe( 'Mosaic resize loop guard', () => {
 		// A genuine resize is still honored.
 		fireResize( 560 );
 		expect( onResize ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+describe( 'Mosaic layout-width anchoring', () => {
+	let computedStyleSpy;
+
+	function defineClientWidth( el, width ) {
+		Object.defineProperty( el, 'clientWidth', { configurable: true, get: () => width } );
+	}
+
+	afterEach( () => {
+		if ( computedStyleSpy ) {
+			computedStyleSpy.mockRestore();
+			computedStyleSpy = undefined;
+		}
+	} );
+
+	function instanceFor( galleryNode ) {
+		// Exercise the geometry helpers without rendering: they only need a ref.
+		const mosaic = new Mosaic( {} );
+		mosaic.gallery = { current: galleryNode };
+		return mosaic;
+	}
+
+	it( 'anchors a lone flex item to the container width (deterministic, not its circular content width)', () => {
+		// container(flex, 800) > item > wrapper > gallery(content-sized, 300)
+		const container = document.createElement( 'div' );
+		const item = document.createElement( 'div' );
+		const wrapper = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		container.appendChild( item );
+		item.appendChild( wrapper );
+		wrapper.appendChild( gallery );
+
+		defineClientWidth( container, 800 );
+		defineClientWidth( gallery, 300 );
+
+		computedStyleSpy = jest
+			.spyOn( window, 'getComputedStyle' )
+			.mockImplementation( el => ( { display: el === container ? 'flex' : 'block' } ) );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.getFlexContainer() ).toBe( container );
+		// Sole flex item: stable container width, NOT the gallery's circular content width.
+		expect( mosaic.getLayoutWidth() ).toBe( 800 );
+	} );
+
+	it( 'gives each gallery a deterministic equal share when the row holds several galleries', () => {
+		// container(flex, 800, 20px gap) > [itemA > galleryA, itemB > galleryB]
+		// Two flex items: lay out to a stable (800 - 20) / 2 = 390 share rather than
+		// galleryA's own content width, which is circular and varies per reload.
+		const container = document.createElement( 'div' );
+		const itemA = document.createElement( 'div' );
+		const itemB = document.createElement( 'div' );
+		const galleryA = document.createElement( 'div' );
+		container.appendChild( itemA );
+		container.appendChild( itemB );
+		itemA.appendChild( galleryA );
+
+		defineClientWidth( container, 800 );
+		defineClientWidth( galleryA, 999 ); // own (circular) width must be ignored
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => ( {
+			display: el === container ? 'flex' : 'block',
+			columnGap: '20px',
+			gap: '20px',
+		} ) );
+
+		const mosaic = instanceFor( galleryA );
+		expect( mosaic.getFlexContainer() ).toBe( container );
+		// (800 - 20 * (2 - 1)) / 2 = 390 — independent of galleryA's own width.
+		expect( mosaic.getLayoutWidth() ).toBe( 390 );
+	} );
+
+	it( 'falls back to the gallery width when there is no flex container', () => {
+		const parent = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		parent.appendChild( gallery );
+
+		defineClientWidth( gallery, 620 );
+
+		computedStyleSpy = jest
+			.spyOn( window, 'getComputedStyle' )
+			.mockImplementation( () => ( { display: 'block' } ) );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.getFlexContainer() ).toBeNull();
+		expect( mosaic.getLayoutWidth() ).toBe( 620 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.js
@@ -101,6 +101,15 @@ describe( 'Mosaic layout-width anchoring', () => {
 		Object.defineProperty( el, 'clientWidth', { configurable: true, get: () => width } );
 	}
 
+	// Make `flexEl` report as a flex container (with an optional column gap) and
+	// every other element as a plain block.
+	function mockFlex( flexEl, columnGap = 'normal' ) {
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => ( {
+			display: el === flexEl ? 'flex' : 'block',
+			columnGap: el === flexEl ? columnGap : 'normal',
+		} ) );
+	}
+
 	afterEach( () => {
 		if ( computedStyleSpy ) {
 			computedStyleSpy.mockRestore();
@@ -128,9 +137,7 @@ describe( 'Mosaic layout-width anchoring', () => {
 		defineClientWidth( container, 800 );
 		defineClientWidth( gallery, 300 );
 
-		computedStyleSpy = jest
-			.spyOn( window, 'getComputedStyle' )
-			.mockImplementation( el => ( { display: el === container ? 'flex' : 'block' } ) );
+		mockFlex( container );
 
 		const mosaic = instanceFor( gallery );
 		expect( mosaic.getFlexContainer() ).toBe( container );
@@ -153,11 +160,7 @@ describe( 'Mosaic layout-width anchoring', () => {
 		defineClientWidth( container, 800 );
 		defineClientWidth( galleryA, 999 ); // own (circular) width must be ignored
 
-		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => ( {
-			display: el === container ? 'flex' : 'block',
-			columnGap: '20px',
-			gap: '20px',
-		} ) );
+		mockFlex( container, '20px' );
 
 		const mosaic = instanceFor( galleryA );
 		expect( mosaic.getFlexContainer() ).toBe( container );
@@ -172,9 +175,7 @@ describe( 'Mosaic layout-width anchoring', () => {
 
 		defineClientWidth( gallery, 620 );
 
-		computedStyleSpy = jest
-			.spyOn( window, 'getComputedStyle' )
-			.mockImplementation( () => ( { display: 'block' } ) );
+		mockFlex( null ); // no flex ancestor
 
 		const mosaic = instanceFor( gallery );
 		expect( mosaic.getFlexContainer() ).toBeNull();

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/resize.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/resize.js
@@ -1,0 +1,65 @@
+import { GUTTER_WIDTH } from '../../../constants';
+import { handleRowResize } from '../resize';
+
+/**
+ * Build a `.tiled-gallery__row` element with the given number of single-image columns.
+ *
+ * @param {number} numCols - Number of columns to create.
+ * @return {HTMLElement} The constructed row element.
+ */
+function buildRow( numCols ) {
+	const row = document.createElement( 'div' );
+	row.className = 'tiled-gallery__row';
+
+	for ( let c = 0; c < numCols; c++ ) {
+		const col = document.createElement( 'div' );
+		col.className = 'tiled-gallery__col';
+
+		const item = document.createElement( 'div' );
+		item.className = 'tiled-gallery__item';
+
+		const img = document.createElement( 'img' );
+		img.dataset.width = '100';
+		img.dataset.height = '100';
+
+		item.appendChild( img );
+		col.appendChild( item );
+		row.appendChild( col );
+	}
+
+	return row;
+}
+
+/**
+ * Sum the inline pixel widths handleRowResize wrote onto a row's items.
+ *
+ * @param {HTMLElement} row - The row element previously passed to handleRowResize.
+ * @return {number} Total of the items' inline `width` values, in pixels.
+ */
+function sumItemWidths( row ) {
+	return Array.from( row.querySelectorAll( '.tiled-gallery__item' ) ).reduce(
+		( sum, item ) => sum + parseFloat( item.style.width ),
+		0
+	);
+}
+
+describe( 'handleRowResize gutter accounting', () => {
+	it.each( [ 2, 3, 4 ] )(
+		'lays a %i-column row out so columns + one rendered gutter per gap fill the width',
+		numCols => {
+			const width = 600;
+			const row = buildRow( numCols );
+
+			handleRowResize( row, width );
+
+			// The DOM renders exactly one gutter per gap (margin between columns).
+			// The laid-out columns plus those rendered gutters must add up to the
+			// measured width. Reserving more gutter space than is rendered makes
+			// every layout pass narrower than its container, which spirals into an
+			// infinite resize loop when the block is a content-sized flex item
+			// (inside a Row/Stack). See JETPACK-1726.
+			const renderedGutters = GUTTER_WIDTH * ( numCols - 1 );
+			expect( sumItemWidths( row ) + renderedGutters ).toBeCloseTo( width, 5 );
+		}
+	);
+} );


### PR DESCRIPTION
Fixes Automattic/jetpack#49564<br>Fixes Automattic/jetpack#49564

## Proposed changes

* Fix an infinite resize loop in the Tiled Gallery block when it is placed inside a Row or Stack block. The mosaic layout reserved two gutters per column gap (`GUTTER_WIDTH * 2`) while the DOM renders only one. Inside a content-sized flex container (Row/Stack) the block's width is driven by its own content, so each `ResizeObserver` pass laid the content out one gutter narrower than it measured — spiralling the gallery toward zero width and snapping back, forever. It now reserves a single gutter per gap, matching the rendered DOM (and every deprecated layout copy).
* Add a defensive re-entrancy guard to the mosaic `ResizeObserver`: it tracks the width of the last layout pass and ignores sub-pixel changes (the signature of a feedback loop rather than a real resize). `triggerResize()` clears the tracked width so genuine content/layout changes still recompute.
* Add unit tests for the gutter accounting and the resize-loop guard.

This is editor/front-end runtime layout only; `save()` output is unchanged for any given attributes, so no block deprecation is required and existing galleries continue to validate.

## Related product discussion/links

* Automattic/jetpack#49564
* [https://github.com/Automattic/jetpack/issues/49564](<https://github.com/Automattic/jetpack/issues/49564>)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a new post or page in the block editor.
* Add a **Row** block (the bug also reproduces with a **Stack** block).
* Inside it, insert a **Tiled Gallery** block and add several images.
  * **Before:** the gallery continuously shrinks until it disappears, then snaps back to full size and repeats, making it hard to edit.
  * **After:** the gallery renders at a stable size and stays put. Confirm you can select and edit images normally.
* Resize the editor (e.g. toggle the settings sidebar): the gallery should adapt to the new width and settle, without looping.
* Sanity-check a Tiled Gallery placed in normal (non-flex) content: it should still render and resize correctly in both the editor and on the front end.

Before:

https://github.com/user-attachments/assets/9e415998-3ba2-4903-a0bc-804d62744d6d

After:

https://github.com/user-attachments/assets/3a226904-2076-431b-bd3d-27a1df736bad