### PR TITLE
VideoPress: remove postcss-custom-properties and unused Calypso color scheme dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5019,9 +5019,6 @@ importers:
         specifier: 4.2.3
         version: 4.2.3
     devDependencies:
-      '@automattic/calypso-color-schemes':
-        specifier: 4.0.0
-        version: 4.0.0
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
@@ -5040,9 +5037,6 @@ importers:
       '@babel/core':
         specifier: 7.29.7
         version: 7.29.7
-      '@csstools/postcss-global-data':
-        specifier: 4.0.0
-        version: 4.0.0(postcss@8.5.14)
       '@jest/globals':
         specifier: 30.4.1
         version: 30.4.1
@@ -5100,9 +5094,6 @@ importers:
       postcss:
         specifier: 8.5.14
         version: 8.5.14
-      postcss-custom-properties:
-        specifier: 12.1.11
-        version: 12.1.11(postcss@8.5.14)
       postcss-loader:
         specifier: 8.2.0
         version: 8.2.0(postcss@8.5.14)(typescript@5.9.3)(webpack@5.107.2)

--- a/projects/packages/videopress/changelog/remove-calypso-color-schemes
+++ b/projects/packages/videopress/changelog/remove-calypso-color-schemes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Drop unused calypso-color-schemes PostCSS global data and dependency.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -73,14 +73,12 @@
 		"tus-js-client": "4.2.3"
 	},
 	"devDependencies": {
-		"@automattic/calypso-color-schemes": "4.0.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@babel/core": "7.29.7",
-		"@csstools/postcss-global-data": "4.0.0",
 		"@jest/globals": "30.4.1",
 		"@storybook/addon-docs": "10.4.6",
 		"@storybook/react": "10.4.6",
@@ -100,7 +98,6 @@
 		"copy-webpack-plugin": "14.0.0",
 		"jest": "30.4.2",
 		"postcss": "8.5.14",
-		"postcss-custom-properties": "12.1.11",
 		"postcss-loader": "8.2.0",
 		"require-from-string": "2.0.2",
 		"sass-embedded": "1.97.3",

--- a/projects/packages/videopress/postcss.config.js
+++ b/projects/packages/videopress/postcss.config.js
@@ -1,21 +1,3 @@
 module.exports = () => ( {
-	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
-		require( 'autoprefixer' ),
-	],
+	plugins: [ require( 'autoprefixer' ) ],
 } );


### PR DESCRIPTION
Split out from the bigger WPDS fallback mechanism PR https://github.com/Automattic/jetpack/pull/50108 to simplify it.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove `@automattic/calypso-color-schemes` from VideoPress: there were no Calypso `--color-*` tokens used anyway in VideoPress styles.
* Remove `postcss-custom-properties` with `preselve: false` setting — this was used to inline Calypso color token values directly in bundles (`color: var( --color-foo )` would translate to `color: #000`) to provide better browser support at the time when `var` wasn't as widely supported; see https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168). For WPDS style tokens we intentionally want to have `var()` preserved; that's how the design system works, and fallback value is there just for backwards/odd case when variable isn't available. That way e.g. color scheme changes apply across components.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Smoke test videopress; no visual changes.

<img width="1437" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9f5b7ca-b492-4116-99e9-25c1a95ab4bb" />
<img width="1671" height="1179" alt="image" src="https://github.com/user-attachments/assets/b6cf2154-a1ea-4bde-a4d9-eaafee3ddb28" />
<img width="1670" height="1180" alt="image" src="https://github.com/user-attachments/assets/3d78a33d-3a44-4e4e-806b-996de1d6e444" />
