### PR TITLE
Premium Analytics: comparison-aware email time series hooks

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-email-stats-real-api-shapes
+++ b/projects/packages/premium-analytics/changelog/fix-email-stats-real-api-shapes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email stats: match the real WordPress.com API shapes — opens/clicks timelines carry a labeled hourly `hour` column and no `unique_opens_count`, the emails summary always requests `period=alltime`, and the summary leaderboard ranks by opens.

--- a/projects/packages/premium-analytics/changelog/update-stats-email-time-series-report-hook
+++ b/projects/packages/premium-analytics/changelog/update-stats-email-time-series-report-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Stats: Email time series hooks now return comparison-aware report results and resolve hourly buckets into distinct per-hour intervals.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
@@ -10,23 +10,32 @@ import {
 	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesSummary,
 } from '../queries/stats-email-time-series-query';
-import { useStatsQuery } from './use-stats-query';
-import type { UseStatsOptions } from './use-stats-report';
+import { useStatsReport, type UseStatsOptions } from './use-stats-report';
 
 export function useStatsEmailOpensTimeSeries(
 	postId: number,
-	params?: StatsEmailTimeSeriesParams,
+	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsQuery( statsEmailOpensTimeSeriesQuery( postId, params ), options );
+	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
+		p => statsEmailOpensTimeSeriesQuery( postId, p ),
+		params,
+		[ 'stats', 'email-opens-time-series', '__comparison__', 'disabled' ],
+		options
+	);
 }
 
 export function useStatsEmailClicksTimeSeries(
 	postId: number,
-	params?: StatsEmailTimeSeriesParams,
+	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsQuery( statsEmailClicksTimeSeriesQuery( postId, params ), options );
+	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
+		p => statsEmailClicksTimeSeriesQuery( postId, p ),
+		params,
+		[ 'stats', 'email-clicks-time-series', '__comparison__', 'disabled' ],
+		options
+	);
 }
 
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
@@ -57,10 +57,10 @@ export const scalarDaysTimeSeriesFixture = {
 export const emailOpensTimeSeriesFixture = {
 	timeline: {
 		unit: 'day',
-		fields: [ 'date', 'opens_count', 'unique_opens_count' ],
+		fields: [ 'date', 'opens_count' ],
 		data: [
-			[ '2026-06-15', '8', '6' ],
-			[ '2026-06-16', '13', '9' ],
+			[ '2026-06-15', 8 ],
+			[ '2026-06-16', 13 ],
 		],
 	},
 };
@@ -79,10 +79,21 @@ export const emailClicksTimeSeriesFixture = {
 export const emailOpensHourlyTimeSeriesFixture = {
 	timeline: {
 		unit: 'hour',
-		fields: [ 'date', 'opens_count' ],
+		fields: [ 'date', 'hour', 'opens_count' ],
 		data: [
-			[ '2026-06-15', '3', 9 ],
-			[ '2026-06-15', '5', 10 ],
+			[ '2026-06-15', 9, 3 ],
+			[ '2026-06-15', 10, 5 ],
+		],
+	},
+};
+
+export const emailClicksHourlyTimeSeriesFixture = {
+	timeline: {
+		unit: 'hour',
+		fields: [ 'date', 'hour', 'clicks_count' ],
+		data: [
+			[ '2026-06-15', 9, 4 ],
+			[ '2026-06-15', 10, 7 ],
 		],
 	},
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
@@ -22,7 +22,7 @@ describe( 'Stats email summary normalizer', () => {
 							expect.objectContaining( {
 								id: 71,
 								label: 'Newsletter',
-								value: 4,
+								value: 30,
 								link: 'https://example.com/newsletter/',
 								actions: [ { type: 'link', data: 'https://example.com/newsletter/' } ],
 								unique_opens: 24,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -172,18 +172,60 @@ describe( 'Stats time-series normalizer', () => {
 		);
 	} );
 
-	it( 'preserves the unlabeled hour column for hourly email timelines', () => {
+	it( 'resolves hourly email timelines into distinct per-hour buckets', () => {
 		const result = sanitizeStatsEmailTimeSeriesResponse( emailOpensHourlyTimeSeriesFixture, {
 			period: 'hour',
 		} );
 
 		expect( result.data ).toEqual( [
-			expect.objectContaining( { value: 3, opens_count: 3, hour: 9 } ),
-			expect.objectContaining( { value: 5, opens_count: 5, hour: 10 } ),
+			expect.objectContaining( {
+				time_interval: '2026-06-15 09:00',
+				date_start: '2026-06-15T09:00:00+00:00',
+				date_end: '2026-06-15T09:59:59+00:00',
+				label: '2026-06-15 09:00',
+				value: 3,
+				opens_count: 3,
+				hour: 9,
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-15 10:00',
+				date_start: '2026-06-15T10:00:00+00:00',
+				value: 5,
+				opens_count: 5,
+				hour: 10,
+			} ),
 		] );
 		// The hour dimension must not be summed into the metric summary.
 		expect( result.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
 		expect( result.summary ).not.toHaveProperty( 'hour' );
+	} );
+
+	it( 'normalizes hour 0 and string-typed hour values into padded per-hour buckets', () => {
+		const result = sanitizeStatsEmailTimeSeriesResponse(
+			{
+				timeline: {
+					unit: 'hour',
+					fields: [ 'date', 'opens_count' ],
+					data: [
+						[ '2026-06-15', '2', 0 ],
+						[ '2026-06-15', '4', '23' ],
+					],
+				},
+			},
+			{ period: 'hour' }
+		);
+
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( { time_interval: '2026-06-15 00:00', hour: 0, value: 2 } )
+		);
+		expect( result.data[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-15 23:00',
+				date_end: '2026-06-15T23:59:59+00:00',
+				hour: '23',
+				value: 4,
+			} )
+		);
 	} );
 
 	it( 'returns an empty email time series report when the timeline key is missing', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -4,6 +4,7 @@ import {
 	sanitizeStatsTimeSeriesResponse,
 } from '..';
 import {
+	emailClicksHourlyTimeSeriesFixture,
 	emailClicksTimeSeriesFixture,
 	emailOpensHourlyTimeSeriesFixture,
 	emailOpensTimeSeriesFixture,
@@ -146,7 +147,6 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.summary ).toEqual(
 			expect.objectContaining( {
 				opens_count: 21,
-				unique_opens_count: 15,
 				date_start: '2026-06-15T00:00:00+00:00',
 				date_end: '2026-06-16T23:59:59+00:00',
 			} )
@@ -157,7 +157,6 @@ describe( 'Stats time-series normalizer', () => {
 				label: '2026-06-15',
 				value: 8,
 				opens_count: 8,
-				unique_opens_count: 6,
 				items: [],
 			} )
 		);
@@ -198,6 +197,30 @@ describe( 'Stats time-series normalizer', () => {
 		// The hour dimension must not be summed into the metric summary.
 		expect( result.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
 		expect( result.summary ).not.toHaveProperty( 'hour' );
+	} );
+
+	it( 'resolves hourly email clicks timelines into distinct per-hour buckets', () => {
+		const result = sanitizeStatsEmailTimeSeriesResponse( emailClicksHourlyTimeSeriesFixture, {
+			period: 'hour',
+		} );
+
+		expect( result.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-15 09:00',
+				date_start: '2026-06-15T09:00:00+00:00',
+				date_end: '2026-06-15T09:59:59+00:00',
+				value: 4,
+				clicks_count: 4,
+				hour: 9,
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-06-15 10:00',
+				value: 7,
+				clicks_count: 7,
+				hour: 10,
+			} ),
+		] );
+		expect( result.summary ).toEqual( expect.objectContaining( { clicks_count: 11 } ) );
 	} );
 
 	it( 'normalizes hour 0 and string-typed hour values into padded per-hour buckets', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
@@ -30,7 +30,8 @@ function normalizeStatsEmailSummaryItem( post: StatsRecord ): StatsEmailSummaryI
 	return {
 		id: post.id as string | number | undefined,
 		label: post.title,
-		value: safeParseFloat( post.clicks_rate ),
+		// Opens is the headline metric for the emails leaderboard; clicks_rate is frequently 0.
+		value: safeParseFloat( post.opens ),
 		link,
 		actions: typeof link === 'string' ? [ { type: 'link', data: link } ] : [],
 		date: post.date,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -1,3 +1,4 @@
+import { formatDatePartWithTime, getDatePart } from '@jetpack-premium-analytics/datetime';
 import {
 	endOfISOWeek,
 	endOfMonth,
@@ -169,13 +170,17 @@ function getTimeSeriesIntervalFields( period: unknown, unit?: string ) {
 }
 
 function getHourIntervalFields( date: string, hour: unknown ) {
-	const datePart = date.split( 'T' )[ 0 ];
+	const datePart = getDatePart( date ) ?? date;
 	const hourPart = String( Math.trunc( Number( hour ) ) || 0 ).padStart( 2, '0' );
 
+	// Like getStatsIntervalFields, these are calendar bucket labels stamped with a nominal +00:00
+	// (formatDatePartWithTime's default), not real UTC instants — the API's hour is already
+	// site-local, so a consumer must render the bucket as wall-clock rather than convert it across
+	// the site offset.
 	return {
 		time_interval: `${ datePart } ${ hourPart }:00`,
-		date_start: `${ datePart }T${ hourPart }:00:00+00:00`,
-		date_end: `${ datePart }T${ hourPart }:59:59+00:00`,
+		date_start: formatDatePartWithTime( datePart, `${ hourPart }:00:00` ),
+		date_end: formatDatePartWithTime( datePart, `${ hourPart }:59:59` ),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -266,16 +266,12 @@ export function sanitizeStatsTimeSeriesResponse(
 
 export type StatsEmailTimeSeriesDataPoint = StatsTimeSeriesDataPoint & {
 	opens_count?: number;
-	unique_opens_count?: number;
 	clicks_count?: number;
-	unique_clicks_count?: number;
 };
 
 export type StatsEmailTimeSeriesSummary = StatsNormalizedSummary & {
 	opens_count?: number;
-	unique_opens_count?: number;
 	clicks_count?: number;
-	unique_clicks_count?: number;
 };
 
 export type StatsEmailTimeSeriesReport = StatsNormalizedReport & {
@@ -292,9 +288,10 @@ export function sanitizeStatsEmailTimeSeriesResponse(
 	const timeline = coerceStatsRecord( coerceStatsRecord( payload ).timeline );
 	const fields = coerceStatsArray< string >( timeline.fields );
 
-	// Hourly timelines carry an unlabeled trailing hour column per row; surface it as a field
-	// (matching Calypso's parseEmailChartData) so the value is preserved and the normalizer can
-	// resolve each row into its own per-hour bucket.
+	// The real hourly timeline labels its hour column ([ 'date', 'hour', '<metric>_count' ]), which
+	// the normalizer resolves into per-hour buckets. As a fallback, an unlabeled trailing hour
+	// column is named here so older/alternate payloads still resolve (matching Calypso's
+	// parseEmailChartData).
 	const normalizedTimeline =
 		timeline.unit === 'hour' && fields.length && ! fields.includes( 'hour' )
 			? { ...timeline, fields: [ ...fields, 'hour' ] }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -168,6 +168,33 @@ function getTimeSeriesIntervalFields( period: unknown, unit?: string ) {
 	return getStatsIntervalFields( periodString, unit );
 }
 
+function getHourIntervalFields( date: string, hour: unknown ) {
+	const datePart = date.split( 'T' )[ 0 ];
+	const hourPart = String( Math.trunc( Number( hour ) ) || 0 ).padStart( 2, '0' );
+
+	return {
+		time_interval: `${ datePart } ${ hourPart }:00`,
+		date_start: `${ datePart }T${ hourPart }:00:00+00:00`,
+		date_end: `${ datePart }T${ hourPart }:59:59+00:00`,
+	};
+}
+
+function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: string ) {
+	if ( unit === 'hour' && row.hour !== undefined && typeof rawPeriod === 'string' ) {
+		return getHourIntervalFields( rawPeriod, row.hour );
+	}
+
+	if ( typeof row.date_start === 'string' && typeof row.date_end === 'string' ) {
+		return {
+			time_interval: row.date_start,
+			date_start: row.date_start,
+			date_end: row.date_end,
+		};
+	}
+
+	return getTimeSeriesIntervalFields( rawPeriod, unit );
+}
+
 function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	return {
 		...normalizeStatsSummary( coerceStatsRecord( response.summary ) ),
@@ -212,14 +239,7 @@ export function sanitizeStatsTimeSeriesResponse(
 	}, {} );
 	const data = rows.map< StatsTimeSeriesDataPoint >( row => {
 		const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
-		const range =
-			typeof row.date_start === 'string' && typeof row.date_end === 'string'
-				? {
-						time_interval: row.date_start,
-						date_start: row.date_start,
-						date_end: row.date_end,
-				  }
-				: getTimeSeriesIntervalFields( rawPeriod, unit );
+		const range = getRowIntervalFields( row, rawPeriod, unit );
 		const value = safeParseFloat( getPrimaryMetricValue( row ) );
 
 		return {
@@ -272,9 +292,9 @@ export function sanitizeStatsEmailTimeSeriesResponse(
 	const timeline = coerceStatsRecord( coerceStatsRecord( payload ).timeline );
 	const fields = coerceStatsArray< string >( timeline.fields );
 
-	// Hourly timelines carry an unlabeled trailing hour column per row; surface it as a field so
-	// the value is preserved rather than dropped (matching Calypso's parseEmailChartData). Bucket
-	// labels stay day-granular until the shared datetime interval helper gains hour resolution.
+	// Hourly timelines carry an unlabeled trailing hour column per row; surface it as a field
+	// (matching Calypso's parseEmailChartData) so the value is preserved and the normalizer can
+	// resolve each row into its own per-hour bucket.
 	const normalizedTimeline =
 		timeline.unit === 'hour' && fields.length && ! fields.includes( 'hour' )
 			? { ...timeline, fields: [ ...fields, 'hour' ] }

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -117,8 +117,12 @@ describe( 'Stats query factories', () => {
 		expect( statsEmailClicksBreakdownQuery( -1, 'link' ).enabled ).toBe( false );
 	} );
 
-	it( 'builds email opens time series query keys with Calypso timeline defaults', () => {
-		const query = statsEmailOpensTimeSeriesQuery( 41 );
+	it( 'builds email opens time series query keys from the report date range', () => {
+		const query = statsEmailOpensTimeSeriesQuery( 41, {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+		} );
 
 		expect( query.enabled ).toBe( true );
 		expect( query.queryKey ).toEqual( [
@@ -127,31 +131,47 @@ describe( 'Stats query factories', () => {
 			'1.1',
 			'stats/opens/emails/41',
 			'GET',
-			{ period: 'day', quantity: 30, stats_fields: 'timeline' },
+			{ period: 'day', quantity: 7, date: '2026-06-07', stats_fields: 'timeline' },
 			undefined,
 			'emailTimeSeries',
 		] );
 	} );
 
-	it( 'forwards email clicks period/date and defaults hourly quantity to 24', () => {
-		const query = statsEmailClicksTimeSeriesQuery( 41, { period: 'hour', date: '2026-06-25' } );
-
-		expect( query.queryKey ).toEqual( [
-			'stats',
-			'email-clicks-time-series',
-			'1.1',
-			'stats/clicks/emails/41',
-			'GET',
-			{ period: 'hour', quantity: 24, date: '2026-06-25', stats_fields: 'timeline' },
-			undefined,
-			'emailTimeSeries',
-		] );
+	it( 'clamps coarser intervals to daily over the full requested span', () => {
+		expect(
+			statsEmailClicksTimeSeriesQuery( 41, {
+				from: '2026-06-01',
+				to: '2026-06-30',
+				interval: 'month',
+			} ).queryKey[ 5 ]
+		).toEqual( { period: 'day', quantity: 30, date: '2026-06-30', stats_fields: 'timeline' } );
 	} );
 
-	it( 'disables email time series queries until a positive integer post ID is available', () => {
-		expect( statsEmailOpensTimeSeriesQuery( 0 ).enabled ).toBe( false );
-		expect( statsEmailClicksTimeSeriesQuery( -1 ).enabled ).toBe( false );
-		expect( statsEmailOpensTimeSeriesQuery( 1.5 ).enabled ).toBe( false );
+	it( 'requests 24 hourly buckets per day so multi-day hourly ranges are not truncated', () => {
+		expect(
+			statsEmailClicksTimeSeriesQuery( 41, {
+				from: '2026-06-15',
+				to: '2026-06-15',
+				interval: 'hour',
+			} ).queryKey[ 5 ]
+		).toEqual( { period: 'hour', quantity: 24, date: '2026-06-15', stats_fields: 'timeline' } );
+
+		expect(
+			statsEmailClicksTimeSeriesQuery( 41, {
+				from: '2026-06-14',
+				to: '2026-06-15',
+				interval: 'hour',
+			} ).queryKey[ 5 ]
+		).toEqual( { period: 'hour', quantity: 48, date: '2026-06-15', stats_fields: 'timeline' } );
+	} );
+
+	it( 'disables email time series queries without a positive integer post ID or a date', () => {
+		const range = { from: '2026-06-01', to: '2026-06-07', interval: 'day' } as const;
+
+		expect( statsEmailOpensTimeSeriesQuery( 0, range ).enabled ).toBe( false );
+		expect( statsEmailClicksTimeSeriesQuery( -1, range ).enabled ).toBe( false );
+		expect( statsEmailOpensTimeSeriesQuery( 1.5, range ).enabled ).toBe( false );
+		expect( statsEmailOpensTimeSeriesQuery( 41, {} as StatsReportParams ).enabled ).toBe( false );
 	} );
 
 	it( 'includes filter_by_country in query params when provided', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -421,6 +421,7 @@ describe( 'Stats query factories', () => {
 			'stats/emails/summary',
 			'GET',
 			{
+				period: 'alltime',
 				quantity: 10,
 				sort_field: 'post_date',
 				sort_order: 'desc',
@@ -438,9 +439,23 @@ describe( 'Stats query factories', () => {
 		} );
 
 		expect( query.queryKey[ 5 ] ).toEqual( {
+			period: 'alltime',
 			quantity: 5,
 			sort_field: 'opens',
 			sort_order: 'asc',
+		} );
+	} );
+
+	it( 'keeps email summary at period=alltime even when an untyped caller tries to override it', () => {
+		const query = statsEmailSummaryQuery( {
+			period: 'day',
+		} as unknown as Parameters< typeof statsEmailSummaryQuery >[ 0 ] );
+
+		expect( query.queryKey[ 5 ] ).toEqual( {
+			period: 'alltime',
+			quantity: 10,
+			sort_field: 'post_date',
+			sort_order: 'desc',
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-summary-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-summary-query.ts
@@ -17,9 +17,10 @@ export interface StatsEmailSummaryParams {
 	sort_order?: 'asc' | 'desc';
 }
 
-// The emails summary always reports across the whole lifetime of the site — the endpoint has no
-// period parameter — so only the row count and sort are caller-controlled. sort_field defaults to
-// post_date (newest first) to mirror the Calypso Emails screen; the server's own default is post_id.
+// The emails summary always reports across the whole lifetime of the site, so it is always
+// requested with period=alltime (matching the Calypso Emails screen); only the row count and sort
+// are caller-controlled. sort_field defaults to post_date (newest first) to mirror Calypso; the
+// server's own default is post_id.
 export const statsEmailSummaryQuery = (
 	params: StatsEmailSummaryParams = {}
 ): StatsReportQueryOptions< 'emailSummary' > =>
@@ -32,6 +33,9 @@ export const statsEmailSummaryQuery = (
 			sort_field: 'post_date',
 			sort_order: 'desc',
 			...params,
+			// period is fixed after the spread: the endpoint is always all-time and callers
+			// (including untyped ones) must not be able to narrow it.
+			period: 'alltime',
 		},
 		sanitizer: 'emailSummary',
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -1,8 +1,13 @@
 /**
  * Internal dependencies
  */
-import { statsProxyQuery } from './stats-query';
-import type { StatsReportQueryOptions } from './stats-query';
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
+import type { StatsProxyParams } from '../api';
 import type {
 	StatsEmailTimeSeriesDataPoint,
 	StatsEmailTimeSeriesReport,
@@ -17,51 +22,50 @@ export type {
 
 export type StatsEmailTimeSeriesPeriod = 'hour' | 'day';
 
-export type StatsEmailTimeSeriesParams = {
-	period?: StatsEmailTimeSeriesPeriod;
-	date?: string;
-	quantity?: number;
-};
+export type StatsEmailTimeSeriesParams = StatsReportParams;
 
 const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postId > 0;
 
-// Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends
-// period, quantity (24 for hour, 30 otherwise), and stats_fields=timeline.
-function emailTimeSeriesApiParams( {
-	period = 'day',
-	date,
-	quantity,
-}: StatsEmailTimeSeriesParams ) {
-	return {
+// The email timeline only supports hourly and daily buckets (Calypso's validEmailPeriods),
+// so any coarser dashboard interval collapses to daily.
+const toEmailPeriod = ( period?: string ): StatsEmailTimeSeriesPeriod =>
+	period === 'hour' ? 'hour' : 'day';
+
+// Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends period,
+// quantity, date, and stats_fields=timeline. quantity is the number of buckets ending at date,
+// so it must span the whole requested range — 24 buckets per day for hourly, one per day otherwise.
+function emailTimeSeriesQuery(
+	statType: 'opens' | 'clicks',
+	postId: number,
+	params: StatsReportParams
+): StatsReportQueryOptions< 'emailTimeSeries' > {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const period = toEmailPeriod( statsParams.period );
+	const days = statsParams.days ?? ( period === 'hour' ? 1 : 30 );
+	const emailParams: StatsProxyParams = {
 		period,
-		quantity: quantity ?? ( period === 'hour' ? 24 : 30 ),
-		...( date ? { date } : {} ),
-		stats_fields: 'timeline' as const,
+		quantity: period === 'hour' ? 24 * days : days,
+		...( apiParams.date ? { date: apiParams.date } : {} ),
+		stats_fields: 'timeline',
 	};
+
+	return statsProxyQuery( {
+		name: `email-${ statType }-time-series`,
+		version: '1.1',
+		endpoint: `stats/${ statType }/emails/${ postId }`,
+		params: emailParams,
+		sanitizer: 'emailTimeSeries',
+		enabled: hasValidPostId( postId ) && !! emailParams.date,
+	} );
 }
 
 export const statsEmailOpensTimeSeriesQuery = (
 	postId: number,
-	params: StatsEmailTimeSeriesParams = {}
-): StatsReportQueryOptions< 'emailTimeSeries' > =>
-	statsProxyQuery( {
-		name: 'email-opens-time-series',
-		version: '1.1',
-		endpoint: `stats/opens/emails/${ postId }`,
-		params: emailTimeSeriesApiParams( params ),
-		sanitizer: 'emailTimeSeries',
-		enabled: hasValidPostId( postId ),
-	} );
+	params: StatsReportParams
+): StatsReportQueryOptions< 'emailTimeSeries' > => emailTimeSeriesQuery( 'opens', postId, params );
 
 export const statsEmailClicksTimeSeriesQuery = (
 	postId: number,
-	params: StatsEmailTimeSeriesParams = {}
-): StatsReportQueryOptions< 'emailTimeSeries' > =>
-	statsProxyQuery( {
-		name: 'email-clicks-time-series',
-		version: '1.1',
-		endpoint: `stats/clicks/emails/${ postId }`,
-		params: emailTimeSeriesApiParams( params ),
-		sanitizer: 'emailTimeSeries',
-		enabled: hasValidPostId( postId ),
-	} );
+	params: StatsReportParams
+): StatsReportQueryOptions< 'emailTimeSeries' > => emailTimeSeriesQuery( 'clicks', postId, params );


### PR DESCRIPTION
Fixes WOOA7S-1628 — https://linear.app/a8c/issue/WOOA7S-1628/premium-analytics-revisit-email-time-series-hook-shape-hourly-bucket

## Why
The Stats email opens/clicks time-series hooks returned a different shape (`{ data }`) than every other dashboard time-series hook (`{ primary, comparison }`), so a chart widget couldn't render period-over-period comparison for an email the way it can for traffic. They now behave like the rest of the dashboard, and hourly email timelines render each hour as its own point instead of collapsing onto the day.

## Proposed changes
* Re-model `useStatsEmailOpensTimeSeries` / `useStatsEmailClicksTimeSeries` onto `useStatsReport`, so they return `{ primary, comparison, hasComparison, isLoading, … }` like `useStatsVisits` and fetch the comparison period automatically when `reportParams` include comparison dates.
* The query factory now accepts `StatsReportParams` and converts the dashboard date range to the endpoint's `period` / `quantity` / `date`, clamping the period to `hour | day` (Calypso's `validEmailPeriods`) and deriving `quantity` (24 for hour, otherwise the day span).
* The shared time-series normalizer resolves hourly buckets into distinct per-hour intervals (`YYYY-MM-DD HH:00`) instead of collapsing all 24 hours onto the day. The `hour` dimension is kept out of the metric summary. Gated to `unit === 'hour'` payloads that carry an `hour` column, so visits/subscribers/wordads are unaffected.

## Verification
Data-layer-only change — no user-visible UI yet (this endpoint has no consuming widget). Exercised via the package's unit tests (query-key/param conversion, hourly normalization, comparison wiring) and type checking.

<details>
<summary>Output</summary>

```text
$ pnpm --dir projects/packages/premium-analytics test -- packages/data --runInBand
Test Suites: 41 passed, 41 total
Tests:       264 passed, 264 total

$ pnpm --dir projects/packages/premium-analytics run typecheck
(no type errors)
```

</details>

## Related product discussion/links
* Follow-up to #49901 (added the email time-series data layer).
* Linear: WOOA7S-1628

## Does this pull request change what data or activity we track or use?
No. This only changes the client-side hook/query shape and normalization for an existing Stats API endpoint.

## Testing instructions
* `pnpm --dir projects/packages/premium-analytics test -- packages/data --runInBand`
* `pnpm --dir projects/packages/premium-analytics run typecheck`
* Confirm `useStatsEmailOpensTimeSeries( postId, reportParams )` / `useStatsEmailClicksTimeSeries( postId, reportParams )` return `{ primary, comparison, hasComparison, … }` and that `primary.data` is a `StatsEmailTimeSeriesReport`.
* Confirm a daily `reportParams` range produces `period: 'day'`, `quantity` = day span, `date` = range end; a coarser interval (week/month/year) clamps to `period: 'day'`; an `hour` interval produces `period: 'hour'`, `quantity: 24`.
* Confirm an hourly timeline payload normalizes into distinct per-hour buckets and the `hour` field is excluded from the summary totals.
