### PR TITLE
Social: avoid admin-owned connection flicker while account actions load

### DIFF
--- a/projects/js-packages/script-data/changelog/fix-social-admin-connection-flicker
+++ b/projects/js-packages/script-data/changelog/fix-social-admin-connection-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add edit_others_posts to the UserCapabilities type.

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -32,6 +32,7 @@ export interface AdminSiteData {
 export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 
 export interface UserCapabilities {
+	edit_others_posts: boolean;
 	manage_options: boolean;
 	manage_modules: boolean;
 }

--- a/projects/packages/assets/changelog/fix-social-admin-connection-flicker
+++ b/projects/packages/assets/changelog/fix-social-admin-connection-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose the current user's edit_others_posts capability in the localized script data.

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -230,8 +230,9 @@ class Script_Data {
 			'display_name' => $current_user->display_name,
 			'id'           => $current_user->ID,
 			'capabilities' => array(
-				'manage_options' => current_user_can( 'manage_options' ),
-				'manage_modules' => current_user_can( 'jetpack_manage_modules' ),
+				'edit_others_posts' => current_user_can( 'edit_others_posts' ),
+				'manage_options'    => current_user_can( 'manage_options' ),
+				'manage_modules'    => current_user_can( 'jetpack_manage_modules' ),
 			),
 		);
 	}

--- a/projects/packages/publicize/_inc/hooks/use-user-can-share-connection.ts
+++ b/projects/packages/publicize/_inc/hooks/use-user-can-share-connection.ts
@@ -9,9 +9,15 @@ import { useSelect } from '@wordpress/data';
  */
 export function useUserCanShareConnection() {
 	return useSelect( select => {
-		const { getUser } = select( coreStore );
-
 		const { current_user } = getScriptData().user;
+
+		const isEditorOrAbove = current_user.capabilities?.edit_others_posts;
+
+		if ( undefined !== isEditorOrAbove ) {
+			return isEditorOrAbove;
+		}
+
+		const { getUser } = select( coreStore );
 
 		// Only the editors and above can mark a connection as shared
 		return Boolean( getUser( current_user.id )?.capabilities?.edit_others_posts );

--- a/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
@@ -242,6 +242,12 @@ export const canUserManageConnection = createRegistrySelector(
 				return true;
 			}
 
+			const isEditorOrAbove = current_user.capabilities?.edit_others_posts;
+
+			if ( undefined !== isEditorOrAbove ) {
+				return isEditorOrAbove;
+			}
+
 			const { getUser } = select( coreStore );
 
 			// The user has to be at least an editor to manage the connection.

--- a/projects/packages/publicize/changelog/fix-social-admin-connection-flicker
+++ b/projects/packages/publicize/changelog/fix-social-admin-connection-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid the "This connection is added by a site administrator" fallback from flickering for editors while the current user record is still resolving.


### PR DESCRIPTION
Fixes SOCIAL-517

## Proposed changes

Expanding a connected account row could briefly show "This connection is added by a site administrator." before the real connection actions appeared, making a manageable connection look temporarily unavailable.

The flicker happened because `canUserManageConnection()` (and `useUserCanShareConnection()`) relied on the async `getUser( current_user.id )` core-store resolver to read the `edit_others_posts` capability. While that user record was unresolved, the capability read as `false`, so the admin-owned fallback rendered until hydration finished.

* Expose the current user's `edit_others_posts` capability directly in the localized script data (`Script_Data::get_current_user_data()`), so it is available synchronously on first paint.
* Add `edit_others_posts` to the `UserCapabilities` type in `@automattic/jetpack-script-data`.
* Read the synchronous capability from `current_user.capabilities` in `canUserManageConnection()` and `useUserCanShareConnection()`, falling back to the async `getUser()` lookup only when it is unavailable.

## Related product discussion/links

* SOCIAL-517

## Does this pull request change what data or activity we track or use?

No new tracking. It adds the current user's existing `edit_others_posts` capability to the data already localized for the admin page.

## Testing instructions

* As a secondary admin/editor user (not the connection owner), open the Jetpack Social admin page or the block editor sharing panel.
* Expand a connected account row that the current user can manage.
* Confirm the row no longer flashes "This connection is added by a site administrator." before the connection actions appear.
* Confirm connections the user genuinely cannot manage still show the admin-owned message.
