### PR TITLE
Agents Manager: gate editor Ask AI button on is_enabled() instead of dev mode

### DIFF
--- a/projects/packages/agents-manager/changelog/update-agents-manager-ai-button-is-enabled
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-ai-button-is-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show the editor Ask AI button whenever Agents Manager is enabled, instead of only in dev contexts.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -272,8 +272,8 @@ class Agents_Manager {
 		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, expose the entry
 		// points in that editor admin bar (CIAB is excluded — it has its own Site Hub UI). The Help
 		// "?" dropdown shows only in the full unified experience (mirroring wp-admin); the Ask AI
-		// button shows in any dev/internal context while the feature is in development. The
-		// wp-calypso admin-bar integration wires both, so no frontend change is needed.
+		// button shows whenever Agents Manager is enabled in this editor. The wp-calypso admin-bar
+		// integration wires both, so no frontend change is needed.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
 			if ( self::is_unified_experience() ) {
@@ -287,8 +287,8 @@ class Agents_Manager {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
-			// Ask AI button — dev/internal contexts only while the feature is in development.
-			if ( self::is_dev_mode() ) {
+			// Ask AI button — shown whenever Agents Manager is enabled in this editor context.
+			if ( self::is_enabled() ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -639,10 +639,12 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Puts the current request into a block-editor screen with Agents Manager enabled
-	 * (block-editor-only, no unified experience), so the editor omnibar branch is reachable.
+	 * Puts the current request into a block-editor screen so the editor omnibar branch is reachable.
+	 *
+	 * @param bool $enable Whether to enable Agents Manager in the block editor (block-editor-only,
+	 *                     no unified experience). Pass false to exercise the not-enabled path.
 	 */
-	private function set_up_block_editor_request() {
+	private function set_up_block_editor_request( $enable = true ) {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'post' );
 		$screen     = get_current_screen();
@@ -654,19 +656,21 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$property->setValue( $screen, true );
 
 		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
-		add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+
+		if ( $enable ) {
+			add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+		}
 	}
 
 	/**
-	 * Tests that the Ask AI button is added to the editor admin bar when the omnibar experiment
-	 * is active in a dev/internal context (here, a proxied request).
+	 * Tests that the Ask AI button is added to the editor admin bar when the omnibar experiment is
+	 * active and Agents Manager is enabled — independent of dev mode (here, a non-proxied request).
 	 */
 	public function test_ai_chat_button_registered_in_editor_omnibar() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
 		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -679,14 +683,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Tests that the Ask AI button is not added to the editor admin bar when the omnibar
-	 * experiment is inactive, even in a dev/internal context.
+	 * experiment is inactive, even though Agents Manager is enabled.
 	 */
 	public function test_ai_chat_button_not_registered_in_editor_without_omnibar() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
 		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( false );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -698,23 +701,20 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the Ask AI button is not added to the editor admin bar outside dev/internal
-	 * contexts, even when the omnibar experiment is active.
+	 * Tests that the Ask AI button is not added to the editor admin bar when Agents Manager is
+	 * not enabled, even while the omnibar experiment is active.
 	 */
-	public function test_ai_chat_button_not_registered_in_editor_outside_dev_mode() {
-		$this->set_up_block_editor_request();
+	public function test_ai_chat_button_not_registered_in_editor_when_not_enabled() {
+		$this->set_up_block_editor_request( false );
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
 		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( false );
 
 		$this->agents_manager->enqueue_scripts();
 
 		$this->assertFalse(
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
 		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* The editor **Omnibar** Ask AI button (added server-side to Gutenberg's "admin bar in editor" admin bar) was gated on `is_dev_mode()`, so it only showed in dev/internal contexts while the feature was in development. It is now gated on `is_enabled()`, so it appears whenever Agents Manager is enabled in the editor — mirroring the `is_unified_experience()` gate used for the Help "?" node right above it.
* Updated the related PHP tests: the "registered" case now proves the button shows independent of dev mode, and the stale "outside dev mode" case is replaced by a "not enabled" case.
* `is_dev_mode()` itself is unchanged and still used elsewhere (the `isDevMode` inline-data flag for tracking, the dev cache-buster, and `should_use_unified_experience()`).

Note: the matching **Toolbar** (editor header pinned-items button) is gated client-side in the Calypso `agents-manager` package and is updated in a separate wp-calypso PR.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Sandbox this PR
* Go to `https://<YOUR_SITE>/wp-admin/admin.php?page=experiments-wp-admin`, and enable the "Toolbar in editor" option
  * You may see an error message, but the Omnibar will still be enabled
* Go to the editor, and the AI entry button will be shown in the Omni-bar
  * Ensure no duplicated AI entry button
