### PR TITLE
Performance: post multiple metrics per CodeVitals scenario (LCP + TTFB + FCP)

### DIFF
--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -69,7 +69,7 @@ CodeVitals is an **append-only** store with no self-service rollback. Once a bad
 
 ### Sanity-range assertions
 
-`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and rejected, and the script exits non-zero so CI surfaces the failure. Live posting is all-or-nothing per run: any sanity failure suppresses the entire POST (nothing lands, so a retried build re-posts the full set exactly once). A dry run still prints the partial payload — the surviving metrics — for diagnostics.
+`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and rejected, and the script exits non-zero so CI surfaces the failure. Live posting is all-or-nothing per run: any sanity failure suppresses the entire POST (nothing lands, so a retried build re-posts the full set exactly once). A dry run still prints the surviving metrics, if any, for diagnostics.
 
 | Metric | Min | Max   |
 | ------ | --- | ----- |

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -69,7 +69,7 @@ CodeVitals is an **append-only** store with no self-service rollback. Once a bad
 
 ### Sanity-range assertions
 
-`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and skipped (not posted), and the script exits non-zero so CI surfaces the failure. Other valid metrics in the same run still post.
+`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and rejected, and the script exits non-zero so CI surfaces the failure. Live posting is all-or-nothing per run: any sanity failure suppresses the entire POST (nothing lands, so a retried build re-posts the full set exactly once). A dry run still prints the partial payload — the surviving metrics — for diagnostics.
 
 | Metric | Min | Max   |
 | ------ | --- | ----- |

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -27,9 +27,17 @@ The test suite is designed to run in TeamCity. See `TEAMCITY-SETUP.md` for detai
 | `WP_ADMIN_USER`        | WordPress admin username (default: admin)                                                                                                                                                                                                                                             |
 | `WP_ADMIN_PASS`        | WordPress admin password (default: password)                                                                                                                                                                                                                                          |
 
-## Metric
+## Metrics
 
-- `wp-admin-dashboard-connection-sim-largestContentfulPaint` - Dashboard LCP with simulated Jetpack connection
+The `jetpackConnected` scenario posts three metrics per run, all in a single CodeVitals call (one per `metrics` entry in `scenarios.js`):
+
+| CodeVitals key                                             | Field  | Type   | Description                                     |
+| ---------------------------------------------------------- | ------ | ------ | ----------------------------------------------- |
+| `wp-admin-dashboard-connection-sim-largestContentfulPaint` | `lcp`  | `lcp`  | Dashboard LCP with simulated Jetpack connection |
+| `wp-admin-dashboard-connection-sim-timeToFirstByte`        | `ttfb` | `ttfb` | Dashboard TTFB (navigation `responseStart`)     |
+| `wp-admin-dashboard-connection-sim-firstContentfulPaint`   | `fcp`  | `fcp`  | Dashboard FCP (first-contentful-paint)          |
+
+Each metric reads its value from `summary.<field>.median` and is range-checked against its `type` in `SANITY_RANGES` before posting.
 
 ## How It Works
 
@@ -71,7 +79,7 @@ CodeVitals is an **append-only** store with no self-service rollback. Once a bad
 | `tbt`  | 0   | 10000 |
 | `cls`  | 0   | 5     |
 
-Add a row when a new metric type starts being posted, and set `metricType` on the scenario so the check applies to it.
+Add a row when a new metric type starts being posted, and set the `type` on the metric so the check applies to it — either `type` on a `metrics[]` entry (the multi-metric shape) or the scenario-level `metricType` (the legacy single-key shape). A keyed metric with no type is refused (never posted unchecked).
 
 ### Staging keys
 

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -69,7 +69,7 @@ CodeVitals is an **append-only** store with no self-service rollback. Once a bad
 
 ### Sanity-range assertions
 
-`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and rejected, and the script exits non-zero so CI surfaces the failure. Live posting is all-or-nothing per run: any sanity failure suppresses the entire POST (nothing lands, so a retried build re-posts the full set exactly once). A dry run still prints the surviving metrics, if any, for diagnostics.
+`post-to-codevitals.js` checks every typed metric against `SANITY_RANGES` in `scenarios.js` before posting. A value outside its range is logged and rejected, and the script exits non-zero so CI surfaces the failure. Live posting is all-or-nothing per run: any sanity failure suppresses the entire POST, so nothing lands and retrying the red build posts the full set exactly once. (That guarantee covers the validation-failure retry only — re-running a green build appends duplicate points unless opt-in cross-commit dedup is enabled.) A dry run still prints the surviving metrics, if any, for diagnostics.
 
 | Metric | Min | Max   |
 | ------ | --- | ----- |

--- a/tools/performance/scripts/measure-lcp.js
+++ b/tools/performance/scripts/measure-lcp.js
@@ -330,8 +330,10 @@ function buildSummary( validResults, iterations, fields = SUMMARY_FIELDS ) {
 	}
 	return {
 		// Flat top-level LCP stats, mirrored for backward-compat (legacy metricKey path +
-		// older readers of summary.median). validResults always carries a finite LCP, so
-		// perField.lcp is always present.
+		// older readers of summary.median). Nothing above enforces a FINITE LCP (the
+		// validResults filter only drops null/undefined), so in the degenerate case where
+		// every LCP sample is non-finite, perField.lcp is absent: the flat mirror is
+		// simply omitted and the poster fails closed on the missing field.
 		...( perField.lcp ?? {} ),
 		successfulIterations: validResults.length,
 		totalIterations: iterations,

--- a/tools/performance/scripts/measure-lcp.js
+++ b/tools/performance/scripts/measure-lcp.js
@@ -286,16 +286,24 @@ function readIterationField( result, field ) {
 /**
  * Summary stats for one field across the valid iterations, rounded to whole ms to match
  * the original LCP-only summary. Non-finite samples (a browser that reported null for a
- * field on some iteration) are dropped before aggregating; a field with NO finite samples
- * returns null so the caller omits it and the poster fails closed on the missing field
- * rather than posting a fabricated 0.
+ * field on some iteration) are dropped before aggregating. A field whose finite samples do
+ * not cover a MAJORITY of the valid iterations returns null so the caller omits it and the
+ * poster fails closed on the missing field rather than posting a fabricated 0 — or, worse, a
+ * thin value (e.g. a field captured on 1 of 5 runs) as a full "median" with stdDev 0, a
+ * low-confidence point indistinguishable from a real full-sample median in the append-only store.
  *
  * @param {Array<number|null|undefined>} values - Raw per-iteration values for the field.
  * @return {{median:number,mean:number,min:number,max:number,stdDev:number}|null} Rounded stats, or null.
  */
 function summarizeField( values ) {
 	const finite = values.filter( v => typeof v === 'number' && Number.isFinite( v ) );
-	if ( finite.length === 0 ) {
+	// Require a STRICT majority of the valid iterations to have produced a finite sample:
+	// finite*2 > n. This keeps single-iteration runs working (1 of 1) while rejecting a thin
+	// field that would otherwise post a lone/minority sample as a trend point — including the
+	// even-count edge (1 of 2, 2 of 4) that a ceil(n/2) floor would let slip through. n=0 also
+	// falls through to null (0 > 0 is false). LCP is unaffected in practice: it is finite on
+	// every valid iteration by construction (validResults already filtered out null LCP).
+	if ( finite.length * 2 <= values.length ) {
 		return null;
 	}
 	return {

--- a/tools/performance/scripts/measure-lcp.js
+++ b/tools/performance/scripts/measure-lcp.js
@@ -251,27 +251,92 @@ async function measureLCP( url, username, password, iterations = 5 ) {
 		);
 	}
 
-	const lcpValues = validResults.map( r => r.lcp );
-
-	// Calculate statistics using shared utilities
-	const median = calcMedian( lcpValues );
-	const mean = calcMean( lcpValues );
-	const stdDev = calcStdDev( lcpValues );
-	const min = Math.min( ...lcpValues );
-	const max = Math.max( ...lcpValues );
-
 	return {
-		summary: {
-			median: Math.round( median ),
-			mean: Math.round( mean ),
-			min: Math.round( min ),
-			max: Math.round( max ),
-			stdDev: Math.round( stdDev ),
-			successfulIterations: validResults.length,
-			totalIterations: iterations,
-		},
+		summary: buildSummary( validResults, iterations ),
 		results,
 		url,
+	};
+}
+
+/**
+ * Metric fields aggregated into the summary. LCP stays first: it is the load-bearing
+ * value (unchanged), and it also populates the flat top-level summary for backward-compat.
+ * TTFB and FCP are already captured per iteration (see the page.evaluate block above);
+ * this is where they finally get aggregated into the summary.
+ */
+const SUMMARY_FIELDS = [ 'lcp', 'ttfb', 'fcp' ];
+
+/**
+ * Read one metric field from a single iteration's result.
+ *
+ * LCP lives at the top level (r.lcp) exactly as before, so its value source is byte-for-byte
+ * unchanged; the other Core Web Vitals come from the captured per-iteration `metrics` block.
+ *
+ * @param {object} result - One entry from the measureLCP results array.
+ * @param {string} field  - Metric field name (e.g. 'lcp', 'ttfb', 'fcp').
+ * @return {number|null|undefined} The raw value, or null/undefined when the browser had none.
+ */
+function readIterationField( result, field ) {
+	if ( field === 'lcp' ) {
+		return result.lcp;
+	}
+	return result.metrics ? result.metrics[ field ] : null;
+}
+
+/**
+ * Summary stats for one field across the valid iterations, rounded to whole ms to match
+ * the original LCP-only summary. Non-finite samples (a browser that reported null for a
+ * field on some iteration) are dropped before aggregating; a field with NO finite samples
+ * returns null so the caller omits it and the poster fails closed on the missing field
+ * rather than posting a fabricated 0.
+ *
+ * @param {Array<number|null|undefined>} values - Raw per-iteration values for the field.
+ * @return {{median:number,mean:number,min:number,max:number,stdDev:number}|null} Rounded stats, or null.
+ */
+function summarizeField( values ) {
+	const finite = values.filter( v => typeof v === 'number' && Number.isFinite( v ) );
+	if ( finite.length === 0 ) {
+		return null;
+	}
+	return {
+		median: Math.round( calcMedian( finite ) ),
+		mean: Math.round( calcMean( finite ) ),
+		min: Math.round( Math.min( ...finite ) ),
+		max: Math.round( Math.max( ...finite ) ),
+		stdDev: Math.round( calcStdDev( finite ) ),
+	};
+}
+
+/**
+ * Build the measurement summary from the per-iteration results.
+ *
+ * Produces a nested `summary.<field>` block ({ median, mean, min, max, stdDev }) for every
+ * field with finite samples, AND mirrors the LCP block's stats flat on the summary root for
+ * backward-compat: the poster's legacy `metricKey` path and older dashboards read
+ * `summary.median` directly, and it must keep returning the same LCP number as before.
+ *
+ * @param {Array}    validResults - Iteration results already filtered to successful runs.
+ * @param {number}   iterations   - Total iterations attempted (for the summary counters).
+ * @param {string[]} [fields]     - Metric fields to aggregate (defaults to SUMMARY_FIELDS).
+ * @return {object} The summary object.
+ */
+function buildSummary( validResults, iterations, fields = SUMMARY_FIELDS ) {
+	const perField = {};
+	for ( const field of fields ) {
+		const stats = summarizeField( validResults.map( r => readIterationField( r, field ) ) );
+		if ( stats ) {
+			perField[ field ] = stats;
+		}
+	}
+	return {
+		// Flat top-level LCP stats, mirrored for backward-compat (legacy metricKey path +
+		// older readers of summary.median). validResults always carries a finite LCP, so
+		// perField.lcp is always present.
+		...( perField.lcp ?? {} ),
+		successfulIterations: validResults.length,
+		totalIterations: iterations,
+		// Per-field nested blocks for the multi-metric poster path (reads summary.<field>.median).
+		...perField,
 	};
 }
 
@@ -424,4 +489,4 @@ if ( isDirectInvocation( import.meta.filename, process.argv[ 1 ] ) ) {
 	} );
 }
 
-export { measureLCP, resolveResultsGit };
+export { measureLCP, resolveResultsGit, buildSummary };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -184,10 +184,16 @@ function checkSanityRange( type, value ) {
 		return { ok: true };
 	}
 
-	const range = SANITY_RANGES[ type ];
-	if ( ! range ) {
+	// Look up the range as an OWN property only. SANITY_RANGES is a plain object, so a type
+	// that happens to name an inherited property ("constructor", "toString", "valueOf", …)
+	// would resolve to a truthy prototype value with undefined min/max, and the range
+	// comparison below (value < undefined || value > undefined) is always false — the value
+	// would post unchecked. A type with no OWN range row is a typo or a forgotten entry and
+	// must fail closed.
+	if ( ! Object.hasOwn( SANITY_RANGES, type ) ) {
 		return { ok: false, reason: `no sanity range is defined for type "${ type }"` };
 	}
+	const range = SANITY_RANGES[ type ];
 
 	if ( value < range.min || value > range.max ) {
 		return { ok: false, reason: `${ value } is outside [${ range.min }, ${ range.max }]` };

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -122,6 +122,17 @@ function extractScenarioMetrics( scenario, summary ) {
 	}
 
 	// Legacy: prefix-based keys with suffixes (untyped — not range-checked)
+	// A posting scenario with none of the three selectors would reach here with an
+	// undefined prefix and post five finite summary stats under literal "undefined_*"
+	// keys — untyped, so unchecked, and with a green build. That is the one fail-open
+	// shape in this function, so refuse it like the sibling guards above.
+	if ( typeof scenario.metricPrefix !== 'string' || ! scenario.metricPrefix.trim() ) {
+		throw new ValidationError(
+			`Scenario "${
+				scenario.key ?? 'unknown'
+			}" posts to CodeVitals but declares no metrics[], metricKey, or metricPrefix; refusing to post under "undefined_*" keys`
+		);
+	}
 	const prefix = scenario.metricPrefix;
 	return [
 		{ key: `${ prefix }_ms`, value: summary.median },

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -58,6 +58,18 @@ function extractScenarioMetrics( scenario, summary ) {
 	if ( Array.isArray( scenario.metrics ) ) {
 		const seen = new Set();
 		return scenario.metrics.map( metric => {
+			// Every entry MUST name a CodeVitals key. Without one, `key` is undefined and the
+			// value lands under the literal key "undefined" in the append-only store — a
+			// permanent garbage point checkSanityRange (which only inspects the value) can't
+			// catch. A missing or blank key is a scenario misconfiguration, so fail closed
+			// here, mirroring the type and duplicate-key guards below.
+			if ( typeof metric.codevitalsKey !== 'string' || ! metric.codevitalsKey.trim() ) {
+				throw new ValidationError(
+					`Scenario "${ scenario.key ?? 'unknown' }" has a metric (field "${
+						metric.field ?? 'unknown'
+					}") with no codevitalsKey; refusing to post to the append-only store`
+				);
+			}
 			// Every keyed metric MUST declare a type so checkSanityRange can range-check it —
 			// the same fail-closed invariant the single-metricKey path enforces below. A
 			// missing type is a scenario misconfiguration, so fail loud here (the dry-run CI

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -490,6 +490,20 @@ async function postToCodeVitals( resultsPath, config ) {
 		return { posted: false, validationFailed, payload };
 	}
 
+	// Atomic per-run posting: any sanity-check failure above already commits this run to
+	// exit 2, so never live-post the surviving subset. CodeVitals is append-only and dedup
+	// is opt-in (off by default), so posting survivors (e.g. a good LCP) just before the
+	// build reds would re-append them as duplicate trend points when the red build is
+	// retried. Posting nothing keeps the retry clean: fix the bad metric, re-run, and the
+	// full set lands exactly once. The dry-run path above still prints the partial payload,
+	// so CI diagnostics keep showing which metrics survived.
+	if ( validationFailed ) {
+		console.error(
+			'✗ Skipping CodeVitals post: one or more metrics failed sanity checks; posting nothing.'
+		);
+		return { posted: false, validationFailed };
+	}
+
 	// Cross-commit dedup (live posts only — kept after the dry-run return so the
 	// token-free CI smoke test still makes zero network calls). CodeVitals is
 	// append-only, so re-testing a commit (a manual re-run, a TeamCity retryBuild,
@@ -593,10 +607,12 @@ async function postToCodeVitals( resultsPath, config ) {
 				? `CodeVitals request timed out after ${ TIMEOUT_MS / 1000 }s`
 				: error.message;
 		console.error( '✗ Failed to post metrics to CodeVitals:', message );
-		// If a metric already failed local validation, the build must fail with the
-		// data-integrity code even though the transport ALSO failed here — bad local
-		// data is never suppressible by --allow-codevitals-failure. A pure transport
-		// failure (no prior validation failure) stays a plain Error (exit 1).
+		// Backstop for the exit-code split: bad local data is never suppressible by
+		// --allow-codevitals-failure, so a validation failure must map to the
+		// data-integrity code even when the transport ALSO failed. The atomic gate above
+		// means a live POST can no longer run with validationFailed set, so this stays
+		// Error (exit 1) today — kept so a future re-ordering of the gate cannot
+		// silently downgrade a validation failure to a suppressible exit 1.
 		const ErrorClass = validationFailed ? ValidationError : Error;
 		throw new ErrorClass( message, { cause: error } );
 	} finally {
@@ -707,7 +723,7 @@ async function main() {
 		const result = await postToCodeVitals( config.resultsPath, config );
 		if ( result.validationFailed ) {
 			console.error(
-				'\n✗ One or more metrics failed sanity checks (see above). Any valid metrics were still processed.'
+				'\n✗ One or more metrics failed sanity checks (see above). Nothing was posted.'
 			);
 			// Exit with the data-integrity code so the runner always fails the build
 			// here, even under --allow-codevitals-failure (that flag is for outages).

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -46,8 +46,51 @@ function exitCodeForError( error ) {
  *
  * Each entry carries its CodeVitals key, value, and (optional) type. The type
  * drives the sanity-range check; untyped legacy entries are posted unchecked.
+ *
+ * Three shapes, in precedence order. A `metrics` array yields one typed entry per element,
+ * each reading its value from summary.<field>.median and posting to its own key (the
+ * FORMS-707 multi-metric-per-scenario path). A single `metricKey` yields one typed entry
+ * reading the flat summary.median (legacy). A `metricPrefix` yields five untyped
+ * prefix-suffixed entries, posted unchecked (legacy).
  */
 function extractScenarioMetrics( scenario, summary ) {
+	// Multi-metric path: a scenario declares several metrics posted together in one call.
+	if ( Array.isArray( scenario.metrics ) ) {
+		const seen = new Set();
+		return scenario.metrics.map( metric => {
+			// Every keyed metric MUST declare a type so checkSanityRange can range-check it —
+			// the same fail-closed invariant the single-metricKey path enforces below. A
+			// missing type is a scenario misconfiguration, so fail loud here (the dry-run CI
+			// smoke test catches it before any post) rather than post an unchecked value.
+			if ( ! metric.type ) {
+				throw new ValidationError(
+					`Scenario "${ scenario.key ?? 'unknown' }" metric "${
+						metric.codevitalsKey ?? metric.field ?? 'unknown'
+					}" has no type; refusing to post an unchecked keyed metric`
+				);
+			}
+			// A metrics array that lists the same key twice would post one value then clobber
+			// it — a scenario-config bug, not bad runtime data. Fail closed here, before any
+			// value is read, mirroring the cross-scenario duplicate-key guard in the loop.
+			if ( seen.has( metric.codevitalsKey ) ) {
+				throw new ValidationError(
+					`Duplicate CodeVitals metric key "${ metric.codevitalsKey }" within scenario "${
+						scenario.key ?? 'unknown'
+					}"`
+				);
+			}
+			seen.add( metric.codevitalsKey );
+			// Read the value from the per-field summary block (summary.<field>.median). A
+			// missing field yields undefined, which checkSanityRange rejects (fail closed)
+			// rather than crashing — never a fabricated value into the append-only store.
+			return {
+				key: metric.codevitalsKey,
+				value: summary?.[ metric.field ]?.median,
+				type: metric.type,
+			};
+		} );
+	}
+
 	// Use explicit metricKey if defined, otherwise fall back to prefix-based keys
 	if ( scenario.metricKey ) {
 		// A posted exact-key metric must declare a metricType so checkSanityRange can

--- a/tools/performance/scripts/post-to-codevitals.js
+++ b/tools/performance/scripts/post-to-codevitals.js
@@ -54,10 +54,30 @@ function exitCodeForError( error ) {
  * prefix-suffixed entries, posted unchecked (legacy).
  */
 function extractScenarioMetrics( scenario, summary ) {
+	const scenarioLabel = scenario.key ?? 'unknown';
 	// Multi-metric path: a scenario declares several metrics posted together in one call.
 	if ( Array.isArray( scenario.metrics ) ) {
+		// An empty metrics[] posts nothing without tripping any guard: solo it falls
+		// through to the fail-closed no-metrics gate, but next to a sibling posting
+		// scenario it would be dropped silently while the run posts green. Declaring
+		// the array and leaving it empty is a scenario misconfiguration either way.
+		if ( scenario.metrics.length === 0 ) {
+			throw new ValidationError(
+				`Scenario "${ scenarioLabel }" declares an empty metrics array; declare at least one metric or drop postToCodeVitals`
+			);
+		}
 		const seen = new Set();
 		return scenario.metrics.map( metric => {
+			// A null/undefined entry would throw a raw TypeError on the key read below,
+			// and a plain Error maps to the suppressible exit 1 — escaping the exit-2
+			// contract every other misconfiguration here honors. Reject the shape first.
+			if ( ! metric || typeof metric !== 'object' ) {
+				throw new ValidationError(
+					`Scenario "${ scenarioLabel }" has a non-object metrics[] entry (${ JSON.stringify(
+						metric
+					) }); refusing to post`
+				);
+			}
 			// Every entry MUST name a CodeVitals key. Without one, `key` is undefined and the
 			// value lands under the literal key "undefined" in the append-only store — a
 			// permanent garbage point checkSanityRange (which only inspects the value) can't
@@ -65,7 +85,7 @@ function extractScenarioMetrics( scenario, summary ) {
 			// here, mirroring the type and duplicate-key guards below.
 			if ( typeof metric.codevitalsKey !== 'string' || ! metric.codevitalsKey.trim() ) {
 				throw new ValidationError(
-					`Scenario "${ scenario.key ?? 'unknown' }" has a metric (field "${
+					`Scenario "${ scenarioLabel }" has a metric (field "${
 						metric.field ?? 'unknown'
 					}") with no codevitalsKey; refusing to post to the append-only store`
 				);
@@ -76,7 +96,7 @@ function extractScenarioMetrics( scenario, summary ) {
 			// smoke test catches it before any post) rather than post an unchecked value.
 			if ( ! metric.type ) {
 				throw new ValidationError(
-					`Scenario "${ scenario.key ?? 'unknown' }" metric "${
+					`Scenario "${ scenarioLabel }" metric "${
 						metric.codevitalsKey ?? metric.field ?? 'unknown'
 					}" has no type; refusing to post an unchecked keyed metric`
 				);
@@ -86,9 +106,7 @@ function extractScenarioMetrics( scenario, summary ) {
 			// value is read, mirroring the cross-scenario duplicate-key guard in the loop.
 			if ( seen.has( metric.codevitalsKey ) ) {
 				throw new ValidationError(
-					`Duplicate CodeVitals metric key "${ metric.codevitalsKey }" within scenario "${
-						scenario.key ?? 'unknown'
-					}"`
+					`Duplicate CodeVitals metric key "${ metric.codevitalsKey }" within scenario "${ scenarioLabel }"`
 				);
 			}
 			seen.add( metric.codevitalsKey );
@@ -128,9 +146,7 @@ function extractScenarioMetrics( scenario, summary ) {
 	// shape in this function, so refuse it like the sibling guards above.
 	if ( typeof scenario.metricPrefix !== 'string' || ! scenario.metricPrefix.trim() ) {
 		throw new ValidationError(
-			`Scenario "${
-				scenario.key ?? 'unknown'
-			}" posts to CodeVitals but declares no metrics[], metricKey, or metricPrefix; refusing to post under "undefined_*" keys`
+			`Scenario "${ scenarioLabel }" posts to CodeVitals but declares no metrics[], metricKey, or metricPrefix; refusing to post under "undefined_*" keys`
 		);
 	}
 	const prefix = scenario.metricPrefix;

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -375,10 +375,12 @@ test( 'dry-run posts all three scenario metrics into the payload, nothing reject
 	assert.equal( Object.keys( result.payload.metrics ).length, 3 );
 } );
 
-test( 'per-type sanity: one out-of-range metric is rejected while the others still post', async () => {
-	// The core multi-metric guarantee: TTFB out of its own range [10,10000] is dropped, but
-	// LCP and FCP — each checked against its OWN type — still land. A per-metric failure must
-	// not take down the whole scenario, and the rejected key must never reach the payload.
+test( 'per-type sanity: one out-of-range metric is rejected, the survivors stay visible in the dry-run payload', async () => {
+	// Each metric is checked against its OWN type: TTFB out of its range [10,10000] is
+	// dropped while LCP and FCP survive into the dry-run payload, so CI diagnostics show
+	// exactly which metrics passed. (A live run with validationFailed posts NOTHING — see
+	// the atomic-post test below — so the partial payload is diagnostic-only.) The
+	// rejected key must never reach the payload.
 	const file = writeResults( 120, { ttfb: 99999, fcp: 400 } );
 	const result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
 	assert.equal( result.validationFailed, true ); // ttfb failed its range
@@ -1041,11 +1043,13 @@ test(
 	}
 );
 
-test( 'a validation failure is not downgraded to exit 1 when a later live POST also fails', async () => {
+test( 'a sanity-check failure suppresses the live POST entirely (atomic per-run posting)', async () => {
 	// Reachable only with 2+ posted metrics (FORMS-707 territory): one metric fails the
-	// sanity check (validationFailed=true) while a valid one remains and is POSTed. If
-	// that POST then fails, the build must STILL exit with the data-integrity code — bad
-	// local data is never suppressible by --allow-codevitals-failure.
+	// sanity check (validationFailed=true) while valid survivors remain. The run is
+	// already committed to exit 2, and CodeVitals is append-only with dedup off by
+	// default — so POSTing the survivors would re-append them as duplicate trend points
+	// when the red build is retried. The live path must post NOTHING: fetch is never
+	// called, and the result still carries validationFailed for main()'s exit-2 mapping.
 	const extra = {
 		key: 'extraMetric',
 		name: 'Extra Metric',
@@ -1062,34 +1066,37 @@ test( 'a validation failure is not downgraded to exit 1 when a later live POST a
 		JSON.stringify( {
 			git: { hash: 'h', branch: 'trunk' },
 			measurements: {
-				jetpackConnected: { summary: jetpackSummary() }, // valid LCP/TTFB/FCP → get POSTed
+				jetpackConnected: { summary: jetpackSummary() }, // valid LCP/TTFB/FCP survivors
 				extraMetric: { summary: { median: 99999 } }, // outside [0,1000] → skipped, flags validationFailed
 			},
 		} )
 	);
 	const origFetch = global.fetch;
-	// A transport failure AFTER a metric already failed local validation.
-	global.fetch = async () => ( { ok: false, status: 500, text: async () => 'boom' } );
-	let err;
+	let fetchCalls = 0;
+	global.fetch = async () => {
+		fetchCalls++;
+		return { ok: true, status: 200, json: async () => ( {} ) };
+	};
+	let result;
 	try {
-		await silenced( () =>
+		result = await silenced( () =>
 			postToCodeVitals( file, {
 				dryRun: false,
 				codeVitalsUrl: 'https://codevitals.test',
 				codeVitalsToken: 'tok-mixed',
 			} )
 		);
-	} catch ( e ) {
-		err = e;
 	} finally {
 		global.fetch = origFetch;
 		SCENARIOS.pop();
 		delete SANITY_RANGES.extratype;
 		fs.rmSync( dir, { recursive: true, force: true } );
 	}
-	assert.ok( err, 'the live post should reject' );
-	// Must map to the always-fatal data-integrity code, not a suppressible exit 1.
-	assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+	assert.equal( fetchCalls, 0, 'a run with a validation failure must never reach fetch' );
+	assert.equal( result.posted, false );
+	// main() maps this to the always-fatal data-integrity exit 2, which
+	// --allow-codevitals-failure can never suppress.
+	assert.equal( result.validationFailed, true );
 } );
 
 // --- isDirectInvocation (the run-when-direct guard) ---

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -113,6 +113,17 @@ test( 'a typed metric with no range row fails closed (typo / forgotten row)', ()
 	assert.equal( checkSanityRange( 'LCP', 120 ).ok, false ); // case mismatch, lookup is exact
 } );
 
+test( 'a type naming an inherited Object property fails closed, not posted unchecked', () => {
+	// SANITY_RANGES is a plain object, so SANITY_RANGES.constructor (and toString/valueOf/
+	// hasOwnProperty) is a truthy inherited value with undefined min/max. A plain `! range`
+	// check would let it through and the value would post unchecked. The lookup must be
+	// own-property-only.
+	assert.equal( checkSanityRange( 'constructor', 999999 ).ok, false );
+	assert.equal( checkSanityRange( 'toString', 999999 ).ok, false );
+	assert.equal( checkSanityRange( 'valueOf', 999999 ).ok, false );
+	assert.equal( checkSanityRange( 'hasOwnProperty', 999999 ).ok, false );
+} );
+
 test( 'non-finite values are rejected, including on min-0 ranges', () => {
 	assert.equal( checkSanityRange( 'tbt', null ).ok, false ); // null coerces to 0; must not pass
 	assert.equal( checkSanityRange( 'cls', null ).ok, false );
@@ -286,10 +297,16 @@ test( 'a keyed scenario without a metricType is rejected, not posted unchecked',
 test( 'an empty metrics array is rejected as a misconfiguration, not silently dropped', () => {
 	// metrics:[] passes Array.isArray and would map to nothing: fail-closed while it is
 	// the only posting scenario, but a SILENT drop (green build) once a sibling posting
-	// scenario contributes a valid key. Reject the config shape outright.
+	// scenario contributes a valid key. Reject the config shape outright — as a
+	// ValidationError (exit 2), since --allow-codevitals-failure must not suppress it.
 	assert.throws(
 		() => extractScenarioMetrics( { key: 'future', metrics: [] }, { lcp: { median: 100 } } ),
-		/declares an empty metrics array/
+		err => {
+			assert.equal( err.name, 'ValidationError' );
+			assert.match( err.message, /declares an empty metrics array/ );
+			assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+			return true;
+		}
 	);
 } );
 
@@ -310,14 +327,20 @@ test( 'a null metrics[] entry maps to the validation exit code, not a suppressib
 test( 'a posting scenario with no metric selector at all is rejected, not posted under undefined_* keys', () => {
 	// Without this guard the legacy branch builds keys from an undefined prefix and posts
 	// five finite summary stats under literal "undefined_*" keys — untyped (unchecked) and
-	// with a green build. The only fail-open extraction shape; must throw like its siblings.
+	// with a green build. The only fail-open extraction shape; must throw like its siblings,
+	// as a ValidationError (exit 2) that --allow-codevitals-failure cannot suppress.
 	assert.throws(
 		() =>
 			extractScenarioMetrics(
 				{ key: 'future' },
 				{ median: 100, mean: 100, min: 90, max: 110, stdDev: 5 }
 			),
-		/no metrics\[\], metricKey, or metricPrefix/
+		err => {
+			assert.equal( err.name, 'ValidationError' );
+			assert.match( err.message, /no metrics\[\], metricKey, or metricPrefix/ );
+			assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+			return true;
+		}
 	);
 } );
 
@@ -1424,6 +1447,49 @@ test( 'buildSummary drops individual non-finite samples before aggregating a fie
 	assert.equal( summary.ttfb.median, 70 ); // median of [60, 80], the null dropped
 	assert.equal( summary.ttfb.min, 60 );
 	assert.equal( summary.ttfb.max, 80 );
+} );
+
+test( 'buildSummary omits a field whose finite samples miss a strict majority of iterations', () => {
+	// A field captured on only a minority of runs (here TTFB on 1 of 3) is too thin to post:
+	// a lone sample would land as a full "median" (stdDev 0) in the append-only store. Below
+	// the strict-majority floor the field is omitted so the poster fails closed instead. LCP/FCP,
+	// captured on every run, still aggregate with their real values.
+	const results = [
+		{ lcp: 100, metrics: { lcp: 100, ttfb: 60, fcp: 200 } },
+		{ lcp: 200, metrics: { lcp: 200, ttfb: null, fcp: 400 } },
+		{ lcp: 300, metrics: { lcp: 300, ttfb: null, fcp: 600 } },
+	];
+	const summary = buildSummary( results, 3 );
+	assert.equal( summary.ttfb, undefined, '1 of 3 finite TTFB → below strict majority → omitted' );
+	assert.equal( summary.lcp.median, 200, 'majority-covered LCP still aggregates its real median' );
+	assert.equal( summary.fcp.median, 400, 'majority-covered FCP still aggregates its real median' );
+	assert.equal( summary.median, 200, 'flat LCP mirror unaffected' );
+} );
+
+test( 'buildSummary strict-majority floor: even-count 1-of-2 is omitted, but single-iteration 1-of-1 is kept', () => {
+	// finite*2 > n. The even-count edge (1 of 2) must NOT post — that is the case a ceil(n/2)
+	// floor would have let through. A single-iteration run (1 of 1) must still post, or
+	// ITERATIONS=1 could never report a metric.
+	const twoRuns = [
+		{ lcp: 100, metrics: { lcp: 100, ttfb: 60, fcp: 200 } },
+		{ lcp: 200, metrics: { lcp: 200, ttfb: null, fcp: 400 } }, // ttfb finite on only 1 of 2
+	];
+	const twoSummary = buildSummary( twoRuns, 2 );
+	assert.equal(
+		twoSummary.ttfb,
+		undefined,
+		'1 of 2 finite TTFB → not a strict majority → omitted'
+	);
+	assert.ok( twoSummary.lcp && twoSummary.fcp, 'fields finite on both runs still aggregate' );
+
+	const oneRun = [ { lcp: 150, metrics: { lcp: 150, ttfb: 55, fcp: 300 } } ];
+	const oneSummary = buildSummary( oneRun, 1 );
+	assert.equal(
+		oneSummary.ttfb.median,
+		55,
+		'1 of 1 finite TTFB → kept (single-iteration runs work)'
+	);
+	assert.equal( oneSummary.median, 150, 'single-iteration LCP still mirrored flat' );
 } );
 
 // --- commit-time plumbing: getGitInfo reads the producer side (real temp git repo) ---

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -283,6 +283,30 @@ test( 'a keyed scenario without a metricType is rejected, not posted unchecked',
 	);
 } );
 
+test( 'an empty metrics array is rejected as a misconfiguration, not silently dropped', () => {
+	// metrics:[] passes Array.isArray and would map to nothing: fail-closed while it is
+	// the only posting scenario, but a SILENT drop (green build) once a sibling posting
+	// scenario contributes a valid key. Reject the config shape outright.
+	assert.throws(
+		() => extractScenarioMetrics( { key: 'future', metrics: [] }, { lcp: { median: 100 } } ),
+		/declares an empty metrics array/
+	);
+} );
+
+test( 'a null metrics[] entry maps to the validation exit code, not a suppressible TypeError', () => {
+	// Without the shape guard, metric.codevitalsKey on null throws a raw TypeError →
+	// exit 1 (suppressible), escaping the exit-2 contract its sibling guards honor.
+	let err;
+	try {
+		extractScenarioMetrics( { key: 'future', metrics: [ null ] }, { lcp: { median: 100 } } );
+	} catch ( e ) {
+		err = e;
+	}
+	assert.equal( err?.name, 'ValidationError' );
+	assert.match( err.message, /non-object metrics\[\] entry/ );
+	assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+} );
+
 test( 'a posting scenario with no metric selector at all is rejected, not posted under undefined_* keys', () => {
 	// Without this guard the legacy branch builds keys from an undefined prefix and posts
 	// five finite summary stats under literal "undefined_*" keys — untyped (unchecked) and

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -207,6 +207,31 @@ test( 'a metrics-array entry missing its type fails closed (never posted uncheck
 	);
 } );
 
+test( 'a metrics-array entry missing its codevitalsKey fails closed (never posts under "undefined")', () => {
+	// Same fail-closed invariant as the type guard: an entry with no key would post its value
+	// under the literal key "undefined" — a permanent garbage point checkSanityRange can't
+	// catch (it only inspects the value). Extraction must throw before any post.
+	assert.throws(
+		() =>
+			extractScenarioMetrics(
+				{
+					key: 'multi',
+					metrics: [
+						{ field: 'lcp', codevitalsKey: 'k-lcp', type: 'lcp' },
+						{ field: 'ttfb', type: 'ttfb' }, // no codevitalsKey
+					],
+				},
+				{ lcp: { median: 120 }, ttfb: { median: 150 } }
+			),
+		err => {
+			assert.equal( err.name, 'ValidationError' );
+			assert.match( err.message, /no codevitalsKey/ );
+			assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+			return true;
+		}
+	);
+} );
+
 test( 'a metrics array that repeats a CodeVitals key fails closed at extraction', () => {
 	// A within-scenario duplicate key would post one value then clobber it. It is a config
 	// bug (value-independent), so it must fail closed at extraction — before any value is
@@ -289,6 +314,10 @@ test( 'every posted keyed metric declares a type with a matching sanity range', 
 			: [ { key: scenario.metricKey, type: scenario.metricType } ];
 		for ( const { key, type } of keyed ) {
 			const label = `${ scenario.key ?? key } → ${ key }`;
+			assert.ok(
+				typeof key === 'string' && key.trim(),
+				`metric on scenario "${ scenario.key }" must declare a non-empty codevitalsKey`
+			);
 			assert.ok( type, `metric "${ label }" must declare a type` );
 			assert.ok(
 				SANITY_RANGES[ type ],

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -679,7 +679,13 @@ test( 'a live post sends the payload as POST and returns posted:true', async () 
 		assert.equal( result.posted, true );
 		assert.equal( sentInit.method, 'POST' );
 		assert.match( String( sentUrl ), /\/api\/log\?token=tok-success$/ );
-		assert.equal( JSON.parse( sentInit.body ).metrics[ LCP_KEY ], 120 );
+		// The dry-run tests pin the payload contract; this pins the LIVE serialization
+		// branch too — all three jetpackConnected metrics in one POST body, nothing extra.
+		const sentMetrics = JSON.parse( sentInit.body ).metrics;
+		assert.equal( sentMetrics[ LCP_KEY ], 120 );
+		assert.equal( sentMetrics[ TTFB_KEY ], 150 );
+		assert.equal( sentMetrics[ FCP_KEY ], 400 );
+		assert.equal( Object.keys( sentMetrics ).length, 3 );
 	} finally {
 		global.fetch = origFetch;
 	}

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -17,7 +17,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { inspect } from 'node:util';
-import { resolveResultsGit } from './measure-lcp.js';
+import { buildSummary, resolveResultsGit } from './measure-lcp.js';
 import {
 	checkSanityRange,
 	exitCodeForError,
@@ -39,16 +39,41 @@ import { SANITY_RANGES, SCENARIOS } from './scenarios.js';
 
 const SCRIPTS_DIR = path.dirname( fileURLToPath( import.meta.url ) );
 const LCP_KEY = 'wp-admin-dashboard-connection-sim-largestContentfulPaint';
+const TTFB_KEY = 'wp-admin-dashboard-connection-sim-timeToFirstByte';
+const FCP_KEY = 'wp-admin-dashboard-connection-sim-firstContentfulPaint';
 
-/** Write a results fixture with the given median LCP and return its path. */
-function writeResults( median ) {
+/**
+ * Build the nested per-field summary the multi-metric jetpackConnected scenario reads.
+ * The poster reads summary.<field>.median for each metrics-array entry; the flat
+ * top-level `median` mirrors LCP for the legacy metricKey path and older readers.
+ */
+function jetpackSummary( { lcp = 120, ttfb = 150, fcp = 400 } = {} ) {
+	return {
+		median: lcp, // flat LCP mirror (backward-compat)
+		lcp: { median: lcp },
+		ttfb: { median: ttfb },
+		fcp: { median: fcp },
+	};
+}
+
+/**
+ * Write a results fixture and return its path. `median` is the LCP median (kept as the
+ * first positional arg so existing single-arg call sites read the same); TTFB and FCP
+ * default to in-range values so the two new metrics post cleanly unless overridden.
+ */
+function writeResults(
+	median,
+	{ ttfb = 150, fcp = 400, hash = 'testhash', branch = 'trunk' } = {}
+) {
 	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-results-' ) );
 	const file = path.join( dir, 'results.json' );
 	fs.writeFileSync(
 		file,
 		JSON.stringify( {
-			git: { hash: 'testhash', branch: 'trunk' },
-			measurements: { jetpackConnected: { summary: { median } } },
+			git: { hash, branch },
+			measurements: {
+				jetpackConnected: { summary: jetpackSummary( { lcp: median, ttfb, fcp } ) },
+			},
 		} )
 	);
 	return file;
@@ -132,6 +157,98 @@ test( 'legacy prefix yields five untyped entries', () => {
 	);
 } );
 
+// --- extractScenarioMetrics: the FORMS-707 multi-metric (metrics-array) path ---
+
+test( 'a metrics array yields one typed entry per element, each from its own summary field', () => {
+	const entries = extractScenarioMetrics(
+		{
+			key: 'multi',
+			metrics: [
+				{ field: 'lcp', codevitalsKey: 'k-lcp', type: 'lcp' },
+				{ field: 'ttfb', codevitalsKey: 'k-ttfb', type: 'ttfb' },
+				{ field: 'fcp', codevitalsKey: 'k-fcp', type: 'fcp' },
+			],
+		},
+		{
+			median: 120, // flat mirror — must NOT be read by the array path
+			lcp: { median: 120 },
+			ttfb: { median: 150 },
+			fcp: { median: 400 },
+		}
+	);
+	assert.deepEqual( entries, [
+		{ key: 'k-lcp', value: 120, type: 'lcp' },
+		{ key: 'k-ttfb', value: 150, type: 'ttfb' },
+		{ key: 'k-fcp', value: 400, type: 'fcp' },
+	] );
+} );
+
+test( 'a metrics-array entry missing its type fails closed (never posted unchecked)', () => {
+	// Same fail-closed invariant as the single-metricKey path: a keyed metric with no type
+	// would post any finite value to the append-only store, so extraction must throw instead.
+	assert.throws(
+		() =>
+			extractScenarioMetrics(
+				{
+					key: 'multi',
+					metrics: [
+						{ field: 'lcp', codevitalsKey: 'k-lcp', type: 'lcp' },
+						{ field: 'ttfb', codevitalsKey: 'k-ttfb' }, // no type
+					],
+				},
+				{ lcp: { median: 120 }, ttfb: { median: 150 } }
+			),
+		err => {
+			assert.equal( err.name, 'ValidationError' );
+			assert.match( err.message, /no type/ );
+			assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+			return true;
+		}
+	);
+} );
+
+test( 'a metrics array that repeats a CodeVitals key fails closed at extraction', () => {
+	// A within-scenario duplicate key would post one value then clobber it. It is a config
+	// bug (value-independent), so it must fail closed at extraction — before any value is
+	// even read — not depend on the loop-level guard, which a skipped sanity check can bypass.
+	assert.throws(
+		() =>
+			extractScenarioMetrics(
+				{
+					key: 'multi',
+					metrics: [
+						{ field: 'lcp', codevitalsKey: 'dup-key', type: 'lcp' },
+						{ field: 'ttfb', codevitalsKey: 'dup-key', type: 'ttfb' }, // same key
+					],
+				},
+				{ lcp: { median: 120 }, ttfb: { median: 150 } }
+			),
+		err => {
+			assert.equal( err.name, 'ValidationError' );
+			assert.match( err.message, /[Dd]uplicate/ );
+			assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+			return true;
+		}
+	);
+} );
+
+test( 'a metrics-array entry with a missing summary field reads undefined (fails closed later, no crash)', () => {
+	// A field absent from the summary (e.g. the browser never captured it) must yield
+	// undefined — not crash on summary.<field>.median — so checkSanityRange rejects it.
+	const entries = extractScenarioMetrics(
+		{
+			key: 'multi',
+			metrics: [
+				{ field: 'lcp', codevitalsKey: 'k-lcp', type: 'lcp' },
+				{ field: 'ttfb', codevitalsKey: 'k-ttfb', type: 'ttfb' },
+			],
+		},
+		{ lcp: { median: 120 } } // no ttfb block
+	);
+	assert.deepEqual( entries[ 1 ], { key: 'k-ttfb', value: undefined, type: 'ttfb' } );
+	assert.equal( checkSanityRange( entries[ 1 ].type, entries[ 1 ].value ).ok, false );
+} );
+
 test( 'a keyed scenario without a metricType is rejected, not posted unchecked', () => {
 	// Without this guard the entry would emit type:undefined and pass the range
 	// check as a "legacy" metric — posting any finite value to an append-only store.
@@ -156,20 +273,49 @@ test( 'a scenario misconfiguration maps to the validation exit code, a transport
 	assert.equal( exitCodeForError( new Error( 'CodeVitals API error (500)' ) ), 1 );
 } );
 
-test( 'every posted exact-key scenario declares a metricType with a matching sanity range', () => {
-	// Config contract for the real SCENARIOS: any scenario that posts an exact metricKey
-	// must declare a metricType that has a SANITY_RANGES row, or it would post unchecked
-	// (or throw at extraction). Pins this as a 2nd posted metric is added (FORMS-707).
-	const posted = SCENARIOS.filter( s => s.postToCodeVitals && s.metricKey );
-	assert.ok( posted.length > 0, 'expected at least one posted exact-key scenario' );
+test( 'every posted keyed metric declares a type with a matching sanity range', () => {
+	// Config contract for the real SCENARIOS: any scenario that posts a keyed metric — via a
+	// single metricKey OR a metrics array — must declare a type that has a SANITY_RANGES row,
+	// or it would post unchecked (or throw at extraction). Covers both the legacy single-key
+	// shape and the FORMS-707 multi-metric shape, so neither can regress the fail-closed rule.
+	const posted = SCENARIOS.filter(
+		s => s.postToCodeVitals && ( s.metricKey || Array.isArray( s.metrics ) )
+	);
+	assert.ok( posted.length > 0, 'expected at least one posted keyed scenario' );
 	for ( const scenario of posted ) {
-		const label = scenario.key ?? scenario.metricKey;
-		assert.ok( scenario.metricType, `scenario "${ label }" must declare a metricType` );
-		assert.ok(
-			SANITY_RANGES[ scenario.metricType ],
-			`scenario "${ label }" type "${ scenario.metricType }" needs a SANITY_RANGES row`
-		);
+		// Normalize both shapes to a list of { key, type } to assert on uniformly.
+		const keyed = Array.isArray( scenario.metrics )
+			? scenario.metrics.map( m => ( { key: m.codevitalsKey, type: m.type } ) )
+			: [ { key: scenario.metricKey, type: scenario.metricType } ];
+		for ( const { key, type } of keyed ) {
+			const label = `${ scenario.key ?? key } → ${ key }`;
+			assert.ok( type, `metric "${ label }" must declare a type` );
+			assert.ok(
+				SANITY_RANGES[ type ],
+				`metric "${ label }" type "${ type }" needs a SANITY_RANGES row`
+			);
+		}
 	}
+} );
+
+test( 'the jetpackConnected scenario posts LCP, TTFB and FCP to their production keys', () => {
+	// Pins the FORMS-707 config: the dashboard scenario declares exactly the three production
+	// keys, each reading its own summary field, so a future edit that drops or renames one
+	// (or swaps in a -staging key) fails here rather than silently in production.
+	const scenario = SCENARIOS.find( s => s.key === 'jetpackConnected' );
+	assert.ok( Array.isArray( scenario.metrics ), 'jetpackConnected must use the metrics array' );
+	assert.deepEqual(
+		scenario.metrics.map( m => ( {
+			field: m.field,
+			codevitalsKey: m.codevitalsKey,
+			type: m.type,
+		} ) ),
+		[
+			{ field: 'lcp', codevitalsKey: LCP_KEY, type: 'lcp' },
+			{ field: 'ttfb', codevitalsKey: TTFB_KEY, type: 'ttfb' },
+			{ field: 'fcp', codevitalsKey: FCP_KEY, type: 'fcp' },
+		]
+	);
 } );
 
 // --- redactToken (keeps the token out of logs and errors) ---
@@ -188,12 +334,106 @@ test( 'redactToken strips the exact token and any token query param', () => {
 
 // --- postToCodeVitals (the accumulation loop + exit semantics) ---
 
-test( 'dry-run posts an in-range metric into the payload, nothing rejected', async () => {
-	const file = writeResults( 120 );
+test( 'dry-run posts all three scenario metrics into the payload, nothing rejected', async () => {
+	const file = writeResults( 120, { ttfb: 150, fcp: 400 } );
 	const result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
 	assert.equal( result.posted, false ); // dry run never posts
 	assert.equal( result.validationFailed, false );
+	// All three production keys, each from its own summary field; LCP unchanged.
 	assert.equal( result.payload.metrics[ LCP_KEY ], 120 );
+	assert.equal( result.payload.metrics[ TTFB_KEY ], 150 );
+	assert.equal( result.payload.metrics[ FCP_KEY ], 400 );
+	assert.equal( Object.keys( result.payload.metrics ).length, 3 );
+} );
+
+test( 'per-type sanity: one out-of-range metric is rejected while the others still post', async () => {
+	// The core multi-metric guarantee: TTFB out of its own range [10,10000] is dropped, but
+	// LCP and FCP — each checked against its OWN type — still land. A per-metric failure must
+	// not take down the whole scenario, and the rejected key must never reach the payload.
+	const file = writeResults( 120, { ttfb: 99999, fcp: 400 } );
+	const result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
+	assert.equal( result.validationFailed, true ); // ttfb failed its range
+	assert.equal( result.payload.metrics[ LCP_KEY ], 120 ); // still posts
+	assert.equal( result.payload.metrics[ FCP_KEY ], 400 ); // still posts
+	assert.ok(
+		! Object.prototype.hasOwnProperty.call( result.payload.metrics, TTFB_KEY ),
+		'the out-of-range TTFB key must not appear in the payload'
+	);
+} );
+
+test( 'a duplicate key within a scenario metrics array fails closed through the posting path', async () => {
+	// End-to-end (not just at extraction): a scenario whose metrics array repeats a key must
+	// exit 2 before anything posts, so the append-only store can't get a clobbered value.
+	const dup = {
+		key: 'dupArray',
+		name: 'Dup Array',
+		postToCodeVitals: true,
+		metrics: [
+			{ field: 'lcp', codevitalsKey: 'dup-array-key', type: 'lcp' },
+			{ field: 'fcp', codevitalsKey: 'dup-array-key', type: 'fcp' }, // same key, twice
+		],
+	};
+	SCENARIOS.push( dup );
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-duparr-' ) );
+	const file = path.join( dir, 'results.json' );
+	fs.writeFileSync(
+		file,
+		JSON.stringify( {
+			git: { hash: 'h', branch: 'trunk' },
+			measurements: {
+				jetpackConnected: { summary: jetpackSummary() },
+				dupArray: { summary: { lcp: { median: 120 }, fcp: { median: 400 } } },
+			},
+		} )
+	);
+	let err;
+	try {
+		await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
+	} catch ( e ) {
+		err = e;
+	} finally {
+		SCENARIOS.pop();
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+	assert.ok( err, 'a duplicate key within a metrics array should reject' );
+	assert.equal( err.name, 'ValidationError' );
+	assert.equal( exitCodeForError( err ), VALIDATION_FAILED_EXIT_CODE );
+	assert.match( err.message, /[Dd]uplicate/ );
+} );
+
+test( 'backward-compat: a legacy single metricKey scenario still posts unchanged', async () => {
+	// FORMS-707 must not regress the legacy shape: a scenario with metricKey/metricType (no
+	// metrics array) still extracts one typed entry from the flat summary.median and posts it.
+	const legacy = {
+		key: 'legacyKeyed',
+		name: 'Legacy Keyed',
+		postToCodeVitals: true,
+		metricKey: 'legacy-single-key',
+		metricType: 'lcp',
+	};
+	SCENARIOS.push( legacy );
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), 'cv-legacy-' ) );
+	const file = path.join( dir, 'results.json' );
+	fs.writeFileSync(
+		file,
+		JSON.stringify( {
+			git: { hash: 'h', branch: 'trunk' },
+			measurements: {
+				jetpackConnected: { summary: jetpackSummary() },
+				legacyKeyed: { summary: { median: 250 } }, // flat summary.median, the legacy contract
+			},
+		} )
+	);
+	let result;
+	try {
+		result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
+	} finally {
+		SCENARIOS.pop();
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+	assert.equal( result.validationFailed, false );
+	assert.equal( result.payload.metrics[ 'legacy-single-key' ], 250 ); // read from flat summary.median
+	assert.equal( result.payload.metrics[ LCP_KEY ], 120 ); // the array-path scenario still posts too
 } );
 
 test( 'a dry run never calls fetch, even with a malformed URL and a token set', async () => {
@@ -251,7 +491,7 @@ test( 'a mixed valid/invalid run keeps the valid metric and excludes the rejecte
 		JSON.stringify( {
 			git: { hash: 'h', branch: 'trunk' },
 			measurements: {
-				jetpackConnected: { summary: { median: 120 } }, // valid LCP → stays in payload
+				jetpackConnected: { summary: jetpackSummary() }, // valid LCP/TTFB/FCP → stay in payload
 				extraMetric: { summary: { median: 99999 } }, // outside [0,1000] → rejected, excluded
 			},
 		} )
@@ -292,7 +532,7 @@ test( 'two scenarios posting the same CodeVitals key fail closed as a validation
 		JSON.stringify( {
 			git: { hash: 'h', branch: 'trunk' },
 			measurements: {
-				jetpackConnected: { summary: { median: 120 } },
+				jetpackConnected: { summary: jetpackSummary() },
 				dupMetric: { summary: { median: 130 } },
 			},
 		} )
@@ -793,7 +1033,7 @@ test( 'a validation failure is not downgraded to exit 1 when a later live POST a
 		JSON.stringify( {
 			git: { hash: 'h', branch: 'trunk' },
 			measurements: {
-				jetpackConnected: { summary: { median: 120 } }, // valid LCP → gets POSTed
+				jetpackConnected: { summary: jetpackSummary() }, // valid LCP/TTFB/FCP → get POSTed
 				extraMetric: { summary: { median: 99999 } }, // outside [0,1000] → skipped, flags validationFailed
 			},
 		} )
@@ -1024,7 +1264,7 @@ test( 'a dry-run payload is stamped with the commit time from the results file',
 		file,
 		JSON.stringify( {
 			git: { hash: 'h', branch: 'trunk', timestamp: 1700000000000 },
-			measurements: { jetpackConnected: { summary: { median: 120 } } },
+			measurements: { jetpackConnected: { summary: jetpackSummary() } },
 		} )
 	);
 	try {
@@ -1033,6 +1273,75 @@ test( 'a dry-run payload is stamped with the commit time from the results file',
 	} finally {
 		fs.rmSync( dir, { recursive: true, force: true } );
 	}
+} );
+
+// --- buildSummary (measure-lcp per-field aggregation; the load-bearing FORMS-707 change) ---
+
+test( 'buildSummary aggregates every field into its own block and mirrors LCP flat', () => {
+	// Each field gets a nested { median, mean, min, max, stdDev } block, and the LCP block is
+	// ALSO mirrored flat on the summary root so the poster's legacy metricKey path and older
+	// readers of summary.median keep working. TTFB/FCP are aggregated for the first time here.
+	const results = [
+		{ lcp: 100, metrics: { lcp: 100, ttfb: 50, fcp: 200 } },
+		{ lcp: 200, metrics: { lcp: 200, ttfb: 70, fcp: 400 } },
+		{ lcp: 300, metrics: { lcp: 300, ttfb: 90, fcp: 600 } },
+	];
+	const summary = buildSummary( results, 3 );
+
+	// Nested per-field blocks (what the multi-metric poster path reads: summary.<field>.median).
+	assert.deepEqual( summary.lcp, { median: 200, mean: 200, min: 100, max: 300, stdDev: 82 } );
+	assert.equal( summary.ttfb.median, 70 );
+	assert.equal( summary.fcp.median, 400 );
+	assert.equal( summary.fcp.min, 200 );
+	assert.equal( summary.fcp.max, 600 );
+
+	// Flat top-level mirror of LCP (backward-compat) — byte-for-byte the old LCP-only summary.
+	assert.equal( summary.median, 200 );
+	assert.equal( summary.mean, 200 );
+	assert.equal( summary.min, 100 );
+	assert.equal( summary.max, 300 );
+	assert.equal( summary.stdDev, 82 );
+
+	// Iteration counters preserved.
+	assert.equal( summary.successfulIterations, 3 );
+	assert.equal( summary.totalIterations, 3 );
+} );
+
+test( 'buildSummary flat LCP mirror matches the old LCP-only summary exactly', () => {
+	// Pins that LCP stays byte-for-byte: same value source (r.lcp), same rounding, same number.
+	const lcpValues = [ 111, 222, 333, 444 ];
+	const results = lcpValues.map( lcp => ( { lcp, metrics: { lcp, ttfb: 40, fcp: 300 } } ) );
+	const summary = buildSummary( results, 4 );
+	assert.equal( summary.median, 278 ); // (222+333)/2 = 277.5 → round 278
+	assert.equal( summary.min, 111 );
+	assert.equal( summary.max, 444 );
+	assert.equal( summary.lcp.median, summary.median ); // nested and flat agree
+} );
+
+test( 'buildSummary omits a field with no finite samples so the poster fails closed', () => {
+	// A field the browser never captured (all null) must be omitted — not a fabricated 0 —
+	// so extractScenarioMetrics reads undefined and checkSanityRange rejects it downstream.
+	const results = [
+		{ lcp: 100, metrics: { lcp: 100, ttfb: null, fcp: 200 } },
+		{ lcp: 200, metrics: { lcp: 200, ttfb: null, fcp: 400 } },
+	];
+	const summary = buildSummary( results, 2 );
+	assert.equal( summary.ttfb, undefined, 'no finite TTFB sample → omitted, not 0' );
+	assert.ok( summary.lcp && summary.fcp, 'fields with samples are still aggregated' );
+	assert.equal( summary.median, 150 ); // flat LCP mirror still present
+} );
+
+test( 'buildSummary drops individual non-finite samples before aggregating a field', () => {
+	// A field present on some iterations but null on others aggregates only the finite ones.
+	const results = [
+		{ lcp: 100, metrics: { lcp: 100, ttfb: 60, fcp: 200 } },
+		{ lcp: 200, metrics: { lcp: 200, ttfb: null, fcp: 400 } }, // ttfb missing this run
+		{ lcp: 300, metrics: { lcp: 300, ttfb: 80, fcp: 600 } },
+	];
+	const summary = buildSummary( results, 3 );
+	assert.equal( summary.ttfb.median, 70 ); // median of [60, 80], the null dropped
+	assert.equal( summary.ttfb.min, 60 );
+	assert.equal( summary.ttfb.max, 80 );
 } );
 
 // --- commit-time plumbing: getGitInfo reads the producer side (real temp git repo) ---
@@ -1481,7 +1790,7 @@ test( 'dedup is bypassed for an unknown hash (still posts, no read)', async () =
 		file,
 		JSON.stringify( {
 			git: { hash: 'unknown', branch: 'trunk' },
-			measurements: { jetpackConnected: { summary: { median: 120 } } },
+			measurements: { jetpackConnected: { summary: jetpackSummary() } },
 		} )
 	);
 	const { fetchImpl, calls } = dedupFetchStub( { evolutionHashes: [ 'unknown' ] } );

--- a/tools/performance/scripts/post-to-codevitals.test.js
+++ b/tools/performance/scripts/post-to-codevitals.test.js
@@ -283,6 +283,20 @@ test( 'a keyed scenario without a metricType is rejected, not posted unchecked',
 	);
 } );
 
+test( 'a posting scenario with no metric selector at all is rejected, not posted under undefined_* keys', () => {
+	// Without this guard the legacy branch builds keys from an undefined prefix and posts
+	// five finite summary stats under literal "undefined_*" keys — untyped (unchecked) and
+	// with a green build. The only fail-open extraction shape; must throw like its siblings.
+	assert.throws(
+		() =>
+			extractScenarioMetrics(
+				{ key: 'future' },
+				{ median: 100, mean: 100, min: 90, max: 110, stdDev: 5 }
+			),
+		/no metrics\[\], metricKey, or metricPrefix/
+	);
+} );
+
 test( 'a scenario misconfiguration maps to the validation exit code, a transport error to 1', () => {
 	let configError;
 	try {
@@ -376,12 +390,14 @@ test( 'dry-run posts all three scenario metrics into the payload, nothing reject
 } );
 
 test( 'per-type sanity: one out-of-range metric is rejected, the survivors stay visible in the dry-run payload', async () => {
-	// Each metric is checked against its OWN type: TTFB out of its range [10,10000] is
-	// dropped while LCP and FCP survive into the dry-run payload, so CI diagnostics show
+	// Each metric is checked against its OWN type: 15000 is out of TTFB's range [10,10000]
+	// but INSIDE the lcp [100,60000] and fcp [50,30000] ranges, so this only fails if the
+	// check really selected the ttfb row — a value out of range for every type would pass
+	// vacuously. LCP and FCP survive into the dry-run payload, so CI diagnostics show
 	// exactly which metrics passed. (A live run with validationFailed posts NOTHING — see
 	// the atomic-post test below — so the partial payload is diagnostic-only.) The
 	// rejected key must never reach the payload.
-	const file = writeResults( 120, { ttfb: 99999, fcp: 400 } );
+	const file = writeResults( 120, { ttfb: 15000, fcp: 400 } );
 	const result = await silenced( () => postToCodeVitals( file, { dryRun: true } ) );
 	assert.equal( result.validationFailed, true ); // ttfb failed its range
 	assert.equal( result.payload.metrics[ LCP_KEY ], 120 ); // still posts

--- a/tools/performance/scripts/scenarios.js
+++ b/tools/performance/scripts/scenarios.js
@@ -22,7 +22,6 @@ export const SCENARIOS = [
 		envVar: 'WP_JETPACK_CONNECTED_URL',
 		defaultUrl: 'http://localhost:8083',
 		header: 'Jetpack Connected (Simulated + 200ms Latency)',
-		metricPrefix: 'wp_admin_lcp_jetpack_connected',
 		// Metrics posted for this scenario, all in a single CodeVitals call. Each entry is:
 		//   field         — the summary field to read the value from (summary.<field>.median)
 		//   codevitalsKey — the exact CodeVitals metric key to post to

--- a/tools/performance/scripts/scenarios.js
+++ b/tools/performance/scripts/scenarios.js
@@ -23,13 +23,32 @@ export const SCENARIOS = [
 		defaultUrl: 'http://localhost:8083',
 		header: 'Jetpack Connected (Simulated + 200ms Latency)',
 		metricPrefix: 'wp_admin_lcp_jetpack_connected',
-		// CodeVitals key for the posted metric. When introducing a NEW metric, post
-		// it to a `-staging` key first (e.g. `…-timeToFirstByte-staging`) for 2-3
-		// builds, inspect it in the CodeVitals UI, then rename to the production key.
-		// See the "Safeguards" section of README.md for the full convention.
-		metricKey: 'wp-admin-dashboard-connection-sim-largestContentfulPaint',
-		// Metric type — drives the sanity-range check in post-to-codevitals.js.
-		metricType: 'lcp',
+		// Metrics posted for this scenario, all in a single CodeVitals call. Each entry is:
+		//   field         — the summary field to read the value from (summary.<field>.median)
+		//   codevitalsKey — the exact CodeVitals metric key to post to
+		//   type          — the SANITY_RANGES key; REQUIRED, drives the range check in
+		//                   post-to-codevitals.js. A keyed metric with no type is refused.
+		// When introducing a NEW metric, post it to a `-staging` key first (e.g.
+		// `…-timeToFirstByte-staging`) for 2-3 builds, inspect it in the CodeVitals UI, then
+		// rename to the production key. See the "Safeguards" section of README.md for the
+		// full convention. (LCP/TTFB/FCP below post straight to production keys by decision.)
+		metrics: [
+			{
+				field: 'lcp',
+				codevitalsKey: 'wp-admin-dashboard-connection-sim-largestContentfulPaint',
+				type: 'lcp',
+			},
+			{
+				field: 'ttfb',
+				codevitalsKey: 'wp-admin-dashboard-connection-sim-timeToFirstByte',
+				type: 'ttfb',
+			},
+			{
+				field: 'fcp',
+				codevitalsKey: 'wp-admin-dashboard-connection-sim-firstContentfulPaint',
+				type: 'fcp',
+			},
+		],
 		postToCodeVitals: true,
 		isBaseline: false,
 	},


### PR DESCRIPTION
Builds on #50046 (merged); the branch is rebased onto trunk so this diff is only the multi-metric layer.

## Proposed changes

* A scenario now declares a `metrics[]` array of `{ field, codevitalsKey, type }` instead of a single `metricKey`, and the poster sends all entries in one API call. `jetpackConnected` posts LCP, TTFB, and FCP to their production keys. The LCP key, value source, and number are unchanged.
* `measure-lcp.js` summarizes each measured field into a nested `summary.<field>` block and keeps the flat LCP mirror for older readers.
* Extraction fails closed (exit 2, never suppressible) on any scenario misconfiguration: a missing or blank key, a missing type, a duplicate key, an empty or malformed `metrics[]`, or no metric selector at all.
* Live posting is all-or-nothing per run: one failed sanity check suppresses the whole POST, so a retried build cannot append duplicate points to the append-only store. Dry runs print the surviving metrics for diagnostics.

## Related product discussion/links

* Linear: FORMS-707
* Base PR: #50046 (commit-time stamping + cross-commit dedup)

## Does this pull request change what data or activity we track or use?

No user data. Adds two internal CI performance metrics (TTFB, FCP), measured in the Docker wp-admin test fixture and posted to CodeVitals next to the existing LCP metric.

## Testing instructions

* From `tools/performance`, run `pnpm test:unit`. The 86 tests cover extraction, per-type sanity ranges, the fail-closed guards, the atomic posting gate, and the legacy `metricKey` path.
* Dry-run the payload (no token, no network):
  ```
  cd tools/performance
  printf '{"git":{"hash":"abc123","branch":"trunk","timestamp":1735660800000},"measurements":{"jetpackConnected":{"summary":{"median":120,"lcp":{"median":120},"ttfb":{"median":150},"fcp":{"median":400}}}}}' > /tmp/fixture.json
  RESULTS_PATH=/tmp/fixture.json pnpm report:dry
  ```
  The payload's `metrics` object should hold the three production keys: LCP 120 (unchanged), TTFB 150, FCP 400.

