### PR TITLE
Move Activity Log above Settings in Jetpack submenu

### DIFF
--- a/projects/packages/activity-log/changelog/jetpack-16-activity-log-menu-order
+++ b/projects/packages/activity-log/changelog/jetpack-16-activity-log-menu-order
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Admin menu: Move Activity Log above Settings.
+Admin Menu: Move "Activity Log" above "Settings".

--- a/projects/packages/activity-log/changelog/jetpack-16-activity-log-menu-order
+++ b/projects/packages/activity-log/changelog/jetpack-16-activity-log-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: Move Activity Log above Settings.

--- a/projects/packages/activity-log/src/class-jetpack-activity-log.php
+++ b/projects/packages/activity-log/src/class-jetpack-activity-log.php
@@ -99,7 +99,7 @@ class Jetpack_Activity_Log {
 			'manage_options',
 			self::PAGE_SLUG,
 			array( __CLASS__, 'render_page' ),
-			14
+			12
 		);
 
 		if ( $page_suffix ) {

--- a/projects/plugins/jetpack/changelog/jetpack-16-activity-log-menu-order-test
+++ b/projects/plugins/jetpack/changelog/jetpack-16-activity-log-menu-order-test
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Update admin menu ordering test coverage.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
@@ -83,10 +83,10 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 		$this->assertLessThan( $search_submenu_position, $backup_submenu_position, 'Jetpack Backup should be above Search in the submenu order.' );
 		$this->assertLessThan( $settings_submenu_position, $search_submenu_position, 'Search should be above Settings in the submenu order.' );
 
-		// Test that Activity Log appears immediately before Settings.
+		// Test that Activity Log appears immediately before Settings when present.
 		if ( in_array( 'Activity Log', $submenu_names, true ) ) {
 			$activity_log_submenu_position = array_search( 'Activity Log', $submenu_names, true );
-			$this->assertLessThan( $settings_submenu_position, $activity_log_submenu_position, 'Activity Log should be above Settings in the submenu order.' );
+			$this->assertSame( $settings_submenu_position - 1, $activity_log_submenu_position, 'Activity Log should be immediately above Settings in the submenu order.' );
 		}
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
@@ -83,10 +83,10 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 		$this->assertLessThan( $search_submenu_position, $backup_submenu_position, 'Jetpack Backup should be above Search in the submenu order.' );
 		$this->assertLessThan( $settings_submenu_position, $search_submenu_position, 'Search should be above Settings in the submenu order.' );
 
-		// Test that external links (those that open in new windows) appear after Settings.
+		// Test that Activity Log appears immediately before Settings.
 		if ( in_array( 'Activity Log', $submenu_names, true ) ) {
 			$activity_log_submenu_position = array_search( 'Activity Log', $submenu_names, true );
-			$this->assertLessThan( $activity_log_submenu_position, $settings_submenu_position, 'Settings should be above Activity Log in the submenu order (external links should be last).' );
+			$this->assertLessThan( $settings_submenu_position, $activity_log_submenu_position, 'Activity Log should be above Settings in the submenu order.' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes JETPACK-1799

Now that Activity Log is no longer an off site redirect, it should appear above "Settings".

## Proposed changes

* Move the Activity Log submenu registration from position `14` to `12`, placing it above Settings at position `13`.
* Update the existing Jetpack admin menu order test expectation for Activity Log and Settings.

## Related product discussion/links

* JETPACK-1799

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp test php packages/activity-log`.
* Run `jp phan packages/activity-log`.
* With Jetpack connected in WP Admin, open the Jetpack submenu and verify `Activity Log` appears above `Settings`.
* I also attempted `jp docker phpunit jetpack -- --filter=Jetpack_Admin_Menu_Test::test_jetpack_admin_menu_order`. The updated assertion failed before the production change as expected, but after the fix the local MariaDB test container repeatedly crashed during WordPress test bootstrap on `DROP TABLE IF EXISTS wptests_usermeta`, so that full Jetpack filtered rerun could not complete locally.
