### PR TITLE
Premium Analytics: prepare semi-circle chart options

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-semi-circle-chart-options
+++ b/projects/packages/premium-analytics/changelog/update-semi-circle-chart-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Improve semi-circle chart sizing and metric display options.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
@@ -25,6 +25,7 @@ import type { ComponentProps } from 'react';
 
 // Default chart configuration
 const DEFAULT_THICKNESS = 0.3;
+const SEMI_CIRCLE_ASPECT_RATIO = 0.5;
 
 export type SemiCircleChartData = ComponentProps< typeof PieSemiCircleChart >[ 'data' ];
 
@@ -45,7 +46,7 @@ export type SemiCircleChartProps = {
 	/**
 	 * Primary metric value (total)
 	 */
-	value: number;
+	value?: number;
 
 	/**
 	 * Optional comparison value (previous period)
@@ -66,6 +67,12 @@ export type SemiCircleChartProps = {
 	 * Show legend below chart
 	 */
 	showLegend?: boolean;
+
+	/**
+	 * Show the center metric value.
+	 * @default true
+	 */
+	showMetric?: boolean;
 
 	/**
 	 * Thickness of the arc (0-1).
@@ -132,6 +139,7 @@ export function SemiCircleChart( {
 	},
 	legendData,
 	showLegend = true,
+	showMetric = true,
 	thickness = DEFAULT_THICKNESS,
 	maxWidth = Infinity,
 	emptyStateIcon,
@@ -191,6 +199,7 @@ export function SemiCircleChart( {
 					className={ styles.chart }
 					thickness={ thickness }
 					clockwise={ false }
+					aspectRatio={ SEMI_CIRCLE_ASPECT_RATIO }
 					withTooltips={ withTooltips }
 					{ ...( tooltipOffsetX !== undefined && {
 						tooltipOffsetX,
@@ -206,14 +215,16 @@ export function SemiCircleChart( {
 					) }
 					resizeDebounceTime={ RESIZE_DEBOUNCE_MS }
 				>
-					<MetricWithComparison
-						className={ styles.metricContainer }
-						value={ value }
-						dataFormat={ dataFormat }
-						previousValue={ hasComparison ? comparisonValue : null }
-						direction="column"
-						align="center"
-					/>
+					{ showMetric && value !== undefined && (
+						<MetricWithComparison
+							className={ styles.metricContainer }
+							value={ value }
+							dataFormat={ dataFormat }
+							previousValue={ hasComparison ? comparisonValue : null }
+							direction="column"
+							align="center"
+						/>
+					) }
 				</PieSemiCircleChart>
 
 				{ showLegend && styledLegendData && (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
@@ -25,7 +25,7 @@ import type { ComponentProps } from 'react';
 
 // Default chart configuration
 const DEFAULT_THICKNESS = 0.3;
-const SEMI_CIRCLE_ASPECT_RATIO = 0.5;
+const DEFAULT_ASPECT_RATIO = 0.5;
 
 export type SemiCircleChartData = ComponentProps< typeof PieSemiCircleChart >[ 'data' ];
 
@@ -79,6 +79,13 @@ export type SemiCircleChartProps = {
 	 * @default 0.3
 	 */
 	thickness?: number;
+
+	/**
+	 * Aspect ratio of the chart (height / width). Keeps the semi-circle's
+	 * intended proportions when the widget cell size changes.
+	 * @default 0.5
+	 */
+	aspectRatio?: number;
 
 	/**
 	 * Width of the chart.
@@ -141,6 +148,7 @@ export function SemiCircleChart( {
 	showLegend = true,
 	showMetric = true,
 	thickness = DEFAULT_THICKNESS,
+	aspectRatio = DEFAULT_ASPECT_RATIO,
 	maxWidth = Infinity,
 	emptyStateIcon,
 	emptyStateText,
@@ -199,7 +207,7 @@ export function SemiCircleChart( {
 					className={ styles.chart }
 					thickness={ thickness }
 					clockwise={ false }
-					aspectRatio={ SEMI_CIRCLE_ASPECT_RATIO }
+					aspectRatio={ aspectRatio }
 					withTooltips={ withTooltips }
 					{ ...( tooltipOffsetX !== undefined && {
 						tooltipOffsetX,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a stable semi-circle chart aspect ratio so the chart keeps its intended proportions when the widget cell size changes.
* Allow SemiCircleChart to hide its center metric for widgets that render percentage segments without a meaningful total.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* Prep for #49928.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run CI=true pnpm --dir projects/packages/premium-analytics run typecheck.
* Smoke-test an existing semi-circle chart widget and confirm the chart still renders with the center metric by default.

<img width="768" height="731" alt="截圖 2026-07-02 凌晨2 37 52" src="https://github.com/user-attachments/assets/0d1ddc0b-c97e-41eb-aa91-8424ce467774" />