### PR TITLE
Premium Analytics: type the Stats post payload and add post_id report param

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-stats-post-data-layer
+++ b/projects/packages/premium-analytics/changelog/add-pa-stats-post-data-layer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: type the Stats post payload (StatsPostMeta) and add single-resource post_id support to report params.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -225,6 +225,7 @@ export type {
 	StatsNormalizedItemBase,
 	StatsNormalizedReport,
 	StatsNormalizedSummary,
+	StatsPostMeta,
 	StatsPostMonthValues,
 	StatsPostRawResponse,
 	StatsPostWeek,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/post.ts
@@ -46,8 +46,11 @@ export const postStatsFixture: StatsPostRawResponse = {
 	highest_week_average: 85,
 	post: {
 		ID: 41,
-		title: 'Hello world',
-		type: 'post',
+		post_title: 'Hello world',
+		post_type: 'post',
+		post_date: '2026-06-22 10:00:00',
+		post_date_gmt: '2026-06-22 18:00:00',
+		post_status: 'publish',
 	},
 };
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/post.test.ts
@@ -51,8 +51,11 @@ describe( 'Stats post normalizer', () => {
 			highest_week_average: 85,
 			post: {
 				ID: 41,
-				title: 'Hello world',
-				type: 'post',
+				post_title: 'Hello world',
+				post_type: 'post',
+				post_date: '2026-06-22 10:00:00',
+				post_date_gmt: '2026-06-22 18:00:00',
+				post_status: 'publish',
 			},
 		} );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -39,6 +39,7 @@ export { sanitizeStatsWordAdsStatsResponse, sanitizeStatsWordAdsEarningsResponse
 export { sanitizeStatsSingleVideoResponse } from './single-video';
 export type { StatsTopPostsItem } from './top-posts';
 export type {
+	StatsPostMeta,
 	StatsPostMonthValues,
 	StatsPostRawResponse,
 	StatsPostResponse,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -41,6 +41,21 @@ type StatsPostRawWeek = {
 	change?: StatsPostRawNumeric;
 };
 
+/**
+ * The `post` field of the Stats post response is the site's raw post row, so it
+ * uses WordPress column names (`post_title`, `post_type`, `post_date_gmt`) — not
+ * the WP REST `title`/`type` shape. Only the fields the dashboard consumes are
+ * modeled; the endpoint returns more.
+ */
+export type StatsPostMeta = {
+	ID?: number;
+	post_title?: string;
+	post_type?: string;
+	post_date?: string;
+	post_date_gmt?: string;
+	post_status?: string;
+};
+
 export type StatsPostRawResponse = {
 	date?: string;
 	views?: StatsPostRawNumeric;
@@ -50,7 +65,7 @@ export type StatsPostRawResponse = {
 	highest_month?: StatsPostRawNumeric;
 	highest_day_average?: StatsPostRawNumeric;
 	highest_week_average?: StatsPostRawNumeric;
-	post?: unknown;
+	post?: StatsPostMeta;
 };
 
 export type StatsPostResponse = {
@@ -62,7 +77,7 @@ export type StatsPostResponse = {
 	highest_month?: number;
 	highest_day_average?: number;
 	highest_week_average?: number;
-	post?: unknown;
+	post?: StatsPostMeta;
 };
 
 function normalizeStatsPostYear( value: unknown ): StatsPostYear {
@@ -130,6 +145,6 @@ export function sanitizeStatsPostResponse( response: unknown ): StatsPostRespons
 		...( payload.highest_week_average !== undefined
 			? { highest_week_average: safeParseFloat( payload.highest_week_average ) }
 			: {} ),
-		...( payload.post !== undefined ? { post: payload.post } : {} ),
+		...( payload.post !== undefined ? { post: payload.post as StatsPostMeta } : {} ),
 	};
 }

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
@@ -288,4 +288,37 @@ describe( 'normalizeReportParams', () => {
 
 		expect( result.date_type ).toBe( 'created' );
 	} );
+
+	/*
+	 * Single-resource scope – post_id survives normalization so detail-page
+	 * widgets stay bound to their post/page.
+	 */
+	it( 'coerces a valid post_id to a positive integer', () => {
+		const result = normalizeReportParams( {
+			from: FRESH_FROM,
+			to: FRESH_TO,
+			post_id: '2428',
+		} );
+
+		expect( result.post_id ).toBe( 2428 );
+	} );
+
+	it( 'omits post_id when search has none', () => {
+		const result = normalizeReportParams( {
+			from: FRESH_FROM,
+			to: FRESH_TO,
+		} );
+
+		expect( result.post_id ).toBeUndefined();
+	} );
+
+	it.each( [ 'foo', '0', '-5', '12.5' ] )( 'drops an invalid post_id (%s)', invalid => {
+		const result = normalizeReportParams( {
+			from: FRESH_FROM,
+			to: FRESH_TO,
+			post_id: invalid,
+		} );
+
+		expect( result.post_id ).toBeUndefined();
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/search.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/search.ts
@@ -48,6 +48,7 @@ export type ReportParams = {
 	filters?: FilterCondition[];
 	section?: string;
 	date_type?: DateType; // For filtering by different date fields (created, paid, completed)
+	post_id?: string | number; // Scopes a report to a single post/page (detail page). String from the URL; numeric at the query layer.
 };
 
 type PartialComparisonFields = Partial<
@@ -114,6 +115,10 @@ export function normalizeReportParams(
 	// Calculate the interval from the resolved date range.
 	const interval = getDefaultIntervalForPeriod( undefined, from, to );
 
+	// A valid single-resource scope is a positive integer post/page ID.
+	const postIdNumber = Number( search?.post_id );
+	const postId = Number.isInteger( postIdNumber ) && postIdNumber > 0 ? postIdNumber : undefined;
+
 	// Params from `search`, or fallback to defaults.
 	const normalized: ReportParams = {
 		from,
@@ -121,6 +126,11 @@ export function normalizeReportParams(
 		interval: interval ?? defaults.interval,
 		preset,
 		date_type: search?.date_type ?? 'created',
+		// Preserve the single-resource scope so detail-page widgets stay bound to
+		// their post/page. Coerce to a positive integer and drop anything else
+		// (non-numeric, zero, negative) so a hand-edited deep link can't push a
+		// malformed post_id into downstream Stats requests.
+		...( postId !== undefined ? { post_id: postId } : {} ),
 	};
 
 	// Add comparison params from search if enabled


### PR DESCRIPTION
## Proposed changes

Data-layer groundwork for the single post/page detail traffic view ([WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view)), split out so the page PR builds on it.

* **Type the Stats `post` payload.** `StatsPostResponse.post` was `unknown`, so consumers had to cast blindly — and a wrong cast (`title`/`type`) compiled fine but silently returned nothing at runtime. Add a `StatsPostMeta` type describing the raw post row the endpoint actually returns (WordPress column names: `post_title`, `post_type`, `post_date_gmt`, …), use it for `StatsPostResponse.post` and the raw response, and export it from the data package. The post fixture and sanitizer test are aligned to the real shape.
* **Add single-resource `post_id` to report params.** Add `post_id` (`string | number`) to `ReportParams` and preserve it through `normalizeReportParams`, coercing to a positive integer and dropping non-numeric / zero / negative values so a hand-edited deep link can't push a malformed ID into downstream Stats requests. The URL carries a string; the query layer (e.g. `statsUtmQuery`) uses a number.

No UI changes — this is the data layer only. The post-detail page that consumes it is in a follow-up PR stacked on this branch.

## Related product discussion/links

* [WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view)

## Does this pull request change what data or activity we track or use?

No. It only types an existing Stats payload and threads an existing URL param through normalization; no new data is tracked or collected.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run typecheck` — passes.
* `pnpm run test -- --runTestsByPath packages/data/src/processing/stats/__tests__/post.test.ts packages/data/src/utils/__tests__/normalize-report-params.test.ts` — the sanitizer test reflects the real `post` shape (`post_title`/`post_type`/`post_date_gmt`); `normalizeReportParams` coerces a valid `post_id` to a positive integer and drops `foo` / `0` / `-5` / `12.5`.
* Type-level: `useStatsPost().data?.post` is now typed `StatsPostMeta | undefined` instead of `unknown`.
