### PR TITLE
VideoPress: compute resumable upload MD5 incrementally in Tus_File

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
+++ b/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Tus_File now folds each chunk into a rolling MD5 as it is written, so a resumable upload's whole-file digest is available on completion without re-reading the assembled file.

--- a/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
+++ b/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-VideoPress: Tus_File now folds each chunk into a rolling MD5 as it is written, so a resumable upload's whole-file digest is available on completion without re-reading the assembled file.
+VideoPress: Large video uploads now finish faster, as the upload is verified as it arrives instead of re-reading the whole file once it completes.

--- a/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
+++ b/projects/packages/videopress/changelog/add-videopress-tus-incremental-upload-hash
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-VideoPress: Large video uploads now finish faster, as the upload is verified as it arrives instead of re-reading the whole file once it completes.
+VideoPress: Resumable video uploads are now verified as they arrive, instead of re-reading the whole file once the upload completes.

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -435,31 +435,47 @@ class Tus_File {
 			$this->close( $input );
 			$this->close( $output );
 
-			$meta = array( 'offset' => $this->offset );
+			$this->persist_upload_meta( $key, $md5_context, $total_bytes );
+		}
 
-			// Build the digest in its own guard so a hashing failure can never skip the offset write below.
-			if ( null !== $md5_context ) {
-				try {
-					if ( $this->offset === $total_bytes ) {
-						$meta['md5']       = hash_final( $md5_context );
-						$meta['md5_state'] = null;
-					} else {
-						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-						$meta['md5_state'] = base64_encode( serialize( $md5_context ) );
-					}
-				} catch ( \Throwable $e ) {
-					Logger::log( 'error', $e );
-				}
-			}
+		return $this->offset;
+	}
 
+	/**
+	 * Persist the upload offset and, when hashing is active, the rolling or final MD5.
+	 *
+	 * Mirrors resume_md5_context(): that reads the rolling state at the start of a request, this writes
+	 * it back at the end. The digest is built inside its own guard so a hashing failure can never skip
+	 * the offset write below.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string            $key         The upload key.
+	 * @param \HashContext|null $md5_context The rolling MD5 context, or null when hashing is inactive.
+	 * @param int               $total_bytes The expected final size, used to detect completion.
+	 */
+	private function persist_upload_meta( $key, $md5_context, $total_bytes ) {
+		$meta = array( 'offset' => $this->offset );
+
+		if ( null !== $md5_context ) {
 			try {
-				$this->cache->set( $key, $meta );
+				if ( $this->offset === $total_bytes ) {
+					$meta['md5']       = hash_final( $md5_context );
+					$meta['md5_state'] = null;
+				} else {
+					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+					$meta['md5_state'] = base64_encode( serialize( $md5_context ) );
+				}
 			} catch ( \Throwable $e ) {
 				Logger::log( 'error', $e );
 			}
 		}
 
-		return $this->offset;
+		try {
+			$this->cache->set( $key, $meta );
+		} catch ( \Throwable $e ) {
+			Logger::log( 'error', $e );
+		}
 	}
 
 	/**

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -463,8 +463,7 @@ class Tus_File {
 					$meta['md5']       = hash_final( $md5_context );
 					$meta['md5_state'] = null;
 				} else {
-					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-					$meta['md5_state'] = base64_encode( serialize( $md5_context ) );
+					$meta['md5_state'] = base64_encode( serialize( $md5_context ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 				}
 			} catch ( \Throwable $e ) {
 				Logger::log( 'error', $e );

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -402,6 +402,9 @@ class Tus_File {
 			throw new File_Exception( 'Upload failed.' );
 		}
 
+		// Resume the rolling MD5 from cached state, if present.
+		$md5_context = $this->resume_md5_context( $key );
+
 		try {
 			$this->seek( $output, $this->offset );
 
@@ -412,6 +415,11 @@ class Tus_File {
 
 				$data  = $this->read( $input, self::CHUNK_SIZE );
 				$bytes = $this->write( $output, $data, self::CHUNK_SIZE );
+
+				if ( null !== $md5_context && $bytes > 0 ) {
+					// Hash only the bytes write() persisted (handles short writes).
+					hash_update( $md5_context, substr( $data, 0, $bytes ) );
+				}
 
 				$this->offset += $bytes;
 
@@ -427,14 +435,64 @@ class Tus_File {
 			$this->close( $input );
 			$this->close( $output );
 
+			$meta = array( 'offset' => $this->offset );
+
+			// Build the digest in its own guard so a hashing failure can never skip the offset write below.
+			if ( null !== $md5_context ) {
+				try {
+					if ( $this->offset === $total_bytes ) {
+						$meta['md5']       = hash_final( $md5_context );
+						$meta['md5_state'] = null;
+					} else {
+						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+						$meta['md5_state'] = base64_encode( serialize( $md5_context ) );
+					}
+				} catch ( \Throwable $e ) {
+					Logger::log( 'error', $e );
+				}
+			}
+
 			try {
-				$this->cache->set( $key, array( 'offset' => $this->offset ) );
+				$this->cache->set( $key, $meta );
 			} catch ( \Throwable $e ) {
 				Logger::log( 'error', $e );
 			}
 		}
 
 		return $this->offset;
+	}
+
+	/**
+	 * Resume the rolling MD5 stored for this upload, or null to skip hashing.
+	 *
+	 * The context is read from the cached `md5_state` (a base64-encoded serialized HashContext) so
+	 * written bytes can be folded into it. Returns null when no usable state is present, leaving the
+	 * caller to hash the assembled file instead.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key The upload key.
+	 *
+	 * @return \HashContext|null
+	 */
+	private function resume_md5_context( $key ) {
+		$meta = $this->cache->get( $key );
+
+		if ( ! is_array( $meta ) || ! isset( $meta['md5_state'] ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$decoded = base64_decode( $meta['md5_state'], true );
+
+		if ( false === $decoded ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+		$context = unserialize( $decoded, array( 'allowed_classes' => array( 'HashContext' ) ) );
+
+		return $context instanceof \HashContext ? $context : null;
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Tus_File_Test.php
+++ b/projects/packages/videopress/tests/php/Tus_File_Test.php
@@ -18,6 +18,20 @@ require_once __DIR__ . '/class-out-of-range-exception.php';
 class Tus_File_Test extends BaseTestCase {
 
 	/**
+	 * Initialize the WordPress filesystem before each test.
+	 */
+	protected function set_up() {
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$this->assertTrue( WP_Filesystem() );
+		$this->assertInstanceOf( \WP_Filesystem_Base::class, $wp_filesystem );
+	}
+
+	/**
 	 * Tests that corrupt uploads throw the global third-party exception.
 	 */
 	public function test_upload_throws_global_out_of_range_exception_when_upload_exceeds_total_bytes() {
@@ -32,12 +46,6 @@ class Tus_File_Test extends BaseTestCase {
 			$this->assertNotFalse( $input_file );
 			$this->assertNotFalse( $output_file );
 
-			if ( ! function_exists( 'WP_Filesystem' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/file.php';
-			}
-
-			$this->assertTrue( WP_Filesystem() );
-			$this->assertInstanceOf( \WP_Filesystem_Base::class, $wp_filesystem );
 			$this->assertTrue( $wp_filesystem->put_contents( $input_file, 'test' ) );
 			set_transient( $cache->build_key( $key ), wp_json_encode( array(), JSON_UNESCAPED_SLASHES ) );
 
@@ -102,11 +110,6 @@ class Tus_File_Test extends BaseTestCase {
 			$this->assertNotFalse( $input_file );
 			$this->assertNotFalse( $output_file );
 
-			if ( ! function_exists( 'WP_Filesystem' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/file.php';
-			}
-
-			$this->assertTrue( WP_Filesystem() );
 			$this->assertTrue( $wp_filesystem->put_contents( $input_file, $contents ) );
 			set_transient( $cache->build_key( $key ), wp_json_encode( array(), JSON_UNESCAPED_SLASHES ) );
 
@@ -142,6 +145,8 @@ class Tus_File_Test extends BaseTestCase {
 	 * Tests that folding chunks in as they arrive yields the same digest as hashing the whole file.
 	 */
 	public function test_incremental_md5_matches_whole_file_digest() {
+		global $wp_filesystem;
+
 		if ( PHP_VERSION_ID < 80100 ) {
 			$this->markTestSkipped( 'Serializing a HashContext between requests requires PHP 8.1+.' );
 		}
@@ -154,7 +159,6 @@ class Tus_File_Test extends BaseTestCase {
 		$key         = 'test-incremental-md5';
 
 		try {
-			$this->prepare_filesystem();
 			$this->seed_rolling_md5( $cache, $key );
 
 			$offset = 0;
@@ -169,7 +173,7 @@ class Tus_File_Test extends BaseTestCase {
 				}
 			}
 
-			$this->assertSame( $contents, $this->read_file( $output_file ) );
+			$this->assertSame( $contents, $wp_filesystem->get_contents( $output_file ) );
 
 			$cached = $cache->get( $key );
 			$this->assertIsArray( $cached );
@@ -186,6 +190,8 @@ class Tus_File_Test extends BaseTestCase {
 	 * Tests that a single chunk larger than the read buffer is hashed across multiple read iterations.
 	 */
 	public function test_incremental_md5_handles_chunk_larger_than_read_buffer() {
+		global $wp_filesystem;
+
 		if ( PHP_VERSION_ID < 80100 ) {
 			$this->markTestSkipped( 'Serializing a HashContext between requests requires PHP 8.1+.' );
 		}
@@ -198,12 +204,11 @@ class Tus_File_Test extends BaseTestCase {
 		$key         = 'test-large-chunk-md5';
 
 		try {
-			$this->prepare_filesystem();
 			$this->seed_rolling_md5( $cache, $key );
 
 			$this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
 
-			$this->assertSame( $contents, $this->read_file( $output_file ) );
+			$this->assertSame( $contents, $wp_filesystem->get_contents( $output_file ) );
 
 			$cached = $cache->get( $key );
 			$this->assertIsArray( $cached );
@@ -225,7 +230,6 @@ class Tus_File_Test extends BaseTestCase {
 		$contents    = 'no hash please';
 
 		try {
-			$this->prepare_filesystem();
 			set_transient( $cache->build_key( $key ), wp_json_encode( array( 'offset' => 0 ), JSON_UNESCAPED_SLASHES ) );
 
 			$this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
@@ -245,14 +249,14 @@ class Tus_File_Test extends BaseTestCase {
 	 * Tests that an unusable rolling state is ignored and no digest is emitted.
 	 */
 	public function test_md5_falls_back_on_unusable_state() {
+		global $wp_filesystem;
+
 		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
 		$cache       = new Transient_Store( 1 );
 		$key         = 'test-md5-unusable';
 		$contents    = 'whole thing in one go';
 
 		try {
-			$this->prepare_filesystem();
-
 			// Well-formed payload that is not a HashContext, to exercise the guard without warnings.
 			$state = base64_encode( serialize( 'broken' ) );
 			set_transient( $cache->build_key( $key ), wp_json_encode( array( 'offset' => 0, 'md5_state' => $state ), JSON_UNESCAPED_SLASHES ) );
@@ -260,7 +264,7 @@ class Tus_File_Test extends BaseTestCase {
 			$offset = $this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
 
 			$this->assertSame( strlen( $contents ), $offset );
-			$this->assertSame( $contents, $this->read_file( $output_file ) );
+			$this->assertSame( $contents, $wp_filesystem->get_contents( $output_file ) );
 
 			$cached = $cache->get( $key );
 			$this->assertIsArray( $cached );
@@ -298,10 +302,12 @@ class Tus_File_Test extends BaseTestCase {
 	 * @return int The new offset after the chunk.
 	 */
 	private function upload_chunk( $cache, $key, $output_file, $chunk, $offset, $total ) {
+		global $wp_filesystem;
+
 		$input_file = tempnam( sys_get_temp_dir(), 'videopress-tus-input-' );
 
 		try {
-			$this->write_file( $input_file, $chunk );
+			$this->assertTrue( $wp_filesystem->put_contents( $input_file, $chunk ) );
 			Tus_File::set_input_stream( $input_file );
 
 			$file = new Tus_File( $key, $cache );
@@ -312,47 +318,6 @@ class Tus_File_Test extends BaseTestCase {
 		} finally {
 			$this->cleanup_file( $input_file );
 		}
-	}
-
-	/**
-	 * Ensure the WordPress filesystem is initialized for the test.
-	 *
-	 * @return void
-	 */
-	private function prepare_filesystem() {
-		global $wp_filesystem;
-
-		if ( ! function_exists( 'WP_Filesystem' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		$this->assertTrue( WP_Filesystem() );
-		$this->assertInstanceOf( \WP_Filesystem_Base::class, $wp_filesystem );
-	}
-
-	/**
-	 * Write contents to a file via the WordPress filesystem.
-	 *
-	 * @param string $path     The file path.
-	 * @param string $contents The contents.
-	 *
-	 * @return void
-	 */
-	private function write_file( $path, $contents ) {
-		global $wp_filesystem;
-		$this->assertTrue( $wp_filesystem->put_contents( $path, $contents ) );
-	}
-
-	/**
-	 * Read a file via the WordPress filesystem.
-	 *
-	 * @param string $path The file path.
-	 *
-	 * @return string
-	 */
-	private function read_file( $path ) {
-		global $wp_filesystem;
-		return $wp_filesystem->get_contents( $path );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Tus_File_Test.php
+++ b/projects/packages/videopress/tests/php/Tus_File_Test.php
@@ -137,4 +137,234 @@ class Tus_File_Test extends BaseTestCase {
 			}
 		}
 	}
+
+	/**
+	 * Tests that folding chunks in as they arrive yields the same digest as hashing the whole file.
+	 */
+	public function test_incremental_md5_matches_whole_file_digest() {
+		if ( PHP_VERSION_ID < 80100 ) {
+			$this->markTestSkipped( 'Serializing a HashContext between requests requires PHP 8.1+.' );
+		}
+
+		$chunks   = array( 'hello ', 'brave ', 'new ', 'world!' );
+		$contents = implode( '', $chunks );
+
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-incremental-md5';
+
+		try {
+			$this->prepare_filesystem();
+			$this->seed_rolling_md5( $cache, $key );
+
+			$offset = 0;
+			foreach ( $chunks as $i => $chunk ) {
+				$offset = $this->upload_chunk( $cache, $key, $output_file, $chunk, $offset, strlen( $contents ) );
+
+				$cached = $cache->get( $key );
+				$this->assertIsArray( $cached );
+				if ( $offset < strlen( $contents ) ) {
+					$this->assertArrayHasKey( 'md5_state', $cached, "Chunk $i should carry rolling state forward." );
+					$this->assertArrayNotHasKey( 'md5', $cached, "Chunk $i should not emit a digest yet." );
+				}
+			}
+
+			$this->assertSame( $contents, $this->read_file( $output_file ) );
+
+			$cached = $cache->get( $key );
+			$this->assertIsArray( $cached );
+			$this->assertSame( md5( $contents ), $cached['md5'], 'The incremental digest should match the whole-file md5.' );
+			$this->assertFalse( isset( $cached['md5_state'] ), 'Rolling state should be cleared once the digest is final.' );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			$cache->delete( $key );
+			$this->cleanup_file( $output_file );
+		}
+	}
+
+	/**
+	 * Tests that a single chunk larger than the read buffer is hashed across multiple read iterations.
+	 */
+	public function test_incremental_md5_handles_chunk_larger_than_read_buffer() {
+		if ( PHP_VERSION_ID < 80100 ) {
+			$this->markTestSkipped( 'Serializing a HashContext between requests requires PHP 8.1+.' );
+		}
+
+		// Several times CHUNK_SIZE (8192) so upload()'s read loop runs many iterations in one request.
+		$contents = str_repeat( 'abcdefgh', 4096 );
+
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-large-chunk-md5';
+
+		try {
+			$this->prepare_filesystem();
+			$this->seed_rolling_md5( $cache, $key );
+
+			$this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
+
+			$this->assertSame( $contents, $this->read_file( $output_file ) );
+
+			$cached = $cache->get( $key );
+			$this->assertIsArray( $cached );
+			$this->assertSame( md5( $contents ), $cached['md5'] );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			$cache->delete( $key );
+			$this->cleanup_file( $output_file );
+		}
+	}
+
+	/**
+	 * Tests that no digest is emitted when the upload was not seeded for incremental hashing.
+	 */
+	public function test_no_md5_emitted_without_seeded_state() {
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-no-md5';
+		$contents    = 'no hash please';
+
+		try {
+			$this->prepare_filesystem();
+			set_transient( $cache->build_key( $key ), wp_json_encode( array( 'offset' => 0 ), JSON_UNESCAPED_SLASHES ) );
+
+			$this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
+
+			$cached = $cache->get( $key );
+			$this->assertIsArray( $cached );
+			$this->assertArrayNotHasKey( 'md5', $cached );
+			$this->assertArrayNotHasKey( 'md5_state', $cached );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			$cache->delete( $key );
+			$this->cleanup_file( $output_file );
+		}
+	}
+
+	/**
+	 * Tests that an unusable rolling state is ignored and no digest is emitted.
+	 */
+	public function test_md5_falls_back_on_unusable_state() {
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-md5-unusable';
+		$contents    = 'whole thing in one go';
+
+		try {
+			$this->prepare_filesystem();
+
+			// Well-formed payload that is not a HashContext, to exercise the guard without warnings.
+			$state = base64_encode( serialize( 'broken' ) );
+			set_transient( $cache->build_key( $key ), wp_json_encode( array( 'offset' => 0, 'md5_state' => $state ), JSON_UNESCAPED_SLASHES ) );
+
+			$offset = $this->upload_chunk( $cache, $key, $output_file, $contents, 0, strlen( $contents ) );
+
+			$this->assertSame( strlen( $contents ), $offset );
+			$this->assertSame( $contents, $this->read_file( $output_file ) );
+
+			$cached = $cache->get( $key );
+			$this->assertIsArray( $cached );
+			$this->assertArrayNotHasKey( 'md5', $cached, 'Unusable rolling state must not yield a digest.' );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			$cache->delete( $key );
+			$this->cleanup_file( $output_file );
+		}
+	}
+
+	/**
+	 * Seed a fresh rolling MD5 state on the cache, as the server does when a normal upload is created.
+	 *
+	 * @param Tus_Abstract_Cache $cache The cache shared across the upload.
+	 * @param string             $key   The upload key.
+	 *
+	 * @return void
+	 */
+	private function seed_rolling_md5( $cache, $key ) {
+		$state = base64_encode( serialize( hash_init( 'md5' ) ) );
+		set_transient( $cache->build_key( $key ), wp_json_encode( array( 'offset' => 0, 'md5_state' => $state ), JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * Upload a single chunk through a fresh Tus_File, as the server does per PATCH request.
+	 *
+	 * @param Tus_Abstract_Cache $cache       The cache shared across the upload.
+	 * @param string             $key         The upload key.
+	 * @param string             $output_file The destination file (appended across chunks).
+	 * @param string             $chunk       The bytes for this request.
+	 * @param int                $offset      The current write offset.
+	 * @param int                $total       The total upload size.
+	 *
+	 * @return int The new offset after the chunk.
+	 */
+	private function upload_chunk( $cache, $key, $output_file, $chunk, $offset, $total ) {
+		$input_file = tempnam( sys_get_temp_dir(), 'videopress-tus-input-' );
+
+		try {
+			$this->write_file( $input_file, $chunk );
+			Tus_File::set_input_stream( $input_file );
+
+			$file = new Tus_File( $key, $cache );
+			$file->set_key( $key );
+			$file->set_meta( $offset, $total, $output_file );
+
+			return $file->upload( $total );
+		} finally {
+			$this->cleanup_file( $input_file );
+		}
+	}
+
+	/**
+	 * Ensure the WordPress filesystem is initialized for the test.
+	 *
+	 * @return void
+	 */
+	private function prepare_filesystem() {
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$this->assertTrue( WP_Filesystem() );
+		$this->assertInstanceOf( \WP_Filesystem_Base::class, $wp_filesystem );
+	}
+
+	/**
+	 * Write contents to a file via the WordPress filesystem.
+	 *
+	 * @param string $path     The file path.
+	 * @param string $contents The contents.
+	 *
+	 * @return void
+	 */
+	private function write_file( $path, $contents ) {
+		global $wp_filesystem;
+		$this->assertTrue( $wp_filesystem->put_contents( $path, $contents ) );
+	}
+
+	/**
+	 * Read a file via the WordPress filesystem.
+	 *
+	 * @param string $path The file path.
+	 *
+	 * @return string
+	 */
+	private function read_file( $path ) {
+		global $wp_filesystem;
+		return $wp_filesystem->get_contents( $path );
+	}
+
+	/**
+	 * Delete a temp file if it exists.
+	 *
+	 * @param string|false $path The file path.
+	 *
+	 * @return void
+	 */
+	private function cleanup_file( $path ) {
+		if ( is_string( $path ) && file_exists( $path ) ) {
+			wp_delete_file( $path );
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes

`Tus_File::upload()` reassembles a resumable upload by streaming each PATCH body to disk. Today the only way to get a whole-file digest of the finished upload is to read the entire assembled file back and hash it — an extra full read pass that, for multi-GB uploads, can be slow enough to matter at finalization time.

This folds the digest into the work `upload()` is already doing:

* When an upload's cached meta carries an `md5_state` (a base64-encoded serialized MD5 `HashContext`), each PATCH folds the bytes it writes into that rolling context and persists it forward.
* On the request that receives the final byte, the context is finalized and the digest is stored as `md5` on the cached meta for the consumer to read.
* A short write hashes only the bytes that were actually persisted.

This is opt-in and best-effort, with no behavior change for existing callers:

* Hashing only runs when something seeded `md5_state` (i.e. normal, in-order uploads). Partial/concatenated uploads, which arrive out of order, are never seeded and are untouched.
* If the rolling state is absent or unusable (e.g. cache eviction, or a payload that isn't a `HashContext`), hashing is skipped and no `md5` is emitted, so the consumer falls back to hashing the file itself.

Carrying a `HashContext` between requests relies on it being serializable, which is the case on PHP 7.4+. On older versions the resumed state simply isn't a `HashContext`, so the guard skips hashing and the consumer falls back — no incorrect digest is ever produced.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jp test php packages/videopress` — the new `Tus_File_Test` cases cover this:
  * `test_incremental_md5_matches_whole_file_digest` — a chunked upload yields a stored `md5` equal to `md5()` of the whole file (skipped below PHP 7.4).
  * `test_no_md5_emitted_without_seeded_state` — an upload with no seeded state emits no `md5` (and no `md5_state`).
  * `test_md5_falls_back_on_unusable_state` — a non-`HashContext` rolling state is ignored and no `md5` is emitted.