### PR TITLE
Newsletter: space Email content notice via Stack gap instead of CSS margin

### DIFF
--- a/projects/packages/newsletter/changelog/update-newsletter-notice-stack-spacing
+++ b/projects/packages/newsletter/changelog/update-newsletter-notice-stack-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter settings: space the Email content private-site notice from the form with a Stack gap instead of a custom CSS margin rule.

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -3,7 +3,7 @@
  */
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { Card, Fieldset, Notice } from '@wordpress/ui';
+import { Card, Fieldset, Notice, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -66,29 +66,31 @@ export function EmailContentSection( {
 			</Card.Header>
 			<Card.Content>
 				<Fieldset.Root disabled={ ! isNewsletterEnabled }>
-					{ ! isSitePublic && (
-						<Notice.Root intent="warning" className="newsletter-email-content-notice">
-							<Notice.Description>
-								{ __(
-									'Featured images will not be used in your emails until the site is public, because access to the images is restricted to your site only.',
-									'jetpack-newsletter'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					) }
+					<Stack gap="lg" direction="column">
+						{ ! isSitePublic && (
+							<Notice.Root intent="warning">
+								<Notice.Description>
+									{ __(
+										'Featured images will not be used in your emails until the site is public, because access to the images is restricted to your site only.',
+										'jetpack-newsletter'
+									) }
+								</Notice.Description>
+							</Notice.Root>
+						) }
 
-					<DataForm
-						data={ data }
-						fields={ fields }
-						form={ {
-							layout: {
-								type: 'regular',
-								labelPosition: 'top',
-							},
-							fields: [ 'wpcom_featured_image_in_email', 'wpcom_subscription_emails_use_excerpt' ],
-						} }
-						onChange={ onChange }
-					/>
+						<DataForm
+							data={ data }
+							fields={ fields }
+							form={ {
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
+								fields: [ 'wpcom_featured_image_in_email', 'wpcom_subscription_emails_use_excerpt' ],
+							} }
+							onChange={ onChange }
+						/>
+					</Stack>
 				</Fieldset.Root>
 			</Card.Content>
 		</Card.Root>

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -86,7 +86,10 @@ export function EmailContentSection( {
 									type: 'regular',
 									labelPosition: 'top',
 								},
-								fields: [ 'wpcom_featured_image_in_email', 'wpcom_subscription_emails_use_excerpt' ],
+								fields: [
+									'wpcom_featured_image_in_email',
+									'wpcom_subscription_emails_use_excerpt',
+								],
 							} }
 							onChange={ onChange }
 						/>

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -37,13 +37,6 @@ body.jetpack_page_jetpack-newsletter {
 	}
 }
 
-// The `@wordpress/ui` Notice is a CSS-module component, so the
-// `.components-notice` rule below can't reach it. Separate the warning
-// notice in the Email content section from the toggle that follows it.
-.newsletter-email-content-notice {
-	margin-block-end: var(--wpds-dimension-gap-lg, 24px);
-}
-
 .newsletter-settings-disabled {
 	position: relative;
 

--- a/projects/packages/newsletter/tests/email-content-section.test.tsx
+++ b/projects/packages/newsletter/tests/email-content-section.test.tsx
@@ -2,9 +2,9 @@
  * Tests for the Email content section's "site is private" warning notice.
  *
  * `@wordpress/ui` and `@wordpress/dataviews` are stubbed to plain HTML so we can
- * assert on the rendered output directly. The `Notice.Root` stub forwards the
- * `className` it receives, which lets us guard the spacing class that separates
- * the notice from the toggle below it (NL-717).
+ * assert on the rendered output directly. The `Stack` stub forwards its `gap`
+ * prop as a data attribute, which lets us guard the spacing that separates the
+ * notice from the toggle below it (NL-717).
  */
 
 jest.mock( '@wordpress/ui', () => ( {
@@ -18,12 +18,13 @@ jest.mock( '@wordpress/ui', () => ( {
 	Fieldset: {
 		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
 	},
+	Stack: ( { children, gap }: { children: React.ReactNode; gap?: string } ) => (
+		<div data-testid="stack" data-gap={ gap }>
+			{ children }
+		</div>
+	),
 	Notice: {
-		Root: ( { children, className }: { children: React.ReactNode; className?: string } ) => (
-			<div role="alert" className={ className }>
-				{ children }
-			</div>
-		),
+		Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
 		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
 	},
 } ) );
@@ -77,7 +78,7 @@ describe( 'EmailContentSection private-site notice', () => {
 		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the warning notice with the spacing class when the site is private', () => {
+	it( 'renders the warning notice spaced from the form via a Stack when the site is private', () => {
 		mockedGetScriptData.mockReturnValue( { isSitePublic: false } as ReturnType<
 			typeof getNewsletterScriptData
 		> );
@@ -86,8 +87,11 @@ describe( 'EmailContentSection private-site notice', () => {
 
 		const notice = screen.getByRole( 'alert' );
 		expect( notice ).toBeInTheDocument();
-		// The spacing class is what keeps the notice from colliding with the
-		// toggle rendered below it (NL-717). Guard it against regressions.
-		expect( notice ).toHaveClass( 'newsletter-email-content-notice' );
+		// The Stack gap is what keeps the notice from colliding with the toggle
+		// rendered below it (NL-717). Guard it against regressions.
+		const stack = screen.getByTestId( 'stack' );
+		expect( stack ).toHaveAttribute( 'data-gap', 'lg' );
+		expect( stack ).toContainElement( notice );
+		expect( stack ).toContainElement( screen.getByTestId( 'data-form' ) );
 	} );
 } );


### PR DESCRIPTION
## Proposed changes

Follow-up to the post-merge review feedback on #50072 ([comment](https://github.com/Automattic/jetpack/pull/50072#issuecomment-4842453950)): from a design-system perspective it's cleaner to space sibling elements with a `Stack` gap rather than a bespoke CSS margin rule.

* Wrap the Email content private-site `Notice` and the `DataForm` in `<Stack gap="lg" direction="column">`, matching the spacing pattern already used across the newsletter settings (`newsletter-settings.tsx`, `subscriptions-section.tsx`, …).
* Drop the now-redundant `.newsletter-email-content-notice { margin-block-end: … }` rule (and its `className`) added in #50072.
* `gap="lg"` (24px) preserves the exact spacing that was reviewed and merged.
* Update the spacing-guard test to assert the `Stack` gap instead of the removed class name.

No functional/visual change — purely how the spacing is expressed.

## Related product discussion/links

* https://github.com/Automattic/jetpack/pull/50072#issuecomment-4842453950

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a private site, go to Jetpack → Newsletter settings → Email content.
* Confirm the "Featured images will not be used…" warning notice still has clear spacing above the featured-image toggle below it (no collision).
* On a public site, confirm the notice is absent and the form spacing is unchanged.
* `cd projects/packages/newsletter && pnpm test` — the `EmailContentSection private-site notice` suite passes.
