### PR TITLE
wpcomsh: preserve WooCommerce.com connection (woocommerce_helper_data) across Playground import

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wccom-2741-preserve-woocommerce-helper-data
+++ b/projects/plugins/wpcomsh/changelog/wccom-2741-preserve-woocommerce-helper-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Playground import: preserve the destination site's WooCommerce.com connection (woocommerce_helper_data) instead of taking the invalid token from the imported backup.

--- a/projects/plugins/wpcomsh/imports/playground/class-sql-postprocessor.php
+++ b/projects/plugins/wpcomsh/imports/playground/class-sql-postprocessor.php
@@ -208,6 +208,10 @@ class SQL_Postprocessor extends \Imports\Backup_Import_Action {
 			'jetpack_private_options',
 			'permalink_structure',
 			'db_version',
+			// Keep the destination site's WooCommerce.com connection. The imported
+			// store's helper token is bound to the old (Playground) site URL, so
+			// taking it from the backup would drop the connection provisioning set up.
+			'woocommerce_helper_data',
 		);
 
 		// Substitute the options.

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundPostprocessTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundPostprocessTest.php
@@ -198,6 +198,41 @@ class PlaygroundPostprocessTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that woocommerce_helper_data from the live (destination) site is preserved
+	 * in the temp options table after save_whitelist_options().
+	 */
+	public function test_save_whitelist_options_preserves_woocommerce_helper_data(): void {
+		global $wpdb;
+
+		$live_value   = '{"auth":{"access_token":"live-token","access_token_secret":"live-secret","site_id":123}}';
+		$import_value = '{"auth":{"access_token":"old-playground-token","access_token_secret":"old-secret","site_id":0}}';
+
+		// Seed the live option (the destination/provisioned value).
+		update_option( 'woocommerce_helper_data', $live_value );
+
+		// Put a different (imported backup) value in the temp options table.
+		$tmp_options = self::TEMPORARY_PREFIX . $wpdb->prefix . 'options';
+		$wpdb->replace(
+			$tmp_options,
+			array(
+				'option_name'  => 'woocommerce_helper_data',
+				'option_value' => $import_value,
+			),
+			array( '%s', '%s' )
+		);
+
+		$processor = new SQL_Postprocessor( 'https://word.press', 'https://word.press', self::TEMPORARY_PREFIX );
+		$processor->save_whitelist_options();
+
+		$result = $wpdb->get_var( "SELECT option_value FROM {$tmp_options} WHERE option_name = 'woocommerce_helper_data'" );
+		$this->assertSame( $live_value, $result );
+
+		// Clean up.
+		delete_option( 'woocommerce_helper_data' );
+		$wpdb->delete( $tmp_options, array( 'option_name' => 'woocommerce_helper_data' ), array( '%s' ) );
+	}
+
+	/**
 	 * Open a database without the valid temporary tables.
 	 */
 	public function test_open_database_with_valid_tables(): void {


### PR DESCRIPTION
Fixes part of WCCOM-2741

## Proposed changes

* Add `woocommerce_helper_data` to the `save_whitelist_options()` whitelist in `SQL_Postprocessor` so that the destination site's WooCommerce.com connection is preserved after a Playground backup import.
* Without this fix, the import overwrites the provisioned `woocommerce_helper_data` option with the stale token from the Playground backup — a token bound to the old Playground URL that is invalid on the new Atomic site.
* The fix mirrors the existing, proven pattern used to preserve the Jetpack connection (`jetpack_options`, `jetpack_private_options`). Because `save_whitelist_options()` reads from the live options table, this is a no-op on non-Woo sites.
* Add a unit test (`test_save_whitelist_options_preserves_woocommerce_helper_data`) to `PlaygroundPostprocessTest` that seeds both the live and temp table with different values and asserts the live value wins.

## Related product discussion/links

* WCCOM-2741

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to https://woocommerce.com/start/#hosts (logged in as A11n e-mail)
* Click Playground
* Click "Launch free trial"
* WooCommerce.com connection should persist