### PR TITLE
AI Admin: restructure MCP settings Read/Write pages to group-based layout

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/mcp/group-intents.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/group-intents.js
@@ -1,0 +1,35 @@
+/**
+ * Build a read/write-aware per-group `group_intents` key: the backend's
+ * SettingsHelper::ability_covered_by_group_intents() only covers an ability
+ * via a compound key shaped "{read|write}:{group}" (e.g. "write:site").
+ * This scopes a group's "Enable all" to the category (Read or Write) it was
+ * toggled from, instead of defaulting every op in the group regardless of category.
+ *
+ * @param {'read'|'write'} category  - Read or write scope.
+ * @param {string}         groupName - Group slug (e.g. "site").
+ * @return {string} Compound intent key (e.g. "write:site").
+ */
+export function groupIntentKey( category, groupName ) {
+	return `${ category }:${ groupName }`;
+}
+
+/**
+ * A group/read/write intent only sets the *default* for abilities with no
+ * explicit per-op override — an explicit override from an earlier individual
+ * toggle always wins. So an "Enable all" action must also force-write an
+ * explicit override for any tool in scope whose current state disagrees with
+ * the new value, or a previously-toggled tool would silently stay stuck.
+ *
+ * @param {Array<[string, object]>} scopedTools - Tools to evaluate, each as [toolId, ability].
+ * @param {boolean}                 enabled     - Target enabled state.
+ * @return {Record<string, boolean>|undefined} Overrides for disagreeing tools, or undefined if none.
+ */
+export function getOverridesToMatch( scopedTools, enabled ) {
+	const overrides = {};
+	scopedTools.forEach( ( [ toolId, tool ] ) => {
+		if ( tool.enabled !== enabled ) {
+			overrides[ toolId ] = enabled;
+		}
+	} );
+	return Object.keys( overrides ).length > 0 ? overrides : undefined;
+}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/groups.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/groups.js
@@ -1,0 +1,110 @@
+/**
+ * Read / Write MCP tools pages — group tools by display group: Content
+ * Authoring, Site, Account, etc. A group's members usually come from one STRAP
+ * facade, but multiple facades can resolve to the same group (e.g. Create Site
+ * into Site), and standalone abilities can declare a group directly in config.
+ * Each settings-visible ability carries a `group` field (a clean slug, e.g.
+ * `site`) matching the `name` of one of the ordered group descriptors returned
+ * by the API (`mcp_abilities.groups`, see utils.js `getGroupDescriptors()`).
+ */
+
+import { __ } from '@wordpress/i18n';
+import { SUB_CATEGORY_ORDER, getSubCategory } from './categories';
+
+const FLAT_SUB_CATEGORY_ORDER = [ ...new Set( Object.values( SUB_CATEGORY_ORDER ).flat() ) ];
+
+/**
+ * Group tools by the API-provided display group, ordered by descriptor order.
+ * Tools with no group (or an unrecognised group slug) fall into a trailing "Other" bucket.
+ *
+ * @param {Array<[string, object]>}                                                  tools            - Tool entries to group, each as [toolId, ability].
+ * @param {Array<{name: string, label: string, description: string, order: number}>} groupDescriptors - Ordered group descriptors from the API.
+ * @return {Array<{group: object|null, label: string, tools: Array<[string, object]>}>} Groups in descriptor order, with an optional trailing "Other" bucket.
+ */
+export function groupToolsByGroup( tools, groupDescriptors ) {
+	const byGroupName = new Map();
+	const unmatched = [];
+
+	for ( const entry of tools ) {
+		const [ , ability ] = entry;
+		const groupName = ability?.group ?? null;
+		if ( groupName === null ) {
+			unmatched.push( entry );
+			continue;
+		}
+		if ( ! byGroupName.has( groupName ) ) {
+			byGroupName.set( groupName, [] );
+		}
+		byGroupName.get( groupName ).push( entry );
+	}
+
+	const groups = [];
+	for ( const descriptor of groupDescriptors ) {
+		const groupTools = byGroupName.get( descriptor.name );
+		if ( groupTools && groupTools.length > 0 ) {
+			groups.push( { group: descriptor, label: descriptor.label, tools: groupTools } );
+		}
+		byGroupName.delete( descriptor.name );
+	}
+
+	// Abilities whose `group` doesn't match any known descriptor (unexpected,
+	// but don't silently drop them) join the unmatched/no-group fallback bucket.
+	for ( const groupTools of byGroupName.values() ) {
+		unmatched.push( ...groupTools );
+	}
+
+	if ( unmatched.length > 0 ) {
+		groups.push( {
+			group: null,
+			label: __( 'Other', 'jetpack' ),
+			tools: unmatched,
+		} );
+	}
+
+	return groups;
+}
+
+/**
+ * Sub-group a set of tools by their API `category` field, ordered by
+ * FLAT_SUB_CATEGORY_ORDER. Tools with no sub-category land in a trailing
+ * bucket with `subCategory: null`. Returns a single-element array when all
+ * tools share the same sub-category (or none).
+ *
+ * @param {Array<[string, object]>} tools - Tool entries to sub-group, each as [toolId, ability].
+ * @return {Array<{subCategory: string|null, tools: Array<[string, object]>}>} Sub-groups in display order; null subCategory bucket is always last.
+ */
+export function groupToolsBySubCategory( tools ) {
+	const bySubCategory = new Map();
+
+	for ( const entry of tools ) {
+		const [ toolId, ability ] = entry;
+		const sub = getSubCategory( toolId, ability ) ?? null;
+		if ( ! bySubCategory.has( sub ) ) {
+			bySubCategory.set( sub, [] );
+		}
+		bySubCategory.get( sub ).push( entry );
+	}
+
+	const result = [];
+
+	for ( const sub of FLAT_SUB_CATEGORY_ORDER ) {
+		if ( bySubCategory.has( sub ) ) {
+			result.push( { subCategory: sub, tools: bySubCategory.get( sub ) } );
+			bySubCategory.delete( sub );
+		}
+	}
+
+	// Any sub-categories not in the known order (future-proofing)
+	for ( const [ sub, subTools ] of bySubCategory ) {
+		if ( sub !== null ) {
+			result.push( { subCategory: sub, tools: subTools } );
+		}
+	}
+
+	// Tools with no resolved sub-category at the end
+	if ( bySubCategory.has( null ) ) {
+		result.push( { subCategory: null, tools: bySubCategory.get( null ) } );
+	}
+
+	return result;
+}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -212,7 +212,9 @@ export default function McpHub( {
 			analytics.tracks.recordEvent( 'jetpack_mcp_enabled_toggled', { enabled } );
 			const abilities = {};
 			if ( enabled ) {
-				readTools.forEach( ( [ toolId ] ) => {
+				// Enable all tools (read + write) by default, matching the backend's
+				// new default-on behavior.
+				availableTools.forEach( ( [ toolId ] ) => {
 					abilities[ toolId ] = true;
 				} );
 			}
@@ -226,7 +228,7 @@ export default function McpHub( {
 				],
 			} );
 		},
-		[ blogId, onUpdate, readTools ]
+		[ blogId, onUpdate, availableTools ]
 	);
 
 	const navigateToRead = useCallback( () => onNavigate( 'read' ), [ onNavigate ] );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -54,6 +54,9 @@ function ToolToggle( { toolId, tool, savingToolIds, onToggle } ) {
 	);
 }
 
+const LABEL_SHOW_OPERATIONS = __( 'Show operations', 'jetpack' );
+const LABEL_HIDE_OPERATIONS = __( 'Hide operations', 'jetpack' );
+
 /**
  * Collapsible card for one display group.
  *
@@ -102,9 +105,7 @@ function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange
 					<Button
 						className="jetpack-ai-mcp__group-chevron"
 						icon={ isOpen ? chevronUp : chevronDown }
-						label={
-							isOpen ? __( 'Hide operations', 'jetpack' ) : __( 'Show operations', 'jetpack' )
-						}
+						label={ isOpen ? LABEL_HIDE_OPERATIONS : LABEL_SHOW_OPERATIONS }
 						aria-expanded={ isOpen }
 						onClick={ handleChevron }
 					/>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -1,31 +1,28 @@
 /**
  * MCP Read tools view.
  *
- * Lists read-only tools grouped by category, with per-tool and per-category toggles.
+ * Lists read-only tools grouped by display group, with per-tool and
+ * per-group toggles. A page-level "Enable all" toggle sits at the top.
+ * Individual tool toggles are collapsed behind a per-group chevron.
  */
 
 import {
+	Button,
 	Card,
 	CardBody,
-	CardDivider,
-	CardHeader,
 	ToggleControl,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { Fragment, useCallback } from '@wordpress/element';
+import { Fragment, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import analytics from 'lib/analytics';
-import {
-	CATEGORY_ORDER,
-	SUB_CATEGORY_ORDER,
-	getDisplayCategory,
-	getSubCategory,
-	isWriteTool,
-	sortTools,
-} from './categories';
+import { isWriteTool } from './categories';
+import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
 import {
 	getAccountMcpAbilities,
+	getGroupDescriptors,
 	getSiteContextToolIds,
 	getSiteLevelEnabled,
 	getSiteMcpAbilities,
@@ -57,36 +54,85 @@ function ToolToggle( { toolId, tool, savingToolIds, onToggle } ) {
 }
 
 /**
- * Category card header with an "Enable all" toggle.
+ * Collapsible card for one display group.
  *
  * @param {object}   props               - Component props.
- * @param {string}   props.categoryName  - Display name of the category.
- * @param {boolean}  props.allEnabled    - Whether all tools in the category are enabled.
+ * @param {object}   props.descriptor    - Group descriptor from the API, or null for "Other".
+ * @param {string}   props.label         - Display label for the group.
+ * @param {Array}    props.groupTools    - Tool entries for this group.
  * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
- * @param {Array}    props.categoryTools - Tools in the category.
- * @param {Function} props.onEnableAll   - Called with (categoryTools, enabled).
+ * @param {Function} props.onToolChange  - Called with (toolId, enabled).
+ * @param {Function} props.onEnableAll   - Called with (groupName|null, groupTools, enabled).
  * @return {object} Component markup.
  */
-function CategoryHeader( { categoryName, allEnabled, savingToolIds, categoryTools, onEnableAll } ) {
-	const handleChange = useCallback(
-		checked => onEnableAll( categoryTools, checked ),
-		[ categoryTools, onEnableAll ]
+function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange, onEnableAll } ) {
+	const allGroupEnabled = groupTools.every( ( [ , t ] ) => t.enabled );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleToggle = useCallback(
+		checked => onEnableAll( descriptor?.name ?? null, groupTools, checked ),
+		[ descriptor, groupTools, onEnableAll ]
 	);
+	const handleChevron = useCallback( () => setIsOpen( open => ! open ), [] );
+
 	return (
-		<CardHeader>
-			<div className="jetpack-ai-mcp__category-header-row">
-				<Text as="h3" weight={ 600 } size={ 14 }>
-					{ categoryName }
-				</Text>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					checked={ allEnabled }
-					disabled={ categoryTools.some( ( [ id ] ) => savingToolIds.has( id ) ) }
-					label={ __( 'Enable all', 'jetpack' ) }
-					onChange={ handleChange }
-				/>
-			</div>
-		</CardHeader>
+		<Card>
+			<CardBody>
+				<div className="jetpack-ai-mcp__group-header">
+					<Stack direction="column" gap="xs" className="jetpack-ai-mcp__group-info">
+						<Text weight={ 600 } size={ 14 }>
+							{ label }
+						</Text>
+						{ descriptor?.description && (
+							<Text variant="muted" size={ 12 }>
+								{ descriptor.description }
+							</Text>
+						) }
+					</Stack>
+					<div className="jetpack-ai-mcp__group-toggle">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ allGroupEnabled }
+							disabled={ groupTools.some( ( [ id ] ) => savingToolIds.has( id ) ) }
+							label={ __( 'Enable all', 'jetpack' ) }
+							onChange={ handleToggle }
+						/>
+					</div>
+					<Button
+						className="jetpack-ai-mcp__group-chevron"
+						icon={ isOpen ? chevronUp : chevronDown }
+						label={ __( 'Show operations', 'jetpack' ) }
+						aria-expanded={ isOpen }
+						onClick={ handleChevron }
+					/>
+				</div>
+				{ isOpen &&
+					groupToolsBySubCategory( groupTools ).map(
+						( { subCategory, tools: subTools }, subIndex ) => (
+							<Fragment key={ subCategory ?? '__ungrouped__' }>
+								{ subIndex > 0 && <div className="jetpack-ai-mcp__sub-divider" /> }
+								<div
+									className={
+										subIndex === 0 ? 'jetpack-ai-mcp__group-body' : 'jetpack-ai-mcp__sub-group-body'
+									}
+								>
+									<Stack direction="column" gap="md">
+										{ subTools.map( ( [ toolId, tool ] ) => (
+											<ToolToggle
+												key={ toolId }
+												toolId={ toolId }
+												tool={ tool }
+												savingToolIds={ savingToolIds }
+												onToggle={ onToolChange }
+											/>
+										) ) }
+									</Stack>
+								</div>
+							</Fragment>
+						)
+					) }
+			</CardBody>
+		</Card>
 	);
 }
 
@@ -119,7 +165,8 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 	const allTools = Object.entries( mergedAbilities ).filter( ( [ , t ] ) => t.visible !== false );
 	const readTools = allTools.filter( ( [ id, t ] ) => ! isWriteTool( id, t ) );
 
-	const buildAbilities = useCallback( overrides => overrides, [] );
+	const groupDescriptors = getGroupDescriptors( mcpAbilities ?? {} );
+	const groups = groupToolsByGroup( readTools, groupDescriptors );
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
@@ -132,125 +179,104 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 				sites: [
 					{
 						blog_id: blogId,
-						abilities: buildAbilities( { [ toolId ]: enabled } ),
+						abilities: { [ toolId ]: enabled },
 					},
 				],
 			} );
 		},
-		[ blogId, buildAbilities, onUpdate ]
+		[ blogId, onUpdate ]
 	);
 
-	const handleEnableAll = useCallback(
-		( categoryTools, enabled ) => {
+	const pageAllEnabled = readTools.length > 0 && readTools.every( ( [ , t ] ) => t.enabled );
+	const isSavingAny = readTools.some( ( [ id ] ) => savingToolIds.has( id ) );
+
+	const handlePageToggle = useCallback(
+		enabled => {
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
-				tool_count: categoryTools.length,
 				view: 'read',
+				scope: 'page',
 			} );
 			const overrides = {};
-			categoryTools.forEach( ( [ toolId ] ) => {
+			readTools.forEach( ( [ toolId ] ) => {
 				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [
 					{
 						blog_id: blogId,
-						abilities: buildAbilities( overrides ),
+						abilities: overrides,
 					},
 				],
 			} );
 		},
-		[ blogId, buildAbilities, onUpdate ]
+		[ blogId, readTools, onUpdate ]
 	);
 
-	// Group by display category
-	const grouped = {};
-	readTools.forEach( ( [ toolId, tool ] ) => {
-		const category = getDisplayCategory( toolId, tool );
-		if ( ! grouped[ category ] ) {
-			grouped[ category ] = [];
-		}
-		grouped[ category ].push( [ toolId, tool ] );
-	} );
-
-	const renderToolToggles = tools =>
-		tools.map( ( [ toolId, tool ] ) => (
-			<ToolToggle
-				key={ toolId }
-				toolId={ toolId }
-				tool={ tool }
-				savingToolIds={ savingToolIds }
-				onToggle={ handleToolChange }
-			/>
-		) );
-
-	const renderSubGroupedTools = ( categoryTools, categoryName ) => {
-		const subGrouped = {};
-		categoryTools.forEach( ( [ toolId, tool ] ) => {
-			const sub = getSubCategory( toolId, tool ) ?? '';
-			if ( ! subGrouped[ sub ] ) {
-				subGrouped[ sub ] = [];
-			}
-			subGrouped[ sub ].push( [ toolId, tool ] );
-		} );
-
-		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
-		const subGroups = order.filter( sub => subGrouped[ sub ]?.length > 0 );
-
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider className="jetpack-ai-mcp__tool-group-divider" /> }
-				<CardBody>
-					<Stack direction="column" gap="md">
-						{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }
-					</Stack>
-				</CardBody>
-			</Fragment>
-		) );
-	};
-
-	if ( readTools.length === 0 ) {
-		return (
-			<Card>
-				<CardBody>
-					<Text variant="muted">{ __( 'No read tools available.', 'jetpack' ) }</Text>
-				</CardBody>
-			</Card>
-		);
-	}
+	const handleGroupEnableAll = useCallback(
+		( groupName, groupTools, enabled ) => {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+				enabled,
+				view: 'read',
+				scope: 'group',
+				group: groupName ?? 'other',
+			} );
+			const overrides = {};
+			groupTools.forEach( ( [ toolId ] ) => {
+				overrides[ toolId ] = enabled;
+			} );
+			onUpdate( {
+				sites: [
+					{
+						blog_id: blogId,
+						abilities: overrides,
+					},
+				],
+			} );
+		},
+		[ blogId, onUpdate ]
+	);
 
 	return (
 		<Stack direction="column" gap="md">
-			{ CATEGORY_ORDER.map( categoryName => {
-				const categoryTools = grouped[ categoryName ];
-				if ( ! categoryTools?.length ) {
-					return null;
-				}
-
-				const allEnabled = categoryTools.every( ( [ , t ] ) => t.enabled );
-				const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
-
-				return (
-					<Card key={ categoryName }>
-						<CategoryHeader
-							categoryName={ categoryName }
-							allEnabled={ allEnabled }
-							savingToolIds={ savingToolIds }
-							categoryTools={ categoryTools }
-							onEnableAll={ handleEnableAll }
+			<Card>
+				<CardBody>
+					<Stack direction="column" gap="md">
+						<Text as="p" variant="muted">
+							{ __( 'Turn individual tools on or off. Changes save automatically.', 'jetpack' ) }
+						</Text>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ pageAllEnabled }
+							disabled={ isSavingAny || readTools.length === 0 }
+							label={ __( 'Enable all', 'jetpack' ) }
+							onChange={ handlePageToggle }
 						/>
-						{ subOrder ? (
-							renderSubGroupedTools( categoryTools, categoryName )
-						) : (
-							<CardBody>
-								<Stack direction="column" gap="md">
-									{ renderToolToggles( categoryTools ) }
-								</Stack>
-							</CardBody>
-						) }
-					</Card>
-				);
-			} ) }
+					</Stack>
+				</CardBody>
+			</Card>
+
+			{ groups.length > 0 ? (
+				<Stack direction="column" gap="sm">
+					{ groups.map( ( { group: descriptor, label, tools: groupTools } ) => (
+						<GroupCard
+							key={ descriptor?.name ?? '__other__' }
+							descriptor={ descriptor }
+							label={ label }
+							groupTools={ groupTools }
+							savingToolIds={ savingToolIds }
+							onToolChange={ handleToolChange }
+							onEnableAll={ handleGroupEnableAll }
+						/>
+					) ) }
+				</Stack>
+			) : (
+				<Card>
+					<CardBody>
+						<Text variant="muted">{ __( 'No read tools available.', 'jetpack' ) }</Text>
+					</CardBody>
+				</Card>
+			) }
 		</Stack>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -19,6 +19,7 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
+import { getOverridesToMatch } from './group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
 import {
 	getAccountMcpAbilities,
@@ -194,14 +195,14 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handlePageToggle = useCallback(
 		enabled => {
+			const overrides = getOverridesToMatch( readTools, enabled );
+			if ( ! overrides ) {
+				return;
+			}
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'read',
 				scope: 'page',
-			} );
-			const overrides = {};
-			readTools.forEach( ( [ toolId ] ) => {
-				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [
@@ -217,15 +218,15 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleGroupEnableAll = useCallback(
 		( groupName, groupTools, enabled ) => {
+			const overrides = getOverridesToMatch( groupTools, enabled );
+			if ( ! overrides ) {
+				return;
+			}
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'read',
 				scope: 'group',
 				group: groupName ?? 'other',
-			} );
-			const overrides = {};
-			groupTools.forEach( ( [ toolId ] ) => {
-				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -101,7 +101,9 @@ function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange
 					<Button
 						className="jetpack-ai-mcp__group-chevron"
 						icon={ isOpen ? chevronUp : chevronDown }
-						label={ __( 'Show operations', 'jetpack' ) }
+						label={
+							isOpen ? __( 'Hide operations', 'jetpack' ) : __( 'Show operations', 'jetpack' )
+						}
 						aria-expanded={ isOpen }
 						onClick={ handleChevron }
 					/>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -128,10 +128,9 @@
 		}
 	}
 
-	// First sub-group when a group row is expanded: full-bleed border separates
-	// from the group header, then inner padding for the tool list.
+	// First sub-group when a group row is expanded: full-bleed, inner padding
+	// for the tool list.
 	&__group-body {
-		border-top: 1px solid var(--color-border-subtle, #dcdcde);
 		margin-inline-start: -16px;
 		margin-inline-end: -16px;
 		padding: 16px;
@@ -143,16 +142,20 @@
 		}
 	}
 
-	// Subsequent sub-groups: same horizontal padding, no top border
-	// (sub-divider provides it).
+	// Subsequent sub-groups: same horizontal padding as group-body.
 	&__sub-group-body {
-		padding: 0 0 16px;
+		padding: 16px 0;
+
+		@media (min-width: 600px) {
+			padding: 20px 0;
+		}
 	}
 
 	// Divider between sub-groups within an expanded group card.
+	// Containers on both sides provide equal padding so spacing is symmetric.
 	&__sub-divider {
 		border-top: 1px solid var(--color-border-subtle, #dcdcde);
-		margin: 16px 0 20px;
+		margin: 0;
 	}
 
 	// Tool toggle descriptions hug their setting title; override WP's

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -86,24 +86,73 @@
 		vertical-align: center;
 	}
 
-	&__category-header-row {
+	// Group header: [info (flex:1)] [toggle] [chevron] on desktop
+	// Mobile: [info (flex:1)] [chevron] on row 1, [toggle (full-width)] on row 2
+	&__group-header {
 		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
 		align-items: center;
+		flex-wrap: wrap;
+		gap: 8px 12px;
+	}
+
+	&__group-info {
+		flex: 1;
+		min-width: 0; // allow text truncation inside flex children
+		order: 1;
+	}
+
+	// On mobile: toggle wraps below the title row (full width, after chevron).
+	// On desktop: toggle sits between info and chevron.
+	&__group-toggle {
+		order: 3;
 		width: 100%;
 
-		// The ToggleControl label uses line-height equal to the toggle height for
-		// vertical alignment, but the FlexBlock wrapper defaults to align-items:
-		// stretch. Force center so the "Enable all" text sits mid-toggle.
+		@media (min-width: 600px) {
+			order: 2;
+			width: auto;
+			flex-shrink: 0;
+		}
+
+		// Force the ToggleControl label to center-align with the toggle handle.
 		.components-toggle-control__label {
 			display: flex;
 			align-items: center;
 		}
 	}
 
-	&__tool-group-divider {
-		margin: 0;
+	&__group-chevron {
+		order: 2; // Mobile: stays inline with title
+
+		@media (min-width: 600px) {
+			order: 3; // Desktop: after toggle
+		}
+	}
+
+	// First sub-group when a group row is expanded: full-bleed border separates
+	// from the group header, then inner padding for the tool list.
+	&__group-body {
+		border-top: 1px solid var(--color-border-subtle, #dcdcde);
+		margin-inline-start: -16px;
+		margin-inline-end: -16px;
+		padding: 16px;
+
+		@media (min-width: 600px) {
+			margin-inline-start: -24px;
+			margin-inline-end: -24px;
+			padding: 20px 24px;
+		}
+	}
+
+	// Subsequent sub-groups: same horizontal padding, no top border
+	// (sub-divider provides it).
+	&__sub-group-body {
+		padding: 0 0 16px;
+	}
+
+	// Divider between sub-groups within an expanded group card.
+	&__sub-divider {
+		border-top: 1px solid var(--color-border-subtle, #dcdcde);
+		margin: 16px 0 20px;
 	}
 
 	// Tool toggle descriptions hug their setting title; override WP's

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/component.js
@@ -5,6 +5,8 @@ import {
 	isWriteTool,
 	sortTools,
 } from '../categories';
+import { getOverridesToMatch, groupIntentKey } from '../group-intents';
+import { groupToolsByGroup, groupToolsBySubCategory } from '../groups';
 
 describe( 'MCP category mapping', () => {
 	test.each( [ 'wpcom-mcp', 'developer-testing' ] )(
@@ -77,6 +79,15 @@ describe( 'MCP category mapping', () => {
 		expect( isWriteTool( 'tool-id' ) ).toBe( false );
 	} );
 
+	test( 'prefers top-level readonly over annotations.readonly', () => {
+		expect( isWriteTool( 'tool-id', { readonly: false, annotations: { readonly: true } } ) ).toBe(
+			true
+		);
+		expect( isWriteTool( 'tool-id', { readonly: true, annotations: { readonly: false } } ) ).toBe(
+			false
+		);
+	} );
+
 	test( 'leaves tool order unchanged', () => {
 		const tools = [
 			[ 'first', {} ],
@@ -84,5 +95,76 @@ describe( 'MCP category mapping', () => {
 		];
 
 		expect( sortTools( tools ) ).toBe( tools );
+	} );
+} );
+
+const GROUPS = [
+	{
+		name: 'content-authoring',
+		label: 'Content Authoring',
+		description: 'Create posts.',
+		order: 0,
+	},
+	{ name: 'site', label: 'Site', description: 'Manage site settings.', order: 1 },
+	{ name: 'account', label: 'Account', description: 'Manage account settings.', order: 2 },
+];
+
+describe( 'MCP group-intents', () => {
+	test( 'groupIntentKey builds a read/write-scoped compound key', () => {
+		expect( groupIntentKey( 'write', 'site' ) ).toBe( 'write:site' );
+		expect( groupIntentKey( 'read', 'account' ) ).toBe( 'read:account' );
+	} );
+
+	test( 'getOverridesToMatch returns overrides only for disagreeing tools', () => {
+		const tools = [
+			[ 'wpcom-mcp/already-on', { enabled: true } ],
+			[ 'wpcom-mcp/needs-on', { enabled: false } ],
+		];
+		expect( getOverridesToMatch( tools, true ) ).toEqual( { 'wpcom-mcp/needs-on': true } );
+	} );
+
+	test( 'getOverridesToMatch returns undefined when every tool matches', () => {
+		expect( getOverridesToMatch( [ [ 'wpcom-mcp/a', { enabled: true } ] ], true ) ).toBeUndefined();
+	} );
+
+	test( 'getOverridesToMatch returns undefined for an empty list', () => {
+		expect( getOverridesToMatch( [], true ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'MCP groups', () => {
+	test( 'groupToolsByGroup orders groups by descriptor order', () => {
+		const tools = [
+			[ 'wpcom-mcp/posts-create', { group: 'content-authoring' } ],
+			[ 'wpcom-mcp/site-settings-update', { group: 'site' } ],
+		];
+		const groups = groupToolsByGroup( tools, GROUPS );
+		expect( groups.map( g => g.group?.name ) ).toEqual( [ 'content-authoring', 'site' ] );
+	} );
+
+	test( 'groupToolsByGroup buckets ungrouped tools into trailing "Other"', () => {
+		const tools = [
+			[ 'wpcom-mcp/standalone', { group: null } ],
+			[ 'wpcom-mcp/posts-create', { group: 'content-authoring' } ],
+		];
+		const groups = groupToolsByGroup( tools, GROUPS );
+		expect( groups ).toHaveLength( 2 );
+		expect( groups[ groups.length - 1 ].group ).toBeNull();
+	} );
+
+	test( 'groupToolsBySubCategory places no-category tools in trailing null bucket', () => {
+		const tools = [ [ 'wpcom-mcp/unknown', {} ] ];
+		const result = groupToolsBySubCategory( tools );
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].subCategory ).toBeNull();
+	} );
+
+	test( 'groupToolsBySubCategory orders posts before comments', () => {
+		const tools = [
+			[ 'wpcom-mcp/list-comments', { category: 'comments' } ],
+			[ 'wpcom-mcp/list-posts', { category: 'posts' } ],
+		];
+		const result = groupToolsBySubCategory( tools );
+		expect( result[ 0 ].tools[ 0 ][ 0 ] ).toBe( 'wpcom-mcp/list-posts' );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/utils.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/utils.js
@@ -72,6 +72,31 @@ export function mergeSiteMcpAbilities( accountAbilities, siteAbilities, defaultE
 }
 
 /**
+ * Get the ordered display-group descriptors for the settings UI's middle
+ * grouping layer, sorted by their `order` field. A group defaults to a STRAP
+ * facade, but some facades are merged into another group (e.g. Create Site
+ * into Site).
+ *
+ * @param {object} mcpAbilities - The mcp_abilities response object.
+ * @return {Array<{name: string, label: string, description: string, order: number}>} Group descriptors sorted by order.
+ */
+export function getGroupDescriptors( mcpAbilities ) {
+	const groups = mcpAbilities?.groups ?? [];
+	return [ ...groups ].sort( ( a, b ) => a.order - b.order );
+}
+
+/**
+ * Get the account-level group "enable all" intents.
+ * Keys are `read`, `write`, or a compound slug like `"write:site"`.
+ *
+ * @param {object} mcpAbilities - The mcp_abilities response object.
+ * @return {Record<string, boolean>} Map of intent keys to enabled state.
+ */
+export function getGroupIntents( mcpAbilities ) {
+	return mcpAbilities?.group_intents ?? {};
+}
+
+/**
  * Check if site-level MCP is enabled for a specific site.
  *
  * @param {object} userSettings - The user settings object (mcp_abilities response body).

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -19,6 +19,7 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
+import { getOverridesToMatch } from './group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
 import {
 	getAccountMcpAbilities,
@@ -194,14 +195,14 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handlePageToggle = useCallback(
 		enabled => {
+			const overrides = getOverridesToMatch( writeTools, enabled );
+			if ( ! overrides ) {
+				return;
+			}
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'write',
 				scope: 'page',
-			} );
-			const overrides = {};
-			writeTools.forEach( ( [ toolId ] ) => {
-				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [
@@ -217,15 +218,15 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleGroupEnableAll = useCallback(
 		( groupName, groupTools, enabled ) => {
+			const overrides = getOverridesToMatch( groupTools, enabled );
+			if ( ! overrides ) {
+				return;
+			}
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'write',
 				scope: 'group',
 				group: groupName ?? 'other',
-			} );
-			const overrides = {};
-			groupTools.forEach( ( [ toolId ] ) => {
-				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -54,6 +54,9 @@ function ToolToggle( { toolId, tool, savingToolIds, onToggle } ) {
 	);
 }
 
+const LABEL_SHOW_OPERATIONS = __( 'Show operations', 'jetpack' );
+const LABEL_HIDE_OPERATIONS = __( 'Hide operations', 'jetpack' );
+
 /**
  * Collapsible card for one display group.
  *
@@ -102,9 +105,7 @@ function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange
 					<Button
 						className="jetpack-ai-mcp__group-chevron"
 						icon={ isOpen ? chevronUp : chevronDown }
-						label={
-							isOpen ? __( 'Hide operations', 'jetpack' ) : __( 'Show operations', 'jetpack' )
-						}
+						label={ isOpen ? LABEL_HIDE_OPERATIONS : LABEL_SHOW_OPERATIONS }
 						aria-expanded={ isOpen }
 						onClick={ handleChevron }
 					/>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -101,7 +101,9 @@ function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange
 					<Button
 						className="jetpack-ai-mcp__group-chevron"
 						icon={ isOpen ? chevronUp : chevronDown }
-						label={ __( 'Show operations', 'jetpack' ) }
+						label={
+							isOpen ? __( 'Hide operations', 'jetpack' ) : __( 'Show operations', 'jetpack' )
+						}
 						aria-expanded={ isOpen }
 						onClick={ handleChevron }
 					/>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -1,32 +1,28 @@
 /**
  * MCP Write tools view.
  *
- * Lists write tools (tools where readonly === false) grouped by category,
- * with per-tool and per-category toggles.
+ * Lists write tools (readonly === false) grouped by display group, with
+ * per-tool and per-group toggles. A page-level "Enable all" toggle sits at
+ * the top. Individual tool toggles are collapsed behind a per-group chevron.
  */
 
 import {
+	Button,
 	Card,
 	CardBody,
-	CardDivider,
-	CardHeader,
 	ToggleControl,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { Fragment, useCallback } from '@wordpress/element';
+import { Fragment, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import analytics from 'lib/analytics';
-import {
-	CATEGORY_ORDER,
-	SUB_CATEGORY_ORDER,
-	getDisplayCategory,
-	getSubCategory,
-	isWriteTool,
-	sortTools,
-} from './categories';
+import { isWriteTool } from './categories';
+import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
 import {
 	getAccountMcpAbilities,
+	getGroupDescriptors,
 	getSiteContextToolIds,
 	getSiteLevelEnabled,
 	getSiteMcpAbilities,
@@ -39,7 +35,7 @@ import {
  * @param {object}   props               - Component props.
  * @param {string}   props.toolId        - Tool identifier.
  * @param {object}   props.tool          - Tool descriptor from the API.
- * @param {boolean}  props.savingToolIds - Whether a save is pending.
+ * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
  * @param {Function} props.onToggle      - Called with (toolId, enabled).
  * @return {object} Component markup.
  */
@@ -58,36 +54,85 @@ function ToolToggle( { toolId, tool, savingToolIds, onToggle } ) {
 }
 
 /**
- * Category card header with an "Enable all" toggle.
+ * Collapsible card for one display group.
  *
  * @param {object}   props               - Component props.
- * @param {string}   props.categoryName  - Display name of the category.
- * @param {boolean}  props.allEnabled    - Whether all tools in the category are enabled.
+ * @param {object}   props.descriptor    - Group descriptor from the API, or null for "Other".
+ * @param {string}   props.label         - Display label for the group.
+ * @param {Array}    props.groupTools    - Tool entries for this group.
  * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
- * @param {Array}    props.categoryTools - Tools in the category.
- * @param {Function} props.onEnableAll   - Called with (categoryTools, enabled).
+ * @param {Function} props.onToolChange  - Called with (toolId, enabled).
+ * @param {Function} props.onEnableAll   - Called with (groupName|null, groupTools, enabled).
  * @return {object} Component markup.
  */
-function CategoryHeader( { categoryName, allEnabled, savingToolIds, categoryTools, onEnableAll } ) {
-	const handleChange = useCallback(
-		checked => onEnableAll( categoryTools, checked ),
-		[ categoryTools, onEnableAll ]
+function GroupCard( { descriptor, label, groupTools, savingToolIds, onToolChange, onEnableAll } ) {
+	const allGroupEnabled = groupTools.every( ( [ , t ] ) => t.enabled );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleToggle = useCallback(
+		checked => onEnableAll( descriptor?.name ?? null, groupTools, checked ),
+		[ descriptor, groupTools, onEnableAll ]
 	);
+	const handleChevron = useCallback( () => setIsOpen( open => ! open ), [] );
+
 	return (
-		<CardHeader>
-			<div className="jetpack-ai-mcp__category-header-row">
-				<Text as="h3" weight={ 600 } size={ 14 }>
-					{ categoryName }
-				</Text>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					checked={ allEnabled }
-					disabled={ categoryTools.some( ( [ id ] ) => savingToolIds.has( id ) ) }
-					label={ __( 'Enable all', 'jetpack' ) }
-					onChange={ handleChange }
-				/>
-			</div>
-		</CardHeader>
+		<Card>
+			<CardBody>
+				<div className="jetpack-ai-mcp__group-header">
+					<Stack direction="column" gap="xs" className="jetpack-ai-mcp__group-info">
+						<Text weight={ 600 } size={ 14 }>
+							{ label }
+						</Text>
+						{ descriptor?.description && (
+							<Text variant="muted" size={ 12 }>
+								{ descriptor.description }
+							</Text>
+						) }
+					</Stack>
+					<div className="jetpack-ai-mcp__group-toggle">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ allGroupEnabled }
+							disabled={ groupTools.some( ( [ id ] ) => savingToolIds.has( id ) ) }
+							label={ __( 'Enable all', 'jetpack' ) }
+							onChange={ handleToggle }
+						/>
+					</div>
+					<Button
+						className="jetpack-ai-mcp__group-chevron"
+						icon={ isOpen ? chevronUp : chevronDown }
+						label={ __( 'Show operations', 'jetpack' ) }
+						aria-expanded={ isOpen }
+						onClick={ handleChevron }
+					/>
+				</div>
+				{ isOpen &&
+					groupToolsBySubCategory( groupTools ).map(
+						( { subCategory, tools: subTools }, subIndex ) => (
+							<Fragment key={ subCategory ?? '__ungrouped__' }>
+								{ subIndex > 0 && <div className="jetpack-ai-mcp__sub-divider" /> }
+								<div
+									className={
+										subIndex === 0 ? 'jetpack-ai-mcp__group-body' : 'jetpack-ai-mcp__sub-group-body'
+									}
+								>
+									<Stack direction="column" gap="md">
+										{ subTools.map( ( [ toolId, tool ] ) => (
+											<ToolToggle
+												key={ toolId }
+												toolId={ toolId }
+												tool={ tool }
+												savingToolIds={ savingToolIds }
+												onToggle={ onToolChange }
+											/>
+										) ) }
+									</Stack>
+								</div>
+							</Fragment>
+						)
+					) }
+			</CardBody>
+		</Card>
 	);
 }
 
@@ -120,7 +165,8 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 	const allTools = Object.entries( mergedAbilities ).filter( ( [ , t ] ) => t.visible !== false );
 	const writeTools = allTools.filter( ( [ id, t ] ) => isWriteTool( id, t ) );
 
-	const buildAbilities = useCallback( overrides => overrides, [] );
+	const groupDescriptors = getGroupDescriptors( mcpAbilities ?? {} );
+	const groups = groupToolsByGroup( writeTools, groupDescriptors );
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
@@ -133,127 +179,106 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 				sites: [
 					{
 						blog_id: blogId,
-						abilities: buildAbilities( { [ toolId ]: enabled } ),
+						abilities: { [ toolId ]: enabled },
 					},
 				],
 			} );
 		},
-		[ blogId, buildAbilities, onUpdate ]
+		[ blogId, onUpdate ]
 	);
 
-	const handleEnableAll = useCallback(
-		( categoryTools, enabled ) => {
+	const pageAllEnabled = writeTools.length > 0 && writeTools.every( ( [ , t ] ) => t.enabled );
+	const isSavingAny = writeTools.some( ( [ id ] ) => savingToolIds.has( id ) );
+
+	const handlePageToggle = useCallback(
+		enabled => {
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
-				tool_count: categoryTools.length,
 				view: 'write',
+				scope: 'page',
 			} );
 			const overrides = {};
-			categoryTools.forEach( ( [ toolId ] ) => {
+			writeTools.forEach( ( [ toolId ] ) => {
 				overrides[ toolId ] = enabled;
 			} );
 			onUpdate( {
 				sites: [
 					{
 						blog_id: blogId,
-						abilities: buildAbilities( overrides ),
+						abilities: overrides,
 					},
 				],
 			} );
 		},
-		[ blogId, buildAbilities, onUpdate ]
+		[ blogId, writeTools, onUpdate ]
 	);
 
-	// Group by display category
-	const grouped = {};
-	writeTools.forEach( ( [ toolId, tool ] ) => {
-		const category = getDisplayCategory( toolId, tool );
-		if ( ! grouped[ category ] ) {
-			grouped[ category ] = [];
-		}
-		grouped[ category ].push( [ toolId, tool ] );
-	} );
-
-	const renderToolToggles = tools =>
-		tools.map( ( [ toolId, tool ] ) => (
-			<ToolToggle
-				key={ toolId }
-				toolId={ toolId }
-				tool={ tool }
-				savingToolIds={ savingToolIds }
-				onToggle={ handleToolChange }
-			/>
-		) );
-
-	const renderSubGroupedTools = ( categoryTools, categoryName ) => {
-		const subGrouped = {};
-		categoryTools.forEach( ( [ toolId, tool ] ) => {
-			const sub = getSubCategory( toolId, tool ) ?? '';
-			if ( ! subGrouped[ sub ] ) {
-				subGrouped[ sub ] = [];
-			}
-			subGrouped[ sub ].push( [ toolId, tool ] );
-		} );
-
-		const order = SUB_CATEGORY_ORDER[ categoryName ] ?? [];
-		const subGroups = order.filter( sub => subGrouped[ sub ]?.length > 0 );
-
-		return subGroups.map( ( subName, index ) => (
-			<Fragment key={ subName }>
-				{ index > 0 && <CardDivider className="jetpack-ai-mcp__tool-group-divider" /> }
-				<CardBody>
-					<Stack direction="column" gap="md">
-						{ renderToolToggles( sortTools( subGrouped[ subName ] ) ) }
-					</Stack>
-				</CardBody>
-			</Fragment>
-		) );
-	};
-
-	if ( writeTools.length === 0 ) {
-		return (
-			<Card>
-				<CardBody>
-					<Text variant="muted">
-						{ __( 'No write tools are available for this site.', 'jetpack' ) }
-					</Text>
-				</CardBody>
-			</Card>
-		);
-	}
+	const handleGroupEnableAll = useCallback(
+		( groupName, groupTools, enabled ) => {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+				enabled,
+				view: 'write',
+				scope: 'group',
+				group: groupName ?? 'other',
+			} );
+			const overrides = {};
+			groupTools.forEach( ( [ toolId ] ) => {
+				overrides[ toolId ] = enabled;
+			} );
+			onUpdate( {
+				sites: [
+					{
+						blog_id: blogId,
+						abilities: overrides,
+					},
+				],
+			} );
+		},
+		[ blogId, onUpdate ]
+	);
 
 	return (
 		<Stack direction="column" gap="md">
-			{ CATEGORY_ORDER.map( categoryName => {
-				const categoryTools = grouped[ categoryName ];
-				if ( ! categoryTools?.length ) {
-					return null;
-				}
-
-				const allEnabled = categoryTools.every( ( [ , t ] ) => t.enabled );
-				const subOrder = SUB_CATEGORY_ORDER[ categoryName ];
-
-				return (
-					<Card key={ categoryName }>
-						<CategoryHeader
-							categoryName={ categoryName }
-							allEnabled={ allEnabled }
-							savingToolIds={ savingToolIds }
-							categoryTools={ categoryTools }
-							onEnableAll={ handleEnableAll }
+			<Card>
+				<CardBody>
+					<Stack direction="column" gap="md">
+						<Text as="p" variant="muted">
+							{ __( 'Turn individual tools on or off. Changes save automatically.', 'jetpack' ) }
+						</Text>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							checked={ pageAllEnabled }
+							disabled={ isSavingAny || writeTools.length === 0 }
+							label={ __( 'Enable all', 'jetpack' ) }
+							onChange={ handlePageToggle }
 						/>
-						{ subOrder ? (
-							renderSubGroupedTools( categoryTools, categoryName )
-						) : (
-							<CardBody>
-								<Stack direction="column" gap="md">
-									{ renderToolToggles( categoryTools ) }
-								</Stack>
-							</CardBody>
-						) }
-					</Card>
-				);
-			} ) }
+					</Stack>
+				</CardBody>
+			</Card>
+
+			{ groups.length > 0 ? (
+				<Stack direction="column" gap="sm">
+					{ groups.map( ( { group: descriptor, label, tools: groupTools } ) => (
+						<GroupCard
+							key={ descriptor?.name ?? '__other__' }
+							descriptor={ descriptor }
+							label={ label }
+							groupTools={ groupTools }
+							savingToolIds={ savingToolIds }
+							onToolChange={ handleToolChange }
+							onEnableAll={ handleGroupEnableAll }
+						/>
+					) ) }
+				</Stack>
+			) : (
+				<Card>
+					<CardBody>
+						<Text variant="muted">
+							{ __( 'No write tools are available for this site.', 'jetpack' ) }
+						</Text>
+					</CardBody>
+				</Card>
+			) }
 		</Stack>
 	);
 }

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mcp-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mcp-settings.php
@@ -184,6 +184,12 @@ class WPCOM_REST_API_V2_Endpoint_MCP_Settings extends WP_REST_Controller {
 		// when derived from WPCOM (no per-site override concept at this layer).
 		$site_level_enabled_default = $site_level_enabled;
 
+		// Group descriptors (AIINT-469) — pass through if the WPCOM endpoint returns them.
+		$groups = array();
+		if ( isset( $body['groups'] ) && is_array( $body['groups'] ) ) {
+			$groups = $body['groups'];
+		}
+
 		// Use only the explicit per-site user overrides returned by WPCOM in user_overrides.abilities.
 		// These are the raw values stored via SettingsHelper — not the computed effective states
 		// (account defaults merged with overrides). Keeping only explicit overrides here lets the
@@ -211,6 +217,7 @@ class WPCOM_REST_API_V2_Endpoint_MCP_Settings extends WP_REST_Controller {
 						),
 					),
 					'site_level_enabled_default' => $site_level_enabled_default,
+					'groups'                     => $groups,
 				),
 			)
 		);

--- a/projects/plugins/jetpack/changelog/aiint-474-mcp-group-restructure
+++ b/projects/plugins/jetpack/changelog/aiint-474-mcp-group-restructure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Admin: restructure MCP settings Read/Write pages to group tools by display group with collapsible per-group tool lists and a page-level Enable all toggle.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-474/jetpack-restructure-ai-admin-page-mcp-settings-to-readwrite-strap

## Proposed changes

* Replace the old display-category grouping on the MCP Read and Write sub-pages with API-driven group descriptors (`mcp_abilities.groups`), matching the Calypso restructure (PR #111954 / AIINT-472)
* Add a collapsible `GroupCard` component per group — group header shows a label, description, and per-group "Enable all" toggle; chevron expands the tool list underneath
* Add a page-level "Enable all" toggle card at the top of each sub-page (Read / Write)
* Wire the PHP endpoint to pass through the `groups` array from WPCOM so group descriptors reach the client
* Add new utility functions: `groupToolsByGroup`, `groupToolsBySubCategory`, `getGroupDescriptors`, `groupIntentKey`, `getOverridesToMatch`
* Extend unit tests to cover the new grouping utilities (24 tests total, up from 16)
* Fix `handleMcpToggle` in `index.jsx` to enable all tools (read + write) when enabling MCP, not just read tools

## Example

| Before | After |
|--------|-------|
| <img width="499" height="865" alt="Screenshot 2026-06-30 at 15 24 24" src="https://github.com/user-attachments/assets/4cde76d5-c61c-4b86-9471-2b636f0fd151" /> | <img width="981" height="864" alt="Screenshot 2026-06-30 at 16 16 36" src="https://github.com/user-attachments/assets/112da142-7855-460f-babf-553b07d650b4" /> |
| <img width="499" height="864" alt="Screenshot 2026-06-30 at 15 24 39" src="https://github.com/user-attachments/assets/20a8c619-9862-427c-bde3-34e04ba5f21d" /> |.<img width="981" height="864" alt="Screenshot 2026-06-30 at 16 16 47" src="https://github.com/user-attachments/assets/3abcfa4c-9054-4b06-9182-1ce5e05926d5" /> |

## Does this pull request change what data or activity we track or use?

No new tracking added. Existing `jetpack_mcp_allowlist_updated` Tracks event now includes a `scope` property (`page` or `group`) and a `group` slug when the event originates from a group-level toggle.

## Testing instructions

Prerequisites: a Jetpack site connected to a WPCOM account with an AI plan that includes MCP access.

1. Go to **Jetpack → AI** in wp-admin and scroll to the MCP section.
2. Enable MCP if not already on — all tools (read + write) should enable at once.
3. Switch to the **Read** tab:
   - A page-level "Enable all" toggle should appear at the top of the card.
   - Tools should be grouped into collapsible cards by display group (e.g. "Content Authoring", "Site").
   - Each group card has its own "Enable all" toggle and a chevron to expand the tool list.
   - Toggling a group "Enable all" should update all tools in that group.
   - Toggling the page "Enable all" should update every read tool.
4. Repeat the same checks on the **Write** tab.
5. Expand a group and toggle individual tools — state should persist on page reload.
6. If the WPCOM endpoint does not yet return `groups`, all tools should fall into a single "Other" group (graceful degradation).
