### PR TITLE
Clean up more unminified JS bloat

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-more-wp-build-bloat
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-more-wp-build-bloat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove unnecessary unminified JS.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -17,10 +17,11 @@
 	"scripts": {
 		"build": "echo 'Not implemented.'",
 		"build:boot-asset": "provide-boot-asset-file",
+		"build:strip-unminified-prod": "strip-unminified-prod",
 		"build:wp-build": "wp-build",
 		"build-js": "pnpm clean && webpack && pnpm run build:wp-build && pnpm run build:boot-asset",
 		"build-production": "echo 'Not implemented.'",
-		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm build-js",
+		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm build-js && pnpm build:strip-unminified-prod",
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",

--- a/projects/packages/podcast/changelog/remove-more-wp-build-bloat
+++ b/projects/packages/podcast/changelog/remove-more-wp-build-bloat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Minify JS in production build.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -21,7 +21,7 @@
 		"build:boot-asset": "provide-boot-asset-file",
 		"build:strip-unminified-prod": "strip-unminified-prod",
 		"build:wp-build": "wp-build",
-		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run clean && concurrently 'pnpm:build:blocks' 'pnpm:build:wp-build' && pnpm run build:strip-unminified-prod && pnpm run build:boot-asset",
+		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run build:strip-unminified-prod",
 		"clean": "rm -rf build/ dist/",
 		"watch": "concurrently 'pnpm:build:blocks --watch' 'pnpm:watch:wp-build'",
 		"watch:wp-build": "wp-build --watch"

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -454,7 +454,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 											aria-label={
 												coverArt?.url
 													? __( 'Replace cover art', 'jetpack-podcast' )
-													: __( 'Set episode cover art', 'jetpack-podcast' )
+													: _x( 'Set episode cover art', '', 'jetpack-podcast' )
 											}
 										>
 											{ coverArtUrl ? (

--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
@@ -2,7 +2,7 @@
  * Library for the `strip-unminified-prod` bin.
  *
  * Background: `@wordpress/build` emits two copies of every route/script/
- * module bundle — a minified `*.min.js` (loaded when SCRIPT_DEBUG is false)
+ * module/widget bundle — a minified `*.min.js` (loaded when SCRIPT_DEBUG is false)
  * and an unminified `*.js` (loaded when SCRIPT_DEBUG is true). It does the
  * same thing for stylesheets, with a slightly different shape (`*.css` /
  * `*.min.css`, with a `$suffix` ternary in the generated `styles.php`
@@ -36,7 +36,7 @@ const STRIPPABLE_EXTS = [ '.js', '.css' ];
 // Patches collapse SCRIPT_DEBUG-driven ternaries to the minified asset.
 // Three shapes need to be handled:
 //
-// 1. Single-line extension ternary in routes.php and scripts.php:
+// 1. Single-line extension ternary in routes.php, scripts.php, and widgets.php:
 //      $extension = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 //
 // 2. Multi-line extension ternary in modules.php (with min_only carve-out):

--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
@@ -11,8 +11,8 @@
  * inflating the payload by ~13 MiB as of this writing.
  *
  * `strip(buildDir)` deletes the unminified siblings under
- * build/{routes,scripts,modules,styles}/** and rewrites the generated
- * routes.php / scripts.php / modules.php / styles.php loaders so the
+ * build/{routes,scripts,modules,styles,widgets}/** and rewrites the generated
+ * routes.php / scripts.php / modules.php / styles.php / widgets.php loaders so the
  * SCRIPT_DEBUG branch collapses to the minified asset — keeping the asset
  * reachable even if a deploy target enables SCRIPT_DEBUG. The function is
  * idempotent and throws if it finds a SCRIPT_DEBUG-driven `.js`/`.min`
@@ -30,7 +30,7 @@
 const { readdirSync, existsSync, unlinkSync, readFileSync, writeFileSync } = require( 'fs' );
 const path = require( 'path' );
 
-const TARGET_SUBDIRS = [ 'routes', 'scripts', 'modules', 'styles' ];
+const TARGET_SUBDIRS = [ 'routes', 'scripts', 'modules', 'styles', 'widgets' ];
 const STRIPPABLE_EXTS = [ '.js', '.css' ];
 
 // Patches collapse SCRIPT_DEBUG-driven ternaries to the minified asset.
@@ -68,12 +68,12 @@ const REPLACEMENTS = [
 // build catches it. Catches both the extension and the suffix shapes.
 const UNMATCHED_SUSPICIOUS_PATTERNS = [ /\?\s*'\.js'\s*:\s*'\.min\.js'/, /\?\s*''\s*:\s*'\.min'/ ];
 
-const PHP_TARGETS = [ 'routes.php', 'scripts.php', 'modules.php', 'styles.php' ];
+const PHP_TARGETS = [ 'routes.php', 'scripts.php', 'modules.php', 'styles.php', 'widgets.php' ];
 
 /**
  * Recursively walk a directory and pass every file path to a callback.
  * Missing directories are silently skipped, since not every consuming
- * package emits all of routes/scripts/modules/styles.
+ * package emits all of routes/scripts/modules/styles/widgets.
  *
  * @param {string}                   dir   - Absolute path to the directory to walk.
  * @param {(filePath: string)=>void} visit - Called once per regular file under `dir`.

--- a/projects/packages/wp-build-polyfills/changelog/remove-more-wp-build-bloat
+++ b/projects/packages/wp-build-polyfills/changelog/remove-more-wp-build-bloat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Strip unminified JS from widgets.

--- a/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/package.json
+++ b/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "@automattic/_strip-unminified-prod-fixture-widget-hello-world",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module"
+}

--- a/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/render.tsx
+++ b/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/render.tsx
@@ -1,0 +1,8 @@
+/**
+ * Dummy widget.
+ *
+ * @return {React.ReactNode} Node.
+ */
+export default function HelloWorld(): React.ReactNode {
+	return <span>Hello, world!</span>;
+}

--- a/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/widget.json
+++ b/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "fixture/hello-world",
+	"title": "Hello World",
+	"description": "A minimal example widget.",
+	"category": "demo",
+	"presentation": "full-bleed"
+}

--- a/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/widget.ts
+++ b/projects/packages/wp-build-polyfills/tests/fixtures/wp-build-source/widgets/hello-world/widget.ts
@@ -1,0 +1,4 @@
+export default {
+	name: 'fixture/hello-world',
+	title: 'Hello World',
+};

--- a/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
@@ -8,10 +8,10 @@
  * The fixture under `tests/fixtures/wp-build-source/` is a minimal
  * wp-build-compatible package exercising the strip script's four targets:
  * one route with `stage` + `route` entries emits paired `.js`/`.min.js`
- * under `build/routes/dashboard/`, and one `wpScript` sub-package with a
+ * under `build/routes/dashboard/`, one `wpScript` sub-package with a
  * `build-style/style.css` emits paired `.css`/`.min.css` under
  * `build/styles/css-test/` plus paired `.js`/`.min.js` under
- * `build/scripts/css-test/`.
+ * `build/scripts/css-test/`, and one widget under `build/widgets/hello-world`.
  *
  * The fixture is *not* a workspace member and ships nothing — `tests/**`
  * is production-exclude in this package's .gitattributes, and the
@@ -43,6 +43,8 @@ const PAIRED_BUNDLES = [
 	[ 'routes/dashboard/route.js', 'routes/dashboard/route.min.js' ],
 	[ 'scripts/css-test/index.js', 'scripts/css-test/index.min.js' ],
 	[ 'styles/css-test/style.css', 'styles/css-test/style.min.css' ],
+	[ 'widgets/hello-world/render.js', 'widgets/hello-world/render.min.js' ],
+	[ 'widgets/hello-world/widget.js', 'widgets/hello-world/widget.min.js' ],
 ];
 
 describe(
@@ -115,9 +117,9 @@ describe(
 		it( 'strips paired unminified bundles and patches every PHP loader', () => {
 			const result = strip( FIXTURE_BUILD );
 			assert.equal( result.skipped, false );
-			// 2 routes paired + 1 wpScript paired + 1 CSS paired = 4 deletions.
-			assert.equal( result.deletedFiles, 4 );
-			assert.equal( result.patchedFiles, 4 );
+			// 2 routes paired + 1 wpScript paired + 1 CSS paired + 1 widget (2 paired) = 6 deletions.
+			assert.equal( result.deletedFiles, 6 );
+			assert.equal( result.patchedFiles, 5 );
 
 			// Paired bundles gone, minified siblings retained.
 			for ( const [ unminified, minified ] of PAIRED_BUNDLES ) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* jetpack-mu-wpcom: Use `strip-unminified-prod`.
* podcast: Correct invocations so production build is actually a production build, not an unminified dev build.
* wp-build-polyfills: Strip widgets too (premium-analytics is using them).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Stuff still work?
* Check the built assets, are they smaller?