### PR TITLE
Cookie Consent: show the banner to everyone when geo is disabled

### DIFF
--- a/projects/packages/cookie-consent/changelog/add-geo-enabled-guard
+++ b/projects/packages/cookie-consent/changelog/add-geo-enabled-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Honor features.geo=false: show the banner to all visitors without a geolocation lookup.

--- a/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
+++ b/projects/packages/cookie-consent/src/modules/cookie-consent/view.ts
@@ -62,6 +62,7 @@ interface StoreConfig {
 	cookiePolicyUrl: string;
 	gdprHonorsGpc: boolean;
 	forcePreview: boolean;
+	geoEnabled?: boolean;
 }
 
 interface GeoApiResponse {
@@ -424,6 +425,14 @@ const { actions } = store( 'jetpack/cookie-consent', {
 
 			// getConfig() is not typed, so we need to assert the type.
 			const config = getConfig() as unknown as StoreConfig;
+
+			// Geo-based rules are disabled: treat every visitor as unknown so the default
+			// (opt-in/show-banner) path applies, without ever calling the geolocation provider.
+			if ( config.geoEnabled === false ) {
+				geoState = { initialized: true, countryCode: UNKNOWN_COUNTRY_CODE, region: '' };
+				return geoState;
+			}
+
 			// PHP (class-cookie-consent.php) always emits a fully-normalized nested `geo`, so the
 			// store config is already the resolved GeoConfig; no client-side reconciliation needed.
 			const geoConfig = config.geo;

--- a/projects/packages/cookie-consent/tests/view.test.ts
+++ b/projects/packages/cookie-consent/tests/view.test.ts
@@ -30,6 +30,7 @@ interface StoreConfig {
 	cookiePolicyUrl: string;
 	gdprHonorsGpc: boolean;
 	forcePreview: boolean;
+	geoEnabled?: boolean;
 }
 
 type Action = ( ...args: unknown[] ) => Generator< unknown, unknown, unknown >;
@@ -163,6 +164,17 @@ describe( 'initializeGeolocation geo-provider error handling', () => {
 		expect( result ).toMatchObject( { initialized: true, countryCode: 'FR', region: 'Brittany' } );
 		expect( cookieWrites.some( write => write.includes( 'country_code=FR' ) ) ).toBe( true );
 		expect( cookieWrites.some( write => write.includes( 'region=Brittany' ) ) ).toBe( true );
+	} );
+} );
+
+describe( 'initializeGeolocation geoEnabled flag', () => {
+	it( 'skips geolocation fetch and treats visitor as unknown when geoEnabled is false', async () => {
+		mockGetConfig.mockReturnValue( { ...makeConfig(), geoEnabled: false } );
+
+		const result = await runAction( storeActions.initializeGeolocation() );
+
+		expect( fetchMock ).not.toHaveBeenCalled();
+		expect( result ).toMatchObject( { initialized: true, countryCode: UNKNOWN_COUNTRY_CODE } );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #

Follow-up to #50114. When a consumer sets `features.geo = false`, the banner should skip geolocation and simply show to everyone. This teaches the banner JS to honor that flag.

**Stacked on #50114** — base is the PR1 branch, so this diff is only the JS change. It will be retargeted to `trunk` after #50114 merges.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* `initializeGeolocation` returns early when `geoEnabled === false`: no geo `fetch`, no `console.warn`. The visitor is treated as `UNKNOWN`, which routes to GDPR opt-in — so the banner is shown to **everyone** (the safe default, never "shown to no one").
* Strict `=== false`: when the flag is absent, the normal geolocation path is untouched.
* Adds an optional `geoEnabled?: boolean` to the store config; test + changelog.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: WOOA7S-1639. Stacked on #50114.

## Does this pull request change what data or activity we track or use?
No new data. The default (`geo` on) is unchanged; when a consumer turns `geo` off, the banner makes **no** geolocation request at all.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
**Unit tests:**
```bash
cd projects/packages/cookie-consent
pnpm test -- view.test.ts   # includes the new geoEnabled:false case
pnpm run typecheck
```

**Manual** — disable geo from a consumer (mu-plugin on a site that has the package):
```php
<?php
use Automattic\Jetpack\CookieConsent\Cookie_Consent;
Cookie_Consent::init( [ 'features' => [ 'geo' => false ] ] );
```
Load any front-end page and confirm: the banner appears for every visitor (regardless of region), and the Network tab shows **no** request to `public-api.wordpress.com/geo/`. Remove the config (or set `geo => true`) and the geo request returns.
