### PR TITLE
Search Dashboard: Hide AI Agent Access on P2 sites

### DIFF
--- a/projects/packages/search/changelog/remove-p2-ai-agent-access
+++ b/projects/packages/search/changelog/remove-p2-ai-agent-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Dashboard: Hide AI Agent Access on P2 sites.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 
 /**
@@ -220,13 +221,12 @@ class Initial_State {
 	/**
 	 * Check whether the AI Agent Access toggle should be available.
 	 *
-	 * Private sites are not eligible because external AI agents cannot read
-	 * their public content.
+	 * Private and P2 sites are not eligible for external AI agent access.
 	 *
 	 * @return bool
 	 */
 	protected function is_ai_agent_access_available() {
-		return ! $this->is_private_site();
+		return ! $this->is_private_site() && ! ( new Host() )->is_p2_site();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initial_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_State_Test.php
@@ -144,10 +144,10 @@ class Initial_State_Test extends Search_TestCase {
 	 * Test that the AI Agent Access toggle is unavailable on P2 sites.
 	 */
 	public function test_ai_agent_access_available_is_false_for_p2_sites() {
-		$original_blog_id       = \Jetpack_Options::get_option( 'id' );
-		$had_is_wpcom           = Constants::is_defined( 'IS_WPCOM' );
-		$original_is_wpcom      = Constants::get_constant( 'IS_WPCOM' );
-		$p2_stylesheet_filter   = function () {
+		$original_blog_id     = \Jetpack_Options::get_option( 'id' );
+		$had_is_wpcom         = Constants::is_defined( 'IS_WPCOM' );
+		$original_is_wpcom    = Constants::get_constant( 'IS_WPCOM' );
+		$p2_stylesheet_filter = function () {
 			return 'pub/p2v2';
 		};
 

--- a/projects/packages/search/tests/php/Initial_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_State_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Search\TestCase as Search_TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -137,6 +138,45 @@ class Initial_State_Test extends Search_TestCase {
 		$state = ( new Initial_State() )->get_initial_state();
 
 		$this->assertFalse( $state['siteData']['aiAgentAccessAvailable'] );
+	}
+
+	/**
+	 * Test that the AI Agent Access toggle is unavailable on P2 sites.
+	 */
+	public function test_ai_agent_access_available_is_false_for_p2_sites() {
+		$original_blog_id       = \Jetpack_Options::get_option( 'id' );
+		$had_is_wpcom           = Constants::is_defined( 'IS_WPCOM' );
+		$original_is_wpcom      = Constants::get_constant( 'IS_WPCOM' );
+		$p2_stylesheet_filter   = function () {
+			return 'pub/p2v2';
+		};
+
+		\Jetpack_Options::update_option( 'id', 12345 );
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		try {
+			$state = ( new Initial_State() )->get_initial_state();
+
+			$this->assertTrue( $state['siteData']['aiAgentAccessAvailable'] );
+
+			add_filter( 'stylesheet', $p2_stylesheet_filter );
+
+			$state = ( new Initial_State() )->get_initial_state();
+
+			$this->assertFalse( $state['siteData']['aiAgentAccessAvailable'] );
+		} finally {
+			remove_filter( 'stylesheet', $p2_stylesheet_filter );
+			if ( false === $original_blog_id ) {
+				\Jetpack_Options::delete_option( 'id' );
+			} else {
+				\Jetpack_Options::update_option( 'id', $original_blog_id );
+			}
+			if ( $had_is_wpcom ) {
+				Constants::set_constant( 'IS_WPCOM', $original_is_wpcom );
+			} else {
+				Constants::clear_single_constant( 'IS_WPCOM' );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Hide the Search dashboard AI Agent Access control on P2 / WP for Teams sites by including `Status\Host::is_p2_site()` in the initial-state availability flag.
* Add PHP coverage for the P2 availability gate, including the non-P2 public-site control path.
* Add a Search package changelog entry.

## Related product discussion/links
* Internal Slack discussion.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `jetpack test php packages/search -v`
* `cd projects/packages/search && pnpm test-scripts`
* `jetpack test php packages/sync -v`
* `jetpack changelog validate packages/search`
* On a P2 WPCOM site, load the Jetpack Search dashboard and confirm the AI Agent Access toggle is absent.
* On a public non-P2 WPCOM site, confirm the AI Agent Access toggle is still available.

## Notes
* `Automattic\Jetpack\Status\Host::is_p2_site()` exists in `projects/packages/status/src/class-host.php` and checks the local WPCOM site ID plus the P2/WP for Teams signals.
* This PR only hides the Jetpack Search dashboard control. The paired WPCOM PR enforces the backend Search Voice / AI Agent Access P2 rejection.
