### PR TITLE
Premium Analytics: top-posts widget honors dashboard date range

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-WOOA7S-1645-top-posts-date-range
+++ b/projects/packages/premium-analytics/changelog/fix-WOOA7S-1645-top-posts-date-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Top posts &amp; pages: Honor the dashboard date-range picker and comparison period instead of the widget's own fixed range.

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -150,6 +150,54 @@ describe( 'TopPostsWidget', () => {
 		).toBe( true );
 	} );
 
+	it( 'does not render deltas when the comparison period has no overlapping posts', async () => {
+		// Comparison returns rows, but for a different post — so no primary row
+		// has a previous value and the comparison UI must stay off.
+		const nonOverlappingComparison = {
+			date: '2026-02-10',
+			days: {},
+			summary: {
+				postviews: [
+					{
+						id: 9,
+						href: 'https://example.com/unrelated/',
+						date: '2026-02-01',
+						title: 'Unrelated Post',
+						type: 'post',
+						views: 99,
+					},
+				],
+				total_views: 99,
+			},
+		};
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-02-10' ) ? nonOverlappingComparison : TOP_POSTS_RESPONSE
+			)
+		);
+
+		render(
+			<TopPostsWidget
+				attributes={ {
+					num: 10,
+					reportParams: {
+						from: '2026-03-01',
+						to: '2026-03-10',
+						comp: '1',
+						compare_from: '2026-02-01',
+						compare_to: '2026-02-10',
+					},
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByRole( 'link', { name: /Hello World Post/ } )
+		).resolves.toBeInTheDocument();
+		// No fabricated per-row delta from placeholder zeros.
+		expect( screen.queryByText( /%/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders the empty state when there are no views', async () => {
 		mockApiFetch.mockResolvedValue( { date: '2026-06-10', days: {} } );
 

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -90,6 +90,66 @@ describe( 'TopPostsWidget', () => {
 		expect( requestedPath ).toContain( 'date=2026-03-10' );
 	} );
 
+	it( 'requests the comparison window and aligns previous views by post URL', async () => {
+		// Same post across both periods so the primary row can pick up a
+		// previous value; keyed by URL, not order.
+		const comparisonResponse = {
+			date: '2026-02-10',
+			days: {},
+			summary: {
+				postviews: [
+					{
+						id: 1,
+						href: 'https://example.com/hello-world/',
+						date: '2026-02-01',
+						title: 'Hello World Post',
+						type: 'post',
+						views: 20,
+					},
+				],
+				total_views: 20,
+			},
+		};
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-02-10' ) ? comparisonResponse : TOP_POSTS_RESPONSE
+			)
+		);
+
+		render(
+			<TopPostsWidget
+				attributes={ {
+					num: 10,
+					reportParams: {
+						from: '2026-03-01',
+						to: '2026-03-10',
+						comp: '1',
+						compare_from: '2026-02-01',
+						compare_to: '2026-02-10',
+					},
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByRole( 'link', { name: /Hello World Post/ } )
+		).resolves.toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls.map(
+			( [ { path } ]: [ { path: string } ] ) => path
+		);
+		expect(
+			requestedPaths.some(
+				p => p.includes( 'start_date=2026-03-01' ) && p.includes( 'date=2026-03-10' )
+			)
+		).toBe( true );
+		expect(
+			requestedPaths.some(
+				p => p.includes( 'start_date=2026-02-01' ) && p.includes( 'date=2026-02-10' )
+			)
+		).toBe( true );
+	} );
+
 	it( 'renders the empty state when there are no views', async () => {
 		mockApiFetch.mockResolvedValue( { date: '2026-06-10', days: {} } );
 

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -58,7 +58,7 @@ describe( 'TopPostsWidget', () => {
 	} );
 
 	it( 'renders the fetched top posts as links', async () => {
-		render( <TopPostsWidget attributes={ { range: 'last-7-days', num: 10 } } /> );
+		render( <TopPostsWidget attributes={ { num: 10 } } /> );
 
 		// The `@wordpress/ui` `Link` appends an "(opens in a new tab)" indicator
 		// to the accessible name, so match the title as a substring.
@@ -68,16 +68,32 @@ describe( 'TopPostsWidget', () => {
 	} );
 
 	it( 'filters rows by post type when the postType attribute is set', async () => {
-		render( <TopPostsWidget attributes={ { range: 'last-7-days', num: 10, postType: 'page' } } /> );
+		render( <TopPostsWidget attributes={ { num: 10, postType: 'page' } } /> );
 
 		await expect( screen.findByText( 'About Page' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Hello World Post' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'requests the dashboard date range from report params', async () => {
+		render(
+			<TopPostsWidget
+				attributes={ { num: 10, reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect(
+			screen.findByRole( 'link', { name: /Hello World Post/ } )
+		).resolves.toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'start_date=2026-03-01' );
+		expect( requestedPath ).toContain( 'date=2026-03-10' );
+	} );
+
 	it( 'renders the empty state when there are no views', async () => {
 		mockApiFetch.mockResolvedValue( { date: '2026-06-10', days: {} } );
 
-		render( <TopPostsWidget attributes={ { range: 'last-7-days' } } /> );
+		render( <TopPostsWidget attributes={ { num: 10 } } /> );
 
 		await expect( screen.findByText( 'No views in this period.' ) ).resolves.toBeInTheDocument();
 	} );

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -258,10 +258,11 @@ function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
 		);
 	}, [ comparison.data, allowedTypes, hasComparison ] );
 
-	// Only render comparison UI when the comparison period actually returned
-	// rows; otherwise every row would fall to a placeholder `previousValue: 0`
-	// and the chart would show a fabricated delta (see AGENTS.md).
-	const withComparison = hasComparison && previousViewsByHref.size > 0;
+	// Only render comparison UI when at least one primary row actually overlaps
+	// the comparison period; otherwise unmatched rows would fall to a placeholder
+	// `previousValue: 0` and the chart would show a fabricated delta (see AGENTS.md).
+	const withComparison =
+		hasComparison && primaryRows.some( row => previousViewsByHref.has( row.href ) );
 
 	const rows = useMemo(
 		() =>

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -61,10 +61,7 @@ export type TopPostRow = {
 // picker — but the host (and Storybook) may also inject them via `attributes`.
 type TopPostsRenderAttributes = TopPostsAttributes & Partial< ReportParamsFieldAttributes >;
 
-type TopPostsReportProps = {
-	num?: number;
-	postType?: string | string[];
-};
+type TopPostsReportProps = Pick< TopPostsAttributes, 'num' | 'postType' >;
 
 /**
  * Maps normalized top-posts rows onto the shape `LeaderboardChart` expects.
@@ -242,30 +239,40 @@ function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
 		return Array.isArray( postType ) ? postType : [ postType ];
 	}, [ postType ] );
 
-	const rows = useMemo( () => {
-		const primaryRows = toTopPostRows(
-			primary.data as StatsNormalizedReport< StatsTopPostsItem >,
-			allowedTypes
-		);
+	const primaryRows = useMemo(
+		() => toTopPostRows( primary.data as StatsNormalizedReport< StatsTopPostsItem >, allowedTypes ),
+		[ primary.data, allowedTypes ]
+	);
 
+	// Comparison-period views keyed by the same post URL the primary rows use.
+	// Empty when comparison is disabled or the comparison query returned no rows.
+	const previousViewsByHref = useMemo( () => {
 		if ( ! hasComparison ) {
-			return primaryRows;
+			return new Map< string, number >();
 		}
-
-		// Align the comparison period to each primary row by post URL — the same
-		// stable key the leaderboard uses — so posts absent last period count as 0.
-		const previousViewsByHref = new Map(
+		return new Map(
 			toTopPostRows(
 				comparison.data as StatsNormalizedReport< StatsTopPostsItem >,
 				allowedTypes
 			).map( row => [ row.href, row.value ] )
 		);
+	}, [ comparison.data, allowedTypes, hasComparison ] );
 
-		return primaryRows.map( row => ( {
-			...row,
-			previousValue: previousViewsByHref.get( row.href ) ?? 0,
-		} ) );
-	}, [ primary.data, comparison.data, allowedTypes, hasComparison ] );
+	// Only render comparison UI when the comparison period actually returned
+	// rows; otherwise every row would fall to a placeholder `previousValue: 0`
+	// and the chart would show a fabricated delta (see AGENTS.md).
+	const withComparison = hasComparison && previousViewsByHref.size > 0;
+
+	const rows = useMemo(
+		() =>
+			withComparison
+				? primaryRows.map( row => ( {
+						...row,
+						previousValue: previousViewsByHref.get( row.href ) ?? 0,
+				  } ) )
+				: primaryRows,
+		[ primaryRows, previousViewsByHref, withComparison ]
+	);
 
 	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
 
@@ -274,8 +281,8 @@ function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
 			rows={ rows }
 			isLoading={ isLoading }
 			isError={ isError }
-			withComparison={ hasComparison }
-			showLegend={ hasComparison }
+			withComparison={ withComparison }
+			showLegend={ withComparison }
 			legendLabels={ legendLabels }
 		/>
 	);

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import {
-	computeDateRangeFromPreset,
-	localTZDate,
 	useStatsTopPosts,
 	type StatsNormalizedReport,
 	type StatsTopPostsItem,
@@ -13,12 +11,14 @@ import {
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	calculateDelta,
+	formatLegendLabels,
+	useWidgetRootContext,
 	type LeaderboardChartData,
 	type LegendLabels,
+	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
-import { format } from 'date-fns';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -57,8 +57,13 @@ export type TopPostRow = {
 	type: string;
 };
 
-type TopPostsProps = {
-	attributes?: TopPostsAttributes;
+// Report params are dashboard-driven — WidgetRoot resolves them from the date
+// picker — but the host (and Storybook) may also inject them via `attributes`.
+type TopPostsRenderAttributes = TopPostsAttributes & Partial< ReportParamsFieldAttributes >;
+
+type TopPostsReportProps = {
+	num?: number;
+	postType?: string | string[];
 };
 
 /**
@@ -212,33 +217,23 @@ function toTopPostRows(
 /**
  * Fetches the top-posts report through the designated `useStatsTopPosts` Stats
  * traffic hook and hands the normalized rows to the presentational
- * `TopPostsLeaderboard`.
+ * `TopPostsLeaderboard`. The date range and comparison period come from the
+ * dashboard picker via `reportParams`.
  *
- * @param props            - Component props.
- * @param props.attributes - Widget attributes.
+ * @param props          - Component props.
+ * @param props.num      - Maximum number of posts to display.
+ * @param props.postType - Post type(s) to keep, or undefined/empty for all.
  * @return The widget content.
  */
-function TopPostsReport( { attributes }: TopPostsProps ) {
-	// Default to the trailing 7 days, matching the Jetpack Stats "Top posts &
-	// pages" card's default range.
-	const range = attributes?.range ?? 'last-7-days';
-	const num = attributes?.num ?? 10;
-	const postType = attributes?.postType;
+function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
+	const { reportParams } = useWidgetRootContext();
 
-	// Resolve the preset to an absolute window. `computeDateRangeFromPreset`
-	// returns ISO strings with a TZ offset; the stats query layer trims them to
-	// the date part, so the raw values can be passed straight through.
-	const today = format( localTZDate(), 'yyyy-MM-dd' );
-	const { from, to } = computeDateRangeFromPreset( range ) ?? {};
+	// The widget's "Number of results" maps to the WPCOM stats API's `max`; the
+	// date range is owned by the dashboard picker and carried in `reportParams`.
+	const statsParams = useMemo( () => ( { ...reportParams, max: num } ), [ reportParams, num ] );
 
-	const { primary, isLoading, isError } = useStatsTopPosts( {
-		from: from ?? today,
-		to: to ?? today,
-		interval: 'day',
-		period: 'day',
-		// The widget's "Number of results" maps to the WPCOM stats API's `max`.
-		max: num,
-	} );
+	const { primary, comparison, hasComparison, isLoading, isError } =
+		useStatsTopPosts( statsParams );
 
 	const allowedTypes = useMemo( () => {
 		if ( postType === undefined || postType === '' ) {
@@ -247,31 +242,63 @@ function TopPostsReport( { attributes }: TopPostsProps ) {
 		return Array.isArray( postType ) ? postType : [ postType ];
 	}, [ postType ] );
 
-	const rows = useMemo(
-		() => toTopPostRows( primary.data as StatsNormalizedReport< StatsTopPostsItem >, allowedTypes ),
-		[ primary.data, allowedTypes ]
-	);
+	const rows = useMemo( () => {
+		const primaryRows = toTopPostRows(
+			primary.data as StatsNormalizedReport< StatsTopPostsItem >,
+			allowedTypes
+		);
 
-	return <TopPostsLeaderboard rows={ rows } isLoading={ isLoading } isError={ isError } />;
+		if ( ! hasComparison ) {
+			return primaryRows;
+		}
+
+		// Align the comparison period to each primary row by post URL — the same
+		// stable key the leaderboard uses — so posts absent last period count as 0.
+		const previousViewsByHref = new Map(
+			toTopPostRows(
+				comparison.data as StatsNormalizedReport< StatsTopPostsItem >,
+				allowedTypes
+			).map( row => [ row.href, row.value ] )
+		);
+
+		return primaryRows.map( row => ( {
+			...row,
+			previousValue: previousViewsByHref.get( row.href ) ?? 0,
+		} ) );
+	}, [ primary.data, comparison.data, allowedTypes, hasComparison ] );
+
+	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	return (
+		<TopPostsLeaderboard
+			rows={ rows }
+			isLoading={ isLoading }
+			isError={ isError }
+			withComparison={ hasComparison }
+			showLegend={ hasComparison }
+			legendLabels={ legendLabels }
+		/>
+	);
 }
 
 /**
  * Widget render entry point.
  *
- * Attributes flow to the inner component via props rather than
- * `WidgetRootContext` — the context's report params are WC-Analytics-shaped
- * and do not fit stats queries. Runs inside `WidgetRoot` so it can reach the
- * analytics query client, keeping the leaderboard prop-driven (and
- * Storybook-friendly).
+ * WidgetRoot provides the analytics query client, chart theme, and the report
+ * params consumed by the inner leaderboard — resolved from the dashboard date
+ * range via context, the same way the other Stats widgets read them. The
+ * widget's own `num`/`postType` settings are forwarded to the inner component.
  *
  * @param props            - Render props supplied by the widget host.
  * @param props.attributes - Widget attributes.
  * @return The rendered widget.
  */
-export default function TopPosts( { attributes }: WidgetRenderProps< TopPostsAttributes > ) {
+export default function TopPosts( {
+	attributes = {},
+}: WidgetRenderProps< TopPostsRenderAttributes > ) {
 	return (
-		<WidgetRoot>
-			<TopPostsReport attributes={ attributes } />
+		<WidgetRoot attributes={ attributes }>
+			<TopPostsReport num={ attributes.num } postType={ attributes.postType } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import type { PresetType } from '@jetpack-premium-analytics/data';
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -11,14 +7,10 @@ import { chartBar } from '@wordpress/icons';
 /**
  * Configurable attributes for the Top posts & pages widget. Mirrors the
  * `attributes` declared on the widget definition below; the host passes the
- * selected values through to `render.tsx`.
+ * selected values through to `render.tsx`. The date range is owned by the
+ * dashboard picker and read from report params, not from attributes.
  */
 export type TopPostsAttributes = {
-	/**
-	 * Date-range preset, e.g. `today`, `last-7-days`, `last-30-days`, `last-year`.
-	 * Resolved to an absolute window at render time.
-	 */
-	range?: PresetType;
 	num?: number;
 	/**
 	 * Post type(s) to keep. When undefined or empty, all types are shown.
@@ -29,26 +21,14 @@ export type TopPostsAttributes = {
 /**
  * Widget type definition.
  *
- * `example.attributes` doubles as the defaults applied to new instances: the
- * trailing 7 days, ten posts, all post types. The `range` preset is resolved
- * to an absolute date window at render time (see render.tsx).
+ * `example.attributes` doubles as the defaults applied to new instances: ten
+ * posts, all post types. The date range comes from the dashboard picker.
  */
 export default {
 	name: 'jpa/stats-top-posts',
 	title: __( 'Top pages by views', 'jetpack-premium-analytics' ),
 	icon: chartBar,
 	attributes: [
-		{
-			id: 'range',
-			label: __( 'Date range', 'jetpack-premium-analytics' ),
-			type: 'text',
-			elements: [
-				{ label: __( 'Today', 'jetpack-premium-analytics' ), value: 'today' },
-				{ label: __( 'Last 7 days', 'jetpack-premium-analytics' ), value: 'last-7-days' },
-				{ label: __( 'Last 30 days', 'jetpack-premium-analytics' ), value: 'last-30-days' },
-				{ label: __( 'Last year', 'jetpack-premium-analytics' ), value: 'last-year' },
-			],
-		},
 		{
 			id: 'num',
 			label: __( 'Number of results', 'jetpack-premium-analytics' ),
@@ -67,7 +47,6 @@ export default {
 	],
 	example: {
 		attributes: {
-			range: 'last-7-days',
 			num: 10,
 		},
 	},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1645/premium-analytics-top-posts-widget-ignores-dashboard-date-range

## Why

The "Top pages by views" widget showed data for its own fixed range (default last 7 days) and never updated when you changed the dashboard date picker, so it disagreed with every other widget on the page and never reflected the selected comparison period. Now it tracks the dashboard date range and comparison like the other Stats widgets.

## Proposed changes

* Read the date range from the dashboard picker via `reportParams` (WidgetRoot context) instead of the widget-local `range` attribute.
* Remove the now-unused `range` attribute and its "Date range" control from `widget.ts`.
* Map the comparison period into each row's `previousValue` (keyed by post URL) so the leaderboard renders period-over-period deltas when comparison is enabled.
* Pass host `attributes` into `<WidgetRoot>` and drop the stale docblock claiming report params don't fit Stats queries.
* Update unit tests: drop `range`, add a test asserting the outgoing `stats/top-posts` request carries the dashboard date window.

## Screenshots

Dashboard set to **Last 30 days (Jun 2–Jul 1)** with **Compare to: May 3–Jun 1**.

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/e16f41a3-f0fa-4558-90db-269e66c3a4cb) | ![after](https://github.com/user-attachments/assets/abfe368d-a01f-4fb0-b7f6-6bfe3eb532e3) |

Before, the widget requested a fixed 7-day window and rendered no comparison delta. After, it honors the 30-day dashboard range and shows the period-over-period delta (`−100%`).

## Verification

The widget's outgoing requests now match the dashboard picker (captured live from the local docker env):

<details>
<summary>Network requests (after)</summary>

```text
# primary period — matches "Last 30 days (Jun 2–Jul 1)"
GET /jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?max=10&period=day&start_date=2026-06-02&days=30&summarize=1&date=2026-07-01

# comparison period — matches "Compare to: May 3–Jun 1"
GET /jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?max=10&period=day&start_date=2026-05-03&days=30&summarize=1&date=2026-06-01
```

For contrast, on trunk the widget made a single request with a fixed 7-day window and no comparison:

```text
GET /jetpack-premium-analytics/v1/proxy/v1.1/stats/top-posts?period=day&max=10&start_date=2026-06-25&days=7&summarize=1&date=2026-07-01
```

</details>

## Related product discussion/links

* https://linear.app/a8c/issue/WOOA7S-1645/premium-analytics-top-posts-widget-ignores-dashboard-date-range

## Does this pull request change what data or activity we track or use?

No. This only changes which date range the existing `stats/top-posts` request uses; no new data is collected.

## Testing instructions

* Open **Premium Analytics** in wp-admin (`?page=jetpack-premium-analytics-wp-admin`).
* Add the **Top pages by views** widget to the Traffic tab if it isn't present.
* Set the dashboard date range to **Last 30 days** and enable a comparison period.
* Confirm the widget's `stats/top-posts` request uses the dashboard window (`start_date`/`date` matching the picker) and a second request is made for the comparison period — before this change it always requested a fixed 7-day window and made no comparison request.
* Change the date range and confirm the widget refetches for the new window.
* Verify comparison deltas render per row when comparison is on.
