### PR TITLE
Podcast: Polish dashboard spacing and CTAs

### DIFF
--- a/projects/packages/podcast/changelog/codex-jetpack-podcast-ui-touchups
+++ b/projects/packages/podcast/changelog/codex-jetpack-podcast-ui-touchups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Welcome screen: Improve spacing and CTA sizing around setup content.

--- a/projects/packages/podcast/changelog/codex-jetpack-podcast-ui-touchups
+++ b/projects/packages/podcast/changelog/codex-jetpack-podcast-ui-touchups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Welcome screen: Improve spacing and CTA sizing around setup content.
+Dashboard: Improve spacing, CTA sizing, and menu placement.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -30,10 +30,10 @@ class Admin_Page {
 	/**
 	 * Where the Podcast item sits in the Jetpack submenu on self-hosted.
 	 *
-	 * Placed after Subscribers (15) and Newsletter (10) to mirror the order
-	 * `wpcom-admin-menu.php` uses on Simple/Atomic.
+	 * Placed after content/product items like Newsletter and Search (10), but
+	 * before Settings (13).
 	 */
-	const MENU_POSITION = 16;
+	const MENU_POSITION = 12;
 
 	/**
 	 * Slug emitted by `@wordpress/build`. wp-build's auto-generated enqueue

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/style.scss
@@ -23,6 +23,11 @@
 // State-driven submit button. Override the primary fill for pending/active so
 // the colour matches the verdict; idle keeps the default theme primary.
 .podcast__pocketcasts-button {
+	text-align: center;
+
+	&.components-button.has-icon {
+		justify-content: center;
+	}
 
 	&--pending {
 
@@ -55,4 +60,3 @@
 		}
 	}
 }
-

--- a/projects/packages/podcast/src/dashboard/distribution/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/style.scss
@@ -105,6 +105,12 @@
 	justify-content: flex-start;
 }
 
+.podcast__submit-visit-button {
+	inline-size: fit-content;
+	max-inline-size: 100%;
+	align-self: flex-start;
+}
+
 .podcast__submit-step-notice {
 	margin-block: 8px 0;
 	margin-inline: 0;

--- a/projects/packages/podcast/src/dashboard/distribution/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/style.scss
@@ -6,7 +6,7 @@
 }
 
 .podcast__distribution-notice.components-notice.is-warning {
-	margin-block: 16px;
+	margin-block: 0 16px;
 }
 
 .podcast__directory-list {

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -288,6 +288,7 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 						</Text>
 					) }
 					<Button
+						className="podcast__submit-visit-button"
 						variant="secondary"
 						__next40pxDefaultSize
 						icon={ external }

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -29,6 +29,7 @@ $bar-fill: #3858e9;
 
 .podcast-stats {
 	padding-block-start: 16px;
+	padding-block-end: 32px;
 	padding-inline: 16px;
 
 	@media (min-width: 783px) {

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -24,15 +24,20 @@ body.jetpack_page_jetpack-podcast {
 }
 
 .podcast__tab-content {
-	padding-block: 8px;
+	box-sizing: border-box;
 }
 
-// Form-style panels (Settings, Distribution, Welcome) sit in a centered
-// column. Episodes (DataViews) stays full-width on purpose so the table can
-// fill its bounded slot.
+// Form-style panels (Settings, Distribution, Welcome) sit in a centered column
+// with shared outer spacing. DataView-backed tabs keep their own layout.
+.podcast__tab-content--narrow,
+.podcast__tab-content--wide {
+	padding-block: 32px;
+	padding-inline: clamp(16px, 3vw, 32px);
+}
+
 .podcast__tab-content--narrow {
 	margin-inline: auto;
-	max-inline-size: 680px;
+	max-inline-size: 744px;
 }
 
 .podcast__tab-content--wide {

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -205,9 +205,11 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 										) }
 									</Text>
 								</VStack>
-								<Button variant="secondary" onClick={ onEnable }>
-									{ __( 'Start your podcast', 'jetpack-podcast' ) }
-								</Button>
+								<HStack justify="flex-start" expanded={ false }>
+									<Button variant="secondary" onClick={ onEnable }>
+										{ __( 'Start your podcast', 'jetpack-podcast' ) }
+									</Button>
+								</HStack>
 								<ul className="podcast__welcome-plan-features">
 									{ freeFeatures.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">
@@ -239,13 +241,15 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 									</HStack>
 									<Text variant="muted">{ paidDescription }</Text>
 								</VStack>
-								<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onUpgradeClick }>
-									{ sprintf(
-										/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
-										__( 'Start your %s podcast', 'jetpack-podcast' ),
-										planName
-									) }
-								</Button>
+								<HStack justify="flex-start" expanded={ false }>
+									<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onUpgradeClick }>
+										{ sprintf(
+											/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
+											__( 'Start your %s podcast', 'jetpack-podcast' ),
+											planName
+										) }
+									</Button>
+								</HStack>
 								<ul className="podcast__welcome-plan-features">
 									{ paidFeatures.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">

--- a/projects/packages/podcast/src/dashboard/welcome/style.scss
+++ b/projects/packages/podcast/src/dashboard/welcome/style.scss
@@ -56,7 +56,7 @@
 }
 
 .podcast__welcome-plans {
-	padding-inline: clamp(0px, 2vw, 16px);
+	padding-inline: 0;
 }
 
 // `outline` instead of `border` so the highlight doesn't add 1px to the

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Admin_Page;
@@ -29,6 +30,7 @@ class Admin_Page_Test extends BaseTestCase {
 		// WorDBless does not reset the admin menu globals between tests.
 		$GLOBALS['menu']    = array();
 		$GLOBALS['submenu'] = array();
+		$this->reset_admin_menu_state();
 		remove_all_actions( 'load-jetpack_page_' . Admin_Page::ADMIN_PAGE_SLUG );
 	}
 
@@ -47,6 +49,26 @@ class Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Reset the shared Admin_Menu queue between tests.
+	 */
+	private function reset_admin_menu_state(): void {
+		$reflection = new \ReflectionClass( Admin_Menu::class );
+
+		foreach ( array( 'initialized' => false, 'menu_items' => array() ) as $property_name => $value ) {
+			if ( ! $reflection->hasProperty( $property_name ) ) {
+				continue;
+			}
+
+			$property = $reflection->getProperty( $property_name );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$property->setAccessible( true );
+			}
+			$property->setValue( null, $value );
+		}
+	}
+
+	/**
 	 * Self-hosted: the page registers through the shared Admin_Menu, which sorts
 	 * items by position. We assert the page-load callback Admin_Menu wires for us.
 	 */
@@ -59,6 +81,42 @@ class Admin_Page_Test extends BaseTestCase {
 				array( Admin_Page::class, 'admin_init' )
 			),
 			'Self-hosted should register the page through Admin_Menu'
+		);
+	}
+
+	/**
+	 * The Podcast submenu should remain above Jetpack Settings.
+	 */
+	public function test_registers_before_settings_on_self_hosted() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'podcast_menu_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		Admin_Menu::add_menu(
+			__( 'Settings', 'jetpack-podcast' ),
+			__( 'Settings', 'jetpack-podcast' ),
+			'manage_options',
+			'jetpack#/settings',
+			null,
+			13
+		);
+		Admin_Page::add_wp_admin_submenu();
+
+		Admin_Menu::admin_menu_hook_callback();
+
+		$slugs = wp_list_pluck( (array) ( $GLOBALS['submenu']['jetpack'] ?? array() ), 2 );
+
+		$this->assertContains( Admin_Page::ADMIN_PAGE_SLUG, $slugs );
+		$this->assertContains( 'jetpack#/settings', $slugs );
+		$this->assertLessThan(
+			array_search( 'jetpack#/settings', $slugs, true ),
+			array_search( Admin_Page::ADMIN_PAGE_SLUG, $slugs, true ),
+			'The Podcast submenu should appear before Jetpack Settings.'
 		);
 	}
 

--- a/projects/packages/podcast/tests/php/Admin_Page_Test.php
+++ b/projects/packages/podcast/tests/php/Admin_Page_Test.php
@@ -54,7 +54,12 @@ class Admin_Page_Test extends BaseTestCase {
 	private function reset_admin_menu_state(): void {
 		$reflection = new \ReflectionClass( Admin_Menu::class );
 
-		foreach ( array( 'initialized' => false, 'menu_items' => array() ) as $property_name => $value ) {
+		foreach (
+			array(
+				'initialized' => false,
+				'menu_items'  => array(),
+			) as $property_name => $value
+		) {
 			if ( ! $reflection->hasProperty( $property_name ) ) {
 				continue;
 			}


### PR DESCRIPTION
Fixes JETPACK-1788

https://www.loom.com/share/64185a7935124e1fb1bfdfc23ac45283 

## Proposed changes
* Add 32px outer spacing around Podcast setup/settings-style content wrappers.
* Preserve the narrow settings/distribution content width while adding outer insets.
* Align the welcome hero, pricing cards, benefit cards, and setup card to the same horizontal inset.
* Keep the Free and Growth pricing CTAs at their natural text width instead of stretching across the cards.
* Add a Podcast package changelog entry.

## Related product discussion/links
* JETPACK-1788: https://linear.app/a8c/issue/JETPACK-1788/podcast-polish-dashboard-spacing-and-ctas

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `jp build packages/podcast`.
* Run `jp test js packages/podcast` and confirm it skips because the package has no `test-js` script.
* Run `jp test php packages/podcast`.
* Run `jp phan packages/podcast`.
* Open the Podcast welcome/enable screen in a local Jetpack dev site and confirm the hero, pricing cards, and lower benefit cards share the same left/right inset with 32px top spacing.
* Open the Distribution and Settings tabs and confirm their tab content has 32px top/bottom and left/right spacing while preserving the narrow content width.
* Open the Stats and Episodes tabs and confirm their tab content wrapper has no added padding.
* Confirm the Free and Growth pricing CTAs fit their text instead of stretching full-width across each card.