### PR TITLE
Publicize: Update connection status schema to use `oneOf`

### DIFF
--- a/projects/packages/publicize/changelog/49599-gemini-schema-oneof.txt
+++ b/projects/packages/publicize/changelog/49599-gemini-schema-oneof.txt
@@ -1,0 +1,1 @@
+Fix: Update REST API status schema to use oneOf for Gemini compatibility while preserving null support

--- a/projects/packages/publicize/changelog/49599-gemini-schema-oneof.txt
+++ b/projects/packages/publicize/changelog/49599-gemini-schema-oneof.txt
@@ -1,1 +1,1 @@
-Fix: Update REST API status schema to use oneOf for Gemini compatibility while preserving null support
+Update REST API status schema to use `oneOf` for Gemini compatibility while preserving null support.

--- a/projects/packages/publicize/changelog/fix-gemini-api-schema-oneof
+++ b/projects/packages/publicize/changelog/fix-gemini-api-schema-oneof
@@ -1,1 +1,4 @@
+Significance: patch
+Type: fixed
+
 Update REST API status schema to use `oneOf` for Gemini compatibility while preserving null support.

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -225,13 +225,20 @@ class Connections_Controller extends Base_Controller {
 				'description' => __( 'Whether the connection is shared with other users.', 'jetpack-publicize-pkg' ),
 			),
 			'status'          => array(
-				'type'        => array( 'string', 'null' ),
+				'type'        => 'string', // Keep this so 'class-connections-post-field.php' doesn't whine about undefined key
 				'description' => __( 'The connection status.', 'jetpack-publicize-pkg' ),
-				'enum'        => array(
-					'ok',
-					'broken',
-					'must_reauth',
-					null,
+				'oneOf'       => array(
+					array(
+						'type' => 'string',
+						'enum' => array(
+							'ok',
+							'broken',
+							'must_reauth',
+						),
+					),
+					array(
+						'type' => 'null',
+					),
 				),
 			),
 			'template'        => array(

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -225,7 +225,6 @@ class Connections_Controller extends Base_Controller {
 				'description' => __( 'Whether the connection is shared with other users.', 'jetpack-publicize-pkg' ),
 			),
 			'status'          => array(
-				'type'        => 'string', // Keep this so 'class-connections-post-field.php' doesn't whine about undefined key
 				'description' => __( 'The connection status.', 'jetpack-publicize-pkg' ),
 				'oneOf'       => array(
 					array(

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -660,7 +660,7 @@ class Connections_Post_Field {
 			return new WP_Error( '__wrong-context__' );
 		}
 
-		$schema_type = isset( $schema['type'] ) ? $schema['type'] : ( isset( $schema['oneOf'] ) ? 'oneOf' : null );
+		$schema_type = $schema['type'] ?? $schema['oneOf'] ?? null;
 
 		switch ( $schema_type ) {
 			case 'array':

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -660,7 +660,9 @@ class Connections_Post_Field {
 			return new WP_Error( '__wrong-context__' );
 		}
 
-		switch ( $schema['type'] ) {
+		$schema_type = isset( $schema['type'] ) ? $schema['type'] : ( isset( $schema['oneOf'] ) ? 'oneOf' : null );
+
+		switch ( $schema_type ) {
 			case 'array':
 				if ( ! isset( $schema['items'] ) ) {
 					return $value;

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -660,7 +660,7 @@ class Connections_Post_Field {
 			return new WP_Error( '__wrong-context__' );
 		}
 
-		$schema_type = $schema['type'] ?? $schema['oneOf'] ?? null;
+		$schema_type = $schema['type'] ?? null;
 
 		switch ( $schema_type ) {
 			case 'array':


### PR DESCRIPTION
Fixes #49599
Follow-up to #50028

## Proposed changes
* Following the feedback in #50028, the `null` value for the connection status is strictly required and intentional.
* However, defining `enum` alongside a multi-type array (`'type' => array('string', 'null')`) causes strict OpenAPI/JSON Schema parsers (like Google Gemini / AI Engine) to crash with the error: `enum: only allowed for STRING type`.
* To fix this while preserving compatibility, this PR introduces the `oneOf` structure for the `status` field.
* It cleanly separates the strict string enum `['ok', 'broken', 'must_reauth']` from the `null` type.
* Note: A top-level `'type' => 'string'` is intentionally retained in the schema to prevent internal `Undefined array key "type"` PHP warnings inside `class-connections-post-field.php`, ensuring backwards compatibility for Jetpack's internal processes.

## Related product discussion/links
* Discussed with @manzoorwanijk in closed PR #50028.

## Does this pull request change what data or activity we track or use?
* No changes to tracking or privacy.

## Testing instructions
1. Local PHPUnit tests pass successfully inside the `publicize` package via `composer test-php`. No warnings.
2. Ensure Jetpack is connected and the AI Engine plugin is configured with Gemini via an MCP server.
3. Test a prompt that queries the REST API.
4. **Before:** Connection fails due to schema validation error on the enum.
5. **After:** The schema successfully parses using the `oneOf` block, and the Gemini API executes the request without crashing.