### PR TITLE
AI Assistant Banner: stack layout on mobile

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-06-30-09-11-53-323782
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-06-30-09-11-53-323782
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the AI assistant dashboard banner layout on mobile so the copy reflows full width and the button stacks below.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -63,20 +63,43 @@ function wpcom_render_ai_assistant_banner() {
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
 	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
-		<div style="display: flex; align-items: center; gap: 16px; padding: 4px 0;">
+		<div class="wpcom-ai-assistant-banner__layout">
 			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
 			</svg>
-			<div style="flex: 1;">
-				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong><br>
-				<?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?>
+			<div class="wpcom-ai-assistant-banner__body">
+				<div class="wpcom-ai-assistant-banner__text">
+					<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong><br>
+					<?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?>
+				</div>
+				<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary">
+					<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
+				</a>
 			</div>
-			<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary">
-				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
-			</a>
 		</div>
 	</div>
 	<style>
+		#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__layout {
+			display: flex;
+			align-items: center;
+			gap: 16px;
+			padding: 4px 0;
+		}
+		#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__layout > svg {
+			flex-shrink: 0;
+		}
+		#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__body {
+			display: flex;
+			align-items: center;
+			gap: 16px;
+			flex: 1;
+		}
+		#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__text {
+			flex: 1;
+		}
+		#wpcom-ai-assistant-banner .button-secondary {
+			white-space: nowrap;
+		}
 		#wpcom-ai-assistant-banner .notice-dismiss {
 			top: 50%;
 			transform: translateY(-50%);
@@ -86,6 +109,35 @@ function wpcom_render_ai_assistant_banner() {
 			font-family: inherit;
 			color: #787c82;
 			background: none;
+		}
+		@media ( max-width: 782px ) {
+			#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__layout {
+				align-items: flex-start;
+				gap: 8px;
+			}
+			#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__layout > svg {
+				width: 18px;
+				height: 18px;
+				margin-top: 4px;
+			}
+			/* Stack the copy and button, keeping both aligned to the text column rather than under the icon. */
+			#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__body {
+				flex-direction: column;
+				align-items: flex-start;
+				gap: 12px;
+			}
+			#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__text {
+				font-size: 13px;
+				line-height: 1.5;
+			}
+			#wpcom-ai-assistant-banner .wpcom-ai-assistant-banner__text strong {
+				font-size: 14px;
+			}
+			/* Keep the dismiss control top-right like every other notice, lined up with the title. */
+			#wpcom-ai-assistant-banner .notice-dismiss {
+				top: 8px;
+				transform: none;
+			}
 		}
 	</style>
 	<?php


### PR DESCRIPTION
## Proposed changes

The WordPress.com dashboard "Bring AI to your site" banner laid out its icon, copy, and "Enable AI assistant" button in a single inline flex row that never reflowed. On narrow/mobile viewports the button held its desktop width, squeezing the copy into a thin column that wrapped after every couple of words.

This moves the banner layout out of inline styles and adds a `max-width: 782px` breakpoint (WP's standard admin mobile breakpoint) that stacks it: the copy goes full width and the button wraps underneath it. The dismiss control stays in the top-right, like every other admin notice. Above the breakpoint the original single-row layout is unchanged. Markup conditions and JS are untouched — the change is purely presentational.

## Related product discussion/links

* DSGCOM-667

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Big Sky–eligible test site, load `/wp-admin/` as an admin who hasn't dismissed the banner.
* Confirm the "Bring AI to your site" banner appears.
* Above 782px wide: icon, copy, and button sit on one row (unchanged).
* Narrow the viewport below 782px: the copy reflows full width and the "Enable AI assistant" button wraps beneath it, while the dismiss X stays in the top-right.

## Before / after (mobile, 390px)

Rendered in a wp-admin notice harness at a 390px-wide viewport (the banner is gated behind WordPress.com Big Sky features, so it can't render on a stock Jurassic Ninja site).

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/dsgcom-667-ai-banner-mobile/mobile-before.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/dsgcom-667-ai-banner-mobile/mobile-after.png) |

Before, the button held its desktop row and squeezed the copy into a thin, badly-wrapping column. After, the copy goes full width and the button wraps underneath it, with the dismiss X kept in the top-right.
