### PR TITLE
Widgets: conform Woo-family render props to WidgetRenderProps<T> contract

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1641-widgets-conform-woo-render-contract
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1641-widgets-conform-woo-render-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: conform woocommerce-analytics-ported widgets to the WidgetRenderProps<T> render contract.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1641-widgets-conform-woo-render-contract
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1641-widgets-conform-woo-render-contract
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Widgets: conform woocommerce-analytics-ported widgets to the WidgetRenderProps<T> render contract.
+Widgets: align the woocommerce-analytics-ported widgets with the shared widget render-props contract.

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/package.json
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/package.json
@@ -8,6 +8,7 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
@@ -29,11 +29,6 @@ type AverageItemsPerOrderRenderProps = WidgetRenderProps< AverageItemsPerOrderRe
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders the avg_items metric with a comparison delta
  * and sparkline.
- *
- * @param props            - Render props.
- * @param props.attributes - Widget attributes.
- * @param props.setError   - Dashboard error-state setter.
- * @return The rendered widget.
  */
 export default function AverageItemsPerOrderRender( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
@@ -1,11 +1,25 @@
+/**
+ * External dependencies
+ */
 import {
 	OrderMetricWidget,
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { AverageItemsPerOrderAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type AverageItemsPerOrderRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type AverageItemsPerOrderRenderAttributes = AverageItemsPerOrderAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type AverageItemsPerOrderRenderProps = WidgetRenderProps< AverageItemsPerOrderRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -15,12 +29,18 @@ type AverageItemsPerOrderRenderProps = {
  * client, chart theme, and resolved report params; OrderMetricWidget fetches
  * the orders report and renders the avg_items metric with a comparison delta
  * and sparkline.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error-state setter.
+ * @return The rendered widget.
  */
 export default function AverageItemsPerOrderRender( {
-	attributes,
+	attributes = {},
+	setError,
 }: AverageItemsPerOrderRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<OrderMetricWidget metricKey="avg_items" />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
@@ -5,6 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget exposes no configurable attributes: report params come from the
+ * dashboard's global date-range state, not host-provided attributes.
+ */
+export type AverageItemsPerOrderAttributes = Record< string, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/average-items-per-order` in

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
@@ -5,8 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: report params come from the
- * dashboard's global date-range state, not host-provided attributes.
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
 export type AverageItemsPerOrderAttributes = Record< string, never >;
 

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/package.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/package.json
@@ -7,6 +7,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -1,14 +1,26 @@
+/**
+ * External dependencies
+ */
 import {
 	BOOKINGS_FILTER,
 	SalesByDeviceWidget,
 	WidgetRoot,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+/**
+ * Internal dependencies
+ */
+import type { BookingsByDeviceAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type BookingsByDeviceRenderAttributes = BookingsByDeviceAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type BookingsByDeviceRenderProps = Pick< WidgetRootProps, 'attributes' > & {
-	setError?: WidgetRootProps[ 'setError' ];
+type BookingsByDeviceRenderProps = WidgetRenderProps< BookingsByDeviceRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 function BookingsByDeviceWidget() {
@@ -21,9 +33,14 @@ function BookingsByDeviceWidget() {
  * Thin composition over the widgets-toolkit: WidgetRoot provides the query
  * client, chart theme, and resolved report params; SalesByDeviceWidget fetches
  * the filtered bookings attribution report and renders the device breakdown.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error-state setter.
+ * @return The rendered widget.
  */
 export default function BookingsByDeviceRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: BookingsByDeviceRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -33,11 +33,6 @@ function BookingsByDeviceWidget() {
  * Thin composition over the widgets-toolkit: WidgetRoot provides the query
  * client, chart theme, and resolved report params; SalesByDeviceWidget fetches
  * the filtered bookings attribution report and renders the device breakdown.
- *
- * @param props            - Render props.
- * @param props.attributes - Widget attributes.
- * @param props.setError   - Dashboard error-state setter.
- * @return The rendered widget.
  */
 export default function BookingsByDeviceRender( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -5,8 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: report params come from the
- * dashboard's global date-range state, not host-provided attributes.
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
 export type BookingsByDeviceAttributes = Record< string, never >;
 

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -5,6 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget exposes no configurable attributes: report params come from the
+ * dashboard's global date-range state, not host-provided attributes.
+ */
+export type BookingsByDeviceAttributes = Record< string, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/bookings-by-device` in

--- a/projects/packages/premium-analytics/widgets/payment-status/package.json
+++ b/projects/packages/premium-analytics/widgets/payment-status/package.json
@@ -10,6 +10,7 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/payment-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/render.tsx
@@ -1,17 +1,25 @@
 /**
  * External dependencies
  */
-import { WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
-import type { ComponentProps } from 'react';
+import {
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 /**
  * Internal dependencies
  */
 import { PaymentStatusWidget } from './payment-status-widget';
+import type { PaymentStatusAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type WidgetRootProps = ComponentProps< typeof WidgetRoot >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type PaymentStatusRenderAttributes = PaymentStatusAttributes &
+	Partial< ReportParamsFieldAttributes >;
 
-type PaymentStatusRenderProps = Pick< WidgetRootProps, 'attributes' > & {
-	setError?: WidgetRootProps[ 'setError' ];
+type PaymentStatusRenderProps = WidgetRenderProps< PaymentStatusRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
 /**
@@ -20,8 +28,16 @@ type PaymentStatusRenderProps = Pick< WidgetRootProps, 'attributes' > & {
  * Thin composition over WidgetRoot: WidgetRoot provides the query client,
  * chart theme, and resolved report params; PaymentStatusWidget renders the
  * paid vs unpaid order revenue donut chart.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error-state setter.
+ * @return The rendered widget.
  */
-export default function PaymentStatusRender( { attributes, setError }: PaymentStatusRenderProps ) {
+export default function PaymentStatusRender( {
+	attributes = {},
+	setError,
+}: PaymentStatusRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<PaymentStatusWidget />

--- a/projects/packages/premium-analytics/widgets/payment-status/render.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/render.tsx
@@ -28,11 +28,6 @@ type PaymentStatusRenderProps = WidgetRenderProps< PaymentStatusRenderAttributes
  * Thin composition over WidgetRoot: WidgetRoot provides the query client,
  * chart theme, and resolved report params; PaymentStatusWidget renders the
  * paid vs unpaid order revenue donut chart.
- *
- * @param props            - Render props.
- * @param props.attributes - Widget attributes.
- * @param props.setError   - Dashboard error-state setter.
- * @return The rendered widget.
  */
 export default function PaymentStatusRender( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -5,8 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: report params come from the
- * dashboard's global date-range state, not host-provided attributes.
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
 export type PaymentStatusAttributes = Record< string, never >;
 

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -5,6 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget exposes no configurable attributes: report params come from the
+ * dashboard's global date-range state, not host-provided attributes.
+ */
+export type PaymentStatusAttributes = Record< string, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/payment-status` in

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/package.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/package.json
@@ -9,6 +9,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/render.tsx
@@ -10,14 +10,22 @@ import {
 	formatLegendLabels,
 	useWidgetError,
 	useWidgetRootContext,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo, type ComponentProps, type CSSProperties } from 'react';
 /**
  * Internal dependencies
  */
 import { buildSalesByUtmData } from './helpers/build-sales-by-utm-data';
+import type { SalesByUtmChannelAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-type SalesByUtmChannelRenderProps = Pick< ComponentProps< typeof WidgetRoot >, 'attributes' > & {
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type SalesByUtmChannelRenderAttributes = SalesByUtmChannelAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type SalesByUtmChannelRenderProps = WidgetRenderProps< SalesByUtmChannelRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
@@ -75,13 +83,13 @@ function SalesByUtmChannelWidget() {
  * this render module fetches the order-attribution report and renders the
  * channel leaderboard.
  *
- * @param root0            - Component props.
- * @param root0.attributes - Widget attributes.
- * @param root0.setError   - Dashboard error-state setter.
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error-state setter.
  * @return The rendered widget.
  */
 export default function SalesByUtmChannelRender( {
-	attributes,
+	attributes = {},
 	setError,
 }: SalesByUtmChannelRenderProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/render.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/render.tsx
@@ -82,11 +82,6 @@ function SalesByUtmChannelWidget() {
  * WidgetRoot provides the query client, chart theme, and resolved report params;
  * this render module fetches the order-attribution report and renders the
  * channel leaderboard.
- *
- * @param props            - Render props.
- * @param props.attributes - Widget attributes.
- * @param props.setError   - Dashboard error-state setter.
- * @return The rendered widget.
  */
 export default function SalesByUtmChannelRender( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
@@ -5,6 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
+ * The widget exposes no configurable attributes: report params come from the
+ * dashboard's global date-range state, not host-provided attributes.
+ */
+export type SalesByUtmChannelAttributes = Record< string, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/sales-by-utm-channel` in

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
@@ -5,8 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: report params come from the
- * dashboard's global date-range state, not host-provided attributes.
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
 export type SalesByUtmChannelAttributes = Record< string, never >;
 

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/package.json
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/package.json
@@ -8,6 +8,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/render.tsx
@@ -1,15 +1,26 @@
 /**
  * External dependencies
  */
-import { WidgetRoot } from '@jetpack-premium-analytics/widgets-toolkit';
-import type { ComponentProps } from 'react';
-
+import {
+	WidgetRoot,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 /**
  * Internal dependencies
  */
 import { VisitorMetricWidget } from './components/visitor-metric-widget';
+import type { VisitorsOverTimeAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
-type RenderProps = Pick< ComponentProps< typeof WidgetRoot >, 'attributes' | 'setError' >;
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
+type VisitorsOverTimeRenderAttributes = VisitorsOverTimeAttributes &
+	Partial< ReportParamsFieldAttributes >;
+
+type VisitorsOverTimeRenderProps = WidgetRenderProps< VisitorsOverTimeRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
 
 /**
  * Visitors over time widget.
@@ -17,8 +28,16 @@ type RenderProps = Pick< ComponentProps< typeof WidgetRoot >, 'attributes' | 'se
  * Thin composition over WidgetRoot: WidgetRoot provides the query client,
  * chart theme, and resolved report params; VisitorMetricWidget fetches the
  * visitors report and renders visitor trends over time.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @param props.setError   - Dashboard error-state setter.
+ * @return The rendered widget.
  */
-export default function VisitorsOverTimeRender( { attributes, setError }: RenderProps ) {
+export default function VisitorsOverTimeRender( {
+	attributes = {},
+	setError,
+}: VisitorsOverTimeRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<VisitorMetricWidget />

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/render.tsx
@@ -28,11 +28,6 @@ type VisitorsOverTimeRenderProps = WidgetRenderProps< VisitorsOverTimeRenderAttr
  * Thin composition over WidgetRoot: WidgetRoot provides the query client,
  * chart theme, and resolved report params; VisitorMetricWidget fetches the
  * visitors report and renders visitor trends over time.
- *
- * @param props            - Render props.
- * @param props.attributes - Widget attributes.
- * @param props.setError   - Dashboard error-state setter.
- * @return The rendered widget.
  */
 export default function VisitorsOverTimeRender( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
@@ -5,8 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: report params come from the
- * dashboard's global date-range state, not host-provided attributes.
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
 export type VisitorsOverTimeAttributes = Record< string, never >;
 

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
@@ -5,6 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 
 /**
+ * The widget exposes no configurable attributes: report params come from the
+ * dashboard's global date-range state, not host-provided attributes.
+ */
+export type VisitorsOverTimeAttributes = Record< string, never >;
+
+/**
  * Widget type definition.
  *
  * Ported from `woocommerce-analytics/visitors-over-time` in


### PR DESCRIPTION
Fixes WOOA7S-1641

## Proposed changes

Part of the Premium Analytics widget consistency cleanup (WOOA7S-1640). Type-only refactor of the five woocommerce-analytics-ported widgets (`average-items-per-order`, `bookings-by-device`, `payment-status`, `sales-by-utm-channel`, `visitors-over-time`) to follow the render-component contract in `.agents/rules/widgets.md`.

- Each `widget.ts` now exports an attribute type (`Record< string, never >`, mirroring `subscribers-chart`) since these widgets expose no configurable attributes.
- Each `render.tsx` types props as `WidgetRenderProps< T > & { setError? }` — composing the widget attribute type with `Partial< ReportParamsFieldAttributes >` — and defaults `attributes = {}`. Previously each hand-rolled its own props shape (five different variants) and left `attributes` undefaulted.
- `average-items-per-order` now accepts `setError` for parity with its siblings.
- Trimmed the render-function doc comments to the minimal house style: removed the `@param`/`@return` tags that only echoed the TypeScript types, keeping the descriptive summary.
- Added `@wordpress/widget-primitives` to each widget's `dependencies`.

No runtime or behavior change. Widget metadata (`widget.json` / `widget.ts` `title`/`description`) is intentionally left untouched — that reconciliation is held for WordPress/gutenberg#79701.

## Related product discussion/links

- Linear: WOOA7S-1641 (parent: WOOA7S-1640)
- Sibling PR: #50112 (WOOA7S-1642 — file & style conventions)

## Does this pull request change what data or activity we track or use?

No. Type-only refactor; no data collection, tracking, or runtime behavior changes.

## Testing instructions

- From the repo root, run `pnpm --filter @automattic/jetpack-premium-analytics typecheck` and lint the changed widgets — both pass clean.
- In Storybook, open each of the five widgets (Average items per order, Bookings by device, Payment status, Sales by UTM channel, Visitors over time) and confirm the Default and WithComparison stories render exactly as before — they still pass `reportParams` through `attributes`.
