### PR TITLE
Fix: Prevent Slideshow block crash when converting from Gallery (#49606)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-gallery-transform-crash
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-gallery-transform-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent Slideshow block crash when converting from Gallery

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
@@ -33,7 +33,18 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/gallery', 'jetpack/tiled-gallery' ],
-			transform: ( { images } ) => {
+			transform: ( { images = [] }, innerBlocks ) => {
+				if ( ! images.length && innerBlocks?.length ) {
+					images = innerBlocks
+						.filter( b => b.name === 'core/image' && b.attributes?.url )
+						.map( ( { attributes } ) => ( {
+							id: attributes.id,
+							url: attributes.url,
+							link: attributes.link,
+							alt: attributes.alt,
+							caption: attributes.caption,
+						} ) );
+				}
 				const validImages = getValidImages( images );
 				if ( validImages.length > 0 ) {
 					return createBlock( 'jetpack/slideshow', {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
@@ -6,7 +6,7 @@ import { createBlock } from '@wordpress/blocks';
  * @param {Array} images - Array of image objects
  * @return {Array} Array of image objects which have id and url
  */
-function getValidImages( images ) {
+function getValidImages( images = [] ) {
 	return images.filter( ( { id, url } ) => id && url );
 }
 
@@ -40,7 +40,7 @@ const transforms = {
 						.map( ( { attributes } ) => ( {
 							id: attributes.id,
 							url: attributes.url,
-							link: attributes.link,
+							link: attributes.href,
 							alt: attributes.alt,
 							caption: attributes.caption,
 						} ) );


### PR DESCRIPTION
Fixes #49606

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fixes an editor crash that occurs when transforming a core `Gallery` block to a Jetpack `Slideshow` block.
* The Slideshow block's transform logic (`extensions/blocks/slideshow/transforms.js`) assumed the top-level `images` attribute would always be populated. However, modern v2 core/gallery blocks store their images in `innerBlocks`.
* This caused `getValidImages( images )` to throw a `TypeError: Cannot read properties of undefined (reading 'filter')` and crash the editor.
* This PR adds an `images = []` default fallback and safely extracts the image data from `innerBlocks` when the top-level attribute is empty or undefined. (This is identical to the fix we applied for the Tiled Gallery block).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Discovered by @davemac during the review of the related Tiled Gallery fix. Thanks for the great catch! 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* No, this PR does not change any data tracking.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to any Post or Page in the Block Editor.
* Add a standard WordPress **Gallery** block and upload or select multiple images.
* Select the Gallery block and click the block icon in the toolbar to **Transform to** a **Slideshow** block.
* **Before this PR:** The editor crashes immediately with a "The editor has encountered an unexpected error" message (`TypeError: Cannot read properties of undefined (reading 'filter')`).
* **After this PR:** The Slideshow block renders successfully, cleanly recovering all the images from the Gallery's `innerBlocks`.