### PR TITLE
Podcast Episode: render the full player in the WPCOM Reader

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-episode-reader-render
+++ b/projects/packages/podcast/changelog/add-podcast-episode-reader-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Podcast Episode block: render the full interactive player in the WPCOM Reader.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -200,8 +200,15 @@ class Podcast_Episode_Block {
 	 */
 	public static function render_block( $attributes, $content, $block = null ) {
 		// Outside the frontend, fall back to the saved direct link so RSS / email / REST export stays
-		// simple and predictable.
-		if ( ! Request::is_frontend() ) {
+		// simple and predictable. The WPCOM Reader is the exception: it serves posts through the REST
+		// API but wants the full interactive player, so detect its render context and render normally.
+		$is_wpcom_reader = false;
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			require_once WP_CONTENT_DIR . '/lib/display-context.php';
+			$is_wpcom_reader = \A8C\Display_Context\READER === \A8C\Display_Context\get_current_context();
+		}
+
+		if ( ! Request::is_frontend() && ! $is_wpcom_reader ) {
 			return $content;
 		}
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -27,7 +27,7 @@ class Podcast_Episode_Block {
 	 * Front-end + editor shared style handle. Side-loaded by
 	 * `Assets::register_script` from the sibling `style.css` bundle.
 	 */
-	const STYLE_HANDLE = 'jetpack-podcast-episode-style';
+	const STYLE_HANDLE = 'jetpack-block-podcast-episode';
 
 	/**
 	 * Front-end view script handle. Enqueued from the render callback


### PR DESCRIPTION
Fixes PODS-188

## Proposed changes

The Podcast Episode block shows a nice interactive player on a normal web page, but in the WPCOM Reader it fell back to a plain "listen" link. This PR makes the Reader render the real player.

* **Render the player in the Reader.** The block normally bails to a plain link anywhere that isn't the front end (RSS, email, exports) to keep those simple, and the Reader was getting caught in that fallback. We now detect the Reader render context and let it render the full player there too.
* **Rename the front-end style handle** to `jetpack-block-podcast-episode`, matching the `jetpack-block-<block>` handle convention the rest of Jetpack's blocks use.

Everything outside the front end and Reader (RSS, email, REST export) still shows the simple link, unchanged.

**Note on styling:** the Reader loads block CSS from its own Calypso bundle (`client/blocks/reader-full-post/`), not from the block's enqueued stylesheet — the same way every other Jetpack block is styled there. So the player's styles are added separately in wp-calypso#112089; this PR only handles the render.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WPCOM/Atomic site with the Podcast module enabled, publish a post with a Podcast Episode block that has a media URL.
* Open that post in the Reader (`wordpress.com/read`).
* Confirm the full interactive player renders (audio/video controls, cover art, metadata) rather than a bare "listen" link.
* Confirm the RSS feed and email export still show the simple link fallback (unchanged).
* Styling of that player is covered by wp-calypso#112089.
