### PR TITLE
jetpack-review-pr skill: catch cross-package version-skew fatals (class_exists → method_exists)

### DIFF
--- a/.agents/skills/jetpack-review-pr.md
+++ b/.agents/skills/jetpack-review-pr.md
@@ -127,6 +127,7 @@ Note: `AGENTS.md` is already loaded in your context via the CLAUDE.md `@AGENTS.m
 | Security patterns | yes | yes | yes |
 | Security threat model | no | if security files | yes |
 | Backward compat | yes | yes | yes |
+| Cross-package version skew (optional-sibling calls) | yes | yes | yes |
 | Error handling | no | yes | yes |
 | Feature gating | no | yes | yes |
 | HTML / a11y / RTL | no | if has_html/has_css | yes |
@@ -169,6 +170,26 @@ Note: `AGENTS.md` is already loaded in your context via the CLAUDE.md `@AGENTS.m
 - **Removed REST endpoints**: Must version or deprecate
 - **Removed public constants/properties**: Fatal errors in consumers
 - Scan diff for removed lines with `public function`, `function jetpack_`, `do_action(`, `apply_filters(`, `register_rest_route`
+
+*Cross-package version skew — calls into optional sibling packages* (all depths — this catches fatal errors):
+
+A monorepo package may call into another package it does NOT list in its own `composer.json` `require` (e.g. my-jetpack → `SEO\Initializer`, `Search\*`, `VideoPress\*`). On trunk every package is at the same version, so the call resolves and CI passes. But standalone plugins (Social, Boost, VideoPress, Protect, …) each bundle their own `jetpack_vendor/` copies, and jetpack-autoloader loads ONE copy of each shared package across all active plugins — frequently an OLDER version than trunk. The symbol you call may not exist at runtime.
+
+- **`class_exists()` is NOT a sufficient guard** when you then call a method, read a constant, or access a property on that class. The class can load from an older bundled copy that predates the member → `Call to undefined method` fatal. Guard the EXACT symbol you use:
+  - method → `method_exists( $class, 'method' )` or `is_callable()`
+  - constant → `defined( "$class::CONST" )`
+  - function → `function_exists()`
+  - property → `property_exists()`
+- `[blocker]`: a newly-added call into a non-`require`d sibling package guarded only by `class_exists()` (or unguarded). The same PR often adds both the new symbol (in package A) and its caller (in package B), so the diff looks self-consistent — the skew only appears across release trains. Check the guard, not the definition; an internally-consistent diff does not prove the symbol ships together everywhere.
+- Detection:
+  ```bash
+  # Cross-package class references added in this diff:
+  gh pr diff <PR> | grep -nE '^\+.*\\Automattic\\Jetpack\\[A-Z][A-Za-z]+\\'
+  # For each referenced package, confirm it is in THIS project's composer.json "require":
+  grep '"automattic/jetpack-<pkg>"' projects/<type>/<name>/composer.json \
+    || echo "OPTIONAL sibling — any method/constant/property access needs a symbol-level guard"
+  ```
+- Precedent: SOCIAL-515 (`SEO\Initializer::is_optin_available()` fatal on Social 9.0.2 standalone), MYJP-308 (Search product fatal on plugins not bundling jetpack-search). Both: `class_exists()` passed, the method was absent from the bundled copy.
 
 *Feature gating* (standard + thorough):
 - New user-facing features (admin pages, blocks, endpoints) should be gated behind feature flags for staged rollout. Flag if ungated.
@@ -253,6 +274,8 @@ grep -r "@automattic/jetpack-<package-name>" projects/*/*/package.json
 ```
 
 Flag changes that could break consumers (changed signatures, removed methods, altered return types). List affected downstream projects.
+
+**Upstream direction too:** if the diff *adds* a call into a monorepo package this project does NOT `require`, that call is subject to version skew on standalone installs — apply the *Cross-package version skew* check from step 4.
 
 ### 6. Test and static analysis (thorough only)
 
@@ -366,6 +389,7 @@ Review depth: **<depth>** (<lines> lines, <N> projects)
 ### Feature Gating
 ### Data / Privacy
 ### Backward Compatibility / Removed Public API
+### Cross-Package Version Skew
 ### Cross-Project Impact
 ### Test Results
 ### Test Coverage Gaps

--- a/.agents/skills/jetpack-review-pr.md
+++ b/.agents/skills/jetpack-review-pr.md
@@ -128,6 +128,7 @@ Note: `AGENTS.md` is already loaded in your context via the CLAUDE.md `@AGENTS.m
 | Security threat model | no | if security files | yes |
 | Backward compat | yes | yes | yes |
 | Cross-package version skew (optional-sibling calls) | yes | yes | yes |
+| Phan suppressions / baseline growth (from diff) | yes | yes | yes |
 | Error handling | no | yes | yes |
 | Feature gating | no | yes | yes |
 | HTML / a11y / RTL | no | if has_html/has_css | yes |
@@ -190,6 +191,27 @@ A monorepo package may call into another package it does NOT list in its own `co
     || echo "OPTIONAL sibling — any method/constant/property access needs a symbol-level guard"
   ```
 - Precedent: SOCIAL-515 (`SEO\Initializer::is_optin_available()` fatal on Social 9.0.2 standalone), MYJP-308 (Search product fatal on plugins not bundling jetpack-search). Both: `class_exists()` passed, the method was absent from the bundled copy.
+
+*Static analysis suppressions — don't silence Phan instead of fixing it* (all depths — diff-visible, can hide fatals):
+
+`jp phan` (the monorepo's PHP static analyzer) runs in CI and must stay green. The shortcut to a green run is to *silence* an error rather than fix it — and a silenced `PhanUndeclared*`, undefined-variable, deprecated-call, or type-mismatch is frequently a real runtime bug (often the same version skew as above) hidden from CI. A PR should make Phan pass by fixing code, not by suppressing it. **Treat a newly-added suppression as a finding in its own right — report it even when you cannot independently confirm the underlying bug, and ask for a fix or a written justification.**
+
+Scan the diff for both silencing mechanisms:
+- **New inline suppressions**: `@phan-suppress-next-line`, `@phan-suppress-current-line`, `@phan-suppress` (docblock), `@phan-file-suppress` (whole file).
+- **Baseline growth**: added entries, or raised "N occurrences" counts, in any `.phan/baseline.php`. The baseline exists only to grandfather *pre-existing* debt for incremental fixing — a PR should shrink or hold it, never grow it. A new baseline entry means the PR is hiding an error it just introduced.
+
+Severity:
+- `[blocker]`: the suppressed issue is a real defect — `PhanUndeclared{Method,ClassMethod,Function,StaticMethod}` (symbol may be absent at runtime — see Cross-package version skew above), `PhanPossiblyUndeclaredVariable`/`PhanUndeclaredVariable` (use-before-init), `PhanDeprecated*` (removed in a future PHP or dependency version), or a `PhanTypeMismatch*` on a security/data path. Fix the code and drop the suppression.
+- `[suggestion]`: a plausible false positive whose inline suppression carries no `-- <reason>` justification. Jetpack convention is that every legitimate suppression states why it is safe, e.g. `// @phan-suppress-current-line PhanUndeclaredFunction -- Guarded by function_exists().` An unexplained suppression can't be reviewed.
+- Discard only when it is a documented false positive WITH a justification comment and the code is provably safe.
+
+Detection:
+```bash
+# Inline suppressions added by this PR:
+gh pr diff <PR> | grep -nE '^\+.*@phan-(suppress|file-suppress)'
+# If the file list includes any .phan/baseline.php, inspect its hunk: every added
+# 'Phan...' entry or raised "N occurrences" count is a newly-hidden error.
+```
 
 *Feature gating* (standard + thorough):
 - New user-facing features (admin pages, blocks, endpoints) should be gated behind feature flags for staged rollout. Flag if ungated.
@@ -298,6 +320,8 @@ After each test command, check the exit code:
 
 If deps are missing, `jp install <project>` and retry once.
 
+If `jp phan` passes only because the diff added `@phan-suppress` annotations or grew `.phan/baseline.php`, that is itself a finding — apply *Static analysis suppressions* from step 4. A green Phan run earned by suppression is not a passing Phan run.
+
 **Test quality review** (read new/modified test files):
 - Coverage: are new public functions/endpoints tested?
 - One assertion per concept, flat structure, no logic in tests
@@ -390,6 +414,7 @@ Review depth: **<depth>** (<lines> lines, <N> projects)
 ### Data / Privacy
 ### Backward Compatibility / Removed Public API
 ### Cross-Package Version Skew
+### Phan Suppressions
 ### Cross-Project Impact
 ### Test Results
 ### Test Coverage Gaps


### PR DESCRIPTION
Fixes # N/A — post-mortem follow-up to SOCIAL-515 (the fix itself shipped in #49988).

## Proposed changes

Harden the `jetpack-review-pr` skill so it catches the class of silent dependency bug behind SOCIAL-515 — a fatal that both human and Claude reviewers missed.

The bug: a package calls into a *sibling* package it does **not** declare in its own `composer.json` `require` (e.g. my-jetpack → `SEO\Initializer`), guarded only by `class_exists()`. On trunk every package is at the same version, so it resolves and CI passes — but standalone plugins (Social, Boost, …) each bundle their own `jetpack_vendor/` copies and the autoloader loads ONE copy across all active plugins, often an *older* one. `class_exists()` then passes while a newly-added method is absent → `Call to undefined method` fatal. It was invisible in review because the introducing PR (#49672) added the new method **and** its `class_exists`-guarded caller in the same self-consistent diff.

* Add a **Cross-package version skew** check to step 4 (runs at all depths — it catches fatals): `class_exists()` is not a sufficient guard before a method/constant/property access on a non-`require`d sibling; the guard must check the exact symbol (`method_exists`/`is_callable`/`defined`/`function_exists`/`property_exists`). Flags such a call as `[blocker]`. Includes a grep detection recipe and the SOCIAL-515 / MYJP-308 precedents.
* Add a row to the step-4 checks table.
* Add an **upstream-direction** note to the cross-project dependency step (step 5) — it previously only checked downstream consumers of a changed package, never calls *into* packages this project doesn't depend on.
* Add a **Cross-Package Version Skew** heading to the full-format report.

Skill-only change under `.agents/` — no product code, no `projects/` files, so no changelog entry is required.

## Related product discussion/links

* SOCIAL-515 — `SEO\Initializer::is_optin_available()` fatal on Social 9.0.2 standalone
* MYJP-308 — same anti-pattern (Search product fatal on plugins not bundling jetpack-search)
* Introducing PR #49672, fix PR #49988

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This change is process documentation (a review skill), validated RED→GREEN against the real before/after diffs:

* Read the new *Cross-package version skew* check in `.agents/skills/jetpack-review-pr.md` (step 4).
* **GREEN** — run `/jetpack-review-pr 49672` (the introducing PR). The review should raise a `[blocker]` for the `class_exists`-guarded `SEO\Initializer::is_optin_available()` call in `projects/packages/my-jetpack/src/class-initializer.php`, recommending `method_exists`.
* **Regression** — run `/jetpack-review-pr 49988` (the fix). The review should raise no version-skew blocker on the corrected `method_exists` guard.
* Baseline for comparison: the same check run against the pre-PR skill misses the fatal (0/3 in testing vs. 3/3 with this change).
