### PR TITLE
Stats: guard core React handles against plugin hijacking

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-272-react-handle-guard
+++ b/projects/packages/stats-admin/changelog/stats-272-react-handle-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Guard the shared react and react-dom script handles on the Stats admin page so a plugin that repoints them to an incompatible bundle can no longer prevent the dashboard from rendering.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -48,6 +48,7 @@ class Dashboard {
 		self::$initialized = true;
 		// Jetpack uses 998 and 'Admin_Menu' uses 1000.
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), $this->menu_priority );
+		React_Handle_Guard::register_snapshot();
 	}
 
 	/**
@@ -131,6 +132,8 @@ class Dashboard {
 	 */
 	public function admin_init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
+		// Runs only on the Stats page (hooked from load-{page_suffix}); PHP_INT_MAX beats plugin overrides.
+		add_action( 'admin_enqueue_scripts', array( React_Handle_Guard::class, 'restore_if_hijacked' ), PHP_INT_MAX );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-react-handle-guard.php
+++ b/projects/packages/stats-admin/src/class-react-handle-guard.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Protects core's React script handles on the Stats admin page.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+/**
+ * Guards the shared `react` / `react-dom` script handles against plugins that repoint
+ * them to an incompatible bundle (e.g. The Events Calendar), which would break every
+ * React consumer on the page — including the Stats dashboard.
+ *
+ * The snapshot is a passive, page-agnostic capture of core's registration. The restore
+ * is page-scoped and only acts when a handle has actually been repointed away from core.
+ * It runs at `admin_enqueue_scripts` / `PHP_INT_MAX`, which beats enqueue-time repointing
+ * (what The Events Calendar does); a plugin repointing later (e.g. on `admin_print_scripts`)
+ * is out of scope.
+ */
+class React_Handle_Guard {
+
+	/**
+	 * The shared React handles this guard protects.
+	 *
+	 * @var string[]
+	 */
+	const HANDLES = array( 'react', 'react-dom' );
+
+	/**
+	 * Snapshot of core's canonical registration, keyed by handle.
+	 *
+	 * @var array<string, \_WP_Dependency>
+	 */
+	private static $snapshot = array();
+
+	/**
+	 * Whether the snapshot hook has already been registered.
+	 *
+	 * @var bool
+	 */
+	private static $snapshot_hooked = false;
+
+	/**
+	 * Register a passive snapshot of core's React handles.
+	 *
+	 * Core registers `react` / `react-dom` on `wp_default_scripts` at the default priority 10
+	 * (via `wp_default_packages`). We snapshot at priority 20 on every firing so we always hold
+	 * the latest registration-time state — core plus any registration-time override (e.g. a page
+	 * builder shipping its own matched React pair) — captured before the `admin_enqueue_scripts`
+	 * repointing this guard defends against. `wp_default_scripts` may already have fired (a plugin
+	 * can instantiate `wp_scripts()` early), so the current state is also captured immediately.
+	 * Admin-only and idempotent.
+	 */
+	public static function register_snapshot() {
+		if ( self::$snapshot_hooked || ! is_admin() ) {
+			return;
+		}
+		self::$snapshot_hooked = true;
+
+		add_action( 'wp_default_scripts', array( __CLASS__, 'snapshot_core_handles' ), 20 );
+
+		if ( did_action( 'wp_default_scripts' ) ) {
+			self::snapshot_core_handles( wp_scripts() );
+		}
+	}
+
+	/**
+	 * Clone core's registration for each protected handle.
+	 *
+	 * @param \WP_Scripts $scripts The scripts registry, as passed by `wp_default_scripts`.
+	 */
+	public static function snapshot_core_handles( $scripts ) {
+		foreach ( self::HANDLES as $handle ) {
+			if ( isset( $scripts->registered[ $handle ] ) ) {
+				self::$snapshot[ $handle ] = clone $scripts->registered[ $handle ];
+			}
+		}
+	}
+
+	/**
+	 * Restore core's registration for any handle that has been repointed away from it.
+	 *
+	 * Call on `admin_enqueue_scripts` at `PHP_INT_MAX`, scoped to a React-mounting page. When a
+	 * handle still matches core's snapshot (the clean-site path), it is left untouched.
+	 */
+	public static function restore_if_hijacked() {
+		$scripts = wp_scripts();
+		foreach ( self::HANDLES as $handle ) {
+			if ( empty( self::$snapshot[ $handle ] ) ) {
+				continue;
+			}
+
+			$original = self::$snapshot[ $handle ];
+			$current  = $scripts->registered[ $handle ] ?? null;
+
+			if ( $current && $current->src === $original->src && $current->ver === $original->ver ) {
+				continue;
+			}
+
+			wp_deregister_script( $handle );
+			wp_register_script( $handle, $original->src, (array) $original->deps, $original->ver, $original->args );
+
+			$restored = $scripts->registered[ $handle ] ?? null;
+			if ( $restored ) {
+				// Reattach the inline data, footer grouping and translations from core's registration.
+				if ( ! empty( $original->extra ) ) {
+					$restored->extra = $original->extra;
+				}
+				$restored->textdomain        = $original->textdomain;
+				$restored->translations_path = $original->translations_path;
+			}
+		}
+	}
+}

--- a/projects/packages/stats-admin/tests/php/React_Handle_Guard_Test.php
+++ b/projects/packages/stats-admin/tests/php/React_Handle_Guard_Test.php
@@ -1,0 +1,132 @@
+<?php
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
+use ReflectionProperty;
+
+/**
+ * Unit tests for the React_Handle_Guard class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class React_Handle_Guard_Test extends Stats_TestCase {
+
+	const CORE_SRC = '/wp-includes/js/dist/vendor/react-dom.min.js';
+
+	/**
+	 * Start every test with clean static guard state, independent of order.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->reset_guard_state();
+	}
+
+	/**
+	 * Register a core-like react/react-dom pair and snapshot it.
+	 */
+	private function register_and_snapshot() {
+		$scripts = wp_scripts();
+		wp_register_script( 'react', '/wp-includes/js/dist/vendor/react.min.js', array(), '18.3.1.1', true );
+		wp_register_script( 'react-dom', self::CORE_SRC, array( 'react' ), '18.3.1.1', true );
+		React_Handle_Guard::snapshot_core_handles( $scripts );
+	}
+
+	/**
+	 * A handle repointed away from core is restored to the snapshot.
+	 */
+	public function test_restore_reverts_hijacked_handle() {
+		$this->register_and_snapshot();
+
+		wp_deregister_script( 'react-dom' );
+		wp_register_script( 'react-dom', 'https://example.com/hijacked-react-dom.js', array( 'react' ), '18', true );
+
+		React_Handle_Guard::restore_if_hijacked();
+
+		$this->assertSame( self::CORE_SRC, wp_scripts()->registered['react-dom']->src );
+		$this->assertSame( '18.3.1.1', wp_scripts()->registered['react-dom']->ver );
+	}
+
+	/**
+	 * When nothing changed, the handle is left untouched.
+	 */
+	public function test_restore_is_noop_when_unchanged() {
+		$this->register_and_snapshot();
+		$before = wp_scripts()->registered['react-dom'];
+
+		React_Handle_Guard::restore_if_hijacked();
+
+		$this->assertSame( $before, wp_scripts()->registered['react-dom'], 'The dependency object should not be re-created when there is no conflict.' );
+	}
+
+	/**
+	 * A version-only change (same src) still counts as a conflict and is restored.
+	 */
+	public function test_restore_reverts_version_only_change() {
+		$this->register_and_snapshot();
+
+		wp_deregister_script( 'react-dom' );
+		wp_register_script( 'react-dom', self::CORE_SRC, array( 'react' ), '17', true );
+
+		React_Handle_Guard::restore_if_hijacked();
+
+		$this->assertSame( '18.3.1.1', wp_scripts()->registered['react-dom']->ver );
+	}
+
+	/**
+	 * Restoring preserves the footer grouping and inline data core attached to the handle.
+	 */
+	public function test_restore_preserves_footer_and_inline_data() {
+		$scripts = wp_scripts();
+		wp_register_script( 'react', '/wp-includes/js/dist/vendor/react.min.js', array(), '18.3.1.1', true );
+		wp_register_script( 'react-dom', self::CORE_SRC, array( 'react' ), '18.3.1.1', true );
+		wp_add_inline_script( 'react-dom', 'window.__reactDomReady = true;', 'after' );
+		$scripts->registered['react-dom']->textdomain = 'jetpack-stats-admin';
+		React_Handle_Guard::snapshot_core_handles( $scripts );
+
+		wp_deregister_script( 'react-dom' );
+		wp_register_script( 'react-dom', 'https://example.com/hijacked-react-dom.js', array( 'react' ), '18', false );
+
+		React_Handle_Guard::restore_if_hijacked();
+
+		$restored = wp_scripts()->registered['react-dom'];
+		$this->assertSame( 1, $restored->extra['group'] ?? null, 'Footer grouping should be preserved.' );
+		$this->assertContains( 'window.__reactDomReady = true;', $restored->extra['after'] ?? array() );
+		$this->assertSame( 'jetpack-stats-admin', $restored->textdomain, 'Text domain should be preserved.' );
+	}
+
+	/**
+	 * Captures the current state via register_snapshot() when wp_default_scripts has already fired.
+	 */
+	public function test_register_snapshot_captures_when_already_fired() {
+		set_current_screen( 'dashboard' );
+
+		wp_register_script( 'react', '/wp-includes/js/dist/vendor/react.min.js', array(), '18.3.1.1', true );
+		wp_register_script( 'react-dom', self::CORE_SRC, array( 'react' ), '18.3.1.1', true );
+
+		React_Handle_Guard::register_snapshot();
+
+		wp_deregister_script( 'react-dom' );
+		wp_register_script( 'react-dom', 'https://example.com/hijacked-react-dom.js', array( 'react' ), '18', true );
+
+		React_Handle_Guard::restore_if_hijacked();
+
+		$this->assertSame( self::CORE_SRC, wp_scripts()->registered['react-dom']->src );
+	}
+
+	/**
+	 * Reset the guard's static state so register_snapshot() can be re-exercised.
+	 */
+	private function reset_guard_state() {
+		foreach ( array(
+			'snapshot'        => array(),
+			'snapshot_hooked' => false,
+		) as $prop => $value ) {
+			$rp = new ReflectionProperty( React_Handle_Guard::class, $prop );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$rp->setAccessible( true );
+			}
+			$rp->setValue( null, $value );
+		}
+	}
+}


### PR DESCRIPTION
Fixes STATS-272

## Why

On some sites, the Jetpack Stats dashboard renders blank or spins forever. The cause is a third-party plugin — confirmed with **The Events Calendar** — that deregisters WordPress core's `react-dom` script handle and re-registers it pointing at its own, incompatible ReactDOM bundle. Because every React consumer on the page shares that handle, `ReactDOM.createRoot` is never defined and the Stats app can't mount. This PR makes the Stats admin page defend its own React surface so the dashboard keeps working regardless of what another active plugin does to the shared handle.

## Proposed changes

* Add `React_Handle_Guard` to the `stats-admin` package. It snapshots WordPress core's canonical `react` / `react-dom` registration (on `wp_default_scripts`, or immediately if that action has already fired), then on the Stats admin page restores the handle at `admin_enqueue_scripts` / `PHP_INT_MAX`.
* The restore is **conflict-gated**: a handle is only deregistered/re-registered when its current `src`/`ver` no longer matches the snapshot (i.e. a plugin repointed it). On a clean site the handles are left completely untouched — no work is done. `$args` (footer/strategy) and `$extra` (inline data, translations) are preserved on restore.
* Scoped to the Stats page only (`toplevel_page_stats`), so plugins like The Events Calendar keep their own React on their own screens.
* Unit tests covering: restore on a repointed `src`, restore on a version-only change, the clean-site no-op (same dependency object retained), footer/inline-data preservation, and the already-fired snapshot path.

## Related product discussion/links

* [STATS-272](https://linear.app/a8c/issue/STATS-272/premium-analytics-harden-statsforms-admin-react-against-react-dom)

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

_Captured on a local WP 7.0 env with a plugin simulating The Events Calendar's `react-dom` repointing (the guard restores the handle only because a conflict is present)._

| Before (guard off — Stats spins forever) | After (guard on — dashboard renders) |
|---|---|
| ![before](https://github.com/user-attachments/assets/7931e490-f926-4fda-8486-486ad898783e) | ![after](https://github.com/user-attachments/assets/00325eb6-854a-4543-8cee-3da553062464) |

## Testing instructions

The guard only acts when another plugin repoints `react`/`react-dom`, so testing needs a conflicting plugin present.

* On a site running **The Events Calendar** (or any plugin that deregisters core's `react-dom` and repoints it at an incompatible bundle), open **Jetpack → Stats**.
* [ ] The Stats dashboard renders — it no longer stays blank or spins forever.
* [ ] In the console, `typeof window.ReactDOM.createRoot === 'function'` and `react`/`react-dom` resolve to the same matched build (no `createRoot is not a function` / `unstable_scheduleCallback` errors).
* [ ] The Events Calendar's own admin screens are unaffected (it keeps its bundle on its own pages).
* [ ] On a site **without** any such plugin, Stats works exactly as before — the guard is a no-op (it does not deregister/re-register the handles).
