### PR TITLE
Premium Analytics: Subscribers chart honors dashboard date range / comparison

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-WOOA7S-1637-subscribers-chart-dashboard-range
+++ b/projects/packages/premium-analytics/changelog/update-WOOA7S-1637-subscribers-chart-dashboard-range
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Subscribers chart: honor the dashboard date-range and comparison picker. The chart window and previous-period overlay now follow the dashboard controls; the in-body "Group by" dropdown only chooses the bucket size within that range.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -27,7 +27,6 @@ const statsHookNames = [
 	'useStatsFollowers',
 	'useStatsPublicize',
 	'useStatsComments',
-	'useStatsSubscribers',
 	'useStatsSubscribersCounts',
 	'useStatsSubscribersReport',
 	'useStatsStreak',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/stats-exports.test.ts
@@ -29,6 +29,7 @@ const statsHookNames = [
 	'useStatsComments',
 	'useStatsSubscribers',
 	'useStatsSubscribersCounts',
+	'useStatsSubscribersReport',
 	'useStatsStreak',
 	'useStatsVisits',
 	'useStatsInsights',

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -69,7 +69,6 @@ export {
 	type StatsCommentsResponse,
 } from './use-stats-comments';
 export {
-	useStatsSubscribers,
 	useStatsSubscribersCounts,
 	useStatsSubscribersReport,
 	type StatsSubscribersCounts,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -71,11 +71,13 @@ export {
 export {
 	useStatsSubscribers,
 	useStatsSubscribersCounts,
+	useStatsSubscribersReport,
 	type StatsSubscribersCounts,
 	type StatsSubscribersCountsParams,
 	type StatsSubscribersCountsResponse,
 	type StatsSubscribersParams,
 	type StatsSubscribersResponse,
+	type StatsSubscribersUnit,
 } from './use-stats-subscribers';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -4,10 +4,13 @@
 import {
 	statsSubscribersCountsQuery,
 	statsSubscribersQuery,
+	statsSubscribersReportQuery,
 } from '../queries/stats-subscribers-query';
 import { useStatsQuery } from './use-stats-query';
+import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
-import type { StatsSubscribersCounts } from '../processing/stats';
+import type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
+import type { StatsReportParams } from '../queries/stats-query';
 import type {
 	StatsSubscribersCountsParams,
 	StatsSubscribersParams,
@@ -17,11 +20,21 @@ export type { StatsSubscribersCounts, StatsSubscribersResponse } from '../proces
 export type {
 	StatsSubscribersCountsParams,
 	StatsSubscribersParams,
+	StatsSubscribersUnit,
 } from '../queries/stats-subscribers-query';
 export type StatsSubscribersCountsResponse = StatsSubscribersCounts;
 
 export function useStatsSubscribers( params: StatsSubscribersParams, options?: UseStatsOptions ) {
 	return useStatsQuery( statsSubscribersQuery( params ), options );
+}
+
+export function useStatsSubscribersReport( params: StatsReportParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsReportParams, StatsSubscribersResponse >(
+		statsSubscribersReportQuery,
+		params,
+		[ 'stats', 'subscribers', '__comparison__', 'disabled' ],
+		options
+	);
 }
 
 export function useStatsSubscribersCounts(

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-subscribers.ts
@@ -3,7 +3,6 @@
  */
 import {
 	statsSubscribersCountsQuery,
-	statsSubscribersQuery,
 	statsSubscribersReportQuery,
 } from '../queries/stats-subscribers-query';
 import { useStatsQuery } from './use-stats-query';
@@ -11,10 +10,7 @@ import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
-import type {
-	StatsSubscribersCountsParams,
-	StatsSubscribersParams,
-} from '../queries/stats-subscribers-query';
+import type { StatsSubscribersCountsParams } from '../queries/stats-subscribers-query';
 
 export type { StatsSubscribersCounts, StatsSubscribersResponse } from '../processing/stats';
 export type {
@@ -23,10 +19,6 @@ export type {
 	StatsSubscribersUnit,
 } from '../queries/stats-subscribers-query';
 export type StatsSubscribersCountsResponse = StatsSubscribersCounts;
-
-export function useStatsSubscribers( params: StatsSubscribersParams, options?: UseStatsOptions ) {
-	return useStatsQuery( statsSubscribersQuery( params ), options );
-}
 
 export function useStatsSubscribersReport( params: StatsReportParams, options?: UseStatsOptions ) {
 	return useStatsReport< StatsReportParams, StatsSubscribersResponse >(

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -73,7 +73,6 @@ export {
 	type StatsCommentsResponse,
 } from './hooks/use-stats-comments';
 export {
-	useStatsSubscribers,
 	useStatsSubscribersCounts,
 	useStatsSubscribersReport,
 	type StatsSubscribersCounts,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -75,11 +75,13 @@ export {
 export {
 	useStatsSubscribers,
 	useStatsSubscribersCounts,
+	useStatsSubscribersReport,
 	type StatsSubscribersCounts,
 	type StatsSubscribersCountsParams,
 	type StatsSubscribersCountsResponse,
 	type StatsSubscribersParams,
 	type StatsSubscribersResponse,
+	type StatsSubscribersUnit,
 } from './hooks/use-stats-subscribers';
 export {
 	useStatsStreak,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/time-series.ts
@@ -23,6 +23,12 @@ export const weeklySubscribersFixture = {
 	data: [ [ '2026-W25', '9' ] ],
 };
 
+export const wpcomWeeklySubscribersFixture = {
+	unit: 'week',
+	fields: [ 'period', 'subscribers' ],
+	data: [ [ '2026W06W29', '9' ] ],
+};
+
 export const invalidWeekSubscribersFixture = {
 	unit: 'week',
 	fields: [ 'period', 'subscribers' ],

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -15,6 +15,7 @@ import {
 	scalarDaysTimeSeriesFixture,
 	visitsFixture,
 	weeklySubscribersFixture,
+	wpcomWeeklySubscribersFixture,
 	yearlySubscribersFixture,
 } from '../__fixtures__/time-series';
 
@@ -69,6 +70,18 @@ describe( 'Stats time-series normalizer', () => {
 				time_interval: '2026-06-15',
 				date_start: '2026-06-15T00:00:00+00:00',
 				date_end: '2026-06-21T23:59:59+00:00',
+				value: 9,
+				subscribers: 9,
+			} )
+		);
+	} );
+
+	it( 'normalizes WPCOM YYYYWMMWDD week labels to date ranges', () => {
+		expect( sanitizeStatsTimeSeriesResponse( wpcomWeeklySubscribersFixture ).data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-29',
+				date_start: '2026-06-29T00:00:00+00:00',
+				date_end: '2026-07-05T23:59:59+00:00',
 				value: 9,
 				subscribers: 9,
 			} )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -131,6 +131,28 @@ function getWeekIntervalFields( period: string ) {
 	return getDateFnsIntervalFields( startOfISOWeek( parsed ), endOfISOWeek( parsed ) );
 }
 
+// WPCOM stats weekly labels arrive as `YYYY'W'MM'W'DD`, where the trailing
+// month/day is the week's start date (e.g. `2026W06W29` → week of 2026-06-29).
+function getWpcomWeekIntervalFields( period: string ) {
+	const match = period.match( /^(\d{4})W(\d{2})W(\d{2})$/ );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const parsed = parse(
+		`${ match[ 1 ] }-${ match[ 2 ] }-${ match[ 3 ] }`,
+		'yyyy-MM-dd',
+		referenceDate
+	);
+
+	if ( ! isValid( parsed ) ) {
+		return null;
+	}
+
+	return getDateFnsIntervalFields( startOfISOWeek( parsed ), endOfISOWeek( parsed ) );
+}
+
 function getMonthIntervalFields( period: string ) {
 	const parsed = parse( period, 'yyyy-MM', referenceDate );
 
@@ -155,7 +177,11 @@ function getTimeSeriesIntervalFields( period: unknown, unit?: string ) {
 	const periodString = typeof period === 'string' ? period : '';
 
 	if ( unit === 'week' ) {
-		return getWeekIntervalFields( periodString ) ?? getStatsIntervalFields( periodString, unit );
+		return (
+			getWeekIntervalFields( periodString ) ??
+			getWpcomWeekIntervalFields( periodString ) ??
+			getStatsIntervalFields( periodString, unit )
+		);
 	}
 
 	if ( unit === 'month' ) {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -35,7 +35,11 @@ import { statsPostQuery } from '../stats-post-query';
 import { statsPublicizeQuery } from '../stats-publicize-query';
 import { statsSingleVideoQuery } from '../stats-single-video-query';
 import { statsStreakQuery } from '../stats-streak-query';
-import { statsSubscribersCountsQuery, statsSubscribersQuery } from '../stats-subscribers-query';
+import {
+	statsSubscribersCountsQuery,
+	statsSubscribersQuery,
+	statsSubscribersReportQuery,
+} from '../stats-subscribers-query';
 import { statsTagsQuery } from '../stats-tags-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
@@ -698,6 +702,38 @@ describe( 'Stats query factories', () => {
 			undefined,
 			'subscribersCounts',
 		] );
+	} );
+
+	it( 'maps a daily dashboard range onto subscribers unit/quantity/date', () => {
+		const query = statsSubscribersReportQuery( {
+			from: '2026-06-01',
+			to: '2026-06-30',
+			interval: 'day',
+		} as StatsReportParams );
+
+		expect( query.enabled ).toBe( true );
+		expect( query.queryKey[ 5 ] ).toEqual( {
+			unit: 'day',
+			quantity: 30,
+			date: '2026-06-30',
+			stat_fields: 'subscribers,subscribers_paid',
+		} );
+	} );
+
+	it( 'clamps unsupported intervals to a supported subscribers unit', () => {
+		const query = statsSubscribersReportQuery( {
+			from: '2026-01-01',
+			to: '2026-06-30',
+			interval: 'quarter',
+		} as StatsReportParams );
+
+		expect( query.queryKey[ 5 ] ).toEqual(
+			expect.objectContaining( { unit: 'month', quantity: 6, date: '2026-06-30' } )
+		);
+	} );
+
+	it( 'disables the subscribers report query until a date range is available', () => {
+		expect( statsSubscribersReportQuery( {} as StatsReportParams ).enabled ).toBe( false );
 	} );
 
 	it( 'builds WordAds stats query keys with Calypso endpoint params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -732,8 +732,11 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
-	it( 'disables the subscribers report query until a date range is available', () => {
-		expect( statsSubscribersReportQuery( {} as StatsReportParams ).enabled ).toBe( false );
+	it( 'disables the subscribers report query and omits date until a range is available', () => {
+		const query = statsSubscribersReportQuery( {} as StatsReportParams );
+
+		expect( query.enabled ).toBe( false );
+		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'date' );
 	} );
 
 	it( 'builds WordAds stats query keys with Calypso endpoint params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -1,11 +1,19 @@
 /**
  * Internal dependencies
  */
+import { getPeriodsBetweenInclusive, reportParamsToStatsQueryParams } from '../utils/stats-params';
 import { statsProxyQuery } from './stats-query';
-import type { StatsReportQueryOptions } from './stats-query';
+import type { StatsReportParams, StatsReportQueryOptions } from './stats-query';
 import type { StatsPeriod } from '../utils/stats-params';
 
 export const statsSubscribersDefaultStatFields = 'subscribers,subscribers_paid';
+
+/**
+ * Granularities the `stats/subscribers` endpoint supports as its `unit`. The
+ * dashboard's finer/coarser intervals (`hour`, `quarter`) have no subscriber
+ * bucket, so they collapse onto these.
+ */
+export type StatsSubscribersUnit = 'day' | 'week' | 'month' | 'year';
 
 export type StatsSubscribersParams = {
 	unit: StatsPeriod | string;
@@ -13,6 +21,16 @@ export type StatsSubscribersParams = {
 	date: string;
 	stat_fields?: string;
 };
+
+/**
+ * Map a stats `period` onto a granularity the subscribers endpoint accepts.
+ *
+ * @param period - The period derived from the dashboard interval.
+ * @return The nearest supported subscribers unit.
+ */
+function toSubscribersUnit( period?: string ): StatsSubscribersUnit {
+	return period === 'week' || period === 'month' || period === 'year' ? period : 'day';
+}
 
 export type StatsSubscribersCountsParams = Record< string, never >;
 
@@ -31,6 +49,46 @@ export const statsSubscribersQuery = (
 		},
 		sanitizer: 'subscribers',
 	} );
+
+/**
+ * Build the subscribers time-series query from dashboard report params.
+ *
+ * The `stats/subscribers` endpoint is quantity-based (`unit` + `quantity` ending
+ * at `date`), not `from`/`to`-based, so the dashboard range is translated here:
+ * the interval picks the `unit`, the range end becomes `date`, and the number of
+ * buckets spanning the range becomes `quantity`. Wrapped in `useStatsReport`,
+ * the comparison window is fetched automatically from the dashboard's compare
+ * range.
+ *
+ * @param params - The dashboard report params.
+ * @return The subscribers query options.
+ */
+export const statsSubscribersReportQuery = (
+	params: StatsReportParams
+): StatsReportQueryOptions< 'subscribers' > => {
+	const {
+		period,
+		start_date: startDate,
+		end_date: endDate,
+	} = reportParamsToStatsQueryParams( params );
+	const unit = toSubscribersUnit( period );
+	const quantity =
+		startDate && endDate ? getPeriodsBetweenInclusive( unit, startDate, endDate ) : 1;
+
+	return statsProxyQuery( {
+		name: 'subscribers',
+		version: '1.1',
+		endpoint: 'stats/subscribers',
+		params: {
+			unit,
+			quantity,
+			...( endDate ? { date: endDate } : {} ),
+			stat_fields: statsSubscribersDefaultStatFields,
+		},
+		sanitizer: 'subscribers',
+		enabled: !! endDate,
+	} );
+};
 
 export const statsSubscribersCountsQuery = (
 	params: StatsSubscribersCountsParams = {}

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -44,7 +44,8 @@ export const statsSubscribersQuery = (
 		params: {
 			unit: params.unit,
 			quantity: params.quantity,
-			date: params.date,
+			// Omit an empty date so a range-less (disabled) query never sends `date=`.
+			...( params.date ? { date: params.date } : {} ),
 			stat_fields: params.stat_fields ?? statsSubscribersDefaultStatFields,
 		},
 		sanitizer: 'subscribers',
@@ -75,19 +76,11 @@ export const statsSubscribersReportQuery = (
 	const quantity =
 		startDate && endDate ? getPeriodsBetweenInclusive( unit, startDate, endDate ) : 1;
 
-	return statsProxyQuery( {
-		name: 'subscribers',
-		version: '1.1',
-		endpoint: 'stats/subscribers',
-		params: {
-			unit,
-			quantity,
-			...( endDate ? { date: endDate } : {} ),
-			stat_fields: statsSubscribersDefaultStatFields,
-		},
-		sanitizer: 'subscribers',
+	// Reuse the endpoint config; only gate on a resolved range end.
+	return {
+		...statsSubscribersQuery( { unit, quantity, date: endDate ?? '' } ),
 		enabled: !! endDate,
-	} );
+	};
 };
 
 export const statsSubscribersCountsQuery = (

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	getPeriodsBetweenInclusive,
 	getStatsPeriodFromInterval,
 	reportParamsToStatsQueryParams,
 	statsQueryParamsToApiParams,
@@ -18,6 +19,22 @@ describe( 'getStatsPeriodFromInterval', () => {
 		[ undefined, 'day' ],
 	] )( 'maps %s to %s', ( interval, period ) => {
 		expect( getStatsPeriodFromInterval( interval ) ).toBe( period );
+	} );
+} );
+
+describe( 'getPeriodsBetweenInclusive', () => {
+	it.each( [
+		[ 'day', '2026-06-01', '2026-06-30', 30 ],
+		[ 'hour', '2026-06-01', '2026-06-02', 2 ],
+		[ 'week', '2026-06-01', '2026-06-28', 4 ],
+		[ 'month', '2026-01-15', '2026-06-15', 6 ],
+		[ 'year', '2024-03-01', '2026-03-01', 3 ],
+	] as const )( 'counts %s buckets inclusive of both ends', ( period, from, to, expected ) => {
+		expect( getPeriodsBetweenInclusive( period, from, to ) ).toBe( expected );
+	} );
+
+	it( 'falls back to one bucket for an inverted range', () => {
+		expect( getPeriodsBetweenInclusive( 'month', '2026-06-01', '2026-01-01' ) ).toBe( 1 );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -1,4 +1,12 @@
 /**
+ * External dependencies
+ */
+import {
+	differenceInCalendarISOWeeks,
+	differenceInCalendarMonths,
+	differenceInCalendarYears,
+} from 'date-fns';
+/**
  * Internal dependencies
  */
 import { getDaysBetweenInclusive } from './interval';
@@ -56,6 +64,44 @@ export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
 		default:
 			return 'day';
 	}
+}
+
+/**
+ * Count the number of `period` buckets spanning a date range, inclusive of both
+ * ends. Used to translate a dashboard date range into the `quantity` param that
+ * quantity-based Stats endpoints (e.g. `stats/subscribers`) expect for the given
+ * `unit`, mirroring how `days` is derived for day-based requests.
+ *
+ * @param period - The bucket granularity.
+ * @param from   - Range start (`yyyy-MM-dd`).
+ * @param to     - Range end (`yyyy-MM-dd`).
+ * @return The bucket count, at least 1.
+ */
+export function getPeriodsBetweenInclusive(
+	period: StatsPeriod,
+	from: string,
+	to: string
+): number {
+	if ( period === 'hour' || period === 'day' ) {
+		return getDaysBetweenInclusive( from, to );
+	}
+
+	const fromDate = new Date( `${ datePart( from ) }T00:00:00Z` );
+	const toDate = new Date( `${ datePart( to ) }T00:00:00Z` );
+
+	const differenceForPeriod = {
+		week: differenceInCalendarISOWeeks,
+		month: differenceInCalendarMonths,
+		year: differenceInCalendarYears,
+	}[ period ];
+
+	const diff = differenceForPeriod( toDate, fromDate );
+
+	if ( Number.isNaN( diff ) || diff < 0 ) {
+		return 1;
+	}
+
+	return diff + 1;
 }
 
 export function reportParamsToStatsQueryParams(

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -539,6 +539,13 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 				2,
 				'0'
 			) }`;
+		} else if ( unit === 'week' ) {
+			// Mirror WPCOM's weekly label shape: YYYY'W'MM'W'DD (week-start date).
+			bucket.setUTCDate( bucket.getUTCDate() - i * stepDays );
+			period = `${ bucket.getUTCFullYear() }W${ String( bucket.getUTCMonth() + 1 ).padStart(
+				2,
+				'0'
+			) }W${ String( bucket.getUTCDate() ).padStart( 2, '0' ) }`;
 		} else {
 			bucket.setUTCDate( bucket.getUTCDate() - i * stepDays );
 			period = bucket.toISOString().slice( 0, 10 );

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -4,7 +4,9 @@
 import {
 	MetricTabsChart,
 	WidgetRoot,
+	useWidgetRootContext,
 	type MetricTab,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -19,13 +21,36 @@ import useSubscribersChart, {
 	type SubscribersChartState,
 	type SubscribersPeriod,
 } from './use-subscribers-chart';
-import type { SubscribersChartAttributes } from './widget';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type SubscribersChartRenderProps = {
+	attributes?: Partial< ReportParamsFieldAttributes >;
+};
 
 const DATA_FORMAT = {
 	type: 'number' as const,
 	options: { useMultipliers: true, decimals: 0 },
 };
+
+/**
+ * Seed the granularity dropdown from the dashboard interval so it opens at the
+ * granularity the range implies; the subscribers endpoint only buckets by
+ * day/week/month, so finer/coarser dashboard intervals collapse onto those.
+ *
+ * @param interval - The dashboard-derived interval.
+ * @return The matching selectable granularity.
+ */
+function defaultPeriodForInterval( interval?: string ): SubscribersPeriod {
+	switch ( interval ) {
+		case 'week':
+			return 'week';
+		case 'month':
+		case 'quarter':
+		case 'year':
+			return 'month';
+		default:
+			return 'day';
+	}
+}
 
 /**
  * The latest value of a metric in a window — each point is the cumulative count
@@ -83,13 +108,18 @@ function buildMetrics( state: SubscribersChartState ): MetricTab[] {
 }
 
 /**
- * Subscribers chart inner component. Owns the granularity dropdown and hands the
- * metric tabs (Subscribers, Paid subscribers) to the shared `MetricTabsChart`.
+ * Subscribers chart inner component. Reads the dashboard date range + comparison
+ * state from `useWidgetRootContext()`, owns the granularity dropdown (which only
+ * chooses the bucket size within that range), and hands the metric tabs
+ * (Subscribers, Paid subscribers) to the shared `MetricTabsChart`.
  *
  * @return The widget body.
  */
 function SubscribersChartInner() {
-	const [ period, setPeriod ] = useState< SubscribersPeriod >( 'day' );
+	const { reportParams } = useWidgetRootContext();
+	const [ period, setPeriod ] = useState< SubscribersPeriod >( () =>
+		defaultPeriodForInterval( reportParams.interval )
+	);
 	const handlePeriodChange = useCallback(
 		( value: string ) => setPeriod( value as SubscribersPeriod ),
 		[]
@@ -101,7 +131,7 @@ function SubscribersChartInner() {
 		{ label: __( 'By months', 'jetpack-premium-analytics' ), value: 'month' },
 	];
 
-	const state = useSubscribersChart( period );
+	const state = useSubscribersChart( reportParams, period );
 	const metrics = useMemo( () => buildMetrics( state ), [ state ] );
 
 	if ( state.isError ) {
@@ -139,20 +169,17 @@ function SubscribersChartInner() {
 /**
  * Widget render entry point.
  *
- * Mirrors the other Stats widgets: `WidgetRoot` provides the analytics query
- * client, and the inner component owns the granularity state. The subscribers
- * query is granularity-driven rather than date-range-driven, so it does not
- * read the dashboard's `reportParams`.
+ * `WidgetRoot` provides the analytics query client and resolves the dashboard's
+ * `reportParams`; the inner component reads that range/comparison state and
+ * layers its own granularity control on top.
  *
  * @param props            - Render props supplied by the widget host.
- * @param props.attributes - Widget attributes (none configurable yet).
+ * @param props.attributes - Widget attributes, carrying host-provided report params.
  * @return The rendered widget.
  */
-export default function SubscribersChart( {
-	attributes = {},
-}: WidgetRenderProps< SubscribersChartAttributes > ) {
+export default function SubscribersChart( { attributes }: SubscribersChartRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes }>
+		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
 			<SubscribersChartInner />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -4,14 +4,13 @@
 import {
 	MetricTabsChart,
 	WidgetRoot,
+	useWidgetError,
 	useWidgetRootContext,
 	type MetricTab,
-	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -21,10 +20,12 @@ import useSubscribersChart, {
 	type SubscribersChartState,
 	type SubscribersPeriod,
 } from './use-subscribers-chart';
+import type { ComponentProps } from 'react';
 
-type SubscribersChartRenderProps = {
-	attributes?: Partial< ReportParamsFieldAttributes >;
-};
+type SubscribersChartRenderProps = Pick<
+	ComponentProps< typeof WidgetRoot >,
+	'attributes' | 'setError'
+>;
 
 const DATA_FORMAT = {
 	type: 'number' as const,
@@ -32,9 +33,12 @@ const DATA_FORMAT = {
 };
 
 /**
- * Seed the granularity dropdown from the dashboard interval so it opens at the
- * granularity the range implies; the subscribers endpoint only buckets by
- * day/week/month, so finer/coarser dashboard intervals collapse onto those.
+ * Default granularity for the dashboard interval: opens the dropdown at the
+ * granularity the range implies (and, until the user picks one explicitly,
+ * keeps following the range). The subscribers endpoint only buckets by
+ * day/week/month, so finer/coarser dashboard intervals collapse onto those —
+ * this mirrors `getStatsPeriodFromInterval` + `toSubscribersUnit` in the data
+ * layer, narrowed to the dropdown's options.
  *
  * @param interval - The dashboard-derived interval.
  * @return The matching selectable granularity.
@@ -117,11 +121,14 @@ function buildMetrics( state: SubscribersChartState ): MetricTab[] {
  */
 function SubscribersChartInner() {
 	const { reportParams } = useWidgetRootContext();
-	const [ period, setPeriod ] = useState< SubscribersPeriod >( () =>
-		defaultPeriodForInterval( reportParams.interval )
-	);
+	// `null` means "follow the dashboard range"; a value is an explicit user
+	// override that then sticks across range changes. This keeps a wide range
+	// from staying stuck on `day` granularity (and blowing up the bucket count)
+	// while the user hasn't picked a granularity themselves.
+	const [ periodOverride, setPeriodOverride ] = useState< SubscribersPeriod | null >( null );
+	const period = periodOverride ?? defaultPeriodForInterval( reportParams.interval );
 	const handlePeriodChange = useCallback(
-		( value: string ) => setPeriod( value as SubscribersPeriod ),
+		( value: string ) => setPeriodOverride( value as SubscribersPeriod ),
 		[]
 	);
 
@@ -134,12 +141,9 @@ function SubscribersChartInner() {
 	const state = useSubscribersChart( reportParams, period );
 	const metrics = useMemo( () => buildMetrics( state ), [ state ] );
 
-	if ( state.isError ) {
-		return (
-			<div className={ styles.root }>
-				<Text>{ __( 'Unable to load subscribers.', 'jetpack-premium-analytics' ) }</Text>
-			</div>
-		);
+	const hasError = useWidgetError( state.isError, state.error, state.refetch );
+	if ( hasError ) {
+		return null; // Dashboard shows error UI via WidgetErrorBoundary.
 	}
 
 	return (
@@ -175,11 +179,12 @@ function SubscribersChartInner() {
  *
  * @param props            - Render props supplied by the widget host.
  * @param props.attributes - Widget attributes, carrying host-provided report params.
+ * @param props.setError   - Host callback to surface a widget error in the dashboard frame.
  * @return The rendered widget.
  */
-export default function SubscribersChart( { attributes }: SubscribersChartRenderProps ) {
+export default function SubscribersChart( { attributes, setError }: SubscribersChartRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
+		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
 			<SubscribersChartInner />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
  * Internal dependencies
  */
 import {
@@ -18,6 +22,18 @@ registerReportMocks();
 
 const SUBSCRIBERS_CHART_RENDER_MODULE = 'storybook/subscribers-chart';
 
+interface SubscribersChartStoryControls {
+	withComparison: boolean;
+}
+
+function renderSubscribersChart( { withComparison }: SubscribersChartStoryControls ) {
+	return (
+		<SubscribersChartRender
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
 // Close-up canvas so the chart fills the frame outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '360px' } }>
@@ -29,47 +45,72 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SubscribersChart',
 	component: SubscribersChartRender,
 	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'Subscriber growth over time. The in-body "Group by" dropdown switches granularity (day/week/month); the previous period is overlaid as a same-colour dashed line and the headline shows the period-over-period delta. Paid subscribers render as a second line when present. Data comes from the designated `useStatsSubscribers` hook; in Storybook it is served by `registerReportMocks`.',
+					'Subscriber growth over time. The date range and previous-period comparison follow the dashboard picker; the in-body "Group by" dropdown chooses the bucket size (day/week/month) within that range. When comparison is on, the previous period is overlaid as a same-colour dashed line and the headline shows the period-over-period delta. Paid subscribers render as a second line when present. Data comes from `useStatsSubscribersReport`; in Storybook it is served by `registerReportMocks`.',
 			},
 		},
 	},
-} satisfies Meta< typeof SubscribersChartRender >;
+} satisfies Meta< SubscribersChartStoryControls >;
 
 export default meta;
 
-type Story = StoryObj< typeof meta >;
-type DashboardStory = StoryObj< WidgetDashboardWithWidgetControls >;
+type Story = StoryObj< SubscribersChartStoryControls >;
 
 /**
- * The widget on its own, populated from mocked subscribers data. Shows both the
- * subscribers and paid-subscribers lines with their previous-period overlays.
+ * The widget on its own, current period only.
  */
 export const Default: Story = {
-	render: () => <SubscribersChartRender attributes={ {} } />,
+	render: renderSubscribersChart,
+	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
 /**
- * Renders the real registered widget through the shared dashboard harness.
+ * Same close-up with the dashboard comparison range applied, so the previous
+ * period is overlaid as a dashed line and the headline shows the delta.
  */
-export const WidgetDashboardWithWidget: DashboardStory = {
-	render: args => (
+export const WithComparison: Story = {
+	render: renderSubscribersChart,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface SubscribersChartDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SubscribersChartStoryControls {}
+
+function SubscribersChartDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: SubscribersChartDashboardStoryProps ) {
+	return (
 		<WidgetDashboardWithWidgetStory
-			{ ...args }
+			{ ...dashboardArgs }
 			widgetType={ widgetDefinition }
 			renderModule={ SUBSCRIBERS_CHART_RENDER_MODULE }
 			renderComponent={ SubscribersChartRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {} }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
 		/>
-	),
+	);
+}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: StoryObj< SubscribersChartDashboardStoryProps > = {
+	render: args => <SubscribersChartDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
@@ -2,30 +2,19 @@
  * External dependencies
  */
 import {
-	useStatsSubscribers,
+	useStatsSubscribersReport,
 	localTZDate,
+	type ReportParams,
 	type StatsSubscribersResponse,
+	type StatsSubscribersUnit,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
-import { format, sub, type Duration } from 'date-fns';
 
 /**
  * Granularity the chart can be grouped by. Maps directly to the WPCOM stats
- * `unit` query param.
+ * `unit` query param and is layered onto the dashboard range as its `period`.
  */
-export type SubscribersPeriod = 'day' | 'week' | 'month';
-
-/**
- * How many periods to request per granularity, and the matching `date-fns`
- * duration key used to step back one full window for the previous period.
- */
-const PERIOD_CONFIG: Record< SubscribersPeriod, { quantity: number; unit: keyof Duration } > = {
-	day: { quantity: 30, unit: 'days' },
-	week: { quantity: 12, unit: 'weeks' },
-	month: { quantity: 12, unit: 'months' },
-};
-
-const DATE_FORMAT = 'yyyy-MM-dd';
+export type SubscribersPeriod = Extract< StatsSubscribersUnit, 'day' | 'week' | 'month' >;
 
 /**
  * A single normalized point on the subscribers chart.
@@ -65,42 +54,35 @@ function toPoints( report: StatsSubscribersResponse | undefined ): SubscribersCh
 }
 
 /**
- * Fetch the subscribers time series for the selected granularity, together
- * with the immediately preceding window so the chart can overlay the previous
- * period and the headline can show a period-over-period delta.
+ * Fetch the subscribers time series for the dashboard's date range at the
+ * selected granularity, together with the dashboard comparison window.
  *
- * Both windows request `quantity` periods; the previous window simply ends one
- * full window earlier. `useStatsSubscribers` is the designated Stats data hook
- * (a non-time-series TanStack query result — no `primary`/`comparison` shape).
+ * The dashboard date range drives the window and the previous-period overlay is
+ * driven by the dashboard's comparison state; the in-body granularity control
+ * only overrides which `unit` the range is bucketed into. Both windows are
+ * fetched by `useStatsSubscribersReport`, which layers the comparison range on
+ * top of `reportParams`.
  *
- * @param period        - Selected granularity (day/week/month).
- * @param referenceDate - The window's end date; defaults to "today" in the
- *                      site timezone (like other Stats widgets) so the terminal
- *                      bucket is correct regardless of the viewer's timezone.
- *                      Injectable for deterministic tests/stories.
+ * @param reportParams - The dashboard report params (date range + comparison).
+ * @param period       - Selected granularity (day/week/month).
  * @return The current/previous series, totals, and load state.
  */
 export default function useSubscribersChart(
-	period: SubscribersPeriod,
-	referenceDate: Date = localTZDate()
+	reportParams: ReportParams,
+	period: SubscribersPeriod
 ): SubscribersChartState {
-	const { quantity, unit } = PERIOD_CONFIG[ period ];
+	const params = useMemo( () => ( { ...reportParams, period } ), [ reportParams, period ] );
+	const report = useStatsSubscribersReport( params );
 
-	const currentDate = format( referenceDate, DATE_FORMAT );
-	const previousDate = format( sub( referenceDate, { [ unit ]: quantity } ), DATE_FORMAT );
-
-	const currentQuery = useStatsSubscribers( { unit: period, quantity, date: currentDate } );
-	const previousQuery = useStatsSubscribers( { unit: period, quantity, date: previousDate } );
-
-	const current = useMemo( () => toPoints( currentQuery.data ), [ currentQuery.data ] );
-	const previous = useMemo( () => toPoints( previousQuery.data ), [ previousQuery.data ] );
+	const current = useMemo( () => toPoints( report.primary.data ), [ report.primary.data ] );
+	const previous = useMemo( () => toPoints( report.comparison.data ), [ report.comparison.data ] );
 
 	return {
 		current,
 		previous,
 		hasPaid: current.some( point => point.paid > 0 ),
-		isLoading: currentQuery.isLoading || previousQuery.isLoading,
-		isFetching: currentQuery.isFetching || previousQuery.isFetching,
-		isError: currentQuery.isError || previousQuery.isError,
+		isLoading: report.isLoading,
+		isFetching: report.isFetching,
+		isError: report.isError,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
@@ -37,6 +37,8 @@ export interface SubscribersChartState {
 	/** True while either window is fetching, including granularity-switch refetches. */
 	isFetching: boolean;
 	isError: boolean;
+	error: Error | null | undefined;
+	refetch: () => void;
 }
 
 /**
@@ -84,5 +86,7 @@ export default function useSubscribersChart(
 		isLoading: report.isLoading,
 		isFetching: report.isFetching,
 		isError: report.isError,
+		error: report.error,
+		refetch: report.refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -5,18 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { trendingUp } from '@wordpress/icons';
 
 /**
- * The widget exposes no configurable attributes: granularity is in-body local
- * state and the date window is derived, not host-provided.
- */
-export type SubscribersChartAttributes = Record< string, never >;
-
-/**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats `stats-subscribers-chart-section` card in
- * wp-calypso. The legacy interval segmented control becomes the in-body
- * "Group by" dropdown; granularity is local UI state rather than a persisted
- * attribute, so the widget declares no attributes.
+ * wp-calypso. The date range and previous-period comparison follow the
+ * dashboard picker; the legacy interval segmented control becomes the in-body
+ * "Group by" dropdown, which only chooses the bucket size within that range.
  */
 export default {
 	name: 'jpa/subscribers-chart',


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1637/subscribers-chart-honor-dashboard-date-range-comparison-picker

## Why

Changing the dashboard date range or comparison picker had no effect on the Subscribers chart — it was the only time-series widget that ignored those controls, driving its own fixed window and always overlaying a self-computed previous period. Now it reads the dashboard's date range and comparison state like every other time-series widget, so the range and the previous-period overlay follow the picker, and the in-body "Group by" control only chooses the bucket size within that range.

## Proposed changes

* Subscribers chart reads the dashboard date range + comparison from `useWidgetRootContext()` → `reportParams` (matching `visitors-over-time` / the traffic chart tabs) instead of driving its own window.
* The previous-period overlay + headline delta now come from the dashboard comparison state, not a self-computed preceding window — so the overlay only shows when comparison is on.
* Added a report-driven `useStatsSubscribersReport` hook: a `useStatsReport`-based hook whose query factory maps the dashboard range onto the quantity-based `stats/subscribers` endpoint (interval → `unit`, range end → `date`, span → `quantity` via the new `getPeriodsBetweenInclusive` helper) and fetches the comparison window automatically.
* Kept the in-body "Group by" dropdown as an explicit granularity control that composes with the dashboard range (it overrides only the bucket `unit`; the window and comparison stay dashboard-driven). Its default follows the range's interval.
* Still reuses `MetricTabsChart`; the change is data/params wiring, not presentation.

## Screenshots

### Before
The chart ignored the dashboard range and always overlaid a self-computed previous window with a delta, over a fixed 30-day window ending today.

![before](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/nova/wooa7s-1637-subscribers-chart-dashboard-range/before.png)

### After — dashboard comparison on (current window + previous-period overlay from the picker)
![after](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/nova/wooa7s-1637-subscribers-chart-dashboard-range/after.png)

### After — "Group by" composes with the same dashboard range (switched to months)
![after-months](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/nova/wooa7s-1637-subscribers-chart-dashboard-range/after-granularity-months.png)

### After — dashboard comparison off (no overlay, no delta)
![after-no-comparison](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/nova/wooa7s-1637-subscribers-chart-dashboard-range/after-no-comparison.png)

## Related product discussion/links

* Linear: [WOOA7S-1637](https://linear.app/a8c/issue/WOOA7S-1637/subscribers-chart-honor-dashboard-date-range-comparison-picker)
* Original port: WOOA7S-1514 (#50064). Sibling reference: `visitors-over-time` / WOOA7S-1504 (traffic chart tabs).

## Does this pull request change what data or activity we track or use?

No. It re-wires which query params the existing `stats/subscribers` request uses (deriving `unit`/`quantity`/`date` from the dashboard range instead of a self-computed window); no new data is collected.

## Testing instructions

Verified in Storybook (`Packages/Premium Analytics/Widgets/SubscribersChart`), the sanctioned review surface for these widgets — it renders the real widget through the real `WidgetDashboard` harness with `registerReportMocks` serving deterministic `stats/subscribers` data that honors `unit`/`quantity`/`date`. The live dashboard needs a WPCOM-connected site for real subscriber data, so Storybook is the reliable functional surface here; the param mapping is additionally covered by unit tests (`getPeriodsBetweenInclusive`, `reportParamsToStatsQueryParams`, stats exports).

Work through the issue's acceptance criteria:

* [ ] The chart reads the date range + comparison from the dashboard via `reportParams` — the `WithComparison` story shows the current window (Jun 2–Jul 1) and the previous-period overlay (May 3–Jun 1) both coming from the picker's default preset + comparison.
* [ ] The previous period is overlaid from the dashboard comparison state, not a self-computed window — the `Default` (comparison off) story shows a single series with no overlay and no delta; the `WithComparison` story shows the dashed overlay + delta.
* [ ] The in-body "Group by" granularity control composes with the dashboard range — switching Day → Week → Month re-buckets the same dashboard window (the range labels stay within the picker's range).
* [ ] `MetricTabsChart` is still used; only the data/params wiring changed.

To reproduce:
1. `jetpack build packages/premium-analytics`
2. From `projects/js-packages/storybook`, run `pnpm run storybook:dev` and open **Packages/Premium Analytics/Widgets/SubscribersChart**.
3. Toggle the `withComparison` control on the `Default`/`WithComparison`/`WidgetDashboardWithWidget` stories and change the "Group by" dropdown; confirm the window follows the range and the overlay follows the comparison toggle.
