### PR TITLE
wpcomsh: suppress Crowdsignal Forms onboarding notices on WoA

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
+++ b/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Crowdsignal Forms: suppress the onboarding admin notices that cluttered the Plugins page on WoA sites after activation.

--- a/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
+++ b/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Crowdsignal Forms: suppress the "getting started" setup notice that cluttered the Plugins page on WoA sites after activation.
+Crowdsignal: suppress the onboarding and "link your account" notices that cluttered the Plugins page on WoA sites after activation.

--- a/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
+++ b/projects/plugins/wpcomsh/changelog/dotprod-91-crowdsignal-plugin-notices
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Crowdsignal Forms: suppress the onboarding admin notices that cluttered the Plugins page on WoA sites after activation.
+Crowdsignal Forms: suppress the "getting started" setup notice that cluttered the Plugins page on WoA sites after activation.

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Crowdsignal Forms tweaks for WoA sites.
+ * Crowdsignal plugin tweaks for WoA sites.
  *
  * @package wpcomsh
  */
@@ -48,3 +48,23 @@ add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 
  * part of the activation clutter, so it is left intact.
  */
 add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false', PHP_INT_MAX );
+
+/**
+ * Suppress the Crowdsignal Dashboard (Polldaddy) "link your account" warning on WoA sites.
+ *
+ * The Crowdsignal Dashboard plugin (slug `polldaddy`) prints a "Crowdsignal features will be
+ * unavailable until you link your Crowdsignal.com account" warning on the Plugins screen and on
+ * its own poll/rating screens whenever no `polldaddy_api_key` option is stored. As with Crowdsignal
+ * Forms, WoA activates this plugin without the user asking, and the account link lives in
+ * WordPress.com-managed state the plugin can't read locally, so the warning is never actionable
+ * here and just clutters the Plugins page.
+ *
+ * Unlike Crowdsignal Forms, this notice has no suppression filter: it is echoed directly from a
+ * named `admin_notices` callback. Remove that callback instead. admin_init runs after all plugins
+ * have loaded (so polldaddy has already registered the callback) but before admin_notices fires,
+ * and remove_action is a no-op when the plugin is inactive.
+ */
+function wpcomsh_suppress_crowdsignal_polldaddy_login_warning() {
+	remove_action( 'admin_notices', 'polldaddy_login_warning' );
+}
+add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_polldaddy_login_warning' );

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -57,7 +57,7 @@ add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 
  */
 function wpcomsh_suppress_crowdsignal_forms_setup_notice( $show ) {
 	$screen = get_current_screen();
-	if ( $screen instanceof WP_Screen && in_array( $screen->id, array( 'plugins', 'dashboard' ), true ) ) {
+	if ( $screen && in_array( $screen->id, array( 'plugins', 'dashboard' ), true ) ) {
 		return false;
 	}
 	return $show;
@@ -85,7 +85,7 @@ add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', 'wpcomsh_suppress_
  * @param WP_Screen $screen The current admin screen.
  */
 function wpcomsh_suppress_crowdsignal_polldaddy_login_warning( $screen ) {
-	if ( $screen instanceof WP_Screen && 'plugins' === $screen->id ) {
+	if ( $screen && 'plugins' === $screen->id ) {
 		remove_action( 'admin_notices', 'polldaddy_login_warning' );
 	}
 }

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -28,7 +28,7 @@ function wpcomsh_suppress_crowdsignal_activation_redirect() {
 add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 );
 
 /**
- * Suppress Crowdsignal Forms' onboarding admin notices on WoA sites.
+ * Suppress Crowdsignal Forms' "getting started" setup notice on WoA sites.
  *
  * On activation Crowdsignal Forms enqueues a persistent "core setup" notice and renders it on
  * the Plugins and Dashboard screens until the user either connects a Crowdsignal account or
@@ -38,8 +38,13 @@ add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 
  * clutters the Plugins page for users who never chose to install it.
  *
  * Crowdsignal Forms exposes a `crowdsignal_forms_show_admin_notice_{notice}` filter for exactly
- * this purpose; returning false keeps each notice from rendering without disturbing its stored
- * state or the plugin's own dismissal handling.
+ * this purpose; returning false keeps the notice from rendering without disturbing its stored
+ * state or the plugin's own dismissal handling. The plugin's own callback on this filter runs at
+ * the default priority and returns true whenever no account is connected, so we hook at
+ * PHP_INT_MAX to have the final say regardless of hook-registration order.
+ *
+ * Only the "core setup" notice is suppressed: the sibling "setup success" notice is gated on a
+ * `?msg=connect` request and is deliberate feedback shown right after a user completes setup, not
+ * part of the activation clutter, so it is left intact.
  */
-add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false' );
-add_filter( 'crowdsignal_forms_show_admin_notice_setup_success', '__return_false' );
+add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false', PHP_INT_MAX );

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -43,11 +43,26 @@ add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 
  * the default priority and returns true whenever no account is connected, so we hook at
  * PHP_INT_MAX to have the final say regardless of hook-registration order.
  *
- * Only the "core setup" notice is suppressed: the sibling "setup success" notice is gated on a
+ * The suppression is scoped to the Plugins and Dashboard screens, which is where the notice is
+ * unsolicited clutter. Upstream also renders it on Crowdsignal Forms' own admin screen; there it
+ * is deliberate setup guidance for a user who navigated in on purpose, so we pass the incoming
+ * value through and leave the plugin's own logic in charge.
+ *
+ * Only the "core setup" notice is touched: the sibling "setup success" notice is gated on a
  * `?msg=connect` request and is deliberate feedback shown right after a user completes setup, not
  * part of the activation clutter, so it is left intact.
+ *
+ * @param bool $show Whether Crowdsignal Forms intends to show the notice.
+ * @return bool
  */
-add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false', PHP_INT_MAX );
+function wpcomsh_suppress_crowdsignal_forms_setup_notice( $show ) {
+	$screen = get_current_screen();
+	if ( $screen && in_array( $screen->id, array( 'plugins', 'dashboard' ), true ) ) {
+		return false;
+	}
+	return $show;
+}
+add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', 'wpcomsh_suppress_crowdsignal_forms_setup_notice', PHP_INT_MAX );
 
 /**
  * Suppress the Crowdsignal Dashboard (Polldaddy) "link your account" warning on WoA sites.
@@ -59,12 +74,19 @@ add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false', 
  * WordPress.com-managed state the plugin can't read locally, so the warning is never actionable
  * here and just clutters the Plugins page.
  *
+ * Scope this to the Plugins screen only. On the plugin's own poll/rating screens the warning is
+ * the intended explanation for why features are unavailable, so leave it there.
+ *
  * Unlike Crowdsignal Forms, this notice has no suppression filter: it is echoed directly from a
- * named `admin_notices` callback. Remove that callback instead. admin_init runs after all plugins
- * have loaded (so polldaddy has already registered the callback) but before admin_notices fires,
- * and remove_action is a no-op when the plugin is inactive.
+ * named `admin_notices` callback. Remove that callback instead. The `current_screen` hook fires
+ * after all plugins have loaded (so polldaddy has already registered the callback) and before
+ * admin_notices renders, and remove_action is a no-op when the plugin is inactive.
+ *
+ * @param WP_Screen $screen The current admin screen.
  */
-function wpcomsh_suppress_crowdsignal_polldaddy_login_warning() {
-	remove_action( 'admin_notices', 'polldaddy_login_warning' );
+function wpcomsh_suppress_crowdsignal_polldaddy_login_warning( $screen ) {
+	if ( $screen instanceof WP_Screen && 'plugins' === $screen->id ) {
+		remove_action( 'admin_notices', 'polldaddy_login_warning' );
+	}
 }
-add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_polldaddy_login_warning' );
+add_action( 'current_screen', 'wpcomsh_suppress_crowdsignal_polldaddy_login_warning' );

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -26,3 +26,20 @@ function wpcomsh_suppress_crowdsignal_activation_redirect() {
 	}
 }
 add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 );
+
+/**
+ * Suppress Crowdsignal Forms' onboarding admin notices on WoA sites.
+ *
+ * On activation Crowdsignal Forms enqueues a persistent "core setup" notice and renders it on
+ * the Plugins and Dashboard screens until the user either connects a Crowdsignal account or
+ * dismisses it. Because WoA activates the plugin during the Simple-to-Atomic transfer and again
+ * on every managed version-bump reactivation, and because the account connection lives in
+ * WordPress.com-managed state the plugin can't read locally, this notice reappears uninvited and
+ * clutters the Plugins page for users who never chose to install it.
+ *
+ * Crowdsignal Forms exposes a `crowdsignal_forms_show_admin_notice_{notice}` filter for exactly
+ * this purpose; returning false keeps each notice from rendering without disturbing its stored
+ * state or the plugin's own dismissal handling.
+ */
+add_filter( 'crowdsignal_forms_show_admin_notice_core_setup', '__return_false' );
+add_filter( 'crowdsignal_forms_show_admin_notice_setup_success', '__return_false' );

--- a/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
+++ b/projects/plugins/wpcomsh/feature-plugins/crowdsignal.php
@@ -57,7 +57,7 @@ add_action( 'admin_init', 'wpcomsh_suppress_crowdsignal_activation_redirect', 1 
  */
 function wpcomsh_suppress_crowdsignal_forms_setup_notice( $show ) {
 	$screen = get_current_screen();
-	if ( $screen && in_array( $screen->id, array( 'plugins', 'dashboard' ), true ) ) {
+	if ( $screen instanceof WP_Screen && in_array( $screen->id, array( 'plugins', 'dashboard' ), true ) ) {
 		return false;
 	}
 	return $show;


### PR DESCRIPTION
Fixes #

Addresses DOTPROD-91.

## Proposed changes

Two Crowdsignal plugins print onboarding notices on the Plugins screen after WoA activates them (during the Simple-to-Atomic transfer and on managed version-bump reactivations), even though the user never chose to install them and the account connection lives in WordPress.com-managed state the plugins can't read locally:

* **Crowdsignal Forms** enqueues a persistent "You are nearly ready to start creating polls" setup notice on the Plugins and Dashboard screens.
* **Crowdsignal Dashboard** (slug `polldaddy`) prints a "Crowdsignal features will be unavailable until you link your Crowdsignal.com account" warning on the Plugins screen and its own poll/rating screens.

This extends the existing WoA Crowdsignal tweaks to suppress both, scoped to the screens where the notices are unsolicited clutter:

* For Crowdsignal Forms, hook its own `crowdsignal_forms_show_admin_notice_core_setup` filter (at `PHP_INT_MAX`, so it wins over the plugin's default-priority callback regardless of hook-registration order), returning false only on the Plugins and Dashboard screens and passing the value through elsewhere so the plugin's own logic still governs its own admin screen. Its sibling "setup success" notice is gated on a post-connect request and is deliberate feedback, so it is left intact.
* Crowdsignal Dashboard has no suppression filter — it echoes the warning from a named `admin_notices` callback — so remove that callback on `current_screen`, but only on the Plugins screen. Its own poll/rating screens keep the warning, where it explains why features are unavailable.

## Related product discussion/links

* DOTPROD-91

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WoA site with the Crowdsignal Forms and Crowdsignal Dashboard (polldaddy) plugins active, visit **Plugins** and **Dashboard**.
* Confirm neither the Crowdsignal Forms "getting started" setup notice nor the Crowdsignal Dashboard "link your account" warning appears there.
* Visit Crowdsignal Forms' own settings screen and confirm its setup notice still behaves as upstream intends; visit the Crowdsignal Dashboard polls/ratings screens and confirm the "link your account" warning still appears.
* Complete the Crowdsignal Forms setup/connect flow and confirm the post-connect success notice still appears (it should not be suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
