### PR TITLE
Premium Analytics: update Locations selector size

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-locations-selectcontrol-size
+++ b/projects/packages/premium-analytics/changelog/fix-locations-selectcontrol-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Locations widget: Use the updated view selector size.

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -176,6 +176,7 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 					) }
 				</Stack>
 				<SelectControl
+					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					label={ __( 'View by', 'jetpack-premium-analytics' ) }
 					hideLabelFromVision


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add the WordPress Components 40px default size opt-in to the Premium Analytics Locations widget view selector.
* This is needed because loading the Premium Analytics dashboard with the Locations widget surfaces a browser console warning that the 36px default size for `wp.components.SelectControl` is deprecated. WordPress deprecated that default in 6.8, and Jetpack currently requires WordPress 6.9, so this warning applies in Jetpack's supported WordPress versions. The shared date range selector already opts into the new default size; this keeps the Locations selector aligned with that current component contract.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* In a Premium Analytics local environment, open the dashboard page that renders the Locations widget.
* Confirm the Locations widget's "View by" selector renders normally.
* Confirm the browser console no longer logs the `wp.components.SelectControl` 36px default size deprecation warning for the Locations selector.
* Run `pnpm --filter @automattic/jetpack-premium-analytics typecheck`.
* Run `pnpm --filter @automattic/jetpack-premium-analytics build`.
* Run `pnpm --filter @automattic/jetpack-premium-analytics test`.
