### PR TITLE
Newsletter widget: remove duplicate webpack build

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-newsletter-widget-double-build
+++ b/projects/plugins/jetpack/changelog/remove-newsletter-widget-double-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter widget: stop building the bundle twice. It was emitted by both the legacy module config (as newsletter-widget.min.js) and its own config (as newsletter-widget.js); only the latter is loaded, so the duplicate min build is removed.

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -172,8 +172,10 @@ class Jetpack_Newsletter_Dashboard_Widget {
 		);
 		$options         = wp_parse_args( $options, $default_options );
 
-		// Get the asset file path. The widget is built unminified (see tools/webpack.config.js),
-		// so read the matching non-minified asset metadata.
+		/*
+		 * Get the asset file path. The widget is built unminified (see tools/webpack.config.js),
+		 * so read the matching non-minified asset metadata.
+		 */
 		$asset_path = JETPACK__PLUGIN_DIR . '_inc/build/' . $asset_name . '.asset.php';
 
 		// Get dependencies and version from asset file

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -172,8 +172,9 @@ class Jetpack_Newsletter_Dashboard_Widget {
 		);
 		$options         = wp_parse_args( $options, $default_options );
 
-		// Get the asset file path
-		$asset_path = JETPACK__PLUGIN_DIR . '_inc/build/' . $asset_name . '.min.asset.php';
+		// Get the asset file path. The widget is built unminified (see tools/webpack.config.js),
+		// so read the matching non-minified asset metadata.
+		$asset_path = JETPACK__PLUGIN_DIR . '_inc/build/' . $asset_name . '.asset.php';
 
 		// Get dependencies and version from asset file
 		$dependencies = array();

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -120,10 +120,7 @@ module.exports = [
 	// Build all the modules.
 	{
 		...sharedWebpackConfig,
-		entry: {
-			...moduleEntries,
-			'newsletter-widget': './modules/subscriptions/newsletter-widget/src/index.tsx',
-		},
+		entry: moduleEntries,
 		plugins: [
 			...sharedWebpackConfig.plugins,
 			...jetpackWebpackConfig.DependencyExtractionPlugin(),
@@ -133,7 +130,11 @@ module.exports = [
 			filename: '[name].min.js', // @todo: Fix this.
 		},
 	},
-	// Build the newsletter widget separately to support translatable strings.
+	/*
+	 * Build the newsletter widget on its own so it gets an unminified `newsletter-widget.js`
+	 * (the legacy module config above forces `[name].min.js`). This is the only build for it;
+	 * the unminified file is what supports extracting translatable strings.
+	 */
 	{
 		...sharedWebpackConfig,
 		entry: {


### PR DESCRIPTION
## Proposed changes

The newsletter dashboard widget was built by two separate webpack configs:

* the legacy module config in `tools/webpack.config.js`, which forces `[name].min.js` and so emitted `newsletter-widget.min.js`, and
* its own config, added later (PR 43403) to support extracting translatable strings, which emits the unminified `newsletter-widget.js`.

Only the unminified `newsletter-widget.js` is ever loaded at runtime (`load_minified_js => false`), so the minified copy was dead weight — roughly 1.5M in the production build.

This PR:

* Removes `newsletter-widget` from the legacy module config so it is built only once (by its own config).
* Updates `Jetpack_Newsletter_Dashboard_Widget::load_admin_scripts()` to read dependency/version metadata from `newsletter-widget.asset.php` instead of the no-longer-generated `newsletter-widget.min.asset.php`. The dependency list is identical between the two; only the cache-busting version hash differed.

This is part of the Jetpack plugin size reduction effort (Tier 2 — build/bundle fixes).

## Related product discussion/links

* Linear: MONOREP-391 (Plugin size: Build and bundle optimization) — https://linear.app/a8c/issue/MONOREP-391

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the Jetpack plugin: `jp build plugins/jetpack`.
* Confirm `projects/plugins/jetpack/_inc/build/` now contains `newsletter-widget.js` (and `.asset.php`, `.css`, `.rtl.css`) but **no** `newsletter-widget.min.js` / `newsletter-widget.min.asset.php`.
* On a connected site, as an admin, go to **wp-admin → Dashboard**. The "Jetpack Newsletter" dashboard widget should render and behave exactly as before (subscriber stats, etc.).
* Switch the site to a non-English locale with Jetpack translations available and confirm the widget's strings are still translated (verifies the translatable-strings build still works).
