### PR TITLE
Podcast: skip connect prompt on wpcom platform

### DIFF
--- a/projects/packages/podcast/changelog/pods-182-fix-wpcom-connect-prompt
+++ b/projects/packages/podcast/changelog/pods-182-fix-wpcom-connect-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: don't show the "Connect Jetpack" prompt on Simple and Atomic sites, which have no Jetpack site connection.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -165,7 +165,7 @@ class Admin_Page {
 		// product name shown in the locked-preview copy (not translated).
 		$data['podcast'] = array(
 			'has_product_access'  => Podcast_Gate::has_product_access(),
-			'is_connected'        => ( new Connection_Manager( 'jetpack' ) )->is_connected(),
+			'is_connected'        => $is_wpcom || ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
 			// Settings only: categories rejects per_page=-1 server-side, stats is a live relay.

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -183,6 +183,19 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
+	 * WPCOM platforms (Simple/Atomic) have no Jetpack site connection, so the
+	 * raw connection check is false. The flag must still report connected so the
+	 * dashboard skips the connect prompt that only makes sense for self-hosted.
+	 */
+	public function test_inject_script_data_reports_connected_on_wpcom_platform() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$data = Admin_Page::inject_podcast_script_data( array() );
+
+		$this->assertTrue( $data['podcast']['is_connected'] );
+	}
+
+	/**
 	 * WordPress.com platforms already get `site.wpcom.blog_id` from
 	 * jetpack-mu-wpcom, so the podcast injection must not overwrite it.
 	 */


### PR DESCRIPTION
Fixes PODS-187

## Proposed changes

Follow-up fix to #49989. That PR added a hard Jetpack site-connection check to the podcast dashboard script data and gated the Stats/Episodes tabs behind it. Simple and Atomic sites run on the WordPress.com platform and have no Jetpack *site* connection, so `Connection_Manager::is_connected()` returns false for all of them — every Simple/Atomic site was incorrectly shown the "Connect Jetpack" prompt.

* Treat wpcom-platform sites (Simple/WoA) as connected, since the connect gate only applies to self-hosted Jetpack.
* Add a regression test asserting `podcast.is_connected` is true on the wpcom platform.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Simple or Atomic site, open the Podcast dashboard and visit the **Stats** and **Episodes** tabs.
* Confirm the tabs render their normal content (or the paid upsell), **not** the "Connect Jetpack" prompt.
* On a disconnected self-hosted Jetpack site, confirm the connect prompt still appears.
* `cd projects/packages/podcast && composer phpunit -- --filter Admin_Page_Test` — 11 tests pass.
