### PR TITLE
wpcomsh: keep the fatal screen from OOMing while it renders

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-fatal-error-screen-oom-cascade
+++ b/projects/plugins/wpcomsh/changelog/fix-fatal-error-screen-oom-cascade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fatal error screen: ensure enough free memory before rendering (raising the limit when headroom is short, or falling back to core's screen) so the screen no longer exhausts memory mid-render on a near-limit request and masks the real error in logs.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/README.md
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/README.md
@@ -43,6 +43,25 @@ re-implement core's recovery-mode email, locale resolution, and styling. The
 any of that. Trade-off: we can't replace core's outer `<body>` chrome, only
 the inner message.
 
+### Not OOMing while rendering the screen
+
+Building the screen allocates — CSS read, output buffer, plugin-header reads,
+user bootstrap. When the request is already near its memory ceiling, that
+allocation itself exhausts memory and throws a *second* fatal, which masks the
+real error: the log ends up pointing at `fatal-error-screen.php` (e.g. the CSS
+`file_get_contents`) instead of whatever actually broke. The original error
+need not be an OOM — any fatal on a request that's near the limit hits this.
+
+So `wpcomsh_customize_fatal_error_message()` first calls
+`wpcomsh_fatal_ensure_render_memory()`, which checks the free headroom
+(`memory_limit` − `memory_get_usage()`) and, if it's short, raises the limit
+enough to render. The decision is based on *available memory*, not the error
+type. If the platform refuses the raise (some hosts cap `ini_set`), it returns
+core's lighter default screen (PHP still logs the real fatal) rather than
+re-fataling. A direct `ini_set` is used rather than `wp_raise_memory_limit()`,
+which runs filters in the fatal path and no-ops when the limit is already high
+(as on Atomic).
+
 ### Why helpers bootstrap WP manually
 
 The fatal handler can fire before `wp-settings.php` finishes. At that point

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -46,6 +46,24 @@ function wpcomsh_fatal_current_user_id() {
 }
 
 /**
+ * Ensure there's memory headroom to render the screen without OOMing.
+ *
+ * Returns false when the headroom can't be secured, so the caller falls back
+ * to core's lighter screen.
+ *
+ * @return bool
+ */
+function wpcomsh_fatal_ensure_render_memory() {
+	$needed = MB_IN_BYTES;
+	$usage  = memory_get_usage( true );
+	$limit  = wp_convert_hr_to_bytes( (string) ini_get( 'memory_limit' ) );
+	if ( $limit <= 0 || $limit - $usage >= $needed ) {
+		return true; // Unlimited, or already enough headroom.
+	}
+	return false !== @ini_set( 'memory_limit', (string) ( $usage + $needed ) ); // phpcs:ignore WordPress.PHP.IniSet.memory_limit_Disallowed,WordPress.PHP.NoSilencedErrors.Discouraged -- bounded bump in the fatal handler; a refused raise is handled by the return value.
+}
+
+/**
  * Identify the extension (plugin, mu-plugin, or theme) associated with a
  * fatal, using the error's absolute file path. Looks up the Name / Version
  * / Description headers so the screen can name the likely cause.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -54,7 +54,7 @@ function wpcomsh_fatal_current_user_id() {
  * @return bool
  */
 function wpcomsh_fatal_ensure_render_memory() {
-	$needed = MB_IN_BYTES;
+	$needed = 2 * MB_IN_BYTES;
 	$usage  = memory_get_usage( true );
 	$limit  = wp_convert_hr_to_bytes( (string) ini_get( 'memory_limit' ) );
 	if ( $limit <= 0 || $limit - $usage >= $needed ) {

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -25,6 +25,13 @@
  * @return string
  */
 function wpcomsh_customize_fatal_error_message( $message, $error = array() ) {
+	// Rendering allocates memory. On a near-limit request that would itself OOM
+	// and mask the real error, so secure headroom first; if we can't, fall back
+	// to core's lighter screen.
+	if ( ! wpcomsh_fatal_ensure_render_memory() ) {
+		return (string) $message;
+	}
+
 	unset( $message );
 
 	wpcomsh_fatal_load_textdomain();


### PR DESCRIPTION
Fixes # <!-- dotcom escalation, no GitHub issue -->

## Proposed changes

The wpcomsh branded fatal-error screen hooks `wp_php_error_message` and, while rendering, allocates memory (CSS `file_get_contents`, output buffer, plugin-header reads via `glob`/`get_plugin_data`, user bootstrap). When a fatal happens on a request that's **already near its memory ceiling**, that rendering allocation itself exhausts memory and throws a **second fatal** — which masks the real one:

* the logged fatal points at `fatal-error-screen.php` (e.g. the CSS read at line ~152) instead of whatever actually broke, and
* the visitor can get a blank page.

Key point: **the original error doesn't have to be an OOM.** Any fatal on a near-limit request triggers this — so the right trigger is *available memory*, not the error type.

This PR makes `wpcomsh_customize_fatal_error_message()` check headroom before it renders:

```php
if ( ! wpcomsh_fatal_ensure_render_memory() ) {
    return (string) $message; // can't secure headroom → core's lighter screen
}
```

`wpcomsh_fatal_ensure_render_memory()`:
* returns immediately (no-op) when there's already enough free memory (`memory_limit − memory_get_usage()`),
* otherwise raises `memory_limit` just enough to render (+2 MB above current usage), using `ini_set`'s return value to tell whether the host allowed it,
* returns `false` when the raise is refused, so the caller falls back to core's default screen (PHP still logs the real fatal) instead of re-fataling.

A direct `ini_set` is used rather than `wp_raise_memory_limit()`, which runs `apply_filters` in the fatal path and no-ops when the limit is already high (as on Atomic).

**Why 2 MB:** the render path was measured at a peak of ~120 KB (dominated by the `.mo` textdomain load; CSS + HTML + plugin header are ~14 KB combined). 2 MB is ~6–16× the realistic peak, covering even a cold cache / large translation catalog.

## Related product discussion/links

* Escalation: p1782814612162629-slack-C02FMH4G8 (dotcom-escalations — "Memory fatal errors increasing in wpcomsh")

## Does this pull request change what data or activity we track or use?

No new data is collected. In the rare fallback case (near-limit request where `memory_limit` can't be raised), our `wpcomsh_fatal_signature` logstash event doesn't fire — but the actual fatal is still logged to logstash by PHP regardless.

## Testing instructions

⚠️ **This is not reliably reproducible synthetically.** The re-fatal needs a specific PHP allocator state — real usage within one ~2 MB chunk of the ceiling *and* no reusable free block for the render's next allocation. `str_repeat`/`ini_set` tricks don't recreate it: one large allocation leaves the chunks' internal free space intact (the render borrows from that), and `memory_get_usage(true)` counts OS-grabbed memory, not that inner free space. In production, bp-better-messages-websocket produced that state consistently under real traffic; a test site generally won't.

So verify it two ways instead:

**1. Isolate the fix locally (A/B).** Trigger any fatal on a wpcomsh site, then flip the guard and compare — this controls for the allocator and proves the raise is what's doing the work:
```php
// temporarily, in wpcomsh_fatal_ensure_render_memory():
return true; // mimics trunk (no raise)
```
Confirm the raise fires on a genuinely near-limit request by logging inside the helper:
```php
error_log( sprintf( 'wpcomsh fatal render: free=%d, raising=%d',
    $limit - memory_get_usage( true ),
    (int) ( $limit - memory_get_usage( true ) < $needed ) ) );
```

**2. Prod telemetry (the real test).** After deploy, watch the logstash count of OOM fatals reported *in* `wpcom-fatal-error/fatal-error-screen.php` — it should drop to ~0, and the underlying fatals should show their real culprit files instead.

**Regression check:** a normal fatal on a request with ample free memory is unchanged — `ensure_render_memory()` is a no-op (doesn't touch `memory_limit`), so the full branded admin view, error details, and `wpcomsh_fatal_signature` logstash event all behave as before.


