### PR TITLE
Stylelint: lint wordpress/theme design token usage

### DIFF
--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -14,7 +14,7 @@ const baseConfig = {
 	rules: {
 		'plugin-wpds/no-unknown-ds-tokens': true,
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
-		'plugin-wpds/no-token-fallback-values': true,
+		'plugin-wpds/no-token-fallback-values': false, // Disabled because `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` is not configured yet.
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -6,7 +6,15 @@ import { fileURLToPath } from 'node:url';
 const baseConfig = {
 	extends: fileURLToPath( import.meta.resolve( '@wordpress/stylelint-config/scss-stylistic' ) ),
 	reportNeedlessDisables: true,
+	plugins: [
+		'@wordpress/theme/stylelint-plugins/no-unknown-ds-tokens',
+		'@wordpress/theme/stylelint-plugins/no-setting-wpds-custom-properties',
+		'@wordpress/theme/stylelint-plugins/no-token-fallback-values',
+	],
 	rules: {
+		'plugin-wpds/no-unknown-ds-tokens': true,
+		'plugin-wpds/no-setting-wpds-custom-properties': true,
+		'plugin-wpds/no-token-fallback-values': true,
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,


### PR DESCRIPTION
Related to to https://github.com/Automattic/jetpack/pull/50108 which adds WPDS token fallbacks at build time across the repo.

## Proposed changes
<!--- Explain what functional changes your PR includes -->

* Adds Stylelint config for consistent clean [WPDS token](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) usage
* Does not enforce `plugin-wpds/no-token-fallback-values` rule for now; https://github.com/Automattic/jetpack/pull/50108 adds fallbacks at which point we can flip this rule to `true`.
* Due to [previous change](https://github.com/Automattic/jetpack/pull/50007/changes#diff-294bd10db07c43b10b4271610c9181fa32e67317ac9a373f495793f0ce8441f2R189-R197), picks `@wordpress/theme` version used by monorepo, _not_ the one referenced by WP Stylelint config. This way Stylelint config and theme versions can diverge without issues; we always reference the WPDS tokens we actually use.

See [build config](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#build-plugins) and [stylelint plugin](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme#stylelint-plugins) docs for `@wordpress/theme` for details.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Lint is passing