### PR TITLE
WPCOM_JSON_API: coerce unrenderable upstream statuses to 502 in output()

### DIFF
--- a/projects/plugins/jetpack/changelog/update-json-api-output-renderable-status
+++ b/projects/plugins/jetpack/changelog/update-json-api-output-renderable-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+JSON API: Coerce upstream error statuses that WordPress can't render (508, Cloudflare 52x) to 502, so a proxied error never silently returns 200.

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -684,7 +684,7 @@ class WPCOM_JSON_API {
 
 		if ( 'text/plain' === $content_type ||
 			'text/html' === $content_type ) {
-			status_header( $status_code );
+			status_header( self::renderable_status_code( $status_code ) );
 			header( 'Content-Type: ' . $content_type );
 			foreach ( $extra as $key => $value ) {
 				header( "$key: $value" );
@@ -706,7 +706,7 @@ class WPCOM_JSON_API {
 			$content_type = 'application/json';
 		}
 
-		status_header( $status_code );
+		status_header( self::renderable_status_code( $status_code ) );
 		header( "Content-Type: $content_type" );
 		if ( isset( $this->query['callback'] ) && is_string( $this->query['callback'] ) ) {
 			$callback = preg_replace( '/[^a-z0-9_.]/i', '', $this->query['callback'] );
@@ -731,6 +731,17 @@ class WPCOM_JSON_API {
 		}
 
 		return $content_type;
+	}
+
+	/**
+	 * Map a status status_header() can't render to a generic proxy error, so it never silently no-ops to 200.
+	 *
+	 * @param int $status_code HTTP status code.
+	 * @return int A status_header()-renderable code.
+	 */
+	public static function renderable_status_code( $status_code ) {
+		// status_header() no-ops on codes WP can't describe (508, Cloudflare 52x), leaving the default 200.
+		return get_status_header_desc( (int) $status_code ) ? (int) $status_code : 502;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Renderable_Status_Code_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Renderable_Status_Code_Test.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * WPCOM_JSON_API::renderable_status_code() unit tests.
+ *
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Renderable_Status_Code_Test
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Tests that renderable_status_code() never returns a status status_header() can't render:
+ * codes WP's get_status_header_desc() doesn't know would otherwise silently no-op to 200.
+ *
+ * @covers \WPCOM_JSON_API::renderable_status_code
+ * @covers \WPCOM_JSON_API
+ */
+#[CoversClass( WPCOM_JSON_API::class )]
+#[CoversMethod( WPCOM_JSON_API::class, 'renderable_status_code' )]
+class WPCOM_JSON_API_Renderable_Status_Code_Test extends WP_UnitTestCase {
+	use WP_UnitTestCase_Fix;
+
+	/**
+	 * Codes WP's get_status_header_desc() knows pass through unchanged.
+	 *
+	 * @param int $input A status_header()-renderable code.
+	 * @dataProvider provide_renderable_codes
+	 */
+	#[DataProvider( 'provide_renderable_codes' )]
+	public function test_renderable_code_passes_through( $input ) {
+		$this->assertSame( $input, WPCOM_JSON_API::renderable_status_code( $input ) );
+	}
+
+	/**
+	 * Data provider: codes get_status_header_desc() can render.
+	 *
+	 * @return array<string, array{int}>
+	 */
+	public static function provide_renderable_codes(): array {
+		return array(
+			'400 Bad Request' => array( 400 ),
+			'404 Not Found'   => array( 404 ),
+			'451 Legal'       => array( 451 ),
+			'500 Server'      => array( 500 ),
+			'502 Bad Gateway' => array( 502 ),
+			'503 Unavailable' => array( 503 ),
+			'511 Network'     => array( 511 ),
+		);
+	}
+
+	/**
+	 * Codes get_status_header_desc() doesn't know (508, Cloudflare 52x, other non-standard) would
+	 * make status_header() no-op to 200; they coerce to 502 instead.
+	 *
+	 * @param int $input A status WP can't describe.
+	 * @dataProvider provide_unrenderable_codes
+	 */
+	#[DataProvider( 'provide_unrenderable_codes' )]
+	public function test_unrenderable_code_coerces_to_502( $input ) {
+		$this->assertSame( 502, WPCOM_JSON_API::renderable_status_code( $input ) );
+	}
+
+	/**
+	 * Data provider: codes WP's get_status_header_desc() doesn't know.
+	 *
+	 * @return array<string, array{int}>
+	 */
+	public static function provide_unrenderable_codes(): array {
+		return array(
+			'508 Loop Detected' => array( 508 ),
+			'520 Cloudflare'    => array( 520 ),
+			'522 Cloudflare'    => array( 522 ),
+			'524 Cloudflare'    => array( 524 ),
+			'599 non-std'       => array( 599 ),
+		);
+	}
+
+	/**
+	 * A numeric-string status is cast and treated like its integer.
+	 */
+	public function test_numeric_string_is_cast() {
+		$this->assertSame( 404, WPCOM_JSON_API::renderable_status_code( '404' ) );
+		$this->assertSame( 502, WPCOM_JSON_API::renderable_status_code( '524' ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Renderable_Status_Code_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Renderable_Status_Code_Test.php
@@ -80,12 +80,4 @@ class WPCOM_JSON_API_Renderable_Status_Code_Test extends WP_UnitTestCase {
 			'599 non-std'       => array( 599 ),
 		);
 	}
-
-	/**
-	 * A numeric-string status is cast and treated like its integer.
-	 */
-	public function test_numeric_string_is_cast() {
-		$this->assertSame( 404, WPCOM_JSON_API::renderable_status_code( '404' ) );
-		$this->assertSame( 502, WPCOM_JSON_API::renderable_status_code( '524' ) );
-	}
 }


### PR DESCRIPTION
## Proposed changes

`WPCOM_JSON_API::output()` hands the upstream status straight to WordPress's `status_header()`, which **silently no-ops on any code `get_status_header_desc()` doesn't recognize** — `508`, Cloudflare `52x`, and other non-standard upstream/proxy codes. When it no-ops, no status line is sent, and the response falls back to PHP's default **`200 OK`**.

This PR adds a `renderable_status_code()` helper that maps any status WordPress can't render to a generic `502`, applied at both `status_header()` call sites in `output()`:

* Renderable codes (`400`, `404`, `500`, …) pass through unchanged.
* Unrenderable codes (`508`, `52x`, `599`) become `502 Bad Gateway`, so a real error status always goes out.
* The `http_envelope` path is untouched — it already sends `200` with the true code in the response body, so the coercion is a no-op there and only affects the raw-status path it is meant to fix.


## Related product discussion/links

* [CONNECT-267](https://linear.app/a8c/issue/CONNECT-267/refactor-proxied-json-api-error-response-handling-into-a-shared-dry) (Part of problem 2)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Unit tests

```
jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Renderable_Status_Code_Test
```

13 tests: renderable codes pass through, unrenderable (`508`, `52x`, `599`) → `502`, numeric-string cast.

### Reproduce on a sandbox

1. Deploy this branch to your sandbox:

   ```
   bin/jetpack-downloader test jetpack update/json-api-output-renderable-status
   ```

WIP
