### PR TITLE
docs: Document npm autopublisher initial setup

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -441,7 +441,30 @@ Note the following will also be done by the build process:
 
 If `.extra.npmjs-autopublish` is set to a truthy value in the project's `composer.json`, a GitHub Action will be included in the mirror repo that will run `npm publish` when a version tag is created. This works with Autotagger. Versions must have a "v" prefix and have 3 components.
 
-You'll also need to [configure the repo as a Trusted Provider](https://docs.npmjs.com/trusted-publishers) at npmjs.com.
+You'll also need to [configure the repo as a Trusted Provider](https://docs.npmjs.com/trusted-publishers) at npmjs.com. NOTE: If the package doesn't exist on npmjs.com yet, it seems (as of June 2026) that you first have to manually `npm publish` a (non-trusted) version in order to be able to configure trusted publising; see https://github.com/npm/documentation/issues/1926 for possible updates. This initial version may be a v0.0.0 that contains only `package.json` metadata.
+
+<details><summary>Example process for setting up a new package</summary>
+
+1. Tag the first release of your package. Find that it didn't get published to npmjs.com, with an error like this from the Npmjs Auto-publisher workflow run:
+   ```
+   npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
+   npm error code E404
+   npm error 404 Not Found - PUT https://registry.npmjs.org/@automattic%2fjetpack-whatever - Not found
+   npm error 404
+   npm error 404  The requested resource '@automattic/jetpack-whatever@0.1.0' could not be found or you do not have permission to access it.
+   npm error 404
+   ```
+2. Locally, create an empty directory.
+3. Copy the package's `package.json` into that empty directory.
+   * Delete any `scripts`, `dependencies`, and so on, just keep the metadata.
+   * Change the version to "0.0.0".
+4. `npm login --scope @automattic` if necessary (or whichever scope the package will be published into).
+5. `npm publish --access public` to publish the dummy version.
+6. May as well set up trusted publishing from the command line: `npm trust github @automattic/jetpack-whatever --repository Automattic/jetpack-whatever --file npmjs-autopublisher.yml --allow-publish`
+7. Re-run the failed Npmjs Auto-publisher workflow run to publish the real version.
+8. Optionally, `npm unpublish` to unpublish that dummy "0.0.0" version.
+
+</details>
 
 Note the following will also be done by the build process:
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The documentation at https://docs.npmjs.com/trusted-publishers assumes your package already exists in npmjs.com, and you're only wanting to enable trusted publishing on it.

Further, as far as I can tell, there isn't actually a way to enable trusted publishing on a package that doesn't already exist.

Add documentation of this, to save others time in the future.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1782760266415389-slack-C05Q5HSS013
https://github.com/Automattic/jetpack/pull/49772#issuecomment-4835924809

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Proofread