### PR TITLE
Content Guidelines AI: align suggestion badge to the left of the chevron

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
@@ -223,15 +223,26 @@ function runAll() {
 			continue;
 		}
 
-		// Badge in the accordion header (the section's heading element).
+		// Badge in the accordion header, to the left of the chevron.
+		//
+		// CollapsibleCard.Header renders the heading wrapping a flex trigger row
+		// whose children are the title/description block and, last, the chevron's
+		// positioner. Appending to the row puts the badge to the right of the
+		// chevron, which pushes the chevron leftward only on sections that have a
+		// badge — so chevrons no longer line up across sections. Insert the badge
+		// before the chevron instead: the chevron stays the last child (flush to
+		// the right and aligned across every section) and the badge sits just to
+		// its left.
 		inject(
 			`badge-${ slug }`,
 			() => {
 				const heading = item.querySelector( 'h1, h2, h3, h4, h5, h6' );
-				const titleStack = heading?.firstElementChild ?? heading;
-				return titleStack
+				const trigger = heading?.firstElementChild ?? heading;
+				const chevron = trigger?.lastElementChild;
+				return trigger
 					? {
-							parent: titleStack,
+							parent: trigger,
+							before: chevron,
 							className: 'jetpack-content-guidelines-ai__badge-container',
 							tag: 'span',
 					  }

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -127,7 +127,6 @@ $cg-diff-removed: #f8d7da;
 
 	display: inline-flex;
 	align-items: center;
-	margin-inline-start: auto;
 }
 
 .jetpack-content-guidelines-ai__badge--loading .components-spinner {

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-ai-badge-alignment
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-ai-badge-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Content Guidelines AI: place the suggestion badge to the left of the section chevron so chevrons stay aligned across sections with and without a badge


### PR DESCRIPTION
Fixes #

Addresses a layout bug reported during the Call for Testing: the "Suggestion" badge in a Guidelines section header renders to the **right** of the expand/collapse chevron. Because the title block has `flex: 1`, only sections that have a badge push the chevron leftward, so the chevrons no longer line up across sections.

The badge is DOM-injected by the Content Guidelines AI feature into the Gutenberg `CollapsibleCard.Header` trigger row (the section header is owned by the Gutenberg guidelines route, which has no knowledge of the AI badge). The trigger row's children are the title/description block and, last, the chevron's positioner. We were appending the badge to the end of that row — after the chevron.

This moves the badge so it is inserted **before** the chevron: the chevron stays the last child (flush-right and aligned across every section) and the badge sits just to its left, matching the alignment suggested in the CFT thread.

<img width="1728" height="875" alt="Screenshot 2026-06-30 at 7 42 01 PM" src="https://github.com/user-attachments/assets/ef4389f9-6207-42f1-9056-1e2d43840afe" />


## Proposed changes
* `lib/inject.js`: inject the suggestion badge before the chevron's positioner in the accordion header instead of appending it after, so the badge sits to the left of the chevron.
* `style.scss`: drop the now-redundant `margin-inline-start: auto` on `.jetpack-content-guidelines-ai__badge-container` — the title block's `flex: 1` already pushes the badge and chevron to the right.

## Related product discussion/links
* CFT comment that reported this: pdtkmj-4DE-p2#comment-8948

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This feature is live for proxied users on WordPress.com Simple/Atomic sites.
* Point your Jetpack beta plugin to this branch - `update/content-guidelines-ai-badge-alignment`
* On a qualifying WordPress.com Simple or Atomic site (proxied), go to **Settings → Guidelines** (`/wp-admin/options-general.php?page=guidelines-wp-admin`).
* Use **Generate guidelines** / per-section **Generate** so that at least one section has a pending **Suggestion** badge while at least one other section does not.
* Confirm the **Suggestion** badge now appears to the **left** of that section's expand/collapse chevron (previously it was to the right).
* Confirm the chevrons line up vertically across all sections, whether or not a section currently has a badge.
* Expand a section with a badge and confirm the badge still hides while expanded (existing behavior) and the chevron stays aligned.
* While a section is generating, confirm the loading spinner shows in the same left-of-chevron position.
