### PR TITLE
Charts: Load GeoChart package explicitly

### DIFF
--- a/projects/js-packages/charts/changelog/fix-geochart-package-loader
+++ b/projects/js-packages/charts/changelog/fix-geochart-package-loader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+GeoChart: Load the required Google Charts package explicitly.

--- a/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
@@ -19,6 +19,9 @@ import { GeoChartProps } from './types';
 
 const DEFAULT_FEATURE_FILL_COLOR = '#ffffff';
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
+// `chartPackages` replaces (not extends) react-google-charts' default `[ 'corechart', 'controls' ]`,
+// so we restate the defaults and add `geochart`. Without it the loader backfills the geochart package
+// late, which can clash with another Google Charts version already loaded on the page.
 const GEO_CHART_PACKAGES: GoogleChartPackages[] = [ 'corechart', 'controls', 'geochart' ];
 
 type GoogleChartOptions = Record< string, unknown >;

--- a/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { FC, useContext, useMemo } from 'react';
-import { Chart } from 'react-google-charts';
+import { Chart, type GoogleChartPackages } from 'react-google-charts';
 /**
  * Internal dependencies
  */
@@ -19,6 +19,7 @@ import { GeoChartProps } from './types';
 
 const DEFAULT_FEATURE_FILL_COLOR = '#ffffff';
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
+const GEO_CHART_PACKAGES: GoogleChartPackages[] = [ 'corechart', 'controls', 'geochart' ];
 
 type GoogleChartOptions = Record< string, unknown >;
 
@@ -154,6 +155,7 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 		>
 			<Chart
 				chartType="GeoChart"
+				chartPackages={ GEO_CHART_PACKAGES }
 				width={ width }
 				height={ height }
 				data={ sanitizedData.data }

--- a/projects/js-packages/charts/src/charts/geo-chart/test/geo-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/test/geo-chart.test.tsx
@@ -4,9 +4,10 @@ import GeoChart, { GeoChartUnresponsive } from '../geo-chart';
 
 // Mock react-google-charts
 jest.mock( 'react-google-charts', () => ( {
-	Chart: jest.fn( ( { data, options, width, height } ) => {
+	Chart: jest.fn( ( { chartPackages, data, options, width, height } ) => {
 		return (
 			<div data-testid="google-chart-mock" data-width={ width } data-height={ height }>
+				<div data-testid="chart-packages">{ JSON.stringify( chartPackages ) }</div>
 				<div data-testid="chart-data">{ JSON.stringify( data ) }</div>
 				<div data-testid="chart-options">{ JSON.stringify( options ) }</div>
 			</div>
@@ -63,6 +64,15 @@ describe( 'GeoChart', () => {
 			const chart = screen.getByTestId( 'google-chart-mock' );
 			expect( chart ).toHaveAttribute( 'data-width', '1200' );
 			expect( chart ).toHaveAttribute( 'data-height', '600' );
+		} );
+
+		test( 'loads the GeoChart package explicitly', () => {
+			renderWithTheme();
+
+			const chartPackages = screen.getByTestId( 'chart-packages' );
+			const packages = JSON.parse( chartPackages.textContent || '[]' );
+
+			expect( packages ).toEqual( [ 'corechart', 'controls', 'geochart' ] );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Load the Google `geochart` package explicitly when rendering [`@automattic/charts` `GeoChart`](https://github.com/Automattic/jetpack/blob/172159d3f0b755bfb53dbc8f2a3a208b34b8b9e9/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx#L22-L23), while preserving the `react-google-charts` default `corechart` and `controls` packages.
* Add unit coverage to verify the GeoChart wrapper passes the expected Google Charts package list.
* Add a patch changelog entry for `@automattic/charts`.

## Why this is being proposed
The [Premium Analytics Locations widget](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/widgets/locations/render.tsx#L206-L211) renders `GeoChart` from `@automattic/charts`. That wrapper delegates to `react-google-charts`, whose default package list is `corechart` and `controls`.

`GeoChart` itself requires the Google Charts `geochart` package. Without requesting that package up front, Google Charts can attempt a later package load after the loader has already initialized with a different version request elsewhere on the page. In the observed page this surfaced as:

`Attempting to load version '51' of Google Charts, but the previously loaded 'current' will be used instead.`

This PR keeps the existing `react-google-charts` defaults and adds only the missing `geochart` package for the `GeoChart` component. That makes the component's loader request match the chart type it renders, and avoids relying on Google Charts internals or another page script to backfill the package later.

## Impact review
* Jetpack: Directly affects `@automattic/charts` `GeoChart` consumers. Current in-repo consumers are [Premium Analytics Locations](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/widgets/locations/render.tsx#L206-L211), [Premium Analytics visitors-by-location](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx#L184-L185), and [Podcast stats locations](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/podcast/src/dashboard/stats/components/stats-locations.tsx#L1-L8). Non-GeoChart consumers of `@automattic/charts` are not expected to change because this prop is passed only by the GeoChart wrapper.
* Calypso: Current Calypso code search shows Calypso has its own [Stats GeoChart implementation and loader](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/geochart/index.jsx), used by [Stats Locations](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx), separate from `@automattic/charts` `GeoChart`. Calypso also consumes `@automattic/charts` for dashboard charts such as [monitoring HTTP responses](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/sites/monitoring-http-responses-card/index.tsx) and [monitoring request methods](https://github.com/Automattic/wp-calypso/blob/trunk/client/dashboard/sites/monitoring-request-methods-card/index.tsx), but those components do not use this wrapper. This PR should only matter to Calypso if it later adopts this `GeoChart` export or upgrades an affected bundled consumer.
* Dotcom: Dotcom legacy Stats GeoChart code was reviewed, but the source is not publicly linkable from this public PR. It uses its own Google Visualization GeoChart path, not this `@automattic/charts` wrapper. Bundled Dotcom/Stats assets that include `@automattic/charts` line-chart code are not expected to change unless they render this package's `GeoChart`.
* Loader behavior: This does not hard-code a Google Charts version. It continues to let `react-google-charts` request its default version, while ensuring the package list includes the package required by the chart type.
* Data/privacy: The change only affects which Google Charts package is requested before rendering. It does not add tracking, change analytics payloads, or alter chart data.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --filter @automattic/charts test -- geo-chart`.
* Run `pnpm --filter @automattic/charts typecheck`.
* Run `pnpm --filter @automattic/charts build`.
* Run `pnpm --filter @automattic/jetpack-premium-analytics typecheck`.
* Run `pnpm --filter @automattic/jetpack-premium-analytics build`.
* Render the Premium Analytics Locations widget and confirm the Google Charts version warning is no longer emitted when GeoChart loads.
