### PR TITLE
POC: cookie-consent reject button on the general Jetpack block (EDI-425)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-cookie-consent-reject-poc
+++ b/projects/plugins/jetpack/changelog/add-cookie-consent-reject-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a gated proof-of-concept consumer of the jetpack-cookie-consent package (EDI-425), behind the JETPACK_COOKIE_CONSENT_POC flag, which renders the Accept/Reject/Customize consent banner and suppresses the legacy cookie-consent block while enabled. Off by default.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -29,6 +29,7 @@
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-cookie-consent": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-error": "@dev",
 		"automattic/jetpack-external-connections": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "caea7600eeca649122fb8ab7843df34b",
+    "content-hash": "22fb97cb2ae71bd4a81e7fbbd18dcafc",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1319,6 +1319,61 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-cookie-consent",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/cookie-consent",
+                "reference": "d5a3c6a3661fd4437cf1817016e3e94778e878c1"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-cookie-consent",
+                "textdomain": "jetpack-cookie-consent",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-cookie-consent/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "GDPR cookie-consent banner, CCPA opt-out, and consent logging for WordPress.",
             "transport-options": {
                 "relative": true
             }
@@ -6057,6 +6112,7 @@
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,
+        "automattic/jetpack-cookie-consent": 20,
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-error": 20,
         "automattic/jetpack-external-connections": 20,

--- a/projects/plugins/jetpack/cookie-consent-poc.php
+++ b/projects/plugins/jetpack/cookie-consent-poc.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * POC: gated consumer of the jetpack-cookie-consent package (EDI-425).
+ *
+ * Proof of concept only — NOT production ready. When explicitly enabled, this
+ * boots the new Accept / Reject / Customize consent banner from the
+ * jetpack-cookie-consent package on a standard Jetpack site, and suppresses the
+ * legacy `eucookielaw` Cookie Consent block (see
+ * extensions/blocks/cookie-consent/cookie-consent.php) so only one banner renders.
+ *
+ * Default is OFF. Enable with either:
+ *   define( 'JETPACK_COOKIE_CONSENT_POC', true ); // in wp-config.php
+ *   add_filter( 'jetpack_enable_cookie_consent_poc', '__return_true' );
+ *
+ * The package additionally needs the WP Consent API plugin active to write
+ * consent state. Out of scope for this POC: admin UI / settings, Consent API
+ * bundling, copy/region configuration, and any rollout decision.
+ *
+ * @link https://linear.app/a8c/issue/EDI-425
+ * @link https://github.com/Automattic/jetpack/pull/49736 (the mirrored Premium Analytics integration)
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\CookieConsent\Cookie_Consent;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Single gate for the cookie-consent reject-button POC (EDI-425).
+ *
+ * Used both to decide whether to boot the package and whether to suppress the
+ * legacy block, so the two stay in lockstep.
+ *
+ * @return bool Whether the POC is enabled.
+ */
+function jetpack_cookie_consent_poc_enabled() {
+	/**
+	 * Filters whether the cookie-consent reject-button POC is enabled.
+	 *
+	 * Defaults to the JETPACK_COOKIE_CONSENT_POC constant.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $enabled Whether the POC is enabled.
+	 */
+	return (bool) apply_filters(
+		'jetpack_enable_cookie_consent_poc',
+		defined( 'JETPACK_COOKIE_CONSENT_POC' ) && JETPACK_COOKIE_CONSENT_POC
+	);
+}
+
+/**
+ * Boot the jetpack-cookie-consent package when the POC is enabled.
+ *
+ * Mirrors the Premium Analytics integration (PR #49736): the only functional
+ * boot step is Cookie_Consent::init().
+ *
+ * @return void
+ */
+function jetpack_cookie_consent_poc_init() {
+	if ( ! jetpack_cookie_consent_poc_enabled() ) {
+		return;
+	}
+
+	if ( class_exists( Cookie_Consent::class ) ) {
+		Cookie_Consent::init();
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -179,6 +179,15 @@ function cookie_consent_register_settings() {
 add_action( 'rest_api_init', __NAMESPACE__ . '\cookie_consent_register_settings' );
 
 /**
+ * POC (EDI-425): when the cookie-consent reject-button POC is enabled, suppress
+ * this legacy `eucookielaw` block so the site doesn't render two banners. Gated
+ * by the same helper that boots the package (see cookie-consent-poc.php).
+ */
+if ( function_exists( 'jetpack_cookie_consent_poc_enabled' ) && jetpack_cookie_consent_poc_enabled() ) {
+	add_filter( 'jetpack_disable_cookie_consent_block', '__return_true' );
+}
+
+/**
  * Add a fallback color to block styles.
  *
  * @since 15.1

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -95,4 +95,8 @@ add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';
 
+// POC (EDI-425): gated consumer of the jetpack-cookie-consent package. Default OFF.
+require_once JETPACK__PLUGIN_DIR . 'cookie-consent-poc.php';
+jetpack_cookie_consent_poc_init();
+
 Jetpack::init();


### PR DESCRIPTION
## What this is

A **proof of concept** — not production-ready — demonstrating the new Accept / Reject / Customize consent banner (with a working **Reject** button) rendering on a **standard Jetpack site**, instead of the legacy accept/dismiss-only `eucookielaw` Cookie Consent block.

It makes [EDI-425](https://linear.app/a8c/issue/EDI-425/improve-the-cookies-and-consent-blockwidget) concrete by wiring the existing [`jetpack-cookie-consent` package](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/cookie-consent) into the Jetpack plugin, behind an opt-in flag.

## How it works

Mirrors the Premium Analytics integration in [#49736](https://github.com/Automattic/jetpack/pull/49736) (composer require + `Cookie_Consent::init()`), pointed at the Jetpack plugin and gated:

- New file `cookie-consent-poc.php` defines a single gate, `jetpack_cookie_consent_poc_enabled()`, defaulting to the `JETPACK_COOKIE_CONSENT_POC` constant (filterable via `jetpack_enable_cookie_consent_poc`).
- `load-jetpack.php` calls `Cookie_Consent::init()` only when the gate is on.
- Behind the **same** gate, the legacy `eucookielaw` block is suppressed via the existing `jetpack_disable_cookie_consent_block` filter, so a site never shows two banners.

**Default is OFF.** Enable with `define( 'JETPACK_COOKIE_CONSENT_POC', true );` in `wp-config.php`. The package also needs the WP Consent API plugin active to write consent state.

## Verification

Loaded the gated code in a database-free WordPress (WorDBless) runtime under both flag states:

- **Flag ON:** gate `true`; the package's banner render is hooked at `wp_footer` priority 999; the legacy block filter `jetpack_disable_cookie_consent_block` returns `true`; the rendered banner is ~8.5 KB and contains the buttons **Accept**, **Reject**, **Customize**, plus the preferences modal (**Save preferences**, **Accept all**, **Reject all**).
- **Flag OFF:** gate `false`; the new banner is not hooked; the legacy filter returns `false` — the old block behaves exactly as today and the package stays dormant.

## Intentionally out of scope

- Admin UI / settings page (the package has none by design)
- WP Consent API bundling / how a self-hosted site gets that dependency
- Copy / region configuration
- Any rollout or productization decision

A separate investigation doc (background, ownership, and the recommended path) accompanies this internally.



## How to test

1. Launch a Jurassic Ninja test site with this branch: https://jurassic.ninja/create?jetpack-beta&branches.jetpack=add/cookie-consent-reject-poc — if it lands on the JN homepage, reload the link once to start the build.
2. Activate the **WP Consent API** plugin on the new site (the package needs it to write consent): `wp plugin install wp-consent-api --activate` (or Plugins → Add New).
3. Enable the POC flag: `wp config set JETPACK_COOKIE_CONSENT_POC true --raw` (or add `define( 'JETPACK_COOKIE_CONSENT_POC', true );` to `wp-config.php`).
4. Load a front-end page with the preview param so the banner shows regardless of region, and confirm a cache MISS (`cache;desc=MISS`; hard-refresh if you get a HIT): `https://<your-jn-site>/?preview_cookie_consent=1`

**Expected:**
- The banner shows **Accept / Reject / Customize**. Clicking **Customize** opens the preferences modal (Required / Analytics / Advertising, plus Save preferences / Accept all / Reject all).
- The legacy `eucookielaw` banner does **not** also appear while the flag is on.
- With the flag **OFF** (default), behavior is unchanged: the old block works and the package stays dormant.

## Does this change what data or activity we track or use?

This POC adds no tracking of its own. It gates the existing `jetpack-cookie-consent` package (which uses the WP Consent API and its own consent log) behind an opt-in flag that is **OFF by default**, so there is no change unless a site explicitly enables it.
