### PR TITLE
docs: document cookie consent lifecycle event API

### DIFF
--- a/projects/packages/cookie-consent/README.md
+++ b/projects/packages/cookie-consent/README.md
@@ -89,6 +89,57 @@ add_filter(
 );
 ```
 
+## Public APIs
+
+### Gating scripts on consent
+
+Consumers that need to gate their own scripts on visitor consent should use the
+WP Consent API directly, not a Cookie Consent lifecycle event:
+
+- JavaScript: call `window.wp_has_consent( category )` for the initial state and
+  listen for the `wp_listen_for_consent_change` DOM event for changes.
+- PHP: call `wp_has_consent( category )` before rendering or enqueueing gated
+  server-side output.
+
+The canonical integration pattern is `woocommerce-analytics`: it gates tracking
+with the WP Consent API state and change event because those APIs model consent
+categories across providers.
+
+### `wp_consent_saved`
+
+Cookie Consent dispatches `wp_consent_saved` on `window` after it writes a
+visitor choice through the WP Consent API. This event is public API and follows
+the package's backward-compatibility policy for documented APIs.
+
+```js
+window.addEventListener( 'wp_consent_saved', event => {
+	const { eventType, choices } = event.detail;
+} );
+```
+
+The event detail has this stable shape:
+
+```ts
+type CookieConsentSavedDetail = {
+	eventType:
+		| 'accept_all'
+		| 'accept_selected'
+		| 'reject_all'
+		| 'auto_granted'
+		| 'opt-out';
+	choices: Partial< Record< string, boolean > >;
+};
+```
+
+`choices` is keyed by Cookie Consent category keys (`consent.categories`;
+currently `analytics` and `advertising`), not raw WP Consent API category names,
+and each present value indicates whether that category was allowed. Use
+`eventType` when you need to distinguish the user action behind the saved choice.
+Use the WP Consent API for category-state gating.
+
+`wp_consent_type_defined` remains an internal implementation event and is not
+part of the public API surface.
+
 ## Theming and customization
 
 The banner, modal, category toggles, and footer-links fallback control are styled from namespaced CSS custom properties (design tokens) with self-contained defaults, so they render consistently regardless of the active theme. The tokens are deliberately **not** derived from theme presets (`--wp--preset--*`): a theme that defines those presets for its own layout (a small spacing scale, an inverted palette, etc.) cannot break or recolor the consent UI.

--- a/projects/packages/cookie-consent/changelog/auto-WOOA7S-1598
+++ b/projects/packages/cookie-consent/changelog/auto-WOOA7S-1598
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Document the public cookie consent lifecycle event and WP Consent API script-gating guidance.

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -11,6 +11,7 @@ import {
 	handleConsentByRegion,
 	isGdprCountry,
 	pertainsToCCPA,
+	saveConsentChoices,
 	setCookie,
 } from '../src/modules/cookie-consent/utils';
 
@@ -200,6 +201,53 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 
 		expect( context.showBanner ).toBe( false );
 		expect( wasDenied( 'statistics' ) ).toBe( true );
+	} );
+} );
+
+describe( 'saveConsentChoices', () => {
+	let consentCalls: Array< [ string, string ] >;
+
+	beforeEach( () => {
+		consentCalls = [];
+		window.wp_set_consent = ( category: string, state: string ) => {
+			consentCalls.push( [ category, state ] );
+		};
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { wp_set_consent?: unknown } ).wp_set_consent;
+	} );
+
+	it( 'dispatches the public wp_consent_saved event with event type and category choices', () => {
+		let savedEvent: CustomEvent | undefined;
+		const listener = ( event: Event ) => {
+			savedEvent = event as CustomEvent;
+		};
+		window.addEventListener( 'wp_consent_saved', listener );
+
+		saveConsentChoices(
+			{
+				analytics: true,
+				advertising: false,
+			},
+			'accept_selected'
+		);
+
+		window.removeEventListener( 'wp_consent_saved', listener );
+
+		expect( consentCalls ).toEqual( [
+			[ 'functional', 'allow' ],
+			[ 'statistics', 'allow' ],
+			[ 'statistics-anonymous', 'allow' ],
+			[ 'marketing', 'deny' ],
+		] );
+		expect( savedEvent?.detail ).toEqual( {
+			eventType: 'accept_selected',
+			choices: {
+				analytics: true,
+				advertising: false,
+			},
+		} );
 	} );
 } );
 


### PR DESCRIPTION
Fixes WOOA7S-1598

## Proposed changes
* Document `wp_consent_saved` as the public Cookie Consent lifecycle event, including the stable `event.detail.eventType` and `event.detail.choices` shape.
* Document that consumers should gate scripts through the WP Consent API (`wp_has_consent` / `wp_listen_for_consent_change`) rather than a Cookie Consent-specific lifecycle event.
* Clarify that `wp_consent_type_defined` remains internal, and add Jest coverage for the public `wp_consent_saved` payload contract.

## Related product discussion/links
* WOOA7S-1598
* WOOA7S-1603

## Does this pull request change what data or activity we track or use?
No. This documents an existing lifecycle event and adds test coverage for its payload; it does not change tracking behavior or collected data.

## Testing instructions

1. In a local WordPress site with the Cookie Consent package loaded by a consuming plugin and the WP Consent API plugin active, visit the front end with `?preview_cookie_consent=1`.
2. In the browser console, add a listener for `wp_consent_saved` that logs `event.detail`.
3. Save a consent choice from the banner, such as accepting all or saving custom preferences.
4. Review `projects/packages/cookie-consent/README.md`, especially the `Public APIs` section.

- Expected: the console output includes an `eventType` matching the user action and `choices` keyed by Cookie Consent category keys such as `analytics` and `advertising`.
- Expected: the README directs category-state script gating to the WP Consent API and describes `wp_consent_type_defined` as internal.