### PR TITLE
Premium Analytics: Align Emails widget header

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1644-emails-widget-header
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1644-emails-widget-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emails widget: Align the header with other dashboard widgets.

--- a/projects/packages/premium-analytics/widgets/emails/emails.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/emails.module.css
@@ -9,18 +9,17 @@
 .header {
 	flex-wrap: wrap;
 	gap: var(--wpds-dimension-gap-sm, 8px);
-	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
-	min-height: 32px;
+	margin-block-end: var(--wpds-dimension-gap-sm, 8px);
 }
 
 .metricSelect {
 	flex: 0 1 220px;
+	inline-size: min(100%, 220px);
 	max-inline-size: 100%;
-	min-inline-size: min(100%, 160px);
+	min-inline-size: 0;
 }
 
 .leaderboard {
-	padding: 0 var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-lg);
 	min-width: 0;
 	min-height: 0;
 	overflow: hidden;
@@ -40,7 +39,6 @@
 }
 
 .placeholder {
-	padding: var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral-weak);
 }
 
@@ -55,16 +53,4 @@
 	height: auto;
 	aspect-ratio: 4 / 3;
 	overflow: hidden;
-}
-
-@container (max-width: 431px) {
-
-	.header {
-		align-items: stretch;
-	}
-
-	.metricSelect {
-		flex-basis: 100%;
-		inline-size: 100%;
-	}
 }

--- a/projects/packages/premium-analytics/widgets/emails/emails.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/emails.module.css
@@ -7,11 +7,16 @@
 }
 
 .header {
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-gap-sm, 8px);
 	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+	min-height: 32px;
 }
 
 .metricSelect {
-	flex-shrink: 0;
+	flex: 0 1 220px;
+	max-inline-size: 100%;
+	min-inline-size: min(100%, 160px);
 }
 
 .leaderboard {
@@ -50,4 +55,16 @@
 	height: auto;
 	aspect-ratio: 4 / 3;
 	overflow: hidden;
+}
+
+@container (max-width: 431px) {
+
+	.header {
+		align-items: stretch;
+	}
+
+	.metricSelect {
+		flex-basis: 100%;
+		inline-size: 100%;
+	}
 }

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -18,6 +19,8 @@ import { Stack, Text } from '@wordpress/ui';
 import styles from './emails.module.css';
 import type { EmailsAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type EmailsRenderAttributes = EmailsAttributes & Partial< ReportParamsFieldAttributes >;
 
 /**
  * Which rate the leaderboard displays. Rows stay in newest-first order
@@ -172,8 +175,7 @@ export const EmailsLeaderboard = ( {
 
 	return (
 		<Stack className={ styles.root }>
-			<Stack direction="row" justify="space-between" align="center" className={ styles.header }>
-				<Text>{ __( 'Latest emails sent', 'jetpack-premium-analytics' ) }</Text>
+			<Stack direction="row" justify="flex-end" align="center" className={ styles.header }>
 				<SelectControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
@@ -249,18 +251,15 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 /**
  * Widget render entry point.
  *
- * Attributes flow to the inner component via props rather than
- * `WidgetRootContext` — the emails summary has no date range, so the
- * WC-Analytics-shaped report params do not apply. Runs inside `WidgetRoot` so
- * it can reach the analytics query client, keeping the leaderboard prop-driven
- * (and Storybook-friendly).
+ * Runs inside `WidgetRoot` so it can reach the analytics query client, keeping
+ * the leaderboard prop-driven (and Storybook-friendly).
  *
- * @param {WidgetRenderProps< EmailsAttributes >} props - The render props supplied by the widget host.
+ * @param {WidgetRenderProps< EmailsRenderAttributes >} props - The render props supplied by the widget host.
  * @return The rendered widget.
  */
-export default function Emails( { attributes }: WidgetRenderProps< EmailsAttributes > ) {
+export default function Emails( { attributes = {} }: WidgetRenderProps< EmailsRenderAttributes > ) {
 	return (
-		<WidgetRoot>
+		<WidgetRoot attributes={ attributes }>
 			<EmailsReport attributes={ attributes } />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -251,8 +251,8 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 /**
  * Widget render entry point.
  *
- * Runs inside `WidgetRoot` so it can reach the analytics query client, keeping
- * the leaderboard prop-driven (and Storybook-friendly).
+ * Passes host attributes into `WidgetRoot` for the widget contract. The email
+ * summary still reads `max` from props because it does not use report params.
  *
  * @param {WidgetRenderProps< EmailsRenderAttributes >} props - The render props supplied by the widget host.
  * @return The rendered widget.

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -203,7 +203,7 @@ export const SizeLarge: Story = {
 
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
- * appears exactly as it does in product (full-bleed framing, sizing, edit mode).
+ * appears exactly as it does in product (content-bleed framing, sizing, edit mode).
  *
  * @param props - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
@@ -216,10 +216,9 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 				name: widgetDefinition.name,
 				title: widgetDefinition.title,
 				icon: widgetDefinition.icon,
-				// Matches widget.json so the host hides its card title (full-bleed),
-				// exactly as it does on the real dashboard — only the widget's own
-				// "Latest emails sent" header shows, no duplicate title.
-				presentation: 'full-bleed',
+				// Matches widget.json so the host renders the standard title/icon
+				// header while the widget body can still bleed to the card edges.
+				presentation: 'content-bleed',
 			} }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -203,7 +203,7 @@ export const SizeLarge: Story = {
 
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
- * appears exactly as it does in product (content-bleed framing, sizing, edit mode).
+ * appears exactly as it does in product (framed card, sizing, edit mode).
  *
  * @param props - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
@@ -216,9 +216,7 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 				name: widgetDefinition.name,
 				title: widgetDefinition.title,
 				icon: widgetDefinition.icon,
-				// Matches widget.json so the host renders the standard title/icon
-				// header while the widget body can still bleed to the card edges.
-				presentation: 'content-bleed',
+				presentation: 'framed',
 			} }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -3,5 +3,5 @@
 	"title": "Emails",
 	"description": "Open and click rates for your latest emails.",
 	"category": "stats",
-	"presentation": "full-bleed"
+	"presentation": "content-bleed"
 }

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -3,5 +3,5 @@
 	"title": "Emails",
 	"description": "Open and click rates for your latest emails.",
 	"category": "stats",
-	"presentation": "content-bleed"
+	"presentation": "framed"
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1644/premium-analytics-align-emails-widget-header

## Proposed changes
* Change the Premium Analytics Emails widget presentation from `full-bleed` to `framed` so it follows the same host-rendered header/card contract as the other leaderboard widgets.
* Remove the widget-owned "Latest emails sent" header text and keep the rate selector aligned inside the widget body.
* Normalize the Emails widget body spacing for a framed card and update the Storybook dashboard harness to match the widget metadata.

## Related product discussion/links
* https://linear.app/a8c/issue/WOOA7S-1644/premium-analytics-align-emails-widget-header

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --dir projects/packages/premium-analytics run typecheck`.
* Run `pnpm --dir projects/packages/premium-analytics run test`.
* Run `CI=1 jp build packages/my-jetpack`.
* Run `CI=1 jp build plugins/jetpack`.
* Run `CI=1 pnpm --dir projects/packages/premium-analytics exec wp-build` and confirm the Emails widget build completes.
* In a local Jetpack Docker site, go to `wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`.
* Add the Emails widget to the dashboard if it is not already visible.
* Confirm the Emails widget uses the same host-rendered header treatment as the other widgets: the card header shows the Emails title/icon once, the old "Latest emails sent" widget-owned title is not shown, and the Open rate / Click rate selector remains visible in the widget body.
