### PR TITLE
SEO: add a site-level WebSite schema node with SearchAction

### DIFF
--- a/projects/packages/seo/changelog/add-website-schema-node
+++ b/projects/packages/seo/changelog/add-website-schema-node
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a site-level WebSite schema node with a SearchAction.

--- a/projects/packages/seo/src/class-schema-builder.php
+++ b/projects/packages/seo/src/class-schema-builder.php
@@ -106,6 +106,12 @@ class Schema_Builder {
 			}
 		}
 
+		$website = Website_Schema_Node::build();
+		if ( null !== $website && null !== $organization ) {
+			$website['publisher'] = array( '@id' => Schema_Node_Ids::organization() );
+		}
+		$graph->add( $website );
+
 		$graph->add( $post_node );
 
 		return $graph->to_document();

--- a/projects/packages/seo/src/class-schema-node-ids.php
+++ b/projects/packages/seo/src/class-schema-node-ids.php
@@ -32,6 +32,15 @@ class Schema_Node_Ids {
 	}
 
 	/**
+	 * `@id` for the site-level WebSite node.
+	 *
+	 * @return string
+	 */
+	public static function website() {
+		return self::site_anchor( 'website' );
+	}
+
+	/**
 	 * Build a stable site-root `@id` from a fragment name.
 	 *
 	 * @param string $fragment Fragment identifier (without the leading `#`).

--- a/projects/packages/seo/src/class-website-schema-node.php
+++ b/projects/packages/seo/src/class-website-schema-node.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Site-level WebSite Schema.org node builder.
+ *
+ * Builds the WebSite JSON-LD node from existing site identity: Site Title,
+ * site URL, Tagline, site language, and core WordPress search.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Builds the site-level WebSite node.
+ */
+class Website_Schema_Node {
+
+	/**
+	 * Build the WebSite node, or null when the site has no name to identify it.
+	 *
+	 * @return array|null
+	 */
+	public static function build() {
+		$name = self::text( get_bloginfo( 'name' ) );
+		if ( '' === $name ) {
+			return null;
+		}
+
+		$node = array(
+			'@type'           => 'WebSite',
+			'@id'             => Schema_Node_Ids::website(),
+			'name'            => $name,
+			'url'             => home_url( '/' ),
+			'potentialAction' => array(
+				'@type'       => 'SearchAction',
+				'target'      => array(
+					'@type'       => 'EntryPoint',
+					'urlTemplate' => home_url( '/?s={search_term_string}' ),
+				),
+				'query-input' => 'required name=search_term_string',
+			),
+		);
+
+		$description = self::text( get_bloginfo( 'description' ) );
+		if ( '' !== $description ) {
+			$node['description'] = $description;
+		}
+
+		$language = self::text( get_bloginfo( 'language' ) );
+		if ( '' !== $language ) {
+			$node['inLanguage'] = $language;
+		}
+
+		return $node;
+	}
+
+	/**
+	 * Normalize a scalar site value to trimmed plain text.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private static function text( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		return trim( wp_strip_all_tags( $value ) );
+	}
+}

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -228,6 +228,42 @@ class SchemaBuilderTest extends TestCase {
 	}
 
 	/**
+	 * The graph includes the site-level WebSite node, referenced to the
+	 * Organization by `publisher`.
+	 */
+	public function test_graph_includes_website_referenced_to_organization() {
+		$this->set_site_name( 'Acme Co' );
+
+		$doc = $this->emit_document( $this->make_post() );
+
+		$this->assertSame( 'WebSite', $doc['@graph'][1]['@type'], 'Site-level nodes come before the page node.' );
+
+		$organization = $this->node_of_type( $doc, 'Organization' );
+		$website      = $this->node_of_type( $doc, 'WebSite' );
+		$this->assertIsArray( $website, 'Expected a WebSite node in the graph.' );
+		$this->assertSame( Schema_Node_Ids::website(), $website['@id'] );
+		$this->assertSame( 'Acme Co', $website['name'] );
+		$this->assertSame( $organization['@id'], $website['publisher']['@id'] );
+		$this->assertSame( 'SearchAction', $website['potentialAction']['@type'] );
+	}
+
+	/**
+	 * Without a Site Title, neither site-level node is emitted and the Article has
+	 * no `publisher` reference.
+	 */
+	public function test_graph_omits_site_level_nodes_without_site_name() {
+		$this->set_site_name( '' );
+
+		$doc = $this->emit_document( $this->make_post() );
+
+		$this->assertNull( $this->node_of_type( $doc, 'Organization' ) );
+		$this->assertNull( $this->node_of_type( $doc, 'WebSite' ) );
+
+		$article = $this->node_of_type( $doc, 'Article' );
+		$this->assertArrayNotHasKey( 'publisher', $article );
+	}
+
+	/**
 	 * A FAQPage joins the graph alongside the Organization, but carries no
 	 * `publisher` (only Article references a publisher).
 	 */

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -236,10 +236,9 @@ class SchemaBuilderTest extends TestCase {
 
 		$doc = $this->emit_document( $this->make_post() );
 
-		$this->assertSame( 'WebSite', $doc['@graph'][1]['@type'], 'Site-level nodes come before the page node.' );
-
 		$organization = $this->node_of_type( $doc, 'Organization' );
 		$website      = $this->node_of_type( $doc, 'WebSite' );
+		$this->assertIsArray( $organization, 'Expected an Organization node in the graph.' );
 		$this->assertIsArray( $website, 'Expected a WebSite node in the graph.' );
 		$this->assertSame( Schema_Node_Ids::website(), $website['@id'] );
 		$this->assertSame( 'Acme Co', $website['name'] );

--- a/projects/packages/seo/tests/php/SchemaNodeIdsTest.php
+++ b/projects/packages/seo/tests/php/SchemaNodeIdsTest.php
@@ -42,6 +42,20 @@ class SchemaNodeIdsTest extends TestCase {
 	}
 
 	/**
+	 * The WebSite id is the site root plus a stable `#website` fragment.
+	 */
+	public function test_website_id_anchors_to_the_site_root() {
+		add_filter(
+			'home_url',
+			static function () {
+				return 'https://example.test/';
+			}
+		);
+
+		$this->assertSame( 'https://example.test/#website', Schema_Node_Ids::website() );
+	}
+
+	/**
 	 * The id is stable across calls — it must not vary per request, or the cross-node
 	 * `@id` references (e.g. the Article publisher) would not resolve.
 	 */

--- a/projects/packages/seo/tests/php/WebsiteSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/WebsiteSchemaNodeTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Website_Schema_Node builder.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Website_Schema_Node
+ */
+#[CoversClass( Website_Schema_Node::class )]
+class WebsiteSchemaNodeTest extends TestCase {
+
+	/**
+	 * Give the site a stable identity for the test.
+	 *
+	 * @param string $name        Site Title.
+	 * @param string $description Tagline.
+	 * @param string $home        Home URL.
+	 * @param string $locale      Locale.
+	 * @return void
+	 */
+	private function set_site_identity( $name, $description = '', $home = 'https://example.test/', $locale = 'en_US' ) {
+		add_filter(
+			'pre_option_blogname',
+			static function () use ( $name ) {
+				return $name;
+			}
+		);
+		add_filter(
+			'pre_option_blogdescription',
+			static function () use ( $description ) {
+				return $description;
+			}
+		);
+		add_filter(
+			'home_url',
+			static function ( $url, $path = '' ) use ( $home ) {
+				return rtrim( $home, '/' ) . $path;
+			},
+			10,
+			2
+		);
+		add_filter(
+			'locale',
+			static function () use ( $locale ) {
+				return $locale;
+			}
+		);
+	}
+
+	/**
+	 * Remove the filters added by the tests so they don't leak across the process.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach (
+			array(
+				'pre_option_blogname',
+				'pre_option_blogdescription',
+				'home_url',
+				'locale',
+			) as $hook
+		) {
+			remove_all_filters( $hook );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * With no Site Title, there is no useful WebSite entity, so nothing is built.
+	 */
+	public function test_emits_nothing_without_a_site_name() {
+		$this->set_site_identity( '' );
+		$this->assertNull( Website_Schema_Node::build() );
+	}
+
+	/**
+	 * The node is built from site identity alone, with a stable `@id` and core
+	 * WordPress search as the SearchAction target.
+	 */
+	public function test_builds_from_site_identity() {
+		$this->set_site_identity( 'Acme Co', 'We make things', 'https://acme.test/', 'es_UY' );
+
+		$node = Website_Schema_Node::build();
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'WebSite', $node['@type'] );
+		$this->assertSame( Schema_Node_Ids::website(), $node['@id'] );
+		$this->assertSame( 'https://acme.test/#website', $node['@id'] );
+		$this->assertSame( 'Acme Co', $node['name'] );
+		$this->assertSame( 'https://acme.test/', $node['url'] );
+		$this->assertSame( 'We make things', $node['description'] );
+		$this->assertSame( 'es-UY', $node['inLanguage'] );
+		$this->assertSame(
+			array(
+				'@type'       => 'SearchAction',
+				'target'      => array(
+					'@type'       => 'EntryPoint',
+					'urlTemplate' => 'https://acme.test/?s={search_term_string}',
+				),
+				'query-input' => 'required name=search_term_string',
+			),
+			$node['potentialAction']
+		);
+	}
+
+	/**
+	 * With no tagline or language, optional properties are omitted rather than
+	 * emitted empty.
+	 */
+	public function test_optional_fields_omitted_when_empty() {
+		$this->set_site_identity( 'Acme Co', '', 'https://acme.test/', '' );
+		$node = Website_Schema_Node::build();
+
+		$this->assertArrayNotHasKey( 'description', $node );
+		$this->assertArrayNotHasKey( 'inLanguage', $node );
+	}
+}


### PR DESCRIPTION
Fixes JETPACK-1780

## Proposed changes
* Add a site-level `WebSite` schema node to the existing schema graph.
* Add a `SearchAction` that points to WordPress core search with `/?s={search_term_string}`.
* Link the WebSite node to the Organization node with `publisher` when Organization is emitted.
* Add focused PHP tests and an SEO package changelog entry.

## Related product discussion/links
* JETPACK-1780

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `jetpack install plugins/jetpack` and `jetpack install packages/seo`
* On a singular post, inspect the emitted JSON-LD and confirm the graph includes a `WebSite` node with a `SearchAction` target URL template ending in `/?s={search_term_string}`.
* Run it through https://validator.schema.org

