### PR TITLE
Charts: address HeatmapChart non-blocking review follow-ups (CHARTS-230)

### DIFF
--- a/projects/js-packages/charts/changelog/charts-230-heatmap-followups
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-followups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: Wrap heatmap chart header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure.

--- a/projects/js-packages/charts/changelog/charts-230-heatmap-followups
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-followups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: HeatmapChart follow-ups — wrap header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure, and let the grid shrink to fit short containers instead of overflowing and scrolling.
+Charts: HeatmapChart follow-ups — wrap header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure, let the grid shrink to fit short containers instead of overflowing and scrolling, and hide the calendar's partial first-month label so it no longer collides with the next month's.

--- a/projects/js-packages/charts/changelog/charts-230-heatmap-followups
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-followups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: HeatmapChart follow-ups — wrap header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure, let the grid shrink to fit short containers instead of overflowing and scrolling, and hide the calendar's partial first-month label so it no longer collides with the next month's.
+Charts: HeatmapChart follow-ups — wrap header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure, let the grid shrink to fit short containers instead of overflowing and scrolling, hide the calendar's partial first-month label so it no longer collides with the next month's, and pick in-cell text color from the fill blended over the actual chart background so it stays legible on any themed (including dark) background.

--- a/projects/js-packages/charts/changelog/charts-230-heatmap-followups
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-followups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: Wrap heatmap chart header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure.
+Charts: HeatmapChart follow-ups — wrap header labels in an ARIA row so the grid keeps a strict grid/row/gridcell structure, and let the grid shrink to fit short containers instead of overflowing and scrolling.

--- a/projects/js-packages/charts/changelog/charts-230-heatmap-min-height
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-min-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Let the heatmap grid shrink to fit short containers instead of overflowing and scrolling.

--- a/projects/js-packages/charts/changelog/charts-230-heatmap-min-height
+++ b/projects/js-packages/charts/changelog/charts-230-heatmap-min-height
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Charts: Let the heatmap grid shrink to fit short containers instead of overflowing and scrolling.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -76,7 +76,7 @@
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {
-	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), transparent);
+	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), var(--heatmap-bg, #fff));
 }
 
 .heatmap-chart__cell--selected {
@@ -101,5 +101,5 @@
 	width: var(--wpds-dimension-size-3xs, 12px);
 	height: var(--wpds-dimension-size-3xs, 12px);
 	border-radius: var(--wpds-border-radius-sm, 2px);
-	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), transparent);
+	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), var(--heatmap-bg, #fff));
 }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -17,9 +17,7 @@
 	gap: var(--heatmap-cell-gap, var(--wpds-dimension-gap-xs, 4px));
 	flex: 1 1 0;
 	width: 100%;
-	// min-height: 0 (not the flex default of `auto`) lets the grid shrink below
-	// its content height, so short widgets size it down to fit instead of the
-	// chart overflowing and scrolling.
+	// Override flex's auto minimum so short widgets do not scroll.
 	min-height: 0;
 
 	&:focus-visible {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -17,8 +17,10 @@
 	gap: var(--heatmap-cell-gap, var(--wpds-dimension-gap-xs, 4px));
 	flex: 1 1 0;
 	width: 100%;
-	// Floor so the grid stays usable when the parent has no explicit height.
-	min-height: 200px;
+	// min-height: 0 (not the flex default of `auto`) lets the grid shrink below
+	// its content height, so short widgets size it down to fit instead of the
+	// chart overflowing and scrolling.
+	min-height: 0;
 
 	&:focus-visible {
 		outline:

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -2,15 +2,7 @@ import { formatNumber, formatNumberCompact } from '@automattic/number-formatters
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -30,18 +22,17 @@ import { ChartLayout } from '../private/chart-layout';
 import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
 import styles from './heatmap-chart.module.scss';
-import { getValueExtent, getNormalizedValue, HeatmapLegend, isPresent } from './private';
+import {
+	getValueExtent,
+	getNormalizedValue,
+	HeatmapContext,
+	HeatmapLegend,
+	isPresent,
+} from './private';
+import type { HeatmapContextValue } from './private';
 import type { HeatmapChartProps, HeatmapTooltipData } from './types';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { CSSProperties, FC } from 'react';
-
-export type HeatmapContextValue = {
-	extent: [ number, number ];
-	/** The resolved primary color (full intensity); the legend mixes toward it in CSS. */
-	primaryColorHex: string;
-};
-
-export const HeatmapContext = createContext< HeatmapContextValue | null >( null );
 
 // Mirrors the color-mix floor in heatmap-chart.module.scss (.heatmap-chart__cell--filled):
 // the rendered fill is the primary mixed over the chart background at 0.15 + 0.85 * intensity.
@@ -87,6 +78,12 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	// Pick the in-cell text color from the cell's actual blended fill luminance (not the data
 	// value), so light text is only used where it out-contrasts dark text. Falls back to dark
 	// text when the primary isn't a resolvable hex (e.g. a bare CSS token).
+	//
+	// Assumes a light chart background: this estimates the fill by blending the primary toward
+	// white via lightenHexColor, whereas the actual CSS fill is color-mix(primary, transparent)
+	// over whatever sits behind the cell. Those match on a light background (the package default);
+	// on a dark background the light/dark choice could invert. Make this background-aware if the
+	// package ever ships a dark chart background.
 	const primaryHex = normalizeColorToHex( primaryColorHex );
 	const cellHasLightText = ( intensity: number ): boolean =>
 		isValidHexColor( primaryHex ) &&
@@ -292,17 +289,20 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						} ) }
 						style={ gridStyle as CSSProperties }
 					>
-						{ /* Corner gutter + column labels; aria-hidden, since each cell's label carries the text. */ }
-						<span aria-hidden="true" />
-						{ data.map( ( column, columnIndex ) => (
-							<span
-								key={ `col-${ columnIndex }` }
-								aria-hidden="true"
-								className={ styles[ 'heatmap-chart__col-label' ] }
-							>
-								{ column.label }
-							</span>
-						) ) }
+						{ /* Corner gutter + column labels wrapped in a row so the grid keeps a strict
+						grid → row structure. aria-hidden, since each data cell's label already
+						carries this text. */ }
+						<div role="row" aria-hidden="true" className={ styles[ 'heatmap-chart__row' ] }>
+							<span />
+							{ data.map( ( column, columnIndex ) => (
+								<span
+									key={ `col-${ columnIndex }` }
+									className={ styles[ 'heatmap-chart__col-label' ] }
+								>
+									{ column.label }
+								</span>
+							) ) }
+						</div>
 
 						{ Array.from( { length: rows } ).map( ( _row, rowIndex ) => {
 							const labelVisible = ! compact || rowIndex % 2 === 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -9,7 +9,7 @@ import {
 	useGlobalChartsContext,
 	GlobalChartsContext,
 } from '../../providers';
-import { attachSubComponents, resolveCssVariable } from '../../utils';
+import { attachSubComponents } from '../../utils';
 import {
 	isValidHexColor,
 	mixHexColors,
@@ -54,7 +54,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	children,
 } ) => {
 	const chartId = useChartId( providedChartId );
-	const { getElementStyles, theme } = useGlobalChartsContext();
+	const { getElementStyles, resolveThemeColor, theme } = useGlobalChartsContext();
 	const { heatmapChart: heatmapChartSettings } = theme;
 	const { nonLegendChildren } = useChartChildren( children, 'HeatmapChart' );
 
@@ -75,17 +75,13 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		overrideColor: primaryColor || heatmapChartSettings.primaryColor,
 	} );
 
-	// Pick the in-cell text color from the cell's actual blended fill luminance (not the data
-	// value), so light text is only used where it out-contrasts dark text. Falls back to dark
-	// text when either color isn't a resolvable hex (e.g. a bare CSS token).
-	//
-	// The fill is the primary mixed over the chart background — the exact opaque equivalent of
-	// the CSS `color-mix(primary, var(--heatmap-bg))`. Resolving the same WPDS background token
-	// the CSS uses keeps the text choice correct on any themed background, light or dark.
+	// Resolve the background in the provider's theme scope so the blended-fill text
+	// color tracks a themed (e.g. dark) background.
+	const chartBackgroundHex = resolveThemeColor( theme.backgroundColor );
+
+	// Choose text color from the blended fill, not the raw value.
+	// If either color cannot resolve to hex, keep dark text.
 	const primaryHex = normalizeColorToHex( primaryColorHex );
-	const chartBackgroundHex = normalizeColorToHex(
-		resolveCssVariable( theme.backgroundColor ) ?? theme.backgroundColor
-	);
 	const cellHasLightText = ( intensity: number ): boolean =>
 		isValidHexColor( primaryHex ) &&
 		isValidHexColor( chartBackgroundHex ) &&
@@ -296,9 +292,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						} ) }
 						style={ gridStyle as CSSProperties }
 					>
-						{ /* Corner gutter + column labels wrapped in a row so the grid keeps a strict
-						grid → row structure. aria-hidden, since each data cell's label already
-						carries this text. */ }
+						{ /* Header row preserves the grid structure; cell aria-labels include this text. */ }
 						<div role="row" aria-hidden="true" className={ styles[ 'heatmap-chart__row' ] }>
 							<span />
 							{ data.map( ( column, columnIndex ) => (
@@ -367,7 +361,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 											>
 												{ drawValues && present && (
 													<span className={ styles[ 'heatmap-chart__cell-value' ] }>
-														{ /* Compact so large values fit the cell; tooltip + aria-label keep full precision. */ }
+														{ /* Compact display; tooltip and aria-label keep full precision. */ }
 														{ formatNumberCompact( value ) }
 													</span>
 												) }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -9,10 +9,10 @@ import {
 	useGlobalChartsContext,
 	GlobalChartsContext,
 } from '../../providers';
-import { attachSubComponents } from '../../utils';
+import { attachSubComponents, resolveCssVariable } from '../../utils';
 import {
 	isValidHexColor,
-	lightenHexColor,
+	mixHexColors,
 	normalizeColorToHex,
 	prefersLightText,
 } from '../../utils/color-utils';
@@ -77,18 +77,24 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 
 	// Pick the in-cell text color from the cell's actual blended fill luminance (not the data
 	// value), so light text is only used where it out-contrasts dark text. Falls back to dark
-	// text when the primary isn't a resolvable hex (e.g. a bare CSS token).
+	// text when either color isn't a resolvable hex (e.g. a bare CSS token).
 	//
-	// Assumes a light chart background: this estimates the fill by blending the primary toward
-	// white via lightenHexColor, whereas the actual CSS fill is color-mix(primary, transparent)
-	// over whatever sits behind the cell. Those match on a light background (the package default);
-	// on a dark background the light/dark choice could invert. Make this background-aware if the
-	// package ever ships a dark chart background.
+	// The fill is the primary mixed over the chart background — the exact opaque equivalent of
+	// the CSS `color-mix(primary, var(--heatmap-bg))`. Resolving the same WPDS background token
+	// the CSS uses keeps the text choice correct on any themed background, light or dark.
 	const primaryHex = normalizeColorToHex( primaryColorHex );
+	const chartBackgroundHex = normalizeColorToHex(
+		resolveCssVariable( theme.backgroundColor ) ?? theme.backgroundColor
+	);
 	const cellHasLightText = ( intensity: number ): boolean =>
 		isValidHexColor( primaryHex ) &&
+		isValidHexColor( chartBackgroundHex ) &&
 		prefersLightText(
-			lightenHexColor( primaryHex, 1 - ( CELL_MIX_FLOOR + ( 1 - CELL_MIX_FLOOR ) * intensity ) )
+			mixHexColors(
+				primaryHex,
+				chartBackgroundHex,
+				1 - ( CELL_MIX_FLOOR + ( 1 - CELL_MIX_FLOOR ) * intensity )
+			)
 		);
 
 	const extent = useMemo( () => getValueExtent( data ), [ data ] );
@@ -244,6 +250,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	const trackSize = compact ? 'var(--heatmap-cell-size)' : 'minmax(0, 1fr)';
 	const gridStyle: Record< string, string | number > = {
 		'--heatmap-primary': primaryColorHex,
+		'--heatmap-bg': theme.backgroundColor,
 		gridTemplateColumns: `auto repeat(${ columns }, ${ trackSize })`,
 		gridTemplateRows: `auto repeat(${ rows }, ${ trackSize })`,
 	};

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -57,14 +57,8 @@ export const buildCalendarHeatmapData = (
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
 	);
 
-	// The first grid column starts on a week boundary that can fall in the tail of
-	// a month, leaving a "partial" first month of just one or two columns. Its
-	// label would then sit directly under the next month's label and overlap it
-	// (labels are wider than a column, especially in the compact layout), so we
-	// suppress the first month's label unless it spans enough columns to clear the
-	// next one. If the whole range stays in that first month there is no next
-	// label to collide with, so we keep it — otherwise a short single-month range
-	// would lose all month context.
+	// Hide short partial first-month labels when a later month follows; compact
+	// cells make adjacent labels collide. Keep the label for single-month ranges.
 	const MIN_FIRST_MONTH_WEEKS = 2;
 	const firstMonth = gridStart.getMonth();
 	let firstMonthWeeks = 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -57,12 +57,31 @@ export const buildCalendarHeatmapData = (
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
 	);
 
+	// The first grid column starts on a week boundary that can fall in the tail of
+	// a month, leaving a "partial" first month of just one or two columns. Its
+	// label would then sit directly under the next month's label and overlap it
+	// (labels are wider than a column, especially in the compact layout), so we
+	// suppress the first month's label unless it spans enough columns to clear the
+	// next one.
+	const MIN_FIRST_MONTH_WEEKS = 2;
+	const firstMonth = gridStart.getMonth();
+	let firstMonthWeeks = 0;
+	while (
+		firstMonthWeeks < weekCount &&
+		addDays( gridStart, firstMonthWeeks * 7 ).getMonth() === firstMonth
+	) {
+		firstMonthWeeks++;
+	}
+	const showFirstMonthLabel = firstMonthWeeks >= MIN_FIRST_MONTH_WEEKS;
+
 	const data: HeatmapColumn[] = [];
 	let previousMonth = -1;
 	for ( let week = 0; week < weekCount; week++ ) {
 		const columnStart = addDays( gridStart, week * 7 );
 		const month = columnStart.getMonth();
-		const label = month !== previousMonth ? format( columnStart, 'MMM' ) : '';
+		const isNewMonth = month !== previousMonth;
+		const label =
+			isNewMonth && ( week !== 0 || showFirstMonthLabel ) ? format( columnStart, 'MMM' ) : '';
 		previousMonth = month;
 
 		const cells: HeatmapCell[] = [];

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -62,7 +62,9 @@ export const buildCalendarHeatmapData = (
 	// label would then sit directly under the next month's label and overlap it
 	// (labels are wider than a column, especially in the compact layout), so we
 	// suppress the first month's label unless it spans enough columns to clear the
-	// next one.
+	// next one. If the whole range stays in that first month there is no next
+	// label to collide with, so we keep it — otherwise a short single-month range
+	// would lose all month context.
 	const MIN_FIRST_MONTH_WEEKS = 2;
 	const firstMonth = gridStart.getMonth();
 	let firstMonthWeeks = 0;
@@ -72,7 +74,8 @@ export const buildCalendarHeatmapData = (
 	) {
 		firstMonthWeeks++;
 	}
-	const showFirstMonthLabel = firstMonthWeeks >= MIN_FIRST_MONTH_WEEKS;
+	const spansLaterMonth = firstMonthWeeks < weekCount;
+	const showFirstMonthLabel = ! spansLaterMonth || firstMonthWeeks >= MIN_FIRST_MONTH_WEEKS;
 
 	const data: HeatmapColumn[] = [];
 	let previousMonth = -1;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-context.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+export type HeatmapContextValue = {
+	extent: [ number, number ];
+	/** The resolved primary color (full intensity); the legend mixes toward it in CSS. */
+	primaryColorHex: string;
+};
+
+/**
+ * Shared between the chart and its legend. Kept in its own module (rather than
+ * exported from `heatmap-chart.tsx`) so the legend can consume it without an
+ * import cycle back to the chart component.
+ */
+export const HeatmapContext = createContext< HeatmapContextValue | null >( null );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-context.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-context.ts
@@ -6,9 +6,5 @@ export type HeatmapContextValue = {
 	primaryColorHex: string;
 };
 
-/**
- * Shared between the chart and its legend. Kept in its own module (rather than
- * exported from `heatmap-chart.tsx`) so the legend can consume it without an
- * import cycle back to the chart component.
- */
+/** Shared by the chart and legend without importing back from `heatmap-chart.tsx`. */
 export const HeatmapContext = createContext< HeatmapContextValue | null >( null );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
@@ -2,8 +2,8 @@ import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import { useContext } from 'react';
 import { useGlobalChartsTheme } from '../../../providers';
-import { HeatmapContext } from '../heatmap-chart';
 import styles from '../heatmap-chart.module.scss';
+import { HeatmapContext } from './heatmap-context';
 import type { CSSProperties, FC } from 'react';
 
 export interface HeatmapLegendProps {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
@@ -15,7 +15,7 @@ export interface HeatmapLegendProps {
 
 export const HeatmapLegend: FC< HeatmapLegendProps > = ( { steps = 5, lessLabel, moreLabel } ) => {
 	const context = useContext( HeatmapContext );
-	const { legend } = useGlobalChartsTheme();
+	const { legend, backgroundColor } = useGlobalChartsTheme();
 	if ( ! context ) {
 		return null;
 	}
@@ -38,6 +38,7 @@ export const HeatmapLegend: FC< HeatmapLegendProps > = ( { steps = 5, lessLabel,
 							style={
 								{
 									'--heatmap-primary': primaryColorHex,
+									'--heatmap-bg': backgroundColor,
 									'--intensity': intensity,
 								} as CSSProperties
 							}

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/index.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/index.ts
@@ -1,5 +1,7 @@
 export { getValueExtent, getNormalizedValue, isPresent } from './use-heatmap-colors';
 export { buildCalendarHeatmapData } from './build-calendar-data';
 export { HeatmapLegend } from './heatmap-legend';
+export { HeatmapContext } from './heatmap-context';
 export type { CalendarHeatmapResult } from './build-calendar-data';
 export type { HeatmapLegendProps } from './heatmap-legend';
+export type { HeatmapContextValue } from './heatmap-context';

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -219,7 +219,7 @@ Everything else — the cell gap, corner radius, in-cell value size, the empty-c
 
 ## Responsive Behavior
 
-By default the chart fills its parent container's dimensions, reflowing fluidly as the container resizes. The parent must have an explicit height, or you can set `aspectRatio` to derive the height from the available width. When neither is provided, the chart falls back to a minimum height so it stays usable rather than collapsing:
+By default the chart fills its parent container's dimensions, reflowing fluidly as the container resizes. Give it a height in one of three ways: an explicit height on the parent, an `aspectRatio` to derive the height from the available width, or fixed `width`/`height` props. Without one of these the chart has no height to fill and collapses, so always constrain it:
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -247,5 +247,5 @@ The heatmap chart is designed for full keyboard and screen reader access:
 - Each cell has an `aria-label` containing the cell name and value (or "No data"). An `aria-label` is used rather than a native `title` so no duplicate browser tooltip appears. Axis labels are decorative (`aria-hidden`) because the cell label already carries that text.
 - **Keyboard navigation**: Tab focuses the chart; arrow keys navigate between cells; the focused cell receives a visible highlight ring, and (when `withTooltips` is set) its tooltip. Escape clears the selection.
 - Color alone is never the sole indicator of value — every cell exposes its value via its accessible label, and `showValues` can render numeric labels inside cells.
-- **In-cell text contrast**: when values are shown, each cell chooses light or dark text from the luminance of its blended fill rather than the raw value, so the number stays legible across the whole scale and with any primary color.
+- **In-cell text contrast**: when values are shown, each cell chooses light or dark text from the luminance of its blended fill rather than the raw value, so the number stays legible across the whole scale — with any primary color and against a themed (including dark) chart background.
 - The component does not use animations by default, and no `prefers-reduced-motion` opt-out is required.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -7,6 +7,7 @@ import {
 	heatmapActivityMatrix,
 	heatmapCalendarSeries,
 	heatmapLargeValueMatrix,
+	heatmapPartialMonthCalendarSeries,
 } from '../../../stories/sample-data';
 import { sharedThemeArgs, themeArgTypes } from '../../../stories/theme-config';
 import { HeatmapChart } from '../index';
@@ -59,6 +60,27 @@ export const Calendar: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
 		return <HeatmapChart { ...args } data={ data } rowLabels={ rowLabels } />;
 	},
 	args: { ...sharedThemeArgs, withTooltips: true, weekStartsOn: 1 },
+	argTypes: {
+		weekStartsOn: {
+			control: { type: 'inline-radio', labels: { 0: 'Sunday', 1: 'Monday' } },
+			options: [ 1, 0 ],
+			table: { category: 'Calendar' },
+		},
+	},
+};
+
+// A year of data that starts late in June, so the calendar's first column is a
+// single-week (partial) June. In compact mode the ~11px cells make month labels
+// far wider than a column, so the partial month's label would collide with the
+// next — this story guards that the partial first-month label is suppressed.
+export const CompactCalendarPartialMonth: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
+	render: ( { weekStartsOn, ...args } ) => {
+		const { data, rowLabels } = buildCalendarHeatmapData( heatmapPartialMonthCalendarSeries, {
+			weekStartsOn,
+		} );
+		return <HeatmapChart { ...args } data={ data } rowLabels={ rowLabels } />;
+	},
+	args: { ...sharedThemeArgs, compact: true, withTooltips: true, weekStartsOn: 1 },
 	argTypes: {
 		weekStartsOn: {
 			control: { type: 'inline-radio', labels: { 0: 'Sunday', 1: 'Monday' } },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -69,10 +69,7 @@ export const Calendar: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
 	},
 };
 
-// A year of data that starts late in June, so the calendar's first column is a
-// single-week (partial) June. In compact mode the ~11px cells make month labels
-// far wider than a column, so the partial month's label would collide with the
-// next — this story guards that the partial first-month label is suppressed.
+// Regression story for a one-column first month label in compact mode.
 export const CompactCalendarPartialMonth: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
 	render: ( { weekStartsOn, ...args } ) => {
 		const { data, rowLabels } = buildCalendarHeatmapData( heatmapPartialMonthCalendarSeries, {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -57,6 +57,18 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data.map( c => c.label ).filter( Boolean )[ 0 ] ).toBe( 'Feb' );
 	} );
 
+	test( 'keeps the first month label when the range never reaches a second month', () => {
+		// A single week entirely within January: there is no later month label to
+		// collide with, so the only month label must stay for context.
+		const singleMonth: DataPointDate[] = [
+			{ dateString: '2024-01-01', value: 1 },
+			{ dateString: '2024-01-03', value: 2 },
+		];
+		const { data } = buildCalendarHeatmapData( singleMonth, { weekStartsOn: 1 } );
+		expect( data ).toHaveLength( 1 );
+		expect( data[ 0 ].label ).toBe( 'Jan' );
+	} );
+
 	test( 'filters out entries with unparseable or missing dates', () => {
 		const mixed: DataPointDate[] = [
 			{ dateString: '2024-01-01', value: 3 },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -35,13 +35,26 @@ describe( 'buildCalendarHeatmapData', () => {
 
 	test( 'labels only the first column of each month', () => {
 		const multiMonth: DataPointDate[] = [
-			{ dateString: '2024-01-29', value: 1 },
+			{ dateString: '2024-01-01', value: 1 },
 			{ dateString: '2024-02-05', value: 1 },
 		];
 		const { data } = buildCalendarHeatmapData( multiMonth );
 		expect( data[ 0 ].label ).toBe( 'Jan' );
 		const labels = data.map( c => c.label ).filter( Boolean );
 		expect( labels ).toContain( 'Feb' );
+	} );
+
+	test( 'suppresses a partial first month label so it cannot collide with the next', () => {
+		// Grid starts on Mon 2024-01-29 (tail of January), so January is a single
+		// partial column. Its label would sit under February's and overlap, so it
+		// is dropped and February becomes the first visible label.
+		const partialFirstMonth: DataPointDate[] = [
+			{ dateString: '2024-01-29', value: 1 },
+			{ dateString: '2024-02-05', value: 1 },
+		];
+		const { data } = buildCalendarHeatmapData( partialFirstMonth, { weekStartsOn: 1 } );
+		expect( data[ 0 ].label ).toBe( '' );
+		expect( data.map( c => c.label ).filter( Boolean )[ 0 ] ).toBe( 'Feb' );
 	} );
 
 	test( 'filters out entries with unparseable or missing dates', () => {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -45,9 +45,7 @@ describe( 'buildCalendarHeatmapData', () => {
 	} );
 
 	test( 'suppresses a partial first month label so it cannot collide with the next', () => {
-		// Grid starts on Mon 2024-01-29 (tail of January), so January is a single
-		// partial column. Its label would sit under February's and overlap, so it
-		// is dropped and February becomes the first visible label.
+		// Jan 29 is the only January column; February should be the first visible label.
 		const partialFirstMonth: DataPointDate[] = [
 			{ dateString: '2024-01-29', value: 1 },
 			{ dateString: '2024-02-05', value: 1 },
@@ -58,8 +56,7 @@ describe( 'buildCalendarHeatmapData', () => {
 	} );
 
 	test( 'keeps the first month label when the range never reaches a second month', () => {
-		// A single week entirely within January: there is no later month label to
-		// collide with, so the only month label must stay for context.
+		// Single-month ranges keep their lone month label.
 		const singleMonth: DataPointDate[] = [
 			{ dateString: '2024-01-01', value: 1 },
 			{ dateString: '2024-01-03', value: 2 },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -222,12 +222,19 @@ describe( 'HeatmapChart', () => {
 		} );
 	} );
 
-	test( 'leaves cell gap and radius to WPDS tokens (no inline overrides)', () => {
+	test( 'keeps a strict grid → row structure (column labels live in a row, not directly under the grid)', () => {
+		renderChart();
+		// The header row is aria-hidden, so include hidden elements when querying for it.
+		const rows = screen.getAllByRole( 'row', { hidden: true } );
+		const headerRow = rows.find( row => within( row ).queryByText( 'W1' ) );
+		expect( headerRow ).toBeDefined();
+	} );
+
+	test( 'leaves the cell gap to WPDS tokens in non-compact mode (no inline override)', () => {
 		renderChart();
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		// Non-compact sets no inline gap/radius — the SCSS falls back to the WPDS tokens.
+		// Non-compact sets no inline gap — the SCSS falls back to the WPDS token.
 		expect( grid.style.getPropertyValue( '--heatmap-cell-gap' ) ).toBe( '' );
-		expect( grid.style.getPropertyValue( '--heatmap-cell-radius' ) ).toBe( '' );
 	} );
 
 	test( 'applies the compact gap inline from the theme compactCellGap', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -186,6 +186,11 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		[ colorCache, groupToColorMap ]
 	);
 
+	const resolveThemeColor = useCallback< GlobalChartsContextValue[ 'resolveThemeColor' ] >(
+		value => ( value ? normalizeColorToHex( value, wrapperRef.current, resolveCssVariable ) : '' ),
+		[]
+	);
+
 	const getElementStyles = useCallback< GlobalChartsContextValue[ 'getElementStyles' ] >(
 		( { data, index, overrideColor, legendShape } ) => {
 			const isSeriesData = data && typeof data === 'object' && 'data' in data && 'options' in data;
@@ -264,6 +269,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 			getChartData,
 			theme: providerTheme,
 			getElementStyles,
+			resolveThemeColor,
 			toggleSeriesVisibility,
 			isSeriesVisible,
 			getHiddenSeries,
@@ -276,6 +282,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 			getChartData,
 			providerTheme,
 			getElementStyles,
+			resolveThemeColor,
 			toggleSeriesVisibility,
 			isSeriesVisible,
 			getHiddenSeries,

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -32,6 +32,7 @@ interface GlobalChartsContextValue {
 	// Theme and styling
 	theme: CompleteChartTheme;
 	getElementStyles: (params: GetElementStylesParams) => ElementStyles;
+	resolveThemeColor: (value: string) => string;
 
 	// Series visibility management for interactive legends
 	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
@@ -44,6 +45,8 @@ interface GlobalChartsContextValue {
 ```
 
 `isColorPaletteResolved` is `false` until the provider's color cache has been resolved from the DOM and painted. Chart components can use this to defer CSS transitions or animations that would otherwise interpolate from a fallback color to the resolved theme color on initial render.
+
+`resolveThemeColor` resolves a color value — including a `--wpds-*` token or `var(...)` expression — to a hex string in the provider's own (theme-scoped) element. Use it when JS needs the *resolved* value of a themed color, such as reading `theme.backgroundColor` to compute text contrast. It resolves at call time, so the result tracks a light/dark theme switch where the token string is unchanged but its resolved value differs. Returns `''` for an empty input.
 
 ## ChartRegistration Type
 

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -2536,6 +2536,46 @@ describe( 'ChartContext', () => {
 				expect( afterRerenderColor ).toBe( '#ff0000' );
 			} );
 		} );
+
+		describe( 'resolveThemeColor', () => {
+			let contextValue: GlobalChartsContextValue;
+
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			const mountProvider = () =>
+				render(
+					<GlobalChartsProvider>
+						<TestComponent />
+					</GlobalChartsProvider>
+				);
+
+			it( 'resolves a CSS variable against the provider scope, not the document root', () => {
+				window.getComputedStyle = jest.fn( ( element: Element ) => ( {
+					getPropertyValue: ( prop: string ) =>
+						prop === '--surface' && element !== document.documentElement ? '#1e1e1e' : '#ffffff',
+				} ) ) as unknown as typeof window.getComputedStyle;
+
+				mountProvider();
+
+				expect( contextValue.resolveThemeColor( 'var(--surface, #fff)' ) ).toBe( '#1e1e1e' );
+			} );
+
+			it( 'passes a resolved color through to hex', () => {
+				mountProvider();
+
+				expect( contextValue.resolveThemeColor( '#abcdef' ) ).toBe( '#abcdef' );
+				expect( contextValue.resolveThemeColor( 'rgb(255, 0, 0)' ) ).toBe( '#ff0000' );
+			} );
+
+			it( 'returns an empty string for an empty value', () => {
+				mountProvider();
+
+				expect( contextValue.resolveThemeColor( '' ) ).toBe( '' );
+			} );
+		} );
 	} );
 
 	describe( 'defaultTheme', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -38,6 +38,9 @@ export interface GlobalChartsContextValue {
 	getChartData: ( id: string ) => ChartRegistration | undefined;
 	theme: CompleteChartTheme;
 	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles;
+	// Resolve a theme color or CSS variable to a hex string in the provider's scope.
+	// Resolves at call time so it tracks ambient theme changes (e.g. a light/dark switch).
+	resolveThemeColor: ( value: string ) => string;
 	// Series visibility management for interactive legends
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
 	isSeriesVisible: ( chartId: string, seriesLabel: string ) => boolean;

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -1077,14 +1077,11 @@ export const heatmapCalendarSeries: DataPointDate[] = Array.from(
 );
 
 /**
- * Year-long daily activity series that starts late in a month (28 Jun 2023).
+ * Calendar series starting on 2023-06-28 to exercise partial first-month labels.
  *
- * The grid's first week column therefore lands in the tail of June, giving a
- * "partial" first month of a single column — used to reproduce the calendar
- * month-label collision (the partial month's label overlapping the next).
  * - Category: time-series
  * - Data points: 365
- * - Suitable for: HeatmapChart (calendar layout, partial first month)
+ * - Suitable for: HeatmapChart (calendar layout)
  */
 export const heatmapPartialMonthCalendarSeries: DataPointDate[] = Array.from(
 	{ length: 365 },

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -1075,3 +1075,21 @@ export const heatmapCalendarSeries: DataPointDate[] = Array.from(
 		value: Math.round( Math.abs( Math.sin( index ) ) * 4 ),
 	} )
 );
+
+/**
+ * Year-long daily activity series that starts late in a month (28 Jun 2023).
+ *
+ * The grid's first week column therefore lands in the tail of June, giving a
+ * "partial" first month of a single column — used to reproduce the calendar
+ * month-label collision (the partial month's label overlapping the next).
+ * - Category: time-series
+ * - Data points: 365
+ * - Suitable for: HeatmapChart (calendar layout, partial first month)
+ */
+export const heatmapPartialMonthCalendarSeries: DataPointDate[] = Array.from(
+	{ length: 365 },
+	( _, index ) => ( {
+		date: new Date( 2023, 5, 28 + index ),
+		value: Math.round( Math.abs( Math.sin( index ) ) * 4 ),
+	} )
+);

--- a/projects/js-packages/charts/src/utils/color-utils.ts
+++ b/projects/js-packages/charts/src/utils/color-utils.ts
@@ -234,12 +234,11 @@ export const lightenHexColor = ( hex: string, blend: number ): string => {
 };
 
 /**
- * Blend one hex color toward another, per-channel in sRGB — the opaque equivalent of a
- * CSS `color-mix(fromHex (1 - blend)%, toHex)`.
+ * Blend one hex color toward another, per-channel in sRGB.
  *
- * @param  fromHex - Starting hex color, returned when blend = 0
- * @param  toHex   - Target hex color, returned when blend = 1
- * @param  blend   - Blend amount toward toHex, clamped to [0, 1]
+ * @param  fromHex - Starting hex color, returned when blend is 0
+ * @param  toHex   - Target hex color, returned when blend is 1
+ * @param  blend   - Amount toward toHex, clamped to [0, 1]
  * @return Blended hex color string
  * @throws {Error} if either hex string is malformed
  */

--- a/projects/js-packages/charts/src/utils/color-utils.ts
+++ b/projects/js-packages/charts/src/utils/color-utils.ts
@@ -234,6 +234,35 @@ export const lightenHexColor = ( hex: string, blend: number ): string => {
 };
 
 /**
+ * Blend one hex color toward another, per-channel in sRGB — the opaque equivalent of a
+ * CSS `color-mix(fromHex (1 - blend)%, toHex)`.
+ *
+ * @param  fromHex - Starting hex color, returned when blend = 0
+ * @param  toHex   - Target hex color, returned when blend = 1
+ * @param  blend   - Blend amount toward toHex, clamped to [0, 1]
+ * @return Blended hex color string
+ * @throws {Error} if either hex string is malformed
+ */
+export const mixHexColors = ( fromHex: string, toHex: string, blend: number ): string => {
+	validateHexColor( fromHex );
+	validateHexColor( toHex );
+
+	const amount = Math.min( 1, Math.max( 0, blend ) );
+	const channel = ( start: number, end: number ): string =>
+		Math.round( start + ( end - start ) * amount )
+			.toString( 16 )
+			.padStart( 2, '0' );
+
+	return `#${ channel(
+		parseInt( fromHex.slice( 1, 3 ), 16 ),
+		parseInt( toHex.slice( 1, 3 ), 16 )
+	) }${ channel(
+		parseInt( fromHex.slice( 3, 5 ), 16 ),
+		parseInt( toHex.slice( 3, 5 ), 16 )
+	) }${ channel( parseInt( fromHex.slice( 5, 7 ), 16 ), parseInt( toHex.slice( 5, 7 ), 16 ) ) }`;
+};
+
+/**
  * WCAG relative luminance of a hex color (0 = black, 1 = white).
  *
  * @param  hex - Hex color string (e.g., '#98C8DF')

--- a/projects/js-packages/charts/src/utils/test/color-utils.test.ts
+++ b/projects/js-packages/charts/src/utils/test/color-utils.test.ts
@@ -2,6 +2,7 @@ import { hsl as d3Hsl } from '@visx/vendor/d3-color';
 import {
 	getColorDistance,
 	lightenHexColor,
+	mixHexColors,
 	isValidHexColor,
 	hexToRgba,
 	validateHexColor,
@@ -582,6 +583,34 @@ describe( 'lightenHexColor', () => {
 		it( 'throws for invalid hex characters', () => {
 			expect( () => lightenHexColor( '#gggggg', 0.5 ) ).toThrow();
 		} );
+	} );
+} );
+
+describe( 'mixHexColors', () => {
+	it( 'returns the from color at blend 0', () => {
+		expect( mixHexColors( '#ff0000', '#0000ff', 0 ) ).toBe( '#ff0000' );
+	} );
+
+	it( 'returns the to color at blend 1', () => {
+		expect( mixHexColors( '#ff0000', '#0000ff', 1 ) ).toBe( '#0000ff' );
+	} );
+
+	it( 'blends halfway between the two colors', () => {
+		expect( mixHexColors( '#000000', '#ffffff', 0.5 ) ).toBe( '#808080' );
+	} );
+
+	it( 'matches lightenHexColor when the target is white', () => {
+		expect( mixHexColors( '#98c8df', '#ffffff', 0.8 ) ).toBe( lightenHexColor( '#98c8df', 0.8 ) );
+	} );
+
+	it( 'clamps blend outside [0, 1]', () => {
+		expect( mixHexColors( '#123456', '#abcdef', -1 ) ).toBe( '#123456' );
+		expect( mixHexColors( '#123456', '#abcdef', 2 ) ).toBe( '#abcdef' );
+	} );
+
+	it( 'throws on a malformed hex', () => {
+		expect( () => mixHexColors( '#fff', '#000000', 0.5 ) ).toThrow();
+		expect( () => mixHexColors( '#000000', 'nope', 0.5 ) ).toThrow();
 	} );
 } );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the HTML/CSS HeatmapChart in #50065. Addresses the CHARTS-230 non-blocking review items and later fixes for sizing, calendar labels, and dark-surface value contrast.

## Proposed changes
* Move `HeatmapContext` into `private/heatmap-context.ts` so the chart and legend do not import from each other.
* Keep the heatmap's ARIA grid structure strict by wrapping hidden column labels in a `role="row"`.
* Make cell fills and legend swatches blend over the theme background token instead of transparent, and compute in-cell value text color from that same blended fill.
* Resolve scoped background tokens from the grid element, before paint, so dark themed containers do not briefly render values with the wrong contrast.
* Let the grid shrink inside short widgets, and update responsive docs to require a parent height, `aspectRatio`, or fixed dimensions.
* Suppress a one-column partial first-month label only when a later month follows, avoiding compact calendar label collisions while keeping single-month labels.
* Add focused tests, the partial-month calendar story/sample data, a color-mixing utility, and the combined changelog entry.

## Related product discussion/links
* Follow-up to #50065. Linear: CHARTS-230 (parent CHARTS-218).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm jetpack test js js-packages/charts`, or focused checks:
  * `pnpm --dir projects/js-packages/charts run test src/charts/heatmap-chart/test/heatmap-chart.test.tsx --runInBand`
  * `pnpm --dir projects/js-packages/charts run test src/charts/heatmap-chart/test/build-calendar-data.test.ts --runInBand`
  * `pnpm --dir projects/js-packages/charts run test src/utils/test/color-utils.test.ts --runInBand`
  * `pnpm --dir projects/js-packages/charts run typecheck`
  * `pnpm --dir projects/js-packages/charts exec eslint --max-warnings=0 src/charts/heatmap-chart/heatmap-chart.tsx`
* In Storybook, verify the HeatmapChart default, calendar, compact calendar partial-month, and composition legend stories.
* Check short fixed-height containers do not scroll, partial first-month labels do not collide with the next month, and in-cell values remain readable on a dark scoped theme without a white-to-dark flash.

### Screenshots

**Default heatmap**

![Default heatmap](https://github.com/user-attachments/assets/e5d9aae6-1f29-4620-8424-e47301027dd4)

**Short widget - grid shrinks to fit, no scroll**

![Heatmap in a 150px-tall widget, full chart visible with no scrollbar](https://github.com/user-attachments/assets/4cf62bf4-f9de-4ef8-87e6-a973fce79e5c)

**Calendar partial-month label - before / after**

Before - the partial first month (`Jun`) collides with `Jul` into an unreadable smear:

![Calendar month labels colliding before the fix](https://github.com/user-attachments/assets/2a2ca7cc-285e-4267-8a78-79754faf8ccd)

After - the partial month's label is suppressed, so the first readable label is `Jul`:

![Calendar month labels readable after the fix](https://github.com/user-attachments/assets/63d8bf4a-3cb0-4ed2-ac5a-7b413161b7f9)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CHARTS-230](https://linear.app/a8c/issue/CHARTS-230/heatmapchart-address-non-blocking-review-follow-ups-from-pr-50065)

<div><a href="https://cursor.com/agents/bc-cbcd89f9-616a-41f9-8b63-102e863d2cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbcd89f9-616a-41f9-8b63-102e863d2cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
