### PR TITLE
SEO: convert schema output to an @graph and add a site-level Organization node

### DIFF
--- a/projects/packages/seo/changelog/add-seo-schema-organization-graph
+++ b/projects/packages/seo/changelog/add-seo-schema-organization-graph
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-SEO: emit a site-level Organization JSON-LD node and convert schema output to a multi-node @graph; the Article node now references the Organization as its publisher.
+Add a site-level Organization node and output schema as a multi-node @graph.

--- a/projects/packages/seo/changelog/add-seo-schema-organization-graph
+++ b/projects/packages/seo/changelog/add-seo-schema-organization-graph
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+SEO: emit a site-level Organization JSON-LD node and convert schema output to a multi-node @graph; the Article node now references the Organization as its publisher.

--- a/projects/packages/seo/src/class-organization-schema-node.php
+++ b/projects/packages/seo/src/class-organization-schema-node.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Site-level Organization Schema.org node builder.
+ *
+ * Builds the Organization JSON-LD node that represents the site as a publishing
+ * entity. Most properties come straight from existing site identity — Site Title,
+ * site URL, Site Logo / Site Icon, and Tagline — so the node is useful with zero
+ * configuration. Properties with no WordPress source (social profiles `sameAs`,
+ * `email`) come from the schema settings, passed in via `$settings`; they are
+ * simply omitted until configured, so an unconfigured site still emits a valid
+ * node.
+ *
+ * The `$settings` argument is the seam the "Organization / Business info" settings
+ * UI plugs into later: it may carry admin overrides for the site-identity fields
+ * plus the `sameAs` / `email` values WordPress can't supply. Today the graph passes
+ * an empty array, so the node is built purely from site identity.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Builds the site-level Organization node.
+ */
+class Organization_Schema_Node {
+
+	/**
+	 * Build the Organization node, or null when the site has no name to identify
+	 * it (an Organization entity with no name is not useful, so we emit nothing
+	 * rather than something invalid).
+	 *
+	 * @param array $settings Optional schema settings: `name`, `description`,
+	 *                        `sameAs` (array of URLs), `email`. Empty values fall
+	 *                        back to site identity (or are omitted entirely).
+	 * @return array|null
+	 */
+	public static function build( array $settings = array() ) {
+		$name = self::text( $settings['name'] ?? '' );
+		if ( '' === $name ) {
+			$name = self::text( get_bloginfo( 'name' ) );
+		}
+		if ( '' === $name ) {
+			return null;
+		}
+
+		$node = array(
+			'@type' => 'Organization',
+			'@id'   => Schema_Node_Ids::organization(),
+			'name'  => $name,
+			'url'   => home_url( '/' ),
+		);
+
+		$description = self::text( $settings['description'] ?? '' );
+		if ( '' === $description ) {
+			$description = self::text( get_bloginfo( 'description' ) );
+		}
+		if ( '' !== $description ) {
+			$node['description'] = $description;
+		}
+
+		$logo = self::logo();
+		if ( null !== $logo ) {
+			$node['logo'] = $logo;
+		}
+
+		$same_as = self::url_list( $settings['sameAs'] ?? array() );
+		if ( ! empty( $same_as ) ) {
+			$node['sameAs'] = $same_as;
+		}
+
+		$email = isset( $settings['email'] ) ? sanitize_email( (string) $settings['email'] ) : '';
+		if ( '' !== $email ) {
+			// Only from explicit settings — never auto-filled from admin_email.
+			$node['email'] = $email;
+		}
+
+		return $node;
+	}
+
+	/**
+	 * The site logo as an ImageObject: the Site Logo (Customizer) when set,
+	 * otherwise the Site Icon. Null when the site has neither.
+	 *
+	 * @return array|null
+	 */
+	private static function logo() {
+		$custom_logo_id = get_theme_mod( 'custom_logo' );
+		if ( $custom_logo_id ) {
+			$src = wp_get_attachment_image_src( $custom_logo_id, 'full' );
+			if ( is_array( $src ) && ! empty( $src[0] ) ) {
+				$image = array(
+					'@type' => 'ImageObject',
+					'url'   => $src[0],
+				);
+				if ( ! empty( $src[1] ) && ! empty( $src[2] ) ) {
+					$image['width']  = (int) $src[1];
+					$image['height'] = (int) $src[2];
+				}
+				return $image;
+			}
+		}
+
+		$icon_url = get_site_icon_url();
+		if ( $icon_url ) {
+			return array(
+				'@type' => 'ImageObject',
+				'url'   => $icon_url,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a scalar setting/site value to trimmed plain text.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private static function text( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		return trim( wp_strip_all_tags( $value ) );
+	}
+
+	/**
+	 * Normalize a list of profile URLs (`sameAs`): keep only non-empty, valid URLs.
+	 *
+	 * @param mixed $value Raw value (expected to be an array of URLs).
+	 * @return array<int, string>
+	 */
+	private static function url_list( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$urls = array();
+		foreach ( $value as $url ) {
+			if ( ! is_string( $url ) ) {
+				continue;
+			}
+			$clean = esc_url_raw( trim( $url ) );
+			if ( '' !== $clean ) {
+				$urls[] = $clean;
+			}
+		}
+
+		return array_values( array_unique( $urls ) );
+	}
+}

--- a/projects/packages/seo/src/class-organization-schema-node.php
+++ b/projects/packages/seo/src/class-organization-schema-node.php
@@ -141,7 +141,18 @@ class Organization_Schema_Node {
 			if ( ! is_string( $url ) ) {
 				continue;
 			}
-			$clean = esc_url_raw( trim( $url ) );
+
+			$url = trim( $url );
+			if ( '' === $url ) {
+				continue;
+			}
+
+			$validated = wp_http_validate_url( $url );
+			if ( false === $validated ) {
+				continue;
+			}
+
+			$clean = esc_url_raw( $validated, array( 'http', 'https' ) );
 			if ( '' !== $clean ) {
 				$urls[] = $clean;
 			}

--- a/projects/packages/seo/src/class-post-schema-node.php
+++ b/projects/packages/seo/src/class-post-schema-node.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Per-post Schema.org node builder.
+ *
+ * Builds the page-level JSON-LD node for the queried singular post: Article (the
+ * default for standard posts) and FAQPage (when the post uses `core/details`
+ * blocks). The type follows the per-post `jetpack_seo_schema_type` override when
+ * set, otherwise a sensible default by post type. Returns an array node or null
+ * when the post should not emit structured data, so the graph can skip it.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use Jetpack_SEO_Posts;
+use WP_Post;
+
+/**
+ * Builds the Article / FAQPage node for a single post.
+ */
+class Post_Schema_Node {
+
+	/**
+	 * Max words kept for a schema `description`, so a long post body doesn't
+	 * dump its full content into the markup.
+	 */
+	const DESCRIPTION_MAX_WORDS = 55;
+
+	/**
+	 * Build the JSON-LD node for the queried post, or null when none applies.
+	 *
+	 * @param WP_Post|null $post The queried post.
+	 * @return array|null
+	 */
+	public static function build( $post ) {
+		if ( ! ( $post instanceof WP_Post ) ) {
+			return null;
+		}
+
+		// Only emit structured data for published content. Previews, drafts, and
+		// private posts are viewable by logged-in users (and may be edge-cached),
+		// so we must not output JSON-LD for anything that isn't publicly published.
+		if ( 'publish' !== $post->post_status ) {
+			return null;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Posts lives in plugins/jetpack; Schema_Builder::emit() guards on class_exists.
+		$override = Jetpack_SEO_Posts::get_post_schema_type( $post );
+		$type     = '' !== $override ? $override : self::default_schema_for_post( $post );
+
+		switch ( $type ) {
+			case 'faq':
+				return self::build_faq( $post );
+			case 'article':
+				return self::build_article( $post );
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Default Schema type for a post when the user has not set an override:
+	 * Article for standard posts, none for pages, attachments, or custom types.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return string
+	 */
+	private static function default_schema_for_post( WP_Post $post ) {
+		// Only standard posts get Article schema by default; everything else
+		// (pages, attachments, custom post types) requires an explicit override.
+		return 'post' === $post->post_type ? 'article' : '';
+	}
+
+	/**
+	 * Article JSON-LD.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return array
+	 */
+	private static function build_article( WP_Post $post ) {
+		$node = array(
+			'@type'            => 'Article',
+			'headline'         => wp_strip_all_tags( get_the_title( $post ) ),
+			'datePublished'    => get_post_time( 'c', true, $post ),
+			'dateModified'     => get_post_modified_time( 'c', true, $post ),
+			'mainEntityOfPage' => array(
+				'@type' => 'WebPage',
+				'@id'   => get_permalink( $post ),
+			),
+			'author'           => array(
+				'@type' => 'Person',
+				'name'  => get_the_author_meta( 'display_name', (int) $post->post_author ),
+			),
+		);
+
+		$image = get_the_post_thumbnail_url( $post, 'full' );
+		if ( $image ) {
+			$node['image'] = $image;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Posts lives in plugins/jetpack; Schema_Builder::emit() guards on class_exists.
+		$description = Jetpack_SEO_Posts::get_post_description( $post );
+		if ( $description ) {
+			// Cap it: get_post_description() falls back to full post_content, which
+			// would otherwise dump the whole body into the markup.
+			$node['description'] = wp_trim_words( wp_strip_all_tags( $description ), self::DESCRIPTION_MAX_WORDS, '' );
+		}
+
+		return $node;
+	}
+
+	/**
+	 * FAQPage JSON-LD, parsed from `core/details` blocks (summary = question,
+	 * rendered content = answer). Returns null when the post has none, so we
+	 * never emit an empty/invalid FAQPage.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return array|null
+	 */
+	private static function build_faq( WP_Post $post ) {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			return null;
+		}
+
+		$items = array();
+		foreach ( parse_blocks( $post->post_content ) as $block ) {
+			if ( 'core/details' !== ( $block['blockName'] ?? '' ) ) {
+				continue;
+			}
+			$question = trim( (string) ( $block['attrs']['summary'] ?? '' ) );
+
+			// Render only the inner blocks for the answer. Rendering the whole
+			// core/details block would re-include the <summary> (the question).
+			$answer_html = '';
+			foreach ( $block['innerBlocks'] ?? array() as $inner_block ) {
+				$answer_html .= render_block( $inner_block );
+			}
+			$answer = trim( wp_strip_all_tags( $answer_html ) );
+			if ( '' === $question || '' === $answer ) {
+				continue;
+			}
+			$items[] = array(
+				'@type'          => 'Question',
+				'name'           => $question,
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => $answer,
+				),
+			);
+		}
+
+		if ( empty( $items ) ) {
+			return null;
+		}
+
+		return array(
+			'@type'      => 'FAQPage',
+			'mainEntity' => $items,
+		);
+	}
+}

--- a/projects/packages/seo/src/class-schema-builder.php
+++ b/projects/packages/seo/src/class-schema-builder.php
@@ -2,35 +2,28 @@
 /**
  * JSON-LD Schema.org markup emitter.
  *
- * Emits per-post structured data into the document `<head>`: Article (the
- * default for posts) and FAQPage (when the post uses `core/details` blocks).
- * The type follows the per-post `jetpack_seo_schema_type` override when set,
- * otherwise a sensible default by post type. Emission is gated on
+ * Serializes a Schema.org `@graph` document into the document `<head>` for the
+ * current singular request. The graph stitches together the page node (Article,
+ * or FAQPage when the post uses `core/details` blocks) built by
+ * {@see Post_Schema_Node}; site-level nodes (Organization, WebSite, …) join the
+ * same graph and cross-reference the page node by `@id`. Emission is gated on
  * `Jetpack_SEO_Utils::is_enabled_jetpack_seo()`.
  *
- * Organization / LocalBusiness (site-level) and HowTo are intentionally out of
- * scope here — they need backing config / structured input. See JETPACK-1701
- * (Expanded schema markup project).
+ * This class owns only the gating and serialization; the individual nodes and
+ * their stable `@id`s live in their own builders ({@see Post_Schema_Node},
+ * {@see Schema_Node_Ids}) and are assembled by {@see Schema_Graph}.
  *
  * @package automattic/jetpack-seo-package
  */
 
 namespace Automattic\Jetpack\SEO;
 
-use Jetpack_SEO_Posts;
 use Jetpack_SEO_Utils;
-use WP_Post;
 
 /**
- * Emits Schema.org JSON-LD into the document head.
+ * Emits a Schema.org JSON-LD `@graph` into the document head.
  */
 class Schema_Builder {
-
-	/**
-	 * Max words kept for a schema `description`, so a long post body doesn't
-	 * dump its full content into the markup.
-	 */
-	const DESCRIPTION_MAX_WORDS = 55;
 
 	/**
 	 * Wire the front-end emitter.
@@ -42,167 +35,79 @@ class Schema_Builder {
 	}
 
 	/**
-	 * Build and echo the JSON-LD block for the current singular request.
+	 * Build and echo the JSON-LD `@graph` block for the current singular request.
 	 *
 	 * @return void
 	 */
 	public static function emit() {
 		// Both plugin classes must be loaded — they're not guaranteed in every
-		// context, and build_for_post() calls Jetpack_SEO_Posts directly.
+		// context, and the post node builder calls Jetpack_SEO_Posts directly.
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Utils lives in plugins/jetpack; guarded by the class_exists check on the same line.
 		if ( ! class_exists( 'Jetpack_SEO_Utils' ) || ! class_exists( 'Jetpack_SEO_Posts' ) || ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
 			return;
 		}
 
+		// Site-level nodes still ride along on the singular request's graph, so a
+		// page that emits no page node (and therefore no graph) emits nothing —
+		// preserving the pre-graph behavior on archives, the home page, and 404s.
 		if ( ! is_singular() ) {
 			return;
 		}
 
-		$node = self::build_for_post( get_queried_object() );
-		if ( ! $node ) {
+		$document = self::build_document( get_queried_object() );
+		if ( null === $document ) {
 			return;
 		}
-
-		$doc = array( '@context' => 'https://schema.org' ) + $node;
 
 		printf(
 			'<script type="application/ld+json">%s</script>',
 			// Default flags escape forward slashes — important inside <script>
 			// so a "</script>" in the data can't break out of the block.
-			wp_json_encode( $doc, JSON_UNESCAPED_UNICODE ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			wp_json_encode( $document, JSON_UNESCAPED_UNICODE ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 	}
 
 	/**
-	 * Build the JSON-LD node for the queried post.
+	 * Assemble the `@graph` document for the queried singular object.
 	 *
-	 * @param WP_Post|null $post The queried post.
+	 * Returns null when the post yields no page node, so the caller emits nothing
+	 * rather than an empty graph. Site-level nodes are only added alongside a page
+	 * node; standalone sitewide emission (home page, archives) is out of scope.
+	 *
+	 * Cross-node references (e.g. the Article `publisher`) are wired here rather
+	 * than inside the individual node builders, which stay self-contained and
+	 * unaware of each other.
+	 *
+	 * @param mixed $queried_object The queried object (expected to be a WP_Post).
 	 * @return array|null
 	 */
-	private static function build_for_post( $post ) {
-		if ( ! ( $post instanceof WP_Post ) ) {
+	private static function build_document( $queried_object ) {
+		$post_node = Post_Schema_Node::build( $queried_object );
+		if ( null === $post_node ) {
 			return null;
 		}
 
-		// Only emit structured data for published content. Previews, drafts, and
-		// private posts are viewable by logged-in users (and may be edge-cached),
-		// so we must not output JSON-LD for anything that isn't publicly published.
-		if ( 'publish' !== $post->post_status ) {
-			return null;
-		}
+		$graph = new Schema_Graph();
 
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Posts lives in plugins/jetpack; emit() guards on class_exists.
-		$override = Jetpack_SEO_Posts::get_post_schema_type( $post );
-		$type     = '' !== $override ? $override : self::default_schema_for_post( $post );
+		// Site-level entities come first, then the page node references them by @id.
+		// Organization is built from site identity alone here. The persisted schema
+		// settings — social profiles (`sameAs`) and any `name`/`logo`/`email`
+		// overrides — are injected through Organization_Schema_Node::build( $settings )
+		// once the schema settings server lands; see the `$settings` seam on that
+		// builder. Until then the argument is intentionally empty, so the output
+		// matches the current site identity and nothing is configurable yet.
+		$organization = Organization_Schema_Node::build();
+		if ( null !== $organization ) {
+			$graph->add( $organization );
 
-		switch ( $type ) {
-			case 'faq':
-				return self::build_faq( $post );
-			case 'article':
-				return self::build_article( $post );
-			default:
-				return null;
-		}
-	}
-
-	/**
-	 * Default Schema type for a post when the user has not set an override:
-	 * Article for standard posts, none for pages, attachments, or custom types.
-	 *
-	 * @param WP_Post $post The post.
-	 * @return string
-	 */
-	private static function default_schema_for_post( WP_Post $post ) {
-		// Only standard posts get Article schema by default; everything else
-		// (pages, attachments, custom post types) requires an explicit override.
-		return 'post' === $post->post_type ? 'article' : '';
-	}
-
-	/**
-	 * Article JSON-LD.
-	 *
-	 * @param WP_Post $post The post.
-	 * @return array
-	 */
-	private static function build_article( WP_Post $post ) {
-		$node = array(
-			'@type'            => 'Article',
-			'headline'         => wp_strip_all_tags( get_the_title( $post ) ),
-			'datePublished'    => get_post_time( 'c', true, $post ),
-			'dateModified'     => get_post_modified_time( 'c', true, $post ),
-			'mainEntityOfPage' => array(
-				'@type' => 'WebPage',
-				'@id'   => get_permalink( $post ),
-			),
-			'author'           => array(
-				'@type' => 'Person',
-				'name'  => get_the_author_meta( 'display_name', (int) $post->post_author ),
-			),
-		);
-
-		$image = get_the_post_thumbnail_url( $post, 'full' );
-		if ( $image ) {
-			$node['image'] = $image;
-		}
-
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Posts lives in plugins/jetpack; emit() guards on class_exists.
-		$description = Jetpack_SEO_Posts::get_post_description( $post );
-		if ( $description ) {
-			// Cap it: get_post_description() falls back to full post_content, which
-			// would otherwise dump the whole body into the markup.
-			$node['description'] = wp_trim_words( wp_strip_all_tags( $description ), self::DESCRIPTION_MAX_WORDS, '' );
-		}
-
-		return $node;
-	}
-
-	/**
-	 * FAQPage JSON-LD, parsed from `core/details` blocks (summary = question,
-	 * rendered content = answer). Returns null when the post has none, so we
-	 * never emit an empty/invalid FAQPage.
-	 *
-	 * @param WP_Post $post The post.
-	 * @return array|null
-	 */
-	private static function build_faq( WP_Post $post ) {
-		if ( ! function_exists( 'parse_blocks' ) ) {
-			return null;
-		}
-
-		$items = array();
-		foreach ( parse_blocks( $post->post_content ) as $block ) {
-			if ( 'core/details' !== ( $block['blockName'] ?? '' ) ) {
-				continue;
+			// Only the Article node carries a publisher; FAQPage does not.
+			if ( 'Article' === ( $post_node['@type'] ?? '' ) ) {
+				$post_node['publisher'] = array( '@id' => Schema_Node_Ids::organization() );
 			}
-			$question = trim( (string) ( $block['attrs']['summary'] ?? '' ) );
-
-			// Render only the inner blocks for the answer. Rendering the whole
-			// core/details block would re-include the <summary> (the question).
-			$answer_html = '';
-			foreach ( $block['innerBlocks'] ?? array() as $inner_block ) {
-				$answer_html .= render_block( $inner_block );
-			}
-			$answer = trim( wp_strip_all_tags( $answer_html ) );
-			if ( '' === $question || '' === $answer ) {
-				continue;
-			}
-			$items[] = array(
-				'@type'          => 'Question',
-				'name'           => $question,
-				'acceptedAnswer' => array(
-					'@type' => 'Answer',
-					'text'  => $answer,
-				),
-			);
 		}
 
-		if ( empty( $items ) ) {
-			return null;
-		}
+		$graph->add( $post_node );
 
-		return array(
-			'@type'      => 'FAQPage',
-			'mainEntity' => $items,
-		);
+		return $graph->to_document();
 	}
 }

--- a/projects/packages/seo/src/class-schema-graph.php
+++ b/projects/packages/seo/src/class-schema-graph.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Schema.org `@graph` document assembler.
+ *
+ * Collects the individual JSON-LD nodes that apply to the current request
+ * (site-level entities such as Organization plus the page node such as Article)
+ * and serializes them into a single `@graph` document. This is the reusable
+ * foundation the site-level schema types build on: each node builder returns an
+ * array (or null when it has nothing valid to emit), and the graph stitches the
+ * non-empty ones together.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Accumulates schema nodes and renders the `@graph` document.
+ */
+class Schema_Graph {
+
+	/**
+	 * Collected nodes, in insertion order.
+	 *
+	 * @var array<int, array>
+	 */
+	private $nodes = array();
+
+	/**
+	 * Add a node to the graph. Null/empty nodes are ignored, so callers can pass
+	 * a builder result straight through without guarding it first.
+	 *
+	 * @param array|null $node A JSON-LD node, or null/empty to skip.
+	 * @return static The graph, for chaining.
+	 */
+	public function add( $node ) {
+		if ( is_array( $node ) && ! empty( $node ) ) {
+			$this->nodes[] = $node;
+		}
+		return $this;
+	}
+
+	/**
+	 * Whether the graph has no nodes to emit.
+	 *
+	 * @return bool
+	 */
+	public function is_empty() {
+		return empty( $this->nodes );
+	}
+
+	/**
+	 * Render the full JSON-LD document, or null when there is nothing to emit so
+	 * the caller can skip output entirely rather than print an empty graph.
+	 *
+	 * @return array|null
+	 */
+	public function to_document() {
+		if ( $this->is_empty() ) {
+			return null;
+		}
+
+		return array(
+			'@context' => 'https://schema.org',
+			'@graph'   => array_values( $this->nodes ),
+		);
+	}
+}

--- a/projects/packages/seo/src/class-schema-node-ids.php
+++ b/projects/packages/seo/src/class-schema-node-ids.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Stable Schema.org node `@id` helpers.
+ *
+ * Site-level nodes (Organization, WebSite, …) and page nodes (Article) live
+ * together in one `@graph` and cross-reference each other by `@id`. Those `@id`s
+ * must be stable URIs — the same across every page of the site — so references
+ * resolve and search engines can de-duplicate the entities. Centralizing them
+ * here keeps every node builder agreeing on the exact same strings.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Builds the canonical `@id` URIs used across the schema graph.
+ */
+class Schema_Node_Ids {
+
+	/**
+	 * `@id` for the site-level Organization node.
+	 *
+	 * Anchored to the site root with a stable fragment, e.g.
+	 * `https://example.com/#organization`, so the Article `publisher`
+	 * reference resolves to the same entity on every page.
+	 *
+	 * @return string
+	 */
+	public static function organization() {
+		return self::site_anchor( 'organization' );
+	}
+
+	/**
+	 * Build a stable site-root `@id` from a fragment name.
+	 *
+	 * @param string $fragment Fragment identifier (without the leading `#`).
+	 * @return string
+	 */
+	private static function site_anchor( $fragment ) {
+		// home_url( '/' ) is the canonical site root and already carries a trailing
+		// slash, giving fragments like `https://example.com/#organization`.
+		return home_url( '/' ) . '#' . $fragment;
+	}
+}

--- a/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
@@ -43,6 +43,12 @@ class OrganizationSchemaNodeTest extends TestCase {
 				return $home;
 			}
 		);
+		add_filter(
+			'pre_option_home',
+			static function () use ( $home ) {
+				return $home;
+			}
+		);
 	}
 
 	/**
@@ -55,6 +61,7 @@ class OrganizationSchemaNodeTest extends TestCase {
 			array(
 				'pre_option_blogname',
 				'pre_option_blogdescription',
+				'pre_option_home',
 				'home_url',
 				'get_site_icon_url',
 				'wp_get_attachment_image_src',
@@ -157,16 +164,20 @@ class OrganizationSchemaNodeTest extends TestCase {
 		$node = Organization_Schema_Node::build(
 			array(
 				'sameAs' => array(
-					'https://twitter.com/acme',
+					'https://example.test/twitter',
 					'',
-					'https://twitter.com/acme',
-					'https://facebook.com/acme',
+					'/relative-profile',
+					'not a url',
+					'javascript:alert(1)',
+					'mailto:hello@acme.test',
+					'https://example.test/twitter',
+					'https://example.test/facebook',
 				),
 			)
 		);
 
 		$this->assertSame(
-			array( 'https://twitter.com/acme', 'https://facebook.com/acme' ),
+			array( 'https://example.test/twitter', 'https://example.test/facebook' ),
 			$node['sameAs']
 		);
 	}

--- a/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
@@ -208,4 +208,23 @@ class OrganizationSchemaNodeTest extends TestCase {
 		$this->assertSame( 'Acme Corporation', $node['name'] );
 		$this->assertSame( 'Custom description', $node['description'] );
 	}
+
+	/**
+	 * A malformed `sameAs` (not an array) is ignored rather than emitted.
+	 */
+	public function test_non_array_same_as_is_ignored() {
+		$this->set_site_identity( 'Acme Co' );
+		$node = Organization_Schema_Node::build( array( 'sameAs' => 'https://twitter.com/acme' ) );
+		$this->assertArrayNotHasKey( 'sameAs', $node );
+	}
+
+	/**
+	 * A malformed (non-string) `name` setting falls back to the site title rather
+	 * than producing an invalid node.
+	 */
+	public function test_non_string_name_falls_back_to_site_title() {
+		$this->set_site_identity( 'Acme Co' );
+		$node = Organization_Schema_Node::build( array( 'name' => array( 'unexpected' ) ) );
+		$this->assertSame( 'Acme Co', $node['name'] );
+	}
 }

--- a/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/OrganizationSchemaNodeTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Organization_Schema_Node builder.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Organization_Schema_Node
+ */
+#[CoversClass( Organization_Schema_Node::class )]
+class OrganizationSchemaNodeTest extends TestCase {
+
+	/**
+	 * Give the site a stable identity (Site Title, Tagline, home URL) for the test.
+	 *
+	 * @param string $name        Site Title.
+	 * @param string $description Tagline.
+	 * @param string $home        Home URL.
+	 * @return void
+	 */
+	private function set_site_identity( $name, $description = '', $home = 'https://example.test/' ) {
+		add_filter(
+			'pre_option_blogname',
+			static function () use ( $name ) {
+				return $name;
+			}
+		);
+		add_filter(
+			'pre_option_blogdescription',
+			static function () use ( $description ) {
+				return $description;
+			}
+		);
+		add_filter(
+			'home_url',
+			static function () use ( $home ) {
+				return $home;
+			}
+		);
+	}
+
+	/**
+	 * Remove the filters added by the tests so they don't leak across the process.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach (
+			array(
+				'pre_option_blogname',
+				'pre_option_blogdescription',
+				'home_url',
+				'get_site_icon_url',
+				'wp_get_attachment_image_src',
+			) as $hook
+		) {
+			remove_all_filters( $hook );
+		}
+		remove_theme_mod( 'custom_logo' );
+		parent::tearDown();
+	}
+
+	/**
+	 * With no Site Title, there is no useful Organization entity, so nothing is built.
+	 */
+	public function test_emits_nothing_without_a_site_name() {
+		$this->set_site_identity( '' );
+		$this->assertNull( Organization_Schema_Node::build() );
+	}
+
+	/**
+	 * The node is built from site identity alone, with a stable `@id` matching the
+	 * shared Organization id used for cross-references.
+	 */
+	public function test_builds_from_site_identity() {
+		$this->set_site_identity( 'Acme Co', 'We make things', 'https://acme.test/' );
+
+		$node = Organization_Schema_Node::build();
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'Organization', $node['@type'] );
+		$this->assertSame( Schema_Node_Ids::organization(), $node['@id'] );
+		$this->assertSame( 'https://acme.test/#organization', $node['@id'] );
+		$this->assertSame( 'Acme Co', $node['name'] );
+		$this->assertSame( 'https://acme.test/', $node['url'] );
+		$this->assertSame( 'We make things', $node['description'] );
+	}
+
+	/**
+	 * With no tagline, the `description` is omitted rather than emitted empty.
+	 */
+	public function test_description_omitted_when_tagline_empty() {
+		$this->set_site_identity( 'Acme Co', '' );
+		$node = Organization_Schema_Node::build();
+		$this->assertArrayNotHasKey( 'description', $node );
+	}
+
+	/**
+	 * The Site Icon provides the logo ImageObject when no Site Logo is set.
+	 */
+	public function test_logo_falls_back_to_site_icon() {
+		$this->set_site_identity( 'Acme Co' );
+		add_filter(
+			'get_site_icon_url',
+			static function () {
+				return 'https://acme.test/icon.png';
+			}
+		);
+
+		$node = Organization_Schema_Node::build();
+
+		$this->assertSame( 'ImageObject', $node['logo']['@type'] );
+		$this->assertSame( 'https://acme.test/icon.png', $node['logo']['url'] );
+	}
+
+	/**
+	 * The Site Logo (Customizer `custom_logo`) is preferred over the Site Icon and
+	 * carries its dimensions when available.
+	 */
+	public function test_logo_prefers_custom_logo_with_dimensions() {
+		$this->set_site_identity( 'Acme Co' );
+		set_theme_mod( 'custom_logo', 42 );
+		add_filter(
+			'wp_get_attachment_image_src',
+			static function () {
+				return array( 'https://acme.test/logo.png', 120, 60 );
+			}
+		);
+		// A Site Icon also exists, but the Site Logo must win.
+		add_filter(
+			'get_site_icon_url',
+			static function () {
+				return 'https://acme.test/icon.png';
+			}
+		);
+
+		$node = Organization_Schema_Node::build();
+
+		$this->assertSame( 'https://acme.test/logo.png', $node['logo']['url'] );
+		$this->assertSame( 120, $node['logo']['width'] );
+		$this->assertSame( 60, $node['logo']['height'] );
+	}
+
+	/**
+	 * `sameAs` comes only from settings (WordPress has no site-level source). Empty
+	 * and invalid entries are dropped and duplicates removed.
+	 */
+	public function test_same_as_from_settings_is_sanitized() {
+		$this->set_site_identity( 'Acme Co' );
+
+		$node = Organization_Schema_Node::build(
+			array(
+				'sameAs' => array(
+					'https://twitter.com/acme',
+					'',
+					'https://twitter.com/acme',
+					'https://facebook.com/acme',
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'https://twitter.com/acme', 'https://facebook.com/acme' ),
+			$node['sameAs']
+		);
+	}
+
+	/**
+	 * Without configured social profiles, `sameAs` is omitted entirely.
+	 */
+	public function test_same_as_omitted_when_unconfigured() {
+		$this->set_site_identity( 'Acme Co' );
+		$this->assertArrayNotHasKey( 'sameAs', Organization_Schema_Node::build() );
+	}
+
+	/**
+	 * `email` is included only when provided in settings (never auto-filled), and
+	 * is sanitized.
+	 */
+	public function test_email_only_from_settings() {
+		$this->set_site_identity( 'Acme Co' );
+
+		$this->assertArrayNotHasKey( 'email', Organization_Schema_Node::build() );
+
+		$node = Organization_Schema_Node::build( array( 'email' => 'hello@acme.test' ) );
+		$this->assertSame( 'hello@acme.test', $node['email'] );
+	}
+
+	/**
+	 * Settings override the site-identity defaults for `name` and `description`.
+	 */
+	public function test_settings_override_site_identity() {
+		$this->set_site_identity( 'Acme Co', 'Default tagline' );
+
+		$node = Organization_Schema_Node::build(
+			array(
+				'name'        => 'Acme Corporation',
+				'description' => 'Custom description',
+			)
+		);
+
+		$this->assertSame( 'Acme Corporation', $node['name'] );
+		$this->assertSame( 'Custom description', $node['description'] );
+	}
+}

--- a/projects/packages/seo/tests/php/PostSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/PostSchemaNodeTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Post_Schema_Node builder.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use WP_Post;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Post_Schema_Node
+ */
+#[CoversClass( Post_Schema_Node::class )]
+class PostSchemaNodeTest extends TestCase {
+
+	/**
+	 * Reset the host-plugin stubs (see tests/php/bootstrap.php) before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		\Jetpack_SEO_Posts::$schema_type = '';
+		\Jetpack_SEO_Posts::$description = '';
+	}
+
+	/**
+	 * Build a WP_Post from a field overrides array, with sensible publish defaults.
+	 *
+	 * @param array $fields Field overrides.
+	 * @return WP_Post
+	 */
+	private function make_post( array $fields = array() ): WP_Post {
+		return new WP_Post(
+			(object) array_merge(
+				array(
+					'ID'            => 1,
+					'post_type'     => 'post',
+					'post_status'   => 'publish',
+					'post_title'    => 'Test post',
+					'post_content'  => '',
+					'post_date'     => '2026-01-01 00:00:00',
+					'post_date_gmt' => '2026-01-01 00:00:00',
+					'post_author'   => 0,
+				),
+				$fields
+			)
+		);
+	}
+
+	/**
+	 * Invoke a private static Post_Schema_Node method by reflection.
+	 *
+	 * @param string $name Method name.
+	 * @param mixed  ...$args Arguments.
+	 * @return mixed
+	 */
+	private function invoke( string $name, ...$args ) {
+		$method = new ReflectionMethod( Post_Schema_Node::class, $name );
+		// setAccessible() is required to invoke a private method on PHP < 8.1, and a
+		// deprecated no-op from 8.1 on — call it only where it's actually needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( null, ...$args );
+	}
+
+	/**
+	 * The default schema type is Article only for standard posts; pages,
+	 * attachments, and custom post types get no default (require an override).
+	 */
+	public function test_default_schema_is_article_only_for_standard_posts() {
+		$this->assertSame( 'article', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'post' ) ) ) );
+		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'page' ) ) ) );
+		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'attachment' ) ) ) );
+		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'product' ) ) ) );
+	}
+
+	/**
+	 * No node is built for unpublished content (previews, drafts, private, etc.),
+	 * even when a logged-in user can view it.
+	 */
+	public function test_no_node_for_unpublished_posts() {
+		foreach ( array( 'draft', 'private', 'pending', 'future', 'auto-draft' ) as $status ) {
+			$this->assertNull(
+				Post_Schema_Node::build( $this->make_post( array( 'post_status' => $status ) ) ),
+				"Expected no node for status: {$status}"
+			);
+		}
+	}
+
+	/**
+	 * A non-WP_Post (e.g. a non-singular queried object) yields no node.
+	 */
+	public function test_no_node_for_non_post() {
+		$this->assertNull( Post_Schema_Node::build( null ) );
+	}
+
+	/**
+	 * A published standard post with no override produces an Article node.
+	 */
+	public function test_published_post_builds_article_by_default() {
+		$node = Post_Schema_Node::build(
+			$this->make_post(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'Hello world',
+				)
+			)
+		);
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'Article', $node['@type'] );
+		$this->assertArrayHasKey( 'headline', $node );
+		$this->assertArrayHasKey( 'datePublished', $node );
+		$this->assertArrayHasKey( 'mainEntityOfPage', $node );
+	}
+
+	/**
+	 * A page with no override produces no node (pages have no default schema).
+	 */
+	public function test_published_page_has_no_default_schema() {
+		$this->assertNull(
+			Post_Schema_Node::build( $this->make_post( array( 'post_type' => 'page' ) ) )
+		);
+	}
+
+	/**
+	 * FAQPage answers are built from a `core/details` block's inner blocks only,
+	 * so the question (the `<summary>`) is not duplicated into the answer text.
+	 */
+	public function test_faq_answer_excludes_the_question() {
+		\Jetpack_SEO_Posts::$schema_type = 'faq';
+
+		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
+		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
+		$content .= '</details><!-- /wp:details -->';
+
+		$node = Post_Schema_Node::build( $this->make_post( array( 'post_content' => $content ) ) );
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'FAQPage', $node['@type'] );
+		$this->assertCount( 1, $node['mainEntity'] );
+
+		$item = $node['mainEntity'][0];
+		$this->assertSame( 'Question', $item['@type'] );
+		$this->assertSame( 'What is SEO?', $item['name'] );
+		$this->assertSame( 'Search engine optimization.', $item['acceptedAnswer']['text'] );
+		$this->assertStringNotContainsString( 'What is SEO?', $item['acceptedAnswer']['text'] );
+	}
+
+	/**
+	 * A "faq" override with no `core/details` blocks yields no node, rather than
+	 * an empty/invalid FAQPage.
+	 */
+	public function test_faq_without_details_blocks_is_null() {
+		\Jetpack_SEO_Posts::$schema_type = 'faq';
+		$node                            = Post_Schema_Node::build(
+			$this->make_post( array( 'post_content' => '<!-- wp:paragraph --><p>No FAQ here.</p><!-- /wp:paragraph -->' ) )
+		);
+		$this->assertNull( $node );
+	}
+}

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -2,6 +2,10 @@
 /**
  * Tests for the Jetpack SEO Schema_Builder.
  *
+ * These exercise the emitted `<script type="application/ld+json">` document end
+ * to end — the real regression surface — rather than the internal node builders
+ * (those are covered by PostSchemaNodeTest / OrganizationSchemaNodeTest).
+ *
  * @package automattic/jetpack-seo
  */
 
@@ -9,7 +13,6 @@ namespace Automattic\Jetpack\SEO;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use WP_Post;
 
 /**
@@ -28,6 +31,33 @@ class SchemaBuilderTest extends TestCase {
 		\Jetpack_SEO_Utils::$enabled     = true;
 		\Jetpack_SEO_Posts::$schema_type = '';
 		\Jetpack_SEO_Posts::$description = '';
+	}
+
+	/**
+	 * Remove any site-identity filters a test added so they don't leak.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		remove_all_filters( 'pre_option_blogname' );
+		remove_all_filters( 'home_url' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Give the site a Site Title so the Organization node is emitted deterministically,
+	 * regardless of the test environment's default `blogname`.
+	 *
+	 * @param string $name Site Title.
+	 * @return void
+	 */
+	private function set_site_name( $name ) {
+		add_filter(
+			'pre_option_blogname',
+			static function () use ( $name ) {
+				return $name;
+			}
+		);
 	}
 
 	/**
@@ -55,88 +85,114 @@ class SchemaBuilderTest extends TestCase {
 	}
 
 	/**
-	 * Invoke a private static Schema_Builder method by reflection.
+	 * Drive Schema_Builder::emit() against a queried singular post and return the
+	 * decoded JSON-LD document, or null when nothing is emitted. This is the
+	 * regression surface that matters: the actual emitted
+	 * `<script type="application/ld+json">` content, not the internal builders.
 	 *
-	 * @param string $name Method name.
-	 * @param mixed  ...$args Arguments.
-	 * @return mixed
+	 * @param WP_Post|null $post Queried singular post, or null for a non-singular request.
+	 * @return array|null Decoded JSON-LD document, or null when emit() outputs nothing.
 	 */
-	private function invoke( string $name, ...$args ) {
-		$method = new ReflectionMethod( Schema_Builder::class, $name );
-		// setAccessible() is required to invoke a private method on PHP < 8.1, and a
-		// deprecated no-op from 8.1 on — call it only where it's actually needed.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
+	private function emit_document( $post ) {
+		global $wp_query;
+		$wp_query = new \WP_Query();
+		if ( $post instanceof WP_Post ) {
+			$wp_query->is_singular       = true;
+			$wp_query->queried_object    = $post;
+			$wp_query->queried_object_id = $post->ID;
 		}
-		return $method->invoke( null, ...$args );
-	}
 
-	/**
-	 * The default schema type is Article only for standard posts; pages,
-	 * attachments, and custom post types get no default (require an override).
-	 */
-	public function test_default_schema_is_article_only_for_standard_posts() {
-		$this->assertSame( 'article', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'post' ) ) ) );
-		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'page' ) ) ) );
-		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'attachment' ) ) ) );
-		$this->assertSame( '', $this->invoke( 'default_schema_for_post', $this->make_post( array( 'post_type' => 'product' ) ) ) );
-	}
+		ob_start();
+		Schema_Builder::emit();
+		$html = (string) ob_get_clean();
 
-	/**
-	 * No structured data is emitted for unpublished content (previews, drafts,
-	 * private, etc.), even when a logged-in user can view it.
-	 */
-	public function test_no_schema_for_unpublished_posts() {
-		foreach ( array( 'draft', 'private', 'pending', 'future', 'auto-draft' ) as $status ) {
-			$this->assertNull(
-				$this->invoke( 'build_for_post', $this->make_post( array( 'post_status' => $status ) ) ),
-				"Expected no schema for status: {$status}"
-			);
+		if ( '' === $html ) {
+			return null;
 		}
-	}
 
-	/**
-	 * A non-WP_Post (e.g. a non-singular queried object) yields no node.
-	 */
-	public function test_no_schema_for_non_post() {
-		$this->assertNull( $this->invoke( 'build_for_post', null ) );
-	}
-
-	/**
-	 * A published standard post with no override produces an Article node.
-	 */
-	public function test_published_post_builds_article_by_default() {
-		$node = $this->invoke(
-			'build_for_post',
-			$this->make_post(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'Hello world',
-				)
-			)
+		$this->assertSame(
+			1,
+			preg_match( '#<script type="application/ld\+json">(.*)</script>#s', $html, $matches ),
+			'emit() output is not a single application/ld+json script block.'
 		);
-
-		$this->assertIsArray( $node );
-		$this->assertSame( 'Article', $node['@type'] );
-		$this->assertArrayHasKey( 'headline', $node );
-		$this->assertArrayHasKey( 'datePublished', $node );
-		$this->assertArrayHasKey( 'mainEntityOfPage', $node );
+		return json_decode( $matches[1], true );
 	}
 
 	/**
-	 * A page with no override produces no node (pages have no default schema).
+	 * Find the first node of a given `@type` in a `@graph` document, or null.
+	 *
+	 * Looking nodes up by type (rather than position) keeps these assertions
+	 * stable as more site-level nodes join the graph.
+	 *
+	 * @param array  $document Decoded `@graph` document.
+	 * @param string $type     The `@type` to find.
+	 * @return array|null
 	 */
-	public function test_published_page_has_no_default_schema() {
-		$this->assertNull(
-			$this->invoke( 'build_for_post', $this->make_post( array( 'post_type' => 'page' ) ) )
-		);
+	private function node_of_type( array $document, string $type ) {
+		foreach ( $document['@graph'] as $node ) {
+			if ( is_array( $node ) && ( $node['@type'] ?? '' ) === $type ) {
+				return $node;
+			}
+		}
+		return null;
 	}
 
 	/**
-	 * FAQPage answers are built from a `core/details` block's inner blocks only,
-	 * so the question (the `<summary>`) is not duplicated into the answer text.
+	 * Nothing is emitted when the SEO feature is disabled.
 	 */
-	public function test_faq_answer_excludes_the_question() {
+	public function test_emits_nothing_when_feature_disabled() {
+		\Jetpack_SEO_Utils::$enabled = false;
+		$this->assertNull( $this->emit_document( $this->make_post() ) );
+	}
+
+	/**
+	 * Nothing is emitted on non-singular requests (home, archives, 404). Site-level
+	 * nodes ride along on the singular request's graph; they are not emitted on
+	 * their own yet.
+	 */
+	public function test_emits_nothing_on_non_singular() {
+		$this->assertNull( $this->emit_document( null ) );
+	}
+
+	/**
+	 * Nothing is emitted for unpublished content, even on a singular request.
+	 */
+	public function test_emits_nothing_for_unpublished() {
+		$this->assertNull( $this->emit_document( $this->make_post( array( 'post_status' => 'draft' ) ) ) );
+	}
+
+	/**
+	 * A page with no schema override yields no page node, so the request emits
+	 * nothing at all (no standalone site-level graph).
+	 */
+	public function test_emits_nothing_for_page_without_override() {
+		$this->assertNull( $this->emit_document( $this->make_post( array( 'post_type' => 'page' ) ) ) );
+	}
+
+	/**
+	 * A published standard post emits a `@graph` document containing an Article
+	 * node. Title/permalink values resolve through DB lookups the dbless test
+	 * environment can't satisfy, so this asserts document shape, not those values.
+	 */
+	public function test_emits_graph_with_article_for_published_post() {
+		$doc = $this->emit_document( $this->make_post( array( 'post_title' => 'Hello world' ) ) );
+
+		$this->assertIsArray( $doc );
+		$this->assertSame( 'https://schema.org', $doc['@context'] );
+		$this->assertIsArray( $doc['@graph'] );
+		$this->assertArrayNotHasKey( '@type', $doc, 'The document is a @graph, not a single top-level node.' );
+
+		$article = $this->node_of_type( $doc, 'Article' );
+		$this->assertIsArray( $article, 'Expected an Article node in the graph.' );
+		$this->assertArrayHasKey( 'headline', $article );
+		$this->assertArrayHasKey( 'datePublished', $article );
+		$this->assertArrayHasKey( 'mainEntityOfPage', $article );
+	}
+
+	/**
+	 * A "faq" override emits a `@graph` document containing a FAQPage node.
+	 */
+	public function test_emits_graph_with_faqpage_for_faq_override() {
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
 		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
@@ -144,29 +200,51 @@ class SchemaBuilderTest extends TestCase {
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';
 
-		$node = $this->invoke( 'build_for_post', $this->make_post( array( 'post_content' => $content ) ) );
+		$doc = $this->emit_document( $this->make_post( array( 'post_content' => $content ) ) );
 
-		$this->assertIsArray( $node );
-		$this->assertSame( 'FAQPage', $node['@type'] );
-		$this->assertCount( 1, $node['mainEntity'] );
-
-		$item = $node['mainEntity'][0];
-		$this->assertSame( 'Question', $item['@type'] );
-		$this->assertSame( 'What is SEO?', $item['name'] );
-		$this->assertSame( 'Search engine optimization.', $item['acceptedAnswer']['text'] );
-		$this->assertStringNotContainsString( 'What is SEO?', $item['acceptedAnswer']['text'] );
+		$this->assertIsArray( $doc );
+		$faq = $this->node_of_type( $doc, 'FAQPage' );
+		$this->assertIsArray( $faq, 'Expected a FAQPage node in the graph.' );
+		$this->assertSame( 'What is SEO?', $faq['mainEntity'][0]['name'] );
 	}
 
 	/**
-	 * A "faq" override with no `core/details` blocks yields no node, rather than
-	 * an empty/invalid FAQPage.
+	 * The graph leads with the site-level Organization node, and the Article
+	 * references it as `publisher` by `@id`.
 	 */
-	public function test_faq_without_details_blocks_is_null() {
+	public function test_graph_leads_with_organization_referenced_as_article_publisher() {
+		$this->set_site_name( 'Acme Co' );
+
+		$doc = $this->emit_document( $this->make_post() );
+
+		$this->assertSame( 'Organization', $doc['@graph'][0]['@type'], 'Site-level nodes come first.' );
+
+		$organization = $this->node_of_type( $doc, 'Organization' );
+		$this->assertIsArray( $organization, 'Expected an Organization node in the graph.' );
+		$this->assertSame( 'Acme Co', $organization['name'] );
+
+		$article = $this->node_of_type( $doc, 'Article' );
+		$this->assertSame( $organization['@id'], $article['publisher']['@id'] );
+	}
+
+	/**
+	 * A FAQPage joins the graph alongside the Organization, but carries no
+	 * `publisher` (only Article references a publisher).
+	 */
+	public function test_faqpage_has_no_publisher_but_graph_has_organization() {
+		$this->set_site_name( 'Acme Co' );
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
-		$node                            = $this->invoke(
-			'build_for_post',
-			$this->make_post( array( 'post_content' => '<!-- wp:paragraph --><p>No FAQ here.</p><!-- /wp:paragraph -->' ) )
-		);
-		$this->assertNull( $node );
+
+		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
+		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
+		$content .= '</details><!-- /wp:details -->';
+
+		$doc = $this->emit_document( $this->make_post( array( 'post_content' => $content ) ) );
+
+		$this->assertIsArray( $this->node_of_type( $doc, 'Organization' ) );
+
+		$faq = $this->node_of_type( $doc, 'FAQPage' );
+		$this->assertArrayNotHasKey( 'publisher', $faq );
 	}
 }

--- a/projects/packages/seo/tests/php/SchemaGraphTest.php
+++ b/projects/packages/seo/tests/php/SchemaGraphTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Schema_Graph assembler.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Schema_Graph
+ */
+#[CoversClass( Schema_Graph::class )]
+class SchemaGraphTest extends TestCase {
+
+	/**
+	 * A graph with no nodes renders no document, so the caller emits nothing.
+	 */
+	public function test_empty_graph_renders_no_document() {
+		$graph = new Schema_Graph();
+		$this->assertTrue( $graph->is_empty() );
+		$this->assertNull( $graph->to_document() );
+	}
+
+	/**
+	 * Null and empty nodes are ignored, so a builder result can be passed straight
+	 * through without the caller guarding it.
+	 */
+	public function test_null_and_empty_nodes_are_skipped() {
+		$graph = new Schema_Graph();
+		$graph->add( null )->add( array() );
+		$this->assertTrue( $graph->is_empty() );
+		$this->assertNull( $graph->to_document() );
+	}
+
+	/**
+	 * The document wraps the collected nodes in a schema.org `@graph`, preserving
+	 * insertion order and serializing the graph as a JSON array (a list).
+	 */
+	public function test_document_wraps_nodes_in_graph_in_order() {
+		$organization = array( '@type' => 'Organization' );
+		$article      = array( '@type' => 'Article' );
+
+		$document = ( new Schema_Graph() )
+			->add( $organization )
+			->add( $article )
+			->to_document();
+
+		$this->assertSame( 'https://schema.org', $document['@context'] );
+		$this->assertSame( array( $organization, $article ), $document['@graph'] );
+		$this->assertSame( array( 0, 1 ), array_keys( $document['@graph'] ), 'The @graph must be a sequential list.' );
+	}
+}

--- a/projects/packages/seo/tests/php/SchemaNodeIdsTest.php
+++ b/projects/packages/seo/tests/php/SchemaNodeIdsTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Schema_Node_Ids helpers.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Schema_Node_Ids
+ */
+#[CoversClass( Schema_Node_Ids::class )]
+class SchemaNodeIdsTest extends TestCase {
+
+	/**
+	 * Remove the home_url filter a test added so it doesn't leak across the process.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		remove_all_filters( 'home_url' );
+		parent::tearDown();
+	}
+
+	/**
+	 * The Organization id is the site root plus a stable `#organization` fragment,
+	 * so it resolves to the same entity on every page.
+	 */
+	public function test_organization_id_anchors_to_the_site_root() {
+		add_filter(
+			'home_url',
+			static function () {
+				return 'https://example.test/';
+			}
+		);
+
+		$this->assertSame( 'https://example.test/#organization', Schema_Node_Ids::organization() );
+	}
+
+	/**
+	 * The id is stable across calls — it must not vary per request, or the cross-node
+	 * `@id` references (e.g. the Article publisher) would not resolve.
+	 */
+	public function test_organization_id_is_stable() {
+		add_filter(
+			'home_url',
+			static function () {
+				return 'https://example.test/';
+			}
+		);
+
+		$this->assertSame( Schema_Node_Ids::organization(), Schema_Node_Ids::organization() );
+	}
+}


### PR DESCRIPTION
Part of JETPACK-1779

Back-end foundation slice for the **Site Schemas** milestone: converts the SEO schema output to a multi-node `@graph` and adds the first site-level node (Organization). This is the shared `@graph` foundation the other site-level schema types (WebSite, LocalBusiness, Person) build on.

**Scope** — this PR is the `@graph` foundation + Organization node only. It does **not** close JETPACK-1779's settings acceptance:

* **In this PR:** convert output to a multi-node `@graph` (Article/FAQ preserved); emit a site-level Organization node from existing site identity; reference it from the Article `publisher`.
* **Not in this PR (follow-ups, so 1779 stays open):** schema settings persistence + REST (social profiles `sameAs`, field overrides) → settings-server PR; the "Organization / Business info" settings UI → settings-UI PR. The Organization builder already accepts a `$settings` array; the graph passes it empty for now, so social profiles / overrides are intentionally not configurable yet.

## Proposed changes

* Refactor `Schema_Builder::emit()` from a single-node emitter into a thin `@graph` serializer. `build_document()` assembles the graph and wires cross-node references (Article → Organization `publisher` by `@id`); the individual node builders stay self-contained and unaware of each other.
* New package-owned schema services under `projects/packages/seo/src/`:
  * `Schema_Graph` — collects nodes and renders the `{ @context, @graph }` document (or null when empty).
  * `Schema_Node_Ids` — stable, site-root-anchored `@id`s (e.g. `https://example.com/#organization`) so nodes cross-reference reliably across every page.
  * `Post_Schema_Node` — the Article / FAQPage builder, moved out of `Schema_Builder` unchanged.
  * `Organization_Schema_Node` — site-level Organization node built from existing site identity (Site Title, home URL, Site Logo → Site Icon fallback, Tagline). `sameAs` / `email` / overrides come from an optional `$settings` seam.
* Emission policy is unchanged: still gated on `is_singular()`. Site-level nodes ride along on the singular request's graph, so the home page, archives, 404s, drafts, and override-less pages still emit nothing.
* Tests: `SchemaBuilderTest` now asserts the real emitted `<script type="application/ld+json">` document (the actual regression surface); new `PostSchemaNodeTest`, `SchemaGraphTest`, `OrganizationSchemaNodeTest`. Adds the emitted-output regression harness for the current Article/FAQ behavior before the conversion.

Example emitted output for a published post (site with a Site Logo and Tagline):

```json
{
  "@context": "https://schema.org",
  "@graph": [
    {
      "@type": "Organization",
      "@id": "https://example.com/#organization",
      "name": "Acme Co",
      "url": "https://example.com/",
      "description": "We make fine widgets",
      "logo": { "@type": "ImageObject", "url": "https://example.com/logo.png", "width": 120, "height": 60 }
    },
    {
      "@type": "Article",
      "headline": "Hello world",
      "datePublished": "2026-01-01T00:00:00+00:00",
      "dateModified": "2026-01-02T00:00:00+00:00",
      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://example.com/hello-world/" },
      "author": { "@type": "Person", "name": "Jane Doe" },
      "publisher": { "@id": "https://example.com/#organization" }
    }
  ]
}
```

## Feature flag

Inherits the existing SEO gate — `Schema_Builder` only loads when the `rsm_jetpack_seo` feature flag is on (default off) **and** the SEO Tools module is active. Sites without the flag see no change at all; only the flagged new-SEO cohort gets the new `@graph` + Organization output. No new flag added.

## Related product discussion/links

* Tracking issue: JETPACK-1779 (Phase 1 - Jetpack SEO: Expanded Schema Markup → Site Schemas)

## Does this pull request change what data or activity we track or use?

No. 
## Testing instructions

**Setup**

* On a test site, turn on the new SEO experience: `add_filter( 'rsm_jetpack_seo', '__return_true' );` (snippet / mu-plugin) and make sure the **SEO Tools** module is active.
* Set **Settings → General → Site Title** and **Tagline**, and add a **Site Logo** (Customizer → Site Identity) — or a **Site Icon** as a fallback.

**New behavior — `@graph` + Organization**

* Open a **published post** on the front end and View Source (or run its URL through Google's [Rich Results Test](https://search.google.com/test/rich-results)).
* Find the `<script type="application/ld+json">` block and confirm:
  * It's now a `@graph` array (not a single top-level node).
  * It contains an **Organization** node with `name` (Site Title), `url`, `logo` (your Site Logo/Icon as an `ImageObject`), and `description` (Tagline).
  * The **Article** node has a `publisher` referencing the Organization's `@id` (e.g. `https://your-site/#organization`).
* Paste the output into the Rich Results Test / schema.org validator → no errors.

**No regression**

* The Article fields are unchanged (`headline`, `datePublished`, `dateModified`, `author`, `mainEntityOfPage`, and `image` when a featured image is set).
* A post with the **FAQ** schema type still emits a valid **FAQPage** (in the graph; FAQPage has no `publisher`).
* No schema is emitted on: the **home page / archives** (non-singular), **draft / private** posts, or a **plain Page** with no schema-type override.

**Automated**

* `pnpm jetpack test php packages/seo` (or `composer phpunit` in `projects/packages/seo`) → 46 pass.
* `pnpm jetpack phan packages/seo` → 0 issues.
