### PR TITLE
Social: roll out the modernized dashboard to 100%

### DIFF
--- a/projects/packages/publicize/changelog/release-social-dashboard
+++ b/projects/packages/publicize/changelog/release-social-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: enable the modernized wp-admin dashboard for all sites by default.

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -260,10 +260,14 @@ class Social_Admin_Page {
 	/**
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
+	 * The modernized Social dashboard now defaults on for every site. Hosts (and
+	 * a11ns who want the legacy view back) can still force the legacy experience
+	 * with `add_filter( self::MODERNIZATION_FILTER, '__return_false' );`.
+	 *
 	 * @return bool
 	 */
 	private static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
+++ b/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
@@ -140,18 +140,22 @@ class Social_Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * When modernization is OFF, the legacy admin script is enqueued.
+	 * Modernization now defaults ON, so with the wp-build chassis available and no
+	 * filter overriding the default, the legacy admin script is NOT enqueued — the
+	 * wp-build dashboard owns the page.
 	 */
-	public function test_enqueue_loads_legacy_script_when_not_modernized() {
+	public function test_enqueue_skips_legacy_script_by_default() {
+		// Define the wp-build render fn in the GLOBAL namespace (via fixture) so
+		// is_wp_build_dashboard_active()'s function_exists() check passes. No
+		// modernization filter is set, so this exercises the new default-on behavior.
+		require_once __DIR__ . '/fixtures/wp-build-render-fn.php';
+
 		Social_Admin_Page::init()->enqueue_admin_scripts();
 
-		$this->assertTrue(
+		$this->assertFalse(
 			wp_script_is( 'social-admin-page', 'enqueued' ),
-			'Legacy Social admin script should be enqueued when modernization is off.'
+			'Legacy script should not be enqueued by default now that modernization is on.'
 		);
-
-		wp_dequeue_script( 'social-admin-page' );
-		wp_deregister_script( 'social-admin-page' );
 	}
 
 	/**

--- a/projects/plugins/social/changelog/release-social-dashboard
+++ b/projects/plugins/social/changelog/release-social-dashboard
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update the e2e connection test to assert on the modernized Social dashboard UI.

--- a/projects/plugins/social/tests/e2e/specs/connection.test.ts
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.ts
@@ -19,7 +19,12 @@ test( 'Jetpack Social connection', async ( { page, admin, requestUtils } ) => {
 	} );
 
 	await test.step( 'Verify connection in Jetpack Social page', async () => {
-		await expect( page.getByRole( 'button', { name: 'Connect accounts' } ) ).toBeVisible();
-		await expect( page.getByRole( 'button', { name: 'Write a post' } ) ).toBeVisible();
+		// The modernized dashboard lands on the Overview tab with no social
+		// accounts connected yet, so assert on its empty state and the
+		// "Add account" header CTA (rendered twice — header + empty state).
+		await expect(
+			page.getByRole( 'heading', { name: 'No accounts connected yet' } )
+		).toBeVisible();
+		await expect( page.getByRole( 'button', { name: 'Add account' } ).first() ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Fixes #

Brings the modernized Jetpack **Social** wp-admin dashboard to 100% on the Jetpack side, mirroring the Newsletter rollout (#50091).

**Do not merge until the Simple-site cohort reaches 100% on the WordPress.com backend.** Like Newsletter, the Simple rollout is staged from a wpcom server-side flag; this PR flips the *Jetpack-side default*, which takes effect on Atomic (WoA) and self-hosted Jetpack sites immediately on merge. Holding it open until Simple is at 100% keeps the two paths consistent.

## Proposed changes
* Flip the `rsm_jetpack_ui_modernization_social` gate (`Social_Admin_Page::is_modernized()`) default from `false` to `true`, so the wp-build Social dashboard (Overview + Settings tabs) loads by default instead of the legacy single-page React app.
* The `function_exists( 'jetpack_social_..._render_page' )` guard in `is_wp_build_dashboard_active()` is unchanged, so a site still falls back to the legacy bundle if the wp-build chassis isn't available.
* **Opt-out is unchanged:** hosts (and a11ns who want the legacy view back) can still force the legacy experience with `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_false' )` — exercised by the existing kill-switch test.
* Unlike Newsletter, the Social gate had **no Jetpack-side cohort scaffolding** to remove (no rollout-percentage constant, a12s carve-out, or blog-ID bucket — its staged rollout lives entirely wpcom-side), so this is a single default flip plus the matching test.

## Related product discussion/links
* Sibling rollout: #50091 (Newsletter to 100%).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a connected Atomic (WoA) or self-hosted Jetpack site, go to **Jetpack → Social** (`admin.php?page=jetpack-social`) and confirm the modernized wp-build dashboard (Overview + Settings tabs) loads by default, instead of the legacy single-page screen.
* Confirm the host opt-out still wins: `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_false' );` restores the legacy Social admin screen.
* PHP unit tests: `composer phpunit` in `projects/packages/publicize` (113 tests pass; `--filter Social_Admin_Page_Test` covers the new default-on behavior, the explicit-on case, and the kill switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
