### PR TITLE
SEO: make the dashboard load-error state recoverable

### DIFF
--- a/projects/packages/seo/_inc/components/load-error.tsx
+++ b/projects/packages/seo/_inc/components/load-error.tsx
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+import type { FC } from 'react';
+
+interface Props {
+	/** The tab-specific error message to show (already translated). */
+	message: string;
+}
+
+// Reload the page — recovers the bootstrap read (see the component docblock).
+const reload = () => window.location.reload();
+
+/**
+ * A recoverable load-error notice for the dashboard screens.
+ *
+ * Each screen reads its state synchronously from the page bootstrap
+ * (`window.JetpackScriptData.seo`, via `getScriptData`) on first render. That
+ * read is one-shot and non-reactive: if the data isn't readable at that single
+ * instant — e.g. a stale or mismatched script bundle after a plugin update, or
+ * a transient gap in the server-side injection — the screen would otherwise
+ * dead-end on a terminal error, even though the data is typically present a
+ * moment later. Pairing the message with a Reload action keeps a momentary,
+ * self-recoverable hiccup from stranding the user: a reload re-runs both the
+ * server-side injection and the asset fetch, which clears either cause.
+ *
+ * @param props         - Component props.
+ * @param props.message - The tab-specific error message (already translated).
+ * @return The recoverable error notice.
+ */
+const LoadError: FC< Props > = ( { message } ) => (
+	<Notice.Root intent="error">
+		<Notice.Description>{ message }</Notice.Description>
+		<Notice.Actions>
+			<Notice.ActionButton onClick={ reload }>
+				{ __( 'Reload', 'jetpack-seo' ) }
+			</Notice.ActionButton>
+		</Notice.Actions>
+	</Notice.Root>
+);
+
+export default LoadError;

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Card, CollapsibleCard, Notice } from '@wordpress/ui';
+import LoadError from '../../components/load-error';
 import type { AiForm } from '../../data/use-ai';
 import type { FC } from 'react';
 
@@ -25,13 +26,7 @@ const AiScreen: FC< Props > = ( { form } ) => {
 	const { enhancer, isSaving, setEnhancerEnabled } = form;
 
 	if ( ! enhancer ) {
-		return (
-			<Notice.Root intent="error">
-				<Notice.Description>
-					{ __( 'Unable to load AI settings.', 'jetpack-seo' ) }
-				</Notice.Description>
-			</Notice.Root>
-		);
+		return <LoadError message={ __( 'Unable to load AI settings.', 'jetpack-seo' ) } />;
 	}
 
 	// The Enhancer requires a supporting plan; when unavailable the card is

--- a/projects/packages/seo/_inc/screens/overview/index.tsx
+++ b/projects/packages/seo/_inc/screens/overview/index.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Notice } from '@wordpress/ui';
 import EnableSeoCard from '../../components/enable-seo-card';
+import LoadError from '../../components/load-error';
 import { coverageStore } from '../../data/coverage-store';
 import getOverview from '../../data/get-overview';
 import { settingsStore } from '../../data/settings-store';
@@ -42,11 +43,7 @@ const OverviewScreen: FC = () => {
 	const goToContent = useCallback( () => navigate( { href: '/content' } ), [ navigate ] );
 
 	if ( ! data ) {
-		return (
-			<Notice.Root intent="error">
-				<Notice.Description>{ __( 'Unable to load overview.', 'jetpack-seo' ) }</Notice.Description>
-			</Notice.Root>
-		);
+		return <LoadError message={ __( 'Unable to load overview.', 'jetpack-seo' ) } />;
 	}
 
 	// When the `seo-tools` module is off, the Overview shows only the enable

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -4,7 +4,8 @@ import { Button, TextareaControl, ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSearch } from '@wordpress/route';
-import { Badge, Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import { Badge, Card, CollapsibleCard, Link, Stack } from '@wordpress/ui';
+import LoadError from '../../components/load-error';
 import SocialPreviewsCard from './social-previews-card';
 import TitleStructureField from './title-structure-field';
 import VerificationCard from './verification-card';
@@ -93,11 +94,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 	}, [ focus ] );
 
 	if ( ! local ) {
-		return (
-			<Notice.Root intent="error">
-				<Notice.Description>{ __( 'Unable to load settings.', 'jetpack-seo' ) }</Notice.Description>
-			</Notice.Root>
-		);
+		return <LoadError message={ __( 'Unable to load settings.', 'jetpack-seo' ) } />;
 	}
 
 	// A sitemap only works when search engines are allowed, so its effective

--- a/projects/packages/seo/changelog/add-seo-recoverable-load-error
+++ b/projects/packages/seo/changelog/add-seo-recoverable-load-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make the SEO dashboard's load-error state recoverable: the Overview, Settings, and AI tabs now offer a Reload action instead of dead-ending, so a transient miss of the bootstrap data no longer strands the page.


### PR DESCRIPTION
Fixes #

Resolves [JETPACK-1777](https://linear.app/a8c/issue/JETPACK-1777).

## Proposed changes

The SEO dashboard's Overview, Settings, and AI tabs each read their state synchronously from the page bootstrap (`window.JetpackScriptData.seo`, via `getScriptData()`) in a one-shot, non-reactive read. If that data isn't readable at first paint — e.g. a stale/mismatched script bundle after a plugin update, or a transient gap in the server-side injection — the screen dead-ended on a terminal "Unable to load…" notice that never cleared, even though the data is typically present a moment later. (The Content tab is unaffected — it loads async via core-data with a real loading state and can't dead-end this way.)

* Add a shared `LoadError` component (`_inc/components/load-error.tsx`) that pairs the error message with a **Reload** action (`window.location.reload()`), so a momentary, self-recoverable hiccup no longer strands the user. A reload re-runs both the server-side injection and the asset fetch, which clears either cause.
* Use it from the Overview, Settings, and AI screens in place of the previous terminal error notices.

## Related product discussion/links

* [JETPACK-1777](https://linear.app/a8c/issue/JETPACK-1777)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The error state is timing-dependent and hard to trigger on demand, so test the recovery affordance directly:

* On a site with the Jetpack SEO product enabled (`add_filter( 'rsm_jetpack_seo', '__return_true' )`), open the SEO dashboard and confirm the Overview, Settings, AI, and Content tabs all render normally.
* To exercise the error UI, temporarily force the empty-data branch in a screen — e.g. in `_inc/screens/overview/index.tsx` set `const data = null;` — reload, and confirm:
  * the "Unable to load overview." notice now shows a **Reload** button, and
  * clicking it reloads the page (remove the forced `null` and the screen recovers).
* Repeat for Settings ("Unable to load settings.") and the AI tab ("Unable to load AI settings.").
