### PR TITLE
Premium Analytics: fix widget grid flicker when resizing widgets vertically

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-dashboard-resize-flicker
+++ b/projects/packages/premium-analytics/changelog/fix-pa-dashboard-resize-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: fix widget grid flicker when resizing a widget vertically by letting the section panel fill the viewport height and scroll internally, so it no longer oscillates with the grid.

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -1,3 +1,14 @@
+// Flex column so the section panel fills the remaining viewport height and
+// scrolls internally instead of collapsing to its content height. Otherwise
+// the panel grows with the widget grid, and the grid (fixed row height)
+// resizes it back, so the two oscillate while resizing a widget (flicker).
+.root {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	min-block-size: 0;
+}
+
 .tabList {
 	border-block-end:
 		var(--wpds-border-width-xs, 1px) solid

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -53,7 +53,7 @@ export function DashboardSections( {
 	);
 
 	return (
-		<Tabs.Root value={ value } onValueChange={ handleValueChange }>
+		<Tabs.Root value={ value } onValueChange={ handleValueChange } className={ styles.root }>
 			<div className={ styles.tabList }>
 				<Tabs.List variant="minimal">
 					{ sections.map( section => (


### PR DESCRIPTION
Fixes WOOA7S-1638

## Proposed changes

Dragging a widget's resize handle _vertically_ in the dashboard edit mode made the whole widget grid flicker. The core Gutenberg dashboard (`admin.php?page=dashboard-wp-admin`), which uses the same `@wordpress/grid` engine, does not.

* **Cause** — a height feedback loop (not a scrollbar issue). The section panel (`Tabs.Panel` / `.content` in `stage.module.scss`) is `flex: 1 1 auto`, but its `Tabs.Root` parent (rendered by `DashboardSections`) was `display: block`, so the flex was inert and the panel collapsed to its content height. Resizing a widget grew the panel, and the grid — whose row height is a fixed `DEFAULT_ROW_HEIGHT` (300px) preset — recomputed and resized the panel back. The two chased each other (~192 grid-height oscillations, 300↔624px, in a 10s drag).
* **Fix** — give `Tabs.Root` a `.root` flex-column class (`display: flex; flex-direction: column; flex: 1 1 auto; min-block-size: 0`) so `.content` fills the remaining viewport height and scrolls internally, matching the core dashboard. The grid can no longer change the container height.

## Related product discussion/links

* WOOA7S-1638

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Premium Analytics** in wp-admin and click **Customize** to enter edit mode.
* Drag a widget's resize handle up and down across a row boundary (vertical resize).
* Confirm the grid no longer flickers and the resized widget tracks the cursor smoothly.


https://github.com/user-attachments/assets/333045b7-4207-4c60-b7a9-8e72e2599f59


