### PR TITLE
Premium Analytics: keep widget-dashboard story settings drawer on-screen

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-settings-drawer
+++ b/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-settings-drawer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the widget-dashboard Storybook story's settings drawer on-screen when the dashboard is wider than the preview canvas.

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -171,21 +171,33 @@ export function WidgetDashboardWithWidget( {
 	return (
 		<GlobalErrorProvider>
 			<HostRootFontSize hostEnvironment={ hostEnvironment }>
-				<div style={ { width: dashboardWidth, maxWidth: '100%' } }>
-					<WidgetDashboard
-						layout={ layout }
-						onLayoutChange={ setLayout }
-						widgetTypes={ [ storyWidgetType ] }
-						resolveWidgetModule={ resolveWidgetModule }
-						gridSettings={ { model: 'grid', rowHeight } }
-						editMode={ currentEditMode }
-						onEditChange={ setCurrentEditMode }
-					>
-						<Page title={ pageTitle } actions={ <WidgetDashboard.Actions /> } hasPadding>
-							<WidgetDashboard.NoWidgetsState />
-							<WidgetDashboard.Widgets />
-						</Page>
-					</WidgetDashboard>
+				{ /*
+				 * Outer box fills the canvas and owns horizontal overflow; the inner
+				 * box holds the simulated `dashboardWidth`. The host widget-settings
+				 * drawer is portaled to <body> and positioned `fixed; right: 0`, so a
+				 * body wider than the visible canvas (which a fixed `dashboardWidth`
+				 * wider than the Storybook preview would cause) pushes the drawer
+				 * off-screen. Containing the overflow here keeps the document at canvas
+				 * width so the drawer stays anchored to the visible viewport edge; the
+				 * wide layout remains inspectable by scrolling the box.
+				 */ }
+				<div style={ { width: '100%', overflowX: 'auto' } }>
+					<div style={ { width: dashboardWidth } }>
+						<WidgetDashboard
+							layout={ layout }
+							onLayoutChange={ setLayout }
+							widgetTypes={ [ storyWidgetType ] }
+							resolveWidgetModule={ resolveWidgetModule }
+							gridSettings={ { model: 'grid', rowHeight } }
+							editMode={ currentEditMode }
+							onEditChange={ setCurrentEditMode }
+						>
+							<Page title={ pageTitle } actions={ <WidgetDashboard.Actions /> } hasPadding>
+								<WidgetDashboard.NoWidgetsState />
+								<WidgetDashboard.Widgets />
+							</Page>
+						</WidgetDashboard>
+					</div>
 				</div>
 			</HostRootFontSize>
 		</GlobalErrorProvider>


### PR DESCRIPTION
## Proposed changes

In the shared `WidgetDashboardWithWidget` Storybook story, opening a widget's settings (⚙ gear → drawer) looked broken — the drawer rendered off the visible canvas. The setting itself works (verified live preview + Save); only the drawer was off-screen.

* **Why:** the host `Drawer` is `position: fixed; right: 0`, portaled to `<body>`, so it anchors to the iframe viewport. The story wrapped the dashboard in one `width: dashboardWidth; max-width: 100%` div, so at the `1644px` desktop preset the grid overflows the document horizontally whenever the preview canvas is narrower — pushing the drawer past the visible pane.
* **How:** wrap the dashboard in a canvas-width scroll box (outer `width: 100%; overflow-x: auto` + inner `width: dashboardWidth`) so the body never overflows and the drawer stays on-screen; the wide layout is still reachable by scrolling.
* **What:** `widgets/stories/widget-dashboard-with-widget.tsx` only.

Storybook-harness fix; real wp-admin renders full-width, so product behavior is unchanged.

## Related product discussion/links

* WOOA7S-1631

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the Premium Analytics Storybook (`storybook:dev`, port 50240).
* Open **Widgets → SubscribersList → Widget Dashboard With Widget** (any widget with a settings attribute).
* With the sidebar + addon panel open (canvas < 1644px), hover the widget → click the ⚙ gear.
* The settings drawer should appear on-screen with its field + Cancel/Save (off-screen before this fix).


https://github.com/user-attachments/assets/6fb71bbd-9085-4eb3-b74d-750ca527b52c


