### PR TITLE
Premium Analytics: prepare widget module registry loading

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-widget-manifest-load-order
+++ b/projects/packages/premium-analytics/changelog/fix-widget-manifest-load-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Widgets: Fix module registry hydration for REST requests.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -67,6 +67,14 @@ class Analytics {
 		Api_Proxy_Controller::register();
 		Notices_Controller::register();
 
+		// Load the widget manifest (defines jpa_get_registered_widget_modules).
+		// Must happen before the is_admin() guard so REST requests can hydrate
+		// the widget type registry and serve /jetpack/v4/widget-modules.
+		$widgets_build = __DIR__ . '/../build/widgets.php';
+		if ( file_exists( $widgets_build ) ) {
+			require_once $widgets_build;
+		}
+
 		// Load the widget type registry: hydration routine, registry-time and
 		// runtime filters, and the registry accessors.
 		require_once __DIR__ . '/widget-types.php';
@@ -86,9 +94,8 @@ class Analytics {
 		// injection and the REST route the "reset to default" action reads.
 		require_once __DIR__ . '/dashboard-layout.php';
 
-		// Load wp-build output (interceptor, modules, routes, page render).
-		// Must stay above the is_admin() gate: build/widgets.php defines the
-		// manifest the widget registry reads, and the registry serves REST
+		// Load wp-build output (interceptor, modules, widget manifest, routes, page render).
+		// Must stay above the is_admin() gate so the registry can serve REST
 		// requests (e.g. /jetpack/v4/widget-modules) where is_admin() is false. The render
 		// pieces here self-gate on admin_init, so loading them globally is inert
 		// off the dashboard. Only the polyfill registration below is admin-scoped.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Load build/widgets.php before widget type registry hydration so REST widget module requests can use the manifest outside dashboard admin requests.
* Keep the generated build entry loaded separately for page and route rendering.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* Prep for #49928.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run php -l projects/packages/premium-analytics/src/class-analytics.php.
* Confirm the Premium Analytics widget module registry can still hydrate for REST requests.
