### PR TITLE
Boost: Treat inlined-CSS Critical CSS result as benign instead of an error

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/inlined-css-notice/inlined-css-notice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/inlined-css-notice/inlined-css-notice.tsx
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { Notice } from '@wordpress/ui';
+import { Link } from 'react-router';
+import type { FC } from 'react';
+
+/**
+ * Shown when Critical CSS generation finished but every page inlines its CSS,
+ * so there is nothing to optimize. A benign, expected outcome - not an error.
+ */
+const InlinedCssNotice: FC = () => {
+	return (
+		<Notice.Root intent="info">
+			<Notice.Title>{ __( 'Critical CSS is not needed', 'jetpack-boost' ) }</Notice.Title>
+			<Notice.Description>
+				{ createInterpolateElement(
+					__(
+						'Your site already inlines its CSS, so Critical CSS is not needed here — there is nothing to optimize. <advanced>View advanced recommendations</advanced> for details.',
+						'jetpack-boost'
+					),
+					{
+						advanced: <Link to="/critical-css-advanced" />,
+					}
+				) }
+			</Notice.Description>
+		</Notice.Root>
+	);
+};
+
+export default InlinedCssNotice;

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.test.ts
@@ -1,0 +1,112 @@
+import {
+	isBenignError,
+	isBenignErrorType,
+	getProvidersWithRealErrors,
+	getInlinedProviders,
+	isAllInlined,
+	isFatalError,
+} from './critical-css-errors';
+import type {
+	CriticalCssState,
+	Provider,
+	CriticalCssErrorDetails,
+} from './stores/critical-css-state-types';
+
+function err(
+	type: CriticalCssErrorDetails[ 'type' ],
+	url = 'https://example.com/'
+): CriticalCssErrorDetails {
+	return { url, message: `${ type } message`, type, meta: {} };
+}
+
+function provider( overrides: Partial< Provider > = {} ): Provider {
+	return {
+		key: 'core_front_page',
+		label: 'Front Page',
+		urls: [ 'https://example.com/' ],
+		success_ratio: 1,
+		status: 'success',
+		...overrides,
+	};
+}
+
+function state(
+	providers: Provider[],
+	status: CriticalCssState[ 'status' ] = 'generated'
+): CriticalCssState {
+	return { providers, status };
+}
+
+const inlined = ( key: string ) =>
+	provider( { key, status: 'error', errors: [ err( 'EmptyCSSError' ) ] } );
+const realError = ( key: string ) =>
+	provider( { key, status: 'error', errors: [ err( 'HttpError' ) ] } );
+const success = ( key: string ) => provider( { key, status: 'success' } );
+
+describe( 'benign error classification', () => {
+	test( 'isBenignError / isBenignErrorType recognise EmptyCSSError only', () => {
+		expect( isBenignError( err( 'EmptyCSSError' ) ) ).toBe( true );
+		expect( isBenignError( err( 'HttpError' ) ) ).toBe( false );
+		expect( isBenignErrorType( 'EmptyCSSError' ) ).toBe( true );
+		expect( isBenignErrorType( 'UnknownError' ) ).toBe( false );
+	} );
+
+	test( 'getInlinedProviders returns only providers whose errors are all benign', () => {
+		const s = state( [ inlined( 'a' ), realError( 'b' ), success( 'c' ) ] );
+		expect( getInlinedProviders( s ).map( p => p.key ) ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'a provider with mixed benign + real errors is not inlined-only', () => {
+		const mixed = provider( {
+			key: 'm',
+			status: 'error',
+			errors: [ err( 'EmptyCSSError' ), err( 'HttpError' ) ],
+		} );
+		expect( getInlinedProviders( state( [ mixed ] ) ) ).toEqual( [] );
+		expect( getProvidersWithRealErrors( state( [ mixed ] ) ).map( p => p.key ) ).toEqual( [ 'm' ] );
+	} );
+
+	test( 'getProvidersWithRealErrors ignores benign-only providers', () => {
+		const s = state( [ inlined( 'a' ), realError( 'b' ) ] );
+		expect( getProvidersWithRealErrors( s ).map( p => p.key ) ).toEqual( [ 'b' ] );
+	} );
+} );
+
+describe( 'isAllInlined', () => {
+	test( 'true when every provider is inlined-only and none succeeded', () => {
+		expect( isAllInlined( state( [ inlined( 'a' ), inlined( 'b' ) ] ) ) ).toBe( true );
+	} );
+	test( 'false when any provider succeeded', () => {
+		expect( isAllInlined( state( [ inlined( 'a' ), success( 'b' ) ] ) ) ).toBe( false );
+	} );
+	test( 'false when a real error is present', () => {
+		expect( isAllInlined( state( [ inlined( 'a' ), realError( 'b' ) ] ) ) ).toBe( false );
+	} );
+	test( 'false unless status is generated', () => {
+		expect( isAllInlined( state( [ inlined( 'a' ) ], 'pending' ) ) ).toBe( false );
+	} );
+	test( 'false when there are no providers', () => {
+		expect( isAllInlined( state( [] ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'isFatalError with benign errors', () => {
+	test( 'all-inlined is NOT fatal (regression target for BOOST-466)', () => {
+		expect( isFatalError( state( [ inlined( 'a' ), inlined( 'b' ) ] ) ) ).toBe( false );
+	} );
+	test( 'real error with no successes IS fatal', () => {
+		expect( isFatalError( state( [ realError( 'a' ) ] ) ) ).toBe( true );
+	} );
+	test( 'mix of benign + real with no successes IS fatal', () => {
+		expect( isFatalError( state( [ inlined( 'a' ), realError( 'b' ) ] ) ) ).toBe( true );
+	} );
+	test( 'one success alongside inlined is not fatal', () => {
+		expect( isFatalError( state( [ success( 'a' ), inlined( 'b' ) ] ) ) ).toBe( false );
+	} );
+	test( "server status 'error' is always fatal", () => {
+		expect( isFatalError( state( [ success( 'a' ) ], 'error' ) ) ).toBe( true );
+	} );
+	test( "'not_generated' is never fatal", () => {
+		expect( isFatalError( state( [ inlined( 'a' ) ], 'not_generated' ) ) ).toBe( false );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
@@ -22,6 +22,78 @@ export type ErrorSet = {
 };
 
 /**
+ * Error types that are benign: the page has no external CSS to optimize, so
+ * Critical CSS simply is not applicable. These are not generation failures.
+ */
+const BENIGN_ERROR_TYPES: Critical_CSS_Error_Type[] = [ 'EmptyCSSError' ];
+
+/**
+ * Whether an error type is benign (the page has no external CSS to optimize).
+ *
+ * @param {Critical_CSS_Error_Type} type - The error type to check.
+ */
+export function isBenignErrorType( type: Critical_CSS_Error_Type ): boolean {
+	return BENIGN_ERROR_TYPES.includes( type );
+}
+
+/**
+ * Whether a single error is benign.
+ *
+ * @param {CriticalCssErrorDetails} error - The error to check.
+ */
+export function isBenignError( error: CriticalCssErrorDetails ): boolean {
+	return isBenignErrorType( error.type );
+}
+
+/**
+ * Providers that have at least one real (non-benign) error.
+ *
+ * @param {CriticalCssState} cssState - The CSS State object.
+ */
+export function getProvidersWithRealErrors( cssState: CriticalCssState ): Provider[] {
+	return cssState.providers.filter( provider =>
+		( provider.errors || [] ).some( error => ! isBenignError( error ) )
+	);
+}
+
+/**
+ * Providers whose errors are all benign - their CSS is inlined, so there is
+ * nothing for Critical CSS to optimize.
+ *
+ * @param {CriticalCssState} cssState - The CSS State object.
+ */
+export function getInlinedProviders( cssState: CriticalCssState ): Provider[] {
+	return cssState.providers.filter( provider => {
+		const errors = provider.errors || [];
+		return errors.length > 0 && errors.every( isBenignError );
+	} );
+}
+
+/**
+ * Whether generation finished with no usable output solely because every page
+ * inlines its CSS. True when: status is 'generated', there is at least one
+ * provider, none succeeded, there are no real errors, and at least one provider
+ * is inlined-only.
+ *
+ * @param {CriticalCssState} cssState - The CSS State object.
+ */
+export function isAllInlined( cssState: CriticalCssState ): boolean {
+	if ( cssState.status !== 'generated' ) {
+		return false;
+	}
+	if ( cssState.providers.length === 0 ) {
+		return false;
+	}
+	if ( cssState.providers.some( provider => provider.status === 'success' ) ) {
+		return false;
+	}
+	if ( getProvidersWithRealErrors( cssState ).length > 0 ) {
+		return false;
+	}
+	return getInlinedProviders( cssState ).length > 0;
+}
+
+/**
  * Given a Critical CSS State, returns whether or not this represents a fatal error.
  *
  * @param {CriticalCssState} cssState - The CSS State object.
@@ -44,7 +116,13 @@ export function isFatalError( cssState: CriticalCssState ): boolean {
 		provider => provider.status === 'success' || provider.status === 'pending'
 	);
 
-	return ! hasActiveProvider;
+	if ( hasActiveProvider ) {
+		return false;
+	}
+
+	// No active provider. Only a real (non-benign) error is a show-stopper; if every
+	// failed provider is inlined-only (EmptyCSSError), generation is not fatal.
+	return getProvidersWithRealErrors( cssState ).length > 0;
 }
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -7,7 +7,12 @@ import RefreshIcon from '$svg/refresh';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from 'react-router';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
-import { getProvidersWithErrors } from '../lib/critical-css-errors';
+import {
+	getProvidersWithRealErrors,
+	getInlinedProviders,
+	isAllInlined,
+} from '../lib/critical-css-errors';
+import InlinedCssNotice from '../inlined-css-notice/inlined-css-notice';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import { Button } from '@automattic/jetpack-components';
 import styles from './status.module.scss';
@@ -34,7 +39,9 @@ const Status: FC< StatusTypes > = ( {
 	const regenerateAction = useRegenerateCriticalCssAction();
 	const successCount =
 		cssState.providers.filter( provider => provider.status === 'success' ).length || 0;
-	const providersWithErrors = getProvidersWithErrors( cssState );
+	const realErrorProviders = getProvidersWithRealErrors( cssState );
+	const inlinedProviders = getInlinedProviders( cssState );
+	const allInlined = isAllInlined( cssState );
 
 	const handleClickRegenerate = () => {
 		recordBoostEvent( 'critical_css_regenerate_clicked', {} );
@@ -58,49 +65,77 @@ const Status: FC< StatusTypes > = ( {
 	return (
 		<div className={ styles.status } data-testid="critical-css-meta">
 			<div className={ styles.summary }>
-				{ overrideText || (
-					<div className={ styles.successes }>
-						{ sprintf(
-							/* translators: %d is a number of CSS Files which were successfully generated */
-							_n( '%d file generated', '%d files generated', successCount, 'jetpack-boost' ),
-							successCount
+				{ allInlined ? (
+					<InlinedCssNotice />
+				) : (
+					<>
+						{ overrideText || (
+							<div className={ styles.successes }>
+								{ sprintf(
+									/* translators: %d is a number of CSS Files which were successfully generated */
+									_n( '%d file generated', '%d files generated', successCount, 'jetpack-boost' ),
+									successCount
+								) }
+
+								{ !! cssState.updated && (
+									<>
+										{ ' ' }
+										<TimeAgo time={ new Date( cssState.updated * 1000 ) } />
+									</>
+								) }
+
+								{ '. ' }
+
+								{ extraText }
+							</div>
 						) }
 
-						{ !! cssState.updated && (
-							<>
-								{ ' ' }
-								<TimeAgo time={ new Date( cssState.updated * 1000 ) } />
-							</>
+						{ cssState.status !== 'pending' && realErrorProviders.length > 0 && (
+							<div className={ clsx( 'failures', styles.failures ) }>
+								<InfoIcon />
+
+								<>
+									{ createInterpolateElement(
+										sprintf(
+											// translators: %d is a number of CSS Files which failed to generate
+											_n(
+												'%d file could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize this file.',
+												'%d files could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize these files.',
+												realErrorProviders.length,
+												'jetpack-boost'
+											),
+											realErrorProviders.length
+										),
+										{
+											advanced: (
+												<Link to="/critical-css-advanced" onClick={ handleAdvancedClick } />
+											),
+										}
+									) }
+								</>
+							</div>
 						) }
 
-						{ '. ' }
+						{ cssState.status !== 'pending' && inlinedProviders.length > 0 && (
+							<div className={ clsx( 'failures', styles.failures ) }>
+								<InfoIcon />
 
-						{ extraText }
-					</div>
-				) }
-
-				{ cssState.status !== 'pending' && providersWithErrors.length > 0 && (
-					<div className={ clsx( 'failures', styles.failures ) }>
-						<InfoIcon />
-
-						<>
-							{ createInterpolateElement(
-								sprintf(
-									// translators: %d is a number of CSS Files which failed to generate
-									_n(
-										'%d file could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize this file.',
-										'%d files could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize these files.',
-										providersWithErrors.length,
-										'jetpack-boost'
-									),
-									providersWithErrors.length
-								),
-								{
-									advanced: <Link to="/critical-css-advanced" onClick={ handleAdvancedClick } />,
-								}
-							) }
-						</>
-					</div>
+								<>
+									{ createInterpolateElement(
+										__(
+											'Some pages inline their CSS and do not need Critical CSS. See the <advanced>advanced recommendations page</advanced> for details.',
+											'jetpack-boost'
+										),
+										{
+											advanced: (
+												<Link to="/critical-css-advanced" onClick={ handleAdvancedClick } />
+											),
+										}
+									) }
+								</>
+							</div>
+						) }
+					</>
 				) }
 			</div>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
@@ -9,6 +9,7 @@ import {
 	ErrorSet,
 	groupErrorsByFrequency,
 	groupRecommendationsByStatus,
+	isBenignErrorType,
 } from '$features/critical-css/lib/critical-css-errors';
 import { BackButton, CloseButton } from '$features/ui';
 import CriticalCssErrorDescription from '$features/critical-css/error-description/error-description';
@@ -40,6 +41,13 @@ export default function AdvancedCriticalCss() {
 	const { activeRecommendations, dismissedRecommendations } =
 		groupRecommendationsByStatus( providersWithIssues );
 
+	const realRecommendations = activeRecommendations.filter(
+		recommendation => ! isBenignErrorType( recommendation.errorType )
+	);
+	const inlinedRecommendations = activeRecommendations.filter( recommendation =>
+		isBenignErrorType( recommendation.errorType )
+	);
+
 	function setDismissed( data: DismissedItem[] ) {
 		setDismissedAction.mutate(
 			data.map( item => ( {
@@ -58,8 +66,13 @@ export default function AdvancedCriticalCss() {
 		}
 	}, [ providersWithIssues, navigate ] );
 	const heading =
-		activeRecommendations.length === 0
+		realRecommendations.length === 0 && inlinedRecommendations.length === 0
 			? __( 'Congratulations, you have dealt with all the recommendations.', 'jetpack-boost' )
+			: realRecommendations.length === 0
+			? __(
+					'Some of your pages inline their CSS, so Critical CSS is not needed for them. This is expected and safe to ignore.',
+					'jetpack-boost'
+			  )
 			: __(
 					'While Jetpack Boost has been able to automatically generate optimized CSS for most of your important files & sections, we have identified a few more that require your attention.',
 					'jetpack-boost'
@@ -92,13 +105,26 @@ export default function AdvancedCriticalCss() {
 				) }
 			</section>
 
-			{ activeRecommendations.map( ( recommendation: ProviderRecommendation ) => (
+			{ realRecommendations.map( ( recommendation: ProviderRecommendation ) => (
 				<Recommendation
 					key={ `${ recommendation.key }-${ recommendation.errorType }` }
 					recommendation={ recommendation }
 					setDismissed={ setDismissed }
 				/>
 			) ) }
+
+			{ inlinedRecommendations.length > 0 && (
+				<>
+					<h4>{ __( 'Pages that inline their CSS', 'jetpack-boost' ) }</h4>
+					{ inlinedRecommendations.map( ( recommendation: ProviderRecommendation ) => (
+						<Recommendation
+							key={ `${ recommendation.key }-${ recommendation.errorType }` }
+							recommendation={ recommendation }
+							setDismissed={ setDismissed }
+						/>
+					) ) }
+				</>
+			) }
 		</div>
 	);
 }

--- a/projects/plugins/boost/changelog/boost-466-critical-css-inline-warning
+++ b/projects/plugins/boost/changelog/boost-466-critical-css-inline-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: treat pages with inlined CSS as a benign state instead of showing a generation error.


### PR DESCRIPTION
Fixes # <!-- Tracked in Linear (BOOST-466), see link below -->

## Proposed changes

Critical CSS now treats an inlined-CSS "no CSS" outcome (`EmptyCSSError`) as a benign _"this page doesn't need Critical CSS"_ state instead of a generation error. When a page's CSS is fully inlined (e.g. block themes like Twenty Twenty-Four), there is no external stylesheet for Critical CSS to draw from, so an empty result is expected — not a failure.

* Add benign-error classification helpers (`isBenignError`, `isBenignErrorType`, `getProvidersWithRealErrors`, `getInlinedProviders`, `isAllInlined`) and update `isFatalError` so a run where every provider fails **only** with `EmptyCSSError` is no longer treated as fatal.
* When the whole site inlines its CSS, the red **"Failed to generate Critical CSS"** show-stopper is replaced with a neutral info notice (_"Critical CSS is not needed"_) that links to the advanced recommendations page.
* In the partial case (some pages succeed, some inline), inlined pages are no longer counted among _"files that could not be automatically generated"_; they get a benign info line instead.
* On the advanced recommendations page, inlined pages appear under an informational **"Pages that inline their CSS"** section rather than under _"…that require your attention"_.
* No backend, schema, or generator-library changes — classification lives entirely in the plugin's UI layer. `EmptyCSSError` providers keep their existing server-side status.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/BOOST-466/update-critical-css-to-not-show-an-error-when-css-is-inline

## Does this pull request change what data or activity we track or use?

No. Existing Tracks events for Critical CSS errors are unchanged.

## Testing instructions

The red error modal only appears when **every** provider yields `EmptyCSSError`, i.e. no page serves a usable external stylesheet. To reproduce deterministically, add an mu-plugin (`wp-content/mu-plugins/force-empty-css.php`) that strips all front-end stylesheets:

```php
<?php
add_action( 'wp_enqueue_scripts', function () {
	if ( is_admin() ) { return; }
	global $wp_styles;
	if ( empty( $wp_styles ) ) { return; }
	foreach ( (array) $wp_styles->queue as $handle ) {
		wp_dequeue_style( $handle );
	}
}, PHP_INT_MAX );
add_filter( 'should_load_separate_core_block_assets', '__return_true' );
```

Then, with a block theme and only Boost active:

* **All-inlined:** Enable Critical CSS and regenerate. **Before:** red "Failed to generate Critical CSS" modal. **After:** a neutral "Critical CSS is not needed" info notice with a working link to the advanced recommendations page — no error styling.
* **Advanced page:** inlined pages appear under "Pages that inline their CSS", not under "require your attention"; dismissal still works.
* **Partial** (change the mu-plugin guard to `if ( ! is_front_page() && ! is_home() ) { return; }` so only the home page inlines): the main status shows "N files generated" with **no** inflated failure count for inlined pages, plus a benign "Some pages inline their CSS…" info line; the other pages still generate.
* **Unit tests:** from `projects/plugins/boost`, run `pnpm exec jest --config=tests/jest.config.cjs app` — 41 pass (15 new in `critical-css-errors.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
