### PR TITLE
AI Launchpad: add a "Create your first gallery" task for photography and portfolio sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-gallery-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-gallery-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Launchpad: add a "Create your first gallery" task for photography and portfolio sites, opening the editor with a gallery pattern.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-cta-spinner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-cta-spinner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: keep a task's CTA spinner visible until the editor opens, so the create-post/page flow no longer looks stalled before navigating.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-cta-spinner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-ai-launchpad-cta-spinner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Launchpad: keep a task's CTA spinner visible until the editor opens, so the create-post/page flow no longer looks stalled before navigating.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/class-ai-launchpad-theme-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-social-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-subscribers-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-about-page-listener.php';
+require_once __DIR__ . '/class-ai-launchpad-gallery-page-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-first-post-listener.php';
 require_once __DIR__ . '/class-ai-launchpad-dev-enable.php';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-gallery-page-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-gallery-page-listener.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * AI Launchpad gallery-page completion listener.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Completes the synthetic `add_gallery_page` task from wp-admin when the AI-created gallery page is published.
+ *
+ * The task is injected by AI_Launchpad_REST (never persisted into the AI output), so completion is gated on the
+ * page's marker meta plus eligibility rather than on the AI task-id list.
+ */
+class AI_Launchpad_Gallery_Page_Listener {
+
+	/**
+	 * Marker meta set by createPatternPage on the AI-created gallery page.
+	 */
+	const META_KEY = '_wpcom_ai_launchpad_gallery_page';
+
+	/**
+	 * Registers the marker meta and the publish watcher.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'init', array( __CLASS__, 'register_meta' ) );
+		add_action( 'transition_post_status', array( __CLASS__, 'maybe_complete' ), 10, 3 );
+	}
+
+	/**
+	 * Registers the marker meta so the block editor preserves it and the create request can set it.
+	 *
+	 * @return void
+	 */
+	public static function register_meta() {
+		register_post_meta(
+			'page',
+			self::META_KEY,
+			array(
+				'type'          => 'boolean',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => static function () {
+					return current_user_can( 'edit_pages' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Completes add_gallery_page when a page carrying the marker is first published.
+	 *
+	 * @param string   $new_status The new post status.
+	 * @param string   $old_status The previous post status.
+	 * @param \WP_Post $post       The post being transitioned.
+	 * @return void
+	 */
+	public static function maybe_complete( $new_status, $old_status, $post ) {
+		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+			return;
+		}
+		if ( ! ( $post instanceof \WP_Post ) || 'page' !== $post->post_type ) {
+			return;
+		}
+		if ( ! get_post_meta( $post->ID, self::META_KEY, true ) ) {
+			return;
+		}
+		// Fail closed: if the gate is unavailable, treat the site as not eligible.
+		if ( ! function_exists( 'wpcom_ai_launchpad_is_eligible' ) || ! wpcom_ai_launchpad_is_eligible() ) {
+			return;
+		}
+
+		// The synthetic id is not in the shared catalog, so wpcom_mark_launchpad_task_complete() would drop it
+		// (wpcom_launchpad_update_task_status() skips unknown ids); write the status option directly instead.
+		$statuses                     = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$statuses['add_gallery_page'] = true;
+		update_option( 'launchpad_checklist_tasks_statuses', $statuses );
+	}
+
+	/**
+	 * Returns the ID of the newest unpublished AI-created gallery page (a `draft` page carrying the marker), or null.
+	 *
+	 * @return int|null
+	 */
+	public static function get_draft_id() {
+		$ids = get_posts(
+			array(
+				'post_type'        => 'page',
+				'post_status'      => 'draft',
+				'posts_per_page'   => 1,
+				'orderby'          => 'date',
+				'order'            => 'DESC',
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => false,
+				'meta_key'         => self::META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- one-off read behind the AI Launchpad eligibility gate.
+			)
+		);
+
+		return empty( $ids ) ? null : (int) $ids[0];
+	}
+}
+
+AI_Launchpad_Gallery_Page_Listener::register();

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -290,8 +290,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				$tasks = $this->build_tasks( $payload['tasks'], false, $niche );
 			}
 
-			$inferred = isset( $payload['inferred'] ) && is_array( $payload['inferred'] ) ? $payload['inferred'] : array();
-			$gallery  = $this->build_gallery_task( $inferred );
+			$gallery = $this->build_gallery_task( $inferred );
 			if ( null !== $gallery ) {
 				$tasks = $this->insert_before_launch_task( $tasks, $gallery );
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -702,7 +702,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			return false;
 		}
 
-		$words = preg_split( '/[\s,&]+/', $niche, -1, PREG_SPLIT_NO_EMPTY );
+		// Split on any non-alphanumeric run so hyphenated/compound niches ("wildlife-photography") tokenize like the client.
+		$words = preg_split( '/[^a-z0-9]+/', $niche, -1, PREG_SPLIT_NO_EMPTY );
 		return array() !== array_intersect( $words, self::GALLERY_NICHE_KEYWORDS );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -289,6 +289,12 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
 				$tasks = $this->build_tasks( $payload['tasks'], false, $niche );
 			}
+
+			$inferred = isset( $payload['inferred'] ) && is_array( $payload['inferred'] ) ? $payload['inferred'] : array();
+			$gallery  = $this->build_gallery_task( $inferred );
+			if ( null !== $gallery ) {
+				$tasks = $this->insert_before_launch_task( $tasks, $gallery );
+			}
 		}
 
 		// The membership tasks' completion is recomputed in build_tasks(), so overlay it to keep
@@ -659,6 +665,111 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
+	 * Visual-work niche keywords that (along with the `portfolio` goal) surface the synthetic gallery task.
+	 */
+	const GALLERY_NICHE_KEYWORDS = array(
+		'photography',
+		'photo',
+		'photos',
+		'photographer',
+		'portfolio',
+		'gallery',
+		'art',
+		'artist',
+		'illustration',
+		'illustrator',
+		'design',
+		'designer',
+		'visual',
+		'painting',
+		'drawing',
+	);
+
+	/**
+	 * Whether the synthetic "Create your first gallery" task should be offered, based on the inferred goal/niche.
+	 *
+	 * @param array $inferred The AI output's `inferred` block.
+	 * @return bool
+	 */
+	private function should_offer_gallery_task( $inferred ) {
+		$goal = isset( $inferred['goal'] ) && is_string( $inferred['goal'] ) ? $inferred['goal'] : '';
+		if ( 'portfolio' === $goal ) {
+			return true;
+		}
+
+		$niche = isset( $inferred['niche'] ) && is_string( $inferred['niche'] ) ? strtolower( $inferred['niche'] ) : '';
+		if ( '' === $niche ) {
+			return false;
+		}
+
+		$words = preg_split( '/[\s,&]+/', $niche, -1, PREG_SPLIT_NO_EMPTY );
+		return array() !== array_intersect( $words, self::GALLERY_NICHE_KEYWORDS );
+	}
+
+	/**
+	 * Builds the synthetic gallery-task entry, or null when it should not be offered.
+	 *
+	 * Completion is read from the status option (written by AI_Launchpad_Gallery_Page_Listener on publish); an
+	 * unpublished marker draft puts it in progress and reopens that draft.
+	 *
+	 * @param array $inferred The AI output's `inferred` block.
+	 * @return array|null
+	 */
+	private function build_gallery_task( $inferred ) {
+		if ( ! $this->should_offer_gallery_task( $inferred ) ) {
+			return null;
+		}
+
+		$statuses  = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$completed = ! empty( $statuses['add_gallery_page'] );
+
+		$in_progress  = false;
+		$calypso_path = null;
+		if ( ! $completed ) {
+			$draft_url = $this->get_in_progress_draft_url( 'add_gallery_page' );
+			if ( null !== $draft_url ) {
+				$in_progress  = true;
+				$calypso_path = $draft_url;
+			}
+		}
+
+		return array(
+			'id'           => 'add_gallery_page',
+			'subtitle'     => __( 'Show your work in a beautiful photo gallery.', 'jetpack-mu-wpcom' ),
+			'title'        => $this->get_task_title( 'add_gallery_page', $in_progress, __( 'Create your first gallery', 'jetpack-mu-wpcom' ) ),
+			'completed'    => $completed,
+			'in_progress'  => $in_progress,
+			'calypso_path' => $calypso_path,
+		);
+	}
+
+	/**
+	 * Inserts a synthetic task immediately before the trailing launch task (or appends it), idempotently by id.
+	 *
+	 * @param array $tasks The enriched task list.
+	 * @param array $task  The synthetic task entry.
+	 * @return array
+	 */
+	private function insert_before_launch_task( $tasks, $task ) {
+		foreach ( $tasks as $existing ) {
+			if ( isset( $existing['id'] ) && $existing['id'] === $task['id'] ) {
+				return $tasks;
+			}
+		}
+
+		$insert_at = count( $tasks );
+		foreach ( $tasks as $index => $existing ) {
+			if ( isset( $existing['id'] ) && in_array( $existing['id'], self::LAUNCH_TASK_IDS, true ) ) {
+				$insert_at = $index;
+				break;
+			}
+		}
+
+		array_splice( $tasks, $insert_at, 0, array( $task ) );
+		return $tasks;
+	}
+
+	/**
 	 * Resolves the editor URL of a site-editor task's in-progress draft, or null when there is none.
 	 *
 	 * The About page is found by its marker meta; the first-post tasks by the latest draft post. Returned as an
@@ -672,6 +783,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 		if ( 'add_about_page' === $task_id ) {
 			$draft_id = AI_Launchpad_About_Page_Listener::get_draft_id();
+		} elseif ( 'add_gallery_page' === $task_id ) {
+			$draft_id = AI_Launchpad_Gallery_Page_Listener::get_draft_id();
 		} elseif ( in_array( $task_id, self::IN_PROGRESS_FIRST_POST_TASK_IDS, true ) ) {
 			$draft_id = AI_Launchpad_First_Post_Listener::get_draft_id();
 		}
@@ -700,6 +813,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		switch ( $task_id ) {
 			case 'add_about_page':
 				return $in_progress ? __( 'Continue working on the About page', 'jetpack-mu-wpcom' ) : $default;
+			case 'add_gallery_page':
+				return $in_progress ? __( 'Continue working on your gallery', 'jetpack-mu-wpcom' ) : $default;
 			case 'first_post_published':
 				return $in_progress
 					? __( 'Continue to write your first post', 'jetpack-mu-wpcom' )

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { pickPattern, type PtkPattern } from './pattern-page.ts';
+import { pickPattern, selectPatternPage, type PtkPattern } from './pattern-page.ts';
 import type { TailoredInferred } from './types.ts';
 
 const inferred: TailoredInferred = {
@@ -46,5 +46,37 @@ describe( 'pickPattern', () => {
 
 	it( 'returns null when no pattern has HTML', () => {
 		assert.equal( pickPattern( [ { title: 'x' }, { title: 'y' } ], inferred ), null );
+	} );
+} );
+
+describe( 'selectPatternPage', () => {
+	const galleryPattern: PtkPattern = {
+		title: 'Gallery Page 1',
+		html: '<!-- wp:gallery --><figure></figure><!-- /wp:gallery -->',
+		categories: { c1: { slug: 'gallery', title: 'Gallery' } },
+	};
+	const aboutPattern: PtkPattern = {
+		title: 'About Hero',
+		html: '<p>about</p>',
+		categories: { c2: { slug: 'about', title: 'About' } },
+	};
+
+	it( 'gallery variant filters to the gallery category and sets the gallery marker', () => {
+		const result = selectPatternPage( [ aboutPattern, galleryPattern ], inferred, 'gallery' );
+		assert.equal( result.content, galleryPattern.html );
+		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
+	} );
+
+	it( 'gallery variant falls back to a bare gallery block when no gallery pattern exists', () => {
+		const result = selectPatternPage( [ aboutPattern ], inferred, 'gallery' );
+		assert.match( result.content, /wp:gallery/ );
+		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
+		assert.equal( result.title, 'Gallery' );
+	} );
+
+	it( 'about variant is unfiltered and sets the about marker', () => {
+		const result = selectPatternPage( [ aboutPattern, galleryPattern ], inferred, 'about' );
+		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_about_page' );
+		assert.equal( result.content, aboutPattern.html );
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
@@ -65,6 +65,8 @@ describe( 'selectPatternPage', () => {
 		const result = selectPatternPage( [ aboutPattern, galleryPattern ], inferred, 'gallery' );
 		assert.equal( result.content, galleryPattern.html );
 		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
+		// The title is fixed, not the matched pattern's name.
+		assert.equal( result.title, 'Gallery' );
 	} );
 
 	it( 'gallery variant falls back to a bare gallery block when no gallery pattern exists', () => {
@@ -72,6 +74,28 @@ describe( 'selectPatternPage', () => {
 		assert.match( result.content, /wp:gallery/ );
 		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
 		assert.equal( result.title, 'Gallery' );
+	} );
+
+	it( 'gallery variant strips an in-pattern heading that repeats the title', () => {
+		const withHeading: PtkPattern = {
+			title: 'Gallery Page 2',
+			html: '<!-- wp:heading --><h2 class="wp-block-heading">Gallery</h2><!-- /wp:heading -->\n<!-- wp:image --><figure></figure><!-- /wp:image -->',
+			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
+		};
+		const result = selectPatternPage( [ withHeading ], inferred, 'gallery' );
+		assert.equal( result.title, 'Gallery' );
+		assert.ok( ! /wp:heading/.test( result.content ), 'redundant heading removed' );
+		assert.ok( /wp:image/.test( result.content ), 'other blocks kept' );
+	} );
+
+	it( 'gallery variant keeps a heading whose text differs from the title', () => {
+		const withHeading: PtkPattern = {
+			title: 'Gallery Page 3',
+			html: '<!-- wp:heading --><h2 class="wp-block-heading">Featured work</h2><!-- /wp:heading -->',
+			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
+		};
+		const result = selectPatternPage( [ withHeading ], inferred, 'gallery' );
+		assert.ok( /Featured work/.test( result.content ), 'non-matching heading kept' );
 	} );
 
 	it( 'about variant is unfiltered and sets the about marker', () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -29,9 +29,10 @@ const VARIANT_CONFIG: Record< PatternVariant, { category: string | null; markerM
 	gallery: { category: 'gallery', markerMeta: '_wpcom_ai_launchpad_gallery_page' },
 };
 
-// An empty core/gallery block, used when the pattern library yields no gallery pattern.
+// An empty core/gallery block, used when the pattern library yields no gallery pattern. The class list mirrors
+// what the gallery block serializes (including the default flex layout) so the editor doesn't flag invalid markup.
 const GALLERY_FALLBACK_HTML =
-	'<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->';
+	'<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped is-layout-flex wp-block-gallery-is-layout-flex"></figure><!-- /wp:gallery -->';
 
 /**
  * Tokenize the inferred niche/vibe/audience into lowercase match words. Goal is
@@ -111,6 +112,25 @@ export function pickPattern(
 }
 
 /**
+ * Remove heading blocks whose visible text just repeats the page title, so a page
+ * with a separately-set title doesn't show that word again as an in-content heading.
+ *
+ * @param html  - The pattern block markup.
+ * @param title - The page title to de-duplicate against.
+ * @return The markup with matching heading blocks removed.
+ */
+function stripHeadingMatching( html: string, title: string ): string {
+	const target = title.trim().toLowerCase();
+	return html.replace( /<!-- wp:heading\b[^]*?<!-- \/wp:heading -->\s*/g, block => {
+		const text = block
+			.replace( /<[^>]*>/g, '' )
+			.trim()
+			.toLowerCase();
+		return text === target ? '' : block;
+	} );
+}
+
+/**
  * Choose the page title, block content, and marker meta for a pattern-page variant.
  *
  * The gallery variant filters the library to the `gallery` category before niche scoring and falls back to a bare
@@ -137,10 +157,14 @@ export function selectPatternPage(
 			  );
 	const pattern = pickPattern( pool, inferred );
 	const fallback = variant === 'gallery' ? GALLERY_FALLBACK_HTML : '';
+	// The gallery page gets a fixed title; the pattern's own name ("Gallery: Two columns…") is not a useful title.
+	const title =
+		variant === 'gallery' ? 'Gallery' : pattern?.title ?? inferred.brand_name ?? 'New page';
+	const rawContent = pattern?.html ?? fallback;
 	return {
-		title:
-			pattern?.title ?? inferred.brand_name ?? ( variant === 'gallery' ? 'Gallery' : 'New page' ),
-		content: pattern?.html ?? fallback,
+		title,
+		// Drop any in-pattern heading that just repeats the title, so the gallery page doesn't show "Gallery" twice.
+		content: variant === 'gallery' ? stripHeadingMatching( rawContent, title ) : rawContent,
 		markerMeta: config.markerMeta,
 	};
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -158,6 +158,8 @@ export function selectPatternPage(
 	const pattern = pickPattern( pool, inferred );
 	const fallback = variant === 'gallery' ? GALLERY_FALLBACK_HTML : '';
 	// The gallery page gets a fixed title; the pattern's own name ("Gallery: Two columns…") is not a useful title.
+	// Left untranslated on purpose: it's a placeholder on the created draft that the user renames before
+	// publishing (like WordPress core's English "Auto Draft"), not a piece of shipped UI copy.
 	const title =
 		variant === 'gallery' ? 'Gallery' : pattern?.title ?? inferred.brand_name ?? 'New page';
 	const rawContent = pattern?.html ?? fallback;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -22,6 +22,17 @@ interface CreatedPage {
 	id: number;
 }
 
+export type PatternVariant = 'about' | 'gallery';
+
+const VARIANT_CONFIG: Record< PatternVariant, { category: string | null; markerMeta: string } > = {
+	about: { category: null, markerMeta: '_wpcom_ai_launchpad_about_page' },
+	gallery: { category: 'gallery', markerMeta: '_wpcom_ai_launchpad_gallery_page' },
+};
+
+// An empty core/gallery block, used when the pattern library yields no gallery pattern.
+const GALLERY_FALLBACK_HTML =
+	'<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"></figure><!-- /wp:gallery -->';
+
 /**
  * Tokenize the inferred niche/vibe/audience into lowercase match words. Goal is
  * excluded: it describes intent, not topic, so it adds noise.
@@ -99,6 +110,41 @@ export function pickPattern(
 	return best;
 }
 
+/**
+ * Choose the page title, block content, and marker meta for a pattern-page variant.
+ *
+ * The gallery variant filters the library to the `gallery` category before niche scoring and falls back to a bare
+ * gallery block so the page always contains a gallery. The about variant is unfiltered (current behaviour).
+ *
+ * @param patterns - The fetched patterns.
+ * @param inferred - The AI-inferred site details.
+ * @param variant  - The pattern-page variant.
+ * @return The title, content HTML, and marker meta key.
+ */
+export function selectPatternPage(
+	patterns: PtkPattern[],
+	inferred: TailoredInferred,
+	variant: PatternVariant
+): { title: string; content: string; markerMeta: string } {
+	const config = VARIANT_CONFIG[ variant ];
+	const pool =
+		config.category === null
+			? patterns
+			: patterns.filter( pattern =>
+					termTitles( pattern.categories ).some( title =>
+						title.toLowerCase().includes( config.category as string )
+					)
+			  );
+	const pattern = pickPattern( pool, inferred );
+	const fallback = variant === 'gallery' ? GALLERY_FALLBACK_HTML : '';
+	return {
+		title:
+			pattern?.title ?? inferred.brand_name ?? ( variant === 'gallery' ? 'Gallery' : 'New page' ),
+		content: pattern?.html ?? fallback,
+		markerMeta: config.markerMeta,
+	};
+}
+
 // Cache the parsed PTK library in module scope; stays null on a failed fetch so a later click can retry.
 let cachedPatterns: PtkPattern[] | null = null;
 
@@ -107,10 +153,12 @@ let cachedPatterns: PtkPattern[] | null = null;
  * and create a draft page from it.
  *
  * @param inferred - The AI-inferred site details.
+ * @param variant  - The pattern-page variant.
  * @return The created page id and its editor URL.
  */
 export async function createPatternPage(
-	inferred: TailoredInferred
+	inferred: TailoredInferred,
+	variant: PatternVariant = 'about'
 ): Promise< { page_id: number; edit_url: string } > {
 	if ( cachedPatterns === null ) {
 		try {
@@ -122,20 +170,25 @@ export async function createPatternPage(
 				}
 			}
 		} catch {
-			// Network/parse failure: leave the cache unset so a later click retries; the page is still created below with empty content.
+			// Network/parse failure: leave the cache unset so a later click retries; the page is still created below.
 		}
 	}
-	const pattern = pickPattern( cachedPatterns ?? [], inferred );
+
+	const { title, content, markerMeta } = selectPatternPage(
+		cachedPatterns ?? [],
+		inferred,
+		variant
+	);
 
 	const page = ( await apiFetch( {
 		path: '/wp/v2/pages',
 		method: 'POST',
 		data: {
-			title: pattern?.title ?? inferred.brand_name ?? 'New page',
-			content: pattern?.html ?? '',
+			title,
+			content,
 			status: 'draft',
-			// Tag as the AI Launchpad About page so the server-side listener can complete add_about_page/update_about_page on publish or edit.
-			meta: { _wpcom_ai_launchpad_about_page: true },
+			// Tag as the AI Launchpad page so the server-side listener can complete the task on publish.
+			meta: { [ markerMeta ]: true },
 		},
 	} ) ) as CreatedPage;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -100,6 +100,12 @@ describe( 'ctaKind', () => {
 	} );
 } );
 
+describe( 'ctaKind gallery', () => {
+	it( 'routes add_gallery_page through the pattern-page flow', () => {
+		assert.equal( ctaKind( 'add_gallery_page' ), 'pattern_page' );
+	} );
+} );
+
 describe( 'toNavigableUrl', () => {
 	it( 'pins Calypso router paths to wordpress.com', () => {
 		assert.equal(
@@ -269,6 +275,27 @@ describe( 'resolveCtaUrl', () => {
 		);
 		assert.equal( url, '/wp-admin/post.php?post=2' );
 		assert.deepEqual( clicked, [ 'add_about_page' ] );
+	} );
+
+	it( 'passes the pattern variant keyed by task id', async () => {
+		const variants: ( string | undefined )[] = [];
+		const handlers = {
+			trackTaskClicked: () => {},
+			createFirstPostDraft: async () => ( { post_id: 1, edit_url: '/wp-admin/post.php?post=1' } ),
+			createPatternPage: async ( _inferred: TailoredOutput[ 'inferred' ], variant?: string ) => {
+				variants.push( variant );
+				return { page_id: 2, edit_url: '/wp-admin/post.php?post=2' };
+			},
+		};
+
+		await resolveCtaUrl(
+			task( { id: 'add_gallery_page', calypso_path: null } ),
+			fixture,
+			handlers
+		);
+		await resolveCtaUrl( task( { id: 'add_about_page', calypso_path: null } ), fixture, handlers );
+
+		assert.deepEqual( variants, [ 'gallery', 'about' ] );
 	} );
 
 	it( 'reopens the existing draft for an in-progress task instead of creating a new one', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -1,3 +1,4 @@
+import type { PatternVariant } from '../lib/pattern-page.ts';
 import type { TailoredInferred, TailoredOutput, FirstPostDraft } from '../lib/types.ts';
 
 /**
@@ -41,7 +42,7 @@ export interface LaunchpadData {
 export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
-const PATTERN_PAGE_TASK_IDS = [ 'add_about_page' ];
+const PATTERN_PAGE_TASK_IDS = [ 'add_about_page', 'add_gallery_page' ];
 // Launch tasks with no catalog deeplink: they open the wordpress.com launch
 // flow. woo_launch_site is excluded — it has its own deeplink.
 const LAUNCH_TASK_IDS = [
@@ -130,7 +131,8 @@ export interface CtaHandlers {
 		draft: FirstPostDraft
 	) => Promise< { post_id: number; edit_url: string } >;
 	createPatternPage: (
-		inferred: TailoredInferred
+		inferred: TailoredInferred,
+		variant?: PatternVariant
 	) => Promise< { page_id: number; edit_url: string } >;
 }
 
@@ -182,7 +184,8 @@ export async function resolveCtaUrl(
 	} else if ( kind === 'first_post' && output ) {
 		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
 	} else if ( kind === 'pattern_page' && output ) {
-		url = ( await handlers.createPatternPage( output.inferred ) ).edit_url;
+		const variant: PatternVariant = task.id === 'add_gallery_page' ? 'gallery' : 'about';
+		url = ( await handlers.createPatternPage( output.inferred, variant ) ).edit_url;
 	} else if ( kind === 'launch' ) {
 		url = siteUrl ? launchSiteUrl( siteUrl ) : null;
 	} else {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -202,13 +202,15 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 				} ).catch( () => {} );
 			}
 			if ( url ) {
+				// Keep the button busy through the page unload; clearing it here would flash
+				// the label back before the browser navigates, making the flow look stalled.
 				navigate( url );
+				return;
 			}
 		} catch {
-			// The finally clears busy so a thrown CTA can't leave the card disabled.
-		} finally {
-			setBusyId( null );
+			// Fall through to clear busy so a thrown CTA can't leave the card disabled.
 		}
+		setBusyId( null );
 	};
 
 	// Complete-on-click tasks with no CTA destination offer "Mark as complete":

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -37,6 +37,8 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 	switch ( taskId ) {
 		case 'site_theme_selected':
 			return __( 'Browse themes', 'jetpack-mu-wpcom' );
+		case 'add_gallery_page':
+			return __( 'Create gallery', 'jetpack-mu-wpcom' );
 		case 'woo_products':
 			return __( 'Add products', 'jetpack-mu-wpcom' );
 		case 'woo_customize_store':

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Gallery_Page_Listener_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Gallery_Page_Listener_Test.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Test class for AI_Launchpad_Gallery_Page_Listener.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/helpers.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-gallery-page-listener.php';
+
+/**
+ * Tests the gallery-page marker listener.
+ *
+ * @covers \AI_Launchpad_Gallery_Page_Listener
+ */
+#[CoversClass( AI_Launchpad_Gallery_Page_Listener::class )]
+class AI_Launchpad_Gallery_Page_Listener_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		\Brain\Monkey\setUp();
+		// This test suite never loads eligibility.php (same as AI_Launchpad_REST_Test), so stub the gate directly.
+		\Brain\Monkey\Functions\when( 'wpcom_ai_launchpad_is_eligible' )->justReturn( true );
+	}
+
+	/**
+	 * Reverting the testing environment to its original state.
+	 */
+	public function tear_down() {
+		\Brain\Monkey\tearDown();
+		parent::tear_down();
+	}
+
+	/**
+	 * Publishing a page carrying the gallery marker completes add_gallery_page.
+	 */
+	public function test_publishing_marked_page_completes_task() {
+		AI_Launchpad_Gallery_Page_Listener::register();
+		do_action( 'init' );
+
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'post_title'  => 'My gallery',
+			)
+		);
+		update_post_meta( $page_id, AI_Launchpad_Gallery_Page_Listener::META_KEY, true );
+
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$statuses = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$this->assertTrue( ! empty( $statuses['add_gallery_page'] ) );
+	}
+
+	/**
+	 * Publishing an unmarked page does not complete the task.
+	 */
+	public function test_publishing_unmarked_page_does_not_complete_task() {
+		AI_Launchpad_Gallery_Page_Listener::register();
+		do_action( 'init' );
+
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'post_title'  => 'Plain page',
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$statuses = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$this->assertArrayNotHasKey( 'add_gallery_page', $statuses );
+	}
+
+	/**
+	 * An ineligible site never completes the task, even for a marked page.
+	 */
+	public function test_ineligible_site_does_not_complete_task() {
+		\Brain\Monkey\Functions\when( 'wpcom_ai_launchpad_is_eligible' )->justReturn( false );
+		AI_Launchpad_Gallery_Page_Listener::register();
+		do_action( 'init' );
+
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'post_title'  => 'Gallery',
+			)
+		);
+		update_post_meta( $page_id, AI_Launchpad_Gallery_Page_Listener::META_KEY, true );
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$statuses = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$this->assertArrayNotHasKey( 'add_gallery_page', $statuses );
+	}
+
+	/**
+	 * Test that register_meta registers the marker meta for pages.
+	 */
+	public function test_registers_marker_meta() {
+		AI_Launchpad_Gallery_Page_Listener::register();
+		do_action( 'init' );
+
+		$this->assertTrue(
+			registered_meta_key_exists( 'post', AI_Launchpad_Gallery_Page_Listener::META_KEY, 'page' )
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -15,6 +15,8 @@ require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-la
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-about-page-listener.php';
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-gallery-page-listener.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-first-post-listener.php';
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-rest.php';
@@ -595,6 +597,111 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The gallery task is injected before the launch task for a portfolio goal, defaulting to todo.
+	 */
+	public function test_get_injects_gallery_task_for_portfolio_goal() {
+		wp_set_current_user( $this->admin_id );
+		// seed_gallery_output seeds [ site_title, site_launched ] — both reliably visible in the test env
+		// (unlike add_about_page, whose visibility gate needs extra meta registered).
+		$this->seed_gallery_output( 'portfolio', 'freelance work' );
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertContains( 'add_gallery_page', $ids );
+		// Injected immediately before the launch task.
+		$this->assertSame( array( 'site_title', 'add_gallery_page', 'site_launched' ), $ids );
+
+		$gallery = null;
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			if ( 'add_gallery_page' === $task['id'] ) {
+				$gallery = $task;
+			}
+		}
+		$this->assertSame( 'Create your first gallery', $gallery['title'] );
+		$this->assertFalse( $gallery['completed'] );
+		$this->assertFalse( $gallery['in_progress'] );
+	}
+
+	/**
+	 * The gallery task is injected for a photo/visual niche even when the goal is not portfolio.
+	 */
+	public function test_get_injects_gallery_task_for_photo_niche() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'build', 'wedding photography' );
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertContains( 'add_gallery_page', $ids );
+	}
+
+	/**
+	 * The gallery task is NOT injected for an unrelated goal + niche.
+	 */
+	public function test_get_omits_gallery_task_for_unrelated_site() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertNotContains( 'add_gallery_page', $ids );
+	}
+
+	/**
+	 * A completed gallery page marks the injected task done.
+	 */
+	public function test_get_marks_gallery_task_complete_from_status_option() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'portfolio', 'sculpture' );
+		update_option( 'launchpad_checklist_tasks_statuses', array( 'add_gallery_page' => true ) );
+
+		$gallery = null;
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			if ( 'add_gallery_page' === $task['id'] ) {
+				$gallery = $task;
+			}
+		}
+		$this->assertTrue( $gallery['completed'] );
+	}
+
+	/**
+	 * An unpublished gallery draft puts the injected task in progress and reopens that draft.
+	 */
+	public function test_get_marks_gallery_task_in_progress_with_draft() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'portfolio', 'sculpture' );
+
+		// The marker-meta draft lookup runs through WP_Query, which WorDBless can't execute, so short-circuit it with
+		// core's posts_pre_query filter to return a seeded draft id (mirrors the About-page in-progress test).
+		$draft_id = 4343;
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $draft_id ) {
+				if ( AI_Launchpad_Gallery_Page_Listener::META_KEY === $query->get( 'meta_key' ) ) {
+					return array( $draft_id );
+				}
+				return $posts;
+			},
+			10,
+			2
+		);
+
+		$gallery = null;
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			if ( 'add_gallery_page' === $task['id'] ) {
+				$gallery = $task;
+			}
+		}
+		$this->assertTrue( $gallery['in_progress'] );
+		$this->assertSame( admin_url( 'post.php?post=' . $draft_id . '&action=edit' ), $gallery['calypso_path'] );
+	}
+
+	/**
+	 * The gallery task is not injected on the ?all_tasks=1 catalog view.
+	 */
+	public function test_get_all_tasks_param_omits_gallery_task() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'portfolio', 'sculpture' );
+		$ids = array_column( $this->call_api( Requests::GET, '', null, array( 'all_tasks' => '1' ) )->get_data()['tasks'], 'id' );
+		$this->assertNotContains( 'add_gallery_page', $ids );
+	}
+
+	/**
 	 * Test that GET with ?all_tasks=1 returns the full catalog (a testing aid),
 	 * bypassing per-site visibility and not depending on any persisted AI output.
 	 */
@@ -1000,6 +1107,40 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 				'source'       => 'ai',
 				'generated_at' => 1717000000,
 				'payload'      => array( 'tasks' => $tasks ),
+			),
+			false
+		);
+	}
+
+	/**
+	 * Seed an AI output whose tasks end on a launch task, with the given inferred goal/niche.
+	 *
+	 * @param string $goal  The inferred goal.
+	 * @param string $niche The inferred niche.
+	 */
+	private function seed_gallery_output( $goal, $niche ) {
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'site_title',
+							'subtitle' => 'Name it.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array(
+						'goal'  => $goal,
+						'niche' => $niche,
+					),
+				),
 			),
 			false
 		);

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -633,6 +633,16 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * A hyphenated/compound niche still matches on its keyword tokens.
+	 */
+	public function test_get_injects_gallery_task_for_hyphenated_niche() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'build', 'wildlife-photography' );
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertContains( 'add_gallery_page', $ids );
+	}
+
+	/**
 	 * The gallery task is NOT injected for an unrelated goal + niche.
 	 */
 	public function test_get_omits_gallery_task_for_unrelated_site() {


### PR DESCRIPTION
Fixes #

## Proposed changes

Adds the AI Launchpad's first **synthetic task**: a "Create your first gallery" task that photography/portfolio sites get in their tailored onboarding list. It opens the editor pre-filled with a niche-scored gallery pattern and completes on publish, mirroring the About-page task. The task is never in the shared launchpad catalog or the AI `TASK_MENU` — it's injected read-side, so the shared catalog stays untouched.

* **Injection** (`AI_Launchpad_REST`): `should_offer_gallery_task()` offers `add_gallery_page` when the inferred goal is `portfolio` or the niche matches a small visual-work keyword set; `insert_before_launch_task()` splices it in just before the launch task. Only in the tailored view (not `?all_tasks=1`).
* **Completion** (`AI_Launchpad_Gallery_Page_Listener`): marker meta `_wpcom_ai_launchpad_gallery_page` on the created page; on first publish it writes the completion directly to `launchpad_checklist_tasks_statuses` (the synthetic id isn't in the shared catalog, so `wpcom_mark_launchpad_task_complete()` would drop it). In-progress "Continue…" reopens the existing draft.
* **Pattern selection** (`pattern-page.ts`): a `gallery` variant filters the PTK library to the Gallery category, scores by niche, and falls back to a bare gallery block. The page gets a fixed **"Gallery"** title (not the pattern's own name), and any in-pattern heading that just repeats the title is stripped so "Gallery" isn't shown twice.
* **CTA spinner fix**: the get-started handler cleared its busy state in a `finally` that ran right after `window.location.href` was set, so the button briefly flashed back to its label before navigating. It now holds the spinner through the page unload for every create-post/page CTA.

## Related product discussion/links

* Linear: DOTCOM-17737 (parent DSGCOM-678)
* Stacked on #50127 (DOTCOM-17736) — base will retarget to `trunk` once that merges.

## Does this pull request change what data or activity we track or use?

No. The task reuses the existing AI Launchpad tracking; no new data is collected.

## Testing instructions

* On an AI-onboarded paid/Atomic site, enable the AI Launchpad and ensure the inferred niche/goal is visual (e.g. niche "photography", or goal "portfolio").
* Go to **wp-admin → AI Launchpad**. Confirm a **"Create your first gallery"** task appears before the launch task.
* Click **Create gallery** — the spinner should hold until the editor opens on a gallery page titled **"Gallery"** with a gallery pattern (no duplicate "Gallery" heading).
* Publish the page, return to the AI Launchpad, and confirm the task shows as completed.
* Save a gallery draft without publishing, reload the list, and confirm the task shows **"Continue…"** and reopens that draft rather than creating a new one.
