### PR TITLE
Newsletter: add bottom margin to Email content private-site notice

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-email-content-notice-margin
+++ b/projects/packages/newsletter/changelog/fix-newsletter-email-content-notice-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter settings: add bottom margin to the Email content private-site notice so it no longer collides with the featured image toggle.

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -67,7 +67,7 @@ export function EmailContentSection( {
 			<Card.Content>
 				<Fieldset.Root disabled={ ! isNewsletterEnabled }>
 					{ ! isSitePublic && (
-						<Notice.Root intent="warning">
+						<Notice.Root intent="warning" className="newsletter-email-content-notice">
 							<Notice.Description>
 								{ __(
 									'Featured images will not be used in your emails until the site is public, because access to the images is restricted to your site only.',

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -37,6 +37,13 @@ body.jetpack_page_jetpack-newsletter {
 	}
 }
 
+// The `@wordpress/ui` Notice is a CSS-module component, so the
+// `.components-notice` rule below can't reach it. Separate the warning notice in
+// the Email content section from the toggle that follows it.
+.newsletter-email-content-notice {
+	margin-block-end: var(--wpds-dimension-gap-lg, 24px);
+}
+
 .newsletter-settings-disabled {
 	position: relative;
 

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -38,8 +38,8 @@ body.jetpack_page_jetpack-newsletter {
 }
 
 // The `@wordpress/ui` Notice is a CSS-module component, so the
-// `.components-notice` rule below can't reach it. Separate the warning notice in
-// the Email content section from the toggle that follows it.
+// `.components-notice` rule below can't reach it. Separate the warning
+// notice in the Email content section from the toggle that follows it.
 .newsletter-email-content-notice {
 	margin-block-end: var(--wpds-dimension-gap-lg, 24px);
 }

--- a/projects/packages/newsletter/tests/email-content-section.test.tsx
+++ b/projects/packages/newsletter/tests/email-content-section.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for the Email content section's "site is private" warning notice.
+ *
+ * `@wordpress/ui` and `@wordpress/dataviews` are stubbed to plain HTML so we can
+ * assert on the rendered output directly. The `Notice.Root` stub forwards the
+ * `className` it receives, which lets us guard the spacing class that separates
+ * the notice from the toggle below it (NL-717).
+ */
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Card: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
+		Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	},
+	Fieldset: {
+		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
+	},
+	Notice: {
+		Root: ( { children, className }: { children: React.ReactNode; className?: string } ) => (
+			<div role="alert" className={ className }>
+				{ children }
+			</div>
+		),
+		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
+	},
+} ) );
+
+jest.mock( '@wordpress/dataviews', () => ( {
+	__esModule: true,
+	DataForm: () => <div data-testid="data-form" />,
+} ) );
+
+jest.mock( '../src/settings/script-data', () => ( {
+	getNewsletterScriptData: jest.fn( () => ( { isSitePublic: true } ) ),
+} ) );
+
+import { render, screen } from '@testing-library/react';
+import { getNewsletterScriptData } from '../src/settings/script-data';
+import { EmailContentSection } from '../src/settings/sections/email-content-section';
+import type { NewsletterSettings } from '../src/settings/types';
+
+const mockedGetScriptData = getNewsletterScriptData as jest.MockedFunction<
+	typeof getNewsletterScriptData
+>;
+
+/**
+ * Render `<EmailContentSection>` with sensible defaults so each test only has to
+ * override the props it cares about.
+ *
+ * @param props - Prop overrides to apply on top of the defaults.
+ * @return RTL render helpers.
+ */
+function renderSection(
+	props: Partial< React.ComponentProps< typeof EmailContentSection > > = {}
+) {
+	return render(
+		<EmailContentSection
+			data={ {} as NewsletterSettings }
+			onChange={ jest.fn() }
+			isNewsletterEnabled={ true }
+			{ ...props }
+		/>
+	);
+}
+
+describe( 'EmailContentSection private-site notice', () => {
+	it( 'does not render the warning notice when the site is public', () => {
+		mockedGetScriptData.mockReturnValue( { isSitePublic: true } as ReturnType<
+			typeof getNewsletterScriptData
+		> );
+
+		renderSection();
+
+		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the warning notice with the spacing class when the site is private', () => {
+		mockedGetScriptData.mockReturnValue( { isSitePublic: false } as ReturnType<
+			typeof getNewsletterScriptData
+		> );
+
+		renderSection();
+
+		const notice = screen.getByRole( 'alert' );
+		expect( notice ).toBeInTheDocument();
+		// The spacing class is what keeps the notice from colliding with the
+		// toggle rendered below it (NL-717). Guard it against regressions.
+		expect( notice ).toHaveClass( 'newsletter-email-content-notice' );
+	} );
+} );


### PR DESCRIPTION
Fixes NL-717

## Proposed changes
* In the Newsletter settings → **Email content** section, the private-site warning `Notice` ("Featured images will not be used in your emails until the site is public…") sat flush against the featured image toggle below it, with no separating space.
* The package's existing `.newsletter-settings .components-notice` margin rule targets the legacy `@wordpress/components` notice, but this view renders the newer `@wordpress/ui` `Notice` — a CSS-module component with scoped class names — so the rule never reached it.
* Added a dedicated `newsletter-email-content-notice` class to the `Notice.Root` (it forwards `className` via `mergeProps`) and a matching `margin-block-end` rule using the standard WPDS gap token (`var(--wpds-dimension-gap-lg, 24px)`), mirroring the existing `newsletter-settings-connect-notice` pattern.
* Added a regression test asserting the notice is hidden on public sites and rendered with the spacing class on private sites.

**Before**

<img width="809" height="265" alt="Screenshot 2026-06-30 at 10 46 57" src="https://github.com/user-attachments/assets/46dc482a-bf05-491a-9586-e73095304a1f" />



**After**

<img width="719" height="263" alt="Screenshot 2026-06-30 at 10 46 42" src="https://github.com/user-attachments/assets/8cc2c887-4fdc-4b29-9152-06f12508c68d" />


## Related product discussion/links
* NL-717

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a **private** site (Settings → Reading → not public/coming-soon), go to **Jetpack → Newsletter** settings and scroll to the **Email content** section.
* Confirm the yellow warning notice now has clear vertical spacing below it, separating it from the "Include the post's featured image in the new post emails" toggle (previously they were flush/cramped).
* On a public site, the notice should not appear at all (unchanged behavior).
