### PR TITLE
Content Guidelines AI: fix per-section button overlap on mobile

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -230,6 +230,16 @@ $cg-diff-removed: #f8d7da;
 	display: inline-flex;
 }
 
+// The per-section Generate/Improve button is injected as a third control into
+// the form's Save/Clear row — a Gutenberg HStack laid out for two buttons and
+// set not to wrap. On narrow viewports the extra button overflows and, because
+// flex items shrink by default, the button labels overlap. Let that row wrap
+// onto multiple lines instead. Scoped through the injected container (a direct
+// child of the HStack) so only the rows we add a button to are affected.
+.guidelines__list-item form :has(> .jetpack-content-guidelines-ai__section-button-container) {
+	flex-wrap: wrap;
+}
+
 // Upgrade notice.
 .jetpack-content-guidelines-ai__upgrade-notice-container {
 	display: contents;

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-ai-mobile-buttons
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-ai-mobile-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Content Guidelines AI: wrap the per-section Save/Clear/Generate button row so the buttons no longer overlap on narrow screens

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-ai-mobile-buttons
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-ai-mobile-buttons
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Content Guidelines AI: wrap the per-section Save/Clear/Generate button row so the buttons no longer overlap on narrow screens
+Content Guidelines AI: Wrap the per-section Save/Clear/Generate button row so the buttons no longer overlap on narrow screens.


### PR DESCRIPTION
Fixes #

Fixes a mobile layout bug reported during CFT testing: on narrow viewports the per-section action row (Save guidelines / Clear guidelines / Generate guidelines) overflows and the button labels overlap.

The Content Guidelines AI feature injects its per-section **Generate/Improve guidelines** button into the Gutenberg guideline form's Save/Clear row. That row is an `HStack` laid out for two buttons and set not to wrap (`wrap={false}`), so nothing sets `flex-wrap` — the extra button overflows the row on mobile, and because flex items shrink by default, the labels overlap. The native two-button layout fits fine on mobile; the overflow is introduced by our injected third button, so this is fixed on the Jetpack (injection) side.

This lets that action row wrap onto multiple lines on narrow viewports. The rule is scoped through the injected container (a direct child of the HStack) so only the rows we add a button to are affected; the native layout is untouched.


**Before:**
<img width="439" height="807" alt="image" src="https://github.com/user-attachments/assets/450505a4-9b67-468c-8e52-667c3ae564c2" />


**After**
<img width="440" height="806" alt="image" src="https://github.com/user-attachments/assets/421684c1-446d-4891-8e37-f469b8c3083a" />


## Proposed changes
* `style.scss`: allow the form's Save/Clear/Generate `HStack` to wrap (`flex-wrap: wrap`) when it contains the injected per-section button, so the buttons no longer overlap on narrow screens.

## Related product discussion/links
* CFT post: pdtkmj-4DE-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This feature is live for proxied users on WordPress.com Simple/Atomic sites.

* On a qualifying WordPress.com Simple or Atomic site (proxied), go to **Settings → Guidelines** (`/wp-admin/options-general.php?page=guidelines-wp-admin`).
* Narrow the browser to a phone width (or use the device toolbar).
* **Before:** the Save guidelines / Clear guidelines / Generate guidelines row overflows and the labels overlap.
* **After:** the buttons wrap onto multiple lines with no clipping or overlap.
* Confirm the desktop layout is unchanged — all three buttons stay on one line when there is room.
* Confirm it holds for both empty sections (button reads "Generate guidelines") and sections with content ("Improve guidelines").
