### PR TITLE
Menu badges: style the top-level Jetpack menu badge with core WP bubble classes

### DIFF
--- a/projects/packages/menu-badges/changelog/fix-jetpack-counter
+++ b/projects/packages/menu-badges/changelog/fix-jetpack-counter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add the core `awaiting-mod` and `update-plugins` classes to the top-level Jetpack menu total badge so it uses WordPress's standard admin-menu bubble styling.

--- a/projects/packages/menu-badges/src/class-menu-renderer.php
+++ b/projects/packages/menu-badges/src/class-menu-renderer.php
@@ -27,8 +27,14 @@ class Menu_Renderer {
 		// target) but ships hidden. The inline style trails the data-jp-* attributes so
 		// strip()'s idempotency regex still matches; setBadgeCount() clears it to reveal.
 		$hidden = $count > 0 ? '' : ' style="display:none"';
-		$attrs  = sprintf(
-			'class="menu-counter count-%1$d" data-jp-menu-badge="%2$s" data-jp-menu-count="%1$d"%3$s%4$s',
+		// The top-level Jetpack total badge carries the core `awaiting-mod` and
+		// `update-plugins` classes so it picks up WordPress's standard menu-bubble styling;
+		// submenu badges use only our own `menu-counter` hook. `menu-counter` is always
+		// present for CSS/JS targeting.
+		$classes = $is_total ? 'awaiting-mod update-plugins menu-counter' : 'menu-counter';
+		$attrs   = sprintf(
+			'class="%1$s count-%2$d" data-jp-menu-badge="%3$s" data-jp-menu-count="%2$d"%4$s%5$s',
+			$classes,
 			$count,
 			esc_attr( $id ),
 			$is_total ? ' data-jp-menu-badge-total="1"' : '',
@@ -48,7 +54,7 @@ class Menu_Renderer {
 	 * @return string
 	 */
 	private static function strip( $title ) {
-		return trim( (string) preg_replace( '/\s*<span class="menu-counter count-\d+" data-jp-menu-badge=.*$/s', '', (string) $title ) );
+		return trim( (string) preg_replace( '/\s*<span class="[^"]*menu-counter count-\d+" data-jp-menu-badge=.*$/s', '', (string) $title ) );
 	}
 
 	/**

--- a/projects/packages/menu-badges/tests/js/menu-badges.test.js
+++ b/projects/packages/menu-badges/tests/js/menu-badges.test.js
@@ -10,7 +10,8 @@ require( '../../src/js/menu-badges.js' );
  */
 function badge( slug, count, isTotal ) {
 	const hidden = count > 0 ? '' : ' style="display:none"';
-	return `<span class="menu-counter count-${ count }" data-jp-menu-badge="${ slug }" data-jp-menu-count="${ count }"${
+	const classes = isTotal ? 'awaiting-mod update-plugins menu-counter' : 'menu-counter';
+	return `<span class="${ classes } count-${ count }" data-jp-menu-badge="${ slug }" data-jp-menu-count="${ count }"${
 		isTotal ? ' data-jp-menu-badge-total="1"' : ''
 	}${ hidden }><span class="count">${ count }</span></span>`;
 }

--- a/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
+++ b/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
@@ -49,9 +49,12 @@ class Menu_Renderer_Test extends TestCase {
 
 		$this->assertStringContainsString( 'count-15', $GLOBALS['submenu']['jetpack'][0][0] );
 		$this->assertStringContainsString( 'data-jp-menu-count="15"', $GLOBALS['submenu']['jetpack'][0][0] );
+		// Submenu badges do NOT get the core `awaiting-mod` class — only `menu-counter`.
+		$this->assertStringNotContainsString( 'awaiting-mod', $GLOBALS['submenu']['jetpack'][0][0] );
 		$this->assertStringContainsString( 'count-1', $GLOBALS['submenu']['jetpack'][1][0] );
-		// Top-level total = 15 + 1 = 16.
+		// Top-level total = 15 + 1 = 16, and it carries the core classes for standard bubble styling.
 		$this->assertStringContainsString( 'count-16', $GLOBALS['menu'][3][0] );
+		$this->assertStringContainsString( 'awaiting-mod update-plugins menu-counter', $GLOBALS['menu'][3][0] );
 		$this->assertStringContainsString( 'data-jp-menu-badge-total="1"', $GLOBALS['menu'][3][0] );
 	}
 


### PR DESCRIPTION
Fixes JETPACK-1572

Before:

<img width="377" height="352" alt="Screenshot 2026-06-29 at 6 01 10 PM" src="https://github.com/user-attachments/assets/e0f4177d-8774-4ab0-969d-95e4772c5a25" />

After:

<img width="365" height="350" alt="Screenshot 2026-06-29 at 6 00 38 PM" src="https://github.com/user-attachments/assets/854d2a93-5937-4a11-b009-fa9ed800554a" />

## Proposed changes

Since this branch was opened, Jetpack menu notification badges (Forms, Boost, Protect, …) were centralized into the `jetpack-menu-badges` package, which is now the sole writer of these badges in wp-admin. This PR moves the badge-styling change into that central renderer:

* `Menu_Renderer::badge_markup()` now adds WordPress core's `awaiting-mod` and `update-plugins` classes to the **top-level Jetpack menu total badge**, so it uses the same markup core uses for admin-menu notification bubbles and picks up the active admin color scheme's bubble color.
* Submenu badges (e.g. Jetpack → Forms) are unchanged — they keep only the internal `menu-counter` hook.
* `Menu_Renderer::strip()`'s idempotency regex is broadened so it still matches the badge span after the extra leading classes are added.
* Test coverage updated (PHP + JS) to assert the top-level badge carries the core classes while submenu badges do not.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Set up a site with Jetpack connected.
* Ensure at least one registered menu badge has a positive count so the top-level Jetpack bubble renders (e.g. submit a form so Forms has unread feedback, or register a test count against `Notification_Counts`).
* In wp-admin, look at the top-level **Jetpack** item in the admin sidebar — its combined-count bubble now carries the `awaiting-mod update-plugins menu-counter` classes.
* Switch the admin color scheme (Users → Profile → Admin Color Scheme, e.g. *Sunrise*) and confirm the bubble tints to match the scheme.
* Verify the Jetpack → Forms submenu badge is unchanged (still `menu-counter` only, no `awaiting-mod`).
