### PR TITLE
Charts: let conversion funnel chart shrink in height-constrained cards

### DIFF
--- a/projects/js-packages/charts/changelog/fix-funnel-chart-shrink-height
+++ b/projects/js-packages/charts/changelog/fix-funnel-chart-shrink-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Conversion Funnel Chart: Let the funnel shrink to fit height-constrained cards instead of enforcing a 200px minimum that forced a scrollbar.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -33,7 +33,7 @@
 
 .funnel-container {
 	flex: 1;
-	min-height: 200px;
+	min-height: 0;
 	width: 100%;
 }
 


### PR DESCRIPTION

## Proposed changes

* **Why:** In height-constrained cards (e.g. a short row on the analytics dashboard), the Conversion Funnel Chart could not fit and its widget chrome showed a scrollbar. The other chart types (donut, line) shrink to fit and never scroll, so the funnel was inconsistent.
* **How:** The funnel's bar area (`.funnel-container`) hard-coded `min-height: 200px`. Every ancestor in the layout already carries `flex: 1; min-height: 0`, so this floor was the only thing blocking shrink. Setting it to `min-height: 0` lets `flex: 1` both fill a tall card and shrink in a short one — matching the donut/line behavior.
* **What:** One-line CSS change in `@automattic/charts`, affecting both funnel consumers (the **Conversion rate** and **Store conversion rate – Bookings** widgets):

```diff
 .funnel-container {
 	flex: 1;
-	min-height: 200px;
+	min-height: 0;
 	width: 100%;
 }
```

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run Storybook and open the `ConversionFunnelChart`  stories.
* Confirm the funnel fills a normally-sized card as before (bars scale and fill height).
* Constrain the card/widget height (e.g. a short dashboard row); confirm the funnel **shrinks to fit 
Verified heights:


https://github.com/user-attachments/assets/cbd661ba-7604-42ec-a3a4-46d603658703

