### PR TITLE
AI Launchpad: add an in-progress state for site-editor tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-17735-ai-launchpad-add-an-in-progress-state-for-site-editor-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-17735-ai-launchpad-add-an-in-progress-state-for-site-editor-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Launchpad: show an in-progress state (drafts icon, "Continue" CTA) for site-editor tasks with an unpublished draft, reopening that draft instead of creating a new one.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/class-ai-launchpad-theme-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-social-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-subscribers-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-about-page-listener.php';
+require_once __DIR__ . '/class-ai-launchpad-first-post-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-dev-enable.php';
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php
@@ -82,6 +82,32 @@ class AI_Launchpad_About_Page_Listener {
 			wpcom_mark_launchpad_task_complete( 'update_about_page' );
 		}
 	}
+
+	/**
+	 * Returns the ID of the newest unpublished AI-created About page (a `draft` page carrying the marker meta), or null.
+	 *
+	 * Backs the "in progress" treatment: an About page saved but not yet published, so the task can reopen that draft
+	 * instead of creating a duplicate.
+	 *
+	 * @return int|null
+	 */
+	public static function get_draft_id() {
+		$ids = get_posts(
+			array(
+				'post_type'        => 'page',
+				'post_status'      => 'draft',
+				'posts_per_page'   => 1,
+				'orderby'          => 'date',
+				'order'            => 'DESC',
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => false,
+				'meta_key'         => self::META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- one-off read behind the AI Launchpad eligibility gate.
+			)
+		);
+
+		return empty( $ids ) ? null : (int) $ids[0];
+	}
 }
 
 AI_Launchpad_About_Page_Listener::register();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-first-post-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-first-post-listener.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * AI Launchpad first-post marker.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Owns the marker meta the AI Launchpad tags onto the first-post draft it creates (`first_post_published` /
+ * `first_post_published_newsletter`).
+ *
+ * The draft is otherwise indistinguishable from any other draft post, so the marker lets the read path recognise the
+ * AI-created draft precisely — used to show the "in progress" treatment and reopen that exact draft, rather than
+ * treating any latest draft on the site as the task's in-progress post. Completion still runs through the catalog's
+ * own `publish_post` listener; this class only registers the meta and looks the draft up.
+ */
+class AI_Launchpad_First_Post_Listener {
+
+	/**
+	 * Marker meta set by createFirstPostDraft on the AI-created first-post draft.
+	 */
+	const META_KEY = '_wpcom_ai_launchpad_first_post';
+
+	/**
+	 * Registers the marker meta.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'init', array( __CLASS__, 'register_meta' ) );
+	}
+
+	/**
+	 * Registers the marker meta so the block editor preserves it and the create request can set it.
+	 *
+	 * The auth callback limits writes to users who can edit posts.
+	 *
+	 * @return void
+	 */
+	public static function register_meta() {
+		register_post_meta(
+			'post',
+			self::META_KEY,
+			array(
+				'type'          => 'boolean',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Returns the ID of the newest unpublished AI-created first post (a `draft` post carrying the marker meta), or null.
+	 *
+	 * @return int|null
+	 */
+	public static function get_draft_id() {
+		$ids = get_posts(
+			array(
+				'post_type'        => 'post',
+				'post_status'      => 'draft',
+				'posts_per_page'   => 1,
+				'orderby'          => 'date',
+				'order'            => 'DESC',
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => false,
+				'meta_key'         => self::META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- one-off read behind the AI Launchpad eligibility gate.
+			)
+		);
+
+		return empty( $ids ) ? null : (int) $ids[0];
+	}
+}
+
+AI_Launchpad_First_Post_Listener::register();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -67,6 +67,17 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
+	 * First-post tasks that can sit "in progress": the AI-created draft post exists but has not been published yet.
+	 *
+	 * Detected through the `_wpcom_ai_launchpad_first_post` marker meta (via AI_Launchpad_First_Post_Listener), so an
+	 * unrelated pre-existing draft never counts. Paired with `add_about_page`, which has its own marker meta.
+	 */
+	const IN_PROGRESS_FIRST_POST_TASK_IDS = array(
+		'first_post_published',
+		'first_post_published_newsletter',
+	);
+
+	/**
 	 * Whether the site's visibility is set to private (`blog_public = -1`).
 	 *
 	 * Read directly to avoid a hard dependency on the Status package in this read path.
@@ -550,16 +561,86 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				? admin_url( self::CTA_OVERRIDES[ $task['id'] ] )
 				: wpcom_launchpad_checklists()->load_calypso_path( $definition );
 
+			$title       = isset( $definition['get_title'] ) ? $definition['get_title']() : '';
+			$in_progress = false;
+
+			// A saved-but-unpublished draft (found by marker meta) puts a site-editor task "in progress": reopen that
+			// draft instead of creating a new one, and surface the drafts icon + a "Continue…" prompt in the card.
+			if ( ! $completed ) {
+				$draft_url = $this->get_in_progress_draft_url( $task['id'] );
+				if ( null !== $draft_url ) {
+					$in_progress  = true;
+					$calypso_path = $draft_url;
+				}
+			}
+
+			// Title follows our precise in-progress signal so it, the icon, and the CTA agree.
+			$title = $this->get_task_title( $task['id'], $in_progress, $title );
+
 			$built[] = array(
 				'id'           => $task['id'],
 				'subtitle'     => $task['subtitle'],
-				'title'        => isset( $definition['get_title'] ) ? $definition['get_title']() : '',
+				'title'        => $title,
 				'completed'    => $completed,
+				'in_progress'  => $in_progress,
 				'calypso_path' => $calypso_path,
 			);
 		}
 
 		return $built;
+	}
+
+	/**
+	 * Resolves the editor URL of a site-editor task's in-progress draft, or null when there is none.
+	 *
+	 * The About page is found by its marker meta; the first-post tasks by the latest draft post. Returned as an
+	 * `admin_url()` so the client reopens the existing draft rather than creating a duplicate.
+	 *
+	 * @param string $task_id The catalog task id.
+	 * @return string|null
+	 */
+	private function get_in_progress_draft_url( $task_id ) {
+		$draft_id = null;
+
+		if ( 'add_about_page' === $task_id ) {
+			$draft_id = AI_Launchpad_About_Page_Listener::get_draft_id();
+		} elseif ( in_array( $task_id, self::IN_PROGRESS_FIRST_POST_TASK_IDS, true ) ) {
+			$draft_id = AI_Launchpad_First_Post_Listener::get_draft_id();
+		}
+
+		if ( null === $draft_id ) {
+			return null;
+		}
+
+		return admin_url( 'post.php?post=' . $draft_id . '&action=edit' );
+	}
+
+	/**
+	 * The card title for a site-editor task, chosen by our precise (marker-based) in-progress signal so the title,
+	 * icon, and CTA stay in agreement.
+	 *
+	 * This overrides `first_post_published`'s catalog title in both states: the catalog swaps it to "Continue…"
+	 * whenever ANY draft exists (a looser signal than our marker), so an unrelated draft would otherwise show a
+	 * "Continue…" title beside the not-started icon. Tasks not listed keep their catalog title.
+	 *
+	 * @param string $task_id     The catalog task id.
+	 * @param bool   $in_progress Whether our marker detected an in-progress draft.
+	 * @param string $default     The catalog-provided title, kept when we don't override.
+	 * @return string
+	 */
+	private function get_task_title( $task_id, $in_progress, $default ) {
+		switch ( $task_id ) {
+			case 'add_about_page':
+				return $in_progress ? __( 'Continue working on the About page', 'jetpack-mu-wpcom' ) : $default;
+			case 'first_post_published':
+				return $in_progress
+					? __( 'Continue to write your first post', 'jetpack-mu-wpcom' )
+					: __( 'Write your first post', 'jetpack-mu-wpcom' );
+			case 'first_post_published_newsletter':
+				return $in_progress ? __( 'Continue writing your first post', 'jetpack-mu-wpcom' ) : $default;
+			default:
+				return $default;
+		}
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
@@ -45,6 +45,9 @@ export async function createFirstPostDraft(
 			title: draft.title,
 			content: toBlocks( draft.paragraphs ),
 			status: 'draft',
+			// Tag as the AI Launchpad first post so the server can recognise this exact draft and show the
+			// in-progress "Continue" treatment, reopening it instead of drafting a second one.
+			meta: { _wpcom_ai_launchpad_first_post: true },
 		},
 	} ) ) as CreatedPost;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -65,6 +65,7 @@ function task( overrides: Partial< EnrichedTask > = {} ): EnrichedTask {
 		subtitle: 'Pick a theme.',
 		title: 'Choose a design',
 		completed: false,
+		in_progress: false,
 		calypso_path: '/themes/example.com',
 		...overrides,
 	};
@@ -155,6 +156,30 @@ describe( 'isTaskActionable', () => {
 		assert.equal( isTaskActionable( launch, null, '' ), false );
 		assert.equal( isTaskActionable( launch, null, 'not-a-url' ), false );
 	} );
+
+	it( 'treats an in-progress task as actionable when it has a draft to reopen', () => {
+		// No AI output: a not-in-progress create-content task would be non-actionable,
+		// so this proves the in-progress reopen path is what makes it actionable.
+		assert.equal(
+			isTaskActionable(
+				task( {
+					id: 'add_about_page',
+					in_progress: true,
+					calypso_path: '/wp-admin/post.php?post=9',
+				} ),
+				null
+			),
+			true
+		);
+		// Flagged in progress but with no draft path there is nothing to reopen.
+		assert.equal(
+			isTaskActionable(
+				task( { id: 'add_about_page', in_progress: true, calypso_path: null } ),
+				null
+			),
+			false
+		);
+	} );
 } );
 
 describe( 'isCompleteOnClickTask', () => {
@@ -244,6 +269,34 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( url, '/wp-admin/post.php?post=2' );
 		assert.deepEqual( clicked, [ 'add_about_page' ] );
+	} );
+
+	it( 'reopens the existing draft for an in-progress task instead of creating a new one', async () => {
+		const { clicked, handlers } = stubHandlers();
+		// The create-page handler would return .../post=2; reopening the draft returns .../post=9.
+		const aboutPage = await resolveCtaUrl(
+			task( {
+				id: 'add_about_page',
+				in_progress: true,
+				calypso_path: 'https://example.com/wp-admin/post.php?post=9&action=edit',
+			} ),
+			fixture,
+			handlers
+		);
+		assert.equal( aboutPage, 'https://example.com/wp-admin/post.php?post=9&action=edit' );
+
+		// The first-post task reopens its draft too, rather than drafting a fresh post (.../post=1).
+		const firstPost = await resolveCtaUrl(
+			task( {
+				id: 'first_post_published',
+				in_progress: true,
+				calypso_path: 'https://example.com/wp-admin/post.php?post=7&action=edit',
+			} ),
+			fixture,
+			handlers
+		);
+		assert.equal( firstPost, 'https://example.com/wp-admin/post.php?post=7&action=edit' );
+		assert.deepEqual( clicked, [ 'add_about_page', 'first_post_published' ] );
 	} );
 
 	it( 'sends launch tasks to the wordpress.com launch flow built from the site URL', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -9,6 +9,9 @@ export interface EnrichedTask {
 	subtitle: string;
 	title: string;
 	completed: boolean;
+	// True when a site-editor task has a saved-but-unpublished draft: the card shows
+	// the drafts icon + a "Continue" CTA, and `calypso_path` reopens that draft.
+	in_progress: boolean;
 	calypso_path: string | null;
 }
 
@@ -173,7 +176,10 @@ export async function resolveCtaUrl(
 
 	const kind = ctaKind( task.id );
 	let url: string | null;
-	if ( kind === 'first_post' && output ) {
+	if ( task.in_progress && task.calypso_path ) {
+		// The task already has an unpublished draft; reopen it rather than creating a duplicate.
+		url = task.calypso_path;
+	} else if ( kind === 'first_post' && output ) {
 		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
 	} else if ( kind === 'pattern_page' && output ) {
 		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
@@ -201,6 +207,10 @@ export function isTaskActionable(
 	output: TailoredOutput | null,
 	siteUrl: string | null = null
 ): boolean {
+	// An in-progress task reopens its existing draft via calypso_path, so it stays actionable.
+	if ( task.in_progress && task.calypso_path ) {
+		return true;
+	}
 	const kind = ctaKind( task.id );
 	if ( ( kind === 'first_post' || kind === 'pattern_page' ) && output ) {
 		return true;
@@ -247,6 +257,7 @@ export function tasksFromFixture( output: TailoredOutput ): EnrichedTask[] {
 		subtitle: task.subtitle,
 		title: humanizeTaskId( task.id ),
 		completed: false,
+		in_progress: false,
 		calypso_path: null,
 	} ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -78,29 +78,28 @@
 	&__title {
 		font-weight: 500;
 		font-size: 14px;
+		color: var(--wpds-color-fg-interactive-neutral, #1e1e1e);
 
 		&.is-done {
 			text-decoration: line-through;
-			color: #757575;
+			color: var(--wpds-color-fg-interactive-neutral-disabled, #8d8d8d);
 		}
 	}
 
 	// The WPDS task icons fill from `currentColor`, so tone them via `color`.
+	// To-do and in-progress share the neutral foreground; only done is dimmed,
+	// keeping each icon the same color as its title.
 	&__icon {
 		flex-shrink: 0;
 		display: inline-flex;
+		color: var(--wpds-color-fg-interactive-neutral, #1e1e1e);
 
 		svg {
 			fill: currentColor;
 		}
 
-		&.is-todo {
-			color: #c3c4c7;
-		}
-
-		// Greyed to sit alongside the struck-through title.
 		&.is-done {
-			color: #757575;
+			color: var(--wpds-color-fg-interactive-neutral-disabled, #8d8d8d);
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { border, published } from '@wordpress/icons';
+import { border, drafts, published } from '@wordpress/icons';
 import { Button, Card, CollapsibleCard } from '@wordpress/ui';
 import { ctaKind, type EnrichedTask } from './model.ts';
 
@@ -24,10 +24,16 @@ interface Props {
  * literals for translation extraction, and `model.ts` is kept free of
  * `@wordpress/*` imports so its node:test suite runs.
  *
- * @param taskId - The catalog task id.
+ * @param taskId     - The catalog task id.
+ * @param inProgress - Whether the task has a saved-but-unpublished draft.
  * @return The translated CTA label.
  */
-function getCtaLabel( taskId: string ): string {
+function getCtaLabel( taskId: string, inProgress: boolean ): string {
+	// An in-progress task reopens its existing draft, so the CTA invites the user to pick up where they left off.
+	if ( inProgress ) {
+		return __( 'Continue', 'jetpack-mu-wpcom' );
+	}
+
 	switch ( taskId ) {
 		case 'site_theme_selected':
 			return __( 'Browse themes', 'jetpack-mu-wpcom' );
@@ -112,8 +118,9 @@ export function TaskCard( {
 		>
 			<CollapsibleCard.Header>
 				<span className="ai-launchpad-tailored-list__header-inner">
-					<span className="ai-launchpad-tailored-list__icon is-todo">
-						<Icon icon={ border } size={ 24 } />
+					<span className="ai-launchpad-tailored-list__icon">
+						{ /* To-do vs in-progress is conveyed by the glyph alone; both share the neutral color. */ }
+						<Icon icon={ task.in_progress ? drafts : border } size={ 24 } />
 					</span>
 					<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
 				</span>
@@ -123,7 +130,7 @@ export function TaskCard( {
 				<div className="ai-launchpad-tailored-list__actions">
 					{ canStart && (
 						<Button variant="solid" onClick={ onGetStarted } loading={ isBusy } disabled={ isBusy }>
-							{ getCtaLabel( task.id ) }
+							{ getCtaLabel( task.id, task.in_progress ) }
 						</Button>
 					) }
 					{ ! canStart && canMarkComplete && (

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -13,6 +13,10 @@ require_once __DIR__ . '/fixtures/memberships-stubs.php';
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-memberships.php';
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-first-post-listener.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-rest.php';
 
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -193,13 +197,113 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'Share your first trail story.', $first_task['subtitle'] );
 		$this->assertSame( 'Write your first post', $first_task['title'] );
 		$this->assertTrue( $first_task['completed'] );
+		$this->assertFalse( $first_task['in_progress'] );
 		$this->assertSame( admin_url( 'post-new.php' ), $first_task['calypso_path'] );
 
 		$last_task = $data['tasks'][5];
 		$this->assertSame( 'site_launched', $last_task['id'] );
 		$this->assertSame( 'Launch your site', $last_task['title'] );
 		$this->assertFalse( $last_task['completed'] );
+		$this->assertFalse( $last_task['in_progress'] );
 		$this->assertNull( $last_task['calypso_path'] );
+	}
+
+	/**
+	 * Test that an unpublished, AI-created About page draft puts the add_about_page task "in progress": the task
+	 * surfaces the `in_progress` flag, a "Continue…" title, and a calypso_path that reopens the existing draft rather
+	 * than creating a new one.
+	 *
+	 * The marker-meta draft lookup runs through WP_Query, which WorDBless can't execute, so it's short-circuited with
+	 * core's `posts_pre_query` filter to return the seeded draft id.
+	 */
+	public function test_get_marks_about_page_in_progress_with_unpublished_draft() {
+		wp_set_current_user( $this->admin_id );
+
+		// add_about_page's catalog visibility gate requires this meta to be registered on pages (as on WoA).
+		register_post_meta( 'page', '_wpcom_template_layout_category', array( 'show_in_rest' => true ) );
+
+		$this->seed_ai_output_with_tasks( array( 'add_about_page', 'site_launched' ) );
+
+		$get_about = function () {
+			foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+				if ( 'add_about_page' === $task['id'] ) {
+					return $task;
+				}
+			}
+			return null;
+		};
+
+		// No draft yet: the task renders in its plain, not-started state.
+		$before = $get_about();
+		$this->assertNotNull( $before );
+		$this->assertFalse( $before['in_progress'] );
+		$this->assertSame( 'Add your About page', $before['title'] );
+
+		// Stand in for a saved-but-unpublished AI About page draft by short-circuiting its marker-meta lookup.
+		$draft_id = 4242;
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $draft_id ) {
+				if ( AI_Launchpad_About_Page_Listener::META_KEY === $query->get( 'meta_key' ) ) {
+					return array( $draft_id );
+				}
+				return $posts;
+			},
+			10,
+			2
+		);
+
+		$after = $get_about();
+		$this->assertNotNull( $after );
+		$this->assertTrue( $after['in_progress'] );
+		$this->assertSame( 'Continue working on the About page', $after['title'] );
+		$this->assertSame( admin_url( 'post.php?post=' . $draft_id . '&action=edit' ), $after['calypso_path'] );
+	}
+
+	/**
+	 * Test that an unpublished AI-created first-post draft puts the newsletter first-post task "in progress": it's
+	 * detected through the first-post marker meta (not any latest draft), gets the drafts-aware "Continue writing"
+	 * title override, and reopens that draft. The marker query is short-circuited via `posts_pre_query` (WorDBless
+	 * can't run WP_Query).
+	 */
+	public function test_get_marks_first_post_in_progress_with_marked_draft() {
+		wp_set_current_user( $this->admin_id );
+
+		$this->seed_ai_output_with_tasks( array( 'first_post_published_newsletter', 'site_launched' ) );
+
+		$get_first_post = function () {
+			foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+				if ( 'first_post_published_newsletter' === $task['id'] ) {
+					return $task;
+				}
+			}
+			return null;
+		};
+
+		// No marked draft: the task renders in its plain, not-started state.
+		$before = $get_first_post();
+		$this->assertNotNull( $before );
+		$this->assertFalse( $before['in_progress'] );
+
+		// Stand in for the AI-created first-post draft by short-circuiting its marker-meta lookup.
+		$draft_id = 5151;
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $draft_id ) {
+				if ( AI_Launchpad_First_Post_Listener::META_KEY === $query->get( 'meta_key' ) ) {
+					return array( $draft_id );
+				}
+				return $posts;
+			},
+			10,
+			2
+		);
+
+		$after = $get_first_post();
+		$this->assertNotNull( $after );
+		$this->assertTrue( $after['in_progress'] );
+		$this->assertSame( 'Continue writing your first post', $after['title'] );
+		$this->assertSame( admin_url( 'post.php?post=' . $draft_id . '&action=edit' ), $after['calypso_path'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-17735

## Proposed changes
* Adds an **In Progress** state to the AI Launchpad's site-editor tasks: when the AI-created draft is saved but not yet published, the task card shows the WPDS `drafts` icon, a "Continue…" title, and its CTA reopens that draft instead of creating a new one.
* Applies to `add_about_page`, `first_post_published`, and `first_post_published_newsletter`.
* Detection is precise via marker meta. The About page keeps its existing `_wpcom_ai_launchpad_about_page` marker; the first-post draft is now tagged with a new `_wpcom_ai_launchpad_first_post` marker (`AI_Launchpad_First_Post_Listener`). An unrelated pre-existing draft never triggers the state, and the AI-drafted first-post content is never discarded.
* Title, icon, and CTA all follow the same marker signal so they can't disagree — the shared catalog's looser "any draft" title heuristic is overridden read-side.
* Icon/title colors use the WPDS neutral tokens: to-do and in-progress `--wpds-color-fg-interactive-neutral` (#1e1e1e), done `--wpds-color-fg-interactive-neutral-disabled` (#8d8d8d).
* All overrides live read-side in `AI_Launchpad_REST::build_tasks()`; the shared launchpad catalog is untouched.

## Related product discussion/links
* DOTCOM-17735 — follow-up to DSGCOM-678 (AI Launchpad first-pass feedback).

## Does this pull request change what data or activity we track or use?
No new tracking. Adds one post-meta marker (`_wpcom_ai_launchpad_first_post`) used solely to identify the AI-created first-post draft.

## Testing instructions
The AI Launchpad is gated behind eligibility; test on an eligible Atomic/WoA site.

* Open the AI Launchpad in wp-admin with a tailored list that includes a first-post task (`first_post_published`). It shows the `border` (to-do) icon and the title "Write your first post".
* Click **Write post** — this drafts the AI first post (tagged with the marker) and opens the editor. Save the draft without publishing, then return to the Launchpad.
* The task now shows the `drafts` icon, the title **"Continue to write your first post"**, and a **Continue** button that reopens that same draft (confirm no duplicate draft is created).
* Publish the draft — the task completes (struck-through, `published` icon).
* For the About page task (`add_about_page`): after saving the pattern-page draft, the task reads **"Continue working on the About page"** and reopens it. Note: `add_about_page` is hidden by the shared catalog's visibility gate on sites where `_wpcom_template_layout_category` isn't registered; exercise it via `GET /wpcom/v2/ai-launchpad?all_tasks=1` there.
* Newsletter first post (`first_post_published_newsletter`) shows **"Continue writing your first post"** when in progress.
