### PR TITLE
Premium Analytics: fix Record<string, never> intersection typecheck failure in 5 widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1646-zero-attribute-widget-typecheck
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1646-zero-attribute-widget-typecheck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TypeScript error in five zero-attribute widget stories (Record<never, never> instead of Record<string, never>).

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
@@ -9,7 +9,7 @@ import { chartBar } from '@wordpress/icons';
  * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
  * when a host injects them (e.g. Storybook and dashboard previews).
  */
-export type AverageItemsPerOrderAttributes = Record< string, never >;
+export type AverageItemsPerOrderAttributes = Record< never, never >;
 
 /**
  * Widget type definition.

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -9,7 +9,7 @@ import { chartBar } from '@wordpress/icons';
  * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
  * when a host injects them (e.g. Storybook and dashboard previews).
  */
-export type BookingsByDeviceAttributes = Record< string, never >;
+export type BookingsByDeviceAttributes = Record< never, never >;
 
 /**
  * Widget type definition.

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -9,7 +9,7 @@ import { chartBar } from '@wordpress/icons';
  * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
  * when a host injects them (e.g. Storybook and dashboard previews).
  */
-export type PaymentStatusAttributes = Record< string, never >;
+export type PaymentStatusAttributes = Record< never, never >;
 
 /**
  * Widget type definition.

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
@@ -9,7 +9,7 @@ import { chartBar } from '@wordpress/icons';
  * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
  * when a host injects them (e.g. Storybook and dashboard previews).
  */
-export type SalesByUtmChannelAttributes = Record< string, never >;
+export type SalesByUtmChannelAttributes = Record< never, never >;
 
 /**
  * Widget type definition.

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
@@ -9,7 +9,7 @@ import { seen } from '@wordpress/icons';
  * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
  * when a host injects them (e.g. Storybook and dashboard previews).
  */
-export type VisitorsOverTimeAttributes = Record< string, never >;
+export type VisitorsOverTimeAttributes = Record< never, never >;
 
 /**
  * Widget type definition.


### PR DESCRIPTION
Fixes WOOA7S-1646

## Why

No user-visible change. CI type checking was failing on trunk (independent of any other PR), so every PR touching `projects/packages/premium-analytics` was showing a red typecheck job regardless of what it actually changed. This fixes the underlying type error so CI reflects real problems again.

## Proposed changes

* `average-items-per-order`, `bookings-by-device`, `payment-status`, `sales-by-utm-channel`, and `visitors-over-time` widgets each declare their (empty) attribute type in `widget.ts` as `Record< string, never >`. That type carries an index signature (`{ [key: string]: never }`), and every widget's `render.tsx` intersects it with `Partial< ReportParamsFieldAttributes >` per `.agents/rules/widgets.md`. Under that intersection, `reportParams` becomes subject to both its own type and the index signature's `never`, so no concrete `{ reportParams: ... }` object can satisfy it — hence `TS2322` in each widget's Storybook stories.
* Switch all 5 to `Record< never, never >`. Mapping over the `never` key type collapses to `{}` with no index signature, so it composes cleanly with `Partial< ReportParamsFieldAttributes >` while still meaning "no widget-specific attributes."
* Verified the fix in isolation with a standalone `tsc --strict` repro before applying it (`Record<string, never> & Partial<...>` fails the same way as the CI error; `Record<never, never> & Partial<...>` passes).
* Likely introduced/exposed by #50113 ("Widgets: conform Woo-family render props to WidgetRenderProps<T> contract").

## Related product discussion/links

* Linear: [WOOA7S-1646](https://linear.app/a8c/issue/WOOA7S-1646/premium-analytics-fix-typecheck-failure-in-5-zero-attribute-widget)
* Originally noticed on PR #49946 ([charts CI run](https://github.com/Automattic/jetpack/actions/runs/28560880402/job/84678143979?pr=49946)); reproduced independently on trunk.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run typecheck` — passes with 0 errors (previously failed with 5 `TS2322` errors, one per affected widget's stories file).
* `pnpm exec eslint` on the 5 changed `widget.ts` files — clean, including `@typescript-eslint/no-empty-object-type` (confirms `Record< never, never >` doesn't trip the lint rule that motivated `Record< string, never >` in the first place).
* Types-only change, no runtime behavior difference — the 5 widgets' `Default` / `WithComparison` / `WidgetDashboardWithWidget` Storybook stories are unaffected.
