### PR TITLE
SEO: fix FAQPage schema to read the question from saved <summary> markup

### DIFF
--- a/projects/packages/seo/changelog/fix-seo-faq-schema-summary
+++ b/projects/packages/seo/changelog/fix-seo-faq-schema-summary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+FAQ schema: read the question from the saved `<summary>` markup so FAQPage JSON-LD emits from real editor-saved Details blocks.

--- a/projects/packages/seo/src/class-post-schema-node.php
+++ b/projects/packages/seo/src/class-post-schema-node.php
@@ -128,7 +128,7 @@ class Post_Schema_Node {
 			if ( 'core/details' !== ( $block['blockName'] ?? '' ) ) {
 				continue;
 			}
-			$question = trim( (string) ( $block['attrs']['summary'] ?? '' ) );
+			$question = self::question_from_details_block( $block );
 
 			// Render only the inner blocks for the answer. Rendering the whole
 			// core/details block would re-include the <summary> (the question).
@@ -136,7 +136,7 @@ class Post_Schema_Node {
 			foreach ( $block['innerBlocks'] ?? array() as $inner_block ) {
 				$answer_html .= render_block( $inner_block );
 			}
-			$answer = trim( wp_strip_all_tags( $answer_html ) );
+			$answer = self::to_plain_text( $answer_html );
 			if ( '' === $question || '' === $answer ) {
 				continue;
 			}
@@ -158,5 +158,38 @@ class Post_Schema_Node {
 			'@type'      => 'FAQPage',
 			'mainEntity' => $items,
 		);
+	}
+
+	/**
+	 * Extract the question text from a `core/details` block's `<summary>`.
+	 *
+	 * The Details block declares `summary` as a `source: "rich-text"` attribute,
+	 * so the value is saved in the `<summary>…</summary>` markup, not in the
+	 * `<!-- wp:details … -->` comment. `parse_blocks()` does not resolve
+	 * source-based attributes (it only returns what's written into the comment),
+	 * so `$block['attrs']['summary']` is always empty for real, editor-saved
+	 * blocks. The summary text does survive in the block's inner HTML, so we read
+	 * it from there instead.
+	 *
+	 * @param array $block A parsed `core/details` block.
+	 * @return string The plain-text question, or '' when the block has no summary.
+	 */
+	private static function question_from_details_block( array $block ) {
+		$inner_html = (string) ( $block['innerHTML'] ?? '' );
+		if ( ! preg_match( '#<summary\b[^>]*>(.*?)</summary>#is', $inner_html, $matches ) ) {
+			return '';
+		}
+		return self::to_plain_text( $matches[1] );
+	}
+
+	/**
+	 * Reduce a fragment of post HTML to the plain text used for a schema value:
+	 * tags stripped, entities decoded, surrounding whitespace trimmed.
+	 *
+	 * @param string $html HTML fragment.
+	 * @return string
+	 */
+	private static function to_plain_text( $html ) {
+		return trim( html_entity_decode( wp_strip_all_tags( (string) $html ), ENT_QUOTES, 'UTF-8' ) );
 	}
 }

--- a/projects/packages/seo/tests/php/PostSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/PostSchemaNodeTest.php
@@ -131,13 +131,18 @@ class PostSchemaNodeTest extends TestCase {
 	}
 
 	/**
-	 * FAQPage answers are built from a `core/details` block's inner blocks only,
-	 * so the question (the `<summary>`) is not duplicated into the answer text.
+	 * The FAQ question is read from the saved `<summary>` markup, and the answer
+	 * from the inner blocks only — so the question is not duplicated into the
+	 * answer text. The fixture uses realistic, editor-saved markup: the summary
+	 * lives only in `<summary>` (a `source: "rich-text"` attribute), never in the
+	 * `<!-- wp:details -->` comment, which is what `parse_blocks()` actually
+	 * returns. Baking the summary into the comment instead would mask the bug
+	 * this builder has to handle (see JETPACK-1793).
 	 */
-	public function test_faq_answer_excludes_the_question() {
+	public function test_faq_question_from_summary_and_answer_excludes_it() {
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content  = '<!-- wp:details -->';
 		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';
@@ -153,6 +158,46 @@ class PostSchemaNodeTest extends TestCase {
 		$this->assertSame( 'What is SEO?', $item['name'] );
 		$this->assertSame( 'Search engine optimization.', $item['acceptedAnswer']['text'] );
 		$this->assertStringNotContainsString( 'What is SEO?', $item['acceptedAnswer']['text'] );
+	}
+
+	/**
+	 * The summary is rich text, so it may carry inline formatting and HTML
+	 * entities. The question must be reduced to decoded plain text, and multiple
+	 * Details blocks each become their own Question entity in document order.
+	 */
+	public function test_faq_summary_is_decoded_plain_text_across_multiple_blocks() {
+		\Jetpack_SEO_Posts::$schema_type = 'faq';
+
+		$content  = '<!-- wp:details -->';
+		$content .= '<details class="wp-block-details"><summary>What is <strong>SEO</strong> &amp; AEO?</summary>';
+		$content .= '<!-- wp:paragraph --><p>Optimization for search and answer engines.</p><!-- /wp:paragraph -->';
+		$content .= '</details><!-- /wp:details -->';
+		$content .= '<!-- wp:details -->';
+		$content .= '<details class="wp-block-details"><summary>Is it free?</summary>';
+		$content .= '<!-- wp:paragraph --><p>Yes.</p><!-- /wp:paragraph -->';
+		$content .= '</details><!-- /wp:details -->';
+
+		$node = Post_Schema_Node::build( $this->make_post( array( 'post_content' => $content ) ) );
+
+		$this->assertIsArray( $node );
+		$this->assertCount( 2, $node['mainEntity'] );
+		$this->assertSame( 'What is SEO & AEO?', $node['mainEntity'][0]['name'] );
+		$this->assertSame( 'Is it free?', $node['mainEntity'][1]['name'] );
+	}
+
+	/**
+	 * A Details block whose `<summary>` is empty produces no question, so it is
+	 * skipped rather than emitting a Question with a blank name.
+	 */
+	public function test_faq_skips_details_block_with_empty_summary() {
+		\Jetpack_SEO_Posts::$schema_type = 'faq';
+
+		$content  = '<!-- wp:details -->';
+		$content .= '<details class="wp-block-details"><summary></summary>';
+		$content .= '<!-- wp:paragraph --><p>An answer with no question.</p><!-- /wp:paragraph -->';
+		$content .= '</details><!-- /wp:details -->';
+
+		$this->assertNull( Post_Schema_Node::build( $this->make_post( array( 'post_content' => $content ) ) ) );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -195,7 +195,7 @@ class SchemaBuilderTest extends TestCase {
 	public function test_emits_graph_with_faqpage_for_faq_override() {
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content  = '<!-- wp:details -->';
 		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';
@@ -235,7 +235,7 @@ class SchemaBuilderTest extends TestCase {
 		$this->set_site_name( 'Acme Co' );
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content  = '<!-- wp:details -->';
 		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';


### PR DESCRIPTION
Fixes JETPACK-1793 ([Linear](https://linear.app/a8c/issue/JETPACK-1793)).

> [!NOTE]
> **Stacked on #50080** (`jetpack-1779-…`, the `@graph` refactor that relocated the builder to `class-post-schema-node.php`). The base branch is set to that PR; please merge #50080 first, after which this will retarget to `trunk`. The diff here is the single FAQ-fix commit on top.

## Proposed changes

FAQ schema (`FAQPage`) has never emitted from real, editor-saved content since it shipped (JETPACK-1680). The `core/details` block stores its `summary` as a `source: "rich-text"` attribute that lives in the saved `<summary>…</summary>` markup, **not** in the `<!-- wp:details … -->` comment. `parse_blocks()` doesn't resolve source-based attributes, so `$block['attrs']['summary']` is always empty → the question is blank → every item is skipped → `build_faq()` returns `null` → no JSON-LD. This affects pages and posts equally.

* Read the FAQ question from the block's **inner HTML** (`<summary>`) instead of the empty comment attribute.
* Reduce both the question and the answer to **decoded plain text** via a shared `to_plain_text()` helper (tags stripped, HTML entities decoded, trimmed) — this also fixes latent entity double-encoding in the answer.
* Replace the unit-test fixtures that **baked the summary into the block comment** (which Gutenberg never does) with **realistic editor-saved markup**, so the regression is genuinely covered. Added cases for rich-text/entity summaries, multiple Details blocks, and an empty `<summary>`.

## Related product discussion/links

* Linear: [JETPACK-1793](https://linear.app/a8c/issue/JETPACK-1793)
* Origin of the FAQ builder / per-post Content surface: [JETPACK-1680](https://linear.app/a8c/issue/JETPACK-1680)
* Builds on the `@graph` refactor: #50080

## Does this pull request change what data or activity we track or use?

No. This only fixes the server-side JSON-LD output for content the author has already opted into (Schema type = FAQ).

## Testing instructions

* Check out this branch and ensure the SEO package autoloader is regenerated (`cd projects/packages/seo && composer dump-autoload`).
* Run the package tests: `composer phpunit` in `projects/packages/seo` — all green (52 tests). The FAQ tests now use realistic markup; reverting just the `src` fix makes them fail, confirming they're real regression tests.

On a live site (with the new SEO experience + SEO Tools active):

* Create a post **and** a page, each with a **Details** block (summary = a question, inner content = the answer).
* Set **Schema type = FAQ** in the editor sidebar (or the Jetpack → SEO → Content tab); publish.
* View source on the front end → a `FAQPage` node now appears in the `@graph`, with `mainEntity[].name` = the `<summary>` text and `acceptedAnswer.text` = the answer.
* Before this fix, the same content emitted no `FAQPage` at all.
