### PR TITLE
Premium Analytics: fix dashboard global error provider

### DIFF
--- a/projects/packages/premium-analytics/changelog/premium-analytics-global-error-provider
+++ b/projects/packages/premium-analytics/changelog/premium-analytics-global-error-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Fix global error handling for widgets.

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -6,6 +6,7 @@
 		"page": "jetpack-premium-analytics"
 	},
 	"dependencies": {
+		"@automattic/jetpack-premium-analytics-data": "link:../../packages/data",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@jetpack-premium-analytics/routing": "workspace:*",
 		"@wordpress/admin-ui": "2.1.0",

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,3 +1,4 @@
+import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -45,46 +46,48 @@ function Dashboard(): JSX.Element {
 	const [ editMode, setEditMode ] = useState( false );
 
 	return (
-		<WidgetDashboard
-			widgetTypes={ widgetTypes }
-			isResolvingWidgetTypes={ isResolvingWidgetTypes }
-			layout={ layout }
-			onLayoutChange={ setLayout }
-			onLayoutReset={ resetLayout }
-			gridSettings={ gridSettings }
-			onGridSettingsChange={ setGridSettings }
-			editMode={ editMode }
-			onEditChange={ setEditMode }
-		>
-			<Page
-				title={ __( 'Analytics', 'jetpack-premium-analytics' ) }
-				subTitle={ __(
-					'Track your site performance and visitor insights.',
-					'jetpack-premium-analytics'
-				) }
-				actions={ <WidgetDashboard.Actions /> }
-				className={ styles.dashboard }
+		<GlobalErrorProvider>
+			<WidgetDashboard
+				widgetTypes={ widgetTypes }
+				isResolvingWidgetTypes={ isResolvingWidgetTypes }
+				layout={ layout }
+				onLayoutChange={ setLayout }
+				onLayoutReset={ resetLayout }
+				gridSettings={ gridSettings }
+				onGridSettingsChange={ setGridSettings }
+				editMode={ editMode }
+				onEditChange={ setEditMode }
 			>
-				<DashboardSections
-					sections={ sections }
-					value={ activeSection }
-					onChange={ setActiveSection }
+				<Page
+					title={ __( 'Analytics', 'jetpack-premium-analytics' ) }
+					subTitle={ __(
+						'Track your site performance and visitor insights.',
+						'jetpack-premium-analytics'
+					) }
+					actions={ <WidgetDashboard.Actions /> }
+					className={ styles.dashboard }
 				>
-					{ sections.map( section => (
-						<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
-							{ activeSection === section.id ? (
-								<>
-									<WidgetDashboard.NoWidgetsState />
-									<WidgetDashboard.Widgets />
-								</>
-							) : null }
-						</Tabs.Panel>
-					) ) }
-				</DashboardSections>
+					<DashboardSections
+						sections={ sections }
+						value={ activeSection }
+						onChange={ setActiveSection }
+					>
+						{ sections.map( section => (
+							<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
+								{ activeSection === section.id ? (
+									<>
+										<WidgetDashboard.NoWidgetsState />
+										<WidgetDashboard.Widgets />
+									</>
+								) : null }
+							</Tabs.Panel>
+						) ) }
+					</DashboardSections>
 
-				<WidgetDashboard.Commands />
-			</Page>
-		</WidgetDashboard>
+					<WidgetDashboard.Commands />
+				</Page>
+			</WidgetDashboard>
+		</GlobalErrorProvider>
 	);
 }
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Wrap the live Premium Analytics dashboard route in `GlobalErrorProvider` so dashboard widgets can call `useGlobalError()` without logging the provider warning.
* Add the dashboard route package dependency needed for the provider import.
* Add a Premium Analytics changelog entry.

This PR is needed because the live dashboard route rendered `WidgetDashboard` directly, while dashboard widgets use the shared widget error hook, which reads from `useGlobalError()`. Storybook already wrapped dashboard-hosted widget stories in `GlobalErrorProvider`, so the warning only appeared in the live dashboard route.

The problem was surfaced while testing the current Premium Analytics dashboard on trunk: the browser console reported `useGlobalError was called outside of GlobalErrorProvider. Wrap your component tree with GlobalErrorProvider.` Tracing that warning showed `useWidgetError()` calling `useGlobalError()` from widget code, with the live route missing the provider wrapper.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --filter @automattic/jetpack-premium-analytics typecheck`.
* Run `pnpm --filter @automattic/jetpack-premium-analytics build`.
* Open the Premium Analytics dashboard with widgets available and confirm the browser console no longer logs `useGlobalError was called outside of GlobalErrorProvider`.
