### PR TITLE
Help Center: align/size the admin-bar Help icon consistently

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-help-center-icon-sizing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-help-center-icon-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: align and size the admin-bar Help icon consistently across viewports

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -201,10 +201,10 @@ class Help_Center {
 					$wp_admin_bar->add_menu(
 						array(
 							'id'     => 'help-center',
-							'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="help-center-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+							'title'  => '<span title="' . __( 'Help Center', 'jetpack-mu-wpcom' ) . '"><svg id="help-center-icon" class="ab-icon" width="24" height="24" viewBox="1.5 1.5 21 21" xmlns="http://www.w3.org/2000/svg">
 												<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
 											</svg>
-											<svg id="help-center-icon-with-notification" class="ab-icon"  width="24" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+											<svg id="help-center-icon-with-notification" class="ab-icon"  width="24" height="24" viewBox="-1 -1 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
 												<path d="M12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2ZM13 18H11V16H13V18ZM13 13.859V15H11V13C11 12.448 11.448 12 12 12C13.103 12 14 11.103 14 10C14 8.897 13.103 8 12 8C10.897 8 10 8.897 10 10H8C8 7.791 9.791 6 12 6C14.209 6 16 7.791 16 10C16 11.862 14.722 13.413 13 13.859Z" fill="currentColor"/>
 												<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" stroke-width="2"/>
 											</svg>
@@ -262,6 +262,14 @@ class Help_Center {
 			'https://widgets.wp.com/help-center/help-center-' . $variant . ( is_rtl() ? '.rtl.css' : '.css' ),
 			array(),
 			$version
+		);
+
+		// The admin-bar Help Center icons carry their desktop viewBox in markup so the glyph
+		// aligns/sizes consistently with the other icons. The desktop and mobile viewBoxes are
+		// concentric, so the mobile appearance is reproduced by scaling about the icon's centre.
+		wp_add_inline_style(
+			'help-center-' . $variant . '-style',
+			'@media (max-width:782px){#help-center-icon{transform:scale(0.875)}#help-center-icon-with-notification{transform:scale(0.8667)}}'
 		);
 
 		// In the block editor the Help Center is already present in the editor toolbar


### PR DESCRIPTION
Fixes #

## Proposed changes
Ports [wp-calypso#111737](https://github.com/Automattic/wp-calypso/pull/111737) to Jetpack's WordPress.com admin-bar Help Center icon (`jetpack-mu-wpcom`), so the Help (?) glyph aligns and sizes consistently with the other admin-bar icons.

* Tweak the inline SVG `viewBox` to absorb the icon's internal padding (desktop values live in markup):
  * `#help-center-icon`: `0 0 24 24` → `1.5 1.5 21 21`
  * `#help-center-icon-with-notification`: `0 0 25 24` → `-1 -1 26 26`
* Add an inline `@media (max-width:782px)` rule that scales each icon down (`0.875` / `0.8667`) to reproduce Calypso's mobile `viewBox`.
  * All four Calypso viewBoxes are concentric about the glyph centre (12,12), so the desktop↔mobile change is a pure centred zoom — reproducible exactly with `transform: scale()`. No markup duplication, no element-ID changes, no JS.
* Glyph geometry is unchanged.

Calypso also removed a fixed `width/height: 27px` + padding override; Jetpack has no such override (the icon already sizes from its `width/height="24"` SVG attributes), so there's no analog to remove.

## Related product discussion/links
* Calypso counterpart: https://github.com/Automattic/wp-calypso/pull/111737

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an Atomic/Simple site (or a Jurassic Ninja site with this `jetpack-mu-wpcom` build), load a logged-in **wp-admin** page with the admin bar visible.
* Desktop (>782px): confirm the Help (?) icon in the admin bar aligns/sizes consistently with the adjacent icons.
* Resize to ≤782px: the icon scales down to its original (smaller) appearance and stays centred.
* Unread variant: force `#help-center-icon-with-notification` visible (or trigger an unread state) and confirm the red notification dot stays correctly positioned at both widths.
* Confirm no console errors and that the icon still toggles between the normal and unread states.

Note: in the **block editor** at ≥600px the icon is rendered by the external `@automattic/help-center` bundle (widgets.wp.com), not by this code — test in plain wp-admin where the inline SVG renders.
