### PR TITLE
Premium Analytics: add explicit return types to Stats data hooks

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-hook-return-types
+++ b/projects/packages/premium-analytics/changelog/add-stats-hook-return-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: Add explicit return types to the data hooks and their shared helpers.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
 import { useCallback } from 'react';
 /**
  * Internal dependencies
@@ -12,6 +12,18 @@ type UseReportOptions = {
 	enabled?: boolean;
 	disabledComparisonKey?: string[];
 };
+
+export interface UseReportResult< TData > {
+	primary: UseQueryResult< TData >;
+	comparison: UseQueryResult< TData >;
+	hasComparison: boolean;
+	isLoading: boolean;
+	isFetching: boolean;
+	hasData: boolean;
+	isError: boolean;
+	error: Error | null;
+	refetch: () => Promise< void >;
+}
 
 type QueryFactory< TData > = (
 	params: any,
@@ -51,7 +63,7 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 	queryFactory: QueryFactory< TData >,
 	params: TParams,
 	options?: UseReportOptions
-) {
+): UseReportResult< TData > {
 	const queryEnabled = options?.enabled ?? true;
 	const comparisonEnabled = hasComparisonEnabled( params );
 	const primaryParams = { ...params };

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-commercial-classification.ts
@@ -1,9 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
+import type { UseMutationResult } from '@tanstack/react-query';
 
 export type StatsAppCommercialClassificationParams = Record< string, never >;
 
-export function useStatsAppCommercialClassificationMutation() {
+export function useStatsAppCommercialClassificationMutation(): UseMutationResult<
+	unknown,
+	Error,
+	StatsAppCommercialClassificationParams | undefined,
+	unknown
+> {
 	const queryClient = useQueryClient();
 
 	return useMutation( {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-dashboard-module-settings.ts
@@ -7,6 +7,7 @@ import {
 	statsAppDashboardModuleSettingsQuery,
 } from '../queries/stats-app-dashboard-module-settings-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 export type StatsAppDashboardModuleSettings = {
 	traffic?: {
@@ -25,14 +26,21 @@ export type StatsAppDashboardModuleSettings = {
 	};
 };
 
-export function useStatsAppDashboardModuleSettings( options?: UseStatsAppOptions ) {
+export function useStatsAppDashboardModuleSettings(
+	options?: UseStatsAppOptions
+): UseQueryResult< StatsAppDashboardModuleSettings > {
 	return useStatsAppQuery< StatsAppDashboardModuleSettings >(
 		statsAppDashboardModuleSettingsQuery< StatsAppDashboardModuleSettings >(),
 		options
 	);
 }
 
-export function useStatsAppDashboardModuleSettingsMutation() {
+export function useStatsAppDashboardModuleSettingsMutation(): UseMutationResult<
+	StatsAppDashboardModuleSettings,
+	Error,
+	StatsAppDashboardModuleSettings,
+	unknown
+> {
 	const queryClient = useQueryClient();
 
 	return useMutation( {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-plan-usage.ts
@@ -3,6 +3,7 @@
  */
 import { statsAppPlanUsageQuery } from '../queries/stats-app-plan-usage-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type StatsAppPlanPeriodUsage = {
 	current_start: string | null;
@@ -38,7 +39,9 @@ export type StatsAppPlanUsage = {
 	upgrade_deadline_date: string | null;
 };
 
-export function useStatsAppPlanUsage( options?: UseStatsAppOptions ) {
+export function useStatsAppPlanUsage(
+	options?: UseStatsAppOptions
+): UseQueryResult< StatsAppPlanUsage > {
 	return useStatsAppQuery< StatsAppPlanUsage >(
 		statsAppPlanUsageQuery< StatsAppPlanUsage >(),
 		options

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
 import { getStatsQueryEnabled } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 
@@ -7,7 +7,7 @@ export type UseStatsAppOptions = UseStatsOptions;
 export function useStatsAppQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsAppOptions
-) {
+): UseQueryResult< TData > {
 	return useQuery( {
 		...queryOptions,
 		enabled: getStatsQueryEnabled( queryOptions, options ),

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-referrers-spam.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-referrers-spam.ts
@@ -1,4 +1,10 @@
-import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
+import {
+	useMutation,
+	useQueryClient,
+	type QueryClient,
+	type UseMutationResult,
+	type UseQueryResult,
+} from '@tanstack/react-query';
 import { fetchStatsProxy } from '../api';
 import {
 	STATS_APP_REFERRERS_SPAM_NAME,
@@ -17,11 +23,18 @@ function invalidateReferrersSpamQueries( queryClient: QueryClient ) {
 	queryClient.invalidateQueries( { queryKey: [ 'stats-app', STATS_APP_REFERRERS_SPAM_NAME ] } );
 }
 
-export function useStatsAppReferrersSpam( options?: UseStatsAppOptions ) {
+export function useStatsAppReferrersSpam(
+	options?: UseStatsAppOptions
+): UseQueryResult< StatsAppReferrersSpamResponse > {
 	return useStatsAppQuery< StatsAppReferrersSpamResponse >( statsAppReferrersSpamQuery(), options );
 }
 
-export function useStatsAppReferrersMarkSpamMutation() {
+export function useStatsAppReferrersMarkSpamMutation(): UseMutationResult<
+	StatsAppReferrersSpamMutationResponse,
+	Error,
+	StatsAppReferrersSpamMutationParams,
+	unknown
+> {
 	const queryClient = useQueryClient();
 
 	return useMutation( {
@@ -35,7 +48,12 @@ export function useStatsAppReferrersMarkSpamMutation() {
 	} );
 }
 
-export function useStatsAppReferrersUnmarkSpamMutation() {
+export function useStatsAppReferrersUnmarkSpamMutation(): UseMutationResult<
+	StatsAppReferrersSpamMutationResponse,
+	Error,
+	StatsAppReferrersSpamMutationParams,
+	unknown
+> {
 	const queryClient = useQueryClient();
 
 	return useMutation( {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-site-has-never-published-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-site-has-never-published-post.ts
@@ -3,7 +3,11 @@
  */
 import { statsAppSiteHasNeverPublishedPostQuery } from '../queries/stats-app-site-has-never-published-post-query';
 import { useStatsAppQuery, type UseStatsAppOptions } from './use-stats-app-query';
-import type { StatsAppSiteHasNeverPublishedPostParams } from '../queries/stats-app-site-has-never-published-post-query';
+import type {
+	StatsAppSiteHasNeverPublishedPostParams,
+	StatsAppSiteHasNeverPublishedPostResponse,
+} from '../queries/stats-app-site-has-never-published-post-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsAppSiteHasNeverPublishedPostParams,
@@ -13,6 +17,6 @@ export type {
 export function useStatsAppSiteHasNeverPublishedPost(
 	params: StatsAppSiteHasNeverPublishedPostParams,
 	options?: UseStatsAppOptions
-) {
+): UseQueryResult< StatsAppSiteHasNeverPublishedPostResponse > {
 	return useStatsAppQuery( statsAppSiteHasNeverPublishedPostQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
@@ -3,13 +3,17 @@
  */
 import { statsArchivesQuery } from '../queries/stats-archives-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsArchivesItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export type StatsArchivesResponse = StatsNormalizedReport< StatsArchivesItem >;
 
-export function useStatsArchives( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsArchives(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsArchivesResponse > {
 	return useStatsReport(
 		statsArchivesQuery,
 		params,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
@@ -3,9 +3,14 @@
  */
 import { statsClicksQuery } from '../queries/stats-clicks-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsClicksItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsClicks( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsClicks(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsClicksItem > > {
 	return useStatsReport( statsClicksQuery, params, 'clicks', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-comments.ts
@@ -5,9 +5,13 @@ import { statsCommentsQuery } from '../queries/stats-comments-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsCommentsParams, StatsCommentsResponse } from '../queries/stats-comments-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type { StatsCommentsParams, StatsCommentsResponse };
 
-export function useStatsComments( params?: StatsCommentsParams, options?: UseStatsOptions ) {
+export function useStatsComments(
+	params?: StatsCommentsParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsCommentsResponse > {
 	return useStatsQuery< StatsCommentsResponse >( statsCommentsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-country-views.ts
@@ -3,9 +3,14 @@
  */
 import { statsCountryViewsQuery } from '../queries/stats-country-views-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsLocationsItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsCountryViews( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsCountryViews(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsLocationsItem > > {
 	return useStatsReport( statsCountryViewsQuery, params, 'country-views', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
@@ -3,6 +3,7 @@
  */
 import { statsDevicesQuery } from '../queries/stats-devices-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsDevices,
@@ -10,7 +11,10 @@ import type {
 	StatsDevicesParams,
 } from '../queries/stats-devices-query';
 
-export function useStatsDevices( params: StatsDevicesParams, options?: UseStatsOptions ) {
+export function useStatsDevices(
+	params: StatsDevicesParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsDevices > {
 	return useStatsReport(
 		statsDevicesQuery,
 		params,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-breakdown.ts
@@ -10,12 +10,13 @@ import {
 } from '../queries/stats-email-breakdown-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export function useStatsEmailOpensBreakdown(
 	postId: number,
 	breakdown: StatsEmailOpensBreakdown,
 	options?: UseStatsOptions
-) {
+): UseQueryResult< StatsEmailBreakdown > {
 	return useStatsQuery( statsEmailOpensBreakdownQuery( postId, breakdown ), options );
 }
 
@@ -23,7 +24,7 @@ export function useStatsEmailClicksBreakdown(
 	postId: number,
 	breakdown: StatsEmailClicksBreakdown,
 	options?: UseStatsOptions
-) {
+): UseQueryResult< StatsEmailBreakdown > {
 	return useStatsQuery( statsEmailClicksBreakdownQuery( postId, breakdown ), options );
 }
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
@@ -3,9 +3,14 @@
  */
 import { statsFileDownloadsQuery } from '../queries/stats-file-downloads-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsFileDownloadsItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsFileDownloads( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsFileDownloads(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsFileDownloadsItem > > {
 	return useStatsReport( statsFileDownloadsQuery, params, 'file-downloads', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-followers.ts
@@ -4,11 +4,18 @@
 import { statsFollowersQuery } from '../queries/stats-followers-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsFollowersParams } from '../queries/stats-followers-query';
+import type {
+	StatsFollowersParams,
+	StatsFollowersResponse,
+} from '../queries/stats-followers-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type { StatsFollowersResponse } from '../queries/stats-followers-query';
 export type { StatsFollowersParams } from '../queries/stats-followers-query';
 
-export function useStatsFollowers( params: StatsFollowersParams = {}, options?: UseStatsOptions ) {
+export function useStatsFollowers(
+	params: StatsFollowersParams = {},
+	options?: UseStatsOptions
+): UseQueryResult< StatsFollowersResponse > {
 	return useStatsQuery( statsFollowersQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-highlights.ts
@@ -4,13 +4,20 @@
 import { statsHighlightsQuery } from '../queries/stats-highlights-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsHighlightsParams } from '../queries/stats-highlights-query';
+import type {
+	StatsHighlightsParams,
+	StatsHighlightsResponse,
+} from '../queries/stats-highlights-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsHighlightsParams,
 	StatsHighlightsResponse,
 } from '../queries/stats-highlights-query';
 
-export function useStatsHighlights( params?: StatsHighlightsParams, options?: UseStatsOptions ) {
+export function useStatsHighlights(
+	params?: StatsHighlightsParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsHighlightsResponse > {
 	return useStatsQuery( statsHighlightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-insights.ts
@@ -4,7 +4,8 @@
 import { statsInsightsQuery } from '../queries/stats-insights-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsInsightsParams } from '../queries/stats-insights-query';
+import type { StatsInsightsParams, StatsInsightsResponse } from '../queries/stats-insights-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsInsightsParams,
@@ -12,6 +13,9 @@ export type {
 	StatsInsightsYear,
 } from '../queries/stats-insights-query';
 
-export function useStatsInsights( params?: StatsInsightsParams, options?: UseStatsOptions ) {
+export function useStatsInsights(
+	params?: StatsInsightsParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsInsightsResponse > {
 	return useStatsQuery( statsInsightsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
@@ -3,12 +3,14 @@
  */
 import { statsLocationsQuery } from '../queries/stats-locations-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsLocationsItem, StatsNormalizedReport } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
 export function useStatsLocations(
 	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
 	options?: UseStatsOptions
-) {
+): UseReportResult< StatsNormalizedReport< StatsLocationsItem > > {
 	return useStatsReport( statsLocationsQuery, params, 'locations', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-post.ts
@@ -5,6 +5,7 @@ import { statsPostQuery } from '../queries/stats-post-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsPostParams, StatsPostResponse } from '../queries/stats-post-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsPostField,
@@ -12,6 +13,9 @@ export type {
 	StatsPostResponse,
 } from '../queries/stats-post-query';
 
-export function useStatsPost( params: StatsPostParams, options?: UseStatsOptions ) {
+export function useStatsPost(
+	params: StatsPostParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsPostResponse > {
 	return useStatsQuery< StatsPostResponse >( statsPostQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-publicize.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-publicize.ts
@@ -8,12 +8,16 @@ import type {
 	StatsPublicizeParams,
 	StatsPublicizeResponse,
 } from '../queries/stats-publicize-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsPublicizeParams,
 	StatsPublicizeResponse,
 } from '../queries/stats-publicize-query';
 
-export function useStatsPublicize( params: StatsPublicizeParams = {}, options?: UseStatsOptions ) {
+export function useStatsPublicize(
+	params: StatsPublicizeParams = {},
+	options?: UseStatsOptions
+): UseQueryResult< StatsPublicizeResponse > {
 	return useStatsQuery< StatsPublicizeResponse >( statsPublicizeQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
 import type { UseStatsOptions } from './use-stats-report';
 
 export function getStatsQueryEnabled< TData = unknown >(
@@ -11,7 +11,7 @@ export function getStatsQueryEnabled< TData = unknown >(
 export function useStatsQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsOptions
-) {
+): UseQueryResult< TData > {
 	return useQuery( {
 		...queryOptions,
 		enabled: getStatsQueryEnabled( queryOptions, options ),

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -3,9 +3,14 @@
  */
 import { statsReferrersQuery } from '../queries/stats-referrers-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport, StatsReferrersItem } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsReferrers( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsReferrers(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsReferrersItem > > {
 	return useStatsReport( statsReferrersQuery, params, 'referrers', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { useReport } from './use-report';
+import { useReport, type UseReportResult } from './use-report';
 import type { StatsReportParams } from '../queries/stats-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -18,7 +18,7 @@ export function useStatsReport< TParams extends StatsReportParams, TData >(
 	params: TParams,
 	reportSlugOrDisabledComparisonKey: string | string[],
 	options?: UseStatsOptions
-) {
+): UseReportResult< TData > {
 	const disabledComparisonKey = Array.isArray( reportSlugOrDisabledComparisonKey )
 		? reportSlugOrDisabledComparisonKey
 		: [ 'stats', reportSlugOrDisabledComparisonKey, '__comparison__', 'disabled' ];

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
@@ -3,9 +3,14 @@
  */
 import { statsSearchTermsQuery } from '../queries/stats-search-terms-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport, StatsSearchTermsItem } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsSearchTerms( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsSearchTerms(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsSearchTermsItem > > {
 	return useStatsReport( statsSearchTermsQuery, params, 'search-terms', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-site.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-site.ts
@@ -7,8 +7,13 @@ import { useQuery } from '@tanstack/react-query';
  */
 import { statsSiteQuery } from '../queries/stats-site-query';
 import type { UseStatsOptions } from './use-stats-report';
+import type { sanitizeStatsSiteResponse } from '../processing/stats';
 import type { StatsQueryParams } from '../utils/stats-params';
+import type { UseQueryResult } from '@tanstack/react-query';
 
-export function useStatsSite( params?: StatsQueryParams, options?: UseStatsOptions ) {
+export function useStatsSite(
+	params?: StatsQueryParams,
+	options?: UseStatsOptions
+): UseQueryResult< ReturnType< typeof sanitizeStatsSiteResponse > > {
 	return useQuery( { ...statsSiteQuery( params ), enabled: options?.enabled ?? true } );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-streak.ts
@@ -5,9 +5,13 @@ import { statsStreakQuery } from '../queries/stats-streak-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsStreakParams, StatsStreakResponse } from '../queries/stats-streak-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type { StatsStreakParams, StatsStreakResponse } from '../queries/stats-streak-query';
 
-export function useStatsStreak( params: StatsStreakParams, options?: UseStatsOptions ) {
+export function useStatsStreak(
+	params: StatsStreakParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsStreakResponse > {
 	return useStatsQuery< StatsStreakResponse >( statsStreakQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -7,11 +7,12 @@ import {
 } from '../queries/stats-subscribers-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsSubscribersCounts } from '../processing/stats';
+import type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
 import type {
 	StatsSubscribersCountsParams,
 	StatsSubscribersParams,
 } from '../queries/stats-subscribers-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
 export type {
@@ -20,13 +21,16 @@ export type {
 } from '../queries/stats-subscribers-query';
 export type StatsSubscribersCountsResponse = StatsSubscribersCounts;
 
-export function useStatsSubscribers( params: StatsSubscribersParams, options?: UseStatsOptions ) {
+export function useStatsSubscribers(
+	params: StatsSubscribersParams,
+	options?: UseStatsOptions
+): UseQueryResult< StatsSubscribersResponse > {
 	return useStatsQuery( statsSubscribersQuery( params ), options );
 }
 
 export function useStatsSubscribersCounts(
 	params?: StatsSubscribersCountsParams,
 	options?: UseStatsOptions
-) {
+): UseQueryResult< StatsSubscribersCountsResponse > {
 	return useStatsQuery( statsSubscribersCountsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-tags.ts
@@ -6,10 +6,14 @@ import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsNormalizedReport, StatsTagsItem } from '../processing/stats';
 import type { StatsTagsParams } from '../queries/stats-tags-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type StatsTagsResponse = StatsNormalizedReport< StatsTagsItem >;
 export type { StatsTagsParams } from '../queries/stats-tags-query';
 
-export function useStatsTags( params: StatsTagsParams = {}, options?: UseStatsOptions ) {
+export function useStatsTags(
+	params: StatsTagsParams = {},
+	options?: UseStatsOptions
+): UseQueryResult< StatsTagsResponse > {
 	return useStatsQuery< StatsTagsResponse >( statsTagsQuery( params ), options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
@@ -3,9 +3,14 @@
  */
 import { statsTopAuthorsQuery } from '../queries/stats-top-authors-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport, StatsTopAuthorsItem } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsTopAuthors( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsTopAuthors(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsTopAuthorsItem > > {
 	return useStatsReport( statsTopAuthorsQuery, params, 'top-authors', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
@@ -3,9 +3,14 @@
  */
 import { statsTopPostsQuery } from '../queries/stats-top-posts-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport, StatsTopPostsItem } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsTopPosts( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsTopPosts(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsTopPostsItem > > {
 	return useStatsReport( statsTopPostsQuery, params, 'top-posts', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-utm.ts
@@ -3,12 +3,16 @@
  */
 import { statsUtmQuery } from '../queries/stats-utm-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsUtmParams, StatsUtmResponse } from '../queries/stats-utm-query';
 
 export type { StatsUtmParams, StatsUtmResponse } from '../queries/stats-utm-query';
 
-export function useStatsUtm( params: StatsUtmParams, options?: UseStatsOptions ) {
+export function useStatsUtm(
+	params: StatsUtmParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsUtmResponse > {
 	return useStatsReport< StatsUtmParams, StatsUtmResponse >(
 		statsUtmQuery,
 		params,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -3,9 +3,14 @@
  */
 import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsVideoPlays( params: StatsReportParams, options?: UseStatsOptions ) {
+export function useStatsVideoPlays(
+	params: StatsReportParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsNormalizedReport< StatsVideoPlaysItem > > {
 	return useStatsReport( statsVideoPlaysQuery, params, 'video-plays', options );
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-visits.ts
@@ -3,6 +3,7 @@
  */
 import { statsVisitsQuery } from '../queries/stats-visits-query';
 import { useStatsReport } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsVisitsParams, StatsVisitsResponse } from '../queries/stats-visits-query';
 
@@ -13,7 +14,10 @@ export type {
 	StatsVisitsStatFields,
 } from '../queries/stats-visits-query';
 
-export function useStatsVisits( params: StatsVisitsParams, options?: UseStatsOptions ) {
+export function useStatsVisits(
+	params: StatsVisitsParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsVisitsResponse > {
 	return useStatsReport< StatsVisitsParams, StatsVisitsResponse >(
 		statsVisitsQuery,
 		params,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-wordads.ts
@@ -4,11 +4,13 @@
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../queries/stats-wordads-query';
 import { useStatsQuery } from './use-stats-query';
 import { useStatsReport, type UseStatsOptions } from './use-stats-report';
+import type { UseReportResult } from './use-report';
 import type { StatsWordAdsEarningsResponse, StatsWordAdsResponse } from '../processing/stats';
 import type {
 	StatsWordAdsEarningsParams,
 	StatsWordAdsParams,
 } from '../queries/stats-wordads-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export type {
 	StatsWordAdsEarnings,
@@ -29,7 +31,10 @@ export type {
 	StatsWordAdsParams,
 } from '../queries/stats-wordads-query';
 
-export function useStatsWordAdsStats( params: StatsWordAdsParams, options?: UseStatsOptions ) {
+export function useStatsWordAdsStats(
+	params: StatsWordAdsParams,
+	options?: UseStatsOptions
+): UseReportResult< StatsWordAdsResponse > {
 	return useStatsReport< StatsWordAdsParams, StatsWordAdsResponse >(
 		statsWordAdsStatsQuery,
 		params,
@@ -41,7 +46,7 @@ export function useStatsWordAdsStats( params: StatsWordAdsParams, options?: UseS
 export function useStatsWordAdsEarnings(
 	params?: StatsWordAdsEarningsParams,
 	options?: UseStatsOptions
-) {
+): UseQueryResult< StatsWordAdsEarningsResponse > {
 	return useStatsQuery< StatsWordAdsEarningsResponse >(
 		statsWordAdsEarningsQuery( params ),
 		options


### PR DESCRIPTION
Fixes #

## Proposed changes

Anyone calling a Premium Analytics Stats hook (`useStatsTopPosts`, `useStatsArchives`, `useStatsAppReferrersSpam`, …) currently has to trace through the query/report helpers to find out what the hook returns, because the return types were left to TypeScript inference. This PR writes those contracts out explicitly so the return shape is visible at the call site and in editor tooltips, the same way `useStatsEmailSummary` and `useStatsCommentFollowers` already do.

* Introduce an exported `UseReportResult< TData >` describing the report helper's `{ primary, comparison, hasComparison, isLoading, isFetching, hasData, isError, error, refetch }` shape, and annotate the shared helpers `useReport`, `useStatsReport`, `useStatsQuery`, and `useStatsAppQuery`.
* Annotate every Stats data hook with its exact return type:
  * report hooks (archives, clicks, country-views, devices, file-downloads, locations, referrers, search-terms, top-authors, top-posts, utm, video-plays, visits, WordAds stats) → `UseReportResult< T >`
  * query / app-query hooks (comments, email-breakdown, followers, highlights, insights, post, publicize, streak, subscribers, tags, site, WordAds earnings, plan-usage, site-has-never-published-post, referrers-spam read) → `UseQueryResult< T >`
  * mutation hooks (commercial-classification, dashboard-module-settings, referrers-spam mark/unmark) → `UseMutationResult< … >`

Each annotation matches the type TypeScript already inferred, so this is a pure typing change with no runtime or behavioural impact. `comment-followers` was already explicitly typed and is left untouched.

## Related product discussion/links

* Follow-up to #49900 (the Stats email summary endpoint), where the same explicit return type was applied; this brings the rest of the Stats hooks in line.

## Does this pull request change what data or activity we track or use?

No. Type-only change; no data, requests, or behaviour are affected.

## Testing instructions

* `pnpm --dir projects/packages/premium-analytics run typecheck` — passes (a clean typecheck is the proof that every explicit annotation matches the previously inferred type).
* `pnpm exec eslint --max-warnings=0 projects/packages/premium-analytics/packages/data/src/hooks/*.ts` — passes.
* No functional behaviour to exercise — confirm the diff is import additions and return-type annotations only.
