### PR TITLE
VideoPress: enable the modernized admin dashboard by default

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-modernization-default-on
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-default-on
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: enable the modernized (wp-build) admin dashboard by default.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -519,10 +519,14 @@ class Admin_UI {
 	/**
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
+	 * The modernized dashboard is enabled by default. A site can opt back into
+	 * the legacy dashboard with:
+	 * add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_false' ).
+	 *
 	 * @return bool
 	 */
 	public static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Flip the `rsm_jetpack_ui_modernization_videopress` filter default from `false` to `true` in `Admin_UI::is_modernized()`, so the modernized (wp-build) VideoPress admin dashboard loads by default instead of the legacy React app.
* Document the opt-out in the method docblock — a site can return to the legacy dashboard with `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_false' )`.
* Approach note for reviewers: the Newsletter/Subscriptions modernization filters express "on by default" via a staged-rollout helper (`is_modernization_rollout_enabled()`, gated on a percentage constant + Automattician check). This PR intentionally goes straight to default-on for 100% of sites. Switching to a phased ramp later is a drop-in: mirror Newsletter's helper and set the percentage.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1782741924977459-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
No. This only changes which admin UI renders by default. The modernized path's initial-state setup (e.g. the cached `get_site_features_from_wpcom()` call) gathers the same paid-feature/pricing data already collected on the legacy path; going default-on widens exposure to it but adds no new tracking.

## Testing instructions
* Build the VideoPress package (or a plugin that bundles it) and open **wp-admin → Jetpack → VideoPress**.
* With no filter set, confirm the **modernized (wp-build) dashboard** now loads by default — overview / library / settings / video-details routes — instead of the legacy React app.
* Add `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_false' );` (snippet or mu-plugin) and reload → confirm the **legacy** dashboard is restored.
* `phpcs` is clean, and no existing PHP test asserts the prior `false` default, so CI is unaffected by the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQbYMqwYS55EBaSNuHs8aD