### PR TITLE
Hide AI editor tools from users not connected to WordPress.com, including on Atomic

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gate-ai-editor-panels-on-connection
+++ b/projects/plugins/jetpack/changelog/fix-gate-ai-editor-panels-on-connection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Don't show the AI writing and SEO editor tools to users who have not connected their WordPress.com account, so they aren't offered tools that would only error out.
+Don't show the AI editor tools to users who have not connected their WordPress.com account, so they aren't offered features that would only error out.

--- a/projects/plugins/jetpack/changelog/fix-gate-ai-editor-panels-on-connection
+++ b/projects/plugins/jetpack/changelog/fix-gate-ai-editor-panels-on-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Don't show the AI writing and SEO editor tools to users who have not connected their WordPress.com account, so they aren't offered tools that would only error out.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -17,7 +17,6 @@ import {
 	PLAN_TYPE_FREE,
 	PLAN_TYPE_UNLIMITED,
 	usePlanType,
-	isUserConnected,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { rawHandler } from '@wordpress/blocks';
@@ -34,6 +33,7 @@ import clsx from 'clsx';
 import UsagePanel from '../../plugins/ai-assistant-plugin/components/usage-panel';
 import { USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } from '../../plugins/ai-assistant-plugin/components/usage-panel/types';
 import ConnectBanner from '../../shared/components/connect-banner';
+import { isCurrentUserConnected } from '../../shared/is-current-user-connected';
 import FeedbackControl from './components/feedback-control';
 import ToolbarControls from './components/toolbar-controls';
 import useAIAssistant from './hooks/use-ai-assistant';
@@ -130,7 +130,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	const isWaitingResponse = requestingState === 'requesting';
 	const isLoadingCompletion = [ 'requesting', 'suggesting' ].includes( requestingState );
 
-	const connected = isUserConnected();
+	const connected = isCurrentUserConnected();
 
 	const { productPageUrl } = useAiProductPage();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -1,12 +1,12 @@
 /*
  * External dependencies
  */
-import { isUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { getBlockType } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 /*
  * Internal dependencies
  */
+import { isCurrentUserConnected } from '../../../../shared/is-current-user-connected';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
@@ -33,8 +33,8 @@ export function canAIAssistantBeEnabled(): boolean {
 		return false;
 	}
 
-	// Do not enable AI Assistant if the site is not connected.
-	const connected = isUserConnected();
+	// Do not enable AI Assistant if the current user is not connected.
+	const connected = isCurrentUserConnected();
 	if ( ! connected ) {
 		return false;
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@automattic/jetpack-ai-client';
 import {
 	useAnalytics,
+	isUserConnected,
 	PLAN_TYPE_FREE,
 	PLAN_TYPE_UNLIMITED,
 	usePlanType,
@@ -250,6 +251,12 @@ export default function AiAssistantPluginSidebar() {
 
 	// If the post type is not viewable, do not render my plugin.
 	if ( ! isViewable ) {
+		return null;
+	}
+
+	// A user who hasn't connected their WordPress.com account can't use the AI
+	// features, so don't show the panel. It would only error out.
+	if ( ! isUserConnected() ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@automattic/jetpack-ai-client';
 import {
 	useAnalytics,
-	isUserConnected,
 	PLAN_TYPE_FREE,
 	PLAN_TYPE_UNLIMITED,
 	usePlanType,
@@ -33,6 +32,7 @@ import { ComponentType, useCallback, useMemo } from 'react';
  */
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
+import { isCurrentUserConnected } from '../../../../shared/is-current-user-connected';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import { getBreveAvailability, canWriteBriefBeEnabled } from '../breve/utils/get-availability';
@@ -256,7 +256,7 @@ export default function AiAssistantPluginSidebar() {
 
 	// A user who hasn't connected their WordPress.com account can't use the AI
 	// features, so don't show the panel. It would only error out.
-	if ( ! isUserConnected() ) {
+	if ( ! isCurrentUserConnected() ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { isUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { applyFilters } from '@wordpress/hooks';
@@ -45,6 +46,7 @@ jest.mock( '@automattic/jetpack-ai-client', () => ( {
 
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
+	isUserConnected: jest.fn(),
 	PLAN_TYPE_FREE: 'free',
 	PLAN_TYPE_UNLIMITED: 'unlimited',
 	usePlanType: () => 'free',
@@ -174,6 +176,18 @@ describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		jest.mocked( applyFilters ).mockReturnValue( null );
+		jest.mocked( isUserConnected ).mockReturnValue( true );
+	} );
+
+	describe( 'connection gating', () => {
+		it( 'renders nothing when the current user is not connected', () => {
+			jest.mocked( isUserConnected ).mockReturnValue( false );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			expect( screen.queryByTestId( 'document-panel' ) ).not.toBeInTheDocument();
+			expect( screen.queryByTestId( 'jetpack-sidebar' ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'imageGenerationHandler filter', () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -1,7 +1,7 @@
-import { isUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { applyFilters } from '@wordpress/hooks';
+import { isCurrentUserConnected } from '../../../../../shared/is-current-user-connected';
 import AiAssistantPluginSidebar from '..';
 
 const mockEditPost = jest.fn();
@@ -46,10 +46,13 @@ jest.mock( '@automattic/jetpack-ai-client', () => ( {
 
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
-	isUserConnected: jest.fn(),
 	PLAN_TYPE_FREE: 'free',
 	PLAN_TYPE_UNLIMITED: 'unlimited',
 	usePlanType: () => 'free',
+} ) );
+
+jest.mock( '../../../../../shared/is-current-user-connected', () => ( {
+	isCurrentUserConnected: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
@@ -176,12 +179,12 @@ describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		jest.mocked( applyFilters ).mockReturnValue( null );
-		jest.mocked( isUserConnected ).mockReturnValue( true );
+		jest.mocked( isCurrentUserConnected ).mockReturnValue( true );
 	} );
 
 	describe( 'connection gating', () => {
 		it( 'renders nothing when the current user is not connected', () => {
-			jest.mocked( isUserConnected ).mockReturnValue( false );
+			jest.mocked( isCurrentUserConnected ).mockReturnValue( false );
 
 			render( <AiAssistantPluginSidebar /> );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { applyFilters } from '@wordpress/hooks';
-import { isCurrentUserConnected } from '../../../../../shared/is-current-user-connected';
 import AiAssistantPluginSidebar from '..';
+import { isCurrentUserConnected } from '../../../../../shared/is-current-user-connected';
 
 const mockEditPost = jest.fn();
 const mockRecordEvent = jest.fn();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
@@ -4,7 +4,6 @@
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import {
 	getJetpackExtensionAvailability,
-	isUserConnected,
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -14,6 +13,7 @@ import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
  */
+import { isCurrentUserConnected } from '../../../../shared/is-current-user-connected';
 import { store } from './store';
 import { useSeoModuleSettings } from './use-seo-module-settings';
 import { useSeoRequests } from './use-seo-requests';
@@ -24,7 +24,7 @@ import type { Block } from '@automattic/jetpack-ai-client';
 
 const isSeoEnhancerEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
-	isUserConnected() &&
+	isCurrentUserConnected() &&
 	! isSimpleSite();
 
 function isPossibleToExtendImageBlock( blockName: string ): boolean {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
@@ -4,6 +4,7 @@
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import {
 	getJetpackExtensionAvailability,
+	isUserConnected,
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -22,7 +23,9 @@ import { useSeoRequests } from './use-seo-requests';
 import type { Block } from '@automattic/jetpack-ai-client';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && ! isSimpleSite();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
+	isUserConnected() &&
+	! isSimpleSite();
 
 function isPossibleToExtendImageBlock( blockName: string ): boolean {
 	return blockName === 'core/image' && isSeoEnhancerEnabled;

--- a/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
@@ -1,11 +1,14 @@
-import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
+import {
+	getJetpackExtensionAvailability,
+	isUserConnected,
+} from '@automattic/jetpack-shared-extension-utils';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true;
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isUserConnected();
 
 class SeoDescriptionPanel extends Component {
 	onMessageChange = value => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
@@ -1,14 +1,12 @@
-import {
-	getJetpackExtensionAvailability,
-	isUserConnected,
-} from '@automattic/jetpack-shared-extension-utils';
+import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { isCurrentUserConnected } from '../../shared/is-current-user-connected';
 import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isUserConnected();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isCurrentUserConnected();
 
 class SeoDescriptionPanel extends Component {
 	onMessageChange = value => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
@@ -6,7 +6,8 @@ import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isCurrentUserConnected();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
+	isCurrentUserConnected();
 
 class SeoDescriptionPanel extends Component {
 	onMessageChange = value => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -7,6 +7,7 @@ import {
 	useModuleStatus,
 	getJetpackExtensionAvailability,
 	getRequiredPlan,
+	isUserConnected,
 } from '@automattic/jetpack-shared-extension-utils';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { PanelBody, PanelRow } from '@wordpress/components';
@@ -47,6 +48,7 @@ const supportsPublishSidebar =
 
 const isSeoEnhancerEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
+	isUserConnected() &&
 	supportsPublishSidebar;
 
 const canHaveAutoEnhance = ! isSimpleSite();

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -7,7 +7,6 @@ import {
 	useModuleStatus,
 	getJetpackExtensionAvailability,
 	getRequiredPlan,
-	isUserConnected,
 } from '@automattic/jetpack-shared-extension-utils';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { PanelBody, PanelRow } from '@wordpress/components';
@@ -25,6 +24,7 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import { isCurrentUserConnected } from '../../shared/is-current-user-connected';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
 import { SeoSummary } from '../ai-assistant-plugin/components/seo-enhancer/seo-summary';
@@ -48,7 +48,7 @@ const supportsPublishSidebar =
 
 const isSeoEnhancerEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
-	isUserConnected() &&
+	isCurrentUserConnected() &&
 	supportsPublishSidebar;
 
 const canHaveAutoEnhance = ! isSimpleSite();

--- a/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
@@ -6,7 +6,8 @@ import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isCurrentUserConnected();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
+	isCurrentUserConnected();
 
 class SeoTitlePanel extends Component {
 	onTitleChange = value => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
@@ -1,14 +1,12 @@
-import {
-	getJetpackExtensionAvailability,
-	isUserConnected,
-} from '@automattic/jetpack-shared-extension-utils';
+import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { isCurrentUserConnected } from '../../shared/is-current-user-connected';
 import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isUserConnected();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isCurrentUserConnected();
 
 class SeoTitlePanel extends Component {
 	onTitleChange = value => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
@@ -1,11 +1,14 @@
-import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
+import {
+	getJetpackExtensionAvailability,
+	isUserConnected,
+} from '@automattic/jetpack-shared-extension-utils';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { CountedTextArea } from './counted-textarea';
 import { withSeoHelper } from './with-seo-helper';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true;
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && isUserConnected();
 
 class SeoTitlePanel extends Component {
 	onTitleChange = value => {

--- a/projects/plugins/jetpack/extensions/shared/is-current-user-connected.ts
+++ b/projects/plugins/jetpack/extensions/shared/is-current-user-connected.ts
@@ -1,0 +1,23 @@
+/*
+ * External dependencies
+ */
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+
+/**
+ * Whether the current user is connected to WordPress.com.
+ *
+ * Unlike `isUserConnected()` from `@automattic/jetpack-shared-extension-utils`,
+ * this does not treat every Atomic (WoA) user as connected. Atomic has per-user
+ * connections, so a user who has disconnected their own account is correctly
+ * reported as not connected. WordPress.com Simple has no per-user connection, so
+ * it is always true there.
+ *
+ * @return {boolean} Whether the current user is connected to WordPress.com.
+ */
+export function isCurrentUserConnected(): boolean {
+	if ( isSimpleSite() ) {
+		return true;
+	}
+
+	return !! window?.JP_CONNECTION_INITIAL_STATE?.connectionStatus?.isUserConnected;
+}

--- a/projects/plugins/jetpack/extensions/shared/test/is-current-user-connected.test.ts
+++ b/projects/plugins/jetpack/extensions/shared/test/is-current-user-connected.test.ts
@@ -1,0 +1,44 @@
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+import { isCurrentUserConnected } from '../is-current-user-connected';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isSimpleSite: jest.fn(),
+} ) );
+
+type TestWindow = {
+	JP_CONNECTION_INITIAL_STATE?: { connectionStatus?: { isUserConnected?: boolean } };
+};
+
+const testWindow = window as unknown as TestWindow;
+
+describe( 'isCurrentUserConnected', () => {
+	afterEach( () => {
+		delete testWindow.JP_CONNECTION_INITIAL_STATE;
+	} );
+
+	it( 'treats every user as connected on WordPress.com Simple', () => {
+		jest.mocked( isSimpleSite ).mockReturnValue( true );
+
+		expect( isCurrentUserConnected() ).toBe( true );
+	} );
+
+	it( 'reports connected when the per-user connection state says so', () => {
+		jest.mocked( isSimpleSite ).mockReturnValue( false );
+		testWindow.JP_CONNECTION_INITIAL_STATE = { connectionStatus: { isUserConnected: true } };
+
+		expect( isCurrentUserConnected() ).toBe( true );
+	} );
+
+	it( 'reports not connected when the per-user connection state says so', () => {
+		jest.mocked( isSimpleSite ).mockReturnValue( false );
+		testWindow.JP_CONNECTION_INITIAL_STATE = { connectionStatus: { isUserConnected: false } };
+
+		expect( isCurrentUserConnected() ).toBe( false );
+	} );
+
+	it( 'reports not connected when there is no connection state', () => {
+		jest.mocked( isSimpleSite ).mockReturnValue( false );
+
+		expect( isCurrentUserConnected() ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

The editor's AI tools (the "Improve with AI" panel, the SEO enhancer, the AI Assistant block/toolbar, and the excerpt generation) loaded for any administrator whose site offered the feature, including users who hadn't connected their own WordPress.com account — who can't use the tools and only hit errors.

The AI blocks already gated on connection via the shared `isUserConnected()` helper, but that helper treats every Atomic (WoA) user as connected, so nothing was gated on Atomic. This adds a local `isCurrentUserConnected()` helper that reads the real per-user signal (`connectionStatus.isUserConnected`, which is correct on Atomic) and short-circuits only WordPress.com Simple (which has no per-user connection). All the AI editor gates now use it:

* `isCurrentUserConnected()` helper (`extensions/shared/is-current-user-connected.ts`).
* Improve with AI panel — hidden for non-connected users.
* SEO enhancer — enhancer UI, title/description placeholder hints, and image alt-text auto-generation.
* `canAIAssistantBeEnabled()` — the AI Assistant block, toolbar, and the excerpt (Content Lens).
* The AI Assistant block's own connect check.

The shared `isUserConnected()` helper is intentionally left unchanged, so its other (non-AI) consumer, External Media, is unaffected.

Behavior by platform: unchanged on Simple (no per-user connection) and self-hosted/VIP (identical result); on Atomic, a user who has disconnected their own account no longer sees the AI tools.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Use a site connected to WordPress.com by one user, plus a second administrator who has **not** connected their own WordPress.com account. This works on self-hosted Jetpack, VIP, and Atomic (where a second user can disconnect their account).

* As the connected user, open the post editor: the AI panels, blocks, and excerpt AI show, as before.
* As the non-connected user, open the post editor:
  * Before this change: the AI tools appear but error when used.
  * After this change: the "Improve with AI" panel, the SEO AI enhancer, and the AI excerpt generation no longer appear.
* Reconnect the second user, reload, and confirm the AI surfaces return.
* On WordPress.com Simple, confirm no change (all admins keep the AI tools).

New unit test in the `AiAssistantPluginSidebar` suite covers the panel rendering nothing when the user isn't connected.
