### PR TITLE
Social: fix Base UI nativeButton console warning on the settings tab

### DIFF
--- a/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
@@ -80,7 +80,12 @@ export default function ContentCreationCard(): JSX.Element {
 					{ isEnabled && (
 						<>
 							<Stack direction="row" gap="md" className="jetpack-social-settings__card-actions">
-								<Button variant="outline" size="compact" render={ <a href={ newNoteUrl } /> }>
+								<Button
+									variant="outline"
+									size="compact"
+									nativeButton={ false }
+									render={ <a href={ newNoteUrl } /> }
+								>
 									{ __( 'Create a note', 'jetpack-publicize-pkg' ) }
 								</Button>
 							</Stack>

--- a/projects/packages/publicize/_inc/components/settings-tab/test/cards.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/cards.test.tsx
@@ -142,11 +142,6 @@ describe( 'ContentCreationCard', () => {
 		await userEvent.click( screen.getByLabelText( 'Append post link' ) );
 
 		expect( actionSpies.updateSocialNotesConfig ).toHaveBeenCalledWith( { append_link: false } );
-
-		// The "Create a note" link renders an <a> through @wordpress/ui's
-		// Button, which logs a Base UI nativeButton notice. It's incidental to
-		// the behavior under test; acknowledge it so jest-console stays happy.
-		expect( console ).toHaveErrored();
 	} );
 
 	it( 'hides the nested options while Social Notes is off', () => {

--- a/projects/packages/publicize/changelog/fix-social-settings-nativebutton-warning
+++ b/projects/packages/publicize/changelog/fix-social-settings-nativebutton-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Base UI nativeButton console warning on the settings tab Create a note button.


### PR DESCRIPTION
When Social standlone plugin is active, the browser console says this on the settings tab in the modern UI

<img width="1116" height="500" alt="image" src="https://github.com/user-attachments/assets/c98189cb-df69-4e09-b527-383dcee2420f" />


## Proposed changes
* Fix a Base UI console warning on the Social admin **Settings** tab. The "Create a note" button in the Content Creation card renders an `<a>` via the `render` prop while Base UI's `nativeButton` defaults to `true`, which triggered: _"A component that acts as a button expected a native `<button>` because the `nativeButton` prop is true."_
* Pass `nativeButton={ false }` alongside `render={ <a> }`, matching the pattern used by `@wordpress/ui`'s own `collapsible-card/header.tsx`. Native button semantics are correctly relaxed for the anchor.
* Remove the now-obsolete `expect( console ).toHaveErrored()` acknowledgement in the settings-tab card test, since the warning no longer fires.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the Social admin app (`jetpack build packages/publicize`) or run the Social plugin with the modern admin UI.
* With the Social plugin active, go to **Jetpack → Social → Settings** tab.
* Enable **Social Notes** so the "Create a note" button renders.
* Open the browser devtools console and confirm there is **no** Base UI `nativeButton` warning.
* Click **Create a note** and confirm it still navigates to the new note screen (`post-new.php?post_type=jetpack-social-note`).
