### PR TITLE
Premium Analytics: link Top posts &amp; Emails widget rows to the post detail view

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-link-posts-to-single-post-stats
+++ b/projects/packages/premium-analytics/changelog/add-link-posts-to-single-post-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: link Top posts &amp; pages and Emails widget rows to the single post/page detail view, carrying the current date range through.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
@@ -30,6 +30,7 @@
 		"react": "18.3.1"
 	},
 	"devDependencies": {
-		"@storybook/react": "10.3.6"
+		"@storybook/react": "10.3.6",
+		"@testing-library/react": "16.3.2"
 	}
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -30,3 +30,4 @@ export {
 	type SubscriberListItem,
 	type SubscriberListProps,
 } from './subscriber-list';
+export { PostStatsLink } from './post-stats-link';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/index.ts
@@ -1,0 +1,1 @@
+export { PostStatsLink } from './post-stats-link';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/post-stats-link.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/post-stats-link.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { WidgetRootContext } from '../widget-root/context';
+import { PostStatsLink } from './post-stats-link';
+import type { WidgetRootContextValue } from '../widget-root/context';
+import type { ReactNode } from 'react';
+
+// Stub the router's client-side link with a plain anchor exposing the resolved
+// `/post/<id>` target so the in-app branch is observable without a real router.
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( {
+		to,
+		params,
+		search,
+		children,
+		className,
+		title,
+	}: {
+		to: string;
+		params: { postId: string };
+		search?: ( prev: Record< string, unknown > ) => Record< string, unknown >;
+		children: ReactNode;
+		className?: string;
+		title?: string;
+	} ) => {
+		const path = to.replace( '$postId', params.postId );
+		const resolved = search ? search( { from: '2026-01-01' } ) : {};
+		const query = new URLSearchParams( resolved as Record< string, string > ).toString();
+		return (
+			<a href={ query ? `${ path }?${ query }` : path } className={ className } title={ title }>
+				{ children }
+			</a>
+		);
+	},
+} ) );
+
+function renderInRoot( ui: ReactNode, isRouterAvailable: boolean ) {
+	const value = {
+		reportParams: {},
+		isRouterAvailable,
+	} as unknown as WidgetRootContextValue;
+
+	return render( <WidgetRootContext.Provider value={ value }>{ ui }</WidgetRootContext.Provider> );
+}
+
+describe( 'PostStatsLink', () => {
+	it( 'links to the in-app post detail route, carrying the current date range', () => {
+		renderInRoot(
+			<PostStatsLink postId={ 42 } href="https://example.com/hello/">
+				Hello
+			</PostStatsLink>,
+			true
+		);
+
+		expect( screen.getByRole( 'link', { name: 'Hello' } ) ).toHaveAttribute(
+			'href',
+			'/post/42?from=2026-01-01'
+		);
+	} );
+
+	it( 'falls back to the external published-post link without a router', () => {
+		renderInRoot(
+			<PostStatsLink postId={ 42 } href="https://example.com/hello/">
+				Hello
+			</PostStatsLink>,
+			false
+		);
+
+		expect( screen.getByRole( 'link', { name: /Hello/ } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/hello/'
+		);
+	} );
+
+	it( 'falls back to the external link when the post ID is not a valid post reference', () => {
+		renderInRoot(
+			<PostStatsLink postId={ 0 } href="https://example.com/home/">
+				Home
+			</PostStatsLink>,
+			true
+		);
+
+		expect( screen.getByRole( 'link', { name: /Home/ } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/home/'
+		);
+	} );
+
+	it( 'renders plain text when neither in-app navigation nor an href is available', () => {
+		renderInRoot( <PostStatsLink>Untitled</PostStatsLink>, false );
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Untitled' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to the external link when rendered outside a WidgetRoot', () => {
+		// Presentational stories render the leaderboard (and this link) with no
+		// provider; it must degrade instead of throwing on the missing context.
+		render(
+			<PostStatsLink postId={ 42 } href="https://example.com/hello/">
+				Hello
+			</PostStatsLink>
+		);
+
+		expect( screen.getByRole( 'link', { name: /Hello/ } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/hello/'
+		);
+	} );
+
+	it( 'carries the selected section into the in-app route search', () => {
+		renderInRoot(
+			<PostStatsLink postId={ 7 } section="email-opens">
+				Newsletter
+			</PostStatsLink>,
+			true
+		);
+
+		expect( screen.getByRole( 'link', { name: 'Newsletter' } ) ).toHaveAttribute(
+			'href',
+			'/post/7?from=2026-01-01&section=email-opens'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/post-stats-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-stats-link/post-stats-link.tsx
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import { Link } from '@wordpress/route';
+import { Link as ExternalLink, Text } from '@wordpress/ui';
+import { useContext } from 'react';
+import { WidgetRootContext } from '../widget-root/context';
+import type { ComponentProps, ReactNode } from 'react';
+
+type PostStatsLinkProps = {
+	/**
+	 * The post/page ID to open the detail view for. Must resolve to a positive
+	 * integer; anything else falls back to the external link (or plain text).
+	 */
+	postId?: string | number;
+	/**
+	 * External URL of the published post/page. Used as the fallback target when
+	 * in-app navigation is unavailable (Storybook, tests). Omit it to fall back
+	 * to plain, non-linked text instead.
+	 */
+	href?: string;
+	/**
+	 * Post-detail tab to open on arrival (the `?section=` param), e.g.
+	 * `email-opens`. Omit to land on the default tab.
+	 */
+	section?: string;
+	/**
+	 * Accessible title/tooltip for the link.
+	 */
+	title?: string;
+	/**
+	 * Class applied to the rendered element.
+	 */
+	className?: string;
+	/**
+	 * The link label.
+	 */
+	children: ReactNode;
+};
+
+/**
+ * Coerce a post ID to the positive-integer string the `/post/$postId` route
+ * accepts, or `null` when it is not a valid post reference.
+ *
+ * @param postId - The candidate post/page ID.
+ * @return The normalized ID string, or null.
+ */
+function normalizePostId( postId?: string | number ): string | null {
+	if ( postId === undefined ) {
+		return null;
+	}
+	const id = String( postId );
+	return /^\d+$/.test( id ) && Number( id ) > 0 ? id : null;
+}
+
+/**
+ * Client-side link into the post/page detail view. Split out so the
+ * router-only `@wordpress/route` `Link` is mounted only when a router exists;
+ * the outer component decides that before rendering this one.
+ *
+ * @param props           - Component props.
+ * @param props.postId    - Validated post/page ID.
+ * @param props.section   - Optional post-detail tab to open.
+ * @param props.title     - Accessible title/tooltip.
+ * @param props.className - Class applied to the anchor.
+ * @param props.children  - The link label.
+ * @return The rendered in-app link.
+ */
+function InAppPostStatsLink( {
+	postId,
+	section,
+	title,
+	className,
+	children,
+}: {
+	postId: string;
+	section?: string;
+	title?: string;
+	className?: string;
+	children: ReactNode;
+} ) {
+	/*
+	 * The router is built dynamically, so `/post/$postId` has no statically-typed
+	 * params/search schema (tanstack widens them to `never`). Cast the props the
+	 * same way the routing package does when it writes the URL. `search` carries
+	 * the current date range and comparison state through unchanged.
+	 */
+	const linkProps = {
+		to: '/post/$postId',
+		params: { postId },
+		search: ( prev: Record< string, unknown > ) => ( {
+			...prev,
+			...( section ? { section } : {} ),
+		} ),
+		className,
+		title,
+	} as unknown as ComponentProps< typeof Link >;
+
+	return <Link { ...linkProps }>{ children }</Link>;
+}
+
+/**
+ * Links a post/page label to its single-post detail view inside the dashboard.
+ *
+ * When rendered under the SPA router, it navigates client-side to
+ * `/post/$postId`, preserving the current date range and comparison state (and
+ * optionally opening a specific `section` tab). Outside a router — Storybook,
+ * unit tests — it degrades to the external published-post link, or to plain
+ * text when no `href` is given.
+ *
+ * @param {PostStatsLinkProps} props - The component props.
+ * @return The rendered link.
+ */
+export function PostStatsLink( {
+	postId,
+	href,
+	section,
+	title,
+	className,
+	children,
+}: PostStatsLinkProps ) {
+	// Read the context directly rather than through `useWidgetRootContext`, which
+	// throws when there is no provider: presentational stories render the
+	// leaderboard (and this link) outside a `WidgetRoot`, and should fall back to
+	// the external link there rather than error.
+	const isRouterAvailable = useContext( WidgetRootContext )?.isRouterAvailable ?? false;
+	const normalizedId = normalizePostId( postId );
+
+	if ( isRouterAvailable && normalizedId ) {
+		return (
+			<InAppPostStatsLink
+				postId={ normalizedId }
+				section={ section }
+				title={ title }
+				className={ className }
+			>
+				{ children }
+			</InAppPostStatsLink>
+		);
+	}
+
+	if ( href ) {
+		return (
+			<ExternalLink
+				className={ className }
+				href={ href }
+				variant="unstyled"
+				openInNewTab
+				title={ title }
+			>
+				{ children }
+			</ExternalLink>
+		);
+	}
+
+	return (
+		<Text className={ className } title={ title }>
+			{ children }
+		</Text>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/context.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/context.tsx
@@ -28,6 +28,13 @@ export type WidgetRootContextValue = {
 	 * ```
 	 */
 	setError?: ( error: WidgetErrorConfig | true | null ) => void;
+
+	/**
+	 * Whether the widget is rendered inside the dashboard SPA router. Falsy in
+	 * hosts without a router (Storybook, unit tests). Widgets use it to decide
+	 * whether they can link to in-app routes such as the post detail page.
+	 */
+	isRouterAvailable?: boolean;
 };
 
 const WidgetRootContext = createContext< WidgetRootContextValue | null >( null );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
@@ -56,6 +56,10 @@ type WidgetRootProps = {
  */
 function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttributes > ) {
 	let search: Record< string, unknown > = {};
+	// A successful `useSearch` doubles as the signal that in-app navigation is
+	// available; it throws (and leaves this false) outside a matched route, e.g.
+	// in Storybook.
+	let isRouterAvailable = false;
 
 	/*
 	 * Read the search params of the current route. `{ strict: false }` returns
@@ -67,6 +71,7 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
 	try {
 		// eslint-disable-next-line react-hooks/rules-of-hooks -- useSearch may throw outside a matched route
 		search = useSearch( { strict: false } );
+		isRouterAvailable = true;
 	} catch {
 		// Do nothing
 	}
@@ -79,7 +84,10 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
 	const hasReportParams =
 		!! attributes?.reportParams && Object.keys( attributes.reportParams ).length > 0;
 
-	return hasReportParams ? attributes.reportParams : search;
+	return {
+		reportParams: hasReportParams ? attributes.reportParams : search,
+		isRouterAvailable,
+	};
 }
 
 /**
@@ -108,7 +116,7 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
  */
 export function WidgetRoot( { attributes, children, setError }: WidgetRootProps ) {
 	const chartTheme = useChartTheme();
-	const rawReportParams = useResolveReportParams( attributes );
+	const { reportParams: rawReportParams, isRouterAvailable } = useResolveReportParams( attributes );
 
 	const { launchedDate } = getStoreInfo();
 	const defaultPreset = getDefaultPreset( launchedDate );
@@ -118,7 +126,10 @@ export function WidgetRoot( { attributes, children, setError }: WidgetRootProps 
 		[ rawReportParams, defaultPreset ]
 	);
 
-	const contextValue = useMemo( () => ( { reportParams, setError } ), [ reportParams, setError ] );
+	const contextValue = useMemo(
+		() => ( { reportParams, setError, isRouterAvailable } ),
+		[ reportParams, setError, isRouterAvailable ]
+	);
 
 	return (
 		<AnalyticsQueryClientProvider>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -31,6 +31,7 @@ export {
 	SubscriberList,
 	type SubscriberListItem,
 	type SubscriberListProps,
+	PostStatsLink,
 } from './components';
 
 /**

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	PostStatsLink,
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	type LeaderboardChartData,
@@ -39,6 +40,17 @@ export type EmailRow = {
 	 */
 	id: string | number;
 	/**
+	 * Post ID backing the email, used to link the row to its single-post detail
+	 * view. Only set when the summary item carries a real post ID (unlike `id`,
+	 * which falls back to the array index for the leaderboard key).
+	 */
+	postId?: string | number;
+	/**
+	 * URL of the published post/page behind the email, used as the fallback link
+	 * target when in-app navigation is unavailable.
+	 */
+	href?: string;
+	/**
 	 * Email subject line.
 	 */
 	label: string;
@@ -58,6 +70,9 @@ export type EmailRow = {
  * (shares are relative to the highest rate in the set). The emails summary has
  * no comparison period, so the comparison fields are zeroed.
  *
+ * Each row links to the email's single-post detail view, opening the tab that
+ * matches the selected metric (email opens or email clicks).
+ *
  * @param rows   - The normalized email rows.
  * @param metric - Which rate to display (`opens` or `clicks`).
  * @return The leaderboard chart data.
@@ -67,6 +82,7 @@ function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): Leaderbo
 	// Shares are relative to the real maximum so the top row always fills, even
 	// when every rate is below 1%. The `> 0` check guards the divide-by-zero.
 	const maxRate = Math.max( ...rows.map( rateOf ), 0 );
+	const section = metric === 'opens' ? 'email-opens' : 'email-clicks';
 
 	return rows.map( row => {
 		const rate = rateOf( row );
@@ -74,9 +90,15 @@ function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): Leaderbo
 		return {
 			id: String( row.id ),
 			label: (
-				<span className={ styles.label } title={ row.label }>
+				<PostStatsLink
+					className={ styles.label }
+					postId={ row.postId }
+					href={ row.href }
+					section={ section }
+					title={ row.label }
+				>
 					{ row.label }
-				</span>
+				</PostStatsLink>
 			),
 			// `LeaderboardChart` formats the value as a percentage, so the rate
 			// is expressed as a fraction here.
@@ -196,9 +218,9 @@ export const EmailsLeaderboard = ( {
 };
 
 /**
- * Flatten the `useStatsEmailSummary` report into the `{ id, label, opensRate,
- * clicksRate }` rows the leaderboard renders, keeping the endpoint's
- * newest-first order and trimming to `max`.
+ * Flatten the `useStatsEmailSummary` report into the `{ id, postId, href,
+ * label, opensRate, clicksRate }` rows the leaderboard renders, keeping the
+ * endpoint's newest-first order and trimming to `max`.
  *
  * @param report - The normalized email-summary report, or undefined while loading.
  * @param max    - Maximum rows to display; `0` keeps all rows.
@@ -211,6 +233,8 @@ function toEmailRows( report: StatsEmailSummary | undefined, max: number ): Emai
 	// `max = 0 → all rows` convention and a guard against an over-long response.
 	return items.slice( 0, max > 0 ? max : undefined ).map( ( item, index ) => ( {
 		id: item.id ?? index,
+		postId: item.id,
+		href: typeof item.link === 'string' ? item.link : undefined,
 		label: String( item.label ?? '' ),
 		opensRate: item.opens_rate,
 		clicksRate: item.clicks_rate,

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -8,13 +8,33 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import TopPostsWidget from '../render';
+import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-// WidgetRoot reads URL search params as a fallback for report params; outside
-// a matched route the real hook warns and throws.
+// WidgetRoot reads URL search params as a fallback for report params and treats
+// a successful `useSearch` as the signal that in-app navigation is available.
+// The stubbed `Link` stands in for the router's client-side link so the rows
+// resolve to the `/post/<id>` detail route the widget now targets.
 jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( {} ),
+	Link: ( {
+		to,
+		params,
+		children,
+		className,
+		title,
+	}: {
+		to: string;
+		params: { postId: string };
+		children: ReactNode;
+		className?: string;
+		title?: string;
+	} ) => (
+		<a href={ to.replace( '$postId', params.postId ) } className={ className } title={ title }>
+			{ children }
+		</a>
+	),
 } ) );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
@@ -57,13 +77,11 @@ describe( 'TopPostsWidget', () => {
 		mockApiFetch.mockResolvedValue( TOP_POSTS_RESPONSE );
 	} );
 
-	it( 'renders the fetched top posts as links', async () => {
+	it( 'links each post to its single-post detail view', async () => {
 		render( <TopPostsWidget attributes={ { num: 10 } } /> );
 
-		// The `@wordpress/ui` `Link` appends an "(opens in a new tab)" indicator
-		// to the accessible name, so match the title as a substring.
 		const link = await screen.findByRole( 'link', { name: /Hello World Post/ } );
-		expect( link ).toHaveAttribute( 'href', 'https://example.com/hello-world/' );
+		expect( link ).toHaveAttribute( 'href', '/post/1' );
 		expect( screen.getByText( 'About Page' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -8,6 +8,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	PostStatsLink,
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	calculateDelta,
@@ -18,7 +19,7 @@ import {
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link, Text } from '@wordpress/ui';
+import { Text } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -33,6 +34,11 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
  * Storybook can build fixtures for `TopPostsLeaderboard`.
  */
 export type TopPostRow = {
+	/**
+	 * Post/page ID, used to link the row to its single-post detail view. Absent
+	 * for rows that are not a single post/page (e.g. the site home or archives).
+	 */
+	id?: string | number;
 	/**
 	 * Post or page title.
 	 */
@@ -70,9 +76,9 @@ type TopPostsReportProps = Pick< TopPostsAttributes, 'num' | 'postType' >;
  * and per-row deltas are derived from each row's `previousValue`; otherwise
  * the comparison fields are zeroed.
  *
- * Each row's label is a link that opens the published post/page in a new tab.
- * The link fills its row so the leaderboard overlay bar gets its height from
- * the label.
+ * Each row's label links to that post/page's single-post detail view inside the
+ * dashboard, carrying the current date range through. The link fills its row so
+ * the leaderboard overlay bar gets its height from the label.
  *
  * @param rows           - The normalized top-posts rows.
  * @param withComparison - Whether to derive previous-period shares and deltas.
@@ -89,15 +95,14 @@ function buildLeaderboardData( rows: TopPostRow[], withComparison: boolean ): Le
 		return {
 			id: `${ index }-${ row.href }`,
 			label: (
-				<Link
+				<PostStatsLink
 					className={ styles.labelLink }
+					postId={ row.id }
 					href={ row.href }
-					variant="unstyled"
-					openInNewTab
 					title={ row.label }
 				>
 					{ row.label }
-				</Link>
+				</PostStatsLink>
 			),
 			currentValue: row.value,
 			currentShare: ( row.value / maxCurrentViews ) * 100,
@@ -184,9 +189,9 @@ export const TopPostsLeaderboard = ( {
 };
 
 /**
- * Flatten the designated `useStatsTopPosts` report into the `{ label, value,
- * href, type }` rows the leaderboard renders, dropping rows without a link and
- * (optionally) filtering by post type.
+ * Flatten the designated `useStatsTopPosts` report into the `{ id, label,
+ * value, href, type }` rows the leaderboard renders, dropping rows without a
+ * link and (optionally) filtering by post type.
  *
  * @param report       - The normalized top-posts report, or undefined while loading.
  * @param allowedTypes - Post types to keep, or null to keep all.
@@ -203,6 +208,7 @@ function toTopPostRows(
 			( item ): item is StatsTopPostsItem & { link: string } => typeof item.link === 'string'
 		)
 		.map( item => ( {
+			id: item.id,
 			label: String( item.label ?? '' ),
 			value: item.views,
 			href: item.link,


### PR DESCRIPTION
> **Depends on #50096** (the post/page detail view). This PR targets `trunk` directly and is scoped to just the linking change. It links to the `/post/$postId` route that ships in #50096, so the links resolve once that PR lands (until then they resolve to a not-found route). No code dependency — this builds, type-checks, and tests independently of #50096.

## Why

Readers looking at the **Top posts &amp; pages** and **Emails** widgets could see which content performed well, but had no way to drill into a single piece from there. Top-posts rows linked out to the published post (leaving analytics), and Emails rows weren't links at all. Now that the single post/page detail view exists (#50096), each row should take the author straight to that post's own traffic and email stats — without losing the date range they were already looking at.

## Proposed changes

* Link every **Top posts &amp; pages** row to that post/page's single-post detail view (`/post/$postId`) instead of the external published post.
* Make every **Emails** row a link to the backing post's detail view, opening the tab that matches the selected metric (**Email opens** or **Email clicks**).
* Carry the dashboard's current date range and "Compare to" comparison state through to the detail page, so it opens on the same window the reader was viewing.
* Add a `PostStatsLink` primitive to `widgets-toolkit` that encapsulates the target: it navigates client-side through the SPA router when one is present, and degrades to the external published-post link (or plain text) in hosts without a router — Storybook and unit tests. `WidgetRoot` now exposes whether a router is available so widgets can make that choice.
* Only link rows backed by a real positive-integer post ID; rows without one (e.g. the site home, archives, or an email with no post ID) keep their previous behavior.

## Related product discussion/links

* Stacked on #50096 — Premium Analytics: add post/page detail traffic view ([WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view)).
* Part of the Jetpack Stats → Premium Analytics migration (widgets under WOOA7S-1458).

## Does this pull request change what data or activity we track or use?

No. It only changes where existing widget rows link to; no new data is tracked or collected.

## Testing instructions

* Build the package: `jetpack build packages/premium-analytics` (or `pnpm run build` inside `projects/packages/premium-analytics`), then build the plugin: `jetpack build plugins/premium-analytics`.
* In wp-admin, open **Premium Analytics** on a connected site with traffic and newsletter data.
* In the **Top posts &amp; pages** widget, click a post/page row → it navigates to that post's detail view (`admin.php?page=jetpack-premium-analytics-wp-admin&p=/post/<id>`), with the current date range preserved. A row without a post ID (e.g. the home page) still opens the published URL.
* In the **Emails** widget, switch **View by** to Open rate / Click rate and click a row → it opens the post detail view on the **Email opens** / **Email clicks** tab respectively, date range preserved.
* Confirm the main dashboard still renders and behaves as before.
* Automated: `pnpm run typecheck`, `pnpm run test` (incl. the new `PostStatsLink` suite and updated top-posts tests), `pnpm run build`, and eslint all pass.

