### PR TITLE
Daily Writing Prompt: render a branded fallback instead of a blank widget

### DIFF
--- a/projects/packages/newsletter/changelog/fix-daily-writing-prompt-empty-state
+++ b/projects/packages/newsletter/changelog/fix-daily-writing-prompt-empty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Daily Writing Prompt widget: show a branded fallback with a Reader link when no prompt is available or the request fails, instead of rendering a blank widget.

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.js
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.js
@@ -7,7 +7,13 @@ import {
 	isWpcomPlatformSite,
 } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Link, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
@@ -15,6 +21,7 @@ import { addQueryArgs } from '@wordpress/url';
 export default () => {
 	const [ prompts, setPrompts ] = useState( [] );
 	const [ index, setIndex ] = useState( 0 );
+	const [ loaded, setLoaded ] = useState( false );
 
 	// Get site type for analytics.
 	const siteType = useMemo( () => getSiteType(), [] );
@@ -38,7 +45,10 @@ export default () => {
 			order: 'desc',
 			force_year: new Date().getFullYear(),
 		} );
-		apiFetch( { path } ).then( setPrompts );
+		apiFetch( { path } )
+			.then( data => setPrompts( Array.isArray( data ) ? data : [] ) )
+			.catch( () => {} )
+			.finally( () => setLoaded( true ) );
 	}, [] );
 
 	const goToPrevious = useCallback( () => setIndex( current => current - 1 ), [] );
@@ -62,10 +72,15 @@ export default () => {
 		} );
 	}, [ siteType ] );
 
-	if ( prompts.length === 0 ) {
+	// Render nothing while the prompts are still loading so the widget stays
+	// empty until we know whether we have a prompt to show. Once the fetch has
+	// settled we always render the branding footer, even when no prompt came
+	// back, so the widget never collapses to a blank box.
+	if ( ! loaded ) {
 		return null;
 	}
 
+	const hasPrompt = prompts.length > 0;
 	const prompt = prompts[ index ];
 
 	const blogId = getSiteData()?.wpcom?.blog_id;
@@ -77,72 +92,102 @@ export default () => {
 
 	return (
 		<Stack direction="column" gap="md">
-			<Stack className="wpcom-daily-writing-prompt--prompt" direction="column" gap="md">
-				<Text variant="body-md" render={ <p /> }>
-					{ prompt.text }
-				</Text>
-				<Stack direction="row" justify="flex-end">
-					<Button variant="minimal" size="small" onClick={ goToPrevious } disabled={ index === 0 }>
-						{ __( '← Previous', 'jetpack-newsletter' ) }
-					</Button>
-					<Button
-						variant="minimal"
-						size="small"
-						onClick={ goToNext }
-						disabled={ index === prompts.length - 1 }
-					>
-						{ __( 'Next →', 'jetpack-newsletter' ) }
-					</Button>
-				</Stack>
-			</Stack>
-			<Stack direction="row" justify="space-between" align="center" gap="sm" wrap="wrap">
-				{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
-				<Button variant="outline" size="compact" onClick={ postAnswer }>
-					{ __( 'Post Answer', 'jetpack-newsletter' ) }
-				</Button>
-				{ prompt.answered_users_sample.length > 0 && (
-					<Stack
-						className="wpcom-daily-writing-prompt--answered-users"
-						direction="row"
-						align="center"
-						gap="xs"
-					>
-						{ prompt.answered_users_count > 0 && (
+			{ hasPrompt ? (
+				<>
+					<Stack className="wpcom-daily-writing-prompt--prompt" direction="column" gap="md">
+						<Text variant="body-md" render={ <p /> }>
+							{ prompt.text }
+						</Text>
+						<Stack direction="row" justify="flex-end">
 							<Button
-								variant="outline"
-								size="compact"
-								tone="neutral"
-								nativeButton={ false }
-								onClick={ recordViewResponsesClick }
-								render={
-									<a
-										href={ new URL( prompt.answered_link ).toString() }
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								}
+								variant="minimal"
+								size="small"
+								onClick={ goToPrevious }
+								disabled={ index === 0 }
 							>
-								{ __( 'View responses', 'jetpack-newsletter' ) }
+								{ __( '← Previous', 'jetpack-newsletter' ) }
 							</Button>
-						) }
-						<span>
-							{ prompt.answered_users_sample.map( sample => {
-								return (
-									<img
-										alt={ __( 'User avatar', 'jetpack-newsletter' ) }
-										src={ addQueryArgs( sample.avatar, {
-											s: 22 * 2,
-										} ) }
-										width={ 22 }
-										height={ 22 }
-										key={ sample.avatar }
-									/>
-								);
-							} ) }
-						</span>
+							<Button
+								variant="minimal"
+								size="small"
+								onClick={ goToNext }
+								disabled={ index === prompts.length - 1 }
+							>
+								{ __( 'Next →', 'jetpack-newsletter' ) }
+							</Button>
+						</Stack>
 					</Stack>
-				) }
-			</Stack>
+					<Stack direction="row" justify="space-between" align="center" gap="sm" wrap="wrap">
+						{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
+						<Button variant="outline" size="compact" onClick={ postAnswer }>
+							{ __( 'Post Answer', 'jetpack-newsletter' ) }
+						</Button>
+						{ prompt.answered_users_sample.length > 0 && (
+							<Stack
+								className="wpcom-daily-writing-prompt--answered-users"
+								direction="row"
+								align="center"
+								gap="xs"
+							>
+								{ prompt.answered_users_count > 0 && (
+									<Button
+										variant="outline"
+										size="compact"
+										tone="neutral"
+										nativeButton={ false }
+										onClick={ recordViewResponsesClick }
+										render={
+											<a
+												href={ new URL( prompt.answered_link ).toString() }
+												target="_blank"
+												rel="noreferrer noopener"
+											/>
+										}
+									>
+										{ __( 'View responses', 'jetpack-newsletter' ) }
+									</Button>
+								) }
+								<span>
+									{ prompt.answered_users_sample.map( sample => {
+										return (
+											<img
+												alt={ __( 'User avatar', 'jetpack-newsletter' ) }
+												src={ addQueryArgs( sample.avatar, {
+													s: 22 * 2,
+												} ) }
+												width={ 22 }
+												height={ 22 }
+												key={ sample.avatar }
+											/>
+										);
+									} ) }
+								</span>
+							</Stack>
+						) }
+					</Stack>
+				</>
+			) : (
+				<Text variant="body-md" render={ <p /> }>
+					{ createInterpolateElement(
+						/* translators: the text inside the <a></a> tags is a link to the WordPress.com Reader. */
+						__(
+							'No writing prompt to show right now. Find more in <a>the Reader</a>.',
+							'jetpack-newsletter'
+						),
+						{
+							a: (
+								<Link
+									tone="neutral"
+									href={ readerUrl }
+									openInNewTab={ openReaderInNewTab }
+									rel={ openReaderInNewTab ? 'noreferrer noopener' : undefined }
+									onClick={ recordReaderClick }
+								/>
+							),
+						}
+					) }
+				</Text>
+			) }
 			<Stack
 				className="wpcom-daily-writing-prompt--branding"
 				direction="row"

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -2,10 +2,13 @@
  * The Daily Writing Prompt widget ships from this package to Simple, Atomic,
  * and self-hosted Jetpack sites alike, so its Jetpack branding has to live in
  * the React component (the one surface shared across every environment). These
- * tests pin that branding contract: once prompts have loaded the widget renders
- * the Jetpack logo so customers can tell which plugin added the widget, and
- * before any prompt loads the widget renders nothing at all so the logo never
- * shows on an empty widget.
+ * tests pin that branding contract. While prompts are still loading the widget
+ * renders nothing at all, so the logo never flashes on a not-yet-populated
+ * widget. Once the fetch has settled the widget always renders the branding
+ * footer (Jetpack logo + Reader link) so customers can tell which plugin added
+ * the widget: when a prompt came back it renders the prompt, and when none did
+ * (an empty response or a failed request) it renders a short fallback message
+ * plus the footer instead of collapsing to a blank box.
  */
 
 const mockApiFetch = jest.fn();
@@ -67,13 +70,65 @@ describe( 'WritingPrompt widget branding', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
-	it( 'renders nothing (and so no logo) before any prompt loads', () => {
+	it( 'renders nothing (and so no logo) while prompts are still loading', () => {
 		mockApiFetch.mockReturnValue( new Promise( () => {} ) );
 
 		const { container } = render( <WritingPrompt /> );
 
 		expect( container ).toBeEmptyDOMElement();
 		expect( screen.queryByRole( 'img', { name: 'Jetpack Logo' } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'WritingPrompt widget empty state', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockGetSiteData.mockReset();
+		mockIsWpcomPlatformSite.mockReset();
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 12345 } } );
+		mockIsWpcomPlatformSite.mockReturnValue( true );
+	} );
+
+	it( 'renders the fallback message and branded footer when no prompt comes back', async () => {
+		mockApiFetch.mockResolvedValue( [] );
+
+		render( <WritingPrompt /> );
+
+		// The fallback view still carries the Jetpack branding and Reader links so the
+		// widget stays useful instead of collapsing to a blank box.
+		// The message links "the Reader" inline to the WordPress.com Reader...
+		const inlineReaderLink = await screen.findByRole( 'link', { name: 'the Reader' } );
+		expect( inlineReaderLink ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/reader?origin_site_id=12345'
+		);
+		expect( screen.getByText( /No writing prompt to show right now/ ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'img', { name: 'Jetpack Logo' } ) ).toBeInTheDocument();
+		// ...and the always-on footer Reader link is still present alongside it.
+		expect(
+			screen.getByRole( 'link', { name: /Read the blogs and topics you follow/ } )
+		).toHaveAttribute( 'href', 'https://wordpress.com/reader?origin_site_id=12345' );
+
+		// None of the prompt-only controls should render without a prompt.
+		expect( screen.queryByRole( 'button', { name: 'Post Answer' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Next/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the fallback view when the prompts request fails', async () => {
+		mockApiFetch.mockRejectedValue( new Error( 'network error' ) );
+
+		render( <WritingPrompt /> );
+
+		// A rejected request must degrade to the same fallback view rather than
+		// leaving the widget stuck on its empty loading state.
+		await expect(
+			screen.findByRole( 'link', { name: 'the Reader' } )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( /No writing prompt to show right now/ ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'img', { name: 'Jetpack Logo' } ) ).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: /Read the blogs and topics you follow/ } )
+		).toBeInTheDocument();
 	} );
 } );
 


### PR DESCRIPTION
Fixes NL-723

## Proposed changes

In some scenarios the Daily Writing Prompt dashboard widget rendered an empty box under its title bar. The widget's container is printed by PHP, but its body is filled client-side by the React component, which returned `null` whenever `prompts` was empty. A still-loading fetch, a failed request, and a genuinely empty API response all shared that empty array — so any of them left the widget as a blank box.

* Track load completion separately (`loaded`) so the component can tell "still loading" from "loaded with no prompt".
* Keep rendering nothing while the fetch is in flight, so the Jetpack logo never flashes on a not-yet-populated widget.
* Once the fetch settles, always render the branding footer. When a prompt came back, show it; when none did (empty response or failed request), show a short fallback message that links "the Reader" inline — reusing the footer's Reader URL, new-tab, and analytics behaviour.
* Add a `.catch` so a rejected request degrades to the same fallback view instead of leaving the widget stuck empty.

<img width="458" height="153" alt="Screenshot 2026-07-01 at 14 20 59" src="https://github.com/user-attachments/assets/0ac84279-8270-4176-ae45-d53f941c859b" />


## Related product discussion/links

* NL-723

## Does this pull request change what data or activity we track or use?

No. The fallback's "the Reader" link reuses the existing `jetpack_newsletter_writing_prompt_reader_click` Tracks event that the footer link already fired; no new tracking is added.

## Testing instructions

The empty state is only reachable when the blogging-prompts API returns nothing or fails, so you need to force it:

* On a connected site, open **wp-admin → Dashboard**. With prompts available, the widget renders as before (confirms the refactor didn't regress the happy path).
* Open DevTools → **Network**, block or override `**/wpcom/v3/blogging-prompts*` so it returns `[]` (or fails the request), then reload the dashboard.
* The widget should now show **"No writing prompt to show right now. Find more in the Reader."** — with "the Reader" as a link — plus the Jetpack logo and the footer Reader link, instead of a blank box.
* While the request is still in flight (before the override resolves), the widget stays empty — no message flash.
