### PR TITLE
Stats: clarify post list column header as "Views: 30 days"

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-270-views-30-days-column
+++ b/projects/packages/stats-admin/changelog/stats-270-views-30-days-column
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stats: clarify the wp-admin post list column header as "Views: 30 days" so the figure's 30-day time window is obvious at a glance.

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -64,8 +64,8 @@ class Admin_Post_List_Column {
 	public function stats_load_admin_css() {
 		?>
 		<style type="text/css">
-			.fixed .column-stats {
-				width: 5em;
+			.wp-list-table.fixed .column-stats {
+				width: 9em;
 				white-space: nowrap;
 			}
 		</style>
@@ -213,13 +213,13 @@ class Admin_Post_List_Column {
 		// If comments position is 0, then prepend the element at the beginning of the array.
 		if ( 0 === $pos ) {
 			return array_merge(
-				array( 'stats' => esc_html__( 'Stats', 'jetpack-stats-admin' ) ),
+				array( 'stats' => esc_html__( 'Views: 30 days', 'jetpack-stats-admin' ) ),
 				$columns
 			);
 		}
 
 		$chunks             = array_chunk( $columns, $pos, true );
-		$chunks[0]['stats'] = esc_html__( 'Stats', 'jetpack-stats-admin' );
+		$chunks[0]['stats'] = esc_html__( 'Views: 30 days', 'jetpack-stats-admin' );
 
 		return call_user_func_array( 'array_merge', $chunks );
 	}

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -50,7 +50,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 
 		// Assert that the 'stats' column is added
 		$this->assertArrayHasKey( 'stats', $columns_with_stats );
-		$this->assertEquals( 'Stats', $columns_with_stats['stats'] );
+		$this->assertEquals( 'Views: 30 days', $columns_with_stats['stats'] );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 
 		// Assert that the 'stats' column is added
 		$this->assertArrayHasKey( 'stats', $columns_with_stats );
-		$this->assertEquals( 'Stats', $columns_with_stats['stats'] );
+		$this->assertEquals( 'Views: 30 days', $columns_with_stats['stats'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/STATS-270

## Why

In the wp-admin Posts/Pages list, the views column showed a small 30-day number under a generic "Stats" header. On a popular evergreen post that reads as trivial (e.g. **17** views) while the "last thirty days" caveat lived in an easy-to-miss tooltip — Matt flagged a post showing 17 inline that actually has 4.1K all-time views. This makes the time window obvious at a glance by labeling the column **"Views: 30 days"**.

Surfacing the all-time figure instead was considered but is prohibitively expensive: all-time views are computed by summing every daily table from publish date to today, per post — for an older post that's thousands of tables, multiplied by every post in the list. There's also no batched all-time endpoint. Clarifying the existing 30-day number in place is the pragmatic, server-friendly fix.

## Proposed changes

* Rename the post/page list stats column header from "Stats" to **"Views: 30 days"** so the figure's time window is clear without hovering.
* Widen the column (`5em` → `9em`, with a slightly more specific selector so it wins over the Likes module's competing `.column-stats` width rule) so the longer header isn't clipped behind the comments column.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/29f2dcda-4255-4621-87f0-9b8b8fba6db3) | ![after](https://github.com/user-attachments/assets/91cdcddd-c36a-4277-b0d8-54911cbd9ee8) |

## Related product discussion/links

* [STATS-270](https://linear.app/a8c/issue/STATS-270)
* Solution rationale (all-time views cost): [STATS-270 comment](https://linear.app/a8c/issue/STATS-270#comment-4a9d773d)

## Does this pull request change what data or activity we track or use?

No. This is a display-only label and styling change; no data, requests, or tracking are altered.

## Testing instructions

Acceptance criteria from STATS-270:

* [ ] The views surface makes its time window obvious and/or gives all-time views more prominence.
* [ ] Change is coordinated with the July 15 stats release.

To verify:

1. On a Jetpack site with Stats enabled, open the **Posts** (or **Pages**) list in wp-admin.
2. Confirm the column previously labeled **"Stats"** now reads **"Views: 30 days"**.
3. Confirm the header is fully visible (not clipped) and the eye icon + 30-day count still render once per published post.
4. Hover the views value — the tooltip still reads "Views for the last thirty days. Click for detailed stats" — and click through to confirm the detailed stats page still opens.
