### PR TITLE
AI Launchpad: filter the themes picker by the inferred niche

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-theme-picker-niche-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-theme-picker-niche-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: point the theme-picker tasks at the themes showcase pre-filtered by the AI-inferred niche, so the theme list feels relevant to what the user is building.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -279,8 +279,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			$payload = is_array( $ai_output ) && isset( $ai_output['payload'] ) && is_array( $ai_output['payload'] )
 				? $ai_output['payload']
 				: array();
-			$niche   = isset( $payload['inferred']['niche'] ) && is_string( $payload['inferred']['niche'] )
-				? trim( $payload['inferred']['niche'] )
+			// Validate `inferred` as an array before reading from it, since a partial write could leave it non-array.
+			$inferred = isset( $payload['inferred'] ) && is_array( $payload['inferred'] ) ? $payload['inferred'] : array();
+			$niche    = isset( $inferred['niche'] ) && is_string( $inferred['niche'] )
+				? trim( $inferred['niche'] )
 				: '';
 
 			$tasks = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -58,6 +58,17 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
+	 * Theme-picker tasks. When the AI infers a niche, these point at the wordpress.com themes showcase
+	 * pre-filtered by that niche, so the theme list feels relevant to what the user is building (instead of
+	 * plain themes.php, which only filters already-installed themes). Falls back to the paths above when no niche.
+	 */
+	const THEME_TASK_IDS = array(
+		'site_theme_selected',
+		'design_selected',
+		'design_completed',
+	);
+
+	/**
 	 * Jetpack Social tasks, hidden on private sites where wpcom does not load Publicize (so their CTA page would 404).
 	 */
 	const SOCIAL_PAGE_TASK_IDS = array(
@@ -267,7 +278,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// Guard the nested payload: partial/failed writes may leave the option without payload.tasks.
 			$tasks = array();
 			if ( is_array( $ai_output ) && isset( $ai_output['payload']['tasks'] ) && is_array( $ai_output['payload']['tasks'] ) ) {
-				$tasks = $this->build_tasks( $ai_output['payload']['tasks'] );
+				$niche = isset( $ai_output['payload']['inferred']['niche'] ) && is_string( $ai_output['payload']['inferred']['niche'] )
+					? trim( $ai_output['payload']['inferred']['niche'] )
+					: '';
+				$tasks = $this->build_tasks( $ai_output['payload']['tasks'], false, $niche );
 			}
 		}
 
@@ -510,11 +524,12 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	/**
 	 * Enriches the persisted tasks with title, completion state, and CTA path from the catalog.
 	 *
-	 * @param array $tasks             The persisted `payload.tasks` array.
-	 * @param bool  $bypass_visibility Skip the catalog visibility gate (for the all-tasks testing view).
+	 * @param array  $tasks             The persisted `payload.tasks` array.
+	 * @param bool   $bypass_visibility Skip the catalog visibility gate (for the all-tasks testing view).
+	 * @param string $niche             The AI-inferred niche, used to pre-filter the theme-picker CTAs.
 	 * @return array
 	 */
-	private function build_tasks( $tasks, $bypass_visibility = false ) {
+	private function build_tasks( $tasks, $bypass_visibility = false, $niche = '' ) {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
 
@@ -557,9 +572,14 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
 				: wpcom_launchpad_checklists()->is_task_complete( $definition );
 
-			$calypso_path = isset( self::CTA_OVERRIDES[ $task['id'] ] )
-				? admin_url( self::CTA_OVERRIDES[ $task['id'] ] )
-				: wpcom_launchpad_checklists()->load_calypso_path( $definition );
+			$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $niche );
+			if ( null !== $theme_showcase_path ) {
+				$calypso_path = $theme_showcase_path;
+			} elseif ( isset( self::CTA_OVERRIDES[ $task['id'] ] ) ) {
+				$calypso_path = admin_url( self::CTA_OVERRIDES[ $task['id'] ] );
+			} else {
+				$calypso_path = wpcom_launchpad_checklists()->load_calypso_path( $definition );
+			}
 
 			$title       = isset( $definition['get_title'] ) ? $definition['get_title']() : '';
 			$in_progress = false;
@@ -588,6 +608,48 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		}
 
 		return $built;
+	}
+
+	/**
+	 * The wordpress.com themes-showcase path for a theme-picker task, pre-filtered by the inferred niche.
+	 *
+	 * Returns null for non-theme tasks or when no niche was inferred, so the caller falls back to the task's
+	 * default CTA. The niche is passed as the showcase's free-text search term (`?s=`), and the client's
+	 * `toNavigableUrl` resolves the relative path against wordpress.com.
+	 *
+	 * @param string $task_id The catalog task id.
+	 * @param string $niche   The AI-inferred niche.
+	 * @return string|null
+	 */
+	private function get_themes_showcase_path( $task_id, $niche ) {
+		if ( '' === $niche || ! in_array( $task_id, self::THEME_TASK_IDS, true ) ) {
+			return null;
+		}
+
+		return '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $this->niche_to_search_term( $niche ) );
+	}
+
+	/**
+	 * Reduces a possibly multi-word niche to a single keyword for the themes-showcase search.
+	 *
+	 * The showcase ANDs its search terms, so a phrase like "ceramics and pottery" matches no theme even
+	 * though "ceramics" and "pottery" each do. Connective/filler words are dropped and the first remaining
+	 * keyword is kept. Falls back to the trimmed niche when nothing survives filtering.
+	 *
+	 * @param string $niche The AI-inferred niche.
+	 * @return string
+	 */
+	private function niche_to_search_term( $niche ) {
+		$stop_words = array( 'and', 'or', 'the', 'a', 'an', 'of', 'for', 'with', 'in', 'on', 'to', 'your', 'my' );
+		$words      = preg_split( '/[\s,&]+/', strtolower( $niche ), -1, PREG_SPLIT_NO_EMPTY );
+
+		foreach ( $words as $word ) {
+			if ( ! in_array( $word, $stop_words, true ) ) {
+				return $word;
+			}
+		}
+
+		return trim( $niche );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -276,12 +276,16 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			$tasks = $this->build_all_catalog_tasks();
 		} else {
 			// Guard the nested payload: partial/failed writes may leave the option without payload.tasks.
+			$payload = is_array( $ai_output ) && isset( $ai_output['payload'] ) && is_array( $ai_output['payload'] )
+				? $ai_output['payload']
+				: array();
+			$niche   = isset( $payload['inferred']['niche'] ) && is_string( $payload['inferred']['niche'] )
+				? trim( $payload['inferred']['niche'] )
+				: '';
+
 			$tasks = array();
-			if ( is_array( $ai_output ) && isset( $ai_output['payload']['tasks'] ) && is_array( $ai_output['payload']['tasks'] ) ) {
-				$niche = isset( $ai_output['payload']['inferred']['niche'] ) && is_string( $ai_output['payload']['inferred']['niche'] )
-					? trim( $ai_output['payload']['inferred']['niche'] )
-					: '';
-				$tasks = $this->build_tasks( $ai_output['payload']['tasks'], false, $niche );
+			if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
+				$tasks = $this->build_tasks( $payload['tasks'], false, $niche );
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -20,6 +20,7 @@ require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-la
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-rest.php';
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WpOrg\Requests\Requests;
 
 /**
@@ -451,6 +452,146 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		// launch task, which routes to the wordpress.com launch flow client-side).
 		$this->assertArrayHasKey( 'site_launched', $paths );
 		$this->assertNull( $paths['site_launched'] );
+	}
+
+	/**
+	 * Test that GET points the theme tasks at the Calypso themes showcase pre-filtered
+	 * by the AI-inferred niche, so the theme list feels relevant to what the user is
+	 * building. This overrides the plain wp-admin themes.php target, which can only
+	 * filter already-installed themes.
+	 *
+	 * The showcase search ANDs its terms, so a multi-word niche is reduced to its first
+	 * keyword — 'ceramics and pottery' matches no theme, but 'ceramics' does.
+	 */
+	public function test_get_filters_theme_ctas_by_inferred_niche() {
+		wp_set_current_user( $this->admin_id );
+
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'site_theme_selected',
+							'subtitle' => 'Pick a gallery-style theme.',
+						),
+						array(
+							'id'       => 'design_selected',
+							'subtitle' => 'Make it yours.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array(
+						'goal'  => 'build',
+						'niche' => 'ceramics and pottery',
+					),
+				),
+			),
+			false
+		);
+
+		$paths = array();
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			$paths[ $task['id'] ] = $task['calypso_path'];
+		}
+
+		$expected = '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=ceramics';
+		$this->assertSame( $expected, $paths['site_theme_selected'] );
+		$this->assertSame( $expected, $paths['design_selected'] );
+		// A non-theme task is untouched by the niche filter.
+		$this->assertNull( $paths['site_launched'] );
+	}
+
+	/**
+	 * Test that a multi-word niche is reduced to a single search keyword: connective
+	 * words are dropped and the first meaningful keyword is kept, so the showcase's
+	 * term-ANDing search still returns matching themes.
+	 *
+	 * @dataProvider provider_niche_search_terms
+	 *
+	 * @param string $niche    The inferred niche.
+	 * @param string $expected The expected `?s=` search term.
+	 */
+	#[DataProvider( 'provider_niche_search_terms' )]
+	public function test_get_reduces_multiword_niche_to_single_keyword( $niche, $expected ) {
+		wp_set_current_user( $this->admin_id );
+
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'site_theme_selected',
+							'subtitle' => 'Pick a theme.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array(
+						'goal'  => 'build',
+						'niche' => $niche,
+					),
+				),
+			),
+			false
+		);
+
+		$path = null;
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			if ( 'site_theme_selected' === $task['id'] ) {
+				$path = $task['calypso_path'];
+			}
+		}
+
+		$this->assertSame( '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $expected ), $path );
+	}
+
+	/**
+	 * Niche → single search keyword expectations.
+	 *
+	 * @return array
+	 */
+	public static function provider_niche_search_terms() {
+		return array(
+			'strips "and" connective'      => array( 'ceramics and pottery', 'ceramics' ),
+			'keeps first of two subjects'  => array( 'photography and travel', 'photography' ),
+			'drops leading adjective-only' => array( 'handmade ceramics', 'handmade' ),
+			'drops ampersand connective'   => array( 'arts & crafts', 'arts' ),
+			'single word is unchanged'     => array( 'cooking', 'cooking' ),
+			'skips leading stop word'      => array( 'the great outdoors', 'great' ),
+		);
+	}
+
+	/**
+	 * Test that without an inferred niche the theme CTAs keep their existing targets
+	 * (the wp-admin override for design_selected), so the filter is purely additive.
+	 */
+	public function test_get_leaves_theme_ctas_unfiltered_without_niche() {
+		wp_set_current_user( $this->admin_id );
+		// seed_ai_output_with_tasks writes no `inferred` block, so there is no niche.
+		$this->seed_ai_output_with_tasks( array( 'site_theme_selected', 'design_selected', 'site_launched' ) );
+
+		$paths = array();
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			$paths[ $task['id'] ] = $task['calypso_path'];
+		}
+
+		// The CTA_OVERRIDES branch keeps its wp-admin target.
+		$this->assertSame( admin_url( 'themes.php' ), $paths['design_selected'] );
+		// The load_calypso_path branch keeps the catalog's default theme path.
+		$this->assertSame( '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '#theme-selected', $paths['site_theme_selected'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

When the AI Launchpad tailors a task list, the "Choose a theme" task now sends the user to the **wordpress.com themes showcase pre-filtered by the AI-inferred niche**, so the theme list feels relevant to what they're building. Previously the theme tasks routed to plain wp-admin `themes.php`, which only filters already-installed themes.

* The three theme-picker tasks (`site_theme_selected`, `design_selected`, `design_completed`) now resolve their CTA to `/themes/{site-slug}?s={keyword}` when a niche was inferred; they fall back to their previous target when no niche is present.
* The niche is reduced to a single search keyword. The showcase ANDs its search terms, so a multi-word phrase like "ceramics and pottery" matches no theme even though "ceramics" and "pottery" each do. Connective/filler words are dropped and the first meaningful keyword is kept.
* All read-side in `AI_Launchpad_REST::build_tasks()`; the shared launchpad task catalog is untouched.

## Related product discussion/links

* DOTCOM-17736 (parent: DSGCOM-678)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the AI Launchpad enabled and a tailored list that includes a theme task (e.g. "Choose a theme"), make sure the persisted AI output has an inferred niche (`wpcom_ai_launchpad_ai_output` → `payload.inferred.niche`).
* Open the AI Launchpad (`wp-admin/admin.php?page=ai-launchpad-wp-admin`), expand the theme task, and click **Browse themes**.
* Confirm it opens the wordpress.com themes showcase with `?s=<first keyword of the niche>` and that the showcase shows matching themes.
* With a multi-word niche such as "photography and travel", confirm the search term is a single keyword ("photography"), not the whole phrase.
* With no inferred niche, confirm the theme tasks still route to their previous target (`themes.php`).
