### PR TITLE
Premium Analytics: add Emails widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1503-emails
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1503-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Emails widget to the Premium Analytics dashboard: a leaderboard of your latest sent emails with a selector to switch between open rate and click rate.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -53,6 +53,7 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
 const STATS_FOLLOWERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/followers';
 const STATS_SUBSCRIBERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/subscribers';
+const STATS_EMAIL_SUMMARY_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/emails/summary';
 const WP_SETTINGS_PATH = '/wp/v2/settings';
 
 const coreSettingsMock = {
@@ -561,6 +562,47 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 	};
 }
 
+/**
+ * Builds a mock Stats "email summary" response so the Emails widget renders
+ * populated in Storybook. The shape matches what `sanitizeStatsEmailSummaryResponse`
+ * expects (`{ posts: [ { title, opens_rate, clicks_rate, … } ] }`); rates are
+ * 0–100 percentages and the rows are newest-first to mirror the live endpoint.
+ *
+ * @return Raw email-summary response.
+ */
+function buildEmailSummaryResponse() {
+	const emails = [
+		{ title: '4 Ways to Make Your Website Stand Out', opens_rate: 38.1, clicks_rate: 3.81 },
+		{ title: 'Develop Locally on Linux with WordPress.com', opens_rate: 41.2, clicks_rate: 5.98 },
+		{ title: '10 Brand-New WordPress.com Themes for 2026', opens_rate: 35.7, clicks_rate: 7.12 },
+		{
+			title: 'WordPress.com Is Now Available in More Languages',
+			opens_rate: 52.4,
+			clicks_rate: 8.93,
+		},
+		{ title: 'WordCamp Europe 2026: What to Expect', opens_rate: 47.9, clicks_rate: 10.25 },
+		{
+			title: 'Click, Comment, Done: A Better Way to Collaborate',
+			opens_rate: 44.3,
+			clicks_rate: 10.38,
+		},
+	];
+	const posts = emails.map( ( email, index ) => ( {
+		id: 2000 + index,
+		title: email.title,
+		href: 'https://example.com',
+		type: 'post',
+		opens_rate: email.opens_rate,
+		clicks_rate: email.clicks_rate,
+		opens: 400 - index * 20,
+		clicks: 40 - index * 3,
+		unique_opens: 380 - index * 20,
+		unique_clicks: 38 - index * 3,
+		total_sends: 1000,
+	} ) );
+	return { posts };
+}
+
 const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
 
@@ -577,6 +619,10 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 		return buildSubscribersResponse(
 			new URLSearchParams( queryIndex === -1 ? '' : requestPath.slice( queryIndex + 1 ) )
 		);
+	}
+
+	if ( requestPath.startsWith( STATS_EMAIL_SUMMARY_PATH ) ) {
+		return buildEmailSummaryResponse();
 	}
 
 	if ( ! requestPath.startsWith( API_BASE ) ) {

--- a/projects/packages/premium-analytics/widgets/emails/emails.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/emails.module.css
@@ -1,0 +1,53 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+.header {
+	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+}
+
+.metricSelect {
+	flex-shrink: 0;
+}
+
+.leaderboard {
+	padding: 0 var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-lg);
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+}
+
+/* The label fills its row; vertical padding sets the overlay bar height (there
+   is no image to size it) and the inline padding insets the text from the bar's
+   rounded left edge. */
+.label {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.placeholder {
+	padding: var(--wpds-dimension-padding-lg);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
+ * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
+ * on .root also resolves to auto, leaving aspect-ratio with no anchor.
+ * Setting height: auto here lets aspect-ratio derive the height from the known
+ * inline size and overflow: hidden clips the chart content. Targets only the
+ * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
+ * tile supplies a real height. */
+:global([inert]:not([inert="true"])) .root {
+	height: auto;
+	aspect-ratio: 4 / 3;
+	overflow: hidden;
+}

--- a/projects/packages/premium-analytics/widgets/emails/package.json
+++ b/projects/packages/premium-analytics/widgets/emails/package.json
@@ -11,7 +11,6 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
-		"@wordpress/widget-primitives": "next",
-		"clsx": "^2.1.1"
+		"@wordpress/widget-primitives": "next"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/emails/package.json
+++ b/projects/packages/premium-analytics/widgets/emails/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-emails",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/components": "35.0.1",
+		"@wordpress/element": "8.0.1",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
+		"clsx": "^2.1.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -12,7 +12,6 @@ import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
-import clsx from 'clsx';
 /**
  * Internal dependencies
  */
@@ -32,7 +31,7 @@ export type EmailMetric = 'opens' | 'clicks';
  */
 export type EmailRow = {
 	/**
-	 * Stable identifier for the email (post ID or, as a fallback, the title).
+	 * Stable identifier for the email (post ID or, as a fallback, the array index).
 	 */
 	id: string | number;
 	/**
@@ -144,7 +143,7 @@ export const EmailsLeaderboard = ( {
 	} else {
 		body = (
 			<LeaderboardChart
-				className={ clsx( styles.leaderboard ) }
+				className={ styles.leaderboard }
 				data={ data }
 				loading={ isLoading }
 				withComparison={ false }
@@ -224,10 +223,7 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 
 	const { data, isLoading, isError } = useStatsEmailSummary( { quantity } );
 
-	const rows = useMemo(
-		() => toEmailRows( data as StatsEmailSummary | undefined, max ),
-		[ data, max ]
-	);
+	const rows = useMemo( () => toEmailRows( data, max ), [ data, max ] );
 
 	return <EmailsLeaderboard rows={ rows } isLoading={ isLoading } isError={ isError } />;
 }

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -20,7 +20,8 @@ import type { EmailsAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 /**
- * Which rate the leaderboard ranks and displays.
+ * Which rate the leaderboard displays. Rows stay in newest-first order
+ * regardless; this only changes the value shown and the overlay bar width.
  */
 export type EmailMetric = 'opens' | 'clicks';
 

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -1,0 +1,253 @@
+/**
+ * External dependencies
+ */
+import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	type LeaderboardChartData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { SelectControl } from '@wordpress/components';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import styles from './emails.module.css';
+import type { EmailsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+/**
+ * Which rate the leaderboard ranks and displays.
+ */
+export type EmailMetric = 'opens' | 'clicks';
+
+/**
+ * A single normalized email row, flattened from the `useStatsEmailSummary`
+ * report into the shape the leaderboard renders. Exported so Storybook can
+ * build fixtures for `EmailsLeaderboard`.
+ */
+export type EmailRow = {
+	/**
+	 * Stable identifier for the email (post ID or, as a fallback, the title).
+	 */
+	id: string | number;
+	/**
+	 * Email subject line.
+	 */
+	label: string;
+	/**
+	 * Open rate as a percentage (0–100).
+	 */
+	opensRate: number;
+	/**
+	 * Click rate as a percentage (0–100).
+	 */
+	clicksRate: number;
+};
+
+/**
+ * Maps normalized email rows onto the shape `LeaderboardChart` expects. The
+ * selected metric drives both the displayed value and the overlay bar width
+ * (shares are relative to the highest rate in the set). The emails summary has
+ * no comparison period, so the comparison fields are zeroed.
+ *
+ * @param rows   - The normalized email rows.
+ * @param metric - Which rate to display (`opens` or `clicks`).
+ * @return The leaderboard chart data.
+ */
+function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): LeaderboardChartData {
+	const rateOf = ( row: EmailRow ) => ( metric === 'opens' ? row.opensRate : row.clicksRate );
+	// `1` guards against division by zero when every rate is 0.
+	const maxRate = Math.max( ...rows.map( rateOf ), 1 );
+
+	return rows.map( row => {
+		const rate = rateOf( row );
+
+		return {
+			id: String( row.id ),
+			label: (
+				<span className={ styles.label } title={ row.label }>
+					{ row.label }
+				</span>
+			),
+			// `LeaderboardChart` formats the value as a percentage, so the rate
+			// is expressed as a fraction here.
+			currentValue: rate / 100,
+			currentShare: ( rate / maxRate ) * 100,
+			previousValue: 0,
+			previousShare: 0,
+			delta: 0,
+		};
+	} );
+}
+
+type EmailsLeaderboardProps = {
+	/**
+	 * Normalized email rows to render. When omitted, the empty state is shown
+	 * (unless `isLoading` is set).
+	 */
+	rows?: EmailRow[];
+	/**
+	 * When `true`, a loading overlay is rendered instead of data.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, an error message is rendered in place of the chart.
+	 */
+	isError?: boolean;
+	/**
+	 * Initial metric. Defaults to `opens`.
+	 */
+	initialMetric?: EmailMetric;
+};
+
+/**
+ * Presentational leaderboard for the "Emails" widget. Lists the most recently
+ * sent emails with a selector to switch between open rate and click rate.
+ *
+ * Takes already-fetched rows via props and owns only the metric selection plus
+ * the loading, error, empty, and populated states. Exported so Storybook can
+ * exercise those states with fixture rows (there is no analytics backend in
+ * Storybook, so the data-connected entry point would only ever show chrome).
+ *
+ * @param {EmailsLeaderboardProps} props - The component props.
+ * @return The rendered leaderboard.
+ */
+export const EmailsLeaderboard = ( {
+	rows = [],
+	isLoading = false,
+	isError = false,
+	initialMetric = 'opens',
+}: EmailsLeaderboardProps ) => {
+	const [ metric, setMetric ] = useState< EmailMetric >( initialMetric );
+
+	const handleMetricChange = useCallback(
+		( value: string ) => setMetric( value as EmailMetric ),
+		[]
+	);
+
+	const data = useMemo( () => buildLeaderboardData( rows, metric ), [ rows, metric ] );
+
+	let body;
+	if ( isError ) {
+		body = (
+			<Text className={ styles.placeholder }>
+				{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }
+			</Text>
+		);
+	} else if ( isLoading && rows.length === 0 ) {
+		body = <WidgetLoadingOverlay />;
+	} else {
+		body = (
+			<LeaderboardChart
+				className={ clsx( styles.leaderboard ) }
+				data={ data }
+				loading={ isLoading }
+				withComparison={ false }
+				withOverlayLabel
+				showLegend={ false }
+				emptyStateText={ __(
+					'Your latest emails will appear here once you send a newsletter.',
+					'jetpack-premium-analytics'
+				) }
+				dataFormat={ {
+					type: 'percentage',
+					options: { decimals: 2, signDisplay: 'never' },
+				} }
+			/>
+		);
+	}
+
+	return (
+		<Stack className={ styles.root }>
+			<Stack direction="row" justify="space-between" align="center" className={ styles.header }>
+				<Text>{ __( 'Latest emails sent', 'jetpack-premium-analytics' ) }</Text>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'View by', 'jetpack-premium-analytics' ) }
+					hideLabelFromVision
+					value={ metric }
+					options={ [
+						{ label: __( 'By open rate', 'jetpack-premium-analytics' ), value: 'opens' },
+						{ label: __( 'By click rate', 'jetpack-premium-analytics' ), value: 'clicks' },
+					] }
+					onChange={ handleMetricChange }
+					className={ styles.metricSelect }
+				/>
+			</Stack>
+			{ body }
+		</Stack>
+	);
+};
+
+/**
+ * Flatten the `useStatsEmailSummary` report into the `{ id, label, opensRate,
+ * clicksRate }` rows the leaderboard renders, keeping the endpoint's
+ * newest-first order and trimming to `max`.
+ *
+ * @param report - The normalized email-summary report, or undefined while loading.
+ * @param max    - Maximum rows to display; `0` keeps all rows.
+ * @return The normalized email rows.
+ */
+function toEmailRows( report: StatsEmailSummary | undefined, max: number ): EmailRow[] {
+	const items = report?.data?.[ 0 ]?.items ?? [];
+
+	return items.slice( 0, max > 0 ? max : undefined ).map( ( item, index ) => ( {
+		id: item.id ?? index,
+		label: String( item.label ?? '' ),
+		opensRate: item.opens_rate,
+		clicksRate: item.clicks_rate,
+	} ) );
+}
+
+type EmailsReportProps = {
+	attributes?: EmailsAttributes;
+};
+
+/**
+ * Fetches the email-summary report through the `useStatsEmailSummary` Stats
+ * hook and hands the normalized rows to the presentational `EmailsLeaderboard`.
+ *
+ * @param {EmailsReportProps} props - The component props.
+ * @return The widget content.
+ */
+function EmailsReport( { attributes }: EmailsReportProps ) {
+	const max = attributes?.max ?? 10;
+	// The summary endpoint accepts 1–30 rows and resets anything outside that
+	// range to 10, so request its maximum when the widget wants "all rows".
+	const quantity = max > 0 ? Math.min( max, 30 ) : 30;
+
+	const { data, isLoading, isError } = useStatsEmailSummary( { quantity } );
+
+	const rows = useMemo(
+		() => toEmailRows( data as StatsEmailSummary | undefined, max ),
+		[ data, max ]
+	);
+
+	return <EmailsLeaderboard rows={ rows } isLoading={ isLoading } isError={ isError } />;
+}
+
+/**
+ * Widget render entry point.
+ *
+ * Attributes flow to the inner component via props rather than
+ * `WidgetRootContext` — the emails summary has no date range, so the
+ * WC-Analytics-shaped report params do not apply. Runs inside `WidgetRoot` so
+ * it can reach the analytics query client, keeping the leaderboard prop-driven
+ * (and Storybook-friendly).
+ *
+ * @param {WidgetRenderProps< EmailsAttributes >} props - The render props supplied by the widget host.
+ * @return The rendered widget.
+ */
+export default function Emails( { attributes }: WidgetRenderProps< EmailsAttributes > ) {
+	return (
+		<WidgetRoot>
+			<EmailsReport attributes={ attributes } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -61,8 +61,9 @@ export type EmailRow = {
  */
 function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): LeaderboardChartData {
 	const rateOf = ( row: EmailRow ) => ( metric === 'opens' ? row.opensRate : row.clicksRate );
-	// `1` guards against division by zero when every rate is 0.
-	const maxRate = Math.max( ...rows.map( rateOf ), 1 );
+	// Shares are relative to the real maximum so the top row always fills, even
+	// when every rate is below 1%. The `> 0` check guards the divide-by-zero.
+	const maxRate = Math.max( ...rows.map( rateOf ), 0 );
 
 	return rows.map( row => {
 		const rate = rateOf( row );
@@ -77,7 +78,7 @@ function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): Leaderbo
 			// `LeaderboardChart` formats the value as a percentage, so the rate
 			// is expressed as a fraction here.
 			currentValue: rate / 100,
-			currentShare: ( rate / maxRate ) * 100,
+			currentShare: maxRate > 0 ? ( rate / maxRate ) * 100 : 0,
 			previousValue: 0,
 			previousShare: 0,
 			delta: 0,
@@ -92,9 +93,15 @@ type EmailsLeaderboardProps = {
 	 */
 	rows?: EmailRow[];
 	/**
-	 * When `true`, a loading overlay is rendered instead of data.
+	 * When `true` and there are no rows yet, the full loading overlay is shown.
 	 */
 	isLoading?: boolean;
+	/**
+	 * When `true`, an in-place chart spinner is shown over existing rows during a
+	 * background refetch. Unlike `isLoading`, this stays `true` while stale data
+	 * is on screen.
+	 */
+	isFetching?: boolean;
 	/**
 	 * When `true`, an error message is rendered in place of the chart.
 	 */
@@ -120,6 +127,7 @@ type EmailsLeaderboardProps = {
 export const EmailsLeaderboard = ( {
 	rows = [],
 	isLoading = false,
+	isFetching = false,
 	isError = false,
 	initialMetric = 'opens',
 }: EmailsLeaderboardProps ) => {
@@ -146,7 +154,7 @@ export const EmailsLeaderboard = ( {
 			<LeaderboardChart
 				className={ styles.leaderboard }
 				data={ data }
-				loading={ isLoading }
+				loading={ isFetching }
 				withComparison={ false }
 				withOverlayLabel
 				showLegend={ false }
@@ -197,6 +205,8 @@ export const EmailsLeaderboard = ( {
 function toEmailRows( report: StatsEmailSummary | undefined, max: number ): EmailRow[] {
 	const items = report?.data?.[ 0 ]?.items ?? [];
 
+	// `quantity` already bounds the request; this slice is the Stats-widget
+	// `max = 0 → all rows` convention and a guard against an over-long response.
 	return items.slice( 0, max > 0 ? max : undefined ).map( ( item, index ) => ( {
 		id: item.id ?? index,
 		label: String( item.label ?? '' ),
@@ -222,11 +232,18 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 	// range to 10, so request its maximum when the widget wants "all rows".
 	const quantity = max > 0 ? Math.min( max, 30 ) : 30;
 
-	const { data, isLoading, isError } = useStatsEmailSummary( { quantity } );
+	const { data, isLoading, isFetching, isError } = useStatsEmailSummary( { quantity } );
 
 	const rows = useMemo( () => toEmailRows( data, max ), [ data, max ] );
 
-	return <EmailsLeaderboard rows={ rows } isLoading={ isLoading } isError={ isError } />;
+	return (
+		<EmailsLeaderboard
+			rows={ rows }
+			isLoading={ isLoading }
+			isFetching={ isFetching }
+			isError={ isError }
+		/>
+	);
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -172,8 +172,8 @@ export const EmailsLeaderboard = ( {
 					hideLabelFromVision
 					value={ metric }
 					options={ [
-						{ label: __( 'By open rate', 'jetpack-premium-analytics' ), value: 'opens' },
-						{ label: __( 'By click rate', 'jetpack-premium-analytics' ), value: 'clicks' },
+						{ label: __( 'Open rate', 'jetpack-premium-analytics' ), value: 'opens' },
+						{ label: __( 'Click rate', 'jetpack-premium-analytics' ), value: 'clicks' },
 					] }
 					onChange={ handleMetricChange }
 					className={ styles.metricSelect }

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -1,17 +1,30 @@
 /**
- * Like `top-posts` (the canonical non-time-series Stats widget), this story
- * exercises the presentational `EmailsLeaderboard` with fixtures rather than the
- * data-connected widget through `WidgetDashboardWithWidget`. `registerReportMocks`
- * only mocks the WC `analytics/reports` endpoints, not the Stats proxy that
- * `useStatsEmailSummary` hits, so a dashboard story would render only the empty
- * state. Fixtures let the populated states render without a backend.
+ * The close-up stories exercise the presentational `EmailsLeaderboard` with
+ * fixtures so each state (populated, loading, empty, error) renders without a
+ * backend. `WidgetDashboardWithWidget` mounts the real dashboard with the
+ * data-connected widget; `registerReportMocks` supplies a mock
+ * `stats/emails/summary` response so it renders populated in product context.
  */
 /**
  * Internal dependencies
  */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
-import { EmailsLeaderboard, type EmailRow } from '../render';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import EmailsRender, { EmailsLeaderboard, type EmailRow } from '../render';
+import widgetDefinition from '../widget';
 import type { Meta, StoryObj, Decorator } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentType } from 'react';
+
+registerReportMocks();
+
+const EMAILS_RENDER_MODULE = 'storybook/emails';
 
 const meta: Meta< typeof EmailsLeaderboard > = {
 	title: 'Packages/Premium Analytics/Widgets/Emails',
@@ -21,7 +34,7 @@ const meta: Meta< typeof EmailsLeaderboard > = {
 		docs: {
 			description: {
 				component:
-					'The "Emails" widget. Lists the most recently sent emails with a selector to switch between open rate and click rate, rendered as a leaderboard. This is the presentational layer — it takes already-fetched rows via props and handles the loading, error, empty, and populated states. The data-connected widget (render.tsx default export) wraps this in WidgetRoot and feeds it the useStatsEmailSummary hook.',
+					'The "Emails" widget. Lists the most recently sent emails with a selector to switch between open rate and click rate, rendered as a leaderboard. The close-up stories drive the presentational `EmailsLeaderboard` with fixtures; `WidgetDashboardWithWidget` mounts the real dashboard with the data-connected widget (fed by a mocked `stats/emails/summary` response).',
 			},
 		},
 	},
@@ -186,4 +199,33 @@ export const SizeLarge: Story = {
 		rows: mockRows,
 	},
 	decorators: [ createSizeDecorator( '576px' ) ],
+};
+
+/**
+ * Renders the data-connected widget through the shared dashboard harness, so it
+ * appears exactly as it does in product (full-bleed framing, sizing, edit mode).
+ *
+ * @param props - The dashboard story controls.
+ * @return The widget mounted inside the real `WidgetDashboard`.
+ */
+function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...props }
+			widgetType={ widgetDefinition }
+			renderModule={ EMAILS_RENDER_MODULE }
+			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: 6 } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
+	render: args => <EmailsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+	},
 };

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -212,7 +212,11 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...props }
-			widgetType={ widgetDefinition }
+			widgetType={ {
+				name: widgetDefinition.name,
+				title: widgetDefinition.title,
+				icon: widgetDefinition.icon,
+			} }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { max: 6 } }

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -216,6 +216,10 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 				name: widgetDefinition.name,
 				title: widgetDefinition.title,
 				icon: widgetDefinition.icon,
+				// Matches widget.json so the host hides its card title (full-bleed),
+				// exactly as it does on the real dashboard — only the widget's own
+				// "Latest emails sent" header shows, no duplicate title.
+				presentation: 'full-bleed',
 			} }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
@@ -1,0 +1,181 @@
+/**
+ * Internal dependencies
+ */
+import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
+import { EmailsLeaderboard, type EmailRow } from '../render';
+import type { Meta, StoryObj, Decorator } from '@storybook/react';
+
+const meta: Meta< typeof EmailsLeaderboard > = {
+	title: 'Packages/Premium Analytics/Widgets/Emails',
+	component: EmailsLeaderboard,
+	tags: [ 'autodocs' ],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Emails" widget. Lists the most recently sent emails with a selector to switch between open rate and click rate, rendered as a leaderboard. This is the presentational layer — it takes already-fetched rows via props and handles the loading, error, empty, and populated states. The data-connected widget (render.tsx default export) wraps this in WidgetRoot and feeds it the useStatsEmailSummary hook.',
+			},
+		},
+	},
+	decorators: [ withChartTheme ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof EmailsLeaderboard >;
+
+const mockRows: EmailRow[] = [
+	{
+		id: 1,
+		label: '4 Ways to Make Your Website Stand Out',
+		opensRate: 38.1,
+		clicksRate: 3.81,
+	},
+	{
+		id: 2,
+		label: 'Develop Locally on Linux with WordPress.com',
+		opensRate: 41.2,
+		clicksRate: 5.98,
+	},
+	{
+		id: 3,
+		label: '10 Brand-New WordPress.com Themes for 2026',
+		opensRate: 35.7,
+		clicksRate: 7.12,
+	},
+	{
+		id: 4,
+		label: 'WordPress.com Is Now Available in More Languages',
+		opensRate: 52.4,
+		clicksRate: 8.93,
+	},
+	{
+		id: 5,
+		label: 'WordCamp Europe 2026: What to Expect',
+		opensRate: 47.9,
+		clicksRate: 10.25,
+	},
+	{
+		id: 6,
+		label: 'Click, Comment, Done: A Better Way to Collaborate',
+		opensRate: 44.3,
+		clicksRate: 10.38,
+	},
+];
+
+const mockLongLabelRows: EmailRow[] = [
+	{
+		id: 1,
+		label:
+			'An exhaustively long, keyword-stuffed subject line that almost certainly needs to be truncated before it overflows the row',
+		opensRate: 22.5,
+		clicksRate: 4.1,
+	},
+	{
+		id: 2,
+		label: 'Your monthly digest: billing, new features, and what is coming next',
+		opensRate: 33.8,
+		clicksRate: 6.7,
+	},
+];
+
+/**
+ * Default populated state — latest emails ranked by open rate.
+ */
+export const Default: Story = {
+	args: {
+		rows: mockRows,
+	},
+};
+
+/**
+ * Click-rate view — the selector defaults to click rate instead of open rate.
+ */
+export const ByClickRate: Story = {
+	args: {
+		rows: mockRows,
+		initialMetric: 'clicks',
+	},
+};
+
+/**
+ * Loading state — the loading overlay renders while data is fetched.
+ */
+export const Loading: Story = {
+	args: {
+		rows: [],
+		isLoading: true,
+	},
+};
+
+/**
+ * Empty state — no emails have been sent yet.
+ */
+export const Empty: Story = {
+	args: {
+		rows: [],
+	},
+};
+
+/**
+ * Error state — the report could not be loaded.
+ */
+export const ErrorState: Story = {
+	args: {
+		isError: true,
+	},
+};
+
+/**
+ * Long subject lines are truncated with an ellipsis so rows stay single-line.
+ */
+export const LongLabels: Story = {
+	args: {
+		rows: mockLongLabelRows,
+	},
+};
+
+/**
+ * Creates a decorator that wraps the story in a fixed-size container so the
+ * widget's responsiveness can be inspected at a given width.
+ *
+ * @param width    - The container width (any CSS length).
+ * @param [height] - The container height; defaults to `auto`.
+ * @return A Storybook decorator.
+ */
+const createSizeDecorator = ( width: string, height = 'auto' ): Decorator => {
+	return Story => (
+		<div
+			style={ {
+				width,
+				height,
+				border: '1px dashed #ccc',
+				borderRadius: '8px',
+				containerType: 'inline-size',
+				containerName: 'widget',
+			} }
+		>
+			<Story />
+		</div>
+	);
+};
+
+/**
+ * Medium container (448px / md breakpoint).
+ */
+export const SizeMedium: Story = {
+	args: {
+		rows: mockRows,
+	},
+	decorators: [ createSizeDecorator( '448px' ) ],
+};
+
+/**
+ * Large container (576px / xl breakpoint).
+ */
+export const SizeLarge: Story = {
+	args: {
+		rows: mockRows,
+	},
+	decorators: [ createSizeDecorator( '576px' ) ],
+};

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
@@ -1,4 +1,12 @@
 /**
+ * Like `top-posts` (the canonical non-time-series Stats widget), this story
+ * exercises the presentational `EmailsLeaderboard` with fixtures rather than the
+ * data-connected widget through `WidgetDashboardWithWidget`. `registerReportMocks`
+ * only mocks the WC `analytics/reports` endpoints, not the Stats proxy that
+ * `useStatsEmailSummary` hits, so a dashboard story would render only the empty
+ * state. Fixtures let the populated states render without a backend.
+ */
+/**
  * Internal dependencies
  */
 import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails.stories.tsx
@@ -88,7 +88,7 @@ const mockLongLabelRows: EmailRow[] = [
 ];
 
 /**
- * Default populated state — latest emails ranked by open rate.
+ * Default populated state — latest emails (newest first) with their open rate.
  */
 export const Default: Story = {
 	args: {

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/stats-emails",
+	"title": "Emails",
+	"description": "Open and click rates for your latest emails.",
+	"category": "stats",
+	"presentation": "full-bleed"
+}

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { envelope } from '@wordpress/icons';
+
+/**
+ * Configurable attributes for the Emails widget. Mirrors the `attributes`
+ * declared on the widget definition below; the host passes the selected values
+ * through to `render.tsx`.
+ */
+export type EmailsAttributes = {
+	/**
+	 * Number of emails to show. `0` means as many as the endpoint returns (max 30).
+	 */
+	max?: number;
+};
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats "Emails" module. Lists the most recently sent
+ * emails with their open and click rates; a selector switches the displayed
+ * metric. The summary endpoint reports across the whole lifetime of the site,
+ * so there is no date range or comparison period.
+ */
+export default {
+	name: 'jpa/stats-emails',
+	title: __( 'Emails', 'jetpack-premium-analytics' ),
+	icon: envelope,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	],
+	example: {
+		attributes: {
+			max: 10,
+		},
+	},
+};


### PR DESCRIPTION
Fixes [WOOA7S-1503](https://linear.app/a8c/issue/WOOA7S-1503/port-jetpack-stats-module-emails)

## Proposed changes

Ports the Jetpack Stats **Emails** module into a registered Premium Analytics widget (`jpa/stats-emails`).

* New widget at `projects/packages/premium-analytics/widgets/emails/` (package.json, widget.json, widget.ts, render.tsx, CSS module, Storybook story).
* Renders a `LeaderboardChart` of the latest sent emails (newest-first), with a selector to switch the displayed metric between **open rate** and **click rate** — modeled on the `locations` widget's local UI state.
* Data comes from the existing `useStatsEmailSummary` hook in `@jetpack-premium-analytics/data`. This is the lifetime email-summary endpoint, so there is **no date range and no comparison period** — the widget follows the non-time-series prop-drill pattern of `top-posts` (wraps `<WidgetRoot>`, prop-drills `attributes`).
* `presentation: full-bleed`; the body renders its own header ("Latest emails sent" + the metric selector), mirroring `locations`.
* Open/click rates (0–100) are formatted as percentages via the toolkit's `percentage` data format (`signDisplay: 'never'`).
* `max` attribute controls the row count; `max = 0` requests the endpoint maximum (30).

**Story note:** like `top-posts` (the canonical non-time-series reference), the Storybook story exercises the presentational `EmailsLeaderboard` with fixtures so the populated states render without a backend — the dashboard-harness mocks (`registerReportMocks`) cover only the WC `analytics/reports` endpoints, not the Stats proxy, so a data-connected dashboard story would only ever show the empty state.

## Related product discussion/links

* [WOOA7S-1503](https://linear.app/a8c/issue/WOOA7S-1503/port-jetpack-stats-module-emails) — Port Jetpack Stats module: Emails (parent: WOOA7S-1458)
* Source module: [`stats-emails.tsx`](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx) in wp-calypso

## Does this pull request change what data or activity we track or use?

No. It reuses the existing `stats/emails/summary` proxy endpoint and `useStatsEmailSummary` hook; no new data is collected.

## Testing instructions

* Build the dashboard plugin: `jp build plugins/premium-analytics --deps`.
* Open the Premium Analytics dashboard: `/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`.
* Click **Customize → Add widget**, add **Emails**, then **Done**.
* Confirm the widget mounts with the "Latest emails sent" header and a "By open rate / By click rate" selector, and that the `stats/emails/summary` request returns 200 (on a site with sent newsletters the rows render with proportional bars and percentages; on a site without, the empty state shows). No console errors should originate from the widget.
* In Storybook (`Packages/Premium Analytics/Widgets/Emails`), check the `Default`, `ByClickRate`, `Loading`, `Empty`, `ErrorState`, and `LongLabels` stories.
