### PR TITLE
Newsletter: roll out the modernized dashboard to 100%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Newsletter: default the modernized Subscribers experience on for all WordPress.com sites, retiring the legacy Calypso Subscribers submenu.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -11,8 +11,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
 use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Status\Visitor;
 
 require_once __DIR__ . '/../../common/wpcom-callout.php';
 
@@ -392,52 +390,18 @@ function wpcom_add_jetpack_submenu() {
 	// Jetpack > Subscribers. Always hide the auto-added Calypso redirect link.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
-	// When the Newsletter modernization filter is on, the unified Newsletter page
-	// owns the Subscribers tab and the legacy Calypso "Subscribers" submenu is
-	// retired, replaced by a transitional announcement page that points there;
-	// otherwise we keep the legacy Calypso submenu. (The wp-admin
-	// subscriber-management variant was removed with the subscribers-dashboard
-	// package and isn't restored.)
-	//
-	// The filter default is the staged-rollout cohort: on for Automatticians (so
-	// a12s can dogfood and test fixes) and for the percentage cohort, bucketed by
-	// the site's stable wpcom blog ID. This mirrors the canonical
-	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
-	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally —
-	// ahead of the class_exists-guarded Subscribers_Announcement use below — so the
-	// a11n check and the bucket math are inlined rather than referenced from the
-	// class. The rollout percentage — the one value that moves to widen the rollout —
-	// is read from the canonical MODERNIZATION_ROLLOUT_PERCENTAGE constant when the
-	// newsletter package is loaded (always so on WordPress.com), falling back to 0
-	// otherwise, so there is no second copy of the number to keep in sync. The
-	// percentage is currently 0 — the Simple-site rollout is driven from the
-	// WordPress.com backend instead.
-	//
-	// The cohort keys on the wpcom blog ID (current blog ID on Simple, stored wpcom
-	// ID on WoA) rather than the transient `IS_WPCOM` constant, so a site keeps its
-	// cohort decision when it is upgraded from Simple to Atomic and doesn't lose the
-	// modernized experience on transfer. The a12s check mirrors the canonical helper:
-	// `is_automattician()` is a WordPress.com global that only exists on Simple sites,
-	// so WoA falls back to the proxied-request check. (This mu-plugin only loads on
-	// WordPress.com, so the canonical helper's all-sites percentage gate reduces to
-	// the wpcom-blog-ID bucket here.)
+	// The unified Newsletter page now owns the Subscribers tab on every site: the
+	// legacy Calypso "Subscribers" submenu is retired and replaced by a transitional
+	// announcement page that points there. (The wp-admin subscriber-management variant
+	// was removed with the subscribers-dashboard package and isn't restored.) Hosts
+	// (and a11ns who want the legacy view back) can still force the old submenu back
+	// with add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' ).
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
-	$rollout_percentage            = defined( '\Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_ROLLOUT_PERCENTAGE' )
-		? (int) constant( '\Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_ROLLOUT_PERCENTAGE' )
-		: 0;
-	$host                          = new Host();
-	$is_automattician              = ( function_exists( 'is_automattician' ) && is_automattician() )
-		|| ( new Visitor() )->is_automattician_feature_flags_only();
-	$rollout_blog_id               = $host->is_wpcom_simple()
-		? (int) get_current_blog_id()
-		: (int) \Jetpack_Options::get_option( 'id' );
-	$modernization_rollout_default = $is_automattician
-		|| ( $rollout_blog_id > 0 && ( $rollout_blog_id % 100 ) < $rollout_percentage );
-	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
+	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 		add_submenu_page(
 			'jetpack',
 			__( 'Subscribers', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
@@ -97,43 +97,38 @@ class WPCOM_Admin_Menu_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * By default — outside the staged-rollout cohort (percentage held at 0%, no
-	 * Automattician) — `wpcom_add_jetpack_submenu()` keeps the legacy Calypso
-	 * "Subscribers" submenu. This drives the non-Simple arm of the inlined cohort
-	 * gate: with no `IS_WPCOM`, the site is bucketed on its stored wpcom blog ID
-	 * (`jetpack_options['id']`), and `200 % 100 = 0` is not `< 0`, so it isn't
-	 * enrolled.
+	 * The Newsletter modernization gate now defaults on for every site, so by default
+	 * `wpcom_add_jetpack_submenu()` retires the legacy Calypso "Subscribers" submenu —
+	 * the unified Newsletter page owns the Subscribers tab. (The transitional
+	 * announcement page is registered by the Newsletter package, which isn't a
+	 * dependency of jetpack-mu-wpcom, so here the legacy link is simply absent.)
 	 */
-	public function test_jetpack_submenu_keeps_legacy_subscribers_link_by_default_on_non_simple_site() {
+	public function test_jetpack_submenu_retires_legacy_subscribers_link_by_default() {
 		\Jetpack_Options::update_option( 'id', 200 );
 
 		wpcom_add_jetpack_submenu();
 
-		$this->assertSame(
-			'https://wordpress.com/subscribers/' . self::$domain,
+		$this->assertNull(
 			$this->get_legacy_subscribers_submenu_slug(),
-			'The legacy Subscribers submenu must remain when the site is outside the rollout cohort.'
+			'The legacy Subscribers submenu must be retired by default now that the rollout is at 100%.'
 		);
 	}
 
 	/**
-	 * The same default on a WordPress.com Simple site, which buckets on the current
-	 * blog ID rather than the stored option — exercising the Simple arm of the cohort
-	 * gate. `Constants::set_constant` flips `Host::is_wpcom_simple()` without an
-	 * irreversible `define()`; the stored option still satisfies the connection's
-	 * site-ID lookup so the function doesn't bail early.
+	 * Hosts (and a11ns who want the legacy view back) can still opt out with
+	 * `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' )`,
+	 * which keeps the legacy Calypso "Subscribers" submenu instead of retiring it.
 	 */
-	public function test_jetpack_submenu_keeps_legacy_subscribers_link_by_default_on_simple_site() {
-		Constants::set_constant( 'IS_WPCOM', true );
-		Status_Cache::clear();
+	public function test_jetpack_submenu_keeps_legacy_subscribers_link_when_modernization_filter_off() {
 		\Jetpack_Options::update_option( 'id', 200 );
+		add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' );
 
 		wpcom_add_jetpack_submenu();
 
 		$this->assertSame(
 			'https://wordpress.com/subscribers/' . self::$domain,
 			$this->get_legacy_subscribers_submenu_slug(),
-			'A Simple site outside the rollout cohort must keep the legacy Subscribers submenu.'
+			'The legacy Subscribers submenu must remain when the modernization gate is filtered off.'
 		);
 	}
 

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Roll the modernized Newsletter dashboard out to all sites and remove the staged-rollout cohort scaffolding.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -14,7 +14,6 @@ use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Status\Visitor;
 use Jetpack_Tracks_Client;
 
 /**
@@ -33,22 +32,6 @@ class Settings {
 	 * wp-build dashboard instead of the legacy Newsletter Settings React app.
 	 */
 	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_newsletter';
-
-	/**
-	 * Percentage of sites the modernized Newsletter experience defaults on for
-	 * during the staged rollout.
-	 *
-	 * Currently 0: the Simple-site rollout is driven from the WordPress.com backend
-	 * instead (a server-side feature-flag value that can be rolled back instantly),
-	 * so the Jetpack-side cohort is held at zero. The cohort code stays in place for
-	 * Atomic (WoA) and self-hosted Jetpack sites; bumping this single number is the
-	 * one-line change that widens the rollout once the Simple cohort is validated.
-	 * Automatticians get the experience regardless of this percentage.
-	 *
-	 * Sites are bucketed deterministically by their wpcom blog ID, so every gate
-	 * that reads this lands on the same answer for a given site.
-	 */
-	const MODERNIZATION_ROLLOUT_PERCENTAGE = 0;
 
 	/**
 	 * Whether the class has been initialized
@@ -286,7 +269,7 @@ class Settings {
 		$is_block_theme         = wp_is_block_theme();
 		$setup_payment_plan_url = ( $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . $site_suffix;
 
-		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', self::is_modernization_rollout_enabled() );
+		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true );
 
 		// Populate blog_id which is needed for API calls on Simple sites.
 		$data['site']['wpcom']['blog_id'] = $blog_id;
@@ -506,83 +489,17 @@ class Settings {
 	}
 
 	/**
-	 * Whether the modernized Newsletter experience should default on for this site.
-	 *
-	 * The release is staged: the modernized dashboard, wp-admin subscriber
-	 * management, and the retired Calypso Subscribers submenu all default on for a
-	 * deterministic slice of sites, keyed on the wpcom blog ID, plus all
-	 * Automatticians.
-	 *
-	 * The percentage cohort (see `MODERNIZATION_ROLLOUT_PERCENTAGE`) spans *all*
-	 * sites — Simple, WoA (Atomic) and self-hosted Jetpack — and is bucketed on the
-	 * wpcom blog ID (`get_current_blog_id()` on Simple, `jetpack_options['id']`
-	 * elsewhere), which is preserved when a Simple site is upgraded to Atomic. Keying
-	 * on the wpcom blog ID rather than the transient `IS_WPCOM` constant means a site
-	 * keeps its cohort decision across the transfer. The percentage is currently 0:
-	 * the Simple-site rollout is driven from the WordPress.com backend instead, and
-	 * this gate stays at zero until the wider rollout is opened by bumping the
-	 * constant. A site with no resolvable wpcom blog ID (e.g. a self-hosted Jetpack
-	 * site that isn't connected) is never bucketed in.
-	 *
-	 * Automatticians get the modernized experience by default regardless of the
-	 * percentage cohort, so a12s can dogfood it and test fixes ahead of the wider
-	 * rollout. This is a dogfooding gate, not an authorization check, so the Simple
-	 * `is_automattician()` global is used without the usual proxied-request pairing;
-	 * Atomic has no non-proxied a12s signal, so it falls back to
-	 * `Visitor::is_automattician_feature_flags_only()` (true for proxied a8c requests).
-	 *
-	 * This is only the filter *default*: hosts (and a11ns who want the legacy view
-	 * back) can still force the experience on or off with the
-	 * `rsm_jetpack_ui_modernization_newsletter` /
-	 * `jetpack_wp_admin_subscriber_management_enabled` filters.
-	 *
-	 * @return bool
-	 */
-	public static function is_modernization_rollout_enabled() {
-		// Automatticians are enrolled regardless of the percentage cohort so they
-		// can dogfood ahead of the wider rollout. Simple exposes the
-		// `is_automattician()` global; Atomic has no non-proxied a12s signal, so we
-		// fall back to the proxied-request check. (Dogfooding gate, so no
-		// `wpcom_is_proxied_request()` pairing on the Simple branch.)
-		if (
-			( function_exists( 'is_automattician' ) && is_automattician() )
-			|| ( new Visitor() )->is_automattician_feature_flags_only()
-		) {
-			return true;
-		}
-
-		// Bucket on the wpcom blog ID, which is stable across a Simple→Atomic
-		// transfer: the current blog ID on Simple, the stored wpcom ID elsewhere. We
-		// read the WoA/Jetpack ID from Jetpack options directly rather than via
-		// `Host::get_wpcom_site_id()`, which additionally requires the Jetpack
-		// connection to be "ready" — that would drop a freshly transferred site out
-		// of the cohort until its connection settles. Guard against an unresolvable
-		// ID so a site without one isn't bucketed as blog ID 0 and enrolled by
-		// accident once the percentage is non-zero.
-		$host    = new Host();
-		$blog_id = $host->is_wpcom_simple()
-			? (int) get_current_blog_id()
-			: (int) \Jetpack_Options::get_option( 'id' );
-		if ( $blog_id <= 0 ) {
-			return false;
-		}
-
-		return ( $blog_id % 100 ) < self::MODERNIZATION_ROLLOUT_PERCENTAGE;
-	}
-
-	/**
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
-	 * Defaults to the staged-rollout cohort (see
-	 * `is_modernization_rollout_enabled()`): on for Automatticians and for the
-	 * percentage cohort (currently 0%), off everywhere else. Hosts can opt in or out
-	 * explicitly with
-	 * `add_filter( self::MODERNIZATION_FILTER, '__return_true' / '__return_false' );`.
+	 * The modernized Newsletter dashboard, wp-admin subscriber management, and the
+	 * retired Calypso Subscribers submenu now default on for every site. Hosts (and
+	 * a11ns who want the legacy view back) can still force the legacy experience with
+	 * `add_filter( self::MODERNIZATION_FILTER, '__return_false' );`.
 	 *
 	 * @return bool
 	 */
 	private static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, self::is_modernization_rollout_enabled() );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -59,7 +59,6 @@ class Settings_Test extends BaseTestCase {
 		( new Connection_Manager() )->reset_connection_status();
 
 		unset( $_GET['page'] );
-		unset( $GLOBALS['jetpack_newsletter_test_is_automattician'] );
 		remove_all_filters( Settings::MODERNIZATION_FILTER );
 		remove_all_filters( 'site_url' );
 		remove_all_filters( 'home_url' );
@@ -169,162 +168,14 @@ class Settings_Test extends BaseTestCase {
 
 	/**
 	 * `is_modernized()` is the canonical gate used by `maybe_load_wp_build`,
-	 * `add_wp_admin_menu`, and `load_admin_scripts`. Its default — the value
-	 * `apply_filters` receives — is the staged-rollout cohort. With the percentage
-	 * cohort held at 0% and no Automattician in the test environment, the default
-	 * must be false.
+	 * `add_wp_admin_menu`, and `load_admin_scripts`. The staged rollout is complete:
+	 * the modernized experience now defaults on for every site, so the value
+	 * `apply_filters` receives must be true.
 	 */
-	public function test_is_modernized_defaults_to_false_outside_rollout() {
-		$this->assertFalse(
-			self::call_private_static_is_modernized(),
-			'Modernization gate must default to false when the site is not in the rollout cohort.'
-		);
-	}
-
-	/**
-	 * The rollout now spans *all* sites: removing the old wpcom-platform gate means a
-	 * self-hosted (non-wpcom) Jetpack site with a resolvable wpcom blog ID enters the
-	 * percentage cohort just like Simple/WoA, bucketed on its stored wpcom ID. At the
-	 * current 0% it is not enrolled; once the percentage is raised it would be, which
-	 * is exactly the "all sites" behavior this asserts against the live constant.
-	 */
-	public function test_self_hosted_connected_site_bucketed_on_wpcom_id() {
-		\Jetpack_Options::update_option( 'id', 200 ); // Non-wpcom site, but a connected wpcom blog ID.
-
-		try {
-			$this->assertSame(
-				( 200 % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
-				Settings::is_modernization_rollout_enabled(),
-				'A self-hosted connected Jetpack site must be bucketed on its wpcom blog ID against the rollout percentage.'
-			);
-		} finally {
-			\Jetpack_Options::delete_option( 'id' );
-		}
-	}
-
-	/**
-	 * Simple sites can be upgraded to Atomic (WoA). The cohort keys on the wpcom blog
-	 * ID, which is preserved across the transfer (read from `jetpack_options['id']` on
-	 * WoA, not the current blog ID), so a site's enrollment decision is identical
-	 * before and after the upgrade — it never silently flips on transfer. Asserted
-	 * against the live percentage so it holds at 0% and after a bump alike.
-	 */
-	public function test_woa_site_bucketed_on_stable_wpcom_blog_id() {
-		$this->set_woa_constants();
-		\Jetpack_Options::update_option( 'id', 200 ); // 200 % 100 = 0.
-
-		try {
-			$this->assertSame(
-				( 200 % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
-				Settings::is_modernization_rollout_enabled(),
-				'A WoA site must be bucketed on its stable wpcom blog ID against the rollout percentage.'
-			);
-		} finally {
-			$this->clear_woa_constants();
-		}
-	}
-
-	/**
-	 * On a site where the wpcom blog ID can't be resolved (e.g. a freshly transferred
-	 * WoA site before its connection settles, or a disconnected self-hosted site), the
-	 * site must not be bucketed as blog ID 0 and enrolled by accident once the
-	 * percentage is non-zero. This holds regardless of the percentage.
-	 */
-	public function test_rollout_disabled_when_wpcom_blog_id_unavailable() {
-		$this->set_woa_constants();
-		\Jetpack_Options::delete_option( 'id' );
-
-		try {
-			$this->assertFalse(
-				Settings::is_modernization_rollout_enabled(),
-				'A site with no resolvable wpcom blog ID must not be enrolled.'
-			);
-		} finally {
-			$this->clear_woa_constants();
-		}
-	}
-
-	/**
-	 * Mark the environment as a WordPress.com on Atomic (WoA) site: Atomic platform
-	 * constants plus the wpcomsh marker `Host::is_woa_site()` keys on. Clears the
-	 * Host cache so the freshly-set constants are observed.
-	 */
-	private function set_woa_constants() {
-		\Automattic\Jetpack\Constants::set_constant( 'ATOMIC_SITE_ID', 12345 );
-		\Automattic\Jetpack\Constants::set_constant( 'ATOMIC_CLIENT_ID', 70 );
-		\Automattic\Jetpack\Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', '/wpcomsh/wpcomsh.php' );
-		\Automattic\Jetpack\Status\Cache::clear();
-	}
-
-	/**
-	 * Undo `set_woa_constants()` and any wpcom blog ID stored for the WoA scenario.
-	 */
-	private function clear_woa_constants() {
-		\Automattic\Jetpack\Constants::clear_single_constant( 'ATOMIC_SITE_ID' );
-		\Automattic\Jetpack\Constants::clear_single_constant( 'ATOMIC_CLIENT_ID' );
-		\Automattic\Jetpack\Constants::clear_single_constant( 'WPCOMSH__PLUGIN_FILE' );
-		\Automattic\Jetpack\Status\Cache::clear();
-		\Jetpack_Options::delete_option( 'id' );
-	}
-
-	/**
-	 * A WordPress.com Simple site is bucketed on its current blog ID (not the stored
-	 * `jetpack_options['id']`). WorDBless reports blog ID 1, so this verifies the
-	 * Simple branch feeds the right ID into the bucket math. Asserted against the live
-	 * percentage so it holds at 0% and after a bump alike.
-	 */
-	public function test_wpcom_simple_site_bucketed_on_current_blog_id() {
-		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
-
-		try {
-			$this->assertSame(
-				( (int) get_current_blog_id() % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
-				Settings::is_modernization_rollout_enabled(),
-				'A WordPress.com Simple site must be bucketed on its current blog ID against the rollout percentage.'
-			);
-		} finally {
-			\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
-		}
-	}
-
-	/**
-	 * Automatticians get the modernized experience by default so they can dogfood it
-	 * outside the percentage cohort. On Simple this rides the `is_automattician()`
-	 * global, which enrolls a11ns regardless of whether the site's blog ID falls in
-	 * the percentage bucket — the only path that enrolls anyone while the percentage
-	 * is held at 0%.
-	 *
-	 * The Atomic half of the carve-out — `Visitor::is_automattician_feature_flags_only()`,
-	 * driven by `AT_PROXIED_REQUEST` — is intentionally not given a dedicated test: its
-	 * *true* path is `Visitor`'s own contract (covered in the jetpack-status package), and
-	 * setting `AT_PROXIED_REQUEST` requires an irreversible `define()` that would need
-	 * `@runInSeparateProcess` (which trips a PHP 7.x WP-core bootstrap warning under
-	 * `failOnWarning`). Its *false* path — that the `Visitor` call is wired in and doesn't
-	 * fatal — is already exercised by every non-a11n cohort test below, where the `||`
-	 * does not short-circuit and so evaluates the `Visitor` branch.
-	 */
-	public function test_rollout_enabled_for_automattician() {
-		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
-
+	public function test_is_modernized_defaults_to_true() {
 		$this->assertTrue(
-			Settings::is_modernization_rollout_enabled(),
-			'Automatticians must be enrolled in the modernization rollout by default.'
-		);
-	}
-
-	/**
-	 * The a11n enrollment is only the filter *default*: an Automattician who wants
-	 * the legacy view back must still be able to force it with `__return_false`,
-	 * so the check has to live in the default fed to `apply_filters`, never as a
-	 * post-filter override.
-	 */
-	public function test_automattician_default_is_still_overridable_by_filter() {
-		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
-		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
-
-		$this->assertFalse(
 			self::call_private_static_is_modernized(),
-			'An Automattician must be able to opt back into the legacy view with __return_false.'
+			'Modernization gate must default to true now that the rollout is at 100%.'
 		);
 	}
 

--- a/projects/packages/newsletter/tests/php/bootstrap.php
+++ b/projects/packages/newsletter/tests/php/bootstrap.php
@@ -13,19 +13,3 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 define( 'WP_DEBUG', true );
 
 \Automattic\Jetpack\Test_Environment::init();
-
-if ( ! function_exists( 'is_automattician' ) ) {
-	/**
-	 * Test stub for the WordPress.com-global `is_automattician()`, which only
-	 * exists on Simple sites and is therefore absent from the package test
-	 * runtime. Tests toggle the return value per case via the
-	 * `$GLOBALS['jetpack_newsletter_test_is_automattician']` flag (defaults to
-	 * false), and reset it in tear down so the stub stays inert elsewhere.
-	 *
-	 * @param int|false $user_id Unused; mirrors the wpcom signature.
-	 * @return bool
-	 */
-	function is_automattician( $user_id = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- mirrors the wpcom global signature.
-		return ! empty( $GLOBALS['jetpack_newsletter_test_is_automattician'] );
-	}
-}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -249,15 +249,11 @@ class Jetpack_Redux_State_Helper {
 
 			/*
 			 * This filter is already documented in jetpack/modules/subscriptions.php.
-			 * Default is the staged rollout (Automatticians plus the percentage cohort,
-			 * currently 0%, bucketed by the stable wpcom blog ID), delegated to the
-			 * canonical Newsletter\Settings helper and guarded so an older packaged copy
-			 * can't fatal.
+			 * Defaults on for every site; hosts can opt out with the filter.
 			 */
 			'isWpAdminSubscriberManagementEnabled' => apply_filters(
 				'jetpack_wp_admin_subscriber_management_enabled',
-				method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
-					&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled()
+				true
 			),
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -42,14 +42,11 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * (mirrors `Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_FILTER`). Checked here, on
 	 * `rest_api_init`, so theme-added filters have a chance to land before the gate evaluates.
 	 *
-	 * The filter default is the staged rollout (Automatticians plus the percentage cohort,
-	 * currently 0%, bucketed by the stable wpcom blog ID), delegated to the canonical
-	 * Newsletter\Settings helper and guarded so an older packaged copy can't fatal.
+	 * The filter defaults on for every site; hosts can opt out with
+	 * `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' )`.
 	 */
 	public function register_routes() {
-		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
-			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
-		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
+		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: enable the modernized wp-admin dashboard and subscriber management for all sites by default.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1030,18 +1030,6 @@ class Jetpack_Subscriptions {
 	 */
 	public function add_subscribers_menu() {
 		/*
-		 * Staged-rollout default for both modernization filters: on for
-		 * Automatticians and for the percentage cohort (currently 0%, bucketed by
-		 * the stable wpcom blog ID), off everywhere else. Delegated to the canonical
-		 * Newsletter\Settings::is_modernization_rollout_enabled() so the cohort math
-		 * has a single source of truth; guarded with method_exists so this bootstrap
-		 * path stays safe if the packaged Newsletter Settings class is an older copy
-		 * that doesn't expose the helper yet.
-		 */
-		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
-			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
-
-		/*
 		 * Once the Newsletter modernization filter is on, the unified Newsletter
 		 * page owns the Subscribers tab and this standalone Calypso shortcut is
 		 * retired. In its place, a transitional announcement page tells people
@@ -1061,7 +1049,7 @@ class Jetpack_Subscriptions {
 		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
 		 * not expose the constant yet.
 		 */
-		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
+		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 			if (
 				! ( new Host() )->is_wpcom_platform()
 				&& class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' )
@@ -1097,11 +1085,10 @@ class Jetpack_Subscriptions {
 		 *
 		 * @since 9.5.0
 		 *
-		 * @param bool If the new dashboard is enabled. Defaults to the staged-rollout
-		 *             cohort: true for Automatticians and the percentage cohort
-		 *             (currently 0%), false elsewhere.
+		 * @param bool If the new dashboard is enabled. Defaults on for every site; hosts
+		 *             can opt out with this filter.
 		 */
-		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', $modernization_rollout_default ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #

Completes the staged rollout that #49036 set up (and that closed #48530). #49036 introduced the cohort gate held at **0%** on the Jetpack side while the Simple-site rollout ran from the WordPress.com backend. With that cohort validated, this PR takes the Jetpack/Atomic side to **100%** and removes the now-unneeded scaffolding.

## Proposed changes
* The modernized Newsletter wp-admin dashboard, wp-admin subscriber management, and the retired Calypso "Subscribers" submenu now **default on for every site** (Simple, WoA/Atomic, and self-hosted Jetpack).
* Both feature filters now default to a plain `true` instead of the cohort result:
  * `rsm_jetpack_ui_modernization_newsletter` — the canonical gate for the wp-build dashboard (applied in `Newsletter\Settings::is_modernized()`, the `wpcom/v2/subscribers/*` REST route registration, the `subscriptions` module menu, and the jetpack-mu-wpcom admin menu).
  * `jetpack_wp_admin_subscriber_management_enabled` — applied in the Newsletter script data, the `subscriptions` module menu, and the Jetpack Redux state.
* Removed the staged-rollout scaffolding now that it always evaluates to `true`:
  * `Newsletter\Settings::MODERNIZATION_ROLLOUT_PERCENTAGE` and `is_modernization_rollout_enabled()` (the Automattician carve-out + the wpcom-blog-ID `% 100` bucket math).
  * The inline mirror of that math in jetpack-mu-wpcom's `wpcom-admin-menu.php`.
  * The `method_exists`-guarded cross-package delegations at the three Jetpack-plugin call sites (they now pass a literal `true`, so there's no sibling-package call left to guard).
  * The `is_automattician()` test stub in the newsletter package bootstrap and the cohort/a12s unit tests; the remaining tests assert the new `true` default and the host opt-out.
* **Opt-out is unchanged:** hosts (and a11ns who want the legacy view back) can still force the legacy experience with `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' )` / `add_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_false' )`.
* The Backup, VideoPress, and Scan `MODERNIZATION_FILTER` constants are separate flags and are intentionally untouched.

## Related product discussion/links
* Predecessor: #49036 (staged the rollout at 0%); tracking issue #48530.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On any connected site (Simple, WoA/Atomic, or self-hosted Jetpack), as a **non-Automattician**, go to **Jetpack → Newsletter** in wp-admin and confirm the modernized wp-build dashboard loads (Subscribers / Settings tabs) instead of the legacy Settings-only screen — the experience is now on for everyone, not just the a12s carve-out / percentage cohort.
* Confirm the standalone Calypso **Jetpack → Subscribers** submenu is gone (replaced by the transitional announcement page where the Newsletter package registers it).
* Confirm `GET /wpcom/v2/subscribers/list` is registered (returns a data / `401` response, not `rest_no_route`).
* Confirm the host opt-out still wins: `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' );` restores the legacy Settings screen and the legacy Calypso Subscribers submenu; `add_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_false' );` restores the legacy subscriber-management default.
* PHP unit tests: `composer phpunit` in `projects/packages/newsletter` (42 tests) and `--filter WPCOM_Admin_Menu_Test` in `projects/packages/jetpack-mu-wpcom` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
