### PR TITLE
Cookie consent: gate banner Tracks loading on analytics consent

### DIFF
--- a/projects/packages/cookie-consent/changelog/auto-WOOA7S-1608
+++ b/projects/packages/cookie-consent/changelog/auto-WOOA7S-1608
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Consent banner: Gate Tracks loading on analytics consent.

--- a/projects/packages/cookie-consent/src/class-cookie-consent.php
+++ b/projects/packages/cookie-consent/src/class-cookie-consent.php
@@ -1319,6 +1319,9 @@ class Cookie_Consent {
 				'cookie_policy_url' => '', // Empty hides the Cookie Policy link; set it to link a consumer's own cookie policy page.
 			),
 			'event_prefix'        => 'jetpack', // Tracks event name prefix; set to 'woocommerceanalytics' for Unified Analytics continuity.
+			'features'            => array(
+				'tracks' => true,
+			),
 			'log'                 => array(
 				'policy_version' => '1',
 				'banner_version' => '1',
@@ -1401,11 +1404,16 @@ class Cookie_Consent {
 		$geo['ccpa_regions']        = is_array( $geo['ccpa_regions'] ) ? self::normalize_ccpa_regions( $geo['ccpa_regions'] ) : $default_config['geo']['ccpa_regions'];
 		$geo['show_on_error']       = (bool) $geo['show_on_error'];
 
-		$config['geo']          = $geo;
-		$config['links']        = self::normalize_links( $config, $default_config['links'] );
-		$config['event_prefix'] = $config['event_prefix'] ?? $default_config['event_prefix'];
-		$config['copy']         = self::normalize_copy( $config['copy'] ?? array(), $default_config['copy'] );
-		$config['consent']      = isset( $config['consent'] ) && is_array( $config['consent'] ) ? $config['consent'] : array();
+		$config['geo']                = $geo;
+		$config['links']              = self::normalize_links( $config, $default_config['links'] );
+		$config['event_prefix']       = $config['event_prefix'] ?? $default_config['event_prefix'];
+		$config['features']           = array_merge(
+			$default_config['features'],
+			isset( $config['features'] ) && is_array( $config['features'] ) ? $config['features'] : array()
+		);
+		$config['features']['tracks'] = (bool) $config['features']['tracks'];
+		$config['copy']               = self::normalize_copy( $config['copy'] ?? array(), $default_config['copy'] );
+		$config['consent']            = isset( $config['consent'] ) && is_array( $config['consent'] ) ? $config['consent'] : array();
 
 		$default_categories = self::get_default_consent_categories( $config['copy'] );
 		$categories         = $config['consent']['categories'] ?? $default_categories;
@@ -1446,19 +1454,6 @@ class Cookie_Consent {
 			return;
 		}
 
-		// Load Automattic Tracks (w.js) for analytics.
-		// External script, version managed by Automattic - no version needed.
-		wp_enqueue_script(
-			'jetpack-cookie-consent-tracks',
-			'https://stats.wp.com/w.js',
-			array(),
-			gmdate( 'YW' ),
-			array(
-				'strategy'  => 'defer',
-				'in_footer' => true,
-			)
-		);
-
 		// Register and enqueue the Interactivity API script module built by webpack.
 		// Only the build version is read from the asset file; module dependencies are
 		// declared explicitly. Script modules may only depend on other script modules,
@@ -1494,6 +1489,7 @@ class Cookie_Consent {
 		$config_data = array(
 			'apiUrl'      => rest_url( 'jetpack/v4/cookie-consent/consent-log' ),
 			'eventPrefix' => $config['event_prefix'],
+			'features'    => $config['features'],
 		);
 
 		// Only expose a REST nonce to logged-in visitors, so the consent logger can

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/features.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/features.ts
@@ -1,0 +1,18 @@
+/**
+ * Feature toggles
+ *
+ * Reads optional feature flags from the cookie-consent frontend config.
+ */
+
+/**
+ * Check whether a named feature is enabled.
+ *
+ * Features are opt-out: a feature counts as enabled unless the consumer explicitly
+ * sets it to `false`, so an unset or unknown feature reads as enabled.
+ *
+ * @param feature Feature key under `jetpackCookieConsentConfig.features`.
+ * @return Whether the feature is enabled.
+ */
+export function isFeatureEnabled( feature: string ): boolean {
+	return window.jetpackCookieConsentConfig?.features?.[ feature ] !== false;
+}

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
@@ -4,6 +4,7 @@
  * Core w.js integration utilities. Can be extracted to a separate package for use across multiple packages.
  */
 
+import { isFeatureEnabled } from './features';
 import type { TrackingProperties } from './types';
 
 const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
@@ -66,15 +67,11 @@ export function ensureTrackingQueue(): void {
 	}
 }
 
-function isTracksEnabled(): boolean {
-	return window.jetpackCookieConsentConfig?.features?.tracks !== false;
-}
-
 /**
  * Load w.js after consent allows cookie-based Tracks.
  */
 export function loadTracksScript(): void {
-	if ( ! isTracksEnabled() || document.getElementById( TRACKS_SCRIPT_ID ) ) {
+	if ( ! isFeatureEnabled( 'tracks' ) || document.getElementById( TRACKS_SCRIPT_ID ) ) {
 		return;
 	}
 
@@ -96,7 +93,7 @@ export function loadTracksScript(): void {
  * @param properties      Event properties object.
  */
 export function recordEvent( eventNameSuffix: string, properties: TrackingProperties ): void {
-	if ( ! isTracksEnabled() ) {
+	if ( ! isFeatureEnabled( 'tracks' ) ) {
 		return;
 	}
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
@@ -11,6 +11,7 @@ const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
 const TRACKS_SCRIPT_URL = 'https://stats.wp.com/w.js';
 const COOKIELESS_PIXEL_URL = 'https://pixel.wp.com/g.gif';
 const COOKIELESS_STAT_PREFIX = 'x_jetpack-cookie-consent';
+const WEEK_IN_MS = 6.048e8;
 
 /**
  * Extract UTM parameters from URL
@@ -79,9 +80,14 @@ export function ensureTracksLoaded(): void {
 		return;
 	}
 
+	// Weekly cache-buster, matching the `?ver=gmdate('YW')` the PHP enqueue used to
+	// apply, so a stale w.js can't be served from cache for more than a week.
+	const url = new URL( TRACKS_SCRIPT_URL );
+	url.searchParams.set( 'ver', String( Math.floor( Date.now() / WEEK_IN_MS ) ) );
+
 	const script = document.createElement( 'script' );
 	script.id = TRACKS_SCRIPT_ID;
-	script.src = TRACKS_SCRIPT_URL;
+	script.src = url.toString();
 	script.defer = true;
 	document.head.appendChild( script );
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
@@ -107,29 +107,18 @@ export function recordEvent( eventNameSuffix: string, properties: TrackingProper
 }
 
 /**
- * Record an allowlisted consent-record Tracks event and load w.js to flush it.
+ * Record a Tracks event and load w.js to flush it.
  *
- * These events document the consent decision itself, so they are not gated on the
- * analytics category.
- *
- * @param eventNameSuffix The event name (must follow Tracks naming conventions).
- * @param properties      Event properties object.
- */
-export function recordConsentEvent(
-	eventNameSuffix: string,
-	properties: TrackingProperties
-): void {
-	recordEvent( eventNameSuffix, properties );
-	loadTracksScript();
-}
-
-/**
- * Record an analytics-gated Tracks event.
+ * Loading w.js is a cookie-setting side effect, so the caller is responsible for
+ * ensuring it is permitted at the call site: either the event documents the
+ * consent decision itself (an allowlisted consent-record event) or the caller has
+ * already verified analytics consent. This helper performs no consent gating of
+ * its own (beyond the `features.tracks` flag honored by recordEvent/loadTracksScript).
  *
  * @param eventNameSuffix The event name (must follow Tracks naming conventions).
  * @param properties      Event properties object.
  */
-export function recordAnalyticsEvent(
+export function recordEventAndLoadTracks(
 	eventNameSuffix: string,
 	properties: TrackingProperties
 ): void {

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
@@ -68,9 +68,13 @@ export function ensureTrackingQueue(): void {
 }
 
 /**
- * Load w.js after consent allows cookie-based Tracks.
+ * Ensure w.js is loaded so queued cookie-based Tracks events can flush.
+ *
+ * Idempotent: injects the loader at most once (guarded by its script id) and
+ * no-ops when Tracks is disabled or the script is already present, so callers can
+ * safely invoke it on every consent-allowed event.
  */
-export function loadTracksScript(): void {
+export function ensureTracksLoaded(): void {
 	if ( ! isFeatureEnabled( 'tracks' ) || document.getElementById( TRACKS_SCRIPT_ID ) ) {
 		return;
 	}
@@ -83,11 +87,13 @@ export function loadTracksScript(): void {
 }
 
 /**
- * Record a Tracks event via w.js
+ * Record a cookie-based Tracks event via w.js.
  *
- * This is the core function for sending events to Automattic Tracks.
- * Events are queued immediately and processed when w.js loads.
- * Use this directly or create wrapper functions for specific events.
+ * The event is queued and w.js is loaded (idempotently) to flush the queue — a
+ * queued event never sends on its own, so recording inherently loads the loader.
+ * Callers must ensure loading w.js is permitted: the event either documents the
+ * consent decision itself (allowlisted) or the caller has verified analytics
+ * consent. The whole call no-ops when the `features.tracks` flag is off.
  *
  * @param eventNameSuffix The event name (must follow Tracks naming conventions).
  * @param properties      Event properties object.
@@ -104,26 +110,9 @@ export function recordEvent( eventNameSuffix: string, properties: TrackingProper
 
 	// Queue the event
 	window._tkq!.push( [ 'recordEvent', eventName, properties ] );
-}
 
-/**
- * Record a Tracks event and load w.js to flush it.
- *
- * Loading w.js is a cookie-setting side effect, so the caller is responsible for
- * ensuring it is permitted at the call site: either the event documents the
- * consent decision itself (an allowlisted consent-record event) or the caller has
- * already verified analytics consent. This helper performs no consent gating of
- * its own (beyond the `features.tracks` flag honored by recordEvent/loadTracksScript).
- *
- * @param eventNameSuffix The event name (must follow Tracks naming conventions).
- * @param properties      Event properties object.
- */
-export function recordEventAndLoadTracks(
-	eventNameSuffix: string,
-	properties: TrackingProperties
-): void {
-	recordEvent( eventNameSuffix, properties );
-	loadTracksScript();
+	// A queued event only sends once w.js loads to drain the queue.
+	ensureTracksLoaded();
 }
 
 /**

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks-utils.ts
@@ -6,6 +6,11 @@
 
 import type { TrackingProperties } from './types';
 
+const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
+const TRACKS_SCRIPT_URL = 'https://stats.wp.com/w.js';
+const COOKIELESS_PIXEL_URL = 'https://pixel.wp.com/g.gif';
+const COOKIELESS_STAT_PREFIX = 'x_jetpack-cookie-consent';
+
 /**
  * Extract UTM parameters from URL
  *
@@ -61,6 +66,25 @@ export function ensureTrackingQueue(): void {
 	}
 }
 
+function isTracksEnabled(): boolean {
+	return window.jetpackCookieConsentConfig?.features?.tracks !== false;
+}
+
+/**
+ * Load w.js after consent allows cookie-based Tracks.
+ */
+export function loadTracksScript(): void {
+	if ( ! isTracksEnabled() || document.getElementById( TRACKS_SCRIPT_ID ) ) {
+		return;
+	}
+
+	const script = document.createElement( 'script' );
+	script.id = TRACKS_SCRIPT_ID;
+	script.src = TRACKS_SCRIPT_URL;
+	script.defer = true;
+	document.head.appendChild( script );
+}
+
 /**
  * Record a Tracks event via w.js
  *
@@ -72,6 +96,10 @@ export function ensureTrackingQueue(): void {
  * @param properties      Event properties object.
  */
 export function recordEvent( eventNameSuffix: string, properties: TrackingProperties ): void {
+	if ( ! isTracksEnabled() ) {
+		return;
+	}
+
 	const eventNamePrefix = window.jetpackCookieConsentConfig?.eventPrefix || 'jetpack';
 	const eventName = `${ eventNamePrefix }_${ eventNameSuffix }`;
 	// Ensure queue exists - w.js will process events when it loads
@@ -79,4 +107,53 @@ export function recordEvent( eventNameSuffix: string, properties: TrackingProper
 
 	// Queue the event
 	window._tkq!.push( [ 'recordEvent', eventName, properties ] );
+}
+
+/**
+ * Record an allowlisted consent-record Tracks event and load w.js to flush it.
+ *
+ * These events document the consent decision itself, so they are not gated on the
+ * analytics category.
+ *
+ * @param eventNameSuffix The event name (must follow Tracks naming conventions).
+ * @param properties      Event properties object.
+ */
+export function recordConsentEvent(
+	eventNameSuffix: string,
+	properties: TrackingProperties
+): void {
+	recordEvent( eventNameSuffix, properties );
+	loadTracksScript();
+}
+
+/**
+ * Record an analytics-gated Tracks event.
+ *
+ * @param eventNameSuffix The event name (must follow Tracks naming conventions).
+ * @param properties      Event properties object.
+ */
+export function recordAnalyticsEvent(
+	eventNameSuffix: string,
+	properties: TrackingProperties
+): void {
+	recordEvent( eventNameSuffix, properties );
+	loadTracksScript();
+}
+
+/**
+ * Record an identity-free aggregate stat via g.gif.
+ *
+ * @param statName Stat name suffix.
+ */
+export function recordCookielessStat( statName: string ): void {
+	const statKey = `${ COOKIELESS_STAT_PREFIX }-${ statName }`;
+	const statValue = `total,${ window.location.hostname }`;
+	const cacheBuster = `${ Date.now() }-${ Math.random().toString( 36 ).slice( 2 ) }`;
+	const url = new URL( COOKIELESS_PIXEL_URL );
+
+	url.searchParams.set( 'v', 'wpcom-no-pv' );
+	url.searchParams.set( statKey, statValue );
+	url.searchParams.set( 'r', cacheBuster );
+
+	new Image().src = url.toString();
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -96,15 +96,16 @@ export function trackPrivacyManageOpen(
 	hasPriorConsent: boolean,
 	hasAnalyticsConsent: boolean
 ): void {
-	if ( ! hasPriorConsent ) {
+	// Without analytics consent — a fresh visitor, or a returning one who declined
+	// analytics — count the open through the identity-free aggregate stat instead of
+	// loading the cookie-setting Tracks bundle.
+	if ( ! hasPriorConsent || ! hasAnalyticsConsent ) {
 		recordCookielessStat( 'privacy-manage-open' );
 		return;
 	}
 
-	if ( hasAnalyticsConsent ) {
-		// The caller has verified analytics consent above, so loading w.js is allowed.
-		recordEvent( 'privacy_manage_open', getCommonProperties() );
-	}
+	// The caller has verified analytics consent above, so loading w.js is allowed.
+	recordEvent( 'privacy_manage_open', getCommonProperties() );
 }
 
 /**

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -6,8 +6,7 @@
 
 import { getCategoryPreferenceKey } from './category-preferences';
 import {
-	recordAnalyticsEvent,
-	recordConsentEvent,
+	recordEventAndLoadTracks,
 	recordCookielessStat,
 	getCommonProperties,
 } from './tracks-utils';
@@ -51,7 +50,12 @@ export function trackPrivacyBannerView(): void {
  * @param preferences Object with consent preferences, keyed by category preference key (e.g. required, analytics, advertising, plus any custom registered categories).
  */
 export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): void {
-	recordConsentEvent( 'privacy_banner_button_accept', getPreferenceProperties( preferences ) );
+	// Allowlisted consent-record event: documents the accepted preferences, so it
+	// is not gated on the analytics category.
+	recordEventAndLoadTracks(
+		'privacy_banner_button_accept',
+		getPreferenceProperties( preferences )
+	);
 }
 
 /**
@@ -60,7 +64,9 @@ export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): voi
  * Fired when the visitor clicks "Reject All" in customize modal.
  */
 export function trackPrivacyBannerReject(): void {
-	recordConsentEvent( 'privacy_banner_button_reject', getCommonProperties() );
+	// Rejecting analytics must not load the cookie-setting Tracks bundle, so record
+	// the rejection as an identity-free aggregate stat instead.
+	recordCookielessStat( 'privacy-banner-button-reject' );
 }
 
 /**
@@ -90,7 +96,8 @@ export function trackPrivacyManageOpen(
 	}
 
 	if ( hasAnalyticsConsent ) {
-		recordAnalyticsEvent( 'privacy_manage_open', getCommonProperties() );
+		// The caller has verified analytics consent above, so loading w.js is allowed.
+		recordEventAndLoadTracks( 'privacy_manage_open', getCommonProperties() );
 	}
 }
 
@@ -100,5 +107,7 @@ export function trackPrivacyManageOpen(
  * Fired when the visitor submits the CCPA "Do Not Sell/Share" opt-out.
  */
 export function trackPrivacyPolicyOptOut(): void {
-	recordConsentEvent( 'privacy_policy_page_button_opt_out', getCommonProperties() );
+	// Opting out must not load the cookie-setting Tracks bundle, so record the
+	// opt-out as an identity-free aggregate stat instead.
+	recordCookielessStat( 'privacy-policy-page-button-opt-out' );
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -5,7 +5,12 @@
  */
 
 import { getCategoryPreferenceKey } from './category-preferences';
-import { recordEvent, getCommonProperties } from './tracks-utils';
+import {
+	recordAnalyticsEvent,
+	recordConsentEvent,
+	recordCookielessStat,
+	getCommonProperties,
+} from './tracks-utils';
 import type { ConsentPreferences, TrackingProperties } from './types';
 
 const DEFAULT_TRACKS_PREFERENCE_KEYS = new Set( [ 'required', 'analytics', 'advertising' ] );
@@ -37,7 +42,7 @@ function getPreferenceProperties( preferences: ConsentPreferences ): TrackingPro
  * Fired when the cookie consent banner is displayed to the visitor.
  */
 export function trackPrivacyBannerView(): void {
-	recordEvent( 'privacy_banner_view', getCommonProperties() );
+	recordCookielessStat( 'privacy-banner-view' );
 }
 
 /**
@@ -46,7 +51,7 @@ export function trackPrivacyBannerView(): void {
  * @param preferences Object with consent preferences, keyed by category preference key (e.g. required, analytics, advertising, plus any custom registered categories).
  */
 export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): void {
-	recordEvent( 'privacy_banner_button_accept', getPreferenceProperties( preferences ) );
+	recordConsentEvent( 'privacy_banner_button_accept', getPreferenceProperties( preferences ) );
 }
 
 /**
@@ -55,7 +60,7 @@ export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): voi
  * Fired when the visitor clicks "Reject All" in customize modal.
  */
 export function trackPrivacyBannerReject(): void {
-	recordEvent( 'privacy_banner_button_reject', getCommonProperties() );
+	recordConsentEvent( 'privacy_banner_button_reject', getCommonProperties() );
 }
 
 /**
@@ -64,16 +69,29 @@ export function trackPrivacyBannerReject(): void {
  * Fired when the visitor clicks "Customize" to open the preferences modal.
  */
 export function trackPrivacyBannerCustomize(): void {
-	recordEvent( 'privacy_banner_button_customize', getCommonProperties() );
+	recordCookielessStat( 'privacy-banner-button-customize' );
 }
 
 /**
  * Track "Manage Privacy Preferences" link click
  *
  * Fired when the visitor opens preferences modal from the footer link.
+ *
+ * @param hasPriorConsent     Whether the visitor already has stored consent choices.
+ * @param hasAnalyticsConsent Whether those stored choices allow analytics.
  */
-export function trackPrivacyManageOpen(): void {
-	recordEvent( 'privacy_manage_open', getCommonProperties() );
+export function trackPrivacyManageOpen(
+	hasPriorConsent: boolean,
+	hasAnalyticsConsent: boolean
+): void {
+	if ( ! hasPriorConsent ) {
+		recordCookielessStat( 'privacy-manage-open' );
+		return;
+	}
+
+	if ( hasAnalyticsConsent ) {
+		recordAnalyticsEvent( 'privacy_manage_open', getCommonProperties() );
+	}
 }
 
 /**
@@ -82,5 +100,5 @@ export function trackPrivacyManageOpen(): void {
  * Fired when the visitor submits the CCPA "Do Not Sell/Share" opt-out.
  */
 export function trackPrivacyPolicyOptOut(): void {
-	recordEvent( 'privacy_policy_page_button_opt_out', getCommonProperties() );
+	recordConsentEvent( 'privacy_policy_page_button_opt_out', getCommonProperties() );
 }

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -43,11 +43,24 @@ export function trackPrivacyBannerView(): void {
 /**
  * Track privacy banner accept button click
  *
- * @param preferences Object with consent preferences, keyed by category preference key (e.g. required, analytics, advertising, plus any custom registered categories).
+ * Fired on both "Accept All" and "Save preferences". When analytics consent is
+ * declined (e.g. saving preferences with analytics unchecked), loading the
+ * cookie-setting Tracks bundle would contradict the visitor's choice, so the
+ * accept is recorded as an identity-free aggregate stat instead.
+ *
+ * @param preferences         Object with consent preferences, keyed by category preference key (e.g. required, analytics, advertising, plus any custom registered categories).
+ * @param hasAnalyticsConsent Whether the saved preferences allow analytics.
  */
-export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): void {
-	// Allowlisted consent-record event: documents the accepted preferences, so it
-	// is not gated on the analytics category.
+export function trackPrivacyBannerAccept(
+	preferences: ConsentPreferences,
+	hasAnalyticsConsent: boolean
+): void {
+	if ( ! hasAnalyticsConsent ) {
+		recordCookielessStat( 'privacy-banner-button-accept' );
+		return;
+	}
+
+	// Analytics granted: allowlisted consent-record event documenting the choice.
 	recordEvent( 'privacy_banner_button_accept', getPreferenceProperties( preferences ) );
 }
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/tracks.ts
@@ -5,11 +5,7 @@
  */
 
 import { getCategoryPreferenceKey } from './category-preferences';
-import {
-	recordEventAndLoadTracks,
-	recordCookielessStat,
-	getCommonProperties,
-} from './tracks-utils';
+import { recordEvent, recordCookielessStat, getCommonProperties } from './tracks-utils';
 import type { ConsentPreferences, TrackingProperties } from './types';
 
 const DEFAULT_TRACKS_PREFERENCE_KEYS = new Set( [ 'required', 'analytics', 'advertising' ] );
@@ -52,10 +48,7 @@ export function trackPrivacyBannerView(): void {
 export function trackPrivacyBannerAccept( preferences: ConsentPreferences ): void {
 	// Allowlisted consent-record event: documents the accepted preferences, so it
 	// is not gated on the analytics category.
-	recordEventAndLoadTracks(
-		'privacy_banner_button_accept',
-		getPreferenceProperties( preferences )
-	);
+	recordEvent( 'privacy_banner_button_accept', getPreferenceProperties( preferences ) );
 }
 
 /**
@@ -97,7 +90,7 @@ export function trackPrivacyManageOpen(
 
 	if ( hasAnalyticsConsent ) {
 		// The caller has verified analytics consent above, so loading w.js is allowed.
-		recordEventAndLoadTracks( 'privacy_manage_open', getCommonProperties() );
+		recordEvent( 'privacy_manage_open', getCommonProperties() );
 	}
 }
 

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
@@ -40,6 +40,9 @@ declare global {
 		jetpackCookieConsentConfig?: {
 			apiUrl: string;
 			eventPrefix?: string;
+			features?: {
+				tracks?: boolean;
+			};
 			categories?: ConsentCategory[];
 			nonce?: string;
 		};

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/types.ts
@@ -40,8 +40,12 @@ declare global {
 		jetpackCookieConsentConfig?: {
 			apiUrl: string;
 			eventPrefix?: string;
+			// Feature toggles. Each feature is enabled unless the consumer sets it to
+			// `false`; `tracks` is the only one read today, but the map stays open so new
+			// features can be gated without a type change.
 			features?: {
 				tracks?: boolean;
+				[ feature: string ]: boolean | undefined;
 			};
 			categories?: ConsentCategory[];
 			nonce?: string;

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/utils.ts
@@ -153,6 +153,21 @@ export function readConsentChoices(): ConsentEventChoices {
 	}, {} );
 }
 
+export function hasAnalyticsConsent( choices: ConsentEventChoices ): boolean {
+	const analyticsCategory = getConsentCategories().find(
+		category =>
+			category.key === 'analytics' ||
+			category.wpConsentMap.includes( 'statistics' ) ||
+			category.wpConsentMap.includes( 'statistics-anonymous' )
+	);
+
+	if ( ! analyticsCategory ) {
+		return choices.analytics === true;
+	}
+
+	return choices[ getCategoryPreferenceKey( analyticsCategory ) ] === true;
+}
+
 export function saveConsentChoices(
 	choices: ConsentEventChoices,
 	eventType: ConsentEventType = 'accept_selected'

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -14,7 +14,7 @@ import {
 	trackPrivacyManageOpen,
 	trackPrivacyPolicyOptOut,
 } from './tracks';
-import { loadTracksScript } from './tracks-utils';
+import { ensureTracksLoaded } from './tracks-utils';
 import {
 	UNKNOWN_COUNTRY_CODE,
 	getCookie,
@@ -153,7 +153,7 @@ function registerTracksConsentListener(): void {
 	window.addEventListener( 'wp_consent_saved', ( event: Event ) => {
 		const consentEvent = event as CustomEvent< ConsentEvent >;
 		if ( consentEvent.detail?.choices && hasAnalyticsConsent( consentEvent.detail.choices ) ) {
-			loadTracksScript();
+			ensureTracksLoaded();
 		}
 	} );
 }
@@ -620,7 +620,7 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				if ( hasConsentSet() ) {
 					// User already made a choice, read from WP Consent API
 					if ( hasAnalyticsConsent( readConsentChoices() ) ) {
-						loadTracksScript();
+						ensureTracksLoaded();
 					}
 					return;
 				}

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -10,14 +10,17 @@ import {
 	trackPrivacyBannerAccept,
 	trackPrivacyBannerCustomize,
 	trackPrivacyBannerReject,
+	trackPrivacyBannerView,
 	trackPrivacyManageOpen,
 	trackPrivacyPolicyOptOut,
 } from './tracks';
+import { loadTracksScript } from './tracks-utils';
 import {
 	UNKNOWN_COUNTRY_CODE,
 	getCookie,
 	setCookie,
 	hasConsentSet,
+	hasAnalyticsConsent,
 	readConsentChoices,
 	saveConsentChoices,
 	isGdprCountry,
@@ -26,7 +29,7 @@ import {
 	getConsentChoices,
 	type GeoConfig,
 } from './utils';
-import type { ConsentEventChoices } from './types';
+import type { ConsentEvent, ConsentEventChoices } from './types';
 
 interface GeoState {
 	initialized: boolean;
@@ -87,6 +90,7 @@ let geoState: GeoState = {
 let openedFromFooter = false;
 let openModalFromFooter: ( () => void ) | null = null;
 let manageLinkConsentListenerRegistered = false;
+let tracksConsentListenerRegistered = false;
 const gdprManageLinkContexts = new Set< GdprManageLinkContext >();
 
 function shouldShowManagePreferencesLink( config: StoreConfig ): boolean {
@@ -137,6 +141,20 @@ function updateManageLinkContexts( config: StoreConfig ): void {
 	const shouldShow = shouldShowManagePreferencesLink( config );
 	gdprManageLinkContexts.forEach( context => {
 		context.isGdprManageLink = shouldShow;
+	} );
+}
+
+function registerTracksConsentListener(): void {
+	if ( tracksConsentListenerRegistered ) {
+		return;
+	}
+
+	tracksConsentListenerRegistered = true;
+	window.addEventListener( 'wp_consent_saved', ( event: Event ) => {
+		const consentEvent = event as CustomEvent< ConsentEvent >;
+		if ( consentEvent.detail?.choices && hasAnalyticsConsent( consentEvent.detail.choices ) ) {
+			loadTracksScript();
+		}
 	} );
 }
 
@@ -339,7 +357,11 @@ const { actions } = store( 'jetpack/cookie-consent', {
 		openManagePreferences: withSyncEvent( ( event: MouseEvent ) => {
 			event.preventDefault();
 
-			trackPrivacyManageOpen();
+			const hasPriorConsent = hasConsentSet();
+			trackPrivacyManageOpen(
+				hasPriorConsent,
+				hasPriorConsent && hasAnalyticsConsent( readConsentChoices() )
+			);
 
 			openModalFromFooter?.();
 		} ),
@@ -551,6 +573,8 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				| FooterLinksFallbackContext
 				| ( CookieBannerContext & CcpaContext );
 
+			registerTracksConsentListener();
+
 			// Initialize CCPA-specific context if present.
 			// The footer-links fallback context also exposes isCcpaRegion (to gate
 			// the "Do Not Sell" link) but has no snackbar; only touch those keys
@@ -589,11 +613,15 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				// Check for force preview mode
 				if ( config.forcePreview ) {
 					context.showBanner = true;
+					trackPrivacyBannerView();
 					return;
 				}
 
 				if ( hasConsentSet() ) {
 					// User already made a choice, read from WP Consent API
+					if ( hasAnalyticsConsent( readConsentChoices() ) ) {
+						loadTracksScript();
+					}
 					return;
 				}
 			}

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -197,7 +197,7 @@ const { actions } = store( 'jetpack/cookie-consent', {
 			// Update context
 			setContextCategories( context, choices );
 
-			trackPrivacyBannerAccept( choices );
+			trackPrivacyBannerAccept( choices, hasAnalyticsConsent( choices ) );
 
 			// Save consent to WP Consent API (this will set the cookies)
 			saveConsentChoices( choices, 'accept_all' );
@@ -233,7 +233,7 @@ const { actions } = store( 'jetpack/cookie-consent', {
 				...context.categories,
 			} );
 
-			trackPrivacyBannerAccept( choices );
+			trackPrivacyBannerAccept( choices, hasAnalyticsConsent( choices ) );
 
 			// Save consent to WP Consent API (this will set the cookies)
 			saveConsentChoices( choices, 'accept_selected' );

--- a/projects/packages/cookie-consent/tests/features.test.ts
+++ b/projects/packages/cookie-consent/tests/features.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Unit tests for cookie-consent feature toggles.
+ */
+
+import { isFeatureEnabled } from '../src/modules/cookie-consent/features';
+
+describe( 'isFeatureEnabled', () => {
+	afterEach( () => {
+		delete ( window as unknown as { jetpackCookieConsentConfig?: unknown } )
+			.jetpackCookieConsentConfig;
+	} );
+
+	it( 'treats an unset feature as enabled', () => {
+		expect( isFeatureEnabled( 'tracks' ) ).toBe( true );
+	} );
+
+	it( 'treats a feature as enabled when config is present but the flag is omitted', () => {
+		window.jetpackCookieConsentConfig = {
+			apiUrl: 'https://example.com/wp-json/jetpack/v4/cookie-consent/consent-log',
+			features: {},
+		};
+
+		expect( isFeatureEnabled( 'tracks' ) ).toBe( true );
+	} );
+
+	it( 'returns false only when the feature is explicitly disabled', () => {
+		window.jetpackCookieConsentConfig = {
+			apiUrl: 'https://example.com/wp-json/jetpack/v4/cookie-consent/consent-log',
+			features: {
+				tracks: false,
+			},
+		};
+
+		expect( isFeatureEnabled( 'tracks' ) ).toBe( false );
+	} );
+
+	it( 'works for arbitrary feature keys', () => {
+		window.jetpackCookieConsentConfig = {
+			apiUrl: 'https://example.com/wp-json/jetpack/v4/cookie-consent/consent-log',
+			features: {
+				'some-future-feature': false,
+			},
+		};
+
+		expect( isFeatureEnabled( 'some-future-feature' ) ).toBe( false );
+		expect( isFeatureEnabled( 'another-feature' ) ).toBe( true );
+	} );
+} );

--- a/projects/packages/cookie-consent/tests/php/Config_Normalization_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Config_Normalization_Test.php
@@ -246,6 +246,45 @@ class Config_Normalization_Test extends TestCase {
 	}
 
 	/**
+	 * The Tracks feature flag defaults on and can be disabled by configuration.
+	 */
+	public function test_normalize_config_preserves_tracks_feature_flag() {
+		$default_config = $this->call_cookie_consent_method( 'get_default_config' );
+
+		$config = $this->call_cookie_consent_method( 'normalize_config', array(), $default_config );
+		$this->assertTrue( $config['features']['tracks'] );
+
+		$config = $this->call_cookie_consent_method(
+			'normalize_config',
+			array(
+				'features' => array(
+					'tracks' => false,
+				),
+			),
+			$default_config
+		);
+		$this->assertFalse( $config['features']['tracks'] );
+	}
+
+	/**
+	 * The frontend loader owns consent-aware Tracks loading, so PHP must not
+	 * enqueue w.js before the visitor's region and consent state are known.
+	 */
+	public function test_enqueue_assets_does_not_enqueue_tracks_script() {
+		global $wp_scripts, $wp_styles;
+
+		$wp_scripts = null;
+		$wp_styles  = null;
+
+		ob_start();
+		Cookie_Consent::enqueue_assets();
+		ob_end_clean();
+
+		$this->assertFalse( wp_script_is( 'jetpack-cookie-consent-tracks', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'jetpack-cookie-consent-tracks', 'enqueued' ) );
+	}
+
+	/**
 	 * Categories keyed with a reserved frontend alias are dropped so they can't
 	 * overwrite a built-in category, and the rejection is surfaced.
 	 */

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -166,12 +166,15 @@ describe( 'trackPrivacyBannerAccept', () => {
 		);
 	} );
 
-	it( 'does not record post-consent manage opens when analytics is denied', () => {
+	it( 'records post-consent manage opens through a cookieless aggregate stat when analytics is denied', () => {
 		trackPrivacyManageOpen( true, false );
 
 		expect( window._tkq ).toBeUndefined();
-		expect( imageSources ).toHaveLength( 0 );
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		const url = new URL( imageSources[ 0 ] );
+		expect( url.searchParams.get( 'x_jetpack-cookie-consent-privacy-manage-open' ) ).toBe(
+			`total,${ window.location.hostname }`
+		);
 	} );
 
 	it( 'records post-consent manage opens through analytics-gated Tracks when analytics is allowed', () => {

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -18,12 +18,16 @@ class MockImage {
 let imageSources: string[];
 
 describe( 'trackPrivacyBannerAccept', () => {
+	let originalImage: typeof Image;
+
 	beforeEach( () => {
 		imageSources = [];
+		originalImage = global.Image;
 		global.Image = MockImage as unknown as typeof Image;
 	} );
 
 	afterEach( () => {
+		global.Image = originalImage;
 		delete ( window as unknown as { _tkq?: unknown } )._tkq;
 		delete ( window as unknown as { jetpackCookieConsentConfig?: unknown } )
 			.jetpackCookieConsentConfig;

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -1,10 +1,32 @@
-import { trackPrivacyBannerAccept } from '../src/modules/cookie-consent/tracks';
+import {
+	trackPrivacyBannerAccept,
+	trackPrivacyBannerCustomize,
+	trackPrivacyBannerReject,
+	trackPrivacyBannerView,
+	trackPrivacyManageOpen,
+} from '../src/modules/cookie-consent/tracks';
+
+const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
+
+class MockImage {
+	set src( value: string ) {
+		imageSources.push( value );
+	}
+}
+
+let imageSources: string[];
 
 describe( 'trackPrivacyBannerAccept', () => {
+	beforeEach( () => {
+		imageSources = [];
+		global.Image = MockImage as unknown as typeof Image;
+	} );
+
 	afterEach( () => {
 		delete ( window as unknown as { _tkq?: unknown } )._tkq;
 		delete ( window as unknown as { jetpackCookieConsentConfig?: unknown } )
 			.jetpackCookieConsentConfig;
+		document.getElementById( TRACKS_SCRIPT_ID )?.remove();
 	} );
 
 	it( 'keeps default preference props and adds custom category props', () => {
@@ -60,6 +82,7 @@ describe( 'trackPrivacyBannerAccept', () => {
 				preferences_personalization: true,
 			} ),
 		] );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
 	} );
 
 	it( 'keeps default preference props as booleans for partial preferences', () => {
@@ -76,5 +99,87 @@ describe( 'trackPrivacyBannerAccept', () => {
 				preferences_advertising: false,
 			} ),
 		] );
+	} );
+
+	it( 'records banner views through a cookieless aggregate stat', () => {
+		trackPrivacyBannerView();
+
+		expect( window._tkq ).toBeUndefined();
+		expect( imageSources ).toHaveLength( 1 );
+
+		const url = new URL( imageSources[ 0 ] );
+		expect( url.origin + url.pathname ).toBe( 'https://pixel.wp.com/g.gif' );
+		expect( url.searchParams.get( 'v' ) ).toBe( 'wpcom-no-pv' );
+		expect( url.searchParams.get( 'x_jetpack-cookie-consent-privacy-banner-view' ) ).toBe(
+			`total,${ window.location.hostname }`
+		);
+	} );
+
+	it( 'records customize clicks through a cookieless aggregate stat', () => {
+		trackPrivacyBannerCustomize();
+
+		expect( window._tkq ).toBeUndefined();
+		const url = new URL( imageSources[ 0 ] );
+		expect(
+			url.searchParams.get( 'x_jetpack-cookie-consent-privacy-banner-button-customize' )
+		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'records pre-consent manage opens through a cookieless aggregate stat', () => {
+		trackPrivacyManageOpen( false, false );
+
+		expect( window._tkq ).toBeUndefined();
+		const url = new URL( imageSources[ 0 ] );
+		expect( url.searchParams.get( 'x_jetpack-cookie-consent-privacy-manage-open' ) ).toBe(
+			`total,${ window.location.hostname }`
+		);
+	} );
+
+	it( 'does not record post-consent manage opens when analytics is denied', () => {
+		trackPrivacyManageOpen( true, false );
+
+		expect( window._tkq ).toBeUndefined();
+		expect( imageSources ).toHaveLength( 0 );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+	} );
+
+	it( 'records post-consent manage opens through analytics-gated Tracks when analytics is allowed', () => {
+		trackPrivacyManageOpen( true, true );
+
+		expect( window._tkq?.[ 0 ] ).toEqual( [
+			'recordEvent',
+			'jetpack_privacy_manage_open',
+			expect.objectContaining( {
+				domain: window.location.hostname,
+			} ),
+		] );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+	} );
+
+	it( 'loads Tracks for reject as an allowlisted consent-record event', () => {
+		trackPrivacyBannerReject();
+
+		expect( window._tkq?.[ 0 ] ).toEqual( [
+			'recordEvent',
+			'jetpack_privacy_banner_button_reject',
+			expect.objectContaining( {
+				domain: window.location.hostname,
+			} ),
+		] );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+	} );
+
+	it( 'honors the tracks feature flag for cookie-based Tracks events', () => {
+		window.jetpackCookieConsentConfig = {
+			apiUrl: 'https://example.com/wp-json/jetpack/v4/cookie-consent/consent-log',
+			features: {
+				tracks: false,
+			},
+		};
+
+		trackPrivacyBannerReject();
+
+		expect( window._tkq ).toBeUndefined();
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -70,12 +70,15 @@ describe( 'trackPrivacyBannerAccept', () => {
 			],
 		};
 
-		trackPrivacyBannerAccept( {
-			required: true,
-			analytics: false,
-			advertising: true,
-			personalization: true,
-		} );
+		trackPrivacyBannerAccept(
+			{
+				required: true,
+				analytics: false,
+				advertising: true,
+				personalization: true,
+			},
+			true
+		);
 
 		expect( window._tkq?.[ 0 ] ).toEqual( [
 			'recordEvent',
@@ -91,9 +94,12 @@ describe( 'trackPrivacyBannerAccept', () => {
 	} );
 
 	it( 'keeps default preference props as booleans for partial preferences', () => {
-		trackPrivacyBannerAccept( {
-			required: true,
-		} );
+		trackPrivacyBannerAccept(
+			{
+				required: true,
+			},
+			true
+		);
 
 		expect( window._tkq?.[ 0 ] ).toEqual( [
 			'recordEvent',
@@ -104,6 +110,26 @@ describe( 'trackPrivacyBannerAccept', () => {
 				preferences_advertising: false,
 			} ),
 		] );
+	} );
+
+	it( 'records accept through a cookieless aggregate stat when analytics is declined', () => {
+		// Saving preferences with analytics unchecked must not load the
+		// cookie-setting Tracks bundle the visitor just declined.
+		trackPrivacyBannerAccept(
+			{
+				required: true,
+				analytics: false,
+				advertising: false,
+			},
+			false
+		);
+
+		expect( window._tkq ).toBeUndefined();
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		const url = new URL( imageSources[ 0 ] );
+		expect( url.searchParams.get( 'x_jetpack-cookie-consent-privacy-banner-button-accept' ) ).toBe(
+			`total,${ window.location.hostname }`
+		);
 	} );
 
 	it( 'records banner views through a cookieless aggregate stat', () => {

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -4,6 +4,7 @@ import {
 	trackPrivacyBannerReject,
 	trackPrivacyBannerView,
 	trackPrivacyManageOpen,
+	trackPrivacyPolicyOptOut,
 } from '../src/modules/cookie-consent/tracks';
 
 const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
@@ -156,17 +157,26 @@ describe( 'trackPrivacyBannerAccept', () => {
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
 	} );
 
-	it( 'loads Tracks for reject as an allowlisted consent-record event', () => {
+	it( 'records reject through a cookieless aggregate stat', () => {
 		trackPrivacyBannerReject();
 
-		expect( window._tkq?.[ 0 ] ).toEqual( [
-			'recordEvent',
-			'jetpack_privacy_banner_button_reject',
-			expect.objectContaining( {
-				domain: window.location.hostname,
-			} ),
-		] );
-		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+		expect( window._tkq ).toBeUndefined();
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		const url = new URL( imageSources[ 0 ] );
+		expect( url.searchParams.get( 'x_jetpack-cookie-consent-privacy-banner-button-reject' ) ).toBe(
+			`total,${ window.location.hostname }`
+		);
+	} );
+
+	it( 'records opt-out through a cookieless aggregate stat', () => {
+		trackPrivacyPolicyOptOut();
+
+		expect( window._tkq ).toBeUndefined();
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		const url = new URL( imageSources[ 0 ] );
+		expect(
+			url.searchParams.get( 'x_jetpack-cookie-consent-privacy-policy-page-button-opt-out' )
+		).toBe( `total,${ window.location.hostname }` );
 	} );
 
 	it( 'honors the tracks feature flag for cookie-based Tracks events', () => {
@@ -177,7 +187,9 @@ describe( 'trackPrivacyBannerAccept', () => {
 			},
 		};
 
-		trackPrivacyBannerReject();
+		// A post-consent manage open is a cookie-based Tracks event, so the flag
+		// must suppress both the queued event and the w.js load.
+		trackPrivacyManageOpen( true, true );
 
 		expect( window._tkq ).toBeUndefined();
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();

--- a/projects/packages/cookie-consent/tests/tracks.test.ts
+++ b/projects/packages/cookie-consent/tests/tracks.test.ts
@@ -190,6 +190,15 @@ describe( 'trackPrivacyBannerAccept', () => {
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
 	} );
 
+	it( 'loads w.js with a weekly cache-busting ver query param', () => {
+		trackPrivacyManageOpen( true, true );
+
+		const script = document.getElementById( TRACKS_SCRIPT_ID ) as HTMLScriptElement;
+		const url = new URL( script.src );
+		expect( url.origin + url.pathname ).toBe( 'https://stats.wp.com/w.js' );
+		expect( url.searchParams.get( 'ver' ) ).toBe( String( Math.floor( Date.now() / 6.048e8 ) ) );
+	} );
+
 	it( 'records reject through a cookieless aggregate stat', () => {
 		trackPrivacyBannerReject();
 

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -10,6 +10,7 @@ import {
 	getCookie,
 	getGeoConfig,
 	handleConsentByRegion,
+	hasAnalyticsConsent,
 	hasConsentSet,
 	isGdprCountry,
 	pertainsToCCPA,
@@ -17,6 +18,14 @@ import {
 	saveConsentChoices,
 	setCookie,
 } from '../src/modules/cookie-consent/utils';
+
+class MockImage {
+	set src( value: string ) {
+		imageSources.push( value );
+	}
+}
+
+let imageSources: string[];
 
 describe( 'setCookie', () => {
 	let writes: string[];
@@ -139,6 +148,8 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 
 	beforeEach( () => {
 		consentCalls = [];
+		imageSources = [];
+		global.Image = MockImage as unknown as typeof Image;
 		window.wp_set_consent = ( category: string, state: string ) => {
 			consentCalls.push( [ category, state ] );
 		};
@@ -169,6 +180,7 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 		expect( wasDenied( 'marketing' ) ).toBe( true );
 		// Functional/required cookies are always allowed.
 		expect( consentCalls ).toContainEqual( [ 'functional', 'allow' ] );
+		expect( imageSources ).toHaveLength( 0 );
 	} );
 
 	it( 'shows the opt-in banner when GPC is absent in a GDPR region', () => {
@@ -179,6 +191,31 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 
 		expect( context.showBanner ).toBe( true );
 		expect( wasDenied( 'statistics' ) ).toBe( false );
+		expect(
+			new URL( imageSources[ 0 ] ).searchParams.get(
+				'x_jetpack-cookie-consent-privacy-banner-view'
+			)
+		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'does not record a banner stat in CCPA regions', () => {
+		setGpc( undefined );
+		const context = { showBanner: false };
+
+		handleConsentByRegion( 'US', 'california', baseConfig, context );
+
+		expect( context.showBanner ).toBe( false );
+		expect( imageSources ).toHaveLength( 0 );
+	} );
+
+	it( 'does not record a banner stat in non-regulated regions', () => {
+		setGpc( undefined );
+		const context = { showBanner: false };
+
+		handleConsentByRegion( 'CA', '', baseConfig, context );
+
+		expect( context.showBanner ).toBe( false );
+		expect( imageSources ).toHaveLength( 0 );
 	} );
 
 	it( 'ignores GPC in a GDPR region when honoring is disabled by config', () => {
@@ -352,6 +389,49 @@ describe( 'registry-driven consent choices', () => {
 			advertising: false,
 			personalization: true,
 		} );
+	} );
+
+	it( 'resolves analytics consent from the configured category registry', () => {
+		expect(
+			hasAnalyticsConsent( {
+				required: true,
+				analytics: true,
+				advertising: false,
+			} )
+		).toBe( true );
+		expect(
+			hasAnalyticsConsent( {
+				required: true,
+				analytics: false,
+				advertising: true,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'resolves analytics consent from a custom analytics category preference key', () => {
+		window.jetpackCookieConsentConfig = {
+			apiUrl: 'https://example.com/wp-json/jetpack/v4/cookie-consent/consent-log',
+			categories: [
+				{
+					key: 'analytics',
+					preferenceKey: 'measurement',
+					required: false,
+					defaultChecked: true,
+					wpConsentMap: [ 'statistics' ],
+				},
+			],
+		};
+
+		expect(
+			hasAnalyticsConsent( {
+				measurement: true,
+			} )
+		).toBe( true );
+		expect(
+			hasAnalyticsConsent( {
+				measurement: false,
+			} )
+		).toBe( false );
 	} );
 
 	it( 'dispatches the public wp_consent_saved event with event type and category choices', () => {

--- a/projects/packages/cookie-consent/tests/utils.test.ts
+++ b/projects/packages/cookie-consent/tests/utils.test.ts
@@ -138,6 +138,7 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 
 	let consentCalls: Array< [ string, string ] >;
 	let originalGpc: PropertyDescriptor | undefined;
+	let originalImage: typeof Image;
 
 	const setGpc = ( value: boolean | undefined ) => {
 		Object.defineProperty( window.navigator, 'globalPrivacyControl', {
@@ -149,6 +150,7 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 	beforeEach( () => {
 		consentCalls = [];
 		imageSources = [];
+		originalImage = global.Image;
 		global.Image = MockImage as unknown as typeof Image;
 		window.wp_set_consent = ( category: string, state: string ) => {
 			consentCalls.push( [ category, state ] );
@@ -157,6 +159,7 @@ describe( 'handleConsentByRegion (GDPR + GPC)', () => {
 	} );
 
 	afterEach( () => {
+		global.Image = originalImage;
 		delete ( window as unknown as { wp_set_consent?: unknown } ).wp_set_consent;
 		if ( originalGpc ) {
 			Object.defineProperty( window.navigator, 'globalPrivacyControl', originalGpc );

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -102,9 +102,6 @@ async function runAction( generator: Generator< unknown, unknown, unknown > ): P
 }
 
 /**
- *
- */
-/**
  * Define the optional WP Consent API setter for tests that need the banner init path.
  */
 function mockWpSetConsent(): void {
@@ -242,6 +239,30 @@ describe( 'Tracks consent gating', () => {
 				'x_jetpack-cookie-consent-privacy-banner-view'
 			)
 		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'loads Tracks on init for a returning visitor who granted analytics', async () => {
+		cookieJar =
+			'wp_consent_functional=allow; wp_consent_statistics=allow; wp_consent_statistics-anonymous=allow';
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( { showBanner: false } );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		await storeCallbacks.init();
+
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+	} );
+
+	it( 'does not load Tracks on init for a returning visitor who denied analytics', async () => {
+		cookieJar = 'wp_consent_functional=allow; wp_consent_statistics=deny';
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( { showBanner: false } );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		await storeCallbacks.init();
+
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		expect( window._tkq ).toBeUndefined();
 	} );
 
 	it( 'loads Tracks when a consent lifecycle event grants analytics', async () => {

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -360,15 +360,19 @@ describe( 'Tracks consent gating', () => {
 		).toBe( `total,${ window.location.hostname }` );
 	} );
 
-	it( 'does not record post-consent manage opens when analytics is denied', () => {
+	it( 'records post-consent manage opens through the cookieless stat when analytics is denied', () => {
 		cookieJar = 'wp_consent_functional=allow; wp_consent_statistics=deny';
 		const event = { preventDefault: jest.fn() } as unknown as MouseEvent;
 
 		storeActions.openManagePreferences( event );
 
 		expect( window._tkq ).toBeUndefined();
-		expect( imageSources ).toHaveLength( 0 );
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		expect(
+			new URL( imageSources[ 0 ] ).searchParams.get(
+				'x_jetpack-cookie-consent-privacy-manage-open'
+			)
+		).toBe( `total,${ window.location.hostname }` );
 	} );
 
 	it( 'records post-consent manage opens when analytics is allowed', () => {

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -46,6 +46,7 @@ let cookieWrites: string[];
 let cookieJar: string;
 let fetchMock: jest.Mock< typeof fetch >;
 let imageSources: string[];
+let originalImage: typeof Image;
 
 const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
 
@@ -118,6 +119,7 @@ beforeEach( async () => {
 	cookieWrites = [];
 	cookieJar = '';
 	imageSources = [];
+	originalImage = global.Image;
 	global.Image = MockImage as unknown as typeof Image;
 	Object.defineProperty( document, 'cookie', {
 		configurable: true,
@@ -139,6 +141,10 @@ beforeEach( async () => {
 	} );
 
 	await import( '../src/modules/cookie-consent/view' );
+} );
+
+afterEach( () => {
+	global.Image = originalImage;
 } );
 
 describe( 'initializeGeolocation geo-provider error handling', () => {

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -315,6 +315,37 @@ describe( 'Tracks consent gating', () => {
 		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
 	} );
 
+	it( 'skips Tracks and records a cookieless accept stat when saving preferences with analytics declined', () => {
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( {
+			categories: { required: true, analytics: false, advertising: false },
+		} );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		storeActions.savePreferences();
+
+		expect( window._tkq ).toBeUndefined();
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+		expect(
+			new URL( imageSources[ 0 ] ).searchParams.get(
+				'x_jetpack-cookie-consent-privacy-banner-button-accept'
+			)
+		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'loads Tracks and records the accept event when saving preferences with analytics granted', () => {
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( {
+			categories: { required: true, analytics: true, advertising: false },
+		} );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		storeActions.savePreferences();
+
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+		expect( window._tkq?.[ 0 ]?.[ 1 ] ).toBe( 'jetpack_privacy_banner_button_accept' );
+	} );
+
 	it( 'records pre-consent manage opens through the cookieless stat', () => {
 		const event = { preventDefault: jest.fn() } as unknown as MouseEvent;
 

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -32,12 +32,28 @@ interface StoreConfig {
 	forcePreview: boolean;
 }
 
-type Action = ( ...args: unknown[] ) => Generator< unknown, unknown, unknown >;
+type Action = ( ...args: unknown[] ) => unknown;
+type StoreDefinition = {
+	actions: Record< string, Action >;
+	callbacks: {
+		init: () => Promise< void >;
+	};
+};
 
 let storeActions: Record< string, Action >;
+let storeCallbacks: StoreDefinition[ 'callbacks' ];
 let cookieWrites: string[];
 let cookieJar: string;
 let fetchMock: jest.Mock< typeof fetch >;
+let imageSources: string[];
+
+const TRACKS_SCRIPT_ID = 'jetpack-cookie-consent-tracks-js';
+
+class MockImage {
+	set src( value: string ) {
+		imageSources.push( value );
+	}
+}
 
 const DEFAULT_GEO: GeoConfig = {
 	provider: 'wpcom',
@@ -85,12 +101,27 @@ async function runAction( generator: Generator< unknown, unknown, unknown > ): P
 	return step.value;
 }
 
+/**
+ *
+ */
+/**
+ * Define the optional WP Consent API setter for tests that need the banner init path.
+ */
+function mockWpSetConsent(): void {
+	Object.defineProperty( window, 'wp_set_consent', {
+		configurable: true,
+		value: jest.fn(),
+	} );
+}
+
 beforeEach( async () => {
 	// Re-import per test so the module-level geoState singleton starts uninitialized.
 	jest.resetModules();
 
 	cookieWrites = [];
 	cookieJar = '';
+	imageSources = [];
+	global.Image = MockImage as unknown as typeof Image;
 	Object.defineProperty( document, 'cookie', {
 		configurable: true,
 		get: () => cookieJar,
@@ -104,12 +135,11 @@ beforeEach( async () => {
 	global.fetch = fetchMock;
 
 	mockGetContext.mockReturnValue( {} );
-	mockStore.mockImplementation(
-		( _namespace: string, config: { actions: Record< string, Action > } ) => {
-			storeActions = config.actions;
-			return config;
-		}
-	);
+	mockStore.mockImplementation( ( _namespace: string, config: StoreDefinition ) => {
+		storeActions = config.actions;
+		storeCallbacks = config.callbacks;
+		return config;
+	} );
 
 	await import( '../src/modules/cookie-consent/view' );
 } );
@@ -119,7 +149,9 @@ describe( 'initializeGeolocation geo-provider error handling', () => {
 		mockGetConfig.mockReturnValue( makeConfig( { showOnError: false } ) );
 		fetchMock.mockRejectedValue( new Error( 'network down' ) );
 
-		const result = await runAction( storeActions.initializeGeolocation() );
+		const result = await runAction(
+			storeActions.initializeGeolocation() as Generator< unknown, unknown, unknown >
+		);
 
 		expect( result ).toEqual( { initialized: true, countryCode: null, region: null } );
 		expect( cookieWrites ).toHaveLength( 0 );
@@ -130,7 +162,9 @@ describe( 'initializeGeolocation geo-provider error handling', () => {
 		mockGetConfig.mockReturnValue( makeConfig( { showOnError: true } ) );
 		fetchMock.mockRejectedValue( new Error( 'network down' ) );
 
-		const result = await runAction( storeActions.initializeGeolocation() );
+		const result = await runAction(
+			storeActions.initializeGeolocation() as Generator< unknown, unknown, unknown >
+		);
 
 		expect( result ).toMatchObject( { initialized: true, countryCode: UNKNOWN_COUNTRY_CODE } );
 		expect(
@@ -143,7 +177,9 @@ describe( 'initializeGeolocation geo-provider error handling', () => {
 		mockGetConfig.mockReturnValue(
 			makeConfig( { provider: 'custom', apiUrl: '', showOnError: false } )
 		);
-		const result = await runAction( storeActions.initializeGeolocation() );
+		const result = await runAction(
+			storeActions.initializeGeolocation() as Generator< unknown, unknown, unknown >
+		);
 
 		expect( result ).toEqual( { initialized: true, countryCode: null, region: null } );
 		expect( fetchMock ).not.toHaveBeenCalled();
@@ -158,7 +194,9 @@ describe( 'initializeGeolocation geo-provider error handling', () => {
 			json: async () => ( { country_short: 'FR', region: 'Brittany' } ),
 		} as unknown as Response );
 
-		const result = await runAction( storeActions.initializeGeolocation() );
+		const result = await runAction(
+			storeActions.initializeGeolocation() as Generator< unknown, unknown, unknown >
+		);
 
 		expect( result ).toMatchObject( { initialized: true, countryCode: 'FR', region: 'Brittany' } );
 		expect( cookieWrites.some( write => write.includes( 'country_code=FR' ) ) ).toBe( true );
@@ -173,9 +211,122 @@ describe( 'updateContextFromGeolocation', () => {
 		mockGetConfig.mockReturnValue( makeConfig( { showOnError: false } ) );
 		fetchMock.mockRejectedValue( new Error( 'network down' ) );
 
-		await runAction( storeActions.updateContextFromGeolocation() );
+		await runAction(
+			storeActions.updateContextFromGeolocation() as Generator< unknown, unknown, unknown >
+		);
 
 		expect( context.isGdprManageLink ).toBe( false );
 		expect( console ).toHaveWarned();
+	} );
+} );
+
+describe( 'Tracks consent gating', () => {
+	afterEach( () => {
+		delete ( window as unknown as { _tkq?: unknown } )._tkq;
+		delete ( window as unknown as { wp_set_consent?: unknown } ).wp_set_consent;
+		document.getElementById( TRACKS_SCRIPT_ID )?.remove();
+	} );
+
+	it( 'records a cookieless banner stat in preview mode', async () => {
+		const context = { showBanner: false };
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( context );
+		mockGetConfig.mockReturnValue( { ...makeConfig(), forcePreview: true } );
+
+		await storeCallbacks.init();
+
+		expect( context.showBanner ).toBe( true );
+		expect( window._tkq ).toBeUndefined();
+		expect(
+			new URL( imageSources[ 0 ] ).searchParams.get(
+				'x_jetpack-cookie-consent-privacy-banner-view'
+			)
+		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'loads Tracks when a consent lifecycle event grants analytics', async () => {
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( {} );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		await storeCallbacks.init();
+		window.dispatchEvent(
+			new CustomEvent( 'wp_consent_saved', {
+				detail: {
+					eventType: 'accept_selected',
+					choices: {
+						required: true,
+						analytics: true,
+						advertising: false,
+					},
+				},
+			} )
+		);
+
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
+	} );
+
+	it( 'does not load Tracks when a consent lifecycle event denies analytics', async () => {
+		mockWpSetConsent();
+		mockGetContext.mockReturnValue( {} );
+		mockGetConfig.mockReturnValue( makeConfig() );
+
+		await storeCallbacks.init();
+		window.dispatchEvent(
+			new CustomEvent( 'wp_consent_saved', {
+				detail: {
+					eventType: 'reject_all',
+					choices: {
+						required: true,
+						analytics: false,
+						advertising: false,
+					},
+				},
+			} )
+		);
+
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+	} );
+
+	it( 'records pre-consent manage opens through the cookieless stat', () => {
+		const event = { preventDefault: jest.fn() } as unknown as MouseEvent;
+
+		storeActions.openManagePreferences( event );
+
+		expect( event.preventDefault ).toHaveBeenCalled();
+		expect( window._tkq ).toBeUndefined();
+		expect(
+			new URL( imageSources[ 0 ] ).searchParams.get(
+				'x_jetpack-cookie-consent-privacy-manage-open'
+			)
+		).toBe( `total,${ window.location.hostname }` );
+	} );
+
+	it( 'does not record post-consent manage opens when analytics is denied', () => {
+		cookieJar = 'wp_consent_functional=allow; wp_consent_statistics=deny';
+		const event = { preventDefault: jest.fn() } as unknown as MouseEvent;
+
+		storeActions.openManagePreferences( event );
+
+		expect( window._tkq ).toBeUndefined();
+		expect( imageSources ).toHaveLength( 0 );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).toBeNull();
+	} );
+
+	it( 'records post-consent manage opens when analytics is allowed', () => {
+		cookieJar =
+			'wp_consent_functional=allow; wp_consent_statistics=allow; wp_consent_statistics-anonymous=allow';
+		const event = { preventDefault: jest.fn() } as unknown as MouseEvent;
+
+		storeActions.openManagePreferences( event );
+
+		expect( window._tkq?.[ 0 ] ).toEqual( [
+			'recordEvent',
+			'jetpack_privacy_manage_open',
+			expect.objectContaining( {
+				domain: window.location.hostname,
+			} ),
+		] );
+		expect( document.getElementById( TRACKS_SCRIPT_ID ) ).not.toBeNull();
 	} );
 } );


### PR DESCRIPTION
Fixes WOOA7S-1608

## Proposed changes

- Stop enqueueing `stats.wp.com/w.js` from PHP on every frontend page load.
- Load Tracks from the cookie-consent frontend only after analytics consent is available, while keeping consent-decision events as allowlisted consent-record events.
- Move pre-consent banner view/customize/manage-open metrics to an identity-free `pixel.wp.com/g.gif?v=wpcom-no-pv` aggregate counter.
- Keep the banner-view aggregate scoped to actual banner impressions: GDPR banner display and preview mode, not CCPA/non-regulated/suppressed-banner flows.

## Related product discussion/links

- WOOA7S-1608

## Does this pull request change what data or activity we track or use?

No, the package is not used in production.

## Testing instructions

### Setup

1. On a local WordPress site, activate the **Premium Analytics** plugin — it is the consumer that ships the Cookie Consent package and enqueues the banner.
2. Install and activate the **WP Consent API** plugin. Consent is written through its `wp_set_consent()` API, so without it the banner shows but Accept/Reject stores nothing and the consent-gated flows can't be tested.
3. Open the browser network panel so you can watch outgoing requests throughout testing.
4. **Reset before every scenario.** Each scenario assumes no prior consent, so start clean each time: open a fresh incognito window, or clear the `wp_consent_*`, `country_code`, and `region` cookies. Clearing `wp_consent_*` is required — several scenarios below store consent (Reject, CCPA auto-grant, non-regulated auto-grant), and leftover consent cookies suppress the GDPR banner so the next scenario would test the wrong state.

### Scenario 1 — GDPR visitor sees the banner without loading Tracks

1. Simulate a GDPR visitor by setting the geo cookies to `country_code=FR` and a **non-empty** `region` (e.g. `region=idf`). Both cookies must be non-empty — if either is missing or empty, the frontend refetches geolocation from the WordPress.com geo API, which resolves to your real (likely non-GDPR) location and hides the banner.
2. Reload the frontend page.
3. Confirm the cookie banner is visible.
4. Confirm `stats.wp.com/w.js` is **not** requested before accepting analytics consent.
5. Confirm a `pixel.wp.com/g.gif` request is made with `x_jetpack-cookie-consent-privacy-banner-view`.

<img width="357"  alt="Screenshot 2026-07-01 at 4 06 20 PM" src="https://github.com/user-attachments/assets/4be7e384-e516-4268-bc2d-8c096f12707b" />

<img width="352"  alt="Screenshot 2026-07-01 at 4 06 08 PM" src="https://github.com/user-attachments/assets/0606d0c2-1c06-40d9-947d-eaf9a084255d" />


### Scenario 2 — Customize before consent uses the cookieless counter

1. As the same GDPR visitor, click **Customize** before making a consent choice.
2. Confirm no `stats.wp.com/w.js` request is made for the customize click.
3. Confirm a `pixel.wp.com/g.gif` request is made with `x_jetpack-cookie-consent-privacy-banner-button-customize`.

### Scenario 3 — Reject uses the cookieless pixel and records the decision

1. Reload as a fresh GDPR visitor, then click **Reject** (open **Customize** first if the reject control lives in the modal).
2. Confirm the banner closes.
3. Confirm no `stats.wp.com/w.js` request is made for the reject click — rejecting analytics must not load the cookie-setting Tracks bundle.
4. Confirm a `pixel.wp.com/g.gif` request is made with `x_jetpack-cookie-consent-privacy-banner-button-reject`.
5. Confirm the decision is still recorded: a `POST` to `/wp-json/jetpack/v4/cookie-consent/consent-log` is sent.

### Scenario 4 — Accept loads Tracks (the consent gate opens)

1. Reload as a fresh GDPR visitor, then click **Accept**.
2. Confirm the banner closes.
3. Confirm `stats.wp.com/w.js` is now requested — accepting analytics is the allowlisted consent-record event that loads Tracks.
4. Confirm a Tracks event fires: a `pixel.wp.com/t.gif` request with `_en=jetpack_privacy_banner_button_accept` and the chosen `preferences_*`.

<img width="346" alt="Screenshot 2026-07-01 at 4 06 39 PM" src="https://github.com/user-attachments/assets/9d590252-4b72-44b1-b011-214e4e48ec53" />

### Scenario 5 — CCPA visitor gets no banner and no pixel

1. Simulate a CCPA visitor with `country_code=US` and `region=california`.
2. Reload the frontend page.
3. Confirm the GDPR banner is not shown.
4. Confirm no `x_jetpack-cookie-consent-privacy-banner-view` pixel is sent for that page load.

### Scenario 6 — Non-regulated visitor gets no banner and no pixel

1. Simulate a non-regulated visitor with `country_code=CA`.
2. Reload the frontend page.
3. Confirm the GDPR banner is not shown.
4. Confirm no `x_jetpack-cookie-consent-privacy-banner-view` pixel is sent for that page load.

### Scenario 7 — Preview mode shows the banner and sends the pixel

1. Visit a frontend page with `?preview_cookie_consent=1`.
2. Confirm the banner is shown in preview mode.
3. Confirm a `pixel.wp.com/g.gif` request is made with `x_jetpack-cookie-consent-privacy-banner-view`.
