### PR TITLE
My Jetpack: stabilize product search ranking while typing a category name

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
@@ -216,6 +216,27 @@ describe( 'searchAndRankItems', () => {
 		expect( result ).toEqual( [] );
 	} );
 
+	it( 'requires every word of a multi-word category query to match a label (AND across labels)', () => {
+		// With one field per label, "performance recommended" matches an item in BOTH categories
+		// (each word exact-matches its own label), while an item in only "Performance" drops out —
+		// the "recommended" term has no field to match. Guards the AND-across-separate-fields
+		// contract of scoreFields that per-label scoring now leans on; a refactor collapsing the
+		// labels back into one field would silently let the "Performance"-only item through.
+		const both = makeCard( { slug: 'both', name: 'Both' } );
+		const onlyPerf = makeCard( { slug: 'only-perf', name: 'OnlyPerf' } );
+		const cardCategories = new Map( [
+			[ both.product.slug, [ 'Performance', 'Recommended' ] ],
+			[ onlyPerf.product.slug, [ 'Performance' ] ],
+		] );
+
+		const result = searchAndRankItems( [ both, onlyPerf ], [], 'performance recommended', {
+			cardCategories,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].kind === 'card' && result[ 0 ].card.product.slug ).toBe( 'both' );
+	} );
+
 	it( 'keeps a stable order whether a category word is partially or fully typed', () => {
 		// Two cards both in "Performance"; `multi` is also in "Recommended". Each category label is
 		// scored on its own, so completing the word "Performance" boosts both equally and does not

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/utils.test.ts
@@ -216,6 +216,29 @@ describe( 'searchAndRankItems', () => {
 		expect( result ).toEqual( [] );
 	} );
 
+	it( 'keeps a stable order whether a category word is partially or fully typed', () => {
+		// Two cards both in "Performance"; `multi` is also in "Recommended". Each category label is
+		// scored on its own, so completing the word "Performance" boosts both equally and does not
+		// reshuffle them — previously the joined "Performance Recommended" label could only ever
+		// prefix-match, so `multi` lost the exact-match bonus and got overtaken on the last keystroke.
+		const single = makeCard( { slug: 'single', name: 'Single' } );
+		const multi = makeCard( { slug: 'multi', name: 'Multi' } );
+		const cardCategories = new Map( [
+			[ single.product.slug, [ 'Performance' ] ],
+			[ multi.product.slug, [ 'Performance', 'Recommended' ] ],
+		] );
+
+		const order = ( result: ReturnType< typeof searchAndRankItems > ) =>
+			result.map( item => ( item.kind === 'card' ? item.card.product.slug : item.module.module ) );
+
+		// `multi` is listed first so the old behavior (it getting overtaken) is observable.
+		const partial = searchAndRankItems( [ multi, single ], [], 'Performanc', { cardCategories } );
+		const full = searchAndRankItems( [ multi, single ], [], 'Performance', { cardCategories } );
+
+		expect( order( full ) ).toHaveLength( 2 );
+		expect( order( partial ) ).toEqual( order( full ) );
+	} );
+
 	it( 'is case-insensitive', () => {
 		const lower = searchAndRankItems( [ akismet, forms ], [], 'forms' );
 		const upper = searchAndRankItems( [ akismet, forms ], [], 'FORMS' );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -204,8 +204,10 @@ function rankBy< T >(
 /**
  * One weighted field per category label. Each label is scored on its own rather than against a
  * space-joined blob, so a multi-category item can still land an exact-match on a single category
- * word — otherwise completing that word would reshuffle results (the joined label could only ever
- * prefix-match). See `scoreTerm` for the match tiers.
+ * word. Otherwise completing that word reshuffles results: a single-category item's joined label
+ * already exact-matches the word, but a multi-category item's joined label (e.g. "Performance
+ * Recommended") can only prefix-match it — so only the multi-category item misses the exact-match
+ * bonus and gets overtaken on the final keystroke. See `scoreTerm` for the match tiers.
  *
  * @param {string[] | undefined} categories - The item's category labels.
  * @return One scored field per label (empty when there are no labels).

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -202,20 +202,33 @@ function rankBy< T >(
 }
 
 /**
+ * One weighted field per category label. Each label is scored on its own rather than against a
+ * space-joined blob, so a multi-category item can still land an exact-match on a single category
+ * word — otherwise completing that word would reshuffle results (the joined label could only ever
+ * prefix-match). See `scoreTerm` for the match tiers.
+ *
+ * @param {string[] | undefined} categories - The item's category labels.
+ * @return One scored field per label (empty when there are no labels).
+ */
+function categoryFields( categories?: string[] ): Array< ScoredField > {
+	return ( categories ?? [] ).map( label => ( { value: label, weight: 2 } ) );
+}
+
+/**
  * The weighted fields for a product card. When provided, the categories the card belongs to
  * are matchable too, so searching a category name surfaces every item in that category.
  *
- * @param {CardItem}           card       - The card.
- * @param {string | undefined} categories - The card's category labels, space-joined.
+ * @param {CardItem}             card       - The card.
+ * @param {string[] | undefined} categories - The card's category labels.
  * @return The weighted fields to match against.
  */
-function cardFields( card: CardItem, categories?: string ): Array< ScoredField > {
+function cardFields( card: CardItem, categories?: string[] ): Array< ScoredField > {
 	return [
 		{ value: card.product.name, weight: 3 },
 		{ value: card.product.title, weight: 3 },
 		{ value: card.module?.name, weight: 3 },
 		{ value: card.module?.search_terms, weight: 2 },
-		{ value: categories, weight: 2 },
+		...categoryFields( categories ),
 		{ value: card.product.description, weight: 1 },
 		{ value: card.module?.description, weight: 1 },
 	];
@@ -225,15 +238,15 @@ function cardFields( card: CardItem, categories?: string ): Array< ScoredField >
  * The weighted fields for a standalone module. When provided, the categories the module
  * belongs to are matchable too.
  *
- * @param {MyJetpackModule}    module     - The module.
- * @param {string | undefined} categories - The module's category labels, space-joined.
+ * @param {MyJetpackModule}      module     - The module.
+ * @param {string[] | undefined} categories - The module's category labels.
  * @return The weighted fields to match against.
  */
-function moduleFields( module: MyJetpackModule, categories?: string ): Array< ScoredField > {
+function moduleFields( module: MyJetpackModule, categories?: string[] ): Array< ScoredField > {
 	return [
 		{ value: module.name, weight: 3 },
 		{ value: module.search_terms, weight: 2 },
-		{ value: categories, weight: 2 },
+		...categoryFields( categories ),
 		{ value: module.description, weight: 1 },
 	];
 }
@@ -339,14 +352,8 @@ export function searchAndRankItems(
 
 	return rankBy( items, terms, item =>
 		item.kind === 'card'
-			? cardFields(
-					item.card,
-					categories?.cardCategories?.get( item.card.product.slug )?.join( ' ' )
-			  )
-			: moduleFields(
-					item.module,
-					categories?.moduleCategories?.get( item.module.module )?.join( ' ' )
-			  )
+			? cardFields( item.card, categories?.cardCategories?.get( item.card.product.slug ) )
+			: moduleFields( item.module, categories?.moduleCategories?.get( item.module.module ) )
 	).map( ( { item } ) => item );
 }
 

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-category-ranking
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-category-ranking
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: keep product search result order stable while typing a category name
+Products: Keep product search result order stable while typing a category name.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-category-ranking
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-search-category-ranking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: keep product search result order stable while typing a category name


### PR DESCRIPTION
Fixes #

## Proposed changes

* Fixes an inconsistency in **My Jetpack → Products** search where finishing a category word reshuffled the results. Typing `Performanc` and `Performance` returned the same products but in a **different order** — items would visibly jump on the final keystroke.
* Root cause: category labels were scored as a single space-joined string (e.g. `"Performance Recommended"` for an item in two categories). A complete category word can only ever *prefix*-match such a joined label, never *exactly* match it — so multi-category items missed the exact-match relevance bonus that single-category items got, and got overtaken once the word was completed.
* Fix: a new `categoryFields()` helper emits **one scored field per category label**. Combined with the existing "best field wins" scoring, a multi-category item can now exact-match a single category word just like a single-category item, so completing the word boosts all matching items equally and the order stays stable.
* Added a regression test asserting partial vs. complete category words return the same order.

This builds on #50056 (search result de-duplication) and is scoped to ranking stability only.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* In wp-admin, go to **Jetpack → My Jetpack → Products**.
* In the search box, type `Performanc` (no trailing "e") and note the result order.
* Type the final `e` to make `Performance`. Confirm the result order **does not change** (before this fix, items such as Boost would jump down the list).
* Confirm category search still works — typing a full category name (`Performance`, `Security`, `Growth`) still surfaces every item in that category.
* Run the unit tests: `cd projects/packages/my-jetpack && pnpm test` — including the new "keeps a stable order whether a category word is partially or fully typed" test in `products/test/utils.test.ts`.
