### PR TITLE
Premium Analytics: show Locations header before drill-down

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-locations-top-level-header
+++ b/projects/packages/premium-analytics/changelog/fix-locations-top-level-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats widgets: Show Locations header before drill-down.

--- a/projects/packages/premium-analytics/changelog/fix-locations-top-level-header
+++ b/projects/packages/premium-analytics/changelog/fix-locations-top-level-header
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Stats widgets: Show Locations header before drill-down.
+Locations widget: Show Locations header before drill-down.

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -15,6 +15,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
+import { Icon, mapMarker } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
@@ -134,6 +135,9 @@ function LocationsInner( { max }: { max: number } ) {
 	const header = (
 		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
 			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
+				<span className={ styles.titleIcon } aria-hidden="true">
+					<Icon icon={ mapMarker } size={ 16 } />
+				</span>
 				{ selectedCountry ? (
 					<>
 						<Button

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -15,9 +15,8 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { Icon } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Stack, Text } from '@wordpress/ui';
+import { Button, Icon, Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -33,6 +32,15 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 type LocationsRenderAttributes = LocationsAttributes & Partial< ReportParamsFieldAttributes >;
 type LocationsWidgetProps = WidgetRenderProps< LocationsRenderAttributes >;
+
+function LocationsHeaderTitle() {
+	return (
+		<span className={ styles.headerTitle }>
+			<Icon icon={ widgetDefinition.icon } size={ 20 } className={ styles.headerIcon } />
+			<span>{ __( 'Locations', 'jetpack-premium-analytics' ) }</span>
+		</span>
+	);
+}
 
 /**
  * Locations widget inner component. Reads report params from WidgetRoot context.
@@ -137,9 +145,6 @@ function LocationsInner( { max }: { max: number } ) {
 	const header = (
 		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
 			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
-				<span className={ styles.titleIcon } aria-hidden="true">
-					<Icon icon={ widgetDefinition.icon } size={ 16 } />
-				</span>
 				{ selectedCountry ? (
 					<>
 						<Button
@@ -147,13 +152,15 @@ function LocationsInner( { max }: { max: number } ) {
 							onClick={ clearSelectedCountry }
 							className={ styles.breadcrumbLink }
 						>
-							{ __( 'Locations', 'jetpack-premium-analytics' ) }
+							<LocationsHeaderTitle />
 						</Button>
 						<Text className={ styles.breadcrumbSeparator }>/</Text>
 						<Text className={ styles.breadcrumbCurrent }>{ selectedCountry.name }</Text>
 					</>
 				) : (
-					<Text>{ __( 'Locations', 'jetpack-premium-analytics' ) }</Text>
+					<Text>
+						<LocationsHeaderTitle />
+					</Text>
 				) }
 			</Stack>
 			<SelectControl

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -132,27 +132,24 @@ function LocationsInner( { max }: { max: number } ) {
 	}, [ comparisonData, data, geoMode, hasComparison ] );
 
 	const header = (
-		<Stack
-			direction="row"
-			justify={ selectedCountry ? 'space-between' : 'flex-end' }
-			align="center"
-			className={ styles.widgetHeader }
-		>
-			{ selectedCountry && (
-				<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
-					<Button
-						variant="unstyled"
-						onClick={ clearSelectedCountry }
-						className={ styles.breadcrumbLink }
-					>
-						{ __( 'Locations', 'jetpack-premium-analytics' ) }
-					</Button>
+		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
+			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
+				{ selectedCountry ? (
 					<>
+						<Button
+							variant="unstyled"
+							onClick={ clearSelectedCountry }
+							className={ styles.breadcrumbLink }
+						>
+							{ __( 'Locations', 'jetpack-premium-analytics' ) }
+						</Button>
 						<Text className={ styles.breadcrumbSeparator }>/</Text>
-						<Text>{ selectedCountry.name }</Text>
+						<Text className={ styles.breadcrumbCurrent }>{ selectedCountry.name }</Text>
 					</>
-				</Stack>
-			) }
+				) : (
+					<Text>{ __( 'Locations', 'jetpack-premium-analytics' ) }</Text>
+				) }
+			</Stack>
 			<SelectControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -158,7 +158,7 @@ function LocationsInner( { max }: { max: number } ) {
 						<Text className={ styles.breadcrumbCurrent }>{ selectedCountry.name }</Text>
 					</>
 				) : (
-					<Text>
+					<Text className={ styles.breadcrumbTitle }>
 						<LocationsHeaderTitle />
 					</Text>
 				) }

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -15,7 +15,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { Icon, mapMarker } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
@@ -24,7 +24,7 @@ import clsx from 'clsx';
  */
 import styles from './style.module.css';
 import useLocationViews, { type GeoMode } from './use-location-views';
-import type { LocationsAttributes } from './widget';
+import widgetDefinition, { type LocationsAttributes } from './widget';
 /**
  * Types
  */
@@ -138,7 +138,7 @@ function LocationsInner( { max }: { max: number } ) {
 		<Stack direction="row" justify="space-between" align="center" className={ styles.widgetHeader }>
 			<Stack direction="row" align="center" gap="xs" className={ styles.breadcrumb }>
 				<span className={ styles.titleIcon } aria-hidden="true">
-					<Icon icon={ mapMarker } size={ 16 } />
+					<Icon icon={ widgetDefinition.icon } size={ 16 } />
 				</span>
 				{ selectedCountry ? (
 					<>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -93,16 +93,18 @@ function LocationsInner( { max }: { max: number } ) {
 			return {
 				id: location.key,
 				label: (
-					<LeaderboardLabel
-						label={ location.label }
-						imageUrl={ imageUrl ?? undefined }
-						imageAlt={ sprintf(
-							/* translators: %s is the country name */
-							__( 'Flag of %s', 'jetpack-premium-analytics' ),
-							location.countryFull
-						) }
-						imageClassName={ styles.leaderboardImage }
-					/>
+					<div className={ styles.leaderboardLabel }>
+						<LeaderboardLabel
+							label={ location.label }
+							imageUrl={ imageUrl ?? undefined }
+							imageAlt={ sprintf(
+								/* translators: %s is the country name */
+								__( 'Flag of %s', 'jetpack-premium-analytics' ),
+								location.countryFull
+							) }
+							imageClassName={ styles.leaderboardImage }
+						/>
+					</div>
 				),
 				currentValue: location.value,
 				previousValue,

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -22,6 +22,7 @@ const storyWidgetType = {
 	name: widgetDefinition.name,
 	title: widgetDefinition.title,
 	icon: widgetDefinition.icon,
+	presentation: 'full-bleed' as const,
 };
 
 interface LocationsStoryControls {

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -102,6 +102,23 @@
 	overflow: hidden;
 }
 
+.leaderboardLabel {
+	min-width: 0;
+	overflow: hidden;
+}
+
+.leaderboardLabel > * {
+	min-width: 0;
+	max-width: 100%;
+}
+
+.leaderboardLabel span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .noMap {
 	grid-template-columns: 1fr;
 }

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -35,6 +35,11 @@
 	font-weight: inherit;
 }
 
+.titleIcon {
+	display: inline-flex;
+	flex: 0 0 auto;
+}
+
 .breadcrumbLink {
 	appearance: none;
 	background: none;

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -114,9 +114,11 @@
 	overflow: hidden;
 }
 
-/* Narrow container (< 480px): hide the map and collapse to a
- * single leaderboard column. */
-@container (max-width: 479px) {
+/* Very narrow containers: hide the map and collapse to a single leaderboard
+ * column. Keep the threshold below a dashboard width-2 tile at the minimum
+ * four-column dashboard width, so the default Locations widget still shows
+ * the map. */
+@container (max-width: 431px) {
 
 	.widgetHeader {
 		align-items: stretch;

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -16,11 +16,15 @@
 }
 
 .widgetHeader {
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-gap-sm, 8px);
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
 	min-height: 32px;
 }
 
 .breadcrumb {
+	flex: 1 1 0;
+	min-inline-size: 0;
 	min-height: 32px;
 	font-size: 13px;
 	font-weight: 500; /* design spec was 499; 500 is the nearest valid CSS value */
@@ -49,11 +53,21 @@
 }
 
 .breadcrumbSeparator {
+	flex: 0 0 auto;
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
+.breadcrumbCurrent {
+	min-inline-size: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .modeSelect {
-	flex-shrink: 0;
+	flex: 0 1 220px;
+	max-inline-size: 100%;
+	min-inline-size: min(100%, 160px);
 }
 
 .content {
@@ -98,6 +112,24 @@
 /* Narrow container (< 480px): hide the map and collapse to a
  * single leaderboard column. */
 @container (max-width: 479px) {
+
+	.widgetHeader {
+		align-items: stretch;
+	}
+
+	.breadcrumb,
+	.modeSelect {
+		flex-basis: 100%;
+	}
+
+	.breadcrumb {
+		order: 2;
+	}
+
+	.modeSelect {
+		inline-size: 100%;
+		order: 1;
+	}
 
 	.geoChart {
 		display: none;

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -27,6 +27,7 @@
 	min-inline-size: 0;
 	min-height: 32px;
 	font-size: 13px;
+	line-height: 20px;
 	font-weight: 500; /* design spec was 499; 500 is the nearest valid CSS value */
 	color: inherit;
 }
@@ -40,10 +41,18 @@
 	align-items: center;
 	min-inline-size: 0;
 	gap: var(--wpds-dimension-gap-xs, 4px);
+	line-height: inherit;
 }
 
 .headerIcon {
 	flex: 0 0 auto;
+}
+
+.breadcrumbTitle,
+.breadcrumbLink {
+	display: inline-flex;
+	align-items: center;
+	min-block-size: 20px;
 }
 
 .breadcrumbLink {
@@ -65,11 +74,13 @@
 
 .breadcrumbSeparator {
 	flex: 0 0 auto;
+	line-height: inherit;
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
 .breadcrumbCurrent {
 	min-inline-size: 0;
+	line-height: inherit;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -35,8 +35,14 @@
 	font-weight: inherit;
 }
 
-.titleIcon {
+.headerTitle {
 	display: inline-flex;
+	align-items: center;
+	min-inline-size: 0;
+	gap: var(--wpds-dimension-gap-xs, 4px);
+}
+
+.headerIcon {
 	flex: 0 0 auto;
 }
 


### PR DESCRIPTION
Part of WOOA7S-1491.

## Proposed changes
* Show the Locations body header before drill-down, so the full-bleed widget still displays `Locations` when the product dashboard hides the host card title.
* Keep the existing drill-down breadcrumb behavior as `Locations / <country>`.
* Let the Locations header wrap on narrow widget widths to avoid collisions with the dropdown.
* Pass `presentation: 'full-bleed'` to the Storybook dashboard story so Storybook matches the product dashboard and does not show a duplicate host title.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Start Storybook and open `Packages/Premium Analytics/Widgets/Locations`.
* Confirm the default/top-level widget shows `Locations` in the body header next to the `View by` dropdown.
* Confirm the `Widget Dashboard With Widget` story shows only one visible `Locations` title.
* Click a country row in the close-up story and confirm the breadcrumb still appears as `Locations / <country>`.
* Build Premium Analytics locally and confirm the local dashboard widget shows `Locations` before drill-down.

|Default story|Widget Dashboard story|Dashboard widget|
|-|-|-|
|<img width="1015" height="516" alt="截圖 2026-07-02 凌晨3 37 04" src="https://github.com/user-attachments/assets/eadaa3a4-abd3-491f-ae3c-1ca0bbdb23bd" />|<img width="1017" height="509" alt="截圖 2026-07-02 凌晨3 37 09" src="https://github.com/user-attachments/assets/49a89a5a-abf9-4a13-a76e-3841e07ac092" />|<img width="649" height="333" alt="截圖 2026-07-02 凌晨3 37 32" src="https://github.com/user-attachments/assets/58fcc816-6f96-4fac-8baf-4bfcd60b5db5" />|