### PR TITLE
Premium Analytics: Align Locations widget guidelines

### DIFF
--- a/projects/packages/premium-analytics/changelog/locations-widget-guideline
+++ b/projects/packages/premium-analytics/changelog/locations-widget-guideline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Locations: Align widget Storybook and comparison states with dashboard guidelines.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -176,6 +176,11 @@ const REGION_COMPARISON_ROWS_BY_COUNTRY: Record< string, StatsLocationItem[] > =
 	],
 };
 
+// Heuristic: a request whose `date` param is more than 1 day ago is treated as the
+// comparison-period request. This works for the default `last-30-days` preset (primary
+// date ≈ today, comparison date ≈ 30 days ago). It would misclassify a `today` preset
+// (comparison date = yesterday, daysFromToday === 1), but the stories only use the default
+// preset so this is fine in practice.
 function isComparisonRequest( path: string ): boolean {
 	const queryString = path.split( '?' )[ 1 ];
 	const requestDate = queryString ? new URLSearchParams( queryString ).get( 'date' ) : null;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1,0 +1,302 @@
+/**
+ * Stats API mock middleware for Storybook.
+ *
+ * Intercepts `@wordpress/api-fetch` requests to the PA Stats proxy and returns
+ * fixture data so Stats-backed widgets render in Storybook without a live
+ * WordPress + WPCOM connection.
+ */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
+
+const STATS_BASE = '/jetpack-premium-analytics/v1/proxy/v1.1/stats';
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+type GeoMode = 'country' | 'region' | 'city';
+
+type StatsLocationItem = {
+	location: string;
+	views: number;
+	country_code: string;
+	coordinates?: {
+		latitude: number;
+		longitude: number;
+	};
+};
+
+const COUNTRY_INFO = {
+	US: { country_full: 'United States', map_region: '021' },
+	GB: { country_full: 'United Kingdom', map_region: '154' },
+	DE: { country_full: 'Germany', map_region: '155' },
+	JP: { country_full: 'Japan', map_region: '030' },
+	FR: { country_full: 'France', map_region: '155' },
+	BR: { country_full: 'Brazil', map_region: '005' },
+	IN: { country_full: 'India', map_region: '034' },
+	AU: { country_full: 'Australia', map_region: '053' },
+	CA: { country_full: 'Canada', map_region: '021' },
+	MX: { country_full: 'Mexico', map_region: '013' },
+	HK: { country_full: 'Hong Kong', map_region: '030' },
+};
+
+const COUNTRY_ROWS: StatsLocationItem[] = [
+	{ location: 'United States', views: 8500, country_code: 'US' },
+	{ location: 'United Kingdom', views: 4200, country_code: 'GB' },
+	{ location: 'Germany', views: 3800, country_code: 'DE' },
+	{ location: 'Japan', views: 3100, country_code: 'JP' },
+	{ location: 'France', views: 2900, country_code: 'FR' },
+	{ location: 'Brazil', views: 2400, country_code: 'BR' },
+	{ location: 'India', views: 2200, country_code: 'IN' },
+	{ location: 'Australia', views: 1800, country_code: 'AU' },
+	{ location: 'Canada', views: 1650, country_code: 'CA' },
+	{ location: 'Mexico', views: 1400, country_code: 'MX' },
+];
+
+const COUNTRY_COMPARISON_ROWS: StatsLocationItem[] = [
+	{ location: 'United States', views: 7900, country_code: 'US' },
+	{ location: 'United Kingdom', views: 4550, country_code: 'GB' },
+	{ location: 'Germany', views: 3200, country_code: 'DE' },
+	{ location: 'Japan', views: 2850, country_code: 'JP' },
+	{ location: 'France', views: 3100, country_code: 'FR' },
+	{ location: 'Brazil', views: 2100, country_code: 'BR' },
+	{ location: 'India', views: 2500, country_code: 'IN' },
+	{ location: 'Australia', views: 1700, country_code: 'AU' },
+	{ location: 'Canada', views: 1800, country_code: 'CA' },
+	{ location: 'Mexico', views: 1220, country_code: 'MX' },
+];
+
+const CITY_ROWS: StatsLocationItem[] = [
+	{
+		location: 'North Bergen',
+		views: 2716,
+		country_code: 'US',
+		coordinates: { latitude: 40.8043, longitude: -74.0121 },
+	},
+	{
+		location: 'Hong Kong',
+		views: 1246,
+		country_code: 'HK',
+		coordinates: { latitude: 22.3193, longitude: 114.1694 },
+	},
+	{
+		location: 'London',
+		views: 476,
+		country_code: 'GB',
+		coordinates: { latitude: 51.5072, longitude: -0.1276 },
+	},
+	{
+		location: 'Tokyo',
+		views: 390,
+		country_code: 'JP',
+		coordinates: { latitude: 35.6762, longitude: 139.6503 },
+	},
+	{
+		location: 'Berlin',
+		views: 330,
+		country_code: 'DE',
+		coordinates: { latitude: 52.52, longitude: 13.405 },
+	},
+];
+
+const CITY_COMPARISON_ROWS: StatsLocationItem[] = [
+	{
+		location: 'North Bergen',
+		views: 2400,
+		country_code: 'US',
+		coordinates: { latitude: 40.8043, longitude: -74.0121 },
+	},
+	{
+		location: 'Hong Kong',
+		views: 1380,
+		country_code: 'HK',
+		coordinates: { latitude: 22.3193, longitude: 114.1694 },
+	},
+	{
+		location: 'London',
+		views: 520,
+		country_code: 'GB',
+		coordinates: { latitude: 51.5072, longitude: -0.1276 },
+	},
+	{
+		location: 'Tokyo',
+		views: 340,
+		country_code: 'JP',
+		coordinates: { latitude: 35.6762, longitude: 139.6503 },
+	},
+	{
+		location: 'Berlin',
+		views: 370,
+		country_code: 'DE',
+		coordinates: { latitude: 52.52, longitude: 13.405 },
+	},
+];
+
+const REGION_ROWS_BY_COUNTRY: Record< string, StatsLocationItem[] > = {
+	US: [
+		{ location: 'California', views: 1800, country_code: 'US' },
+		{ location: 'New York', views: 1280, country_code: 'US' },
+		{ location: 'Texas', views: 1090, country_code: 'US' },
+		{ location: 'Florida', views: 920, country_code: 'US' },
+		{ location: 'Illinois', views: 640, country_code: 'US' },
+	],
+	GB: [
+		{ location: 'England', views: 2100, country_code: 'GB' },
+		{ location: 'Scotland', views: 760, country_code: 'GB' },
+		{ location: 'Wales', views: 420, country_code: 'GB' },
+		{ location: 'Northern Ireland', views: 280, country_code: 'GB' },
+	],
+	DE: [
+		{ location: 'North Rhine-Westphalia', views: 980, country_code: 'DE' },
+		{ location: 'Bavaria', views: 820, country_code: 'DE' },
+		{ location: 'Berlin', views: 610, country_code: 'DE' },
+		{ location: 'Hesse', views: 460, country_code: 'DE' },
+	],
+};
+
+const REGION_COMPARISON_ROWS_BY_COUNTRY: Record< string, StatsLocationItem[] > = {
+	US: [
+		{ location: 'California', views: 1620, country_code: 'US' },
+		{ location: 'New York', views: 1400, country_code: 'US' },
+		{ location: 'Texas', views: 970, country_code: 'US' },
+		{ location: 'Florida', views: 880, country_code: 'US' },
+		{ location: 'Illinois', views: 720, country_code: 'US' },
+	],
+	GB: [
+		{ location: 'England', views: 2200, country_code: 'GB' },
+		{ location: 'Scotland', views: 690, country_code: 'GB' },
+		{ location: 'Wales', views: 450, country_code: 'GB' },
+		{ location: 'Northern Ireland', views: 240, country_code: 'GB' },
+	],
+	DE: [
+		{ location: 'North Rhine-Westphalia', views: 900, country_code: 'DE' },
+		{ location: 'Bavaria', views: 870, country_code: 'DE' },
+		{ location: 'Berlin', views: 540, country_code: 'DE' },
+		{ location: 'Hesse', views: 500, country_code: 'DE' },
+	],
+};
+
+function isComparisonRequest( path: string ): boolean {
+	const queryString = path.split( '?' )[ 1 ];
+	const requestDate = queryString ? new URLSearchParams( queryString ).get( 'date' ) : null;
+
+	if ( ! requestDate ) {
+		return false;
+	}
+
+	const today = new Date().toISOString().slice( 0, 10 );
+	const daysFromToday = Math.floor(
+		( Date.parse( today ) - Date.parse( requestDate ) ) / DAY_IN_MS
+	);
+
+	return daysFromToday > 1;
+}
+
+function getRequestDate( query: URLSearchParams ) {
+	return query.get( 'date' ) || new Date().toISOString().slice( 0, 10 );
+}
+
+function getLocationRows(
+	geoMode: GeoMode,
+	query: URLSearchParams,
+	isComparison: boolean
+): StatsLocationItem[] {
+	if ( geoMode === 'city' ) {
+		return isComparison ? CITY_COMPARISON_ROWS : CITY_ROWS;
+	}
+
+	if ( geoMode === 'region' ) {
+		const countryCode = query.get( 'filter_by_country' ) || 'US';
+		const regionRows = isComparison ? REGION_COMPARISON_ROWS_BY_COUNTRY : REGION_ROWS_BY_COUNTRY;
+
+		return regionRows[ countryCode ] ?? regionRows.US;
+	}
+
+	return isComparison ? COUNTRY_COMPARISON_ROWS : COUNTRY_ROWS;
+}
+
+function buildStatsLocationViewsResponse(
+	geoMode: GeoMode,
+	query: URLSearchParams,
+	isComparison: boolean
+) {
+	const rows = getLocationRows( geoMode, query, isComparison );
+	const date = getRequestDate( query );
+	const totalViews = rows.reduce( ( sum, item ) => sum + item.views, 0 );
+
+	return {
+		date,
+		period: query.get( 'period' ) || 'day',
+		'country-info': COUNTRY_INFO,
+		summary: {
+			views: rows,
+			other_views: 0,
+			total_views: totalViews,
+		},
+		days: {
+			[ date ]: {
+				views: rows,
+				other_views: 0,
+				total_views: totalViews,
+			},
+		},
+	};
+}
+
+function getStatsMock( path: string ): unknown | null {
+	const withoutBase = path.slice( STATS_BASE.length );
+	const queryIndex = withoutBase.indexOf( '?' );
+	const subPath = queryIndex === -1 ? withoutBase : withoutBase.slice( 0, queryIndex );
+	const query = new URLSearchParams( queryIndex === -1 ? '' : withoutBase.slice( queryIndex + 1 ) );
+	const locationViewsMatch = subPath.match( /^\/location-views\/(country|region|city)$/ );
+
+	if ( locationViewsMatch ) {
+		return buildStatsLocationViewsResponse(
+			locationViewsMatch[ 1 ] as GeoMode,
+			query,
+			isComparisonRequest( path )
+		);
+	}
+
+	return null;
+}
+
+function prepareStatsMockResponse( mock: unknown, parse?: boolean ) {
+	if ( parse === false ) {
+		return new Response( JSON.stringify( mock ), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		} );
+	}
+
+	return mock;
+}
+
+const statsMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
+	const requestPath = options.path ?? options.url ?? '';
+
+	if ( ! requestPath.startsWith( STATS_BASE ) ) {
+		return next( options );
+	}
+
+	const mock = getStatsMock( requestPath );
+
+	if ( mock !== null ) {
+		return prepareStatsMockResponse( mock, options.parse );
+	}
+
+	return prepareStatsMockResponse( { data: [], summary: {} }, options.parse );
+};
+
+let registered = false;
+
+/**
+ * Registers the Stats API mock middleware. Idempotent.
+ */
+export function registerStatsMocks(): void {
+	if ( registered ) {
+		return;
+	}
+	registered = true;
+	apiFetch.use( statsMocksMiddleware );
+}

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -36,8 +36,8 @@ type LocationsWidgetProps = WidgetRenderProps< LocationsRenderAttributes >;
 /**
  * Locations widget inner component. Reads report params from WidgetRoot context.
  *
- * @param props     - Component props.
- * @param props.max - Maximum rows to display.
+ * @param root0     - Component props.
+ * @param root0.max - Maximum rows to display.
  * @return The rendered widget content.
  */
 function LocationsInner( { max }: { max: number } ) {
@@ -192,6 +192,9 @@ function LocationsInner( { max }: { max: number } ) {
 		);
 	}
 
+	// Explicit empty branch (rather than emptyStateText on LeaderboardChart) keeps the
+	// header breadcrumb and "View by" selector visible so users can switch mode or drill
+	// back up — consistent with the pattern used when chart chrome must remain interactive.
 	if ( ! data.length ) {
 		return (
 			<>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -254,7 +254,7 @@ function LocationsInner( { max }: { max: number } ) {
  * @param root0.attributes - Widget attributes (max).
  * @return The rendered Locations widget.
  */
-export default function Locations( { attributes }: LocationsWidgetProps ) {
+export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 	const max = attributes?.max ?? 10;
 
 	return (

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -58,12 +58,14 @@ function LocationsInner( { max }: { max: number } ) {
 	// Drill-down (region) takes priority over topMode; city mode disables drill-down.
 	const geoMode: GeoMode = selectedCountry ? 'region' : topMode;
 
-	const { data, comparisonData, hasComparison, isLoading, isError } = useLocationViews( {
-		reportParams,
-		max,
-		geoMode,
-		countryFilter: selectedCountry?.code,
-	} );
+	const { data, comparisonData, hasComparison, isLoading, isFetching, hasData, isError } =
+		useLocationViews( {
+			reportParams,
+			max,
+			geoMode,
+			countryFilter: selectedCountry?.code,
+		} );
+	const showLoading = isLoading || ( isFetching && hasData );
 
 	const geoData = useMemo( (): GeoData => {
 		const header: GoogleDataTableColumn[] = [
@@ -130,28 +132,27 @@ function LocationsInner( { max }: { max: number } ) {
 	}, [ comparisonData, data, geoMode, hasComparison ] );
 
 	const header = (
-		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
-			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
-				{ selectedCountry ? (
+		<Stack
+			direction="row"
+			justify={ selectedCountry ? 'space-between' : 'flex-end' }
+			align="center"
+			className={ styles.widgetHeader }
+		>
+			{ selectedCountry && (
+				<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
 					<Button
 						variant="unstyled"
 						onClick={ clearSelectedCountry }
 						className={ styles.breadcrumbLink }
 					>
-						{ __( 'Top Locations', 'jetpack-premium-analytics' ) }
+						{ __( 'Locations', 'jetpack-premium-analytics' ) }
 					</Button>
-				) : (
-					<Text variant="heading-md" render={ <h3 /> }>
-						{ __( 'Top Locations', 'jetpack-premium-analytics' ) }
-					</Text>
-				) }
-				{ selectedCountry && (
 					<>
 						<Text className={ styles.breadcrumbSeparator }>/</Text>
 						<Text>{ selectedCountry.name }</Text>
 					</>
-				) }
-			</Stack>
+				</Stack>
+			) }
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
@@ -217,6 +218,7 @@ function LocationsInner( { max }: { max: number } ) {
 		<>
 			{ header }
 			<div className={ styles.content }>
+				{ showLoading && <WidgetLoadingOverlay /> }
 				<div className={ clsx( styles.chartArea, geoMode === 'city' && styles.noMap ) }>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -5,10 +5,13 @@ import { GeoChart } from '@automattic/charts';
 import {
 	LeaderboardChart,
 	LeaderboardLabel,
+	WidgetLoadingOverlay,
 	WidgetRoot,
+	calculateDelta,
 	flagUrl,
 	useWidgetRootContext,
 	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -20,26 +23,25 @@ import clsx from 'clsx';
  */
 import styles from './style.module.css';
 import useLocationViews, { type GeoMode } from './use-location-views';
+import type { LocationsAttributes } from './widget';
 /**
  * Types
  */
 import type { GeoData, GoogleDataTableColumn, GoogleDataTableRow } from '@automattic/charts';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-interface LocationsAttributes {
-	max?: number;
-}
+type LocationsRenderAttributes = LocationsAttributes & Partial< ReportParamsFieldAttributes >;
+type LocationsWidgetProps = WidgetRenderProps< LocationsRenderAttributes >;
 
 /**
  * Locations widget inner component. Reads report params from WidgetRoot context.
  *
- * @param root0            - Render props.
- * @param root0.attributes - Widget attributes (max).
+ * @param props     - Component props.
+ * @param props.max - Maximum rows to display.
  * @return The rendered widget content.
  */
-function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes > ) {
+function LocationsInner( { max }: { max: number } ) {
 	const { reportParams } = useWidgetRootContext();
-	const max = attributes?.max ?? 10;
 
 	const [ topMode, setTopMode ] = useState< 'country' | 'city' >( 'country' );
 	const [ selectedCountry, setSelectedCountry ] = useState< { code: string; name: string } | null >(
@@ -56,7 +58,7 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 	// Drill-down (region) takes priority over topMode; city mode disables drill-down.
 	const geoMode: GeoMode = selectedCountry ? 'region' : topMode;
 
-	const { data, isLoading, isError } = useLocationViews( {
+	const { data, comparisonData, hasComparison, isLoading, isError } = useLocationViews( {
 		reportParams,
 		max,
 		geoMode,
@@ -76,12 +78,17 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 
 	const leaderboardData = useMemo( () => {
 		const maxValue = Math.max( ...data.map( l => l.value ), 0 );
+		const maxComparisonValue = Math.max( ...comparisonData.map( l => l.value ), 0 );
+		const comparisonMap = new Map(
+			comparisonData.map( location => [ location.key, location.value ] )
+		);
 
 		return data.map( location => {
 			const imageUrl = flagUrl( location.countryCode );
+			const previousValue = hasComparison ? comparisonMap.get( location.key ) ?? 0 : 0;
 
 			return {
-				id: location.countryCode + '_' + location.label,
+				id: location.key,
 				label: (
 					<LeaderboardLabel
 						label={ location.label }
@@ -95,10 +102,13 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 					/>
 				),
 				currentValue: location.value,
-				previousValue: 0,
+				previousValue,
 				currentShare: maxValue > 0 ? ( location.value / maxValue ) * 100 : 0,
-				previousShare: 0,
-				delta: 0,
+				previousShare:
+					hasComparison && maxComparisonValue > 0
+						? ( previousValue / maxComparisonValue ) * 100
+						: 0,
+				delta: hasComparison ? calculateDelta( location.value, previousValue ) : 0,
 				// Country mode: click to drill into regions.
 				// Region/city mode: rows are not interactive.
 				...( geoMode === 'country' &&
@@ -117,84 +127,98 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 					} ),
 			};
 		} ) as LeaderboardChartData;
-	}, [ data, geoMode ] );
+	}, [ comparisonData, data, geoMode, hasComparison ] );
 
-	if ( isLoading ) {
-		return (
-			<Stack align="center" justify="center" className={ clsx( styles.root, styles.placeholder ) }>
-				<Text>{ __( 'Loading locations…', 'jetpack-premium-analytics' ) }</Text>
+	const header = (
+		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
+			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
+				{ selectedCountry ? (
+					<Button
+						variant="unstyled"
+						onClick={ clearSelectedCountry }
+						className={ styles.breadcrumbLink }
+					>
+						{ __( 'Top Locations', 'jetpack-premium-analytics' ) }
+					</Button>
+				) : (
+					<Text variant="heading-md" render={ <h3 /> }>
+						{ __( 'Top Locations', 'jetpack-premium-analytics' ) }
+					</Text>
+				) }
+				{ selectedCountry && (
+					<>
+						<Text className={ styles.breadcrumbSeparator }>/</Text>
+						<Text>{ selectedCountry.name }</Text>
+					</>
+				) }
 			</Stack>
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'View by', 'jetpack-premium-analytics' ) }
+				hideLabelFromVision
+				value={ topMode }
+				options={ [
+					{ label: __( 'Countries', 'jetpack-premium-analytics' ), value: 'country' },
+					{ label: __( 'Cities', 'jetpack-premium-analytics' ), value: 'city' },
+				] }
+				onChange={ handleModeChange }
+				className={ styles.modeSelect }
+			/>
+		</Stack>
+	);
+
+	if ( isLoading && data.length === 0 ) {
+		return (
+			<>
+				{ header }
+				<div className={ styles.content }>
+					<WidgetLoadingOverlay />
+				</div>
+			</>
 		);
 	}
 
 	if ( isError ) {
 		return (
-			<Stack align="center" justify="center" className={ clsx( styles.root, styles.placeholder ) }>
-				<Text>{ __( 'Could not load location data.', 'jetpack-premium-analytics' ) }</Text>
-			</Stack>
+			<>
+				{ header }
+				<div className={ styles.content }>
+					<Stack align="center" justify="center" className={ styles.placeholder }>
+						<Text>{ __( 'Could not load location data.', 'jetpack-premium-analytics' ) }</Text>
+					</Stack>
+				</div>
+			</>
 		);
 	}
 
 	if ( ! data.length ) {
 		return (
-			<Stack align="center" justify="center" className={ clsx( styles.root, styles.placeholder ) }>
-				<Text>
-					{ __(
-						'Stats on where your visitors are viewing from will appear here.',
-						'jetpack-premium-analytics'
-					) }
-				</Text>
-			</Stack>
+			<>
+				{ header }
+				<div className={ styles.content }>
+					<Stack align="center" justify="center" className={ styles.placeholder }>
+						<Text>
+							{ __(
+								'Stats on where your visitors are viewing from will appear here.',
+								'jetpack-premium-analytics'
+							) }
+						</Text>
+					</Stack>
+				</div>
+			</>
 		);
 	}
 
 	return (
-		<Stack className={ styles.root }>
-			<Stack
-				direction="row"
-				justify="space-between"
-				align="center"
-				className={ styles.widgetHeader }
-			>
-				<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
-					{ selectedCountry ? (
-						<Button
-							variant="unstyled"
-							onClick={ clearSelectedCountry }
-							className={ styles.breadcrumbLink }
-						>
-							{ __( 'Top Locations', 'jetpack-premium-analytics' ) }
-						</Button>
-					) : (
-						<Text>{ __( 'Top Locations', 'jetpack-premium-analytics' ) }</Text>
-					) }
-					{ selectedCountry && (
-						<>
-							<Text className={ styles.breadcrumbSeparator }>/</Text>
-							<Text>{ selectedCountry.name }</Text>
-						</>
-					) }
-				</Stack>
-				<SelectControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'View by', 'jetpack-premium-analytics' ) }
-					hideLabelFromVision
-					value={ topMode }
-					options={ [
-						{ label: __( 'Countries', 'jetpack-premium-analytics' ), value: 'country' },
-						{ label: __( 'Cities', 'jetpack-premium-analytics' ), value: 'city' },
-					] }
-					onChange={ handleModeChange }
-					className={ styles.modeSelect }
-				/>
-			</Stack>
+		<>
+			{ header }
 			<div className={ styles.content }>
 				<div className={ clsx( styles.chartArea, geoMode === 'city' && styles.noMap ) }>
 					<LeaderboardChart
 						data={ leaderboardData }
 						withOverlayLabel
-						withComparison={ false }
+						withComparison={ hasComparison }
 						showLegend={ false }
 						dataFormat={ {
 							type: 'number',
@@ -214,7 +238,7 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
 					) }
 				</div>
 			</div>
-		</Stack>
+		</>
 	);
 }
 
@@ -227,10 +251,14 @@ function LocationsInner( { attributes }: WidgetRenderProps< LocationsAttributes 
  * @param root0.attributes - Widget attributes (max).
  * @return The rendered Locations widget.
  */
-export default function Locations( { attributes }: WidgetRenderProps< LocationsAttributes > ) {
+export default function Locations( { attributes }: LocationsWidgetProps ) {
+	const max = attributes?.max ?? 10;
+
 	return (
-		<WidgetRoot>
-			<LocationsInner attributes={ attributes } />
+		<WidgetRoot attributes={ attributes }>
+			<div className={ styles.root }>
+				<LocationsInner max={ max } />
+			</div>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -1,0 +1,124 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import LocationsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+registerStatsMocks();
+
+const LOCATIONS_RENDER_MODULE = 'storybook/locations';
+
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+};
+
+interface LocationsStoryControls {
+	withComparison: boolean;
+}
+
+interface LocationsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		LocationsStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+function getLocationsAttributes(
+	withComparison = false
+): ComponentProps< typeof LocationsRender >[ 'attributes' ] {
+	return {
+		max: 10,
+		reportParams: getDefaultQueryParams( withComparison ),
+	};
+}
+
+function renderLocationsWidget( { withComparison }: LocationsStoryControls ) {
+	return <LocationsRender attributes={ getLocationsAttributes( withComparison ) } />;
+}
+
+function LocationsDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <LocationsRender { ...( props as ComponentProps< typeof LocationsRender > ) } />;
+}
+
+function LocationsDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: LocationsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ LOCATIONS_RENDER_MODULE }
+			renderComponent={ LocationsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getLocationsAttributes( withComparison ) }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Locations',
+	component: LocationsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Locations" widget. Shows visitor views by country or city, with country drill-down into regions, using the global dashboard date range.',
+			},
+		},
+	},
+} satisfies Meta< LocationsStoryControls >;
+
+export default meta;
+
+type DashboardStory = StoryObj< LocationsDashboardStoryProps >;
+
+export const Default: StoryObj< LocationsStoryControls > = {
+	render: renderLocationsWidget,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+export const WithComparison: StoryObj< LocationsStoryControls > = {
+	render: renderLocationsWidget,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <LocationsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 2,
+		widgetHeight: 1,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -7,12 +7,17 @@
 }
 
 .placeholder {
+	flex: 1 1 0;
+	min-block-size: 0;
+	inline-size: 100%;
 	min-height: 200px;
 	color: var(--wpds-color-fg-content-neutral-weak);
+	text-align: center;
 }
 
 .widgetHeader {
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+	min-height: 32px;
 }
 
 .breadcrumb {
@@ -52,6 +57,7 @@
 }
 
 .content {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	padding: var(--wpds-dimension-padding-lg);

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -89,9 +89,6 @@ export default function useLocationViews( {
 	const { primary, comparison, hasComparison, isLoading, isError } =
 		useStatsLocations( statsParams );
 
-	// isLoading: true only on the initial fetch (no data yet) — used to show the
-	// full loading placeholder. isFetching covers background refetches where
-	// stale data is already available; those should not blank the widget.
 	const report = primary.data as StatsNormalizedReport< StatsLocationsItem > | undefined;
 	const comparisonReport = comparison.data as
 		| StatsNormalizedReport< StatsLocationsItem >

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -34,6 +34,8 @@ interface LocationViewsState {
 	comparisonData: LocationView[];
 	hasComparison: boolean;
 	isLoading: boolean;
+	isFetching: boolean;
+	hasData: boolean;
 	isError: boolean;
 }
 
@@ -86,7 +88,7 @@ export default function useLocationViews( {
 		...( countryFilter ? { filter_by_country: countryFilter } : {} ),
 	} as Parameters< typeof useStatsLocations >[ 0 ];
 
-	const { primary, comparison, hasComparison, isLoading, isError } =
+	const { primary, comparison, hasComparison, isLoading, isFetching, hasData, isError } =
 		useStatsLocations( statsParams );
 
 	const report = primary.data as StatsNormalizedReport< StatsLocationsItem > | undefined;
@@ -109,6 +111,8 @@ export default function useLocationViews( {
 		comparisonData: comparisonItems,
 		hasComparison,
 		isLoading,
+		isFetching,
+		hasData,
 		isError,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -14,6 +14,7 @@ export type GeoMode = 'country' | 'region' | 'city';
  * A single normalized location-views row for the widget.
  */
 export interface LocationView {
+	key: string;
 	label: string;
 	countryCode: string;
 	countryFull: string;
@@ -30,6 +31,8 @@ interface UseLocationViewsArgs {
 
 interface LocationViewsState {
 	data: LocationView[];
+	comparisonData: LocationView[];
+	hasComparison: boolean;
 	isLoading: boolean;
 	isError: boolean;
 }
@@ -44,10 +47,14 @@ function toLocationView( item: StatsLocationsItem ): LocationView | null {
 	if ( ! item.countryCode ) {
 		return null;
 	}
+	const label = typeof item.label === 'string' ? item.label : String( item.label );
+	const countryFull = item.countryFull ?? item.countryCode;
+
 	return {
-		label: typeof item.label === 'string' ? item.label : String( item.label ),
+		key: `${ item.countryCode }:${ label }`,
+		label,
 		countryCode: item.countryCode,
-		countryFull: item.countryFull ?? item.countryCode,
+		countryFull,
 		value: item.views,
 		region: item.region ?? '',
 	};
@@ -79,23 +86,31 @@ export default function useLocationViews( {
 		...( countryFilter ? { filter_by_country: countryFilter } : {} ),
 	} as Parameters< typeof useStatsLocations >[ 0 ];
 
-	const { primary } = useStatsLocations( statsParams );
+	const { primary, comparison, hasComparison, isLoading, isError } =
+		useStatsLocations( statsParams );
 
 	// isLoading: true only on the initial fetch (no data yet) — used to show the
 	// full loading placeholder. isFetching covers background refetches where
 	// stale data is already available; those should not blank the widget.
-	const isLoading = primary.isLoading;
-	const isError = primary.isError;
-
 	const report = primary.data as StatsNormalizedReport< StatsLocationsItem > | undefined;
+	const comparisonReport = comparison.data as
+		| StatsNormalizedReport< StatsLocationsItem >
+		| undefined;
 	const rawItems = report?.data?.[ 0 ]?.items ?? [];
+	const rawComparisonItems = comparisonReport?.data?.[ 0 ]?.items ?? [];
 	const items = rawItems
+		.map( toLocationView )
+		.filter( ( v ): v is LocationView => v !== null )
+		.slice( 0, max > 0 ? max : undefined );
+	const comparisonItems = rawComparisonItems
 		.map( toLocationView )
 		.filter( ( v ): v is LocationView => v !== null )
 		.slice( 0, max > 0 ? max : undefined );
 
 	return {
 		data: items,
+		comparisonData: comparisonItems,
+		hasComparison,
 		isLoading,
 		isError,
 	};

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -4,6 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { mapMarker } from '@wordpress/icons';
 
+export type LocationsAttributes = {
+	max?: number;
+};
+
 /**
  * Widget type definition.
  *
@@ -15,15 +19,14 @@ import { mapMarker } from '@wordpress/icons';
  * Date range comes from WidgetRoot's reportParams (the shared dashboard date
  * picker).
  *
- * Known limitations: delta/comparison rows all show 0 (follow-up). Google
- * GeoChart `provinces` resolution is unavailable for some territories (e.g.
- * Taiwan); those fall back to the world map without regional detail.
+ * Known limitation: Google GeoChart `provinces` resolution is unavailable for
+ * some territories (e.g. Taiwan); those fall back to the world map without
+ * regional detail.
  */
 export default {
 	name: 'jpa/locations',
 	title: __( 'Locations', 'jetpack-premium-analytics' ),
 	icon: mapMarker,
-	presentation: 'full-bleed',
 	attributes: [
 		{
 			id: 'max',


### PR DESCRIPTION
Fixes N/A

## Proposed changes

Aligns the existing Premium Analytics **Locations** widget with the current widget guidelines.

- Adds comparison-period support to the Locations leaderboard.
- Passes widget attributes into `WidgetRoot`.
- Keeps the Locations header visible through loading, error, and empty states.
- Adds Locations Storybook coverage with Stats proxy mocks for location views.
- Adds `Default`, `WithComparison`, and `WidgetDashboardWithWidget` Storybook stories.
- Keeps the existing country-to-region drill-down behavior unchanged.

## Related product discussion/links

- N/A

## Does this pull request change what data or activity we track or use?

No. This only changes how existing Stats Locations data is displayed and mocked in Storybook.

## Testing instructions

Run:

```bash
pnpm --dir projects/packages/premium-analytics run typecheck
pnpm --dir projects/packages/premium-analytics run build:wp-build
```

In Storybook:

1. Open `Packages/Premium Analytics/Widgets/Locations`.
2. Confirm `Default`, `WithComparison`, and `WidgetDashboardWithWidget` render correctly.
3. Confirm comparison deltas appear in `WithComparison`.
4. In the dashboard story, click a country row to drill into regions.
5. Use the breadcrumb to return to Top Locations.

On a Jetpack-connected test site with location stats:

1. Open **Premium Analytics**.
2. Confirm **Locations** renders with the updated header and spacing.
3. Enable a comparison date range and confirm row deltas are shown.
4. Click a country row and verify the existing region drill-down behavior still works.

<img width="1106" height="680" alt="截圖 2026-07-01 上午8 54 20" src="https://github.com/user-attachments/assets/c46ccd6e-8554-4b01-a588-db01a769db90" />