### PR TITLE
Premium Analytics: show all widgets in the Add widget gallery

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-widget-gallery-per-page
+++ b/projects/packages/premium-analytics/changelog/fix-widget-gallery-per-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show every widget in the "Add widget" gallery. The dashboard fetched widget types with core-data's default query, which caps results at 10 per page, so any widget registered past the tenth was silently hidden. Fetch the full set with per_page: -1.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -86,9 +86,17 @@ function Dashboard(): JSX.Element {
 		select =>
 			(
 				select( coreStore ) as unknown as {
-					getEntityRecords: ( kind: string, name: string ) => WidgetModuleRecord[] | null;
+					getEntityRecords: (
+						kind: string,
+						name: string,
+						query?: Record< string, unknown >
+					) => WidgetModuleRecord[] | null;
 				}
-			 ).getEntityRecords( 'root', 'widgetModule' ),
+			 )
+				// `per_page: -1` returns every widget type. Without it, core-data's default
+				// query (`per_page: 10`) caps the mapped records at 10, silently hiding any
+				// widget past the tenth from the "Add widget" gallery.
+				.getEntityRecords( 'root', 'widgetModule', { per_page: -1 } ),
 		[]
 	);
 


### PR DESCRIPTION
## Proposed changes

Anyone customizing the Premium Analytics dashboard could only see the first 10 widgets in the **Add widget** gallery — any widget registered past the tenth (currently Top posts, Visitors over time, and the incoming Traffic chart) was silently missing, with no error and no way to add it.

The dashboard read widget types with `getEntityRecords( 'root', 'widgetModule' )` and **no query**. core-data's default query is `per_page: 10`, and its queried-data reducer maps only that page's worth of records into the query's result list — so even though the `/jetpack/v4/widget-modules` endpoint returns every widget (and all of them land in the entity's items map), the selector returned just the first 10. Registration order therefore decided visibility.

* `routes/dashboard/stage.tsx`: fetch the full set with `getEntityRecords( 'root', 'widgetModule', { per_page: -1 } )`. A widget picker should list every widget, not page them.

## Related product discussion/links
* Surfaced while porting the Traffic chart widget (WOOA7S-1504); this fix unblocks it and is a prerequisite for that PR.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build: `jetpack build packages/premium-analytics`, then `jp build plugins/premium-analytics --deps`.
* Open **Premium Analytics → Traffic → Customize → Add widget** on a dashboard with more than 10 registered widget types.
* Before this change the gallery lists exactly 10 widgets (Top posts / Visitors over time are absent). After it, every registered widget type appears.
* In the browser console, `wp.data.select('core').getEntityRecords('root','widgetModule',{per_page:-1}).length` returns the full count (e.g. 13), while the old no-query call returned 10.
