### PR TITLE
Premium Analytics: fix widget dashboard Storybook stories flickering on vertical resize

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-resize-flicker
+++ b/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-resize-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: fix the widget dashboard Storybook stories flickering when resizing a widget vertically, by bounding the story container height so the page scrolls internally.

--- a/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-resize-flicker
+++ b/projects/packages/premium-analytics/changelog/fix-widget-dashboard-story-resize-flicker
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix the widget dashboard Storybook stories flickering when resizing a widget vertically, by bounding the story container height so the page scrolls internally.
+Storybook: Fix widget dashboard stories flickering when resizing widgets vertically.

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -180,9 +180,32 @@ export function WidgetDashboardWithWidget( {
 				 * off-screen. Containing the overflow here keeps the document at canvas
 				 * width so the drawer stays anchored to the visible viewport edge; the
 				 * wide layout remains inspectable by scrolling the box.
+				 *
+				 * Both boxes are flex columns with a bounded (viewport) height so the
+				 * `Page` inside resolves its `height: 100%` and its content area becomes
+				 * the internal scroll surface — matching how the real dashboard fills the
+				 * wp-admin viewport. Without a definite height the page collapses to its
+				 * content height and the fixed-row-height grid resizes it back on every
+				 * vertical widget resize, so the two oscillate and the grid flickers.
 				 */ }
-				<div style={ { width: '100%', overflowX: 'auto' } }>
-					<div style={ { width: dashboardWidth } }>
+				<div
+					style={ {
+						blockSize: '100vh',
+						display: 'flex',
+						flexDirection: 'column',
+						inlineSize: '100%',
+						overflowX: 'auto',
+					} }
+				>
+					<div
+						style={ {
+							display: 'flex',
+							flex: '1 1 auto',
+							flexDirection: 'column',
+							inlineSize: dashboardWidth,
+							minBlockSize: 0,
+						} }
+					>
 						<WidgetDashboard
 							layout={ layout }
 							onLayoutChange={ setLayout }


### PR DESCRIPTION
Fixes WOOA7S-1650

## Proposed changes

Every widget's `WidgetDashboardWithWidget` Storybook story flickers when a widget is resized vertically in edit mode — the same class of bug as the real dashboard fix in #50102 (WOOA7S-1638), just relocated to the story harness.

- **Why** — All per-widget dashboard stories render the real `WidgetDashboard` through the shared helper `widgets/stories/widget-dashboard-with-widget.tsx`, which wrapped the dashboard in `width`-only `<div>`s with **no definite height**. `@wordpress/admin-ui`'s `Page` is `height: 100%` and its content area is the `flex-grow: 1; overflow: auto` scroll surface — but with no definite-height parent, `height: 100%` resolves to auto and the page collapses to its content height. The fixed-row-height grid then resized the page back on every vertical resize, so the two oscillated (flicker). In product this doesn't happen because the SPA shell gives `Page` the wp-admin viewport height, so the content area scrolls internally and the grid never changes the container height.
- **How** — Make the shared helper's wrapper a bounded (viewport) height flex column (`block-size: 100vh` outer + `flex: 1 1 auto; min-block-size: 0` inner) so `Page` resolves its `height: 100%` and its content area becomes the internal scroll surface, matching production. The existing horizontal-overflow containment (to keep the settings drawer anchored) is preserved.
- **What** — One change in `widget-dashboard-with-widget.tsx` fixes every widget dashboard story at once. No product/runtime code is touched — this is Storybook-only.

## Related product discussion/links

- WOOA7S-1650
- Follows #50102 (WOOA7S-1638), the same fix for the real dashboard.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run Storybook: `pnpm --filter=@automattic/jetpack-storybook run storybook:dev` (port 50240).
- Open any widget's **WidgetDashboardWithWidget** story (e.g. _Packages / Premium Analytics / Widgets / Clicks_).
- Toggle the **editMode** control on, then drag a widget's resize handle up and down across a row boundary.
- Confirm the grid no longer flickers and the resized widget tracks the cursor smoothly; when the grid grows taller than the frame, the section scrolls internally instead of the whole page growing.


https://github.com/user-attachments/assets/4f699e69-243b-4660-920c-8ad2c76cca52

