### PR TITLE
Performance: -v2 CodeVitals metric key for validation run

### DIFF
--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -29,7 +29,7 @@ The test suite is designed to run in TeamCity. See `TEAMCITY-SETUP.md` for detai
 
 ## Metric
 
-- `wp-admin-dashboard-connection-sim-largestContentfulPaint` - Dashboard LCP with simulated Jetpack connection
+- `wp-admin-dashboard-connection-sim-largestContentfulPaint-v2` - Dashboard LCP with simulated Jetpack connection
 
 ## How It Works
 

--- a/tools/performance/scripts/measure-lcp.js
+++ b/tools/performance/scripts/measure-lcp.js
@@ -385,6 +385,10 @@ async function main() {
 		git: {
 			hash: process.env.GIT_COMMIT || 'unknown',
 			branch: process.env.GIT_BRANCH || 'unknown',
+			// Commit time of the code under test (epoch ms), for CodeVitals trend
+			// ordering. Omitted when the runner couldn't determine it (JSON.stringify
+			// drops undefined); the poster then warns and falls back to build time.
+			timestamp: Number( process.env.GIT_COMMIT_TIMESTAMP_MS ) || undefined,
 		},
 	};
 

--- a/tools/performance/scripts/measure-lcp.js
+++ b/tools/performance/scripts/measure-lcp.js
@@ -6,6 +6,7 @@
 import fs from 'fs';
 import path from 'path';
 import { chromium } from 'playwright';
+import { isDirectInvocation, pairedCommitTimestampMs } from './post-to-codevitals.js';
 import { SCENARIOS, getScenarioUrl } from './scenarios.js';
 import { median as calcMedian, mean as calcMean, stdDev as calcStdDev } from './stats.js';
 
@@ -382,14 +383,7 @@ async function main() {
 				: { enabled: false },
 		},
 		measurements,
-		git: {
-			hash: process.env.GIT_COMMIT || 'unknown',
-			branch: process.env.GIT_BRANCH || 'unknown',
-			// Commit time of the code under test (epoch ms), for CodeVitals trend
-			// ordering. Omitted when the runner couldn't determine it (JSON.stringify
-			// drops undefined); the poster then warns and falls back to build time.
-			timestamp: Number( process.env.GIT_COMMIT_TIMESTAMP_MS ) || undefined,
-		},
+		git: resolveResultsGit( process.env ),
 	};
 
 	fs.writeFileSync( outputPath, JSON.stringify( output, null, 2 ) );
@@ -399,9 +393,35 @@ async function main() {
 	process.exit( hasFailures ? 1 : 0 );
 }
 
-main().catch( error => {
-	console.error( 'Fatal error:', error );
-	process.exit( 1 );
-} );
+/**
+ * Build the `git` block written into the results file from the environment.
+ *
+ * The commit time is stamped ONLY when paired with a GIT_COMMIT hash, via the shared
+ * pairedCommitTimestampMs rule (mirrors the runner's resolveCommitTimestampEnv and the
+ * poster's config gate). This is the DOMINANT timestamp channel: the poster PREFERS this
+ * results.git.timestamp over its own env fallback, so a lone/stale inherited
+ * GIT_COMMIT_TIMESTAMP_MS written here would backdate the append-only trend regardless of
+ * the poster-side guard. A lone value is dropped to undefined (JSON.stringify omits it);
+ * the poster then warns and falls back to build time.
+ *
+ * @param {object} env - Environment object (process.env or a test double).
+ * @return {{hash: string, branch: string, timestamp: (number|undefined)}} The results git block.
+ */
+function resolveResultsGit( env ) {
+	return {
+		hash: env.GIT_COMMIT || 'unknown',
+		branch: env.GIT_BRANCH || 'unknown',
+		timestamp: Number( pairedCommitTimestampMs( env ) ) || undefined,
+	};
+}
 
-export { measureLCP };
+// Run only when executed directly (node measure-lcp.js / pnpm measure), not when imported
+// by the unit tests, so importing resolveResultsGit never launches a browser via main().
+if ( isDirectInvocation( import.meta.filename, process.argv[ 1 ] ) ) {
+	main().catch( error => {
+		console.error( 'Fatal error:', error );
+		process.exit( 1 );
+	} );
+}
+
+export { measureLCP, resolveResultsGit };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -253,10 +253,13 @@ function resolvePostTimestamp( results, config ) {
  * targets `config.codeVitalsUrl` (codevitals.run today). Until the read and write
  * backends are reconciled — the FORMS-705 host/metric work — a hash written to
  * codevitals.run may not appear here, so dedup is effectively a no-op until then.
- * That is safe: it can only fail to skip (a possible duplicate), never wrongly skip
- * a commit that was not actually posted. Because that safety rests on an unverified
- * cross-backend coupling, `main()` keeps dedup OPT-IN (off by default) until GATE-1
- * is mechanically resolved — see CODEVITALS_ENABLE_DEDUP.
+ * That "can only fail to skip, never wrongly skip" guarantee holds ONLY while dedup is
+ * off (the default): with no read, no skip can happen. If an operator enables it before
+ * GATE-1, metric 58 is a different, *populated* trunk series (not the codevitals.run
+ * write target), so a coincidental hash match there could WRONGLY skip a real post on
+ * the append-only, no-rollback store. So `main()` keeps dedup OPT-IN (off by default)
+ * until GATE-1 mechanically proves the read series IS the write series — see
+ * CODEVITALS_ENABLE_DEDUP. Do not enable it before then.
  *
  * @param {string} hash   - Monorepo commit hash about to be posted.
  * @param {string} branch - Branch to scope the evolution query to.
@@ -268,7 +271,7 @@ async function hashAlreadyPosted( hash, branch, config ) {
 		return false; // can't dedup an unknown hash — let it post
 	}
 
-	const TIMEOUT_MS = 15000;
+	const TIMEOUT_MS = config.dedupTimeoutMs ?? 15000;
 	const controller = new AbortController();
 	const timeoutId = setTimeout( () => controller.abort(), TIMEOUT_MS );
 	try {
@@ -299,8 +302,16 @@ async function hashAlreadyPosted( hash, branch, config ) {
 		const body = await response.json();
 		clearTimeout( timeoutId );
 		// The gitaudit API returns { data: [ { hash, measuredAt, ... }, ... ] }.
-		const points = Array.isArray( body?.data ) ? body.data : [];
-		return points.some( point => point?.hash === hash );
+		if ( ! Array.isArray( body?.data ) ) {
+			// Fail open (post proceeds), but warn — every other degraded dedup path warns,
+			// and a silent {data: undefined} would make API/schema drift look like a valid
+			// empty series ("dedup never skips") with no signal at go-live.
+			console.warn(
+				'⚠ Dedup check skipped: evolution response had no data array (unexpected shape). Proceeding with post.'
+			);
+			return false;
+		}
+		return body.data.some( point => point?.hash === hash );
 	} catch ( error ) {
 		clearTimeout( timeoutId );
 		const reason =
@@ -495,24 +506,35 @@ async function postToCodeVitals( resultsPath, config ) {
 	}
 }
 
+/**
+ * Decide whether cross-commit dedup runs, from CLI args and env. Dedup is OPT-IN (off
+ * by default) until GATE-1 is resolved — see hashAlreadyPosted's NOTE. An explicit
+ * opt-out always wins over an opt-in, so a wrapper that forces `--dedup` can still be
+ * disabled with `--no-dedup` / CODEVITALS_SKIP_DEDUP.
+ *
+ * NOTE: `--dedup`/`--no-dedup` only take effect when post-to-codevitals.js is invoked
+ * directly. The TeamCity runner (run-performance-tests.js) does not forward CLI flags to
+ * this child, so the pipeline must toggle dedup via the CODEVITALS_ENABLE_DEDUP env var.
+ *
+ * @param {string[]} argv - Process argv (or any arg list).
+ * @param {object}   env  - Environment object (process.env or a test double).
+ * @return {boolean} True when dedup should run.
+ */
+function resolveDedupEnabled( argv, env ) {
+	const truthy = value => [ '1', 'true', 'yes' ].includes( ( value || '' ).toLowerCase() );
+	const optedIn = argv.includes( '--dedup' ) || truthy( env.CODEVITALS_ENABLE_DEDUP );
+	const optedOut = argv.includes( '--no-dedup' ) || truthy( env.CODEVITALS_SKIP_DEDUP );
+	return optedIn && ! optedOut;
+}
+
 async function main() {
 	console.log( 'CodeVitals Integration' );
 	console.log( '=====================\n' );
 
 	const dryRun = process.argv.includes( '--dry-run' );
-	const truthy = value => [ '1', 'true', 'yes' ].includes( ( value || '' ).toLowerCase() );
-	// Cross-commit dedup is OPT-IN until GATE-1 is resolved. The dedup read series
-	// (gitaudit metric 58) is not yet proven to be the series the poster writes to
-	// (codevitals.run), so a default-on dedup could in principle wrongly skip a real
-	// post on the append-only, no-rollback store. Enable it explicitly once the read
-	// and write backends are confirmed coupled: `--dedup` or CODEVITALS_ENABLE_DEDUP=1.
-	// An explicit opt-out (`--no-dedup` / CODEVITALS_SKIP_DEDUP) always wins, so a
-	// wrapper that passes --dedup can still be forced off.
-	const dedupEnabled =
-		( process.argv.includes( '--dedup' ) || truthy( process.env.CODEVITALS_ENABLE_DEDUP ) ) &&
-		! process.argv.includes( '--no-dedup' ) &&
-		! truthy( process.env.CODEVITALS_SKIP_DEDUP );
-	const skipDedup = ! dedupEnabled;
+	// Cross-commit dedup is OPT-IN until GATE-1 is resolved — see resolveDedupEnabled
+	// (the argv/env truth table) and hashAlreadyPosted's NOTE for why default-off matters.
+	const skipDedup = ! resolveDedupEnabled( process.argv, process.env );
 
 	// Configuration from environment
 	const config = {
@@ -618,6 +640,7 @@ export {
 	redactToken,
 	resolvePostTimestamp,
 	hashAlreadyPosted,
+	resolveDedupEnabled,
 	ValidationError,
 	VALIDATION_FAILED_EXIT_CODE,
 };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -462,8 +462,21 @@ async function postToCodeVitals( resultsPath, config ) {
 	}
 	url.searchParams.set( 'token', config.codeVitalsToken );
 
-	const TIMEOUT_MS = 30000; // 30 second timeout
+	// Keep ONE abort timer armed across the whole response — fetch() headers AND the
+	// response.text()/response.json() body read — and clear it in a single finally. Clearing
+	// right after fetch (the old shape) left the body read unbounded, so a server that sent
+	// headers then stalled the body could hang past this timeout (undici's ~300s default at
+	// best). With the timer live through the body, controller.abort() makes that read reject
+	// with AbortError → caught → reported as a clean timeout. This mirrors the bounded dedup
+	// read in hashAlreadyPosted. Timeout is configurable (default 30s) so the body-stall
+	// regression tests can use a short bound instead of waiting the full 30s.
+	const TIMEOUT_MS = config.postTimeoutMs ?? 30000;
 	const controller = new AbortController();
+	// The finally below always clears this timer, so it is never left unused by an early
+	// return/throw; the lint rule only fires because the first textual reference now lives in
+	// that finally — which is the whole point of the fix (the timer must stay armed across the
+	// body read, so it cannot be cleared early).
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- cleared in finally
 	const timeoutId = setTimeout( () => controller.abort(), TIMEOUT_MS );
 
 	try {
@@ -475,7 +488,6 @@ async function postToCodeVitals( resultsPath, config ) {
 			body: JSON.stringify( payload ),
 			signal: controller.signal,
 		} );
-		clearTimeout( timeoutId );
 
 		if ( ! response.ok ) {
 			const errorText = await response.text();
@@ -487,6 +499,12 @@ async function postToCodeVitals( resultsPath, config ) {
 		try {
 			data = await response.json();
 		} catch ( jsonError ) {
+			// A stalled OK body aborts as AbortError — let it through so the outer catch
+			// reports the timeout, not a misleading "invalid JSON". A genuinely unparseable
+			// body (any other error) keeps the invalid-JSON message.
+			if ( jsonError.name === 'AbortError' ) {
+				throw jsonError;
+			}
 			throw new Error( `CodeVitals returned invalid JSON: ${ jsonError.message }`, {
 				cause: jsonError,
 			} );
@@ -494,7 +512,6 @@ async function postToCodeVitals( resultsPath, config ) {
 		console.log( '✓ Metrics posted successfully to CodeVitals' );
 		return { posted: true, data, validationFailed };
 	} catch ( error ) {
-		clearTimeout( timeoutId );
 		// Scrub the token from the caught error and its whole cause chain before we
 		// log it or re-use it as `cause`. fetch/undici can echo the token-bearing
 		// URL in a message or stack, so a caller that logs err.cause or
@@ -512,6 +529,8 @@ async function postToCodeVitals( resultsPath, config ) {
 		// failure (no prior validation failure) stays a plain Error (exit 1).
 		const ErrorClass = validationFailed ? ValidationError : Error;
 		throw new ErrorClass( message, { cause: error } );
+	} finally {
+		clearTimeout( timeoutId );
 	}
 }
 

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -538,6 +538,24 @@ function resolveDedupEnabled( argv, env ) {
 	return optedIn && ! optedOut;
 }
 
+/**
+ * The env commit timestamp to trust at this (poster) entrypoint, mirroring the runner's
+ * paired-override rule in resolveCommitTimestampEnv.
+ *
+ * GIT_COMMIT_TIMESTAMP_MS is honored ONLY as a pair with a GIT_COMMIT hash override. A
+ * lone GIT_COMMIT_TIMESTAMP_MS (no GIT_COMMIT) is orphaned: trusting it would stamp the
+ * results-file hash with an unrelated inherited time, so we drop it and let
+ * resolvePostTimestamp fall back to results.git.timestamp (the runner-produced, provenance
+ * -matched value) or build time. The runner always sets GIT_COMMIT before spawning this
+ * child, so its env handoff is unaffected; this only closes the direct `pnpm report` path.
+ *
+ * @param {object} env - Environment object (process.env or a test double).
+ * @return {string|undefined} The paired env timestamp, or undefined when unpaired.
+ */
+function pairedCommitTimestampMs( env ) {
+	return env.GIT_COMMIT ? env.GIT_COMMIT_TIMESTAMP_MS : undefined;
+}
+
 async function main() {
 	console.log( 'CodeVitals Integration' );
 	console.log( '=====================\n' );
@@ -556,8 +574,10 @@ async function main() {
 		gitHash: process.env.GIT_COMMIT,
 		gitBranch: process.env.GIT_BRANCH || 'trunk',
 		// Commit time of the code under test, in epoch ms, supplied by the runner. The
-		// poster prefers results.git.timestamp and only uses this as a fallback.
-		commitTimestampMs: process.env.GIT_COMMIT_TIMESTAMP_MS,
+		// poster prefers results.git.timestamp and only uses this as a fallback. Honored
+		// only when paired with a GIT_COMMIT hash override (see pairedCommitTimestampMs),
+		// so a lone inherited timestamp can't backdate a direct `pnpm report` run.
+		commitTimestampMs: pairedCommitTimestampMs( process.env ),
 		resultsPath:
 			process.env.RESULTS_PATH || path.join( import.meta.dirname, '../results/lcp-results.json' ),
 		dryRun,
@@ -652,6 +672,7 @@ export {
 	resolvePostTimestamp,
 	hashAlreadyPosted,
 	resolveDedupEnabled,
+	pairedCommitTimestampMs,
 	ValidationError,
 	VALIDATION_FAILED_EXIT_CODE,
 };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -254,7 +254,9 @@ function resolvePostTimestamp( results, config ) {
  * backends are reconciled — the FORMS-705 host/metric work — a hash written to
  * codevitals.run may not appear here, so dedup is effectively a no-op until then.
  * That is safe: it can only fail to skip (a possible duplicate), never wrongly skip
- * a commit that was not actually posted.
+ * a commit that was not actually posted. Because that safety rests on an unverified
+ * cross-backend coupling, `main()` keeps dedup OPT-IN (off by default) until GATE-1
+ * is mechanically resolved — see CODEVITALS_ENABLE_DEDUP.
  *
  * @param {string} hash   - Monorepo commit hash about to be posted.
  * @param {string} branch - Branch to scope the evolution query to.
@@ -281,21 +283,28 @@ async function hashAlreadyPosted( hash, branch, config ) {
 			headers: { Accept: 'application/json' },
 			signal: controller.signal,
 		} );
-		clearTimeout( timeoutId );
 		if ( ! response.ok ) {
+			clearTimeout( timeoutId );
 			console.warn(
 				`⚠ Dedup check skipped: evolution endpoint returned HTTP ${ response.status }. Proceeding with post.`
 			);
 			return false;
 		}
+		// Read the body with the abort timer still armed — only clear it once json()
+		// settles. Clearing right after fetch (as the live-POST path does) leaves the
+		// body read unbounded, so a server that sends headers then stalls the body
+		// could hang here (undici's ~300s default at best) and block the post,
+		// violating "a flaky read must never block a post". With the timer live,
+		// controller.abort() makes json() reject with AbortError → caught → fail open.
 		const body = await response.json();
+		clearTimeout( timeoutId );
 		// The gitaudit API returns { data: [ { hash, measuredAt, ... }, ... ] }.
 		const points = Array.isArray( body?.data ) ? body.data : [];
 		return points.some( point => point?.hash === hash );
 	} catch ( error ) {
 		clearTimeout( timeoutId );
 		const reason =
-			error?.name === 'AbortError' ? `timed out after ${ TIMEOUT_MS / 1000 }s` : error.message;
+			error?.name === 'AbortError' ? `timed out after ${ TIMEOUT_MS / 1000 }s` : error?.message;
 		console.warn( `⚠ Dedup check skipped (${ reason }). Proceeding with post.` );
 		return false;
 	}
@@ -396,8 +405,10 @@ async function postToCodeVitals( resultsPath, config ) {
 	// token-free CI smoke test still makes zero network calls). CodeVitals is
 	// append-only, so re-testing a commit (a manual re-run, a TeamCity retryBuild,
 	// or the Scheduler double-triggering) would append a second point for the same
-	// hash. Skip the post if this hash already has metrics. Disable with --no-dedup
-	// / CODEVITALS_SKIP_DEDUP, or by leaving dedupBaseUrl unset (the unit tests do).
+	// hash. Skip the post if this hash already has metrics. This is gated OFF by
+	// default in main() until GATE-1 (read/write backend coupling) is resolved, so it
+	// runs here only when a caller opts in (config.skipDedup false + dedupBaseUrl set);
+	// the unit tests opt in by passing dedupBaseUrl, live runs via CODEVITALS_ENABLE_DEDUP.
 	if ( ! config.skipDedup && config.dedupBaseUrl ) {
 		if ( await hashAlreadyPosted( payload.hash, payload.branch, config ) ) {
 			console.log(
@@ -489,11 +500,19 @@ async function main() {
 	console.log( '=====================\n' );
 
 	const dryRun = process.argv.includes( '--dry-run' );
-	// Opt out of the cross-commit dedup read (e.g. to force a re-post, or if the read
-	// backend is down). Either the flag or a truthy CODEVITALS_SKIP_DEDUP disables it.
-	const skipDedup =
-		process.argv.includes( '--no-dedup' ) ||
-		[ '1', 'true', 'yes' ].includes( ( process.env.CODEVITALS_SKIP_DEDUP || '' ).toLowerCase() );
+	const truthy = value => [ '1', 'true', 'yes' ].includes( ( value || '' ).toLowerCase() );
+	// Cross-commit dedup is OPT-IN until GATE-1 is resolved. The dedup read series
+	// (gitaudit metric 58) is not yet proven to be the series the poster writes to
+	// (codevitals.run), so a default-on dedup could in principle wrongly skip a real
+	// post on the append-only, no-rollback store. Enable it explicitly once the read
+	// and write backends are confirmed coupled: `--dedup` or CODEVITALS_ENABLE_DEDUP=1.
+	// An explicit opt-out (`--no-dedup` / CODEVITALS_SKIP_DEDUP) always wins, so a
+	// wrapper that passes --dedup can still be forced off.
+	const dedupEnabled =
+		( process.argv.includes( '--dedup' ) || truthy( process.env.CODEVITALS_ENABLE_DEDUP ) ) &&
+		! process.argv.includes( '--no-dedup' ) &&
+		! truthy( process.env.CODEVITALS_SKIP_DEDUP );
+	const skipDedup = ! dedupEnabled;
 
 	// Configuration from environment
 	const config = {
@@ -533,7 +552,7 @@ async function main() {
 	console.log(
 		`  Dedup: ${
 			dryRun || config.skipDedup
-				? 'off'
+				? 'off (opt in with CODEVITALS_ENABLE_DEDUP=1 once GATE-1 is resolved)'
 				: `on (metric ${ config.dedupMetricId } @ ${ config.dedupBaseUrl })`
 		}`
 	);

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -305,7 +305,7 @@ async function hashAlreadyPosted( hash, branch, config ) {
 		if ( ! Array.isArray( body?.data ) ) {
 			// Fail open (post proceeds), but warn — every other degraded dedup path warns,
 			// and a silent {data: undefined} would make API/schema drift look like a valid
-			// empty series ("dedup never skips") with no signal at go-live.
+			// empty series ("dedup never skips") with no signal once dedup is enabled.
 			console.warn(
 				'⚠ Dedup check skipped: evolution response had no data array (unexpected shape). Proceeding with post.'
 			);
@@ -521,7 +521,9 @@ async function postToCodeVitals( resultsPath, config ) {
  * @return {boolean} True when dedup should run.
  */
 function resolveDedupEnabled( argv, env ) {
-	const truthy = value => [ '1', 'true', 'yes' ].includes( ( value || '' ).toLowerCase() );
+	// String()-coerce: process.env values are always strings, but this helper is exported,
+	// so a future caller passing a non-string env double must not TypeError on toLowerCase.
+	const truthy = value => [ '1', 'true', 'yes' ].includes( String( value ?? '' ).toLowerCase() );
 	const optedIn = argv.includes( '--dedup' ) || truthy( env.CODEVITALS_ENABLE_DEDUP );
 	const optedOut = argv.includes( '--no-dedup' ) || truthy( env.CODEVITALS_SKIP_DEDUP );
 	return optedIn && ! optedOut;

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -211,21 +211,30 @@ function sanitizeErrorChain( error, token ) {
  * order a backfilled or re-run commit by when CI ran rather than when the code
  * landed, scrambling both the trend graph and the scheduler's catch-up logic.
  * Prefer the commit time carried in the results file, then the runner-provided env
- * value, and only fall back to Date.now() (with a warning) when neither is a sane
- * positive epoch-ms number.
+ * value, and only fall back to Date.now() (with a warning) when neither is a plausible
+ * epoch-ms value — a gross unit error (e.g. epoch seconds, which would post as 1970) is
+ * rejected the same as a non-numeric one.
  *
  * @param {object} results - Parsed results file (may carry git.timestamp in ms).
  * @param {object} config  - Poster config (may carry commitTimestampMs from env).
  * @return {number} Epoch milliseconds to post.
  */
 function resolvePostTimestamp( results, config ) {
+	// A posted timestamp is epoch *milliseconds*. Bound it to a wide plausible window so a
+	// gross unit mistake can't silently corrupt the append-only trend: a 10-digit
+	// epoch-*seconds* value (e.g. 1700000000) is below MIN and would post as 1970, and a
+	// micro/nanosecond value is far above MAX. The window only catches unit errors, never
+	// a normal commit time.
+	const MIN_PLAUSIBLE_MS = 1_000_000_000_000; // ≈ 2001-09-09
+	const MAX_PLAUSIBLE_MS = 4_102_444_800_000; // ≈ 2100-01-01
 	// A numeric string (env vars are always strings) is fine; a non-numeric one
 	// coerces to NaN and is rejected below.
 	for ( const candidate of [ results?.git?.timestamp, config?.commitTimestampMs ] ) {
 		const ms = Number( candidate );
-		// A real commit time is a positive, finite epoch-ms. Reject 0, NaN, negatives,
-		// and empty strings so a malformed field can't poison the trend ordering.
-		if ( Number.isFinite( ms ) && ms > 0 ) {
+		// A real commit time is a finite epoch-ms inside the plausible window. Reject 0,
+		// NaN, negatives, empty strings, and out-of-window unit errors so a malformed
+		// field can't poison the trend ordering.
+		if ( Number.isFinite( ms ) && ms >= MIN_PLAUSIBLE_MS && ms <= MAX_PLAUSIBLE_MS ) {
 			return ms;
 		}
 	}

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -265,15 +265,18 @@ async function hashAlreadyPosted( hash, branch, config ) {
 	if ( ! hash || hash === 'unknown' ) {
 		return false; // can't dedup an unknown hash — let it post
 	}
-	const url =
-		`${ config.dedupBaseUrl }/api/repos/${ config.dedupRepo }` +
-		`/perf/evolution/${ config.dedupMetricId }` +
-		`?branch=${ encodeURIComponent( branch ) }&limit=200`;
 
 	const TIMEOUT_MS = 15000;
 	const controller = new AbortController();
 	const timeoutId = setTimeout( () => controller.abort(), TIMEOUT_MS );
 	try {
+		// Build the URL inside the try so even a pathological branch (a lone surrogate
+		// that makes encodeURIComponent throw) is caught and fails open — the "never
+		// block a post" contract stays total, not just total for the fetch itself.
+		const url =
+			`${ config.dedupBaseUrl }/api/repos/${ config.dedupRepo }` +
+			`/perf/evolution/${ config.dedupMetricId }` +
+			`?branch=${ encodeURIComponent( branch ) }&limit=200`;
 		const response = await fetch( url, {
 			headers: { Accept: 'application/json' },
 			signal: controller.signal,

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -202,6 +202,102 @@ function sanitizeErrorChain( error, token ) {
 	}
 }
 
+/**
+ * Resolve the timestamp to stamp on the CodeVitals point: the time the code under
+ * test was COMMITTED, not when this build happened to run.
+ *
+ * CodeVitals orders a trend by this value, and the Scheduler reads the most recent
+ * point by it to decide "last tested commit". A build-time stamp (Date.now()) would
+ * order a backfilled or re-run commit by when CI ran rather than when the code
+ * landed, scrambling both the trend graph and the scheduler's catch-up logic.
+ * Prefer the commit time carried in the results file, then the runner-provided env
+ * value, and only fall back to Date.now() (with a warning) when neither is a sane
+ * positive epoch-ms number.
+ *
+ * @param {object} results - Parsed results file (may carry git.timestamp in ms).
+ * @param {object} config  - Poster config (may carry commitTimestampMs from env).
+ * @return {number} Epoch milliseconds to post.
+ */
+function resolvePostTimestamp( results, config ) {
+	// A numeric string (env vars are always strings) is fine; a non-numeric one
+	// coerces to NaN and is rejected below.
+	for ( const candidate of [ results?.git?.timestamp, config?.commitTimestampMs ] ) {
+		const ms = Number( candidate );
+		// A real commit time is a positive, finite epoch-ms. Reject 0, NaN, negatives,
+		// and empty strings so a malformed field can't poison the trend ordering.
+		if ( Number.isFinite( ms ) && ms > 0 ) {
+			return ms;
+		}
+	}
+	console.warn(
+		'⚠ No commit timestamp available (results.git.timestamp / GIT_COMMIT_TIMESTAMP_MS); ' +
+			'falling back to the current time, which orders this point by build time, not commit time.'
+	);
+	return Date.now();
+}
+
+/**
+ * Whether a commit hash already has a data point in CodeVitals, so a re-run or
+ * retry doesn't append a duplicate to the append-only trend.
+ *
+ * Reads the same gitaudit repo-scoped evolution endpoint the Scheduler uses to
+ * compute "last tested commit", so dedup and scheduling agree on what counts as
+ * already tested. Needs no token (the read endpoint is unauthenticated, like the
+ * Scheduler's curl).
+ *
+ * Fails OPEN: any read error, timeout, non-OK status, or unexpected body shape
+ * returns false (the post proceeds). Missing a real data point is worse than a rare
+ * duplicate, and a flaky read must never block a legitimate post.
+ *
+ * NOTE (GATE-1): this reads gitaudit (metric `config.dedupMetricId`) while the POST
+ * targets `config.codeVitalsUrl` (codevitals.run today). Until the read and write
+ * backends are reconciled — the FORMS-705 host/metric work — a hash written to
+ * codevitals.run may not appear here, so dedup is effectively a no-op until then.
+ * That is safe: it can only fail to skip (a possible duplicate), never wrongly skip
+ * a commit that was not actually posted.
+ *
+ * @param {string} hash   - Monorepo commit hash about to be posted.
+ * @param {string} branch - Branch to scope the evolution query to.
+ * @param {object} config - Poster config (dedupBaseUrl, dedupRepo, dedupMetricId).
+ * @return {Promise<boolean>} True only on a confirmed existing point for this hash.
+ */
+async function hashAlreadyPosted( hash, branch, config ) {
+	if ( ! hash || hash === 'unknown' ) {
+		return false; // can't dedup an unknown hash — let it post
+	}
+	const url =
+		`${ config.dedupBaseUrl }/api/repos/${ config.dedupRepo }` +
+		`/perf/evolution/${ config.dedupMetricId }` +
+		`?branch=${ encodeURIComponent( branch ) }&limit=200`;
+
+	const TIMEOUT_MS = 15000;
+	const controller = new AbortController();
+	const timeoutId = setTimeout( () => controller.abort(), TIMEOUT_MS );
+	try {
+		const response = await fetch( url, {
+			headers: { Accept: 'application/json' },
+			signal: controller.signal,
+		} );
+		clearTimeout( timeoutId );
+		if ( ! response.ok ) {
+			console.warn(
+				`⚠ Dedup check skipped: evolution endpoint returned HTTP ${ response.status }. Proceeding with post.`
+			);
+			return false;
+		}
+		const body = await response.json();
+		// The gitaudit API returns { data: [ { hash, measuredAt, ... }, ... ] }.
+		const points = Array.isArray( body?.data ) ? body.data : [];
+		return points.some( point => point?.hash === hash );
+	} catch ( error ) {
+		clearTimeout( timeoutId );
+		const reason =
+			error?.name === 'AbortError' ? `timed out after ${ TIMEOUT_MS / 1000 }s` : error.message;
+		console.warn( `⚠ Dedup check skipped (${ reason }). Proceeding with post.` );
+		return false;
+	}
+}
+
 /** Post metrics to CodeVitals. */
 async function postToCodeVitals( resultsPath, config ) {
 	// Everything from here until the live POST is local data-integrity work: a missing
@@ -281,7 +377,8 @@ async function postToCodeVitals( resultsPath, config ) {
 		metrics,
 		baseMetrics: {}, // Empty object - we don't use baseline normalization
 		hash: results.git?.hash || config.gitHash || 'unknown',
-		timestamp: Date.now(),
+		// Commit time of the code under test, not build time — see resolvePostTimestamp.
+		timestamp: resolvePostTimestamp( results, config ),
 		branch: results.git?.branch || config.gitBranch || 'trunk',
 	};
 
@@ -290,6 +387,21 @@ async function postToCodeVitals( resultsPath, config ) {
 		console.log( '— DRY RUN — building payload only, not posting to CodeVitals —' );
 		console.log( JSON.stringify( payload, null, 2 ) );
 		return { posted: false, validationFailed, payload };
+	}
+
+	// Cross-commit dedup (live posts only — kept after the dry-run return so the
+	// token-free CI smoke test still makes zero network calls). CodeVitals is
+	// append-only, so re-testing a commit (a manual re-run, a TeamCity retryBuild,
+	// or the Scheduler double-triggering) would append a second point for the same
+	// hash. Skip the post if this hash already has metrics. Disable with --no-dedup
+	// / CODEVITALS_SKIP_DEDUP, or by leaving dedupBaseUrl unset (the unit tests do).
+	if ( ! config.skipDedup && config.dedupBaseUrl ) {
+		if ( await hashAlreadyPosted( payload.hash, payload.branch, config ) ) {
+			console.log(
+				`✓ Commit ${ payload.hash } already has metrics in CodeVitals (metric ${ config.dedupMetricId }); skipping post.`
+			);
+			return { posted: false, skipped: true, validationFailed, payload };
+		}
 	}
 
 	console.log( 'Posting metrics to CodeVitals...' );
@@ -374,6 +486,11 @@ async function main() {
 	console.log( '=====================\n' );
 
 	const dryRun = process.argv.includes( '--dry-run' );
+	// Opt out of the cross-commit dedup read (e.g. to force a re-post, or if the read
+	// backend is down). Either the flag or a truthy CODEVITALS_SKIP_DEDUP disables it.
+	const skipDedup =
+		process.argv.includes( '--no-dedup' ) ||
+		[ '1', 'true', 'yes' ].includes( ( process.env.CODEVITALS_SKIP_DEDUP || '' ).toLowerCase() );
 
 	// Configuration from environment
 	const config = {
@@ -383,9 +500,19 @@ async function main() {
 		codeVitalsToken: process.env.CODEVITALS_TOKEN,
 		gitHash: process.env.GIT_COMMIT,
 		gitBranch: process.env.GIT_BRANCH || 'trunk',
+		// Commit time of the code under test, in epoch ms, supplied by the runner. The
+		// poster prefers results.git.timestamp and only uses this as a fallback.
+		commitTimestampMs: process.env.GIT_COMMIT_TIMESTAMP_MS,
 		resultsPath:
 			process.env.RESULTS_PATH || path.join( import.meta.dirname, '../results/lcp-results.json' ),
 		dryRun,
+		skipDedup,
+		// Read backend for the dedup check — the same gitaudit endpoint, repo, and
+		// metric the Scheduler reads, so "already tested" means the same thing to both.
+		dedupBaseUrl:
+			process.env.CODEVITALS_DEDUP_URL || 'https://gitaudit-server-production.up.railway.app',
+		dedupRepo: process.env.CODEVITALS_REPO || 'Automattic/jetpack',
+		dedupMetricId: process.env.CODEVITALS_DEDUP_METRIC_ID || '58',
 	};
 
 	// A live post needs a token; a dry run does not, so CI can smoke-test it.
@@ -400,6 +527,13 @@ async function main() {
 	console.log( `  Results Path: ${ config.resultsPath }` );
 	console.log( `  Git Hash: ${ config.gitHash || 'unknown' }` );
 	console.log( `  Git Branch: ${ config.gitBranch }` );
+	console.log(
+		`  Dedup: ${
+			dryRun || config.skipDedup
+				? 'off'
+				: `on (metric ${ config.dedupMetricId } @ ${ config.dedupBaseUrl })`
+		}`
+	);
 	console.log( '' );
 
 	try {
@@ -460,6 +594,8 @@ export {
 	exitCodeForError,
 	isDirectInvocation,
 	redactToken,
+	resolvePostTimestamp,
+	hashAlreadyPosted,
 	ValidationError,
 	VALIDATION_FAILED_EXIT_CODE,
 };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -545,9 +545,10 @@ function resolveDedupEnabled( argv, env ) {
  * GIT_COMMIT_TIMESTAMP_MS is honored ONLY as a pair with a GIT_COMMIT hash override. A
  * lone GIT_COMMIT_TIMESTAMP_MS (no GIT_COMMIT) is orphaned: trusting it would stamp the
  * results-file hash with an unrelated inherited time, so we drop it and let
- * resolvePostTimestamp fall back to results.git.timestamp (the runner-produced, provenance
- * -matched value) or build time. The runner always sets GIT_COMMIT before spawning this
- * child, so its env handoff is unaffected; this only closes the direct `pnpm report` path.
+ * resolvePostTimestamp fall back to results.git.timestamp (itself paired with GIT_COMMIT at
+ * the measure-lcp write site, so it is provenance-matched) or build time. The runner always
+ * sets GIT_COMMIT before spawning this child, so its env handoff is unaffected; this gate
+ * closes the direct `pnpm report` config channel (measure-lcp closes the dominant one).
  *
  * @param {object} env - Environment object (process.env or a test double).
  * @return {string|undefined} The paired env timestamp, or undefined when unpaired.

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -258,17 +258,17 @@ function resolvePostTimestamp( results, config ) {
  * returns false (the post proceeds). Missing a real data point is worse than a rare
  * duplicate, and a flaky read must never block a legitimate post.
  *
- * NOTE (GATE-1): this reads gitaudit (metric `config.dedupMetricId`) while the POST
- * targets `config.codeVitalsUrl` (codevitals.run today). Until the read and write
- * backends are reconciled — the FORMS-705 host/metric work — a hash written to
- * codevitals.run may not appear here, so dedup is effectively a no-op until then.
- * That "can only fail to skip, never wrongly skip" guarantee holds ONLY while dedup is
- * off (the default): with no read, no skip can happen. If an operator enables it before
- * GATE-1, metric 58 is a different, *populated* trunk series (not the codevitals.run
- * write target), so a coincidental hash match there could WRONGLY skip a real post on
- * the append-only, no-rollback store. So `main()` keeps dedup OPT-IN (off by default)
- * until GATE-1 mechanically proves the read series IS the write series — see
- * CODEVITALS_ENABLE_DEDUP. Do not enable it before then.
+ * IMPORTANT: the read and write backends must match before dedup can be trusted. This
+ * reads gitaudit (metric `config.dedupMetricId`) while the POST targets
+ * `config.codeVitalsUrl` (codevitals.run today). Until the two are reconciled (the
+ * FORMS-705 host/metric work), a hash written to codevitals.run may not appear here, so
+ * dedup is effectively a no-op. The "can only fail to skip, never wrongly skip" guarantee
+ * holds ONLY while dedup is off (the default): with no read, no skip can happen. If an
+ * operator enables dedup before the backends match, metric 58 is a different, *populated*
+ * trunk series (not the codevitals.run write target), so a coincidental hash match there
+ * could WRONGLY skip a real post on the append-only, no-rollback store. So `main()` keeps
+ * dedup OPT-IN (off by default) until the read series is proven to be the write series.
+ * See CODEVITALS_ENABLE_DEDUP. Do not enable it before then.
  *
  * @param {string} hash   - Monorepo commit hash about to be posted.
  * @param {string} branch - Branch to scope the evolution query to.
@@ -426,8 +426,9 @@ async function postToCodeVitals( resultsPath, config ) {
 	// append-only, so re-testing a commit (a manual re-run, a TeamCity retryBuild,
 	// or the Scheduler double-triggering) would append a second point for the same
 	// hash. Skip the post if this hash already has metrics. This is gated OFF by
-	// default in main() until GATE-1 (read/write backend coupling) is resolved, so it
-	// runs here only when a caller opts in (config.skipDedup false + dedupBaseUrl set);
+	// default in main() until the dedup read and write backends are reconciled (see the
+	// IMPORTANT note above), so it runs here only when a caller opts in (config.skipDedup
+	// false + dedupBaseUrl set);
 	// the unit tests opt in by passing dedupBaseUrl, live runs via CODEVITALS_ENABLE_DEDUP.
 	if ( ! config.skipDedup && config.dedupBaseUrl ) {
 		if ( await hashAlreadyPosted( payload.hash, payload.branch, config ) ) {
@@ -536,7 +537,8 @@ async function postToCodeVitals( resultsPath, config ) {
 
 /**
  * Decide whether cross-commit dedup runs, from CLI args and env. Dedup is OPT-IN (off
- * by default) until GATE-1 is resolved — see hashAlreadyPosted's NOTE. An explicit
+ * by default) until the dedup read and write backends are reconciled (see
+ * hashAlreadyPosted's note). An explicit
  * opt-out always wins over an opt-in, so a wrapper that forces `--dedup` can still be
  * disabled with `--no-dedup` / CODEVITALS_SKIP_DEDUP.
  *
@@ -581,8 +583,9 @@ async function main() {
 	console.log( '=====================\n' );
 
 	const dryRun = process.argv.includes( '--dry-run' );
-	// Cross-commit dedup is OPT-IN until GATE-1 is resolved — see resolveDedupEnabled
-	// (the argv/env truth table) and hashAlreadyPosted's NOTE for why default-off matters.
+	// Cross-commit dedup is OPT-IN until the dedup read and write backends are reconciled.
+	// See resolveDedupEnabled (the argv/env truth table) and hashAlreadyPosted's note for
+	// why default-off matters.
 	const skipDedup = ! resolveDedupEnabled( process.argv, process.env );
 
 	// Configuration from environment
@@ -625,7 +628,7 @@ async function main() {
 	console.log(
 		`  Dedup: ${
 			dryRun || config.skipDedup
-				? 'off (opt in with CODEVITALS_ENABLE_DEDUP=1 once GATE-1 is resolved)'
+				? 'off (opt in with CODEVITALS_ENABLE_DEDUP=1 once the dedup read and write backends are reconciled)'
 				: `on (metric ${ config.dedupMetricId } @ ${ config.dedupBaseUrl })`
 		}`
 	);

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -902,6 +902,7 @@ function dedupFetchStub( {
 	evolutionHashes = [],
 	evolutionStatus = 200,
 	throwOnEvolution = false,
+	rejectBody = false, // headers arrive OK but json() rejects (stalled/truncated body)
 	evolutionBody, // when set, returned verbatim from the evolution json() (for bad-shape tests)
 } ) {
 	const calls = { evolution: 0, post: 0, evolutionUrl: null };
@@ -915,10 +916,14 @@ function dedupFetchStub( {
 			return {
 				ok: evolutionStatus >= 200 && evolutionStatus < 300,
 				status: evolutionStatus,
-				json: async () =>
-					evolutionBody !== undefined
+				json: async () => {
+					if ( rejectBody ) {
+						throw new Error( 'body read failed' );
+					}
+					return evolutionBody !== undefined
 						? evolutionBody
-						: { data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ) },
+						: { data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ) };
+				},
 				text: async () => '',
 			};
 		}
@@ -980,6 +985,24 @@ test( 'dedup fails open on a non-OK read status', async () => {
 	try {
 		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
 		assert.equal( result.posted, true );
+		assert.equal( calls.post, 1 );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup fails open (still posts) when the response body read fails', async () => {
+	// Headers arrive OK but json() rejects — a truncated/stalled body, or a server that
+	// answers headers then dies. The abort timer stays armed across the body read (so a
+	// real stall is bounded by the 15s abort, not undici's ~300s default), and the
+	// rejection is caught and turned into a fail-open. The post must still happen.
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { rejectBody: true } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, true, 'a failed body read must never block a post' );
 		assert.equal( calls.post, 1 );
 	} finally {
 		global.fetch = origFetch;

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -902,20 +902,23 @@ function dedupFetchStub( {
 	evolutionHashes = [],
 	evolutionStatus = 200,
 	throwOnEvolution = false,
+	evolutionBody, // when set, returned verbatim from the evolution json() (for bad-shape tests)
 } ) {
-	const calls = { evolution: 0, post: 0 };
+	const calls = { evolution: 0, post: 0, evolutionUrl: null };
 	const fetchImpl = async u => {
 		if ( String( u ).includes( '/perf/evolution/' ) ) {
 			calls.evolution++;
+			calls.evolutionUrl = String( u );
 			if ( throwOnEvolution ) {
 				throw new Error( 'network down' );
 			}
 			return {
 				ok: evolutionStatus >= 200 && evolutionStatus < 300,
 				status: evolutionStatus,
-				json: async () => ( {
-					data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ),
-				} ),
+				json: async () =>
+					evolutionBody !== undefined
+						? evolutionBody
+						: { data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ) },
 				text: async () => '',
 			};
 		}
@@ -1016,6 +1019,88 @@ test( 'dedup is skipped (no read) when dedupBaseUrl is unset, as in the other li
 		);
 		assert.equal( calls.evolution, 0 );
 		assert.equal( result.posted, true );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup queries the configured metric / repo / branch (endpoint identity)', async () => {
+	// A wrong metric id, repo, or branch would silently query the wrong series and
+	// never find a real duplicate. Pin the URL the read actually hits.
+	const file = writeResults( 120 ); // git.branch = 'trunk'
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'someoneelse' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		const u = calls.evolutionUrl;
+		assert.ok( u, 'the evolution endpoint should have been queried' );
+		assert.match(
+			u,
+			/^https:\/\/gitaudit\.test\/api\/repos\/Automattic\/jetpack\/perf\/evolution\/58\b/
+		);
+		assert.match( u, /[?&]branch=trunk\b/ );
+		assert.match( u, /[?&]limit=200\b/ );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup is bypassed for an unknown hash (still posts, no read)', async () => {
+	// A results file with hash:'unknown' can't be deduped; it must skip the read and
+	// still post (fail open), matching the pre-existing "post unknown" behaviour.
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-unknownhash-' ) );
+	const file = path.join( dir, 'results.json' );
+	fs.writeFileSync(
+		file,
+		JSON.stringify( {
+			git: { hash: 'unknown', branch: 'trunk' },
+			measurements: { jetpackConnected: { summary: { median: 120 } } },
+		} )
+	);
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'unknown' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( calls.evolution, 0, 'no read for an unknown hash' );
+		assert.equal( result.posted, true );
+	} finally {
+		global.fetch = origFetch;
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+} );
+
+test( 'dedup fails open on an unexpected (non-{data:[]}) read body', async () => {
+	const file = writeResults( 120 );
+	// 200 OK but the body isn't the expected { data: [...] } shape (e.g. an HTML/SPA
+	// response or an API change). Must fail open and post, not throw.
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionBody: { unexpected: 'shape' } } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, true );
+		assert.equal( calls.post, 1 );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'a dry run makes no dedup read even when dedup is fully configured', async () => {
+	// Pins the ordering: the dry-run early return must precede the dedup block, so the
+	// token-free CI smoke test never touches the network even with dedupBaseUrl set.
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'testhash' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () =>
+			postToCodeVitals( file, { ...DEDUP_CONFIG, dryRun: true } )
+		);
+		assert.equal( calls.evolution, 0, 'a dry run must not hit the dedup endpoint' );
+		assert.equal( calls.post, 0 );
+		assert.equal( result.posted, false );
 	} finally {
 		global.fetch = origFetch;
 	}

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -17,6 +17,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { inspect } from 'node:util';
+import { resolveResultsGit } from './measure-lcp.js';
 import {
 	checkSanityRange,
 	exitCodeForError,
@@ -1052,6 +1053,33 @@ test( 'resolveCommitTimestampEnv: paired override honored, lone timestamp droppe
 		resolveCommitTimestampEnv( { committedAtMs: null }, { GIT_COMMIT_TIMESTAMP_MS: '999' } ).value,
 		null,
 		'a lone timestamp is dropped even when there is no HEAD time to fall back to'
+	);
+} );
+
+test( 'resolveResultsGit: the dominant channel pairs the commit time with GIT_COMMIT', () => {
+	// Paired (hash + time): both are written, as a coherent pair.
+	assert.deepEqual(
+		resolveResultsGit( {
+			GIT_COMMIT: 'deadbeef',
+			GIT_BRANCH: 'trunk',
+			GIT_COMMIT_TIMESTAMP_MS: '1600000000000',
+		} ),
+		{ hash: 'deadbeef', branch: 'trunk', timestamp: 1600000000000 }
+	);
+	// Lone GIT_COMMIT_TIMESTAMP_MS (no hash): the stale time is DROPPED so it can't be
+	// written into results.git.timestamp and backdate the trend (the poster prefers this
+	// value over its own guarded env fallback). This is R6-IMPORTANT-1, the dominant channel.
+	assert.deepEqual( resolveResultsGit( { GIT_COMMIT_TIMESTAMP_MS: '1600000000000' } ), {
+		hash: 'unknown',
+		branch: 'unknown',
+		timestamp: undefined,
+	} );
+	// Hash override with no paired time: hash written, time omitted (poster build-time falls back).
+	assert.equal( resolveResultsGit( { GIT_COMMIT: 'deadbeef' } ).timestamp, undefined );
+	// Paired but non-numeric time → dropped, not NaN.
+	assert.equal(
+		resolveResultsGit( { GIT_COMMIT: 'deadbeef', GIT_COMMIT_TIMESTAMP_MS: 'nope' } ).timestamp,
+		undefined
 	);
 } );
 

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -28,7 +28,7 @@ import {
 	resolvePostTimestamp,
 	VALIDATION_FAILED_EXIT_CODE,
 } from './post-to-codevitals.js';
-import { shouldFailBuildOnPostError } from './run-performance-tests.js';
+import { getGitInfo, shouldFailBuildOnPostError } from './run-performance-tests.js';
 import { SANITY_RANGES, SCENARIOS } from './scenarios.js';
 
 const SCRIPTS_DIR = path.dirname( fileURLToPath( import.meta.url ) );
@@ -883,6 +883,99 @@ test( 'a dry-run payload is stamped with the commit time from the results file',
 	}
 } );
 
+// --- commit-time plumbing: getGitInfo reads the producer side (real temp git repo) ---
+
+/**
+ * Make a throwaway git repo with one commit and return its dir. `body` becomes the
+ * commit message body (used to exercise Upstream-Ref parsing). Caller removes the dir.
+ */
+function initTempGitRepo( body = '' ) {
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-git-' ) );
+	const git = args => execFileSync( 'git', args, { cwd: dir, stdio: 'pipe' } );
+	git( [ 'init', '-q', '-b', 'trunk' ] );
+	git( [ 'config', 'user.email', 't@example.com' ] );
+	git( [ 'config', 'user.name', 'Test' ] );
+	git( [ 'config', 'commit.gpgsign', 'false' ] );
+	fs.writeFileSync( path.join( dir, 'file.txt' ), 'x' );
+	git( [ 'add', '-A' ] );
+	git( [ 'commit', '-q', '-m', 'subject', ...( body ? [ '-m', body ] : [] ) ] );
+	return dir;
+}
+
+test( 'getGitInfo: plain commit → hash is mirror HEAD and committedAtMs is %ct × 1000', () => {
+	const savedCommit = process.env.GIT_COMMIT;
+	delete process.env.GIT_COMMIT; // don't let the host env override hash selection
+	const dir = initTempGitRepo();
+	try {
+		const head = execFileSync( 'git', [ 'rev-parse', 'HEAD' ], { cwd: dir, stdio: 'pipe' } )
+			.toString()
+			.trim();
+		const ct = Number(
+			execFileSync( 'git', [ 'show', '-s', '--format=%ct', 'HEAD' ], { cwd: dir, stdio: 'pipe' } )
+				.toString()
+				.trim()
+		);
+		const info = getGitInfo( dir );
+		assert.equal( info.hash, head );
+		assert.equal( info.mirrorHash, head );
+		assert.equal( info.branch, 'trunk' );
+		assert.equal( info.committedAtMs, ct * 1000, 'commit time is epoch seconds × 1000' );
+	} finally {
+		if ( savedCommit === undefined ) {
+			delete process.env.GIT_COMMIT;
+		} else {
+			process.env.GIT_COMMIT = savedCommit;
+		}
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+} );
+
+test( 'getGitInfo: an Upstream-Ref footer wins over the mirror hash (monorepo SHA is posted)', () => {
+	const savedCommit = process.env.GIT_COMMIT;
+	delete process.env.GIT_COMMIT;
+	const upstream = 'a'.repeat( 40 );
+	const dir = initTempGitRepo( `Upstream-Ref: Automattic/jetpack@${ upstream }` );
+	try {
+		const head = execFileSync( 'git', [ 'rev-parse', 'HEAD' ], { cwd: dir, stdio: 'pipe' } )
+			.toString()
+			.trim();
+		const info = getGitInfo( dir );
+		assert.equal( info.hash, upstream, 'hash comes from the Upstream-Ref, not mirror HEAD' );
+		assert.equal( info.mirrorHash, head, 'mirrorHash still tracks the real checkout' );
+		assert.ok( info.committedAtMs > 0 );
+	} finally {
+		if ( savedCommit === undefined ) {
+			delete process.env.GIT_COMMIT;
+		} else {
+			process.env.GIT_COMMIT = savedCommit;
+		}
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+} );
+
+test( 'getGitInfo: a non-git directory degrades to unknown hash and null commit time', () => {
+	const savedCommit = process.env.GIT_COMMIT;
+	delete process.env.GIT_COMMIT;
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-nogit-' ) );
+	try {
+		const info = getGitInfo( dir );
+		assert.equal( info.hash, 'unknown' );
+		assert.equal( info.mirrorHash, 'unknown' );
+		assert.equal(
+			info.committedAtMs,
+			null,
+			'no git metadata → null, so the poster build-time falls back'
+		);
+	} finally {
+		if ( savedCommit === undefined ) {
+			delete process.env.GIT_COMMIT;
+		} else {
+			process.env.GIT_COMMIT = savedCommit;
+		}
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+} );
+
 // --- cross-commit dedup (gitaudit evolution read; fetch stubbed, no network) ---
 
 const DEDUP_CONFIG = {
@@ -1052,14 +1145,16 @@ test( 'dedup fails open (still posts) when the response body read fails', async 
 
 test(
 	'dedup body read stays bounded: a body that hangs until abort still fails open and posts',
-	{ timeout: 5000 },
+	{ timeout: 20000 },
 	async () => {
 		// The regression guard for the round-2 body-read fix: the abort timer must stay
 		// armed across response.json(). The stub's json() never settles on its own — only
 		// the AbortController signal rejects it — so this passes only if the timer is still
 		// live during the body read. dedupTimeoutMs=50 stands in for the 15s production
 		// timer; the per-test timeout turns a reverted fix (timer cleared after headers,
-		// abort never fires, json() hangs) into a clean failure instead of a hang.
+		// abort never fires, json() hangs) into a clean failure instead of a hang. The
+		// budget is deliberately wide (~400x the 50ms abort) so a cold `node --test`
+		// warmup can't false-fail correct code; only a genuine hang reaches 20s.
 		const file = writeResults( 120 );
 		const { fetchImpl, calls } = dedupFetchStub( { stallBodyUntilAbort: true } );
 		const origFetch = global.fetch;

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -24,6 +24,7 @@ import {
 	isDirectInvocation,
 	postToCodeVitals,
 	redactToken,
+	resolvePostTimestamp,
 	VALIDATION_FAILED_EXIT_CODE,
 } from './post-to-codevitals.js';
 import { shouldFailBuildOnPostError } from './run-performance-tests.js';
@@ -832,4 +833,190 @@ test( 'shouldFailBuildOnPostError: a transport failure is suppressible only with
 	assert.equal( shouldFailBuildOnPostError( { status: 1 }, false ), true ); // fatal by default
 	assert.equal( shouldFailBuildOnPostError( undefined, true ), false ); // unknown exit, flag set
 	assert.equal( shouldFailBuildOnPostError( undefined, false ), true );
+} );
+
+// --- resolvePostTimestamp (stamp commit time, not build time) ---
+
+test( 'resolvePostTimestamp prefers the results commit time over env and build time', () => {
+	const ts = resolvePostTimestamp(
+		{ git: { timestamp: 1700000000000 } },
+		{ commitTimestampMs: '1600000000000' }
+	);
+	assert.equal( ts, 1700000000000 );
+} );
+
+test( 'resolvePostTimestamp falls back to the env commit time (numeric string ok)', () => {
+	const ts = resolvePostTimestamp( { git: {} }, { commitTimestampMs: '1600000000000' } );
+	assert.equal( ts, 1600000000000 );
+} );
+
+test( 'resolvePostTimestamp rejects non-positive / non-numeric values and uses build time', async () => {
+	const before = Date.now();
+	// git.timestamp 0 and a non-numeric env value are both invalid → build-time fallback.
+	const ts = await silenced( () =>
+		resolvePostTimestamp( { git: { timestamp: 0 } }, { commitTimestampMs: 'not-a-number' } )
+	);
+	assert.ok( ts >= before && ts <= Date.now() + 1000, 'falls back to the current time' );
+	// A negative epoch must never be posted, even if present.
+	const fromNegative = await silenced( () =>
+		resolvePostTimestamp( { git: { timestamp: -5 } }, {} )
+	);
+	assert.ok( fromNegative > 0, 'a negative timestamp is rejected in favour of build time' );
+} );
+
+test( 'a dry-run payload is stamped with the commit time from the results file', async () => {
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-ts-' ) );
+	const file = path.join( dir, 'results.json' );
+	fs.writeFileSync(
+		file,
+		JSON.stringify( {
+			git: { hash: 'h', branch: 'trunk', timestamp: 1700000000000 },
+			measurements: { jetpackConnected: { summary: { median: 120 } } },
+		} )
+	);
+	try {
+		const result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
+		assert.equal( result.payload.timestamp, 1700000000000 );
+	} finally {
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+} );
+
+// --- cross-commit dedup (gitaudit evolution read; fetch stubbed, no network) ---
+
+const DEDUP_CONFIG = {
+	dryRun: false,
+	codeVitalsUrl: 'https://codevitals.test',
+	codeVitalsToken: 'tok-dedup',
+	dedupBaseUrl: 'https://gitaudit.test',
+	dedupRepo: 'Automattic/jetpack',
+	dedupMetricId: '58',
+};
+
+/**
+ * A fetch stub that answers the dedup evolution GET ({ data: [...] }) and records
+ * whether the live POST was reached. Branches on the URL: the evolution read
+ * contains `/perf/evolution/`, the post contains `/api/log`.
+ */
+function dedupFetchStub( {
+	evolutionHashes = [],
+	evolutionStatus = 200,
+	throwOnEvolution = false,
+} ) {
+	const calls = { evolution: 0, post: 0 };
+	const fetchImpl = async u => {
+		if ( String( u ).includes( '/perf/evolution/' ) ) {
+			calls.evolution++;
+			if ( throwOnEvolution ) {
+				throw new Error( 'network down' );
+			}
+			return {
+				ok: evolutionStatus >= 200 && evolutionStatus < 300,
+				status: evolutionStatus,
+				json: async () => ( {
+					data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ),
+				} ),
+				text: async () => '',
+			};
+		}
+		calls.post++;
+		return { ok: true, status: 200, json: async () => ( { ok: true } ), text: async () => '' };
+	};
+	return { fetchImpl, calls };
+}
+
+test( 'dedup skips the post when the commit hash already has metrics', async () => {
+	const file = writeResults( 120 ); // git.hash = 'testhash'
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'testhash' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, false );
+		assert.equal( result.skipped, true );
+		assert.equal( calls.evolution, 1 );
+		assert.equal( calls.post, 0, 'must not POST when the hash is already present' );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup proceeds with the post when the hash is not yet present', async () => {
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'someoneelse' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, true );
+		assert.equal( calls.post, 1 );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup fails open (still posts) when the read endpoint throws', async () => {
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { throwOnEvolution: true } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, true, 'a flaky dedup read must never block a post' );
+		assert.equal( calls.post, 1 );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup fails open on a non-OK read status', async () => {
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionStatus: 500 } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () => postToCodeVitals( file, DEDUP_CONFIG ) );
+		assert.equal( result.posted, true );
+		assert.equal( calls.post, 1 );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup makes no read call when skipDedup is set', async () => {
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'testhash' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		const result = await silenced( () =>
+			postToCodeVitals( file, { ...DEDUP_CONFIG, skipDedup: true } )
+		);
+		assert.equal( calls.evolution, 0, 'no dedup read when skipDedup is set' );
+		assert.equal( result.posted, true );
+	} finally {
+		global.fetch = origFetch;
+	}
+} );
+
+test( 'dedup is skipped (no read) when dedupBaseUrl is unset, as in the other live-post tests', async () => {
+	const file = writeResults( 120 );
+	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'testhash' ] } );
+	const origFetch = global.fetch;
+	global.fetch = fetchImpl;
+	try {
+		// No dedupBaseUrl → dedup is inert, so existing live-post tests keep making a
+		// single POST call and never hit the evolution endpoint.
+		const result = await silenced( () =>
+			postToCodeVitals( file, {
+				dryRun: false,
+				codeVitalsUrl: 'https://codevitals.test',
+				codeVitalsToken: 'tok-no-dedup-config',
+			} )
+		);
+		assert.equal( calls.evolution, 0 );
+		assert.equal( result.posted, true );
+	} finally {
+		global.fetch = origFetch;
+	}
 } );

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -38,7 +38,7 @@ import {
 import { SANITY_RANGES, SCENARIOS } from './scenarios.js';
 
 const SCRIPTS_DIR = path.dirname( fileURLToPath( import.meta.url ) );
-const LCP_KEY = 'wp-admin-dashboard-connection-sim-largestContentfulPaint';
+const LCP_KEY = 'wp-admin-dashboard-connection-sim-largestContentfulPaint-v2';
 
 /** Write a results fixture with the given median LCP and return its path. */
 function writeResults( median ) {

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -28,7 +28,11 @@ import {
 	resolvePostTimestamp,
 	VALIDATION_FAILED_EXIT_CODE,
 } from './post-to-codevitals.js';
-import { getGitInfo, shouldFailBuildOnPostError } from './run-performance-tests.js';
+import {
+	getGitInfo,
+	resolveCommitTimestampEnv,
+	shouldFailBuildOnPostError,
+} from './run-performance-tests.js';
 import { SANITY_RANGES, SCENARIOS } from './scenarios.js';
 
 const SCRIPTS_DIR = path.dirname( fileURLToPath( import.meta.url ) );
@@ -865,6 +869,34 @@ test( 'resolvePostTimestamp rejects non-positive / non-numeric values and uses b
 	assert.ok( fromNegative > 0, 'a negative timestamp is rejected in favour of build time' );
 } );
 
+test( 'resolvePostTimestamp rejects unit errors (epoch seconds, micro/nanoseconds) as implausible', async () => {
+	const before = Date.now();
+	// A 10-digit epoch-*seconds* value (e.g. 1700000000) would post as 1970-01-20 if taken
+	// as ms. It must be rejected, not silently backdated into the append-only trend.
+	const fromSeconds = await silenced( () =>
+		resolvePostTimestamp( { git: { timestamp: 1700000000 } }, {} )
+	);
+	assert.notEqual( fromSeconds, 1700000000, 'epoch-seconds value is not posted verbatim' );
+	assert.ok(
+		fromSeconds >= before && fromSeconds <= Date.now() + 1000,
+		'an epoch-seconds value falls back to build time'
+	);
+	// Micro/nanosecond magnitudes are far in the future and equally implausible as ms.
+	const fromMicros = await silenced( () =>
+		resolvePostTimestamp( { git: {} }, { commitTimestampMs: '1700000000000000' } )
+	);
+	assert.ok(
+		fromMicros >= before && fromMicros <= Date.now() + 1000,
+		'a microsecond-magnitude value falls back to build time'
+	);
+	// A real epoch-ms value at the window edges is still accepted unchanged.
+	assert.equal(
+		resolvePostTimestamp( { git: { timestamp: 1_000_000_000_000 } }, {} ),
+		1_000_000_000_000,
+		'a plausible epoch-ms value passes through'
+	);
+} );
+
 test( 'a dry-run payload is stamped with the commit time from the results file', async () => {
 	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-ts-' ) );
 	const file = path.join( dir, 'results.json' );
@@ -974,6 +1006,52 @@ test( 'getGitInfo: a non-git directory degrades to unknown hash and null commit 
 		}
 		fs.rmSync( dir, { recursive: true, force: true } );
 	}
+} );
+
+// --- resolveCommitTimestampEnv (GIT_COMMIT + GIT_COMMIT_TIMESTAMP_MS are a paired override) ---
+
+test( 'resolveCommitTimestampEnv: paired override honored, lone timestamp dropped, source surfaced', () => {
+	const headInfo = { committedAtMs: 1700000000000 };
+
+	// Paired override (both env vars set): the caller-supplied timestamp wins, no warning.
+	const paired = resolveCommitTimestampEnv( headInfo, {
+		GIT_COMMIT: 'deadbeef',
+		GIT_COMMIT_TIMESTAMP_MS: '1600000000000',
+	} );
+	assert.equal( paired.value, '1600000000000' );
+	assert.equal( paired.warn, false );
+
+	// Lone GIT_COMMIT_TIMESTAMP_MS (no hash override) is orphaned → dropped for HEAD time,
+	// so it can't stamp HEAD's hash with an unrelated time. This is R4-IMPORTANT-1.
+	const lone = resolveCommitTimestampEnv( headInfo, { GIT_COMMIT_TIMESTAMP_MS: '999' } );
+	assert.equal( lone.value, '1700000000000', 'a lone timestamp does not win over HEAD time' );
+	assert.equal( lone.warn, false );
+
+	// Empty-string timestamp counts as absent, not a paired override.
+	const empty = resolveCommitTimestampEnv( headInfo, {
+		GIT_COMMIT: 'deadbeef',
+		GIT_COMMIT_TIMESTAMP_MS: '',
+	} );
+	assert.equal( empty.value, '1700000000000' );
+
+	// Hash override with no paired timestamp gets HEAD time but flags the provenance split.
+	const hashOnly = resolveCommitTimestampEnv( headInfo, { GIT_COMMIT: 'deadbeef' } );
+	assert.equal( hashOnly.value, '1700000000000' );
+	assert.equal( hashOnly.warn, true, 'an unpaired hash override warns about the split' );
+
+	// No env at all: plain HEAD time, no warning.
+	const plain = resolveCommitTimestampEnv( headInfo, {} );
+	assert.equal( plain.value, '1700000000000' );
+	assert.equal( plain.warn, false );
+
+	// No HEAD metadata and no paired override → null (caller unsets so the poster falls
+	// back to build time); a lone orphaned timestamp is still not trusted here.
+	assert.equal( resolveCommitTimestampEnv( { committedAtMs: null }, {} ).value, null );
+	assert.equal(
+		resolveCommitTimestampEnv( { committedAtMs: null }, { GIT_COMMIT_TIMESTAMP_MS: '999' } ).value,
+		null,
+		'a lone timestamp is dropped even when there is no HEAD time to fall back to'
+	);
 } );
 
 // --- cross-commit dedup (gitaudit evolution read; fetch stubbed, no network) ---

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -22,6 +22,7 @@ import {
 	exitCodeForError,
 	extractScenarioMetrics,
 	isDirectInvocation,
+	pairedCommitTimestampMs,
 	postToCodeVitals,
 	redactToken,
 	resolveDedupEnabled,
@@ -1052,6 +1053,22 @@ test( 'resolveCommitTimestampEnv: paired override honored, lone timestamp droppe
 		null,
 		'a lone timestamp is dropped even when there is no HEAD time to fall back to'
 	);
+} );
+
+test( 'pairedCommitTimestampMs: the env timestamp is trusted only when paired with GIT_COMMIT', () => {
+	// Paired override (both set): the env timestamp is carried into config.
+	assert.equal(
+		pairedCommitTimestampMs( { GIT_COMMIT: 'deadbeef', GIT_COMMIT_TIMESTAMP_MS: '1600000000000' } ),
+		'1600000000000'
+	);
+	// Lone GIT_COMMIT_TIMESTAMP_MS (no hash override) is dropped — it can't backdate a
+	// direct `pnpm report` run by stamping the results-file hash with an inherited time.
+	assert.equal(
+		pairedCommitTimestampMs( { GIT_COMMIT_TIMESTAMP_MS: '1600000000000' } ),
+		undefined
+	);
+	// Nothing set: undefined (resolvePostTimestamp uses results.git.timestamp / build time).
+	assert.equal( pairedCommitTimestampMs( {} ), undefined );
 } );
 
 // --- cross-commit dedup (gitaudit evolution read; fetch stubbed, no network) ---

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -24,6 +24,7 @@ import {
 	isDirectInvocation,
 	postToCodeVitals,
 	redactToken,
+	resolveDedupEnabled,
 	resolvePostTimestamp,
 	VALIDATION_FAILED_EXIT_CODE,
 } from './post-to-codevitals.js';
@@ -902,11 +903,12 @@ function dedupFetchStub( {
 	evolutionHashes = [],
 	evolutionStatus = 200,
 	throwOnEvolution = false,
-	rejectBody = false, // headers arrive OK but json() rejects (stalled/truncated body)
+	rejectBody = false, // headers arrive OK but json() rejects synchronously (truncated body)
+	stallBodyUntilAbort = false, // headers arrive OK but json() settles only when init.signal aborts
 	evolutionBody, // when set, returned verbatim from the evolution json() (for bad-shape tests)
 } ) {
 	const calls = { evolution: 0, post: 0, evolutionUrl: null };
-	const fetchImpl = async u => {
+	const fetchImpl = async ( u, init ) => {
 		if ( String( u ).includes( '/perf/evolution/' ) ) {
 			calls.evolution++;
 			calls.evolutionUrl = String( u );
@@ -920,6 +922,25 @@ function dedupFetchStub( {
 					if ( rejectBody ) {
 						throw new Error( 'body read failed' );
 					}
+					if ( stallBodyUntilAbort ) {
+						// Never settle on our own: only the abort signal rejects this, the way
+						// undici aborts an in-flight body read. This passes ONLY if the abort
+						// timer is still armed across json() — if the production code cleared it
+						// after the headers (the reverted-fix shape), abort never fires, this
+						// promise hangs, and the test times out (the regression we want to catch).
+						return new Promise( ( resolve, reject ) => {
+							const abort = () => {
+								const err = new Error( 'The operation was aborted' );
+								err.name = 'AbortError';
+								reject( err );
+							};
+							if ( init?.signal?.aborted ) {
+								abort();
+							} else {
+								init?.signal?.addEventListener( 'abort', abort, { once: true } );
+							}
+						} );
+					}
 					return evolutionBody !== undefined
 						? evolutionBody
 						: { data: evolutionHashes.map( h => ( { hash: h, measuredAt: '2026-01-01' } ) ) };
@@ -932,6 +953,26 @@ function dedupFetchStub( {
 	};
 	return { fetchImpl, calls };
 }
+
+test( 'resolveDedupEnabled: dedup is opt-in (off by default) and an explicit opt-out always wins', () => {
+	const noEnv = {};
+	// Default: OFF — the GATE-1 safety default.
+	assert.equal( resolveDedupEnabled( [], noEnv ), false );
+	// Opt in by flag or a truthy env value.
+	assert.equal( resolveDedupEnabled( [ '--dedup' ], noEnv ), true );
+	assert.equal( resolveDedupEnabled( [], { CODEVITALS_ENABLE_DEDUP: '1' } ), true );
+	assert.equal( resolveDedupEnabled( [], { CODEVITALS_ENABLE_DEDUP: 'true' } ), true );
+	// A non-truthy env value does not enable.
+	assert.equal( resolveDedupEnabled( [], { CODEVITALS_ENABLE_DEDUP: '0' } ), false );
+	assert.equal( resolveDedupEnabled( [], { CODEVITALS_ENABLE_DEDUP: 'no' } ), false );
+	// Opt-out wins over opt-in, whichever side it comes from.
+	assert.equal( resolveDedupEnabled( [ '--dedup', '--no-dedup' ], noEnv ), false );
+	assert.equal( resolveDedupEnabled( [ '--dedup' ], { CODEVITALS_SKIP_DEDUP: '1' } ), false );
+	assert.equal(
+		resolveDedupEnabled( [], { CODEVITALS_ENABLE_DEDUP: '1', CODEVITALS_SKIP_DEDUP: 'yes' } ),
+		false
+	);
+} );
 
 test( 'dedup skips the post when the commit hash already has metrics', async () => {
 	const file = writeResults( 120 ); // git.hash = 'testhash'
@@ -1008,6 +1049,32 @@ test( 'dedup fails open (still posts) when the response body read fails', async 
 		global.fetch = origFetch;
 	}
 } );
+
+test(
+	'dedup body read stays bounded: a body that hangs until abort still fails open and posts',
+	{ timeout: 5000 },
+	async () => {
+		// The regression guard for the round-2 body-read fix: the abort timer must stay
+		// armed across response.json(). The stub's json() never settles on its own — only
+		// the AbortController signal rejects it — so this passes only if the timer is still
+		// live during the body read. dedupTimeoutMs=50 stands in for the 15s production
+		// timer; the per-test timeout turns a reverted fix (timer cleared after headers,
+		// abort never fires, json() hangs) into a clean failure instead of a hang.
+		const file = writeResults( 120 );
+		const { fetchImpl, calls } = dedupFetchStub( { stallBodyUntilAbort: true } );
+		const origFetch = global.fetch;
+		global.fetch = fetchImpl;
+		try {
+			const result = await silenced( () =>
+				postToCodeVitals( file, { ...DEDUP_CONFIG, dedupTimeoutMs: 50 } )
+			);
+			assert.equal( result.posted, true, 'a stalled body read must abort and fail open, not hang' );
+			assert.equal( calls.post, 1 );
+		} finally {
+			global.fetch = origFetch;
+		}
+	}
+);
 
 test( 'dedup makes no read call when skipDedup is set', async () => {
 	const file = writeResults( 120 );

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -680,6 +680,98 @@ test( 'a native abort (DOMException with a getter-only message) does not crash r
 	assert.match( err.message, /timed out/ );
 } );
 
+// A response-body reader (json()/text()) that never settles on its own — only the fetch
+// abort signal rejects it, the way undici aborts an in-flight body read. Proves the live-POST
+// timer stays armed ACROSS the body read: if the production code cleared it after headers (the
+// old shape), abort never fires, this hangs, and the per-test timeout fails instead of hanging
+// forever. Mirrors dedupFetchStub's stallBodyUntilAbort for the live-POST path.
+function bodyStallsUntilAbort( init ) {
+	return new Promise( ( resolve, reject ) => {
+		const abort = () => {
+			const err = new Error( 'The operation was aborted' );
+			err.name = 'AbortError';
+			reject( err );
+		};
+		if ( init?.signal?.aborted ) {
+			abort();
+		} else {
+			init?.signal?.addEventListener( 'abort', abort, { once: true } );
+		}
+	} );
+}
+
+test(
+	'live POST body read stays bounded: a stalled OK json() body aborts to a timeout, not a hang',
+	{ timeout: 20000 },
+	async () => {
+		// The live POST used to clear its abort timer right after fetch() resolved, leaving
+		// response.json() unbounded — a server that sends 200 headers then stalls the body would
+		// hang past the 30s timeout (undici's ~300s default at best). The timer now stays armed
+		// through the body read, so the stalled json() aborts. postTimeoutMs=50 stands in for the
+		// 30s production timer; the per-test timeout turns a reverted fix into a clean failure.
+		const file = writeResults( 120 );
+		const origFetch = global.fetch;
+		global.fetch = async ( url, init ) => ( {
+			ok: true,
+			status: 200,
+			text: async () => '',
+			json: () => bodyStallsUntilAbort( init ),
+		} );
+		let err;
+		try {
+			await silenced( () =>
+				postToCodeVitals( file, {
+					dryRun: false,
+					codeVitalsUrl: 'https://codevitals.test',
+					codeVitalsToken: 'tok-stall-ok',
+					postTimeoutMs: 50,
+				} )
+			);
+		} catch ( e ) {
+			err = e;
+		} finally {
+			global.fetch = origFetch;
+		}
+		assert.ok( err, 'a stalled OK body must abort, not hang' );
+		assert.match( err.message, /timed out/, 'a body-read abort is a timeout, not "invalid JSON"' );
+	}
+);
+
+test(
+	'live POST body read stays bounded: a stalled non-OK text() body aborts to a timeout, not a hang',
+	{ timeout: 20000 },
+	async () => {
+		// Same regression guard on the error branch: a non-OK response reads response.text() for
+		// the error message, and that read must be bounded by the same armed timer. A 500 whose
+		// body stalls aborts cleanly instead of hanging.
+		const file = writeResults( 120 );
+		const origFetch = global.fetch;
+		global.fetch = async ( url, init ) => ( {
+			ok: false,
+			status: 500,
+			json: async () => ( {} ),
+			text: () => bodyStallsUntilAbort( init ),
+		} );
+		let err;
+		try {
+			await silenced( () =>
+				postToCodeVitals( file, {
+					dryRun: false,
+					codeVitalsUrl: 'https://codevitals.test',
+					codeVitalsToken: 'tok-stall-err',
+					postTimeoutMs: 50,
+				} )
+			);
+		} catch ( e ) {
+			err = e;
+		} finally {
+			global.fetch = origFetch;
+		}
+		assert.ok( err, 'a stalled error body must abort, not hang' );
+		assert.match( err.message, /timed out/ );
+	}
+);
+
 test( 'a validation failure is not downgraded to exit 1 when a later live POST also fails', async () => {
 	// Reachable only with 2+ posted metrics (FORMS-707 territory): one metric fails the
 	// sanity check (validationFailed=true) while a valid one remains and is POSTed. If

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -1264,7 +1264,7 @@ function dedupFetchStub( {
 
 test( 'resolveDedupEnabled: dedup is opt-in (off by default) and an explicit opt-out always wins', () => {
 	const noEnv = {};
-	// Default: OFF — the GATE-1 safety default.
+	// Default: OFF, the safe default until the dedup read and write backends match.
 	assert.equal( resolveDedupEnabled( [], noEnv ), false );
 	// Opt in by flag or a truthy env value.
 	assert.equal( resolveDedupEnabled( [ '--dedup' ], noEnv ), true );

--- a/tools/performance/scripts/run-performance-tests.js
+++ b/tools/performance/scripts/run-performance-tests.js
@@ -169,10 +169,15 @@ function checkDocker() {
 	}
 }
 
-/** Get git hash and branch from jetpack-production mirror. */
-function getGitInfo() {
+/**
+ * Get git hash, branch, and commit time from the jetpack-production mirror.
+ *
+ * @param {string} pluginDir - Directory to read git metadata from; defaults to PLUGIN_DIR (parameterized for tests).
+ * @return {{hash: string, mirrorHash: string, branch: string, committedAtMs: number|null}} Resolved git info for the posted point.
+ */
+function getGitInfo( pluginDir = PLUGIN_DIR ) {
 	// Git commands must run from the plugin directory (where jetpack-production is checked out)
-	const gitOpts = { cwd: PLUGIN_DIR, silent: true };
+	const gitOpts = { cwd: pluginDir, silent: true };
 
 	// Get the mirror commit hash
 	let mirrorHash = 'unknown';
@@ -465,8 +470,10 @@ async function main() {
 	process.env.GIT_BRANCH = gitInfo.branch;
 	// Carry the commit time to measure-lcp.js (writes it into results.git.timestamp)
 	// and to the post-to-codevitals.js child, so the posted point is ordered by when
-	// the code landed, not when this build ran.
-	if ( gitInfo.committedAtMs ) {
+	// the code landed, not when this build ran. Don't clobber a caller-supplied value:
+	// GIT_COMMIT + GIT_COMMIT_TIMESTAMP_MS are a paired override, so if someone set the
+	// timestamp explicitly (to pair it with a GIT_COMMIT hash), keep theirs over HEAD's.
+	if ( gitInfo.committedAtMs && ! process.env.GIT_COMMIT_TIMESTAMP_MS ) {
 		process.env.GIT_COMMIT_TIMESTAMP_MS = String( gitInfo.committedAtMs );
 	}
 	process.env.ITERATIONS = options.iterations.toString();
@@ -549,4 +556,4 @@ if ( isDirectInvocation( import.meta.filename, process.argv[ 1 ] ) ) {
 	} );
 }
 
-export { shouldFailBuildOnPostError };
+export { shouldFailBuildOnPostError, getGitInfo };

--- a/tools/performance/scripts/run-performance-tests.js
+++ b/tools/performance/scripts/run-performance-tests.js
@@ -228,6 +228,51 @@ function getGitInfo( pluginDir = PLUGIN_DIR ) {
 	return { hash, mirrorHash, branch, committedAtMs };
 }
 
+/**
+ * Resolve the GIT_COMMIT_TIMESTAMP_MS to carry to the measurement/poster children.
+ *
+ * GIT_COMMIT and GIT_COMMIT_TIMESTAMP_MS form a *paired* override: setting both posts an
+ * arbitrary commit hash at its own committer time. The env timestamp is honored ONLY when
+ * paired with a GIT_COMMIT hash override. A lone GIT_COMMIT_TIMESTAMP_MS (no GIT_COMMIT)
+ * is orphaned and dropped in favour of HEAD's own commit time, so it can't stamp HEAD's
+ * hash with an unrelated time. A GIT_COMMIT hash override with no paired timestamp falls
+ * back to HEAD time but flags the provenance split (warn) rather than pairing it silently.
+ *
+ * Must be called BEFORE GIT_COMMIT is overwritten with the resolved hash, so it sees the
+ * caller's original override intent.
+ *
+ * @param {object} gitInfo - Result of getGitInfo (uses committedAtMs).
+ * @param {object} env     - Environment carrying GIT_COMMIT / GIT_COMMIT_TIMESTAMP_MS.
+ * @return {{value: (string|null), source: (string|null), warn: boolean}} The string to set (null → unset/drop), the source for logging, and whether to warn.
+ */
+function resolveCommitTimestampEnv( gitInfo, env ) {
+	const hasHashOverride = Boolean( env.GIT_COMMIT );
+	const hasTimestamp =
+		env.GIT_COMMIT_TIMESTAMP_MS !== undefined && env.GIT_COMMIT_TIMESTAMP_MS !== '';
+
+	if ( hasHashOverride && hasTimestamp ) {
+		return {
+			value: env.GIT_COMMIT_TIMESTAMP_MS,
+			source: 'paired GIT_COMMIT override',
+			warn: false,
+		};
+	}
+	if ( gitInfo.committedAtMs ) {
+		// A lone GIT_COMMIT_TIMESTAMP_MS is dropped here. A hash override without a paired
+		// timestamp gets HEAD's time — surface that split instead of pairing it silently.
+		return {
+			value: String( gitInfo.committedAtMs ),
+			source: hasHashOverride
+				? 'HEAD commit time (GIT_COMMIT hash override has no paired GIT_COMMIT_TIMESTAMP_MS)'
+				: 'HEAD commit time',
+			warn: hasHashOverride,
+		};
+	}
+	// No HEAD git metadata and no paired override: the poster falls back to build time
+	// (with its own warning). Drop any orphaned timestamp so it isn't trusted.
+	return { value: null, source: null, warn: false };
+}
+
 /** Ensure the Jetpack plugin is available (clone from jetpack-production if needed). */
 function ensurePlugin() {
 	// Check if plugin directory exists and has jetpack.php
@@ -465,16 +510,24 @@ async function main() {
 		console.log( '✓ Setup complete\n' );
 	}
 
+	// Resolve the commit timestamp to carry forward BEFORE we overwrite GIT_COMMIT with
+	// the resolved hash below, so the paired-override check sees the caller's original env.
+	const commitTs = resolveCommitTimestampEnv( gitInfo, process.env );
+
 	// Set environment variables for the measurement script
 	process.env.GIT_COMMIT = gitInfo.hash;
 	process.env.GIT_BRANCH = gitInfo.branch;
-	// Carry the commit time to measure-lcp.js (writes it into results.git.timestamp)
-	// and to the post-to-codevitals.js child, so the posted point is ordered by when
-	// the code landed, not when this build ran. Don't clobber a caller-supplied value:
-	// GIT_COMMIT + GIT_COMMIT_TIMESTAMP_MS are a paired override, so if someone set the
-	// timestamp explicitly (to pair it with a GIT_COMMIT hash), keep theirs over HEAD's.
-	if ( gitInfo.committedAtMs && ! process.env.GIT_COMMIT_TIMESTAMP_MS ) {
-		process.env.GIT_COMMIT_TIMESTAMP_MS = String( gitInfo.committedAtMs );
+	// Carry the commit time to measure-lcp.js (writes it into results.git.timestamp) and
+	// on to the post-to-codevitals.js child, so the posted point is ordered by when the
+	// code landed, not when this build ran. A lone GIT_COMMIT_TIMESTAMP_MS is not trusted
+	// (see resolveCommitTimestampEnv); we log the winning source so the choice isn't silent.
+	if ( commitTs.value ) {
+		process.env.GIT_COMMIT_TIMESTAMP_MS = commitTs.value;
+		( commitTs.warn ? console.warn : console.log )(
+			`  Commit timestamp: ${ commitTs.value }ms (${ commitTs.source })`
+		);
+	} else {
+		delete process.env.GIT_COMMIT_TIMESTAMP_MS;
 	}
 	process.env.ITERATIONS = options.iterations.toString();
 	process.env.OUTPUT_PATH = path.join( __dirname, '../results/lcp-results.json' );
@@ -556,4 +609,4 @@ if ( isDirectInvocation( import.meta.filename, process.argv[ 1 ] ) ) {
 	} );
 }
 
-export { shouldFailBuildOnPostError, getGitInfo };
+export { shouldFailBuildOnPostError, getGitInfo, resolveCommitTimestampEnv };

--- a/tools/performance/scripts/run-performance-tests.js
+++ b/tools/performance/scripts/run-performance-tests.js
@@ -196,10 +196,31 @@ function getGitInfo() {
 	// Prefer upstream (monorepo) hash for CodeVitals tracking, fall back to mirror hash
 	const hash = process.env.GIT_COMMIT || upstreamHash || mirrorHash;
 
+	// Commit time of the checked-out plugin HEAD (the code under test), in epoch ms.
+	// CodeVitals orders its trend by the posted timestamp and the Scheduler reads the
+	// latest point to decide "last tested", so we stamp commit time, not build time.
+	// The mirror's commit date tracks when the monorepo commit landed, which is the
+	// value we want; if git metadata is unavailable the poster falls back to build
+	// time with a warning.
+	let committedAtMs = null;
+	try {
+		const committerEpoch = execFile(
+			'git',
+			[ 'show', '-s', '--format=%ct', 'HEAD' ],
+			gitOpts
+		)?.trim();
+		const seconds = Number( committerEpoch );
+		if ( Number.isFinite( seconds ) && seconds > 0 ) {
+			committedAtMs = seconds * 1000;
+		}
+	} catch {
+		// No git metadata (e.g. plugin extracted from a zip); leave null.
+	}
+
 	// Always use 'trunk' as the branch - we're tracking performance on the main branch
 	const branch = 'trunk';
 
-	return { hash, mirrorHash, branch };
+	return { hash, mirrorHash, branch, committedAtMs };
 }
 
 /** Ensure the Jetpack plugin is available (clone from jetpack-production if needed). */
@@ -442,6 +463,12 @@ async function main() {
 	// Set environment variables for the measurement script
 	process.env.GIT_COMMIT = gitInfo.hash;
 	process.env.GIT_BRANCH = gitInfo.branch;
+	// Carry the commit time to measure-lcp.js (writes it into results.git.timestamp)
+	// and to the post-to-codevitals.js child, so the posted point is ordered by when
+	// the code landed, not when this build ran.
+	if ( gitInfo.committedAtMs ) {
+		process.env.GIT_COMMIT_TIMESTAMP_MS = String( gitInfo.committedAtMs );
+	}
 	process.env.ITERATIONS = options.iterations.toString();
 	process.env.OUTPUT_PATH = path.join( __dirname, '../results/lcp-results.json' );
 

--- a/tools/performance/scripts/scenarios.js
+++ b/tools/performance/scripts/scenarios.js
@@ -27,7 +27,7 @@ export const SCENARIOS = [
 		// it to a `-staging` key first (e.g. `…-timeToFirstByte-staging`) for 2-3
 		// builds, inspect it in the CodeVitals UI, then rename to the production key.
 		// See the "Safeguards" section of README.md for the full convention.
-		metricKey: 'wp-admin-dashboard-connection-sim-largestContentfulPaint',
+		metricKey: 'wp-admin-dashboard-connection-sim-largestContentfulPaint-v2',
 		// Metric type — drives the sanity-range check in post-to-codevitals.js.
 		metricType: 'lcp',
 		postToCodeVitals: true,


### PR DESCRIPTION
Temporary branch off `add/codevitals-commit-time-and-dedup` (#50046) that points the poster at the new `wp-admin-dashboard-connection-sim-largestContentfulPaint-v2` metric (CodeVitals id 200), so a commit-time validation sweep writes to a fresh series instead of the production one.

## Change
- `scenarios.js`: `metricKey` → the `-v2` key. `metricType` stays `lcp`, so the `[100, 60000]` sanity range still applies.
- `post-to-codevitals.test.js`: `LCP_KEY` → `-v2`. The unit suite gates the Tester's post; a stale constant would abort the build before it posts.
- `README.md`: doc reference.

## Verified
- Dry-run payload carries `"wp-admin-dashboard-connection-sim-largestContentfulPaint-v2": 120`.
- Full unit suite green (68/68), the same check as the Tester's `pnpm test` gate.

Targets the feature branch, not trunk, and is not for merge. It exists to run the pipeline against metric 200. No changelog entry (throwaway validation branch).
