### PR TITLE
My Jetpack: de-duplicate product search results

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
@@ -163,6 +163,27 @@ describe( 'searchAndRankItems', () => {
 		expect( result ).toHaveLength( 1 );
 	} );
 
+	it( 'drops a standalone module already attached to a matching card (Forms regression)', () => {
+		// buildCards attaches the contact-form module to the Forms card, while contact-form is
+		// ALSO listed as a standalone module. The card already represents it, so it appears once.
+		const formsWithModule: CardItem = { ...forms, module: formsModule };
+		const result = searchAndRankItems( [ formsWithModule ], [ formsModule ], 'forms' );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ] ).toMatchObject( { kind: 'card' } );
+	} );
+
+	it( 'drops a standalone module whose slug matches a card product slug (VideoPress regression)', () => {
+		// VideoPress is a card (slug "videopress") and is also listed as a "videopress" module.
+		const videopressCard = makeCard( { slug: 'videopress', name: 'VideoPress' } );
+		const videopressModule = makeModule( { module: 'videopress', name: 'VideoPress' } );
+		const cardWithModule: CardItem = { ...videopressCard, module: videopressModule };
+		const result = searchAndRankItems( [ cardWithModule ], [ videopressModule ], 'videopress' );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ] ).toMatchObject( { kind: 'card' } );
+	} );
+
 	it( 'returns an empty array when nothing matches', () => {
 		expect( searchAndRankItems( [ forms ], [ formsModule ], 'zzzznotathing' ) ).toEqual( [] );
 	} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -319,29 +319,23 @@ export function searchAndRankItems(
 	// the module it already carries, so the same product never surfaces as both a card and a
 	// standalone module (e.g. Forms' contact-form module, or VideoPress listed in two categories).
 	const seen = new Set< string >();
-	const cardsBySlug = new Map< string, CardItem >();
-	const modulesBySlug = new Map< string, MyJetpackModule >();
+	const items: Array< SearchResultItem > = [];
 
 	cards.forEach( card => {
 		if ( card?.product?.slug && ! seen.has( card.product.slug ) ) {
-			cardsBySlug.set( card.product.slug, card );
 			seen.add( card.product.slug );
 			if ( card.module?.module ) {
 				seen.add( card.module.module );
 			}
+			items.push( { kind: 'card', card } );
 		}
 	} );
 	modules.forEach( module => {
 		if ( module?.module && ! seen.has( module.module ) ) {
-			modulesBySlug.set( module.module, module );
 			seen.add( module.module );
+			items.push( { kind: 'module', module } );
 		}
 	} );
-
-	const items: Array< SearchResultItem > = [
-		...[ ...cardsBySlug.values() ].map( card => ( { kind: 'card' as const, card } ) ),
-		...[ ...modulesBySlug.values() ].map( module => ( { kind: 'module' as const, module } ) ),
-	];
 
 	return rankBy( items, terms, item =>
 		item.kind === 'card'

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -315,17 +315,26 @@ export function searchAndRankItems(
 
 	const terms = searchTerms( search );
 
+	// One slug space governs de-duplication: a card claims both its product slug and the slug of
+	// the module it already carries, so the same product never surfaces as both a card and a
+	// standalone module (e.g. Forms's contact-form module, or VideoPress listed in two categories).
+	const seen = new Set< string >();
 	const cardsBySlug = new Map< string, CardItem >();
 	const modulesBySlug = new Map< string, MyJetpackModule >();
 
 	cards.forEach( card => {
-		if ( card?.product?.slug && ! cardsBySlug.has( card.product.slug ) ) {
+		if ( card?.product?.slug && ! seen.has( card.product.slug ) ) {
 			cardsBySlug.set( card.product.slug, card );
+			seen.add( card.product.slug );
+			if ( card.module?.module ) {
+				seen.add( card.module.module );
+			}
 		}
 	} );
 	modules.forEach( module => {
-		if ( module?.module && ! modulesBySlug.has( module.module ) ) {
+		if ( module?.module && ! seen.has( module.module ) ) {
 			modulesBySlug.set( module.module, module );
+			seen.add( module.module );
 		}
 	} );
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -317,7 +317,7 @@ export function searchAndRankItems(
 
 	// One slug space governs de-duplication: a card claims both its product slug and the slug of
 	// the module it already carries, so the same product never surfaces as both a card and a
-	// standalone module (e.g. Forms's contact-form module, or VideoPress listed in two categories).
+	// standalone module (e.g. Forms' contact-form module, or VideoPress listed in two categories).
 	const seen = new Set< string >();
 	const cardsBySlug = new Map< string, CardItem >();
 	const modulesBySlug = new Map< string, MyJetpackModule >();

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-duplicates
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-duplicates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: de-duplicate search results so a product no longer appears twice (e.g. Forms, VideoPress)


### PR DESCRIPTION
Before:
<img width="697" height="197" alt="Screenshot 2026-06-29 at 7 35 34 AM" src="https://github.com/user-attachments/assets/faf7a9d4-3973-4a9e-97ef-4b141f92783c" />


After:

<img width="735" height="270" alt="Screenshot 2026-06-29 at 3 07 07 PM" src="https://github.com/user-attachments/assets/c9fd1a44-0e23-486f-b837-88cbff701d68" />


## Proposed changes

* Fixes duplicate results in **My Jetpack → Products** search. A product that is both a product card and a separately-listed module appeared **twice** in the results — most visibly for **Forms** (card `jetpack-forms` ↔ the `contact-form` module) and **VideoPress** (card `videopress` ↔ the `videopress` module).
* Root cause: `searchAndRankItems()` de-duplicated cards and modules in two independent maps keyed by different slug spaces (`product.slug` vs `module.module`), so the same product could survive in both and be emitted twice.
* Fix: de-duplication now runs in a single slug space. Each card claims both its product slug *and* the slug of the module it already carries, so a standalone module that a card already represents is dropped. Genuine standalone modules are unaffected.
* Added regression tests for the Forms and VideoPress cases.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* In wp-admin, go to **Jetpack → My Jetpack → Products**.
* In the search box, type `Forms`. Confirm **Forms** appears only **once** in the results (it previously appeared twice).
* Clear the box and type `VideoPress`. Confirm **VideoPress** appears only **once** (previously twice).
* Confirm genuine fuzzy matches are unaffected — searching `Forms` still surfaces Akismet Anti-spam and Site Verification (their descriptions mention forms).
* Run the unit tests: `cd projects/packages/my-jetpack && pnpm test` — including the two new regression tests in `products/test/utils.test.ts`.
