### PR TITLE
AI Launchpad: first-pass design-feedback fixes (DSGCOM-678)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-dsgcom-678-feedback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-dsgcom-678-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: address first-pass design feedback (DSGCOM-678) — a single-open accordion task list that auto-expands the next task on skip or completion, WPDS state icons, a Site Editor / Customizer quick link on the site preview, full-width goal copy on mobile, more general social-task subtitles, and removal of the redundant write-3-posts task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -10,10 +10,7 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
-// helpers.php defines the shared option reader the listeners depend on, so it
-// loads first. The REST controller and completion listeners self-register on
-// their own hooks (rest_api_init / init) at load time, and must run on every
-// request regardless of which admin page is showing.
+// helpers.php defines the shared option reader the listeners depend on, so it loads first.
 require_once __DIR__ . '/helpers.php';
 require_once __DIR__ . '/eligibility.php';
 require_once __DIR__ . '/class-ai-launchpad-memberships.php';
@@ -31,10 +28,7 @@ require_once __DIR__ . '/class-ai-launchpad-dev-enable.php';
 class AI_Launchpad {
 
 	/**
-	 * Admin page slug. The `-wp-admin` suffix is the wp-build convention for
-	 * pages that integrate with the standard wp-admin chrome: the generated
-	 * page PHP only enqueues its assets when `$_GET['page']` matches
-	 * `<page-id>-wp-admin`.
+	 * Admin page slug. The `-wp-admin` suffix is the wp-build convention for pages that integrate with wp-admin chrome.
 	 */
 	const MENU_SLUG = 'ai-launchpad-wp-admin';
 
@@ -71,12 +65,7 @@ class AI_Launchpad {
 	/**
 	 * Whether the current site is eligible for the AI Launchpad.
 	 *
-	 * MVP gate: paid plan, not already AI-onboarded, and explicitly enabled for
-	 * the site via the `wpcom_ai_launchpad_enabled` option (set per-site over
-	 * wp-cli). Replaces the earlier automattician/blog-sticker check, which did
-	 * not work on Atomic: `is_automattician()` is undefined there and blog
-	 * stickers require the wpcom sandbox. The option works identically on Simple
-	 * and Atomic and is context-independent (admin, REST, and CLI agree).
+	 * Gate: paid plan, not already AI-onboarded, and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled` option.
 	 *
 	 * @return bool
 	 */
@@ -84,10 +73,7 @@ class AI_Launchpad {
 		static $eligible = null;
 
 		if ( null === $eligible ) {
-			// Cheapest gate first: the per-site option disqualifies the vast
-			// majority of sites with a single option read, before the more
-			// expensive purchases lookup in has_paid_plan() runs on every admin
-			// page. Memoized since the result is stable for the request.
+			// Cheapest gate first: the per-site option disqualifies most sites before the more expensive purchases lookup.
 			$eligible = self::is_enabled_for_site()
 				&& ! self::was_ai_onboarded()
 				&& self::has_paid_plan();
@@ -139,9 +125,7 @@ class AI_Launchpad {
 			return;
 		}
 
-		// The render callback only exists when build/build.php has been loaded,
-		// which happens on the AI Launchpad page itself. On other admin screens
-		// the menu just needs a registered slug.
+		// The render callback only exists once build/build.php is loaded, which happens on the AI Launchpad page itself.
 		$callback = function_exists( self::RENDER_CALLBACK )
 			? self::RENDER_CALLBACK
 			: '__return_empty_string';
@@ -205,15 +189,11 @@ class AI_Launchpad {
 	/**
 	 * Fix import map ordering for the wp-build boot script.
 	 *
-	 * In wp-admin, _wp_footer_scripts (classic scripts) and print_import_map
-	 * both hook into admin_print_footer_scripts at priority 10, but
-	 * _wp_footer_scripts is registered first. This causes the inline
-	 * import("@wordpress/boot") to execute before the import map exists.
+	 * In wp-admin both _wp_footer_scripts and print_import_map hook admin_print_footer_scripts at priority 10, but
+	 * _wp_footer_scripts runs first, so the inline import("@wordpress/boot") executes before the import map exists.
+	 * This moves the import() call to a <script type="module"> printed at priority 20, after the import map.
 	 *
-	 * This fix moves the import() call from the classic inline script to a
-	 * <script type="module"> printed at priority 20 (after the import map).
-	 *
-	 * @todo Remove once @wordpress/build ships with the loader.js fix upstream
+	 * @todo Remove once @wordpress/build ships the loader.js fix upstream
 	 *       (WordPress/gutenberg#76870) and Jetpack updates the dependency.
 	 */
 	private static function fix_boot_import_map_ordering() {
@@ -227,7 +207,6 @@ class AI_Launchpad {
 					return;
 				}
 
-				// Find and extract the import("@wordpress/boot") inline script.
 				$boot_script = null;
 				$remaining   = array();
 				foreach ( $data as $line ) {
@@ -242,7 +221,6 @@ class AI_Launchpad {
 					return;
 				}
 
-				// Remove from the classic script handle.
 				wp_scripts()->add_data( $handle, 'after', $remaining );
 
 				// Re-emit as a module script after the import map.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php
@@ -6,15 +6,11 @@
  */
 
 /**
- * Completes the About-page tasks from wp-admin when the AI Launchpad selected
- * them: `add_about_page` (the AI-created About page is first published) and
- * `update_about_page` (it is edited again afterwards).
+ * Completes the AI-selected About-page tasks from wp-admin: `add_about_page` (first published) and
+ * `update_about_page` (edited again afterwards).
  *
- * The catalog's own completion for these depends on the `_wpcom_template_layout_category`
- * meta, which is provided by the dotcom editor toolkit and is not registered on
- * Atomic, and on the AI's `createPatternPage` only ever creating a draft. So this
- * tags the AI-created About page with its own marker meta and watches that page's
- * publish/update transitions instead — independent of the layout-category meta.
+ * The catalog's own completion depends on the `_wpcom_template_layout_category` meta, which is not registered on
+ * Atomic, so this tags the AI-created About page with its own marker meta and watches that page's transitions instead.
  */
 class AI_Launchpad_About_Page_Listener {
 
@@ -34,9 +30,9 @@ class AI_Launchpad_About_Page_Listener {
 	}
 
 	/**
-	 * Registers the marker meta so the block editor preserves it and the create
-	 * request can set it. Protected (underscore-prefixed), so the auth callback
-	 * limits writes to users who can edit pages.
+	 * Registers the marker meta so the block editor preserves it and the create request can set it.
+	 *
+	 * The auth callback limits writes to users who can edit pages.
 	 *
 	 * @return void
 	 */
@@ -56,9 +52,8 @@ class AI_Launchpad_About_Page_Listener {
 	}
 
 	/**
-	 * Completes the About-page tasks on the AI About page's status transitions:
-	 * first publish -> add_about_page, a later edit of the published page ->
-	 * update_about_page. Only fires for the marked page and AI-selected tasks.
+	 * Completes the About-page tasks on the marked page's status transitions: first publish -> add_about_page,
+	 * a later edit of the published page -> update_about_page.
 	 *
 	 * @param string   $new_status The new post status.
 	 * @param string   $old_status The previous post status.
@@ -80,12 +75,10 @@ class AI_Launchpad_About_Page_Listener {
 		}
 
 		if ( 'publish' !== $old_status ) {
-			// First publish of the AI About page.
 			if ( in_array( 'add_about_page', $ai_task_ids, true ) ) {
 				wpcom_mark_launchpad_task_complete( 'add_about_page' );
 			}
 		} elseif ( in_array( 'update_about_page', $ai_task_ids, true ) ) {
-			// A later edit of the already-published AI About page.
 			wpcom_mark_launchpad_task_complete( 'update_about_page' );
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-dev-enable.php
@@ -2,37 +2,20 @@
 /**
  * AI Launchpad no-CLI test-enable handler.
  *
- * Lets a tester turn the AI Launchpad on (and reset its state) for a site
- * straight from the browser, removing the `wp option update
- * wpcom_ai_launchpad_enabled 1` / reset-script SSH steps that testing otherwise
- * requires. Modeled on the existing wpcom query-param overrides
- * (wpcom-dashboard-redesign-override.php `?enable-dashboard-redesign=1`,
- * jetpack stats `?enable_new_stats=1`), which likewise flip a feature straight
- * from a `$_GET` flag.
+ * Lets a tester turn the AI Launchpad on (and reset its state) for a site straight from the browser.
  *
  * Recognized query args (on any admin page, for a `manage_options` user):
  *   ?enable-ai-launchpad=1  Set wpcom_ai_launchpad_enabled to 1.
  *   ?enable-ai-launchpad=0  Delete wpcom_ai_launchpad_enabled (turn back off).
- *   ?reset-ai-launchpad=1   Clear the wizard / AI-output / dismissed / task-status
- *                           options so the wizard runs fresh.
+ *   ?reset-ai-launchpad=1   Clear the wizard / AI-output / dismissed / task-status options so the wizard runs fresh.
  *
- * Each action redirects to the clean AI Launchpad page URL so a refresh does not
- * re-fire it.
+ * Hooked on `admin_menu`, not `admin_init`: when the feature is OFF its page is unregistered and
+ * `user_can_access_admin_page()` dies before `admin_init`; `admin_menu` fires before that check, so the page's own
+ * URL can self-enable instead of dying first.
  *
- * Hooked on `admin_menu`, not `admin_init`: when the feature is OFF its admin
- * page is unregistered, and WordPress runs the `user_can_access_admin_page()`
- * check (and dies with "you are not allowed to access this page") in
- * wp-admin/menu.php — which loads *before* `admin_init`. `admin_menu` fires
- * inside that same file but before the access check, so handling it there lets
- * the launchpad page's own URL self-enable instead of dying first.
- *
- * Gate: `current_user_can( 'manage_options' )` only — no nonce, matching the
- * wpcom precedents, so the URL stays bookmarkable/shareable. NOTE: this ships to
- * production on real sites, where it lets any paid-site admin self-enable the
- * (otherwise OFF) feature on their own site. That exposure was reviewed and
- * accepted as an interim testing affordance; tighten the gate before the
- * controlled rollout (DOTOBRD-456) if the feature must stay invisible to
- * customers.
+ * Gate: `current_user_can( 'manage_options' )` only — no nonce, so the URL stays bookmarkable. This ships to
+ * production, where it lets any paid-site admin self-enable the (otherwise OFF) feature on their own site; tighten
+ * the gate before the controlled rollout if the feature must stay invisible to customers.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -48,9 +31,9 @@ class AI_Launchpad_Dev_Enable {
 	const OPTION_ENABLED = 'wpcom_ai_launchpad_enabled';
 
 	/**
-	 * Options cleared by a reset, matching docs/bin/reset-ai-launchpad-test-site.sh.
-	 * The first three reference the REST controller's canonical constants so a
-	 * rename there can't silently leave the reset clearing a stale option name.
+	 * Options cleared by a reset.
+	 *
+	 * The first three reference the REST controller's constants so a rename there can't leave a stale option name here.
 	 */
 	const RESET_OPTIONS = array(
 		AI_Launchpad_REST::OPTION_WIZARD,
@@ -60,9 +43,7 @@ class AI_Launchpad_Dev_Enable {
 	);
 
 	/**
-	 * Redirect targets returned by handle(): nothing to do, the AI Launchpad page,
-	 * or the wp-admin dashboard. Kept as abstract tokens (not URLs) so handle() can
-	 * be unit-tested without loading the AI Launchpad page bootstrap.
+	 * Redirect targets returned by handle(), kept as abstract tokens (not URLs) so handle() can be unit-tested.
 	 */
 	const REDIRECT_NONE      = '';
 	const REDIRECT_PAGE      = 'page';
@@ -78,10 +59,9 @@ class AI_Launchpad_Dev_Enable {
 	}
 
 	/**
-	 * Acts on the test-enable / reset query params, then redirects so a refresh
-	 * does not re-fire the action. Disabling lands on the dashboard (the gated
-	 * page is gone); everything else lands on the AI Launchpad page, where the
-	 * fresh request re-registers the now-eligible menu.
+	 * Acts on the test-enable / reset query params, then redirects so a refresh does not re-fire the action.
+	 *
+	 * Disabling lands on the dashboard (the gated page is gone); everything else lands on the AI Launchpad page.
 	 *
 	 * @return void
 	 */
@@ -101,11 +81,9 @@ class AI_Launchpad_Dev_Enable {
 	}
 
 	/**
-	 * Applies the requested option changes and returns where to send the user, as
-	 * one of the REDIRECT_* tokens. Split from the redirect/exit — and kept free of
-	 * the AI Launchpad page bootstrap — so it can be unit-tested in isolation. No-op
-	 * (and cheap) on the overwhelming majority of admin requests, which carry
-	 * neither param.
+	 * Applies the requested option changes and returns where to send the user, as one of the REDIRECT_* tokens.
+	 *
+	 * Split from the redirect/exit so it can be unit-tested in isolation.
 	 *
 	 * @return string One of the REDIRECT_* constants (REDIRECT_NONE when there is
 	 *                nothing to do: no recognized param, or no capability).
@@ -142,11 +120,7 @@ class AI_Launchpad_Dev_Enable {
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		// Disabling removes the (eligibility-gated) launchpad page, so land on the
-		// dashboard rather than the now-inaccessible page. Otherwise go to the
-		// launchpad: the redirect starts a fresh request where the menu
-		// re-registers. (On a site without a paid plan the page stays gated, but
-		// that is out of scope — the feature requires a paid plan.)
+		// Disabling removes the gated launchpad page, so land on the dashboard rather than the now-inaccessible page.
 		return $disabling ? self::REDIRECT_DASHBOARD : self::REDIRECT_PAGE;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-listeners.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-listeners.php
@@ -6,11 +6,10 @@
  */
 
 /**
- * Registers the existing Launchpad completion listeners for the tasks the AI
- * Launchpad selected, mirroring Launchpad_Task_Lists::add_hooks_for_active_tasks()
- * without the fullscreen-launchpad gate. Task selection is read from the
- * `wpcom_ai_launchpad_ai_output` option; completion writes go through each
- * task's own `add_listener_callback` into `launchpad_checklist_tasks_statuses`.
+ * Registers the existing Launchpad completion listeners for the AI-selected tasks, without the fullscreen gate.
+ *
+ * Task selection is read from `wpcom_ai_launchpad_ai_output`; completion writes go through each task's own
+ * `add_listener_callback` into `launchpad_checklist_tasks_statuses`.
  */
 class AI_Launchpad_Listeners {
 
@@ -25,9 +24,7 @@ class AI_Launchpad_Listeners {
 	}
 
 	/**
-	 * Treats AI-selected tasks as active so their shared completion callbacks
-	 * write status even when the task is absent from the site's `site_intent`
-	 * task list.
+	 * Treats AI-selected tasks as active so their completion callbacks write status even when absent from `site_intent`.
 	 *
 	 * @param bool   $is_active Whether the task is active per the site_intent task list.
 	 * @param string $task_id   The task being completed.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-memberships.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-memberships.php
@@ -8,18 +8,10 @@
  */
 
 /**
- * Recomputes the memberships task completion from Jetpack_Memberships' local
- * signals, which the AI Launchpad REST read path uses instead of the catalog's
- * own `is_complete_callback`s for these tasks.
+ * Recomputes the memberships task completion from Jetpack_Memberships' local signals.
  *
- * The catalog computes these from `wpcom_launchpad_get_membership_settings()`,
- * which returns null under `IS_ATOMIC`, so `wpcom_launchpad_is_stripe_connected`
- * / `wpcom_launchpad_has_paid_membership_plans` are always false on Atomic — and
- * because those callbacks recompute (ignoring any stored option), an
- * option-writing listener could not surface them. The real state is readable
- * locally on Atomic, though: Jetpack_Memberships syncs the connected-account
- * flag down as a site option and mirrors membership plans as the local
- * `jp_mem_plan` CPT. This reads those instead.
+ * The catalog's own callbacks are always false on Atomic (their membership settings return null there), so the REST
+ * read path uses this instead. Jetpack_Memberships syncs the connected-account flag and membership plans down locally.
  */
 class AI_Launchpad_Memberships {
 
@@ -59,8 +51,7 @@ class AI_Launchpad_Memberships {
 		switch ( $task_id ) {
 			case 'stripe_connected':
 			case 'set_up_payments':
-				// Stripe connected = a payment method is set up; wpcom completes both
-				// on Stripe-connect (memberships/connected-accounts.php).
+				// A connected account means a payment method is set up; wpcom completes both on Stripe-connect.
 				return (bool) Jetpack_Memberships::has_connected_account();
 			case 'paid_offer_created':
 				return (bool) Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -20,26 +20,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	const LAUNCH_TASK_IDS = array( 'site_launched', 'blog_launched', 'woo_launch_site', 'link_in_bio_launched', 'videopress_launched' );
 
 	/**
-	 * Tasks whose completion the AI Launchpad writes when the user clicks their CTA,
-	 * because the real signal is unreachable when the launchpad runs in wp-admin:
+	 * Tasks the AI Launchpad marks complete on CTA click, because their real signal is unreachable from wp-admin.
 	 *
-	 * - The acknowledgment tasks (complete_profile … site_monitoring_page) complete
-	 *   on click / page-visit in Calypso, which writes the status to Calypso's
-	 *   *selected* site — never from the wp-admin context.
-	 * - setup_ssh's real signal (an SSH user exists) is only readable through the
-	 *   wpcom hosting endpoint, which rejects the launchpad's Atomic context (blog
-	 *   token 401, Jetpack-user token 403). Calypso's own hosting form completes it
-	 *   optimistically when the user creates SFTP credentials; this reuses that
-	 *   strategy, ticking it when the user opens the same hosting page via the CTA.
-	 * - share_site has no real signal at all (sharing is a transient client action;
-	 *   even Calypso completes it optimistically when the user copies/shares the URL)
-	 *   and no CTA destination, so the tailored list offers a "Mark as complete"
-	 *   button that hits this route.
-	 *
-	 * The AI Launchpad runs in wp-admin (on both Simple and Atomic), so it marks
-	 * these complete locally on CTA click. Server-side allowlist so the complete-task
-	 * route can only tick these ids, never arbitrary catalog tasks. Mirrored
-	 * client-side in model.ts (COMPLETE_ON_CLICK_TASK_IDS).
+	 * Server-side allowlist so the complete-task route can only tick these ids. Mirrored client-side in model.ts.
 	 */
 	const COMPLETE_ON_CLICK_TASK_IDS = array(
 		'complete_profile',
@@ -53,27 +36,20 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
-	 * Tasks whose catalog `is_visible_callback` encodes an `IS_WPCOM`-only platform
-	 * assumption that the AI Launchpad overrides because it retrieves the same data
-	 * cross-platform. `add_10_email_subscribers` is gated by
-	 * `wpcom_launchpad_are_newsletter_subscriber_counts_available` (false off
-	 * WordPress.com), but AI_Launchpad_Subscribers_Listener reads the count on
-	 * Atomic via `/sites/{id}/subscribers/stats`, so the task must still render and
-	 * its visibility gate is skipped here.
+	 * Tasks whose catalog visibility gate encodes an `IS_WPCOM`-only assumption the AI Launchpad overrides.
+	 *
+	 * `add_10_email_subscribers` is gated off WordPress.com, but AI_Launchpad_Subscribers_Listener reads the count on
+	 * Atomic, so the task must still render and its visibility gate is skipped here.
 	 */
 	const FORCE_VISIBLE_TASK_IDS = array(
 		'add_10_email_subscribers',
 	);
 
 	/**
-	 * CTA destinations the AI Launchpad repoints to wp-admin, keyed by task id and
-	 * mapping to an `admin_url()` path. The catalog sends these to Calypso flows
-	 * that are a poor fit for the wp-admin AI Launchpad: connect_social_media goes
-	 * to Calypso `/marketing/connections` even though it completes on the wp-admin
-	 * Jetpack Social page (where this lands it, matching drive_traffic), and the
-	 * design "Select a design" tasks go to a Calypso setup step-flow rather than the
-	 * theme browser. Overridden on read so the shared catalog (used by the legacy
-	 * launchpad too) is left untouched.
+	 * CTA destinations the AI Launchpad repoints to wp-admin, keyed by task id, each mapping to an `admin_url()` path.
+	 *
+	 * The catalog sends these to Calypso flows that are a poor fit for wp-admin. Overridden on read so the shared
+	 * catalog (used by the legacy launchpad too) is left untouched.
 	 */
 	const CTA_OVERRIDES = array(
 		'connect_social_media' => 'admin.php?page=jetpack-social',
@@ -82,12 +58,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
-	 * Jetpack Social tasks, hidden on private sites. wpcom does not load Publicize
-	 * (and so the Jetpack Social admin page their CTA points to) on a private site,
-	 * mirroring Publicize_Setup::should_load(). The AI Launchpad runs only on the
-	 * wpcom platform, so the private-site flag (`blog_public = -1`) is the whole
-	 * condition — Publicize's additional `is_wpcom_platform()` check is always true
-	 * here.
+	 * Jetpack Social tasks, hidden on private sites where wpcom does not load Publicize (so their CTA page would 404).
 	 */
 	const SOCIAL_PAGE_TASK_IDS = array(
 		'connect_social_media',
@@ -96,10 +67,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
-	 * Whether the site's visibility is set to private (`blog_public = -1`), the
-	 * core of Jetpack's Status::is_private_site(). Read directly to avoid a hard
-	 * dependency on the Status package in this read path; the launchpad is
-	 * wpcom-only, where this option is the private-site signal.
+	 * Whether the site's visibility is set to private (`blog_public = -1`).
+	 *
+	 * Read directly to avoid a hard dependency on the Status package in this read path.
 	 *
 	 * @return bool
 	 */
@@ -130,8 +100,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_read' ),
 					'args'                => array(
-						// Testing aid: render the full task catalog (visibility bypassed,
-						// no tailoring) so every task can be exercised from one site.
+						// Testing aid: render the full task catalog so every task can be exercised from one site.
 						'all_tasks' => array(
 							'description' => 'Return the full task catalog instead of the tailored list (testing aid).',
 							'type'        => 'boolean',
@@ -255,13 +224,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	/**
 	 * Returns a 404 error for ineligible sites, true otherwise.
 	 *
-	 * The eligibility gate itself is owned by the AI Launchpad loader.
-	 *
 	 * @return true|WP_Error
 	 */
 	private function check_eligibility() {
-		// Fail closed: if the gate is unavailable for any reason, treat the site
-		// as not eligible rather than exposing the endpoint to every capable user.
+		// Fail closed: if the gate is unavailable, treat the site as not eligible.
 		if ( ! function_exists( 'wpcom_ai_launchpad_is_eligible' ) || ! wpcom_ai_launchpad_is_eligible() ) {
 			return new WP_Error(
 				'ai_launchpad_not_eligible',
@@ -283,22 +249,18 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		$wizard    = get_option( self::OPTION_WIZARD );
 		$ai_output = get_option( self::OPTION_AI_OUTPUT );
 
-		// Testing aid: ?all_tasks=1 renders the whole catalog (visibility bypassed),
-		// independent of the persisted tailored output, so every task can be
-		// exercised from a single site.
+		// Testing aid: ?all_tasks=1 renders the whole catalog, independent of the persisted tailored output.
 		if ( $request instanceof WP_REST_Request && $request->get_param( 'all_tasks' ) ) {
 			$tasks = $this->build_all_catalog_tasks();
 		} else {
-			// Guard the nested payload: partial/legacy/failed writes may leave the
-			// option as an array without payload.tasks, which would warn and break.
+			// Guard the nested payload: partial/failed writes may leave the option without payload.tasks.
 			$tasks = array();
 			if ( is_array( $ai_output ) && isset( $ai_output['payload']['tasks'] ) && is_array( $ai_output['payload']['tasks'] ) ) {
 				$tasks = $this->build_tasks( $ai_output['payload']['tasks'] );
 			}
 		}
 
-		// The membership tasks' completion is recomputed in build_tasks() (their
-		// option is never written on Atomic), so overlay it here to keep
+		// The membership tasks' completion is recomputed in build_tasks(), so overlay it to keep
 		// checklist_statuses consistent with tasks[].completed for them.
 		$checklist_statuses = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
 		foreach ( $tasks as $task ) {
@@ -314,30 +276,21 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'checklist_statuses' => $checklist_statuses,
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
-			// Site context the client needs: the front-end URL drives the launch-task
-			// CTA (its host is the launch-flow site slug) and the tailored-list
-			// preview thumbnail; the title labels that preview; the editor URL is the
-			// preview's quick link into the Site Editor. Title and description also
-			// pre-fill the wizard's Name and Brief description fields so they reflect
-			// the site's current identity.
+			// Site context the client needs for the launch-task CTA, the preview thumbnail/title, and wizard prefill.
 			'site'               => array(
 				'url'         => home_url(),
 				'title'       => get_bloginfo( 'name' ),
 				'description' => get_bloginfo( 'description' ),
-				// Block themes open the Site Editor; classic themes (which can't use it)
-				// fall back to the Customizer, their equivalent appearance editor.
+				// Block themes open the Site Editor; classic themes fall back to the Customizer.
 				'edit_url'    => wp_is_block_theme() ? admin_url( 'site-editor.php' ) : admin_url( 'customize.php' ),
 			),
 		);
 	}
 
 	/**
-	 * Persists the wizard input to the wizard option and, on completion, writes
-	 * the entered Name and Brief description back to the site's identity options
-	 * (blogname / blogdescription) so the wizard reflects and updates the real
-	 * site title and tagline. Empty values are skipped so the wizard never blanks
-	 * an existing title or tagline. Values are already sanitized by the route's
-	 * sanitize_callbacks; update_option re-runs core's option sanitizers too.
+	 * Persists the wizard input and writes the entered Name and Brief description back to blogname / blogdescription.
+	 *
+	 * Empty values are skipped so the wizard never blanks an existing title or tagline.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
@@ -358,8 +311,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			update_option( 'blogname', $request['site_name'] );
 		}
 		if ( '' !== trim( (string) $request['description'] ) ) {
-			// The tagline is rendered inline by themes, so collapse the textarea
-			// brief's newlines to keep blogdescription single-line.
+			// Collapse the textarea brief's newlines to keep the inline-rendered tagline single-line.
 			update_option( 'blogdescription', sanitize_text_field( $request['description'] ) );
 		}
 
@@ -431,12 +383,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * Marks an acknowledgment task complete. These tasks have no completion signal
-	 * in wp-admin — in Calypso they complete on click/page-visit, written to
-	 * Calypso's selected site — so the client calls this when the user clicks the
-	 * task's CTA. Restricted to the COMPLETE_ON_CLICK_TASK_IDS allowlist and to
-	 * tasks actually on the site's AI-selected list, so the route can't tick
-	 * arbitrary catalog tasks.
+	 * Marks an acknowledgment task complete when the user clicks its CTA, since these tasks have no wp-admin signal.
+	 *
+	 * Restricted to the COMPLETE_ON_CLICK_TASK_IDS allowlist and to tasks on the site's AI-selected list.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array|WP_Error
@@ -452,8 +401,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			);
 		}
 
-		// Only tasks the AI actually put on this site's list may be completed, so a
-		// capable user can't tick a task that isn't on their launchpad.
+		// Only tasks the AI put on this site's list may be completed.
 		if ( ! in_array( $task_id, wpcom_ai_launchpad_get_ai_task_ids(), true ) ) {
 			return new WP_Error(
 				'ai_launchpad_task_not_selected',
@@ -519,10 +467,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * Builds the enriched task list for every task in the catalog, bypassing the
-	 * per-site visibility gate. Backs the `?all_tasks=1` testing aid; each task is
-	 * enriched in isolation so one that can't be built in this context is skipped
-	 * rather than breaking the whole view.
+	 * Builds the enriched task list for every catalog task, bypassing the visibility gate (backs `?all_tasks=1`).
+	 *
+	 * Each task is enriched in isolation so one that can't be built is skipped rather than breaking the whole view.
 	 *
 	 * @return array
 	 */
@@ -560,10 +507,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
 
-		// Some catalog visibility callbacks call is_plugin_active() (e.g. the
-		// WooCommerce tasks), which lives in wp-admin/includes/plugin.php and is not
-		// loaded during a REST request. Load it once so the is_visible() gate below
-		// can't fatal on those callbacks.
+		// Some catalog visibility callbacks call is_plugin_active(), which is not loaded during a REST request.
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -579,8 +523,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				continue;
 			}
 
-			// The Jetpack Social tasks point at an admin page wpcom doesn't load on
-			// a private site, so hide them there — their CTA would 404.
+			// The Jetpack Social tasks point at an admin page wpcom doesn't load on a private site, so hide them there.
 			if ( $is_private_site && in_array( $task['id'], self::SOCIAL_PAGE_TASK_IDS, true ) ) {
 				continue;
 			}
@@ -588,15 +531,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			$definition       = $definitions[ $task['id'] ];
 			$definition['id'] = $task['id'];
 
-			// Honor the catalog's own visibility gate, mirroring the legacy
-			// Launchpad_Task_Lists::build(): drop any task the catalog would hide
-			// on this site (e.g. WooCommerce tasks with no WooCommerce, or
-			// goal-gated tasks). The AI can select from the full menu, but a task
-			// it picks that is not applicable here must not render — the CTA would
-			// 404 and the task could never complete. Filtering on read (rather than
-			// rejecting on write) keeps the deterministic fallback usable: its fixed
-			// per-goal lists also contain conditionally-visible tasks, so gating the
-			// write path could strand a goal with too few surviving tasks.
+			// Honor the catalog's own visibility gate: a task the catalog would hide here must not render, since its
+			// CTA would 404 and it could never complete. Filtered on read so the deterministic fallback stays usable.
 			if (
 				! $bypass_visibility
 				&& ! in_array( $task['id'], self::FORCE_VISIBLE_TASK_IDS, true )
@@ -605,9 +541,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				continue;
 			}
 
-			// The membership tasks' catalog callbacks recompute from membership
-			// settings that are null on Atomic (always false there); recompute them
-			// from Jetpack_Memberships' local signals instead.
+			// The membership tasks' catalog callbacks are always false on Atomic; recompute from local signals instead.
 			$completed = AI_Launchpad_Memberships::has_override( $task['id'] )
 				? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
 				: wpcom_launchpad_checklists()->is_task_complete( $definition );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -316,13 +316,17 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'is_eligible'        => true,
 			// Site context the client needs: the front-end URL drives the launch-task
 			// CTA (its host is the launch-flow site slug) and the tailored-list
-			// preview thumbnail; the title labels that preview. Title and
-			// description also pre-fill the wizard's Name and Brief description
-			// fields so they reflect the site's current identity.
+			// preview thumbnail; the title labels that preview; the editor URL is the
+			// preview's quick link into the Site Editor. Title and description also
+			// pre-fill the wizard's Name and Brief description fields so they reflect
+			// the site's current identity.
 			'site'               => array(
 				'url'         => home_url(),
 				'title'       => get_bloginfo( 'name' ),
 				'description' => get_bloginfo( 'description' ),
+				// Block themes open the Site Editor; classic themes (which can't use it)
+				// fall back to the Customizer, their equivalent appearance editor.
+				'edit_url'    => wp_is_block_theme() ? admin_url( 'site-editor.php' ) : admin_url( 'customize.php' ),
 			),
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-social-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-social-listener.php
@@ -12,18 +12,12 @@ use Automattic\Jetpack\Publicize\Connections;
 use Automattic\Jetpack\Publicize\Publicize_Utils;
 
 /**
- * Completes the Jetpack Social tasks from wp-admin when the AI Launchpad selected
- * them: `connect_social_media` / `drive_traffic` (a Publicize connection exists)
- * and `post_sharing_enabled` (the Publicize module is active).
+ * Completes the AI-selected Jetpack Social tasks from wp-admin: `connect_social_media` /
+ * `drive_traffic` (a Publicize connection exists) and `post_sharing_enabled` (the Publicize module is active).
  *
- * These catalog tasks have no `add_listener_callback` and complete in Calypso
- * only, so a wp-admin launchpad never ticks them. Jetpack Social runs locally,
- * so the real state is readable — but there is no local "connection created"
- * action on Atomic (connections are created through a proxied wpcom request).
- * This reconciles when the AI Launchpad page loads: the gate keeps the Publicize
- * connection lookup off every other admin page, and the per-task completion
- * check short-circuits once a task is done, so the lookup only runs while a
- * selected social task is still incomplete.
+ * These catalog tasks have no `add_listener_callback` and there is no local "connection created" action on Atomic, so
+ * this reconciles the local state when the AI Launchpad page loads. The page gate keeps the lookup off every other
+ * admin page, and it only runs while a selected social task is still incomplete.
  */
 class AI_Launchpad_Social_Listener {
 
@@ -42,9 +36,7 @@ class AI_Launchpad_Social_Listener {
 	 * @return void
 	 */
 	public static function maybe_complete_social_tasks() {
-		// Only reconcile on the AI Launchpad page itself — that is where completion
-		// must show, and it keeps the Publicize connection lookup off every other
-		// admin page.
+		// Only reconcile on the AI Launchpad page, keeping the Publicize connection lookup off every other admin page.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['page'] ) || AI_Launchpad::MENU_SLUG !== sanitize_key( wp_unslash( $_GET['page'] ) ) ) {
 			return;
@@ -67,9 +59,8 @@ class AI_Launchpad_Social_Listener {
 			wpcom_mark_launchpad_task_complete( 'post_sharing_enabled' );
 		}
 
-		// connect_social_media / drive_traffic complete once a Publicize connection
-		// exists. connect_social_media id-maps to drive_traffic, so completing
-		// either writes the same status; we mark whichever the AI selected.
+		// connect_social_media / drive_traffic complete once a Publicize connection exists. connect_social_media
+		// id-maps to drive_traffic, so we mark whichever the AI selected.
 		$connection_tasks = array_filter(
 			array( 'connect_social_media', 'drive_traffic' ),
 			static function ( $task_id ) use ( $ai_task_ids, $task_lists ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-subscribers-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-subscribers-listener.php
@@ -8,25 +8,19 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\AI_Launchpad;
 
 /**
- * Completes the subscriber-count tasks from wp-admin when the AI Launchpad
- * selected them: `subscribers_added` / `import_subscribers` (the site has at
- * least one email subscriber) and `add_10_email_subscribers` (at least ten).
+ * Completes the AI-selected subscriber-count tasks from wp-admin: `subscribers_added` /
+ * `import_subscribers` (at least one email subscriber) and `add_10_email_subscribers` (at least ten).
  *
- * The catalog completes these in Calypso only (an option write on import-start)
- * or via `wpcom_launchpad_get_newsletter_subscriber_count`, which hard-requires
- * `IS_WPCOM` and so returns 0 on Atomic. But the real count is retrievable on
- * Atomic through `fetch_subscriber_counts()` — the same `jetpack.fetchSubscriberCounts`
- * call Jetpack's Subscribe block already makes there. This reconciles when the
- * AI Launchpad page loads: the page gate keeps the lookup off every other admin
- * page, and the per-task completion check short-circuits once a task is done, so
- * the lookup only runs while a selected subscriber task is still incomplete.
+ * The catalog completes these in Calypso only, or via a helper that returns 0 on Atomic, so this reconciles the real
+ * count via `fetch_subscriber_counts()` when the AI Launchpad page loads. The page gate keeps the lookup off every
+ * other admin page, and it only runs while a selected subscriber task is still incomplete.
  */
 class AI_Launchpad_Subscribers_Listener {
 
 	/**
 	 * Tasks that complete once the site has at least one email subscriber.
-	 * `import_subscribers` id-maps to `subscribers_added`, so completing either
-	 * writes the same status; we mark whichever the AI selected.
+	 *
+	 * `import_subscribers` id-maps to `subscribers_added`, so we mark whichever the AI selected.
 	 */
 	const SUBSCRIBERS_ADDED_TASKS = array( 'subscribers_added', 'import_subscribers' );
 
@@ -51,9 +45,7 @@ class AI_Launchpad_Subscribers_Listener {
 	 * @return void
 	 */
 	public static function maybe_complete_subscriber_tasks() {
-		// Only reconcile on the AI Launchpad page itself — that is where completion
-		// must show, and it keeps the remote subscribers/stats call off every other
-		// admin page.
+		// Only reconcile on the AI Launchpad page, keeping the remote call off every other admin page.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['page'] ) || AI_Launchpad::MENU_SLUG !== sanitize_key( wp_unslash( $_GET['page'] ) ) ) {
 			return;
@@ -76,7 +68,7 @@ class AI_Launchpad_Subscribers_Listener {
 		$first_ten_pending = in_array( 'add_10_email_subscribers', $ai_task_ids, true )
 			&& ! $task_lists->is_task_id_complete( 'add_10_email_subscribers' );
 
-		// Nothing selected-and-incomplete: skip the remote call entirely.
+		// Nothing selected-and-incomplete: skip the remote call.
 		if ( empty( $added_tasks ) && ! $first_ten_pending ) {
 			return;
 		}
@@ -98,10 +90,7 @@ class AI_Launchpad_Subscribers_Listener {
 	}
 
 	/**
-	 * The site's email subscriber count, retrieved on Atomic via Jetpack's
-	 * `fetch_subscriber_counts()` (the Subscribe block's `jetpack.fetchSubscriberCounts`
-	 * path, transient-cached). The blog-token `subscribers/stats` REST endpoint is
-	 * not reliably reachable here, so this uses the proven counts path instead.
+	 * The site's email subscriber count, retrieved on Atomic via Jetpack's `fetch_subscriber_counts()`.
 	 *
 	 * @return int|null The email subscriber count, or null when it cannot be retrieved.
 	 */
@@ -112,8 +101,7 @@ class AI_Launchpad_Subscribers_Listener {
 
 		$counts = \Automattic\Jetpack\Extensions\Subscriptions\fetch_subscriber_counts();
 
-		// On Atomic the helper reports a 'failed' status when the wpcom call errored;
-		// treat that as unknown rather than zero so a transient failure never sticks.
+		// Treat a 'failed' status as unknown rather than zero, so a transient failure never sticks.
 		if ( isset( $counts['status'] ) && 'failed' === $counts['status'] ) {
 			return null;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-theme-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-theme-listener.php
@@ -6,13 +6,9 @@
  */
 
 /**
- * Marks the `site_theme_selected` task complete on `switch_theme` when the AI
- * Launchpad selected it.
+ * Marks the `site_theme_selected` task complete on `switch_theme` when the AI Launchpad selected it.
  *
- * The catalog's `site_theme_selected` task has no `add_listener_callback`, so
- * AI_Launchpad_Listeners does not register completion for it - it completes only
- * via `is_complete_callback` polling. This listener fills that gap by writing the
- * completion directly when the user activates a new theme.
+ * The catalog's task has no `add_listener_callback`, so this listener writes completion directly on theme activation.
  */
 class AI_Launchpad_Theme_Listener {
 
@@ -28,9 +24,8 @@ class AI_Launchpad_Theme_Listener {
 	/**
 	 * Marks `site_theme_selected` complete when it is among the AI-selected tasks.
 	 *
-	 * Writes the completion directly (ungated) rather than through the
-	 * `*_if_active` path: the AI-selected task may not be in the site's legacy
-	 * site_intent task list, which the `*_if_active` path would silently no-op on.
+	 * Writes directly rather than through the `*_if_active` path, which would no-op when the task is absent from
+	 * the site's legacy site_intent list.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/eligibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/eligibility.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * AI Launchpad eligibility — single source of truth shared by the admin-menu
- * gate (AI_Launchpad::register_menu) and the REST controller
- * (AI_Launchpad_REST::check_eligibility), which both resolve to this.
+ * AI Launchpad eligibility — single source of truth shared by the admin-menu gate and the REST controller.
  *
  * @package automattic/jetpack-mu-wpcom
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -9,9 +9,6 @@ if ( ! function_exists( 'wpcom_ai_launchpad_get_ai_task_ids' ) ) {
 	/**
 	 * The AI-selected task IDs from the `wpcom_ai_launchpad_ai_output` option.
 	 *
-	 * The single reader of the option's task list, shared by the completion
-	 * listeners and the theme listener.
-	 *
 	 * @return string[] Task IDs, empty when the option is unset or malformed.
 	 */
 	function wpcom_ai_launchpad_get_ai_task_ids() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -7,32 +7,21 @@ import type { TailorResult } from './lib/types.ts';
 import type { LaunchpadData } from './tailored-list/model.ts';
 
 /**
- * Orchestrates the AI Launchpad flow: a new user (no persisted AI output) sees
- * the wizard, finishes it, and transitions to the tailored list; a returning
- * user (output already persisted) lands straight on the tailored list.
- *
- * On load it reads `GET /ai-launchpad` once to decide the view. When the wizard
- * finishes it hands the in-flight tailor promise to the list, which shows the
- * skeleton until the AI call and its PUT settle, then renders the six tasks.
- *
- * View selection uses local React state (no `@wordpress/data` store), matching
- * the wizard and tailored-list streams.
+ * Orchestrates the AI Launchpad flow: new users see the wizard, returning users
+ * land straight on the tailored list.
  *
  * @return The orchestrated AI Launchpad element.
  */
 export function App() {
-	// `null` while the initial read is in flight; the skeleton-free wizard and
-	// list both decide their own loading UI once a view is chosen.
+	// null while the initial read is in flight.
 	const [ view, setView ] = useState< View | null >( null );
 	const [ pendingTailor, setPendingTailor ] = useState< Promise< TailorResult > | undefined >();
-	// The composite read used to decide the view; handed to the list so a
-	// returning user doesn't fetch the same expensive endpoint twice.
+	// Handed to the list so returning users don't refetch the same endpoint.
 	const [ initialData, setInitialData ] = useState< LaunchpadData | undefined >();
 
 	useEffect( () => {
 		let cancelled = false;
-		// Testing aid: ?all_tasks=1 skips the wizard and renders the full task
-		// catalog (the endpoint returns every task, visibility bypassed).
+		// Testing aid: ?all_tasks=1 skips the wizard and renders the full catalog.
 		const allTasks = isAllTasksMode( window.location.search );
 		const path = allTasks ? '/wpcom/v2/ai-launchpad?all_tasks=1' : '/wpcom/v2/ai-launchpad';
 		apiFetch< LaunchpadData >( { path } ).then( data => {
@@ -64,10 +53,8 @@ export function App() {
 		);
 	}
 
-	// After the wizard, the list runs the fresh tailor flow (initialData would be
-	// the pre-wizard read); returning users render straight from initialData. The
-	// site context is path-independent, so it's passed either way — that lets the
-	// loading skeleton show the site preview before the tailored read lands.
+	// After the wizard the list runs the fresh tailor flow; returning users render
+	// from initialData. Site is passed either way so the skeleton can show the preview.
 	return (
 		<TailoredList
 			pendingTailor={ pendingTailor }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -1,9 +1,8 @@
 import type { GoalSlug, TailoredOutput, TailoredTask, WizardInput } from './types.ts';
 
 /**
- * Deterministic English subtitles for the catalog task IDs the fallback can
- * emit. Unmapped IDs get a generic subtitle so the schema's minLength:1 on
- * subtitle is always satisfied.
+ * English subtitles for catalog task IDs. Unmapped IDs get a generic subtitle so
+ * subtitle's minLength:1 is always satisfied.
  */
 const TASK_SUBTITLES: Record< string, string > = {
 	first_post_published: 'Write and publish your first post.',
@@ -28,10 +27,7 @@ const TASK_SUBTITLES: Record< string, string > = {
 const GENERIC_SUBTITLE = 'Get this set up.';
 
 /**
- * Per-goal task ID lists. Exactly six IDs each; the last is always a launch
- * task. Drawn from the snake_case catalog menu. These mirror the deterministic
- * intent of the PoC's select-tasks.ts: a first-creation task, niche/foundation
- * tasks, then a launch task.
+ * Per-goal task ID lists. Exactly six IDs each; the last is always a launch task.
  */
 const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 	write: [
@@ -110,10 +106,6 @@ function clamp( value: string, max: number ): string {
 
 /**
  * Deterministic fallback when the AI call fails or returns invalid output.
- * Produces schema-valid output for every goal: exactly six tasks with a launch
- * task last, an `inferred` blob seeded from the wizard input, and a generic
- * two-paragraph first-post draft. Stream B's PUT /tailored validates this
- * against the same schema, so it must always validate.
  *
  * @param input - The collected wizard input.
  * @return A schema-valid tailored output.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
@@ -6,9 +6,8 @@ interface CreatedPost {
 }
 
 /**
- * Escape HTML-significant characters in plain text. The AI-drafted paragraphs
- * are plain prose, so escaping keeps untrusted output from injecting markup
- * (stored XSS) or breaking the surrounding block delimiters.
+ * Escape HTML-significant characters in plain text to keep AI-drafted output
+ * from injecting markup (stored XSS) or breaking block delimiters.
  *
  * @param text - The plain text to escape.
  * @return The escaped text, safe to embed in HTML.
@@ -30,9 +29,8 @@ function toBlocks( paragraphs: string[] ): string {
 }
 
 /**
- * Create a WordPress draft post from the AI-drafted first post and return the
- * new post id with its block-editor URL. Content is emitted as Gutenberg
- * paragraph blocks so the editor opens with structured blocks, not raw HTML.
+ * Create a WordPress draft post from the AI-drafted first post, emitting content
+ * as Gutenberg paragraph blocks.
  *
  * @param draft - The AI-drafted first post.
  * @return The created post id and its editor URL.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/jwt.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/jwt.ts
@@ -2,13 +2,9 @@ import { isSimpleSite } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Jetpack AI JWT, minted from the site and cached in localStorage.
- *
- * Ported from `@automattic/jetpack-ai-client`'s `requestJwt`: that package can't
- * currently be bundled by wp-build — its build output is misconfigured (tsgo
- * emits to `build/src/` instead of the `build/` that `package.json` `main`
- * points at, and skips asset files), so consumers can't resolve it. We only need
- * this one function, so we inline it against `@wordpress/api-fetch`.
+ * Jetpack AI JWT, minted from the site and cached in localStorage. Inlined from
+ * `@automattic/jetpack-ai-client`'s `requestJwt`, which wp-build can't currently
+ * bundle.
  */
 
 interface TokenData {
@@ -49,9 +45,7 @@ export async function requestJwt(): Promise< TokenData > {
 
 	const isSimple = isSimpleSite();
 
-	// Fail fast with a clear message rather than forming a bad request
-	// (`/sites/undefined/…` → 404, or `X-WP-Nonce: undefined` → 403) that would
-	// only surface downstream as "the AI never works".
+	// Fail fast with a clear message rather than forming a bad request that only surfaces downstream.
 	if ( isSimple && ! siteId ) {
 		throw new Error(
 			'[AI Launchpad] cannot mint a JWT: missing site id (JP_CONNECTION_INITIAL_STATE.siteSuffix).'

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/orchestration.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/orchestration.ts
@@ -1,9 +1,8 @@
 import type { TailoredOutput } from './types.ts';
 
 /**
- * The slice of `GET /wpcom/v2/ai-launchpad` the host orchestration reads to
- * decide which view to show on load. Only the fields the decision depends on
- * are typed here; the tailored list types the rest of the response itself.
+ * The slice of `GET /wpcom/v2/ai-launchpad` the host reads to decide which view
+ * to show on load.
  */
 export interface OrchestrationData {
 	ai_output: {
@@ -15,10 +14,8 @@ export interface OrchestrationData {
 export type View = 'wizard' | 'list';
 
 /**
- * Decide the initial view from the composite read. A site that has never run
- * the wizard has no persisted AI output (`ai_output` is null) and is treated as
- * a new user who should see the wizard; a site with AI output already has a
- * tailored list to show, so the wizard is skipped.
+ * Decide the initial view: sites with no persisted AI output see the wizard,
+ * sites with output see the list.
  *
  * @param data - The relevant slice of the `GET /ai-launchpad` response.
  * @return The view to render on load.
@@ -28,10 +25,8 @@ export function decideInitialView( data: OrchestrationData ): View {
 }
 
 /**
- * Whether the page was opened in the all-tasks testing mode (`?all_tasks=1` on
- * the admin page URL). In this mode the app skips the wizard and renders the
- * full task catalog (see the `all_tasks` param on `GET /ai-launchpad`), so every
- * task can be exercised from a single site.
+ * Whether the page was opened in all-tasks testing mode (`?all_tasks=1`), which
+ * skips the wizard and renders the full task catalog.
  *
  * @param search - The page's `location.search` string.
  * @return True when the all-tasks param is enabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -8,8 +8,7 @@ interface PtkTaxonomyTerm {
 	slug?: string;
 }
 
-// PTK returns categories/tags as a slug-keyed map of terms; an empty taxonomy
-// can come back as `[]` rather than `{}`, so both shapes must be handled.
+// PTK returns taxonomies as a slug-keyed map, or `[]` when empty, so both shapes must be handled.
 type PtkTaxonomy = Record< string, PtkTaxonomyTerm > | PtkTaxonomyTerm[];
 
 export interface PtkPattern {
@@ -24,9 +23,8 @@ interface CreatedPage {
 }
 
 /**
- * Tokenize the inferred niche/vibe/audience into lowercase match words. The
- * goal is intentionally excluded: it describes intent (e.g. "sell", "publish")
- * rather than topic, so it adds noise to a topical pattern match.
+ * Tokenize the inferred niche/vibe/audience into lowercase match words. Goal is
+ * excluded: it describes intent, not topic, so it adds noise.
  *
  * @param inferred - The AI-inferred site details.
  * @return The match words.
@@ -41,8 +39,7 @@ function nicheWords( inferred: TailoredInferred ): string[] {
 }
 
 /**
- * Extract the human-readable term titles from a PTK taxonomy, which may arrive
- * as a slug-keyed map or (when empty) as an array.
+ * Extract the human-readable term titles from a PTK taxonomy.
  *
  * @param taxonomy - The categories or tags collection.
  * @return The term titles.
@@ -56,8 +53,7 @@ function termTitles( taxonomy: PtkTaxonomy | undefined ): string[] {
 
 /**
  * Count how many match words appear in a pattern's title, category titles, or
- * tag titles. Categories/tags are keyed by slug, so the matchable text is the
- * term titles, not the keys.
+ * tag titles.
  *
  * @param pattern - The candidate pattern.
  * @param words   - The niche match words.
@@ -103,15 +99,12 @@ export function pickPattern(
 	return best;
 }
 
-// The full PTK library is stable within a session, so cache the parsed list in
-// module scope: repeated "Get started" clicks reuse it instead of re-downloading
-// and re-scoring it. Stays null on a failed fetch so a later click can retry.
+// Cache the parsed PTK library in module scope; stays null on a failed fetch so a later click can retry.
 let cachedPatterns: PtkPattern[] | null = null;
 
 /**
- * Fetch the English pattern library, pick a pattern matching the inferred
- * niche, and create a draft page from it. Returns the new page id and its
- * block-editor URL. The pattern HTML is used as-is (no AI rewrite for v1).
+ * Fetch the English pattern library, pick a pattern matching the inferred niche,
+ * and create a draft page from it.
  *
  * @param inferred - The AI-inferred site details.
  * @return The created page id and its editor URL.
@@ -129,9 +122,7 @@ export async function createPatternPage(
 				}
 			}
 		} catch {
-			// Network/parse failure: leave the cache unset so a later click retries.
-			// The page is still created below (with empty content) rather than
-			// throwing and stranding the CTA.
+			// Network/parse failure: leave the cache unset so a later click retries; the page is still created below with empty content.
 		}
 	}
 	const pattern = pickPattern( cachedPatterns ?? [], inferred );
@@ -143,9 +134,7 @@ export async function createPatternPage(
 			title: pattern?.title ?? inferred.brand_name ?? 'New page',
 			content: pattern?.html ?? '',
 			status: 'draft',
-			// Tag this as the AI Launchpad About page so the server-side listener
-			// can complete add_about_page / update_about_page when it is published
-			// or edited, independent of the catalog's layout-category meta.
+			// Tag as the AI Launchpad About page so the server-side listener can complete add_about_page/update_about_page on publish or edit.
 			meta: { _wpcom_ai_launchpad_about_page: true },
 		},
 	} ) ) as CreatedPage;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
@@ -46,28 +46,21 @@ function startPrewarm( input: WizardInput ): void {
 	}
 	cache = {
 		key,
-		// The prewarmed call persists on its own; a settled-but-unread promise
-		// is harmless. Swallow rejections here so the background fire never
-		// surfaces an unhandled rejection; the Finish handler awaits its own
-		// result and handles errors there.
+		// Swallow rejections so the background fire never surfaces an unhandled rejection; the Finish handler handles errors on its own await.
 		promise: tailor( input ).catch( () => null as unknown as TailorResult ),
 	};
 }
 
 /**
- * Background-fire the tailor call while the user fills in the wizard. After
- * PREWARM_DELAY_MS of idle (no further state changes), the call starts and its
- * promise is cached in module scope keyed by the input. The Finish handler can
- * reuse it via `getPrewarmedTailor`.
+ * Background-fire the tailor call while the user fills in the wizard, caching its
+ * promise for `getPrewarmedTailor` to reuse.
  *
  * @param state - The partial wizard input collected so far.
  */
 export function usePrewarm( state: Partial< WizardInput > ): void {
 	const timer = useRef< ReturnType< typeof setTimeout > >();
 
-	// Depend on the stable cache key, not the `state` object: the call site passes
-	// a fresh object every render, so keying on identity would clear and re-arm the
-	// debounce on every unrelated re-render, eroding the head start it exists for.
+	// Depend on the stable cache key, not the `state` object, which is fresh every render and would re-arm the debounce on every re-render.
 	const input = isComplete( state ) ? state : null;
 	const key = input ? cacheKey( input ) : '';
 
@@ -77,16 +70,13 @@ export function usePrewarm( state: Partial< WizardInput > ): void {
 		}
 		timer.current = setTimeout( () => startPrewarm( input ), PREWARM_DELAY_MS );
 		return () => clearTimeout( timer.current );
-		// `key` is the stable identity of `input`; depending on `input` itself
-		// would defeat the point.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ key ] );
 }
 
 /**
  * Return the prewarmed tailor promise for this input if one is in flight or
- * settled, otherwise start a fresh tailor call. Lets the Finish handler reuse
- * the head start from `usePrewarm`.
+ * settled, otherwise start a fresh tailor call.
  *
  * @param input - The collected wizard input.
  * @return The tailored result.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -3,13 +3,11 @@ import type { WizardInput } from './types.ts';
 /**
  * Allowed task IDs the model may pick from. Snake_case catalog IDs drawn from
  * launchpad-task-definitions.php (verified 2026-06-02). A PHP test
- * (AI_Launchpad_Task_Menu_Test) guards this list against catalog drift; making
- * the catalog the single source is tracked in DOTOBRD-472.
+ * (AI_Launchpad_Task_Menu_Test) guards this list against catalog drift.
  */
 export const TASK_MENU: readonly string[] = [
 	'first_post_published',
 	'first_post_published_newsletter',
-	'write_3_posts',
 	'site_theme_selected',
 	'add_about_page',
 	'add_new_page',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -1,9 +1,8 @@
 import type { WizardInput } from './types.ts';
 
 /**
- * Allowed task IDs the model may pick from. Snake_case catalog IDs drawn from
- * launchpad-task-definitions.php (verified 2026-06-02). A PHP test
- * (AI_Launchpad_Task_Menu_Test) guards this list against catalog drift.
+ * Allowed task IDs the model may pick from, drawn from the catalog. A PHP test
+ * guards this list against catalog drift.
  */
 export const TASK_MENU: readonly string[] = [
 	'first_post_published',
@@ -61,17 +60,9 @@ export const TASK_MENU: readonly string[] = [
 ];
 
 /**
- * Build the single combined prompt sent to jetpack-ai-query. Produces three
- * parts in one JSON response, in inference-first order: an inferred-context
- * blob, a relevance-ranked task list, and a starter blog post draft.
- *
- * The model infers the site's niche/audience FIRST, then selects the 6 most
- * relevant tasks from the menu (ranked against the user's own words rather than
- * a fixed per-goal template) and writes a specific subtitle for each. Emitting
- * `inferred` before `tasks` grounds selection in the niche without a second
- * call. English only (v1; i18n tracked in DOTOBRD-474). Hard rules mirror the
- * server-side validation in class-ai-launchpad-rest.php (launch task last,
- * woo/newsletter gating, subtitle sanitization) so valid output is not rejected.
+ * Build the single combined prompt sent to jetpack-ai-query, producing the
+ * inferred blob, task list, and first-post draft in one JSON response. Hard rules
+ * mirror the server-side validation so valid output is not rejected.
  *
  * @param input - The collected wizard input.
  * @return The prompt string.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -113,6 +113,7 @@ HARD RULES (do not break - the server rejects output that violates these):
 - The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", "woo_launch_site", or "link_in_bio_launched".
 - Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
 - Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
+- For the social tasks "connect_social_media", "drive_traffic", and "post_sharing_enabled", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
 - Subtitles must be plain text: no URLs, no HTML, and no template syntax such as {{ }} or [[ ]].
 
 ============ STEP 3 - first_post_draft ============

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
@@ -14,10 +14,8 @@ interface JsonSchema {
 }
 
 /**
- * Inlined copy of contracts/agent-output-schema.json. Bundling the schema as a
- * constant keeps this module free of JSON-import-attribute syntax that differs
- * between the webpack bundle and the node:test runner. The unit test asserts
- * this constant deep-equals the committed contract file, so drift is caught.
+ * Inlined copy of contracts/agent-output-schema.json; a unit test asserts it
+ * matches the committed contract, so drift is caught.
  */
 export const AGENT_OUTPUT_SCHEMA: JsonSchema = {
 	type: 'object',
@@ -73,10 +71,8 @@ export const AGENT_OUTPUT_SCHEMA: JsonSchema = {
 };
 
 /**
- * Validate a value against the subset of JSON Schema the agent output uses:
- * type, required, additionalProperties:false, enum, minLength, maxLength,
- * minItems, maxItems, items, properties. Returns a list of human-readable
- * errors; an empty list means the value is valid.
+ * Validate a value against the subset of JSON Schema the agent output uses.
+ * Returns human-readable errors; an empty list means valid.
  *
  * @param value  - The value to validate.
  * @param schema - The schema to validate against.
@@ -149,9 +145,8 @@ export function validateAgainstSchema( value: unknown, schema: JsonSchema, path 
 
 /**
  * Parse the raw `content` string returned by jetpack-ai-query and validate it
- * against the agent output schema. Returns the typed output on success, or
- * null if the JSON is malformed or fails schema validation. Callers fall back
- * to the deterministic picker on null.
+ * against the agent output schema. Returns the typed output, or null if the JSON
+ * is malformed or fails validation.
  *
  * @param content - The raw JSON string from `choices[0].message.content`.
  * @return The validated output, or null.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -15,11 +15,8 @@ interface AiQueryResponse {
 }
 
 /**
- * Outcome of a single jetpack-ai-query attempt. `retryable` distinguishes
- * transient failures worth a second attempt (5xx/429, empty content, or
- * malformed/schema-invalid JSON that a re-roll often fixes) from failures where
- * a retry would not help or would only add latency (auth/quota 4xx, network
- * errors, and timeouts).
+ * Outcome of a single jetpack-ai-query attempt; `retryable` flags transient
+ * failures worth a second attempt.
  */
 type FetchOutcome = { ok: true; output: TailoredOutput } | { ok: false; retryable: boolean };
 
@@ -73,9 +70,7 @@ async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
 
 		return { ok: true, output };
 	} catch {
-		// Network error or timeout (abort): fall back to the deterministic picker.
-		// Not retried - a timeout retry only doubles the wait before the fallback.
-		// The AI call itself is logged server-side by the AI Proxy.
+		// Network error or timeout: not retried, since a retry only doubles the wait before the fallback.
 		return { ok: false, retryable: false };
 	} finally {
 		clearTimeout( timeout );
@@ -84,9 +79,7 @@ async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
 
 /**
  * Call jetpack-ai-query, retrying once on a transient/validation failure, and
- * return the validated output or null. The retry hardens the happy path against
- * the occasional malformed JSON or transient proxy error without unbounded
- * latency: timeouts and auth/quota failures are not retried.
+ * return the validated output or null.
  *
  * @param input - The collected wizard input.
  * @return The validated output, or null.
@@ -100,8 +93,7 @@ async function fetchAiOutputWithRetry( input: WizardInput ): Promise< TailoredOu
 }
 
 /**
- * Persist the tailored output via Stream B's PUT /tailored. The body is the
- * unwrapped schema payload; the source is passed as a query parameter.
+ * Persist the tailored output via Stream B's PUT /tailored.
  *
  * @param output - The tailored output to persist.
  * @param source - Whether the output came from AI or the fallback.
@@ -115,13 +107,8 @@ async function persist( output: TailoredOutput, source: TailorSource ): Promise<
 }
 
 /**
- * Tailor the launchpad from the wizard input: call jetpack-ai-query with the
- * combined prompt (retrying once on a transient/validation failure), validate
- * the response against the agent output schema, and fall back to the
- * deterministic picker on any failure (network, timeout, auth, quota, malformed
- * or schema-invalid output). The result is persisted via Stream B's
- * PUT /tailored, tagged with its source. If the AI output is rejected by the
- * server (422), retry the persist with the deterministic fallback.
+ * Tailor the launchpad from the wizard input, falling back to the deterministic
+ * picker on any failure and persisting the result tagged with its source.
  *
  * @param input - The collected wizard input.
  * @return The tailored result, tagged with whether it came from AI or fallback.
@@ -139,8 +126,7 @@ export async function tailor( input: WizardInput ): Promise< TailorResult > {
 			} );
 			return { source: 'ai', output: aiOutput };
 		} catch {
-			// PUT rejected the AI output (e.g. 422 / per-site catalog filtering);
-			// fall through to the deterministic fallback below.
+			// PUT rejected the AI output; fall through to the deterministic fallback below.
 		}
 	}
 
@@ -148,9 +134,7 @@ export async function tailor( input: WizardInput ): Promise< TailorResult > {
 	try {
 		await persist( fallbackOutput, 'fallback' );
 	} catch {
-		// The deterministic fallback is meant to be guaranteed. Even if the write
-		// fails, still return it so the consumer renders the local list instead of
-		// an empty launchpad.
+		// Even if the write fails, still return the fallback so the consumer renders a list, not an empty launchpad.
 	}
 	trackAiResponseReceived( {
 		duration_ms: Math.round( performance.now() - start ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
@@ -8,9 +8,7 @@ declare global {
 
 /**
  * Records a Tracks event with `launchpad_variant: 'ai'` baked in, so call sites
- * can't forget it. Mirrors the `_tkq` recording pattern already used elsewhere
- * in jetpack-mu-wpcom (jetpack-global-styles/customizer-fonts), which is what
- * `@automattic/jetpack-analytics`'s `tracks.recordEvent` pushes under the hood.
+ * can't forget it.
  *
  * @param eventName - The Tracks event name, already feature-prefixed.
  * @param props     - Event properties. No PII: task IDs are fine, free text is not.
@@ -55,13 +53,8 @@ export function trackTaskClicked( props: { task_id: string } ): void {
 }
 
 /**
- * Records the launched event (the project's headline "% of new users who
- * launch" KPI).
- *
- * Intentionally unwired in the MVP: site launch completes server-side via the
- * Launchpad listeners — often while this page isn't open — so there is no
- * reliable client-side trigger here. Launch attribution is wired by the
- * product-analytics funnel instrumentation (DOTOBRD-473).
+ * Records the launched event. Intentionally unwired in the MVP: launch completes
+ * server-side, so there is no reliable client-side trigger here.
  */
 export function trackLaunched(): void {
 	record( 'jetpack_ai_launchpad_launched' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
@@ -28,9 +28,8 @@ export interface FirstPostDraft {
 }
 
 /**
- * Mirrors contracts/agent-output-schema.json. Length and content constraints
- * (exactly 6 tasks, subtitle <= 200 chars, exactly 2 paragraphs, ...) are
- * enforced by Ajv validation, not by the type system.
+ * Mirrors contracts/agent-output-schema.json. Length and content constraints are
+ * enforced by validation, not by the type system.
  */
 export interface TailoredOutput {
 	tasks: TailoredTask[];

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
@@ -4,25 +4,20 @@ import { SitePreview } from './site-preview.tsx';
 import type { ReactNode } from 'react';
 
 interface Props {
-	// The line under the heading: the "X of N completed" progress for the loaded
-	// list, or the "Tailoring your checklist…" copy while the AI call is in flight.
+	// The status line under the heading.
 	progressLabel: string;
 	// Site context for the preview card; omitted when unknown (dev fixtures).
 	siteUrl: string | null;
 	siteTitle?: string | null;
-	// The wp-admin Site Editor URL: the preview thumbnail's quick link.
+	// The Site Editor URL: the preview thumbnail's quick link.
 	siteEditUrl?: string | null;
 	// The left column: the task cards, or the loading skeleton.
 	children: ReactNode;
 }
 
 /**
- * The shared chrome for the tailored list and its loading state: a centered
- * content column with a heading and a progress/status line, the supplied
- * content (task cards or skeleton) on the left, and the site preview on the
- * right. Sharing this between the loaded and loading states keeps the
- * wizard→tailoring→list transition seamless — only the left column and the
- * status line change.
+ * The shared chrome for the tailored list and its loading state: a heading and
+ * status line, the supplied content on the left, and the site preview on the right.
  *
  * @param props               - Component props.
  * @param props.progressLabel - The status line under the heading.
@@ -33,8 +28,8 @@ interface Props {
  * @return The layout element.
  */
 export function Layout( { progressLabel, siteUrl, siteTitle, siteEditUrl, children }: Props ) {
-	// Without a site URL there's no preview, so collapse to a single column —
-	// otherwise the grid reserves an empty preview track and squeezes the tasks.
+	// Without a site URL, collapse to a single column so the grid doesn't reserve
+	// an empty preview track that squeezes the tasks.
 	const hasPreview = !! siteUrl;
 
 	return (

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
@@ -10,6 +10,8 @@ interface Props {
 	// Site context for the preview card; omitted when unknown (dev fixtures).
 	siteUrl: string | null;
 	siteTitle?: string | null;
+	// The wp-admin Site Editor URL: the preview thumbnail's quick link.
+	siteEditUrl?: string | null;
 	// The left column: the task cards, or the loading skeleton.
 	children: ReactNode;
 }
@@ -26,10 +28,11 @@ interface Props {
  * @param props.progressLabel - The status line under the heading.
  * @param props.siteUrl       - The site's front-end URL (for the preview).
  * @param props.siteTitle     - The site name (for the preview).
+ * @param props.siteEditUrl   - The Site Editor URL (preview quick link).
  * @param props.children      - The left column content.
  * @return The layout element.
  */
-export function Layout( { progressLabel, siteUrl, siteTitle, children }: Props ) {
+export function Layout( { progressLabel, siteUrl, siteTitle, siteEditUrl, children }: Props ) {
 	// Without a site URL there's no preview, so collapse to a single column —
 	// otherwise the grid reserves an empty preview track and squeezes the tasks.
 	const hasPreview = !! siteUrl;
@@ -48,7 +51,7 @@ export function Layout( { progressLabel, siteUrl, siteTitle, children }: Props )
 				} ) }
 			>
 				{ children }
-				<SitePreview siteUrl={ siteUrl } siteTitle={ siteTitle } />
+				<SitePreview siteUrl={ siteUrl } siteTitle={ siteTitle } siteEditUrl={ siteEditUrl } />
 			</div>
 		</div>
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -292,6 +292,30 @@ describe( 'nextIncompleteId', () => {
 		const tasks = [ task( { id: 'a', completed: true } ), task( { id: 'b', completed: true } ) ];
 		assert.equal( nextIncompleteId( tasks ), null );
 	} );
+
+	it( 'advances to the next incomplete task after the given id', () => {
+		const tasks = [
+			task( { id: 'a', completed: true } ),
+			task( { id: 'b', completed: false } ),
+			task( { id: 'c', completed: false } ),
+		];
+		assert.equal( nextIncompleteId( tasks, 'b' ), 'c' );
+	} );
+
+	it( 'wraps back to a remaining incomplete task when none follow the given id', () => {
+		const tasks = [
+			task( { id: 'a', completed: false } ),
+			task( { id: 'b', completed: false } ),
+			task( { id: 'c', completed: true } ),
+		];
+		// Skipping the last incomplete task (b) leaves only a earlier in the list.
+		assert.equal( nextIncompleteId( tasks, 'b' ), 'a' );
+	} );
+
+	it( 'returns null when the given id was the only incomplete task', () => {
+		const tasks = [ task( { id: 'a', completed: true } ), task( { id: 'b', completed: true } ) ];
+		assert.equal( nextIncompleteId( tasks, 'b' ), null );
+	} );
 } );
 
 describe( 'tasksFromFixture', () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { validateAgainstSchema } from '../lib/schema-validator.ts';
 import {
 	ctaKind,
-	firstIncompleteIndex,
+	nextIncompleteId,
 	isCompleteOnClickTask,
 	isTaskActionable,
 	launchSiteUrl,
@@ -273,24 +273,24 @@ describe( 'resolveCtaUrl', () => {
 	} );
 } );
 
-describe( 'firstIncompleteIndex', () => {
-	it( 'returns the first incomplete task index', () => {
+describe( 'nextIncompleteId', () => {
+	it( 'returns the first incomplete task id', () => {
 		const tasks = [
 			task( { id: 'a', completed: true } ),
 			task( { id: 'b', completed: false } ),
 			task( { id: 'c', completed: false } ),
 		];
-		assert.equal( firstIncompleteIndex( tasks ), 1 );
+		assert.equal( nextIncompleteId( tasks ), 'b' );
 	} );
 
-	it( 'returns 0 when nothing is complete', () => {
+	it( 'returns the first id when nothing is complete', () => {
 		const tasks = [ task( { id: 'a' } ), task( { id: 'b' } ) ];
-		assert.equal( firstIncompleteIndex( tasks ), 0 );
+		assert.equal( nextIncompleteId( tasks ), 'a' );
 	} );
 
-	it( 'returns -1 when everything is complete', () => {
+	it( 'returns null when everything is complete', () => {
 		const tasks = [ task( { id: 'a', completed: true } ), task( { id: 'b', completed: true } ) ];
-		assert.equal( firstIncompleteIndex( tasks ), -1 );
+		assert.equal( nextIncompleteId( tasks ), null );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -244,14 +244,15 @@ export function isTaskActionable(
 }
 
 /**
- * The index of the first incomplete task, or -1 when every task is complete.
- * Drives which card auto-expands on first render.
+ * The id of the first incomplete task, driving which card the accordion
+ * auto-expands. Returns null when every task is complete.
  *
- * @param tasks - The enriched tasks.
- * @return The index of the first incomplete task, or -1.
+ * @param tasks - The enriched tasks (skipped tasks already coerced to completed).
+ * @return The first incomplete task id, or null.
  */
-export function firstIncompleteIndex( tasks: EnrichedTask[] ): number {
-	return tasks.findIndex( task => ! task.completed );
+export function nextIncompleteId( tasks: EnrichedTask[] ): string | null {
+	const next = tasks.find( task => ! task.completed );
+	return next ? next.id : null;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -1,9 +1,8 @@
 import type { TailoredInferred, TailoredOutput, FirstPostDraft } from '../lib/types.ts';
 
 /**
- * The shape of a single enriched task in Stream B's `GET /ai-launchpad/`
- * response: AI subtitle merged with the catalog's title, completion state, and
- * deeplink path.
+ * A single enriched task: AI subtitle merged with the catalog's title,
+ * completion state, and deeplink path.
  */
 export interface EnrichedTask {
 	id: string;
@@ -15,22 +14,18 @@ export interface EnrichedTask {
 
 /** The site context the list needs (front-end URL for the launch CTA + preview). */
 export interface SiteData {
-	// Optional: the fields come from an un-validated REST response, so consumers
-	// must tolerate them being absent (coalesce to null) rather than trust the type.
+	// Fields come from an un-validated REST response, so consumers must tolerate
+	// them being absent (coalesce to null) rather than trust the type.
 	url?: string;
 	// The site name, used to label the preview card and pre-fill the wizard Name.
 	title?: string;
-	// The site tagline (blogdescription), used to pre-fill the wizard description.
+	// The site tagline, used to pre-fill the wizard description.
 	description?: string;
-	// The site's appearance-editor URL, used as the preview thumbnail's quick link:
-	// the Site Editor on block themes, the Customizer on classic ones.
+	// The appearance-editor URL (Site Editor on block themes, Customizer on classic).
 	edit_url?: string | null;
 }
 
-/**
- * The relevant slice of Stream B's `GET /ai-launchpad/` response. Only the
- * fields the tailored list renders from are typed here.
- */
+/** The slice of the `GET /ai-launchpad/` response the tailored list renders from. */
 export interface LaunchpadData {
 	tasks: EnrichedTask[];
 	ai_output: {
@@ -44,9 +39,8 @@ export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
 const PATTERN_PAGE_TASK_IDS = [ 'add_about_page' ];
-// Launch tasks that have no catalog deeplink: they send the user to the
-// wordpress.com launch flow. woo_launch_site is excluded — it has its own
-// wc-admin deeplink and is handled as a plain deeplink.
+// Launch tasks with no catalog deeplink: they open the wordpress.com launch
+// flow. woo_launch_site is excluded — it has its own deeplink.
 const LAUNCH_TASK_IDS = [
 	'site_launched',
 	'blog_launched',
@@ -55,10 +49,9 @@ const LAUNCH_TASK_IDS = [
 ];
 
 /**
- * Resolve how a task's "Get started" CTA behaves. First-creation tasks draft a
- * real post via Stream F's `createFirstPostDraft`; page-creating tasks build a
- * pattern page via `createPatternPage`; launch tasks open the wordpress.com
- * launch flow; everything else deeplinks to the catalog's `calypso_path`.
+ * Resolve how a task's "Get started" CTA behaves: first-creation tasks draft a
+ * post, page-creating tasks build a pattern page, launch tasks open the launch
+ * flow, everything else deeplinks to the catalog's `calypso_path`.
  *
  * @param taskId - The catalog task ID.
  * @return The CTA kind.
@@ -77,12 +70,8 @@ export function ctaKind( taskId: string ): CtaKind {
 }
 
 /**
- * Tasks marked complete client-side when their CTA is clicked, because the real
- * signal is unreachable in wp-admin where the AI Launchpad runs (on both Simple
- * and Atomic). The acknowledgment tasks complete on click / page-visit in Calypso
- * (a write to Calypso's selected site, never from wp-admin); setup_ssh's SSH-user
- * signal is unreachable from the Atomic context, so this reuses Calypso's
- * optimistic hosting-form completion. Mirrors COMPLETE_ON_CLICK_TASK_IDS in
+ * Tasks marked complete client-side on CTA click, because their real completion
+ * signal is unreachable from wp-admin. Mirrors the same list in
  * class-ai-launchpad-rest.php.
  */
 const COMPLETE_ON_CLICK_TASK_IDS = [
@@ -108,9 +97,8 @@ export function isCompleteOnClickTask( taskId: string ): boolean {
 }
 
 /**
- * Build the wordpress.com launch-flow URL for a launch task. Launch tasks have
- * no catalog deeplink; the legacy launchpad widget routes them to
- * `/start/launch-site` keyed by the site slug (the host of the site's home URL).
+ * Build the wordpress.com launch-flow URL for a launch task, keyed by the site
+ * slug (the host of the site's home URL).
  *
  * @param siteUrl - The site's front-end URL (from the composite read).
  * @return The launch-flow URL, or null if the site URL can't be parsed.
@@ -120,9 +108,8 @@ export function launchSiteUrl( siteUrl: string ): string | null {
 	try {
 		slug = new URL( siteUrl ).host;
 	} catch {
-		// A malformed/relative home URL (e.g. a broken `home_url` filter) can't
-		// produce a launch slug; return null so the CTA is hidden rather than
-		// throwing on click.
+		// A malformed/relative home URL can't produce a launch slug; return null
+		// so the CTA is hidden rather than throwing on click.
 		return null;
 	}
 	return `https://wordpress.com/start/launch-site?siteSlug=${ encodeURIComponent(
@@ -132,8 +119,7 @@ export function launchSiteUrl( siteUrl: string ): string | null {
 
 /**
  * The CTA side effects injected into {@link resolveCtaUrl}, so the routing can
- * be unit-tested without pulling `@wordpress/*` into the test runner. The
- * component wires these to the real Stream F / Stream G implementations.
+ * be unit-tested without pulling `@wordpress/*` into the test runner.
  */
 export interface CtaHandlers {
 	trackTaskClicked: ( props: { task_id: string } ) => void;
@@ -146,34 +132,20 @@ export interface CtaHandlers {
 }
 
 /**
- * Make a resolved CTA destination safe to navigate to from wp-admin.
- *
- * Catalog deeplinks arrive in three shapes: absolute URLs (`admin_url()`-based
- * wp-admin links, Stripe connect URLs, the synthesized launch URL), site-relative
- * wp-admin paths (e.g. the editor URL of a freshly created draft), and Calypso
- * router paths (e.g. `/me`, `/marketing/connections/{slug}`) that are relative
- * to wordpress.com. The launchpad runs in wp-admin, so a Calypso path navigated
- * via `window.location` would resolve against the *site* host and 404; only those
- * must be pinned to wordpress.com.
- *
- * This mirrors the legacy launchpad dashboard widget, which rebases relative task
- * links with `new URL( href, 'https://wordpress.com' )` (see
- * `wpcom-dashboard-widgets/wpcom-launchpad-widget`). The one difference: that
- * widget's task admin links are already absolute, whereas our created-content
- * CTAs return site-relative `/wp-admin/…` editor URLs, so those are excluded from
- * the rebase. Absolute URLs don't start with `/` and pass through unchanged.
+ * Make a resolved CTA destination safe to navigate to from wp-admin. Calypso
+ * router paths are pinned to wordpress.com so they don't resolve against the site
+ * host and 404; site-relative wp-admin paths and absolute URLs pass through.
  *
  * @param url - The resolved destination URL or path.
  * @return The navigable URL.
  */
 export function toNavigableUrl( url: string ): string {
-	// Site-relative wp-admin paths must resolve against the current site. Match the
-	// root path too (`/wp-admin`, `/wp-admin?…`, `/wp-admin#…`), not just `/wp-admin/`.
+	// Site-relative wp-admin paths must resolve against the current site.
 	if ( /^\/wp-admin(\/|\?|#|$)/.test( url ) ) {
 		return url;
 	}
-	// Calypso router paths are relative to wordpress.com; absolute URLs (Stripe,
-	// admin_url(), the launch URL) don't start with `/` and fall through unchanged.
+	// Calypso router paths are relative to wordpress.com; absolute URLs don't
+	// start with `/` and fall through unchanged.
 	if ( url.startsWith( '/' ) ) {
 		return new URL( url, 'https://wordpress.com' ).href;
 	}
@@ -182,11 +154,8 @@ export function toNavigableUrl( url: string ): string {
 
 /**
  * Fire the Tracks event and resolve the destination URL for a "Get started"
- * click. First-creation tasks draft a post; page-creating tasks build a pattern
- * page; everything else uses the catalog deeplink. The resolved URL is run
- * through {@link toNavigableUrl} so Calypso paths point at wordpress.com rather
- * than the site host. Returns the URL to navigate to, or null when the task has
- * no actionable destination.
+ * click, run through {@link toNavigableUrl}. Returns null when the task has no
+ * actionable destination.
  *
  * @param task     - The clicked task.
  * @param output   - The AI output (post draft + inferred details), or null.
@@ -218,11 +187,9 @@ export async function resolveCtaUrl(
 }
 
 /**
- * Whether a task's "Get started" CTA has a destination — i.e. whether
- * {@link resolveCtaUrl} would resolve to a non-null URL. Create-content tasks
- * (first post / pattern page) are actionable when the AI output is present;
- * every other task is actionable only when it has a deeplink path. Used to hide
- * the CTA for tasks that would otherwise be a silent no-op.
+ * Whether a task's "Get started" CTA has a destination. Create-content tasks are
+ * actionable when the AI output is present; every other task only when it has a
+ * deeplink path. Used to hide the CTA for tasks that would be a silent no-op.
  *
  * @param task    - The task.
  * @param output  - The AI output, or null.
@@ -239,21 +206,16 @@ export function isTaskActionable(
 		return true;
 	}
 	if ( kind === 'launch' ) {
-		// Only actionable when a launch URL can actually be built — keeps this in
-		// lockstep with resolveCtaUrl (no CTA shown for a missing/malformed URL).
+		// Only actionable when a launch URL can be built, in lockstep with resolveCtaUrl.
 		return !! siteUrl && launchSiteUrl( siteUrl ) !== null;
 	}
 	return task.calypso_path !== null;
 }
 
 /**
- * The id of the next incomplete task to auto-expand, driving the accordion's
- * single-open behavior. With no `afterId`, returns the first incomplete task
- * (the card that opens on mount). With `afterId` (the task just skipped or
- * completed), returns the first incomplete task *after* it so focus moves down
- * the list; if nothing follows, falls back to any remaining incomplete task so
- * the user is always pointed at outstanding work. Returns null when every task
- * is complete.
+ * The id of the next incomplete task to auto-expand. With no `afterId`, the first
+ * incomplete task; with `afterId`, the first incomplete task after it, falling
+ * back to any remaining incomplete task. Returns null when every task is complete.
  *
  * @param tasks   - The enriched tasks (skipped tasks already coerced to completed).
  * @param afterId - The id to advance past, or undefined to take the first.
@@ -273,9 +235,7 @@ export function nextIncompleteId( tasks: EnrichedTask[], afterId?: string ): str
 }
 
 /**
- * Derive the enriched task list from a dev fixture (the schema-shaped AI
- * output). Used only in dev mode, where there is no server to enrich the AI
- * output with catalog titles or completion state. Titles fall back to a
+ * Derive the enriched task list from a dev fixture. Titles fall back to a
  * humanized task ID; everything renders as incomplete with no deeplink.
  *
  * @param output - The schema-valid AI output fixture.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -22,6 +22,9 @@ export interface SiteData {
 	title?: string;
 	// The site tagline (blogdescription), used to pre-fill the wizard description.
 	description?: string;
+	// The site's appearance-editor URL, used as the preview thumbnail's quick link:
+	// the Site Editor on block themes, the Customizer on classic ones.
+	edit_url?: string | null;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -244,15 +244,29 @@ export function isTaskActionable(
 }
 
 /**
- * The id of the first incomplete task, driving which card the accordion
- * auto-expands. Returns null when every task is complete.
+ * The id of the next incomplete task to auto-expand, driving the accordion's
+ * single-open behavior. With no `afterId`, returns the first incomplete task
+ * (the card that opens on mount). With `afterId` (the task just skipped or
+ * completed), returns the first incomplete task *after* it so focus moves down
+ * the list; if nothing follows, falls back to any remaining incomplete task so
+ * the user is always pointed at outstanding work. Returns null when every task
+ * is complete.
  *
- * @param tasks - The enriched tasks (skipped tasks already coerced to completed).
- * @return The first incomplete task id, or null.
+ * @param tasks   - The enriched tasks (skipped tasks already coerced to completed).
+ * @param afterId - The id to advance past, or undefined to take the first.
+ * @return The next incomplete task id, or null.
  */
-export function nextIncompleteId( tasks: EnrichedTask[] ): string | null {
-	const next = tasks.find( task => ! task.completed );
-	return next ? next.id : null;
+export function nextIncompleteId( tasks: EnrichedTask[], afterId?: string ): string | null {
+	const incomplete = tasks.filter( task => ! task.completed );
+	if ( incomplete.length === 0 ) {
+		return null;
+	}
+	if ( afterId === undefined ) {
+		return incomplete[ 0 ].id;
+	}
+	const fromIndex = tasks.findIndex( task => task.id === afterId );
+	const next = incomplete.find( task => tasks.indexOf( task ) > fromIndex );
+	return ( next ?? incomplete[ 0 ] ).id;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -1,4 +1,7 @@
 import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
+import type { ReactNode } from 'react';
 
 interface Props {
 	// The site's front-end URL, from the composite read. When absent (older
@@ -6,6 +9,10 @@ interface Props {
 	siteUrl: string | null;
 	// The site name; falls back to the domain when absent.
 	siteTitle?: string | null;
+	// The site's appearance-editor URL (Site Editor on block themes, Customizer on
+	// classic ones). When present the thumbnail becomes a quick link; when absent
+	// it renders as a plain thumbnail.
+	siteEditUrl?: string | null;
 }
 
 /**
@@ -14,16 +21,20 @@ interface Props {
  * site. The preview is a non-interactive iframe of the front end with the
  * banners/overlay hidden, mirroring the wp-admin dashboard's site-management
  * widget — it renders immediately rather than waiting on an mShots screenshot.
+ * When an editor URL is known the thumbnail doubles as a quick link into the
+ * site's appearance editor — the Site Editor on block themes, the Customizer on
+ * classic ones — with a hover "Edit site" overlay, matching the PoC affordance.
  * Rendered in both the loading and loaded states so the layout is stable across
  * the wizard→tailoring→list transition. Returns nothing when the site URL is
  * unknown (e.g. dev fixtures), so the list still renders without it.
  *
- * @param props           - Component props.
- * @param props.siteUrl   - The site's front-end URL.
- * @param props.siteTitle - The site name (falls back to the domain).
+ * @param props             - Component props.
+ * @param props.siteUrl     - The site's front-end URL.
+ * @param props.siteTitle   - The site name (falls back to the domain).
+ * @param props.siteEditUrl - The Site Editor URL (makes the thumbnail a quick link).
  * @return The preview element, or null when there's no site URL.
  */
-export function SitePreview( { siteUrl, siteTitle }: Props ) {
+export function SitePreview( { siteUrl, siteTitle, siteEditUrl }: Props ) {
 	if ( ! siteUrl ) {
 		return null;
 	}
@@ -35,17 +46,38 @@ export function SitePreview( { siteUrl, siteTitle }: Props ) {
 		// A malformed home URL still renders: fall back to the raw string.
 	}
 
+	const thumbnail = (
+		<iframe
+			className="ai-launchpad-tailored-list__preview-iframe"
+			title={ siteTitle || domain }
+			src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
+			inert="true"
+			tabIndex={ -1 }
+		/>
+	);
+
+	// With a known editor URL the thumbnail reveals a centered "Edit site" button
+	// (a WPDS Button rendered as a link) on hover/focus; otherwise it stays a
+	// plain, non-interactive thumbnail.
+	let frame: ReactNode;
+	if ( siteEditUrl ) {
+		frame = (
+			<div className="ai-launchpad-tailored-list__preview-frame is-editable">
+				{ thumbnail }
+				<span className="ai-launchpad-tailored-list__preview-edit">
+					<Button variant="solid" size="compact" render={ <a href={ siteEditUrl } /> }>
+						{ __( 'Edit site', 'jetpack-mu-wpcom' ) }
+					</Button>
+				</span>
+			</div>
+		);
+	} else {
+		frame = <div className="ai-launchpad-tailored-list__preview-frame">{ thumbnail }</div>;
+	}
+
 	return (
 		<aside className="ai-launchpad-tailored-list__preview">
-			<div className="ai-launchpad-tailored-list__preview-frame">
-				<iframe
-					className="ai-launchpad-tailored-list__preview-iframe"
-					title={ siteTitle || domain }
-					src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
-					inert="true"
-					tabIndex={ -1 }
-				/>
-			</div>
+			{ frame }
 			<p className="ai-launchpad-tailored-list__preview-title">{ siteTitle || domain }</p>
 			<ExternalLink className="ai-launchpad-tailored-list__preview-link" href={ siteUrl }>
 				{ domain }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -4,29 +4,19 @@ import { Button } from '@wordpress/ui';
 import type { ReactNode } from 'react';
 
 interface Props {
-	// The site's front-end URL, from the composite read. When absent (older
-	// reads, dev fixtures) the preview is omitted entirely.
+	// The site's front-end URL. When absent the preview is omitted entirely.
 	siteUrl: string | null;
 	// The site name; falls back to the domain when absent.
 	siteTitle?: string | null;
-	// The site's appearance-editor URL (Site Editor on block themes, Customizer on
-	// classic ones). When present the thumbnail becomes a quick link; when absent
-	// it renders as a plain thumbnail.
+	// The appearance-editor URL. When present the thumbnail becomes a quick link.
 	siteEditUrl?: string | null;
 }
 
 /**
- * The site-preview card shown to the right of the tailored list: a live,
- * scaled-down preview of the site's front end, the site name, and a link to the
- * site. The preview is a non-interactive iframe of the front end with the
- * banners/overlay hidden, mirroring the wp-admin dashboard's site-management
- * widget — it renders immediately rather than waiting on an mShots screenshot.
- * When an editor URL is known the thumbnail doubles as a quick link into the
- * site's appearance editor — the Site Editor on block themes, the Customizer on
- * classic ones — with a hover "Edit site" overlay, matching the PoC affordance.
- * Rendered in both the loading and loaded states so the layout is stable across
- * the wizard→tailoring→list transition. Returns nothing when the site URL is
- * unknown (e.g. dev fixtures), so the list still renders without it.
+ * The site-preview card shown to the right of the tailored list: a scaled-down
+ * iframe of the site's front end, the site name, and a link to the site. When an
+ * editor URL is known the thumbnail doubles as a quick link with a hover "Edit
+ * site" overlay. Returns null when the site URL is unknown.
  *
  * @param props             - Component props.
  * @param props.siteUrl     - The site's front-end URL.
@@ -56,9 +46,8 @@ export function SitePreview( { siteUrl, siteTitle, siteEditUrl }: Props ) {
 		/>
 	);
 
-	// With a known editor URL the thumbnail reveals a centered "Edit site" button
-	// (a WPDS Button rendered as a link) on hover/focus; otherwise it stays a
-	// plain, non-interactive thumbnail.
+	// With a known editor URL the thumbnail reveals an "Edit site" button on
+	// hover/focus; otherwise it stays a plain thumbnail.
 	let frame: ReactNode;
 	if ( siteEditUrl ) {
 		frame = (

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/skeleton.tsx
@@ -2,9 +2,7 @@ const PLACEHOLDER_COUNT = 5;
 
 /**
  * Loading placeholder for the tailored list's task column, shown while the AI
- * call is in flight. Rendered inside {@link Layout} so the heading and site
- * preview stay put; only these shimmering bars stand in for the task cards
- * until the real ones arrive.
+ * call is in flight.
  *
  * @return The skeleton element.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -94,17 +94,22 @@
 		}
 	}
 
-	// The inline SVG task icons use `currentColor`, so tone them via `color`.
+	// The WPDS task icons fill from `currentColor`, so tone them via `color`.
 	&__icon {
 		flex-shrink: 0;
+		display: inline-flex;
 
-		// Incomplete tasks: a light dashed ring.
+		svg {
+			fill: currentColor;
+		}
+
+		// Incomplete tasks: a light dashed ring (the `border` icon).
 		&.is-todo {
 			color: #c3c4c7;
 		}
 
-		// Completed tasks: a check-in-circle, greyed to sit alongside the
-		// struck-through title.
+		// Completed tasks: a check-in-circle (the `published` icon), greyed to sit
+		// alongside the struck-through title.
 		&.is-done {
 			color: #757575;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -141,6 +141,7 @@
 	// shows a ~1200px-wide front-end view regardless of the frame's actual size.
 	&__preview-frame {
 		position: relative;
+		display: block;
 		width: 100%;
 		max-width: 300px;
 		aspect-ratio: 4 / 3;
@@ -148,6 +149,46 @@
 		border: 1px solid #e0e0e0;
 		border-radius: 8px;
 		background: #f6f7f7;
+
+		// When the thumbnail links into the site editor, reveal the centered
+		// "Edit site" button overlay on hover, or when the button itself is focused.
+		&.is-editable {
+
+			&:hover,
+			&:focus-within {
+				border-color: var(--wp-admin-theme-color, #3858e9);
+
+				.ai-launchpad-tailored-list__preview-edit {
+					opacity: 1;
+				}
+			}
+		}
+	}
+
+	// The dimmed overlay that centers the "Edit site" button over the thumbnail.
+	&__preview-edit {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.55);
+		opacity: 0;
+		transition: opacity 120ms ease;
+
+		// The WPDS Button renders as a link here, and wp-admin's unlayered
+		// `a { color }` would otherwise win over the Button's layered foreground
+		// color and tint the label admin-blue. Re-assert the Button's own
+		// foreground color (white on the solid variant) with an unlayered rule.
+		a {
+
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				color: var(--wp-ui-button-foreground-color, #fff);
+			}
+		}
 	}
 
 	&__preview-iframe {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -1,9 +1,6 @@
 .ai-launchpad-tailored-list {
 
-	// The centered content column shared by the loaded list and its loading
-	// state: heading + progress line, then a two-column grid (tasks | preview).
-	// A responsive, generous top pad pushes the content off the admin chrome
-	// without relying on a fixed-height container to vertically center.
+	// Centered content column: heading + progress, then a tasks | preview grid.
 	&__layout {
 		max-width: 960px;
 		margin: 0 auto;
@@ -40,15 +37,13 @@
 		gap: 32px;
 		align-items: start;
 
-		// Reserve the preview track only when there's a preview to show, so a
-		// missing site URL doesn't leave an empty gutter squeezing the tasks.
+		// Reserve the preview track only when there's a preview to show.
 		&.has-preview {
 			grid-template-columns: minmax(0, 1fr) 300px;
 		}
 	}
 
-	// Stack the preview under the tasks on narrow screens (WP admin's mobile
-	// breakpoint), so neither column gets squeezed.
+	// Stack the preview under the tasks on narrow screens.
 	@media (max-width: 782px) {
 
 		&__columns.has-preview {
@@ -56,9 +51,8 @@
 		}
 	}
 
-	// The task column itself: a vertical stack of cards (and skeleton bars),
-	// wrapped in a padded grey container so the white cards read as a grouped
-	// checklist. The padding matches the inter-card gap.
+	// The task column: a padded grey container so the white cards read as a
+	// grouped checklist.
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
@@ -66,17 +60,14 @@
 	background: #f6f7f7;
 	border-radius: 8px;
 
-	// Tighten the @wordpress/ui Card padding so the cards read as compact
-	// checklist rows rather than full content cards. Zero the header→content
-	// margin (it otherwise leaves a gap below the header even when collapsed);
-	// the expanded gap is re-added on the subtitle, inside the clipped panel.
+	// Tighten the Card padding for compact rows; zero the header→content margin
+	// (re-added on the subtitle, so a collapsed card shows no gap).
 	&__card {
 		--wp-ui-card-padding: 16px;
 		--wp-ui-card-header-content-margin: 0;
 	}
 
-	// The icon + title row placed inside the (clickable) card header. The
-	// CollapsibleCard supplies the chevron trigger beside it.
+	// The icon + title row inside the clickable card header.
 	&__header-inner {
 		display: flex;
 		align-items: center;
@@ -103,20 +94,17 @@
 			fill: currentColor;
 		}
 
-		// Incomplete tasks: a light dashed ring (the `border` icon).
 		&.is-todo {
 			color: #c3c4c7;
 		}
 
-		// Completed tasks: a check-in-circle (the `published` icon), greyed to sit
-		// alongside the struck-through title.
+		// Greyed to sit alongside the struck-through title.
 		&.is-done {
 			color: #757575;
 		}
 	}
 
-	// 8px top re-creates the header→content gap (the card's own margin is zeroed
-	// above); being inside the panel, it's clipped when the card is collapsed.
+	// Re-creates the header→content gap zeroed above; clipped when collapsed.
 	&__subtitle {
 		margin: 8px 0 16px;
 		color: #757575;
@@ -128,17 +116,14 @@
 		gap: 8px;
 	}
 
-	// The site-preview card in the right column: a live scaled site preview +
-	// name + link.
+	// The site-preview card in the right column.
 	&__preview {
 		display: flex;
 		flex-direction: column;
 	}
 
-	// A square frame holding a desktop-width iframe scaled down to fit, mirroring
-	// the wp-admin dashboard site-management widget (renders immediately, no
-	// mShots wait). The iframe is 4× the frame and scaled 0.25, so the frame
-	// shows a ~1200px-wide front-end view regardless of the frame's actual size.
+	// A frame holding a desktop-width iframe scaled to 0.25 (4× the frame) so it
+	// shows a ~1200px-wide front-end view.
 	&__preview-frame {
 		position: relative;
 		display: block;
@@ -150,8 +135,7 @@
 		border-radius: 8px;
 		background: #f6f7f7;
 
-		// When the thumbnail links into the site editor, reveal the centered
-		// "Edit site" button overlay on hover, or when the button itself is focused.
+		// Reveal the "Edit site" overlay on hover or when the button is focused.
 		&.is-editable {
 
 			&:hover,
@@ -176,10 +160,8 @@
 		opacity: 0;
 		transition: opacity 120ms ease;
 
-		// The WPDS Button renders as a link here, and wp-admin's unlayered
-		// `a { color }` would otherwise win over the Button's layered foreground
-		// color and tint the label admin-blue. Re-assert the Button's own
-		// foreground color (white on the solid variant) with an unlayered rule.
+		// The Button renders as a link; wp-admin's unlayered `a { color }` would win
+		// over its layered foreground color, so re-assert it with an unlayered rule.
 		a {
 
 			&,
@@ -200,10 +182,9 @@
 		border: 0;
 		transform: scale(0.25);
 		transform-origin: top left;
-		// Nudge the scaled view up to crop the logged-in admin bar (~32px at the
-		// 1200px render width → ~8px at scale 0.25), mirroring the dashboard widget.
+		// Nudge up to crop the logged-in admin bar (~32px → ~8px at scale 0.25).
 		translate: 0 -8px;
-		// Purely a thumbnail — the link below is the interactive affordance.
+		// Purely a thumbnail; the link below is interactive.
 		pointer-events: none;
 	}
 
@@ -217,8 +198,7 @@
 		font-size: 13px;
 	}
 
-	// Stacked under the tasks on mobile, the preview spans the full column width.
-	// Declared after the base rule above so it wins at the mobile breakpoint.
+	// Full-width on mobile; placed after the base rule to win at the breakpoint.
 	@media (max-width: 782px) {
 
 		&__preview-frame {
@@ -226,7 +206,7 @@
 		}
 	}
 
-	// Loading placeholders: solid shimmering bars standing in for the task cards.
+	// Loading placeholders standing in for the task cards.
 	&__skeleton-bar {
 		display: block;
 		height: 56px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -101,6 +101,11 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	const [ siteTitle, setSiteTitle ] = useState< string | null >(
 		() => initialData?.site?.title ?? site?.title ?? null
 	);
+	// The wp-admin Site Editor URL: the preview thumbnail's quick link. Same
+	// seeding story as siteUrl/siteTitle; null on classic themes.
+	const [ siteEditUrl, setSiteEditUrl ] = useState< string | null >(
+		() => initialData?.site?.edit_url ?? site?.edit_url ?? null
+	);
 
 	useEffect( () => {
 		// Returning users: render from the data the host already fetched, so the
@@ -111,6 +116,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 			if ( initialData.site ) {
 				setSiteUrl( initialData.site.url ?? null );
 				setSiteTitle( initialData.site.title ?? null );
+				setSiteEditUrl( initialData.site.edit_url ?? null );
 			}
 			return;
 		}
@@ -135,6 +141,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 			if ( data?.site ) {
 				setSiteUrl( data.site.url ?? null );
 				setSiteTitle( data.site.title ?? null );
+				setSiteEditUrl( data.site.edit_url ?? null );
 			}
 
 			if ( data && data.tasks.length > 0 ) {
@@ -178,6 +185,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				progressLabel={ __( 'Tailoring your checklist…', 'jetpack-mu-wpcom' ) }
 				siteUrl={ siteUrl }
 				siteTitle={ siteTitle }
+				siteEditUrl={ siteEditUrl }
 			>
 				<TailoredListSkeleton />
 			</Layout>
@@ -271,7 +279,12 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	};
 
 	return (
-		<Layout progressLabel={ progressLabel } siteUrl={ siteUrl } siteTitle={ siteTitle }>
+		<Layout
+			progressLabel={ progressLabel }
+			siteUrl={ siteUrl }
+			siteTitle={ siteTitle }
+			siteEditUrl={ siteEditUrl }
+		>
 			<div className="ai-launchpad-tailored-list">
 				{ visibleTasks.map( task => (
 					<TaskCard

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -244,6 +244,13 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 			setTasks( prev =>
 				prev ? prev.map( t => ( t.id === task.id ? { ...t, completed: true } : t ) ) : prev
 			);
+			// Advance the accordion to the next task, mirroring Skip — otherwise the
+			// just-completed card (now a non-collapsible done card) keeps openId, so
+			// no remaining CollapsibleCard matches and the whole list collapses.
+			const afterComplete = ( tasks ?? [] ).map( t =>
+				t.id === task.id || skippedIds.has( t.id ) ? { ...t, completed: true } : t
+			);
+			setOpenId( nextIncompleteId( afterComplete, task.id ) );
 		} catch {
 			// Leave the task incomplete on failure.
 		} finally {
@@ -251,8 +258,16 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		}
 	};
 
+	// Skipping a task marks it complete (in memory) and expands the next
+	// incomplete task, as the design asks. Compute the next id from the list the
+	// skip produces so a just-skipped task is never re-opened.
 	const handleSkip = ( task: EnrichedTask ) => {
-		setSkippedIds( prev => new Set( prev ).add( task.id ) );
+		const nextSkipped = new Set( skippedIds ).add( task.id );
+		setSkippedIds( nextSkipped );
+		const afterSkip = ( tasks ?? [] ).map( t =>
+			nextSkipped.has( t.id ) ? { ...t, completed: true } : t
+		);
+		setOpenId( nextIncompleteId( afterSkip, task.id ) );
 	};
 
 	return (

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -1,12 +1,12 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { createFirstPostDraft } from '../lib/first-post.ts';
 import { createPatternPage } from '../lib/pattern-page.ts';
 import { trackTaskClicked } from '../lib/tracks.ts';
 import { Layout } from './layout.tsx';
 import {
-	firstIncompleteIndex,
+	nextIncompleteId,
 	isCompleteOnClickTask,
 	isTaskActionable,
 	resolveCtaUrl,
@@ -80,6 +80,17 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	);
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
+	// The single expanded card (accordion: only one open at a time). Seeded to the
+	// first incomplete task for returning users (initialData present on first
+	// render); the wizard→list path has no tasks yet, so the load effect opens it
+	// once the read lands. `null` means every card is collapsed — a state the user
+	// can reach by toggling the open card shut, which must not auto-reopen.
+	const [ openId, setOpenId ] = useState< string | null >( () =>
+		initialData?.tasks ? nextIncompleteId( initialData.tasks ) : null
+	);
+	// Guards the one-time auto-open so the load effect doesn't fight a user who has
+	// collapsed every card. True already when seeded from initialData above.
+	const didAutoOpen = useRef( !! initialData?.tasks );
 	// The site's front-end URL, used to build the launch CTA and the preview
 	// thumbnail; the title labels the preview. Seeded from the read (returning users)
 	// or the host's `site` prop (wizard path, so the skeleton shows the preview),
@@ -142,6 +153,16 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 			cancelled = true;
 		};
 	}, [ pendingTailor, initialData ] );
+
+	// Open the first incomplete card once the tasks first arrive on the
+	// wizard→list path (returning users are seeded synchronously above). Guarded
+	// so it runs only once and never reopens a list the user has collapsed.
+	useEffect( () => {
+		if ( ! didAutoOpen.current && tasks && tasks.length > 0 ) {
+			setOpenId( nextIncompleteId( tasks ) );
+			didAutoOpen.current = true;
+		}
+	}, [ tasks ] );
 
 	const visibleTasks = useMemo(
 		() =>
@@ -234,15 +255,10 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		setSkippedIds( prev => new Set( prev ).add( task.id ) );
 	};
 
-	// The first incomplete task opens on mount; because the cards are uncontrolled
-	// (defaultOpen), the user can then collapse it — or all of them — without it
-	// reopening. Computed from the initial render (skippedIds is empty then).
-	const firstOpenIndex = firstIncompleteIndex( visibleTasks );
-
 	return (
 		<Layout progressLabel={ progressLabel } siteUrl={ siteUrl } siteTitle={ siteTitle }>
 			<div className="ai-launchpad-tailored-list">
-				{ visibleTasks.map( ( task, index ) => (
+				{ visibleTasks.map( task => (
 					<TaskCard
 						key={ task.id }
 						task={ task }
@@ -251,7 +267,8 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 						canMarkComplete={
 							isCompleteOnClickTask( task.id ) && ! isTaskActionable( task, output, siteUrl )
 						}
-						defaultOpen={ index === firstOpenIndex }
+						isOpen={ openId === task.id }
+						onOpenChange={ open => setOpenId( open ? task.id : null ) }
 						onGetStarted={ () => handleGetStarted( task ) }
 						onMarkComplete={ () => handleMarkComplete( task ) }
 						onSkip={ () => handleSkip( task ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -31,38 +31,26 @@ function navigate( url: string ): void {
 }
 
 interface Props {
-	// When the host transitions here straight from the wizard, the AI tailoring
-	// is still in flight and its PUT /tailored has not necessarily landed. The
-	// host passes the tailor promise so the list waits for it to settle before
-	// reading GET /ai-launchpad — otherwise the GET races the PUT and returns an
-	// empty task list. While awaiting, the skeleton shows. Its resolved result is
-	// also used as a local fallback when the read yields nothing (e.g. the
-	// fallback PUT failed). Omitted for returning users, where output is persisted.
+	// In-flight tailor promise on the wizard→list path. The list waits for it to
+	// settle before reading GET /ai-launchpad, otherwise the GET races the PUT and
+	// returns an empty list. Its resolved result is a local fallback when the read
+	// yields nothing. Omitted for returning users.
 	pendingTailor?: Promise< TailorResult >;
 
-	// Returning users: the host already fetched the composite read to decide the
-	// view, so it hands the data down here to avoid fetching the same expensive
-	// endpoint a second time. Omitted on the wizard→list path.
+	// The composite read the host already fetched, to avoid refetching the same
+	// endpoint. Omitted on the wizard→list path.
 	initialData?: LaunchpadData;
 
-	// Site context (URL + title) for the preview card. The host always has this
-	// from its initial composite read, so it's passed on the wizard→list path too
-	// — that lets the loading skeleton show the preview before the tailored read
-	// lands. The fetched/initialData site (when present) takes precedence.
+	// Site context for the preview card, passed on the wizard→list path too so the
+	// skeleton can show the preview. The fetched site takes precedence.
 	site?: SiteData;
 }
 
 /**
  * The tailored launchpad list: task cards rendered from the AI output inside a
- * centered layout with a heading, "X of N completed" progress, and a site
- * preview. The first incomplete task auto-expands; each task offers an
- * action-specific CTA and "Skip". While the AI output is loading, the same
- * layout is shown with a shimmering skeleton and "Tailoring your checklist…".
- *
- * Titles, completion state, and deeplink paths come from Stream B's
- * `GET /ai-launchpad/`; subtitles come from the AI. In dev mode the list
- * renders from a committed fixture so it can be worked on before the AI call
- * exists.
+ * layout with a heading, "X of N completed" progress, and a site preview. The
+ * first incomplete task auto-expands; each task offers an action-specific CTA and
+ * "Skip". While loading, a skeleton is shown in the same layout.
  *
  * @param props               - Component props.
  * @param props.pendingTailor - In-flight tailor call to await before fetching.
@@ -71,29 +59,24 @@ interface Props {
  * @return The tailored-list element.
  */
 export function TailoredList( { pendingTailor, initialData, site }: Props = {} ) {
-	// Returning users arrive with the composite read already done, so seed straight
-	// from it — otherwise the first frame shows the "Tailoring…" loading copy before
-	// the effect runs. The wizard→list path has no initialData and starts as loading.
+	// Returning users seed straight from initialData so the first frame isn't the
+	// loading copy. The wizard→list path has no initialData and starts as loading.
 	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( () => initialData?.tasks ?? null );
 	const [ output, setOutput ] = useState< TailoredOutput | null >(
 		() => initialData?.ai_output?.payload ?? null
 	);
 	const [ skippedIds, setSkippedIds ] = useState< Set< string > >( () => new Set() );
 	const [ busyId, setBusyId ] = useState< string | null >( null );
-	// The single expanded card (accordion: only one open at a time). Seeded to the
-	// first incomplete task for returning users (initialData present on first
-	// render); the wizard→list path has no tasks yet, so the load effect opens it
-	// once the read lands. `null` means every card is collapsed — a state the user
-	// can reach by toggling the open card shut, which must not auto-reopen.
+	// The single expanded card (accordion: only one open at a time). `null` means
+	// every card is collapsed — a state the user can reach by toggling the open card
+	// shut, which must not auto-reopen.
 	const [ openId, setOpenId ] = useState< string | null >( () =>
 		initialData?.tasks ? nextIncompleteId( initialData.tasks ) : null
 	);
 	// Guards the one-time auto-open so the load effect doesn't fight a user who has
-	// collapsed every card. True already when seeded from initialData above.
+	// collapsed every card.
 	const didAutoOpen = useRef( !! initialData?.tasks );
-	// The site's front-end URL, used to build the launch CTA and the preview
-	// thumbnail; the title labels the preview. Seeded from the read (returning users)
-	// or the host's `site` prop (wizard path, so the skeleton shows the preview),
+	// Seeded from the read (returning users) or the host's `site` prop (wizard path),
 	// then overridden once the read lands.
 	const [ siteUrl, setSiteUrl ] = useState< string | null >(
 		() => initialData?.site?.url ?? site?.url ?? null
@@ -101,15 +84,13 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	const [ siteTitle, setSiteTitle ] = useState< string | null >(
 		() => initialData?.site?.title ?? site?.title ?? null
 	);
-	// The wp-admin Site Editor URL: the preview thumbnail's quick link. Same
-	// seeding story as siteUrl/siteTitle; null on classic themes.
+	// The Site Editor URL: the preview thumbnail's quick link; null on classic themes.
 	const [ siteEditUrl, setSiteEditUrl ] = useState< string | null >(
 		() => initialData?.site?.edit_url ?? site?.edit_url ?? null
 	);
 
 	useEffect( () => {
-		// Returning users: render from the data the host already fetched, so the
-		// expensive composite read isn't run a second time.
+		// Returning users: render from the data the host already fetched.
 		if ( initialData ) {
 			setTasks( initialData.tasks );
 			setOutput( initialData.ai_output?.payload ?? null );
@@ -123,9 +104,8 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 
 		let cancelled = false;
 		( async () => {
-			// When arriving from the wizard, wait for the tailor call to settle so
-			// the PUT /tailored has persisted before we read it back. A rejected
-			// tailor still gives us its in-memory output as a local fallback.
+			// Wait for the tailor call to settle so the PUT has persisted before we
+			// read it back. A rejected tailor still gives its in-memory output as a fallback.
 			const result = await Promise.resolve( pendingTailor ).catch( () => undefined );
 
 			let data: LaunchpadData | null = null;
@@ -148,8 +128,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				setTasks( data.tasks );
 				setOutput( data.ai_output?.payload ?? null );
 			} else if ( result?.output ) {
-				// Read returned nothing (e.g. the fallback PUT failed): render the
-				// in-memory result so the user still gets the deterministic list.
+				// Read returned nothing: render the in-memory result instead.
 				setOutput( result.output );
 				setTasks( tasksFromFixture( result.output ) );
 			} else {
@@ -161,9 +140,8 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		};
 	}, [ pendingTailor, initialData ] );
 
-	// Open the first incomplete card once the tasks first arrive on the
-	// wizard→list path (returning users are seeded synchronously above). Guarded
-	// so it runs only once and never reopens a list the user has collapsed.
+	// Open the first incomplete card once the tasks first arrive on the wizard→list
+	// path. Guarded so it runs only once and never reopens a collapsed list.
 	useEffect( () => {
 		if ( ! didAutoOpen.current && tasks && tasks.length > 0 ) {
 			setOpenId( nextIncompleteId( tasks ) );
@@ -213,11 +191,9 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				},
 				siteUrl
 			);
-			// Acknowledgment tasks have no completion signal in wp-admin (they
-			// complete only in Calypso), so clicking the CTA is the completion.
-			// Persist it before navigating away (same-tab nav unloads the page,
-			// cancelling an un-awaited request), best-effort so a failed write never
-			// blocks the navigation.
+			// These tasks have no completion signal in wp-admin, so clicking the CTA
+			// is the completion. Persist it before navigating (same-tab nav cancels an
+			// un-awaited request); best-effort so a failed write never blocks navigation.
 			if ( isCompleteOnClickTask( task.id ) ) {
 				await apiFetch( {
 					path: '/wpcom/v2/ai-launchpad/complete-task',
@@ -229,17 +205,15 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				navigate( url );
 			}
 		} catch {
-			// Swallow: the finally clears busy so a thrown CTA (e.g. a failed
-			// pattern fetch) can't leave the card permanently disabled.
+			// The finally clears busy so a thrown CTA can't leave the card disabled.
 		} finally {
 			setBusyId( null );
 		}
 	};
 
-	// Complete-on-click tasks with no CTA destination (e.g. share_site) can't be
-	// "started", so the card offers "Mark as complete": persist the completion and
-	// flip the card to done in place (no navigation). Only flips on a successful
-	// write so a failed POST doesn't show a completion that reverts on reload.
+	// Complete-on-click tasks with no CTA destination offer "Mark as complete":
+	// persist the completion and flip the card to done in place. Only flips on a
+	// successful write so a failed POST doesn't show a completion that reverts on reload.
 	const handleMarkComplete = async ( task: EnrichedTask ) => {
 		setBusyId( task.id );
 		try {
@@ -253,8 +227,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				prev ? prev.map( t => ( t.id === task.id ? { ...t, completed: true } : t ) ) : prev
 			);
 			// Advance the accordion to the next task, mirroring Skip — otherwise the
-			// just-completed card (now a non-collapsible done card) keeps openId, so
-			// no remaining CollapsibleCard matches and the whole list collapses.
+			// just-completed (now non-collapsible) card keeps openId and the list collapses.
 			const afterComplete = ( tasks ?? [] ).map( t =>
 				t.id === task.id || skippedIds.has( t.id ) ? { ...t, completed: true } : t
 			);
@@ -266,9 +239,8 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		}
 	};
 
-	// Skipping a task marks it complete (in memory) and expands the next
-	// incomplete task, as the design asks. Compute the next id from the list the
-	// skip produces so a just-skipped task is never re-opened.
+	// Skipping marks a task complete (in memory) and expands the next incomplete
+	// task. Compute the next id from the post-skip list so it's never re-opened.
 	const handleSkip = ( task: EnrichedTask ) => {
 		const nextSkipped = new Set( skippedIds ).add( task.id );
 		setSkippedIds( nextSkipped );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,44 +1,8 @@
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { border, published } from '@wordpress/icons';
 import { Button, Card, CollapsibleCard } from '@wordpress/ui';
 import { ctaKind, type EnrichedTask } from './model.ts';
-
-// WPDS doesn't ship a "todo / dashed-circle" or "check-in-circle" icon yet (only
-// `check`), so we inline both. Sized at 24px to line up with each other;
-// `currentColor` lets us tone them via CSS.
-const taskActiveIcon = (
-	<svg
-		className="ai-launchpad-tailored-list__icon is-todo"
-		width={ 24 }
-		height={ 24 }
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-hidden="true"
-	>
-		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" strokeDasharray="3 2.5" />
-	</svg>
-);
-
-const taskDoneIcon = (
-	<svg
-		className="ai-launchpad-tailored-list__icon is-done"
-		width={ 24 }
-		height={ 24 }
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-hidden="true"
-	>
-		<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
-		<path
-			d="M8 12.5L11 15.5L16 9.5"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
 
 interface Props {
 	task: EnrichedTask;
@@ -132,7 +96,9 @@ export function TaskCard( {
 			<Card.Root className="ai-launchpad-tailored-list__card is-completed">
 				<Card.Header>
 					<span className="ai-launchpad-tailored-list__header-inner">
-						{ taskDoneIcon }
+						<span className="ai-launchpad-tailored-list__icon is-done">
+							<Icon icon={ published } size={ 24 } />
+						</span>
 						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
 					</span>
 				</Card.Header>
@@ -144,7 +110,9 @@ export function TaskCard( {
 		<CollapsibleCard.Root className="ai-launchpad-tailored-list__card" defaultOpen={ defaultOpen }>
 			<CollapsibleCard.Header>
 				<span className="ai-launchpad-tailored-list__header-inner">
-					{ taskActiveIcon }
+					<span className="ai-launchpad-tailored-list__icon is-todo">
+						<Icon icon={ border } size={ 24 } />
+					</span>
 					<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
 				</span>
 			</CollapsibleCard.Header>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -9,7 +9,8 @@ interface Props {
 	isBusy: boolean;
 	canStart: boolean;
 	canMarkComplete: boolean;
-	defaultOpen: boolean;
+	isOpen: boolean;
+	onOpenChange: ( open: boolean ) => void;
 	onGetStarted: () => void;
 	onMarkComplete: () => void;
 	onSkip: () => void;
@@ -68,14 +69,18 @@ function getCtaLabel( taskId: string ): string {
  * the always-visible header, which is the toggle trigger); expanding reveals the
  * AI subtitle and the action-specific CTA / "Skip" actions.
  *
+ * Open state is controlled by the parent so the list behaves as an accordion:
+ * only one card is open at a time.
+ *
  * @param props                 - The component props.
  * @param props.task            - The enriched task to render.
  * @param props.isBusy          - Whether the primary action is in flight.
  * @param props.canStart        - Whether the task has an actionable CTA destination.
  * @param props.canMarkComplete - Whether the task offers a "Mark as complete" button
  *                              (a complete-on-click task with no CTA destination).
- * @param props.defaultOpen     - Whether the card starts expanded (uncontrolled, so
- *                              the user can then collapse it without it reopening).
+ * @param props.isOpen          - Whether the card is expanded (controlled by the parent).
+ * @param props.onOpenChange    - Called with the requested open state when the header
+ *                              is toggled, so the parent can enforce single-open.
  * @param props.onGetStarted    - Called when the primary CTA is clicked.
  * @param props.onMarkComplete  - Called when "Mark as complete" is clicked.
  * @param props.onSkip          - Called when "Skip" is clicked.
@@ -86,7 +91,8 @@ export function TaskCard( {
 	isBusy,
 	canStart,
 	canMarkComplete,
-	defaultOpen,
+	isOpen,
+	onOpenChange,
 	onGetStarted,
 	onMarkComplete,
 	onSkip,
@@ -107,7 +113,11 @@ export function TaskCard( {
 	}
 
 	return (
-		<CollapsibleCard.Root className="ai-launchpad-tailored-list__card" defaultOpen={ defaultOpen }>
+		<CollapsibleCard.Root
+			className="ai-launchpad-tailored-list__card"
+			open={ isOpen }
+			onOpenChange={ onOpenChange }
+		>
 			<CollapsibleCard.Header>
 				<span className="ai-launchpad-tailored-list__header-inner">
 					<span className="ai-launchpad-tailored-list__icon is-todo">

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -17,16 +17,12 @@ interface Props {
 }
 
 /**
- * Resolve the action-specific label for a task's primary CTA. A static,
- * translatable map keyed first by task id (the most specific) then by
- * {@link ctaKind} (the behavioral class), falling back to a generic
- * "Get started" so a task with no entry still gets a sensible button.
+ * Resolve the action-specific label for a task's primary CTA, keyed first by task
+ * id then by {@link ctaKind}, falling back to a generic "Get started".
  *
- * The map lives here rather than in `model.ts` because the labels must be
- * `__()` literals (so they're extracted for translation) and `model.ts` is
- * intentionally free of `@wordpress/*` imports so its node:test suite runs.
- * Labels are AI-independent on purpose — AI output is English-only today
- * (DOTOBRD-474), so deriving labels from it would regress i18n.
+ * The map lives here rather than in `model.ts` because the labels must be `__()`
+ * literals for translation extraction, and `model.ts` is kept free of
+ * `@wordpress/*` imports so its node:test suite runs.
  *
  * @param taskId - The catalog task id.
  * @return The translated CTA label.
@@ -43,8 +39,8 @@ function getCtaLabel( taskId: string ): string {
 			return __( 'Set up payments', 'jetpack-mu-wpcom' );
 		case 'connect_social_media':
 			return __( 'Connect socials', 'jetpack-mu-wpcom' );
-		// Both the AI-selectable catalog id and the deterministic fallback id for
-		// growing a subscriber list, so the label holds on the fallback path too.
+		// Both the AI-selectable id and the deterministic fallback id, so the label
+		// holds on the fallback path too.
 		case 'subscribers_added':
 		case 'add_10_email_subscribers':
 			return __( 'Add subscribers', 'jetpack-mu-wpcom' );
@@ -63,14 +59,10 @@ function getCtaLabel( taskId: string ): string {
 }
 
 /**
- * A single task in the tailored list. Completed tasks render as a plain card
- * with a struck-through title and a check-in-circle icon, and aren't expandable.
- * Incomplete tasks render as a `CollapsibleCard` (dashed-circle icon + title in
- * the always-visible header, which is the toggle trigger); expanding reveals the
- * AI subtitle and the action-specific CTA / "Skip" actions.
- *
- * Open state is controlled by the parent so the list behaves as an accordion:
- * only one card is open at a time.
+ * A single task in the tailored list. Completed tasks render as a plain card with
+ * a struck-through title and aren't expandable. Incomplete tasks render as a
+ * `CollapsibleCard` that expands to reveal the subtitle and the CTA / "Skip"
+ * actions. Open state is controlled by the parent so the list acts as an accordion.
  *
  * @param props                 - The component props.
  * @param props.task            - The enriched task to render.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/details-step.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/details-step.tsx
@@ -13,8 +13,7 @@ interface Props {
 }
 
 /**
- * Example placeholders per goal, grounded in the WordPress.com site
- * classification taxonomy and the "what users want to build" analysis.
+ * Example placeholders per goal.
  *
  * @param goal - The selected goal, or null.
  * @return The placeholder variants for the goal.
@@ -75,8 +74,7 @@ function intentVariants( goal: GoalSlug | null ): string[] {
  */
 function useIntentPlaceholder( goal: GoalSlug | null ): string {
 	const variants = intentVariants( goal );
-	// `variants` is derived from `goal` alone; re-rolling the example once per
-	// goal change (not on every render) is the intended rotating behavior.
+	// Re-roll the example once per goal change, not on every render.
 	return useMemo(
 		() => pickPlaceholder( variants ),
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/goals-step.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/goals-step.tsx
@@ -11,7 +11,7 @@ interface GoalOption {
 }
 
 /**
- * The six goal cards shown on step 1, with PoC copy.
+ * The six goal cards shown on step 1.
  *
  * @return The goal options.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
@@ -111,8 +111,15 @@
 	color: #50575e;
 	line-height: 1.4;
 	// Balance the short two-line copy so a single word never orphans onto its
-	// own last line (e.g. "expertise.", "goods.").
+	// own last line (e.g. "expertise.", "goods.") in the narrow two-column grid.
 	text-wrap: balance;
+
+	// On mobile the cards stack full-width, where `balance` keeps the lines short
+	// instead of letting longer copy (Educate, Portfolio) span the container.
+	// `pretty` still avoids orphans but fills the available width first.
+	@media (max-width: 600px) {
+		text-wrap: pretty;
+	}
 }
 
 .ai-launchpad-wizard__footer {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
@@ -110,13 +110,10 @@
 	font-size: 12px;
 	color: #50575e;
 	line-height: 1.4;
-	// Balance the short two-line copy so a single word never orphans onto its
-	// own last line (e.g. "expertise.", "goods.") in the narrow two-column grid.
+	// Balance the copy so a single word never orphans onto its own last line.
 	text-wrap: balance;
 
-	// On mobile the cards stack full-width, where `balance` keeps the lines short
-	// instead of letting longer copy (Educate, Portfolio) span the container.
-	// `pretty` still avoids orphans but fills the available width first.
+	// On full-width mobile cards, `pretty` avoids orphans while filling the width.
 	@media (max-width: 600px) {
 		text-wrap: pretty;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -26,10 +26,8 @@ interface Props {
 	initialIntent?: string;
 	// User locale, forwarded to the wizard payload and the AI call.
 	locale?: string;
-	// Fired once Finish completes, so the host can swap the wizard for the
-	// tailored list. Receives the persisted wizard input and the in-flight
-	// tailor promise, so the host can hand the promise to the tailored list and
-	// have it wait for PUT /tailored to land before reading the output back.
+	// Fired once Finish completes, with the persisted input and the in-flight
+	// tailor promise, so the host can swap to the tailored list.
 	onComplete?: ( input: WizardInput, tailoring: Promise< TailorResult > ) => void;
 }
 
@@ -74,9 +72,7 @@ export function Wizard( {
 			return;
 		}
 		const payload = buildWizardPayload( goal, state );
-		// Persist in the background; the flow advances on the tailoring promise
-		// below, so a failed best-effort save must not surface as an unhandled
-		// rejection.
+		// Persist in the background, best-effort so a failed save isn't an unhandled rejection.
 		apiFetch( {
 			path: '/wpcom/v2/ai-launchpad/wizard',
 			method: 'PUT',


### PR DESCRIPTION
Fixes #

Implements the first pass of design feedback for the AI Launchpad (DSGCOM-678). The feature stays OFF in production (gated); these are UI/UX and copy fixes plus a comments-only cleanup.

## Proposed changes
* **Accordion task list** — only one task card is open at a time; opening another collapses the active one. The first incomplete task auto-expands on load.
* **Auto-advance** — skipping *or* completing a task auto-expands the next incomplete task.
* **WPDS state icons** — replace the inline SVGs with `@wordpress/icons` `border` (active) and `published` (done).
* **Site editor quick link** — the preview thumbnail reveals a compact "Edit site" button on hover, linking to the Site Editor on block themes and the Customizer on classic themes.
* **Mobile wizard copy** — goal-card descriptions (Educate, Portfolio) span the full container width on mobile.
* **Drop `write_3_posts`** — removed from the tailoring menu (redundant with "Write your first post").
* **Generic social copy** — social-task subtitles stay general and no longer name specific networks.
* **Comments cleanup** — trimmed verbose docblocks/inline comments across the feature and removed internal ticket references (comments-only; no behavior change).

## Related product discussion/links
* DSGCOM-678 — design feedback (first pass)
* Follow-ups filed: DOTCOM-17735 (in-progress task state), DOTCOM-17736 (themes filtered by niche), DOTCOM-17737 ("Create your first gallery" task), DOTCOM-17738 (rework the "sell" sequence)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
The feature is gated off in production. On a paid WordPress.com (Simple or Atomic) test site with the AI Launchpad enabled:

* Open the **AI Launchpad** item in the wp-admin menu.
* In the wizard on a mobile viewport, confirm the **Educate** and **Portfolio** card copy spans the full width.
* On the tailored list:
  * Confirm only **one** task card is open at a time; opening another collapses the previous.
  * **Skip** a task → the next incomplete task expands. Use **Mark as complete** on a no-CTA task (e.g. "Share your site") → the next task expands.
  * Confirm icons: dashed ring for active tasks, check-in-circle + struck-through title for done.
* Hover the **site preview** thumbnail → a compact "Edit site" button appears; it opens the Site Editor (block theme) or Customizer (classic theme).
* Confirm the AI no longer surfaces a "Write 3 posts" task, and that the social task reads generically (no specific networks).
