### PR TITLE
Social: load connections via a store resolver

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/index.tsx
@@ -1,11 +1,9 @@
 import { Disabled } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useIsModernized } from '../../hooks/use-is-modernized';
-import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store } from '../../social-store';
 import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
@@ -27,7 +25,6 @@ const ConnectionManagement = ( {
 	// outline, rows supply their own padding). The legacy admin page / block
 	// editor keep the trunk `style.module.scss` classes byte-for-byte.
 	const listStyles = isModernized ? modernStyles : styles;
-	const { refresh } = useSocialMediaConnections();
 
 	const {
 		connections: rawConnections,
@@ -51,10 +48,6 @@ const ConnectionManagement = ( {
 		}
 		return a.service_name.localeCompare( b.service_name );
 	} );
-
-	useEffect( () => {
-		refresh();
-	}, [ refresh ] );
 
 	const getService = useService();
 

--- a/projects/packages/publicize/_inc/hooks/use-refresh-connections/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-refresh-connections/index.ts
@@ -4,26 +4,20 @@ import { usePageVisibility } from 'react-page-visibility';
 import useSelectSocialMediaConnections from '../use-social-media-connections';
 
 /**
- * Hook that provides a function to refresh the connections.
+ * Hook that provides a function to refresh the connections when the page
+ * regains focus. The initial load is handled by the `getConnections` resolver.
  *
  * @return The refreshConnections function.
  */
 export default function useRefreshConnections() {
 	const shouldAutoRefresh = useRef( false );
-	const isInitialRefresh = useRef( true );
 
 	const pageHasFocus = usePageVisibility();
 	const { refresh: refreshConnections } = useSelectSocialMediaConnections();
 
-	const initialRefresh = useDebounce( refreshConnections, 0 );
 	const debouncedRefresh = useDebounce( refreshConnections, 2000 );
 
 	return () => {
-		if ( isInitialRefresh.current ) {
-			initialRefresh();
-			isInitialRefresh.current = false;
-		}
-
 		if ( ! pageHasFocus ) {
 			shouldAutoRefresh.current = true;
 			debouncedRefresh.cancel();

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -4,7 +4,6 @@ import { dispatch as coreDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { getSocialScriptData } from '../../utils/script-data';
 import { CUSTOMIZE_PER_NETWORK_KEY } from '../constants';
 import { Connection, EditorConnection, KeyringResponse, KeyringResult } from '../types';
 import {
@@ -223,15 +222,19 @@ export function abortRefreshConnectionsRequest() {
 }
 
 /**
- * Effect handler which will refresh the connection test results.
+ * Fetch connections from the server and merge them into the store.
  *
- * @param syncToMeta - Whether to sync the connection state to the post meta.
- * @return A thunk to refresh connection test results.
+ * @param queryParams - Query params for the connections endpoint, e.g. `{ test_connections: 1 }` to run connection tests.
+ * @param syncToMeta  - Whether to sync the connection state to the post meta.
+ * @return A thunk to fetch connections.
  */
-export function refreshConnectionTestResults( syncToMeta = false ) {
+export function fetchConnections(
+	queryParams: Record< string, string | number > = {},
+	syncToMeta = false
+) {
 	return async function ( { dispatch, select } ) {
 		try {
-			const path = getSocialScriptData().api_paths.refreshConnections;
+			const path = addQueryArgs( '/wpcom/v2/publicize/connections', queryParams );
 
 			// Wait until all connections are done updating/deleting.
 			while (
@@ -260,10 +263,20 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
 			// If the request was aborted.
 			if ( 'AbortError' === e.name ) {
 				// Fire it again to run after the current operation that cancelled the request.
-				dispatch( refreshConnectionTestResults( syncToMeta ) );
+				dispatch( fetchConnections( queryParams, syncToMeta ) );
 			}
 		}
 	};
+}
+
+/**
+ * Refresh the connection test results.
+ *
+ * @param syncToMeta - Whether to sync the connection state to the post meta.
+ * @return A thunk to refresh connection test results.
+ */
+export function refreshConnectionTestResults( syncToMeta = false ) {
+	return fetchConnections( { test_connections: 1 }, syncToMeta );
 }
 
 /**

--- a/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
+++ b/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
@@ -192,21 +192,12 @@ describe( 'Social store actions: connectionData', () => {
 	} );
 
 	describe( 'refreshConnectionTestResults', () => {
-		const refreshConnections = '/wpcom/v2/publicize/connection-test-results';
-		beforeAll( () => {
-			global.JetpackScriptData = {
-				social: {
-					api_paths: {
-						refreshConnections,
-					},
-				},
-			};
-		} );
+		const connectionsPath = '/wpcom/v2/publicize/connections';
 
 		it( 'should refresh connection test results', async () => {
 			// Mock apiFetch response.
 			apiFetch.setFetchHandler( async ( { path } ) => {
-				if ( path.startsWith( refreshConnections ) ) {
+				if ( path.startsWith( connectionsPath ) ) {
 					return connections.map( connection => ( {
 						...connection,
 						status: 'broken',

--- a/projects/packages/publicize/_inc/social-store/resolvers.ts
+++ b/projects/packages/publicize/_inc/social-store/resolvers.ts
@@ -6,6 +6,7 @@ import {
 	type RenderPostIntent,
 	type RenderResult,
 } from '../utils/render-messages';
+import { getSocialScriptData } from '../utils/script-data';
 import { normalizeShareStatus } from '../utils/share-status';
 import { setConnections } from './actions/connection-data';
 import {
@@ -20,6 +21,7 @@ import {
 	receiveTrafficReferrersError,
 } from './actions/traffic-stats';
 import {
+	Connection,
 	PostShareStatus,
 	RenderedMessageBatch,
 	TrafficInterval,
@@ -32,11 +34,27 @@ import {
  * @return {Function} Resolver
  */
 export function getConnections() {
-	return function ( { dispatch, registry } ) {
+	return async function ( { dispatch, registry } ) {
 		const editor = registry.select( editorStore );
+
+		/*
+		 * The standalone admin page has no post to read connections from, so
+		 * fetch them from the server. Resolving here — rather than in a component
+		 * mount effect — lets the store dedupe the request across mounts (and
+		 * StrictMode's dev-only double mount).
+		 */
 		if ( ! editor.getCurrentPostId() ) {
+			try {
+				const freshConnections = await apiFetch< Array< Connection > >( {
+					path: getSocialScriptData().api_paths.refreshConnections,
+				} );
+				dispatch( setConnections( freshConnections ) );
+			} catch {
+				// Leave connections empty; the UI falls back to its empty state.
+			}
 			return;
 		}
+
 		// Get the initial connections from the post meta
 		const connections = editor.getEditedPostAttribute( 'jetpack_publicize_connections' );
 

--- a/projects/packages/publicize/_inc/social-store/resolvers.ts
+++ b/projects/packages/publicize/_inc/social-store/resolvers.ts
@@ -35,37 +35,34 @@ export function getConnections() {
 	return async function ( { dispatch, registry } ) {
 		const editor = registry.select( editorStore );
 
-		/*
-		 * If we are not in the editor
-		 */
-		if ( ! editor.getCurrentPostId() ) {
-			await dispatch( fetchConnections( { test_connections: 1 } ) );
-			return;
+		// In the editor, seed the list from the post meta for a fast initial
+		// paint before the server fetch below merges in fresh test results.
+		if ( editor.getCurrentPostId() ) {
+			const connections = editor.getEditedPostAttribute( 'jetpack_publicize_connections' );
+
+			/**
+			 * If by any chance the REST meta validation fails,
+			 * the value can be in the following format:
+			 *
+			 * {
+			 * "errors": { "rest_invalid_type": [] },
+			 * "error_data": { "rest_invalid_type": { "param": "" } }
+			 * }
+			 *
+			 * It's because of https://github.com/Automattic/jetpack/blob/42a62f9821d4d5c89866e09813eafaad7648d243/projects/packages/publicize/src/class-connections-post-field.php#L224-L228
+			 *
+			 * So, we need to check if the value is actually an array or not.
+			 */
+			if ( Array.isArray( connections ) ) {
+				dispatch( setConnections( connections ) );
+			} else {
+				// eslint-disable-next-line no-console
+				console.error( 'Invalid connections data received from the post meta.', connections );
+			}
 		}
 
-		// Get the initial connections from the post meta
-		const connections = editor.getEditedPostAttribute( 'jetpack_publicize_connections' );
-
-		/**
-		 * If by any chance the REST meta validation fails,
-		 * the value can be in the following format:
-		 *
-		 * {
-		 * "errors": { "rest_invalid_type": [] },
-		 * "error_data": { "rest_invalid_type": { "param": "" } }
-		 * }
-		 *
-		 * It's because of https://github.com/Automattic/jetpack/blob/42a62f9821d4d5c89866e09813eafaad7648d243/projects/packages/publicize/src/class-connections-post-field.php#L224-L228
-		 *
-		 * So, we need to check if the value is actually an array or not.
-		 */
-		if ( ! Array.isArray( connections ) ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Invalid connections data received from the post meta.', connections );
-			return;
-		}
-
-		dispatch( setConnections( connections || [] ) );
+		// Fetch fresh connections (with test results) from the server.
+		await dispatch( fetchConnections( { test_connections: 1 } ) );
 	};
 }
 

--- a/projects/packages/publicize/_inc/social-store/resolvers.ts
+++ b/projects/packages/publicize/_inc/social-store/resolvers.ts
@@ -6,9 +6,8 @@ import {
 	type RenderPostIntent,
 	type RenderResult,
 } from '../utils/render-messages';
-import { getSocialScriptData } from '../utils/script-data';
 import { normalizeShareStatus } from '../utils/share-status';
-import { setConnections } from './actions/connection-data';
+import { fetchConnections, setConnections } from './actions/connection-data';
 import {
 	finishRenderingMessages,
 	receiveRenderedMessages,
@@ -21,7 +20,6 @@ import {
 	receiveTrafficReferrersError,
 } from './actions/traffic-stats';
 import {
-	Connection,
 	PostShareStatus,
 	RenderedMessageBatch,
 	TrafficInterval,
@@ -38,20 +36,10 @@ export function getConnections() {
 		const editor = registry.select( editorStore );
 
 		/*
-		 * The standalone admin page has no post to read connections from, so
-		 * fetch them from the server. Resolving here — rather than in a component
-		 * mount effect — lets the store dedupe the request across mounts (and
-		 * StrictMode's dev-only double mount).
+		 * If we are not in the editor
 		 */
 		if ( ! editor.getCurrentPostId() ) {
-			try {
-				const freshConnections = await apiFetch< Array< Connection > >( {
-					path: getSocialScriptData().api_paths.refreshConnections,
-				} );
-				dispatch( setConnections( freshConnections ) );
-			} catch {
-				// Leave connections empty; the UI falls back to its empty state.
-			}
+			await dispatch( fetchConnections( { test_connections: 1 } ) );
 			return;
 		}
 

--- a/projects/packages/publicize/_inc/types.ts
+++ b/projects/packages/publicize/_inc/types.ts
@@ -30,7 +30,6 @@ export type ConnectionService = {
 };
 
 export interface ApiPaths {
-	refreshConnections: string;
 	resharePost: string;
 	socialToggleBase: 'settings' | 'social/settings';
 }

--- a/projects/packages/publicize/changelog/fix-social-refresh-connections
+++ b/projects/packages/publicize/changelog/fix-social-refresh-connections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load Publicize connections via a store resolver so the modern admin page fetches them even when there are no connections, and avoid a duplicate request.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -253,10 +253,9 @@ class Publicize_Script_Data {
 	public static function get_api_paths() {
 
 		return array(
-			'refreshConnections' => '/wpcom/v2/publicize/connections?test_connections=1',
 			// The complete path will be like `/jetpack/v4/social/settings`.
-			'socialToggleBase'   => Utils::should_use_jetpack_module_endpoint() ? 'settings' : 'social/settings',
-			'resharePost'        => '/wpcom/v2/publicize/share-post/{postId}',
+			'socialToggleBase' => Utils::should_use_jetpack_module_endpoint() ? 'settings' : 'social/settings',
+			'resharePost'      => '/wpcom/v2/publicize/share-post/{postId}',
 		);
 	}
 


### PR DESCRIPTION
See p1782891805694709/1782503021.848109-slack-C08PN0LHCCT

## Proposed changes

Loads Publicize connections through the `getConnections` store resolver instead of a component mount effect, and tidies up how the connections path is built.

* **Fix (modern UI): connections now load even when there are none.** The connection refresh used to live in `ConnectionManagement`. The legacy admin page always mounts that component (via `SocialModuleToggle`), so it worked fine there. The modern admin page only mounts it once at least one connection exists, so with zero connections the empty state never triggered a fetch. Loading is now owned by the `getConnections` resolver, so it runs regardless of connection count in both UIs.
* **Fix (modern UI, dev builds): no more double request.** Because the refresh was a component mount effect, React 18 StrictMode double-invoked it, firing two `test_connections` requests. StrictMode only wraps the modern dashboard chassis (the legacy page renders without it), and the double-invoke only happens in dev React builds — so this was modern-UI + dev-only. Resolver-based loading is deduped by the store's resolution cache, so it fires exactly once regardless of how many components read the selector or how many times StrictMode remounts them.
* **Unified initial-load path.**
  * Admin page (no post): the resolver fetches connections from the server.
  * Editor (has post): the resolver seeds the list from post meta for a fast initial paint, then merges fresh test results from the server.
* **Refactor: `fetchConnections` action.** Extracted the fetch logic out of `refreshConnectionTestResults` into a reusable `fetchConnections( queryParams )` action. `refreshConnectionTestResults` now delegates with `{ test_connections: 1 }`.
* **Cleanup: connections path.** The endpoint path is now a client-side literal built with `addQueryArgs`, with `test_connections=1` supplied as a query param in JS. Removed the backend-supplied `refreshConnections` API path (and its `ApiPaths` type entry) that had the query param baked in.
* **`useRefreshConnections` is now focus-only.** Dropped its on-render initial refresh (the resolver owns initial load); it still refreshes when the tab regains focus. The post-publish refresh is unchanged.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?

No. This only changes *when/how* the existing connections endpoint is called; it introduces no new tracking or data collection.

## Testing instructions

Test on **both the classic and modern Social UI**.

To enable the modern UI, add this filter (e.g. in a mu-plugin / snippet):

```php
add_filter( 'rsm_jetpack_ui_modernization_social', '__return_true' );
```

Open the browser Network tab and filter for `publicize/connections` throughout.

> **Simulating zero connections:** the store is hydrated from PHP with the user's connections, so to exercise the empty-state path either use a site/account with no social connections, or temporarily force the initial state empty in `Publicize_Script_Data::get_store_initial_state()`:
> ```php
> 'connections' => array(), // instead of Connections::get_all_for_user()
> ```

### Admin page — `wp-admin/admin.php?page=jetpack-social`

* **With zero connections:** load the page and confirm the connections list/empty state renders, and that a single `GET /wpcom/v2/publicize/connections?test_connections=1` request fires (previously, in the modern UI, it fired **zero** times in this state).
* **With one or more connections:** reload and confirm the list renders and exactly **one** `test_connections` request fires (previously **two** under StrictMode dev builds).
* Add a connection via "Connect an account" and confirm it appears in the list.
* Repeat all of the above with the modern UI filter enabled **and** disabled.

### Block editor

* Open a post with the Jetpack sidebar → "Share to social media" panel and confirm connections load (fast paint from post meta, then test statuses refresh from the server).
* Switch to another browser tab and back; confirm connections refresh on regaining focus.
* Publish a post that has enabled connections and confirm the connections refresh afterwards.

### Regression checks

* `jetpack test js packages/publicize` passes.
* No console errors on any of the above screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)