### PR TITLE
Premium Analytics: drop GlobalErrorProvider wrapper from total-sales stories

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-total-sales-story-global-error-provider
+++ b/projects/packages/premium-analytics/changelog/fix-total-sales-story-global-error-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Total sales over time: drop the GlobalErrorProvider wrapper from the Storybook stories to match the sibling over-time widgets.

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { GlobalErrorProvider, getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -82,11 +82,9 @@ function renderTotalSalesOverTime( { withComparison, preset }: TotalSalesOverTim
 	ensureLineChartComposition();
 
 	return (
-		<GlobalErrorProvider>
-			<TotalSalesOverTimeRender
-				attributes={ getTotalSalesOverTimeAttributes( withComparison, preset ) }
-			/>
-		</GlobalErrorProvider>
+		<TotalSalesOverTimeRender
+			attributes={ getTotalSalesOverTimeAttributes( withComparison, preset ) }
+		/>
 	);
 }
 
@@ -98,19 +96,15 @@ function TotalSalesOverTimeDashboardStory( {
 	ensureLineChartComposition();
 
 	return (
-		<GlobalErrorProvider>
-			<WidgetDashboardWithWidgetStory
-				{ ...dashboardStoryArgs }
-				widgetType={ widgetDefinition }
-				renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
-				renderComponent={
-					TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > >
-				}
-				attributes={ {
-					reportParams: getDefaultQueryParams( withComparison, preset ),
-				} }
-			/>
-		</GlobalErrorProvider>
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardStoryArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
+			renderComponent={ TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison, preset ),
+			} }
+		/>
 	);
 }
 


### PR DESCRIPTION
### Proposed changes

Follow-up parity cleanup for the Total sales over time widget (WOOA7S-1486). It shipped in #49729 with a Storybook inconsistency that couldn't be fixed in-place once merged.

**Why:** the widget's Storybook stories still wrapped the render output in `<GlobalErrorProvider>`, unlike the sibling over-time widgets (gross/net/coupon), which pass `setError` through to `WidgetRoot` and leave the baseline `useGlobalError` notice visible. `render.tsx` was already correct — only the stories diverged, so the harness behaved differently for this one widget.

**How:** removed the `<GlobalErrorProvider>` wrapper (and its now-unused import) from `renderTotalSalesOverTime` and the dashboard story, matching `net-sales-over-time`.

**What:** stories-only change — no runtime or widget behavior change.

### Testing instructions

- Run Storybook and open **Total sales over time → Default / WithComparison / WidgetDashboardWithWidget**.
- Stories render exactly as before; the console now shows the same baseline `useGlobalError` notice as the sibling over-time widgets (parity), with no widget-specific errors.

### Other information

- `eslint` + `tsgo` typecheck clean; changelog check passes.
- No new dependencies; no user-facing/production impact.