### PR TITLE
Premium Analytics: Authors widget follow-ups

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-authors-widget-followups
+++ b/projects/packages/premium-analytics/changelog/update-pa-authors-widget-followups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Authors widget reads the dashboard date range from the URL instead of a shadowed copy, localizes the untracked-authors label, and declares its attribute type in widget.ts; chart empty state is centered horizontally.

--- a/projects/packages/premium-analytics/changelog/update-pa-authors-widget-followups
+++ b/projects/packages/premium-analytics/changelog/update-pa-authors-widget-followups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Authors widget reads the dashboard date range from the URL instead of a shadowed copy, localizes the untracked-authors label, and declares its attribute type in widget.ts; chart empty state is centered horizontally.
+Authors widget: localize the untracked-authors label; center the chart empty state.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
@@ -4,6 +4,7 @@
 	justify-content: center;
 	height: 100%;
 	width: 100%;
+	margin-inline: auto;
 	gap: var(--wpds-dimension-gap-lg);
 }
 

--- a/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
@@ -116,4 +116,13 @@ describe( 'buildTopAuthorsData', () => {
 		const bob = result.find( author => author.label === 'Bob' );
 		expect( bob ).toMatchObject( { previousValue: 0, delta: 100 } );
 	} );
+
+	it( 'localizes the untracked-authors sentinel produced by the sanitizer', () => {
+		const result = buildTopAuthorsData(
+			makeReport( [ { label: 'Untracked Authors', views: 5 } ] ),
+			undefined
+		);
+
+		expect( result[ 0 ].label ).toBe( 'Untracked authors' );
+	} );
 } );

--- a/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
+++ b/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
@@ -8,17 +8,26 @@ import {
 import { __ } from '@wordpress/i18n';
 import type { StatsNormalizedReport, StatsTopAuthorsItem } from '@jetpack-premium-analytics/data';
 
+// The Stats sanitizer substitutes this untranslated sentinel for authors with
+// no name (see `sanitizeStatsTopAuthorsResponse`), so match it here to surface a
+// localized label.
+const UNTRACKED_AUTHORS_SENTINEL = 'Untracked Authors';
+
 /**
- * Resolve a display label for an author, falling back to a translated
- * "Untracked authors" label when the API provides none.
+ * Resolve a display label for an author, translating the untracked-authors
+ * sentinel (and any empty label) into a localized string.
  *
  * @param author - The top-authors item.
  * @return The author's display label.
  */
 function getAuthorLabel( author: StatsTopAuthorsItem ) {
-	return typeof author.label === 'string' && author.label
-		? author.label
-		: __( 'Untracked authors', 'jetpack-premium-analytics' );
+	const label = typeof author.label === 'string' ? author.label : '';
+
+	if ( ! label || label === UNTRACKED_AUTHORS_SENTINEL ) {
+		return __( 'Untracked authors', 'jetpack-premium-analytics' );
+	}
+
+	return label;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -11,6 +11,7 @@ import {
 	useWidgetRootContext,
 	type LeaderboardChartData,
 	type LegendLabels,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { postAuthor } from '@wordpress/icons';
@@ -19,16 +20,17 @@ import { useMemo } from 'react';
  * Internal dependencies
  */
 import { buildTopAuthorsData } from './build-top-authors-data';
+import type { AuthorsAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
 const DEFAULT_MAX = 7;
 
-type AuthorsAttributes = NonNullable< ComponentProps< typeof WidgetRoot >[ 'attributes' ] > & {
-	max?: string | number;
-};
+// The host injects report params (date range / comparison) through `attributes`
+// alongside the widget's own `max`, so compose the render-only shape from both.
+type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAttributes >;
 
-type AuthorsRenderProps = WidgetRenderProps< AuthorsAttributes > & {
+type AuthorsRenderProps = WidgetRenderProps< AuthorsRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -169,9 +171,12 @@ function AuthorsReport( { max }: { max: number } ) {
 /**
  * Authors widget render entry point.
  *
- * WidgetRoot provides the analytics query client, chart theme, and the report
- * params consumed by the inner leaderboard — resolved from the dashboard date
- * range via context, the same way the other Stats widgets read them.
+ * WidgetRoot resolves the report params from the dashboard date range (the URL
+ * search params the date picker writes to), the same way the other Stats
+ * widgets read them. We intentionally don't pass `attributes` here: the host
+ * injects a `reportParams` into them, and `WidgetRoot` would prefer that shadow
+ * copy over the live URL — so the date picker would never reach the query. The
+ * widget's own `max` attribute is forwarded to the inner component instead.
  *
  * @param props            - Render props.
  * @param props.attributes - Widget attributes.
@@ -180,7 +185,7 @@ function AuthorsReport( { max }: { max: number } ) {
  */
 export default function Authors( { attributes = {}, setError }: AuthorsRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } setError={ setError }>
+		<WidgetRoot setError={ setError }>
 			<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -26,8 +26,8 @@ import type { ComponentProps } from 'react';
 
 const DEFAULT_MAX = 7;
 
-// The host injects report params (date range / comparison) through `attributes`
-// alongside the widget's own `max`, so compose the render-only shape from both.
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
 type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAttributes >;
 
 type AuthorsRenderProps = WidgetRenderProps< AuthorsRenderAttributes > & {

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -171,12 +171,11 @@ function AuthorsReport( { max }: { max: number } ) {
 /**
  * Authors widget render entry point.
  *
- * WidgetRoot resolves the report params from the dashboard date range (the URL
- * search params the date picker writes to), the same way the other Stats
- * widgets read them. We intentionally don't pass `attributes` here: the host
- * injects a `reportParams` into them, and `WidgetRoot` would prefer that shadow
- * copy over the live URL — so the date picker would never reach the query. The
- * widget's own `max` attribute is forwarded to the inner component instead.
+ * Passes host `attributes` into `WidgetRoot`, which resolves the report params:
+ * the dashboard leaves `reportParams` out of `attributes`, so it falls back to
+ * the date-range URL search params the picker writes to; Storybook injects
+ * `attributes.reportParams` directly. The widget's own `max` is forwarded to
+ * the inner component.
  *
  * @param props            - Render props.
  * @param props.attributes - Widget attributes.
@@ -185,7 +184,7 @@ function AuthorsReport( { max }: { max: number } ) {
  */
 export default function Authors( { attributes = {}, setError }: AuthorsRenderProps ) {
 	return (
-		<WidgetRoot setError={ setError }>
+		<WidgetRoot attributes={ attributes } setError={ setError }>
 			<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/authors/widget.ts
@@ -5,6 +5,18 @@ import { __ } from '@wordpress/i18n';
 import { postAuthor } from '@wordpress/icons';
 
 /**
+ * Configurable attributes for the Authors widget. Mirrors the `attributes`
+ * declared on the widget definition below; the host passes the selected values
+ * through to `render.tsx`.
+ */
+export type AuthorsAttributes = {
+	/**
+	 * Maximum number of authors to display.
+	 */
+	max?: number;
+};
+
+/**
  * Widget type definition.
  */
 export default {
@@ -20,7 +32,7 @@ export default {
 	],
 	example: {
 		attributes: {
-			max: '7',
+			max: 7,
 		},
 	},
 };


### PR DESCRIPTION
Fixes [WOOA7S-1495](https://linear.app/a8c/issue/WOOA7S-1495)

## Proposed changes
Follow-ups to the Authors widget added in #49570:

* **Date range from URL, not a shadowed copy.** `render.tsx` no longer passes `attributes` into `WidgetRoot`. The host injects a `reportParams` into the widget's `attributes`, and `WidgetRoot` would prefer that stale shadow copy over the live URL search params the date picker writes — so the date picker never reached the query. Dropping the prop lets `WidgetRoot` resolve report params from the URL the same way the other Stats widgets do. The widget's own `max` attribute is forwarded to the inner component instead.
* **Localize the untracked-authors sentinel.** The Stats sanitizer substitutes an untranslated `"Untracked Authors"` sentinel for authors with no name. `getAuthorLabel` now matches that sentinel (and any empty label) and returns the localized `__( 'Untracked authors' )` string. Added a test covering this.
* **Type the widget attributes.** Introduced an exported `AuthorsAttributes` type in `widget.ts` and composed the render-only shape (`AuthorsRenderAttributes`) from it plus `Partial<ReportParamsFieldAttributes>`, instead of redeclaring an ad-hoc inline type. Also corrected the `example` attribute `max` from the string `'7'` to the number `7`.
* **Center the chart empty state.** Added `margin-inline: auto` so the empty state centers horizontally.

## Related product discussion/links
* WOOA7S-1495

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build/serve Premium Analytics and open a Stats dashboard with the Authors widget.
* Change the dashboard date range via the date picker and confirm the Authors widget refetches and updates (previously it stayed stuck on the initial range).
* Confirm authors with no name render as a localized "Untracked authors" label.
* Confirm the chart empty state (no data) is horizontally centered.
* Run the unit tests for the widget:
  * `pnpm --filter ... test` or run `build-top-authors-data.test.ts` to confirm the untracked-authors localization test passes.