### PR TITLE
Cookie Consent: send a REST nonce from the consent logger so logged-in user IDs are recorded

### DIFF
--- a/projects/packages/cookie-consent/changelog/fix-consent-logger-nonce
+++ b/projects/packages/cookie-consent/changelog/fix-consent-logger-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Consent log: send a REST nonce for logged-in visitors so the consent row records the real user ID instead of 0.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -1105,15 +1105,26 @@ class Cookie_Consent {
 		// Resolve the configured Tracks event prefix once so it can be shared below.
 		$config = self::get_config();
 
+		$config_data = array(
+			'apiUrl'      => rest_url( 'jetpack/v4/cookie-consent/consent-log' ),
+			'eventPrefix' => $config['event_prefix'],
+		);
+
+		// Only expose a REST nonce to logged-in visitors, so the consent logger can
+		// authenticate and record the real user_id. Anonymous visitors deliberately get
+		// none: their pages are full-page-cached, a cached nonce would go stale and make
+		// core reject the request (rest_cookie_invalid_nonce). Without a nonce core treats
+		// the request as anonymous and stores user_id = 0, which is correct for them.
+		if ( is_user_logged_in() ) {
+			$config_data['nonce'] = wp_create_nonce( 'wp_rest' );
+		}
+
 		// Pass REST API URL and Tracks event prefix to the module via global config.
 		wp_print_inline_script_tag(
 			sprintf(
 				'window.jetpackCookieConsentConfig = %s;',
 				wp_json_encode(
-					array(
-						'apiUrl'      => rest_url( 'jetpack/v4/cookie-consent/consent-log' ),
-						'eventPrefix' => $config['event_prefix'],
-					),
+					$config_data,
 					JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 				)
 			),

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/logger.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/logger.ts
@@ -24,12 +24,20 @@ async function logConsentEvent(
 		return;
 	}
 
+	const headers: Record< string, string > = {
+		'Content-Type': 'application/json',
+	};
+	// Send the REST nonce when present (logged-in visitors only) so the request
+	// authenticates and the consent row records the real user_id instead of 0.
+	const nonce = window.jetpackCookieConsentConfig?.nonce;
+	if ( nonce ) {
+		headers[ 'X-WP-Nonce' ] = nonce;
+	}
+
 	try {
 		const response = await fetch( apiUrl, {
 			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-			},
+			headers,
 			body: JSON.stringify( {
 				event_type: eventType,
 				url: window.location.href,

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
@@ -41,6 +41,7 @@ declare global {
 		jetpackCookieConsentConfig?: {
 			apiUrl: string;
 			eventPrefix?: string;
+			nonce?: string;
 		};
 		wp_set_consent?: ( category: string, value: 'allow' | 'deny' ) => void;
 		wp_consent_type?: ConsentType;


### PR DESCRIPTION
Related to WOOA7S-1563 / #49852 (prerequisite for the consent-log personal-data exporter/eraser).

## Proposed changes

The consent logger posts to the REST write endpoint with no `X-WP-Nonce` header. For a **logged-in** visitor the browser still sends the auth cookie, so WordPress core (`rest_cookie_check_errors`) sees a cookie-authenticated request without a REST nonce and forces it anonymous — `wp_set_current_user( 0 )`. As a result, every consent row, **even for logged-in users**, was written with `customer_id` (renamed `user_id` in #49852) `= 0`. The POST still returns 200 because the route is `permission_callback => '__return_true'`, so it failed silently.

This is load-bearing for the personal-data exporter/eraser in #49852, which matches consent rows by user ID: with every row stored as `0`, it would match nothing for a real logged-in user.

**Why**

- The logger never sent a REST nonce, so core could not authenticate the cookie-bearing request and downgraded it to anonymous. The captured `user_id` was therefore always `0`, making per-user export/erasure impossible.

**How**

- Localize a `wp_rest` nonce into `jetpackCookieConsentConfig` — **only for logged-in visitors**. Anonymous visitors deliberately get no nonce: their pages are full-page-cached, and a cached nonce would go stale and make core reject the request with `rest_cookie_invalid_nonce` (403). Without a nonce, core treats the request as anonymous and stores `user_id = 0`, which is correct for them. This keeps anonymous logging — the bulk of the traffic — working unchanged.
- The logger attaches `X-WP-Nonce` only when the nonce is present.

**What**

- `class-cookie-consent.php` — conditionally add a `wp_rest` nonce to the localized config when `is_user_logged_in()`.
- `logger.ts` — send the `X-WP-Nonce` header when a nonce is present.
- `types.ts` — add the optional `nonce` field to the config type.

## Does this pull request change what data or activity we track or use?

No new data is collected. This fixes attribution of an **existing** field: consent rows for logged-in users now record the real user ID instead of `0`. Anonymous behavior is unchanged.

## Testing instructions

### Environment setup

The cookie-consent code ships inside the **Premium Analytics** plugin (Composer path dependency), which is the only consumer that boots `Cookie_Consent::init()` — registering the consent-log REST routes and enqueuing the logger.

1. On the test site, activate the **Premium Analytics** plugin and the **WP Consent API** plugin.
2. Load any front-end page and confirm `window.jetpackCookieConsentConfig` is defined in the browser console (this proves the logger is enqueued). The visible banner additionally needs a GDPR region or `?preview_cookie_consent=1`, but **the banner is not required** for this test — the steps below POST to the same endpoint the banner uses.

### Verify

Run both cases on the **same** site (same IP) and compare the stored user ID. To read rows back as admin: `GET /wp-json/jetpack/v4/cookie-consent/consent-log?per_page=100` (needs `manage_privacy_options` + an `X-WP-Nonce`).

1. **Logged-in** — while logged in, load a front-end page and confirm `window.jetpackCookieConsentConfig.nonce` is present. Accept consent (or `POST` to the consent-log endpoint with the `X-WP-Nonce` header). Confirm the new row's user ID is your **real** user ID, not `0`.
2. **Anonymous** — repeat logged out: confirm there is **no** `nonce` in the config, the `POST` still returns `200` (not `403`), and the row's user ID is `0`.

Verified live with this branch active (the column is `customer_id` on trunk, renamed `user_id` by #49852):

| Scenario              | `X-WP-Nonce` sent       | POST status  | Stored user ID |
| --------------------- | ----------------------- | ------------ | -------------- |
| Logged-in (user ID 1) | yes (nonce in config)   | 200          | `1`            |
| Anonymous             | no (no nonce in config) | 200 (no 403) | `0`            |
