### PR TITLE
Newsletter: link to site visibility settings from Coming Soon notice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-721-coming-soon-site-visibility-link
+++ b/projects/plugins/jetpack/changelog/fix-nl-721-coming-soon-site-visibility-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: link to the site visibility settings from the Coming Soon notice in the pre-publish panel.

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -462,7 +462,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		);
 	} else if ( isComingSoon() ) {
 		text = __(
-			'Your site is in Coming Soon mode. Emails are sent only when your site is public.',
+			'Your site is in Coming Soon mode. Emails are sent only when your site is public. <visibilityLink>Update your site visibility</visibilityLink>.',
 			'jetpack'
 		);
 	} else if ( isSendingInProgress ) {
@@ -495,6 +495,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 				{ createInterpolateElement( text, {
 					strong: <strong />,
 					link: <a href={ getJetpackEmailStatsLink( blogId, postId ) } />,
+					visibilityLink: <a href={ getSiteVisibilitySettingsLink() } />,
 				} ) }
 			</p>
 			{ showWontResendMessage && (
@@ -522,6 +523,17 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
  */
 export function getJetpackEmailStatsLink( blogId, postId ) {
 	return getAdminUrl( `admin.php?page=stats#!/stats/email/opens/day/${ postId }/${ blogId }` );
+}
+
+/**
+ * Get the link to the site visibility settings, where a user can take their site
+ * out of Coming Soon mode. The Coming Soon / privacy controls live on the Reading
+ * settings page (see the `blog_privacy_selector` hook).
+ *
+ * @return {string} - The admin URL for the Reading settings page.
+ */
+export function getSiteVisibilitySettingsLink() {
+	return getAdminUrl( 'options-reading.php' );
 }
 
 export default SubscribersAffirmation;

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
@@ -8,6 +8,7 @@ import {
 	shouldShowWontResendMessage,
 	getSentCopyLine,
 	getJetpackEmailStatsLink,
+	getSiteVisibilitySettingsLink,
 } from '../subscribers-affirmation';
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
@@ -372,5 +373,18 @@ describe( 'getJetpackEmailStatsLink', () => {
 		expect( result ).toBe(
 			'https://admin.example.com/admin.php?page=stats#!/stats/email/opens/day/456/123'
 		);
+	} );
+} );
+
+describe( 'getSiteVisibilitySettingsLink', () => {
+	beforeEach( () => {
+		getAdminUrl.mockClear();
+	} );
+
+	test( 'links to the Reading settings page where site visibility is changed', () => {
+		const result = getSiteVisibilitySettingsLink();
+
+		expect( getAdminUrl ).toHaveBeenCalledWith( 'options-reading.php' );
+		expect( result ).toBe( 'https://admin.example.com/options-reading.php' );
 	} );
 } );


### PR DESCRIPTION
Fixes NL-721

## Proposed changes

When a site is in Coming Soon mode, the Newsletter subscribers affirmation panel (pre-publish and post-publish) explained that emails are only sent once the site is public — but gave the user no way to get to the setting that controls that.

* Append an **"Update your site visibility"** link to the Coming Soon notice in `subscribers-affirmation.js`.
* The link points to the Reading settings page (`options-reading.php`), which is where the wpcom Coming Soon / Launch / privacy controls render (via the `blog_privacy_selector` hook used by the mu-wpcom `replace-site-visibility` feature). This destination works for Simple, Atomic, and self-hosted contexts.
* Add a `getSiteVisibilitySettingsLink()` helper (mirroring the existing `getJetpackEmailStatsLink()`) and wire a new `<visibilityLink>` token into the existing `createInterpolateElement` map.

## Related product discussion/links

* NL-721

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Use a WordPress.com site (Simple or Atomic) that is in **Coming Soon** mode.
2. Create or edit a post and open the **Newsletter** / pre-publish panel where the subscribers affirmation appears.
3. Confirm the notice now reads: *"Your site is in Coming Soon mode. Emails are sent only when your site is public. Update your site visibility."*
4. Confirm **"Update your site visibility"** is a link that opens the Reading settings page (`options-reading.php`), where the site visibility / Coming Soon controls live.
5. Confirm the rest of the affirmation copy (already sent, sending in progress, will be sent, etc.) is unchanged.

Automated: `jest --config=tests/jest.config.extensions.js extensions/shared/memberships/test/subscribers-affirmation-test.js` — 40/40 pass, including a new regression test for `getSiteVisibilitySettingsLink()`.
