### PR TITLE
Premium Analytics: update Stats widget porting guidelines

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -499,6 +499,10 @@ behavior across Stats widgets.
 - Top-level body header: for `full-bleed` widgets, render any required title/body controls inside
   the widget body because the host title is hidden. For framed widgets, avoid repeating the host
   title inside the body unless design explicitly calls for a separate body heading.
+- Body header icon: when a Stats widget renders its own body title, include the widget icon before
+  the title and source it from that widget's `widgetDefinition.icon`. For drill-down widgets, use
+  the same title helper for the top-level title and the breadcrumb root title so the icon/title
+  presentation stays consistent before and after drill-down.
 - Header controls: `SelectControl` in widget headers should use `__next40pxDefaultSize` and
   `__nextHasNoMarginBottom`, with the visible label hidden from sighted users when the header
   context already names the control.

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -442,7 +442,10 @@ widget content so padding and sizing stay consistent. If the current widget stat
 body chrome such as a breadcrumb, dropdown, or view selector, keep that chrome available and
 replace only the content area with the state message. Full-bleed widgets do not get a visible
 host card title in the product dashboard, so if the widget needs a title-like body header it must
-render that header itself and keep it visible across these states. Composite widgets may use a
+render that header itself and keep it visible across these states. Define full-bleed Stats widget
+body headers before early returns, and render them for loading, empty, error, and populated states;
+do not return a bare loading overlay or placeholder that drops the widget title, breadcrumb, or
+header controls. Composite widgets may use a
 custom placeholder instead of `LeaderboardChart`'s `emptyStateText`, but the state should still be
 centered inside the content area.
 

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -146,6 +146,9 @@ Notes:
 
 - `name` in both `widget.json` and `widget.ts` MUST use the `jpa/` prefix
   (e.g. `jpa/<widget-name>`).
+- Stats chart and leaderboard widgets should use `"presentation": "full-bleed"` in
+  `widget.json`. Use a framed widget only when product/design specifically asks for a
+  contained card surface.
 - Keep `render.tsx` thin: compose toolkit primitives (`WidgetRoot`,
   `OrderMetricWidget`, etc.) rather than reimplementing data fetching, chart wiring, or
   theming.
@@ -224,7 +227,10 @@ not be merged.
 ### Story template
 
 Every widget ships three stories: a **Default** close-up, a **WithComparison** close-up, and a
-**WidgetDashboardWithWidget** story that mounts the real dashboard. This template is
+**WidgetDashboardWithWidget** story that mounts the real dashboard. Treat these as the canonical
+review surface: prefer Storybook controls for widget-specific selectors instead of adding a
+separate story per selector value. Add an extra story only when the state cannot be reached through
+controls and needs direct review. This template is
 self-contained — copy it as the base rather than an existing widget's story file, which may
 have drifted. `meta.component` is the widget's render component; widget-specific args
 (comparison toggles, view selectors, …) are wired as Storybook controls.
@@ -322,6 +328,8 @@ export const WithComparison: Story = {
 
 **3. `WidgetDashboardWithWidget`** — mounts the real `WidgetDashboard` so the widget renders
 exactly as it does in product, inheriting the size / edit-mode / host-environment controls:
+default `withComparison` to `true` so this story exercises dashboard comparison plumbing and
+graceful fallback behavior.
 
 ```tsx
 interface MyWidgetDashboardStoryProps
@@ -403,6 +411,10 @@ before writing any Stats widget — many mistakes here are silent at build time.
 `useStatsSearchTerms`, `useStatsLocations`, `useStatsDevices`, …). Look there first —
 do not call `fetchStatsProxy` or `apiFetch` directly from a widget.
 
+If a port needs data-layer processing, fixtures, or proxy behavior that is broader than the
+widget UI itself, prefer a small prep PR before the widget PR. This keeps review focused and
+makes it clearer whether a discussion is about endpoint correctness or widget presentation.
+
 Each hook returns `{ primary, comparison, isLoading, isError, … }`. For the standard
 leaderboard/list widgets, reach data through:
 
@@ -432,6 +444,11 @@ the content area with the state message. Composite widgets may use a custom plac
 of `LeaderboardChart`'s `emptyStateText`, but the state should still be centered inside the
 content area.
 
+Known unsupported endpoint states should use product-specific copy rather than the generic
+"Could not load" fallback (for example unsupported Jetpack-site responses). Map the relevant
+status code or normalized error code in the widget/view helper, and render that message through
+the same content wrapper as every other state.
+
 **Comparison data**
 
 Stats hooks built on `useStatsReport()` return `{ primary, comparison, hasComparison, ... }`.
@@ -452,18 +469,27 @@ render a visible delta/sparkline from placeholder values.
 
 **Drill-down leaderboards**
 
-Rows with children may be interactive and drill into a second-level leaderboard. Rows without
-children must not look like drill-down rows. If a row has an external `href` and no children,
-render it as a normal external link even when sibling rows drill down.
+Rows with children may be interactive and drill into a second-level leaderboard; render those
+rows as button-like drill-down actions, not as external links. Rows without children must not
+look like drill-down rows. If a row has an external `href` and no children, render it as a normal
+external link even when sibling rows drill down.
 
 When a leaderboard drills down, use a breadcrumb in the widget body header to navigate back to
 the parent list. The child list should show child labels only; do not repeat the selected parent
 label in every row if the breadcrumb already identifies that parent. Header controls such as
 dropdowns should wrap cleanly on narrow widget widths instead of colliding with the breadcrumb.
+Keep drill-down state local to the widget until a shared toolkit primitive exists, but match this
+behavior across Stats widgets.
 
 **Visual conventions**
 
 - Widget title: `<Text variant="heading-md" render={ <h3 /> }>`
+- Dashboard render: avoid duplicating the dashboard-provided widget title. If the close-up
+  component can show its own title, pass `showTitle={ false }` from dashboard stories and
+  dashboard render paths.
+- Header controls: `SelectControl` in widget headers should use `__next40pxDefaultSize` and
+  `__nextHasNoMarginBottom`, with the visible label hidden from sighted users when the header
+  context already names the control.
 - View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`
 - Leaderboard row height: custom labels should produce a stable 36px row height. For the common
   `<Text>` label case, `padding: var(--wpds-dimension-padding-sm)` is enough when the text
@@ -472,6 +498,9 @@ dropdowns should wrap cleanly on narrow widget widths instead of colliding with 
 - Empty state: pass `emptyStateText` to `LeaderboardChart` — do not add a separate
   `data.length === 0` render branch in the widget, unless the widget has a composite layout
   that needs to preserve body chrome or replace a non-leaderboard chart area.
+- Default dashboard: when the ported module is expected in the Premium Analytics default
+  dashboard, add its widget type to the default layout seed and update the matching test in the
+  same PR. Otherwise call out why it is picker-only or gated.
 - Widget picker preview: add this to the CSS Module so the preview tile renders at a
   sensible aspect ratio instead of collapsing:
 

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -426,6 +426,12 @@ const items  = report?.data?.[ 0 ]?.items ?? [];
 Date-range conversion (`from`/`to` → `period`/`end_date`/`days`) is handled inside
 the query factory — do not do it in the widget or the view hook.
 
+Display labels should be keyed by the endpoint dimension, not only by the raw key. If the
+same raw key can mean different things for different dimensions (for example `chrome` as a
+browser versus `chrome` as an operating system/platform), keep separate label maps and choose
+the correct one from the active dimension before calling `formatDisplayLabel()`. Map values
+should be translated with `__()`; use the formatter's fallback only for unknown raw keys.
+
 **`max` semantics**
 
 `max = 0` means "all rows". Use `slice( 0, max > 0 ? max : undefined )`, never
@@ -489,9 +495,10 @@ behavior across Stats widgets.
 **Visual conventions**
 
 - Widget title: `<Text variant="heading-md" render={ <h3 /> }>`
-- Dashboard render: avoid duplicating the dashboard-provided widget title. If the close-up
-  component can show its own title, pass `showTitle={ false }` from dashboard stories and
-  dashboard render paths.
+- Body title visibility: full-bleed widgets should render the same body header in close-up
+  stories, the dashboard story, the product dashboard, and loading/empty/error/drill-down
+  states. Avoid ad hoc `showTitle` toggles; if a title looks duplicated, fix the widget's
+  `presentation` metadata or Storybook wrapper instead of hiding the body header in one context.
 - Storybook dashboard metadata: pass the same `presentation` used by `widget.json` into the
   `WidgetDashboardWithWidget` story helper. This is especially important for `full-bleed`
   widgets because the product host hides its card title; if Storybook omits `presentation`, it

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -438,11 +438,12 @@ Show `<WidgetLoadingOverlay />` only when there is no data yet:
 to the chart component so an in-place spinner appears without hiding the rows.
 
 Loading, empty, and error states should live in the same body/content wrapper as the normal
-widget content so padding and sizing stay consistent. If the widget has interactive body chrome
-such as a breadcrumb, dropdown, or view selector, keep that chrome available and replace only
-the content area with the state message. Composite widgets may use a custom placeholder instead
-of `LeaderboardChart`'s `emptyStateText`, but the state should still be centered inside the
-content area.
+widget content so padding and sizing stay consistent. If the current widget state has interactive
+body chrome such as a breadcrumb, dropdown, or view selector, keep that chrome available and
+replace only the content area with the state message. Do not add a static widget title to the
+body just to balance a top-level header layout; the dashboard/widget chrome owns the widget
+title. Composite widgets may use a custom placeholder instead of `LeaderboardChart`'s
+`emptyStateText`, but the state should still be centered inside the content area.
 
 Known unsupported endpoint states should use product-specific copy rather than the generic
 "Could not load" fallback (for example unsupported Jetpack-site responses). Map the relevant
@@ -487,6 +488,9 @@ behavior across Stats widgets.
 - Dashboard render: avoid duplicating the dashboard-provided widget title. If the close-up
   component can show its own title, pass `showTitle={ false }` from dashboard stories and
   dashboard render paths.
+- Top-level body header: do not repeat the widget title inside the body when the dashboard
+  already renders it. Body headers are for body-level controls or drill-down breadcrumbs, not
+  duplicate titles.
 - Header controls: `SelectControl` in widget headers should use `__next40pxDefaultSize` and
   `__nextHasNoMarginBottom`, with the visible label hidden from sighted users when the header
   context already names the control.

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -440,10 +440,11 @@ to the chart component so an in-place spinner appears without hiding the rows.
 Loading, empty, and error states should live in the same body/content wrapper as the normal
 widget content so padding and sizing stay consistent. If the current widget state has interactive
 body chrome such as a breadcrumb, dropdown, or view selector, keep that chrome available and
-replace only the content area with the state message. Do not add a static widget title to the
-body just to balance a top-level header layout; the dashboard/widget chrome owns the widget
-title. Composite widgets may use a custom placeholder instead of `LeaderboardChart`'s
-`emptyStateText`, but the state should still be centered inside the content area.
+replace only the content area with the state message. Full-bleed widgets do not get a visible
+host card title in the product dashboard, so if the widget needs a title-like body header it must
+render that header itself and keep it visible across these states. Composite widgets may use a
+custom placeholder instead of `LeaderboardChart`'s `emptyStateText`, but the state should still be
+centered inside the content area.
 
 Known unsupported endpoint states should use product-specific copy rather than the generic
 "Could not load" fallback (for example unsupported Jetpack-site responses). Map the relevant
@@ -488,9 +489,13 @@ behavior across Stats widgets.
 - Dashboard render: avoid duplicating the dashboard-provided widget title. If the close-up
   component can show its own title, pass `showTitle={ false }` from dashboard stories and
   dashboard render paths.
-- Top-level body header: do not repeat the widget title inside the body when the dashboard
-  already renders it. Body headers are for body-level controls or drill-down breadcrumbs, not
-  duplicate titles.
+- Storybook dashboard metadata: pass the same `presentation` used by `widget.json` into the
+  `WidgetDashboardWithWidget` story helper. This is especially important for `full-bleed`
+  widgets because the product host hides its card title; if Storybook omits `presentation`, it
+  may show a fake host title and make a correct body header look duplicated.
+- Top-level body header: for `full-bleed` widgets, render any required title/body controls inside
+  the widget body because the host title is hidden. For framed widgets, avoid repeating the host
+  title inside the body unless design explicitly calls for a separate body heading.
 - Header controls: `SelectControl` in widget headers should use `__next40pxDefaultSize` and
   `__nextHasNoMarginBottom`, with the visible label hidden from sighted users when the header
   context already names the control.

--- a/projects/packages/premium-analytics/changelog/update-widget-porting-guideline
+++ b/projects/packages/premium-analytics/changelog/update-widget-porting-guideline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats widgets: Update porting guidelines.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Update the Premium Analytics Stats widget porting guidelines based on recent widget ports.
* Document expectations for full-bleed presentation, canonical Storybook stories, dashboard comparison coverage, state wrappers, unsupported error copy, drill-down behavior, header controls, default dashboard registration, and data-layer prep PR scope.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Review `projects/packages/premium-analytics/AGENTS.md` and confirm the guidance matches the current Stats widget porting conventions.
* Confirm the changelog entry is present.
