### PR TITLE
Premium Analytics: port Stats Referrers widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-referrers-widget
+++ b/projects/packages/premium-analytics/changelog/add-pa-referrers-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Referrers widget to the Premium Analytics dashboard: a ranked leaderboard of the websites and search engines referring visitors, with drill-down into referrer groups and sources, backed by the Jetpack Stats API.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -218,8 +218,9 @@ const MOCK_CLICKS_COMPARISON = {
 
 // Exercises every referrer shape the widget renders: a multi-source group that
 // drills down twice (group → source → domain), a single-result group (which the
-// normalizer flattens into the result itself), and childless domains that
-// render as display-only rows (label + favicon, no outbound links).
+// normalizer flattens into the result itself), and childless domains with URLs
+// that render as outbound links (label + favicon), while rows with children
+// drill down.
 const MOCK_REFERRERS = {
 	date: '2026-06-29',
 	period: 'day',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -216,6 +216,197 @@ const MOCK_CLICKS_COMPARISON = {
 	},
 };
 
+// Exercises every referrer shape the widget renders: a multi-source group that
+// drills down twice (group → source → domain), a single-result group (which the
+// normalizer flattens into the result itself), and childless domains that
+// render as display-only rows (label + favicon, no outbound links).
+const MOCK_REFERRERS = {
+	date: '2026-06-29',
+	period: 'day',
+	days: {},
+	summary: {
+		groups: [
+			{
+				group: 'Search Engines',
+				name: 'Search Engines',
+				icon: 'https://www.google.com/s2/favicons?domain=google.com&sz=32',
+				total: 4801,
+				results: [
+					{
+						name: 'Google Search',
+						icon: 'https://www.google.com/s2/favicons?domain=google.com&sz=32',
+						views: 3936,
+						children: [
+							{
+								name: 'google.com',
+								url: 'https://www.google.com/',
+								views: 3760,
+							},
+							{
+								name: 'google.co.uk',
+								url: 'https://www.google.co.uk/',
+								views: 176,
+							},
+						],
+					},
+					{
+						name: 'Bing',
+						icon: 'https://www.google.com/s2/favicons?domain=bing.com&sz=32',
+						views: 542,
+						children: [
+							{
+								name: 'bing.com',
+								url: 'https://www.bing.com/',
+								views: 542,
+							},
+						],
+					},
+					{
+						name: 'DuckDuckGo',
+						icon: 'https://www.google.com/s2/favicons?domain=duckduckgo.com&sz=32',
+						views: 323,
+						children: [
+							{
+								name: 'duckduckgo.com',
+								url: 'https://duckduckgo.com/',
+								views: 323,
+							},
+						],
+					},
+				],
+			},
+			{
+				group: 'WordPress.com Reader',
+				name: 'WordPress.com Reader',
+				icon: 'https://www.google.com/s2/favicons?domain=wordpress.com&sz=32',
+				total: 1240,
+				results: [
+					{
+						name: 'WordPress.com Reader',
+						url: 'https://wordpress.com/read',
+						views: 1240,
+					},
+				],
+			},
+			{
+				group: 'twitter.com',
+				name: 'twitter.com',
+				url: 'https://twitter.com/',
+				icon: 'https://www.google.com/s2/favicons?domain=twitter.com&sz=32',
+				total: 920,
+				results: { views: 920 },
+			},
+			{
+				group: 'linkedin.com',
+				name: 'linkedin.com',
+				url: 'https://www.linkedin.com/',
+				icon: 'https://www.google.com/s2/favicons?domain=linkedin.com&sz=32',
+				total: 610,
+				results: { views: 610 },
+			},
+			{
+				group: 'news.ycombinator.com',
+				name: 'news.ycombinator.com',
+				url: 'https://news.ycombinator.com/',
+				total: 480,
+				results: { views: 480 },
+			},
+		],
+		other_views: 120,
+		total_views: 8171,
+	},
+};
+
+const MOCK_REFERRERS_COMPARISON = {
+	date: '2026-05-30',
+	period: 'day',
+	days: {},
+	summary: {
+		groups: [
+			{
+				group: 'Search Engines',
+				name: 'Search Engines',
+				icon: 'https://www.google.com/s2/favicons?domain=google.com&sz=32',
+				total: 4160,
+				results: [
+					{
+						name: 'Google Search',
+						icon: 'https://www.google.com/s2/favicons?domain=google.com&sz=32',
+						views: 3410,
+						children: [
+							{
+								name: 'google.com',
+								url: 'https://www.google.com/',
+								views: 3280,
+							},
+							{
+								name: 'google.co.uk',
+								url: 'https://www.google.co.uk/',
+								views: 130,
+							},
+						],
+					},
+					{
+						name: 'Bing',
+						icon: 'https://www.google.com/s2/favicons?domain=bing.com&sz=32',
+						views: 480,
+						children: [
+							{
+								name: 'bing.com',
+								url: 'https://www.bing.com/',
+								views: 480,
+							},
+						],
+					},
+					{
+						name: 'DuckDuckGo',
+						icon: 'https://www.google.com/s2/favicons?domain=duckduckgo.com&sz=32',
+						views: 270,
+						children: [
+							{
+								name: 'duckduckgo.com',
+								url: 'https://duckduckgo.com/',
+								views: 270,
+							},
+						],
+					},
+				],
+			},
+			{
+				group: 'WordPress.com Reader',
+				name: 'WordPress.com Reader',
+				icon: 'https://www.google.com/s2/favicons?domain=wordpress.com&sz=32',
+				total: 1390,
+				results: [
+					{
+						name: 'WordPress.com Reader',
+						url: 'https://wordpress.com/read',
+						views: 1390,
+					},
+				],
+			},
+			{
+				group: 'twitter.com',
+				name: 'twitter.com',
+				url: 'https://twitter.com/',
+				icon: 'https://www.google.com/s2/favicons?domain=twitter.com&sz=32',
+				total: 1050,
+				results: { views: 1050 },
+			},
+			{
+				group: 'linkedin.com',
+				name: 'linkedin.com',
+				url: 'https://www.linkedin.com/',
+				icon: 'https://www.google.com/s2/favicons?domain=linkedin.com&sz=32',
+				total: 540,
+				results: { views: 540 },
+			},
+		],
+		other_views: 90,
+		total_views: 7230,
+	},
+};
+
 const MOCK_FILE_DOWNLOADS_FILES = [
 	{
 		relative_url: '/annual-report-2025.pdf',
@@ -775,6 +966,10 @@ function getStatsMock( path: string ): unknown | null {
 
 	if ( subPath.startsWith( '/clicks' ) ) {
 		return isComparison ? MOCK_CLICKS_COMPARISON : MOCK_CLICKS;
+	}
+
+	if ( subPath.startsWith( '/referrers' ) ) {
+		return isComparison ? MOCK_REFERRERS_COMPARISON : MOCK_REFERRERS;
 	}
 
 	if ( subPath.startsWith( '/file-downloads' ) ) {

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -114,6 +114,39 @@ describe( 'ReferrersWidget', () => {
 
 		await expect( screen.findByText( 'jetpack.com' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: /all referrers/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'resets the drill-down to the top level when the date range changes', async () => {
+		const { rerender } = render(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		const groupButton = await screen.findByRole( 'button', {
+			name: /view referrers for search engines/i,
+		} );
+
+		fireEvent.click( groupButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+		await expect(
+			screen.findByRole( 'button', { name: /view all referrers/i } )
+		).resolves.toBeInTheDocument();
+
+		// A new date range loads a different report; the stale drill path should clear.
+		rerender(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-30-days' ) } }
+			/>
+		);
+
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'button', { name: /view all referrers/i } )
+			).not.toBeInTheDocument()
+		);
+		await expect(
+			screen.findByRole( 'button', { name: /view referrers for search engines/i } )
+		).resolves.toBeInTheDocument();
 	} );
 
 	it( 'renders childless referrers as plain rows without outbound links', async () => {

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -149,15 +149,16 @@ describe( 'ReferrersWidget', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
-	it( 'renders childless referrers as plain rows without outbound links', async () => {
+	it( 'renders childless referrers with a URL as outbound links that open in a new tab', async () => {
 		render(
 			<ReferrersWidget
 				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
 			/>
 		);
 
-		await expect( screen.findByText( 'jetpack.com' ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		const link = await screen.findByRole( 'link', { name: /jetpack\.com/i } );
+		expect( link ).toHaveAttribute( 'href', 'https://jetpack.com/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import ReferrersWidget, { toReferrerRows } from '../render';
+import type { StatsNormalizedReport, StatsReferrersItem } from '@jetpack-premium-analytics/data';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const REFERRERS_RESPONSE = {
+	date: '2026-06-29',
+	days: {},
+	summary: {
+		groups: [
+			{
+				group: 'Search Engines',
+				name: 'Search Engines',
+				icon: 'https://wordpress.com/i/stats/search-engine.png',
+				total: 4801,
+				results: [
+					{
+						name: 'Google Search',
+						icon: 'https://www.google.com/s2/favicons?domain=google.com&sz=32',
+						views: 3936,
+						children: [
+							{
+								name: 'google.com',
+								url: 'https://www.google.com/',
+								views: 3920,
+							},
+						],
+					},
+					{
+						name: 'Bing',
+						icon: 'https://www.google.com/s2/favicons?domain=bing.com&sz=32',
+						views: 542,
+						children: [
+							{
+								name: 'bing.com',
+								url: 'https://www.bing.com/',
+								views: 523,
+							},
+						],
+					},
+				],
+			},
+			{
+				group: 'jetpack.com',
+				name: 'jetpack.com',
+				url: 'https://jetpack.com/',
+				total: 18,
+				results: { views: 18 },
+			},
+		],
+		other_views: 0,
+		total_views: 4819,
+	},
+};
+
+describe( 'ReferrersWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( REFERRERS_RESPONSE );
+	} );
+
+	it( 'drills down through nested referrer groups and navigates back', async () => {
+		render(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		const groupButton = await screen.findByRole( 'button', {
+			name: /view referrers for search engines/i,
+		} );
+
+		fireEvent.click( groupButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		// Second level: sources inside the group can drill down again, and the
+		// back link points at the full top-level list.
+		await expect(
+			screen.findByRole( 'button', { name: /all referrers/i } )
+		).resolves.toBeInTheDocument();
+		const sourceButton = await screen.findByRole( 'button', {
+			name: /view referrers for google search/i,
+		} );
+
+		fireEvent.click( sourceButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		// Third level: leaf domains render as plain text and the back link is
+		// labelled after the parent list.
+		await expect( screen.findByText( 'google.com' ) ).resolves.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: /search engines/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		// Back at the second level, going back again returns to the top list.
+		await expect(
+			screen.findByRole( 'button', { name: /view referrers for google search/i } )
+		).resolves.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: /all referrers/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'jetpack.com' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /all referrers/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders childless referrers as plain rows without outbound links', async () => {
+		render(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		await expect( screen.findByText( 'jetpack.com' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'toReferrerRows', () => {
+	it( 'merges comparison values by scoped key before slicing primary rows', () => {
+		const primary = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29 00:00:00',
+					date_end: '2026-06-29 23:59:59',
+					items: [
+						{
+							label: 'Search Engines',
+							views: 4801,
+							link: null,
+							icon: 'https://example.com/search-engine.png',
+							labelIcon: null,
+							children: [
+								{
+									label: 'Google Search',
+									views: 3936,
+									link: null,
+									icon: 'https://example.com/google.png',
+									labelIcon: null,
+									children: [
+										{
+											label: 'google.com',
+											views: 3920,
+											link: 'https://www.google.com/',
+											icon: null,
+											labelIcon: 'external',
+											children: null,
+										},
+									],
+								},
+							],
+						},
+						{
+							label: 'jetpack.com',
+							views: 18,
+							link: 'https://jetpack.com/',
+							icon: null,
+							labelIcon: 'external',
+							children: null,
+						},
+					] satisfies StatsReferrersItem[],
+				},
+			],
+		} satisfies StatsNormalizedReport< StatsReferrersItem >;
+
+		const comparison = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-22',
+					date_start: '2026-06-22 00:00:00',
+					date_end: '2026-06-22 23:59:59',
+					items: [
+						{
+							label: 'Search Engines',
+							views: 4100,
+							link: null,
+							icon: 'https://example.com/search-engine.png',
+							labelIcon: null,
+							children: [
+								{
+									label: 'Google Search',
+									views: 3300,
+									link: null,
+									icon: 'https://example.com/google.png',
+									labelIcon: null,
+									children: [
+										{
+											label: 'google.com',
+											views: 3290,
+											link: 'https://www.google.com/',
+											icon: null,
+											labelIcon: 'external',
+											children: null,
+										},
+									],
+								},
+							],
+						},
+					] satisfies StatsReferrersItem[],
+				},
+			],
+		} satisfies StatsNormalizedReport< StatsReferrersItem >;
+
+		expect( toReferrerRows( primary, comparison, 1 ) ).toEqual( [
+			{
+				label: 'Search Engines',
+				value: 4801,
+				previousValue: 4100,
+				href: undefined,
+				icon: 'https://example.com/search-engine.png',
+				children: [
+					{
+						label: 'Google Search',
+						value: 3936,
+						previousValue: 3300,
+						href: undefined,
+						icon: 'https://example.com/google.png',
+						children: [
+							{
+								label: 'google.com',
+								value: 3920,
+								previousValue: 3290,
+								href: 'https://www.google.com/',
+								icon: 'https://example.com/google.png',
+								children: undefined,
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
+
+	it( 'keeps all rows when max is 0', () => {
+		const report = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29 00:00:00',
+					date_end: '2026-06-29 23:59:59',
+					items: [
+						{
+							label: 'a.com',
+							views: 2,
+							link: 'https://a.com/',
+							icon: null,
+							labelIcon: 'external',
+							children: null,
+						},
+						{
+							label: 'b.com',
+							views: 1,
+							link: 'https://b.com/',
+							icon: null,
+							labelIcon: 'external',
+							children: null,
+						},
+					] satisfies StatsReferrersItem[],
+				},
+			],
+		} satisfies StatsNormalizedReport< StatsReferrersItem >;
+
+		expect( toReferrerRows( report, undefined, 0 ) ).toHaveLength( 2 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -99,8 +99,8 @@ describe( 'ReferrersWidget', () => {
 
 		fireEvent.click( sourceButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
 
-		// Third level: leaf domains render as plain text and the back link is
-		// labelled after the parent list.
+		// Third level: URL-backed leaf domains render as outbound links and the
+		// back link is labelled after the parent list.
 		await expect( screen.findByText( 'google.com' ) ).resolves.toBeInTheDocument();
 
 		fireEvent.click( screen.getByRole( 'button', { name: /search engines/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.

--- a/projects/packages/premium-analytics/widgets/referrers/package.json
+++ b/projects/packages/premium-analytics/widgets/referrers/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-referrers",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.0.1",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
+		"@wordpress/widget-primitives": "next"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/referrers/package.json
+++ b/projects/packages/premium-analytics/widgets/referrers/package.json
@@ -6,10 +6,10 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
-		"@wordpress/element": "8.0.1",
+		"@wordpress/element": "8.2.0",
 		"@wordpress/i18n": "^6.9.0",
-		"@wordpress/icons": "^13.0.0",
-		"@wordpress/ui": "0.13.0",
-		"@wordpress/widget-primitives": "next"
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -368,14 +368,16 @@ function ReferrersInner( { max }: { max: number } ) {
 	);
 
 	const goBack = useCallback( () => {
-		const nextPath = ( drillPath ?? [] ).slice( 0, -1 );
+		// Step back from the resolved trail, not the raw drillPath, so a refetch
+		// that dropped the deepest row still moves the view back one visible level.
+		const nextPath = trail.slice( 0, -1 ).map( row => row.label );
 
 		if ( nextPath.length ) {
 			setDrillPath( nextPath );
 		} else {
 			resetDrillDown();
 		}
-	}, [ drillPath, setDrillPath, resetDrillDown ] );
+	}, [ trail, setDrillPath, resetDrillDown ] );
 
 	// The back link is labelled after the list it returns to: the parent row
 	// one level up, or the full top-level list. The visible label stays short

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -369,17 +369,25 @@ function ReferrersInner( { max }: { max: number } ) {
 	}, [ drillPath, setDrillPath, resetDrillDown ] );
 
 	// The back link is labelled after the list it returns to: the parent row
-	// one level up, or the full top-level list.
-	const backLabel =
-		trail.length > 1
-			? trail[ trail.length - 2 ].label
-			: __( 'All referrers', 'jetpack-premium-analytics' );
+	// one level up, or the full top-level list. The visible label stays short
+	// while the accessible name spells out the action.
+	const parentLabel = trail.length > 1 ? trail[ trail.length - 2 ].label : null;
+	const backLabel = parentLabel ?? __( 'All referrers', 'jetpack-premium-analytics' );
+	const backAriaLabel = parentLabel
+		? sprintf(
+				/* translators: %s is the parent referrer group or source label. */
+				__( 'Back to %s', 'jetpack-premium-analytics' ),
+				parentLabel
+		  )
+		: __( 'View all referrers', 'jetpack-premium-analytics' );
 
 	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
 
 	return (
-		<>
-			{ trail.length > 0 && <WidgetBackLink label={ backLabel } onClick={ goBack } /> }
+		<div className={ styles.content }>
+			{ trail.length > 0 && (
+				<WidgetBackLink label={ backLabel } ariaLabel={ backAriaLabel } onClick={ goBack } />
+			) }
 			<ReferrersLeaderboard
 				rows={ activeRows }
 				isLoading={ showLoading }
@@ -389,7 +397,7 @@ function ReferrersInner( { max }: { max: number } ) {
 				legendLabels={ legendLabels }
 				onDrillDown={ drillInto }
 			/>
-		</>
+		</div>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -13,14 +13,12 @@ import {
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	calculateDelta,
-	formatLegendLabels,
 	useWidgetDrillDown,
 	useWidgetRootContext,
 	type LeaderboardChartData,
-	type LegendLabels,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 /**
@@ -243,8 +241,6 @@ export type ReferrersLeaderboardProps = {
 	isLoading?: boolean;
 	isError?: boolean;
 	withComparison?: boolean;
-	showLegend?: boolean;
-	legendLabels?: LegendLabels;
 	onDrillDown?: ( row: ReferrerRow ) => void;
 };
 
@@ -256,8 +252,6 @@ export type ReferrersLeaderboardProps = {
  * @param props.isLoading      - When true, show a loading overlay.
  * @param props.isError        - When true, show an error message.
  * @param props.withComparison - When true, render comparison deltas.
- * @param props.showLegend     - When true, show the period legend below the chart.
- * @param props.legendLabels   - Custom legend labels for the current/comparison periods.
  * @param props.onDrillDown    - Callback fired when a row with child referrers is selected.
  * @return The rendered leaderboard.
  */
@@ -266,8 +260,6 @@ export function ReferrersLeaderboard( {
 	isLoading = false,
 	isError = false,
 	withComparison = false,
-	showLegend = false,
-	legendLabels,
 	onDrillDown,
 }: ReferrersLeaderboardProps ) {
 	if ( isError ) {
@@ -288,8 +280,7 @@ export function ReferrersLeaderboard( {
 			loading={ isLoading }
 			withComparison={ withComparison }
 			withOverlayLabel
-			showLegend={ showLegend }
-			legendLabels={ legendLabels }
+			showLegend={ false }
 			emptyStateText={ __( 'No referrers in this period.', 'jetpack-premium-analytics' ) }
 			dataFormat={ DATA_FORMAT }
 		/>
@@ -328,6 +319,14 @@ function ReferrersInner( { max }: { max: number } ) {
 		drillDown: setDrillPath,
 		resetDrillDown,
 	} = useWidgetDrillDown< string[] >();
+
+	// Changing the dashboard date range loads a different set of referrers, so
+	// any drill-down path from the previous range no longer makes sense — return
+	// to the top-level list. Keyed on the range only, so background refetches and
+	// comparison toggles keep the current drill position.
+	useEffect( () => {
+		resetDrillDown();
+	}, [ reportParams.from, reportParams.to, resetDrillDown ] );
 
 	// Resolve the path against the current rows each render, so a refetch that
 	// drops a selected row falls back to the deepest level that still exists.
@@ -381,8 +380,6 @@ function ReferrersInner( { max }: { max: number } ) {
 		  )
 		: __( 'View all referrers', 'jetpack-premium-analytics' );
 
-	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
-
 	return (
 		<div className={ styles.content }>
 			{ trail.length > 0 && (
@@ -393,8 +390,6 @@ function ReferrersInner( { max }: { max: number } ) {
 				isLoading={ showLoading }
 				isError={ isError }
 				withComparison={ hasComparison }
-				showLegend={ hasComparison }
-				legendLabels={ legendLabels }
 				onDrillDown={ drillInto }
 			/>
 		</div>

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -20,7 +20,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Stack, Text } from '@wordpress/ui';
+import { Link, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -49,8 +49,8 @@ export type ReferrerRow = {
 	 */
 	previousValue?: number;
 	/**
-	 * External referrer URL. Kept for row identity and comparison matching;
-	 * the widget does not render outbound links.
+	 * External referrer URL. Used for row identity, comparison matching, and to
+	 * render leaf rows (no children) as an outbound link.
 	 */
 	href?: string;
 	/**
@@ -208,11 +208,21 @@ function buildLeaderboardData(
 	return rows.map( ( row, index ) => {
 		const previousValue = row.previousValue ?? 0;
 		const hasChildren = !! row.children?.length;
+		const shouldRenderLink = !! row.href && ! hasChildren;
 
 		return {
 			id: `${ index }-${ row.href ?? row.label }`,
-			// Rows are display-only: label and favicon, never an outbound link.
-			label: (
+			label: shouldRenderLink ? (
+				<Link
+					className={ styles.labelLink }
+					href={ row.href }
+					variant="unstyled"
+					openInNewTab
+					title={ row.label }
+				>
+					<ReferrerLabel row={ row } />
+				</Link>
+			) : (
 				<span className={ styles.labelText } title={ row.label }>
 					<ReferrerLabel row={ row } />
 				</span>

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -1,0 +1,419 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsReferrers,
+	type StatsNormalizedReport,
+	type StatsReferrersItem,
+	type StatsReportParams,
+} from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	WidgetBackLink,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	calculateDelta,
+	formatLegendLabels,
+	useWidgetDrillDown,
+	useWidgetRootContext,
+	type LeaderboardChartData,
+	type LegendLabels,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import type { ReferrersAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type ReferrersRenderAttributes = ReferrersAttributes & Partial< ReportParamsFieldAttributes >;
+
+const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
+
+/**
+ * A single normalized referrer row, ready for the leaderboard.
+ */
+export type ReferrerRow = {
+	/**
+	 * Referrer group, source, or domain label.
+	 */
+	label: string;
+	/**
+	 * View count for the selected period.
+	 */
+	value: number;
+	/**
+	 * View count for the comparison period.
+	 */
+	previousValue?: number;
+	/**
+	 * External referrer URL. Kept for row identity and comparison matching;
+	 * the widget does not render outbound links.
+	 */
+	href?: string;
+	/**
+	 * Optional favicon URL.
+	 */
+	icon?: string | null;
+	/**
+	 * Child referrers for drill-down. Referrer groups can nest twice
+	 * (e.g. Search Engines → Google Search → google.com).
+	 */
+	children?: ReferrerRow[];
+};
+
+function getItemLabel( item: StatsReferrersItem ): string {
+	if ( typeof item.label === 'string' && item.label ) {
+		return item.label;
+	}
+
+	return item.link ?? '';
+}
+
+type NormalizedReferrerItem = {
+	key: string;
+	label: string;
+	value: number;
+	previousValue: number;
+	href?: string;
+	icon?: string | null;
+	children?: NormalizedReferrerItem[];
+};
+
+// Keys are scoped by the parent chain so same-named rows at different drill
+// levels (e.g. a "google.com" group and a "google.com" child of Google Search)
+// don't collide in the comparison lookup.
+function getItemKey( item: StatsReferrersItem, parentKey?: string ): string {
+	const ownKey = item.link ?? getItemLabel( item );
+
+	return parentKey ? `${ parentKey } > ${ ownKey }` : ownKey;
+}
+
+function buildReferrerItemLookup(
+	items: StatsReferrersItem[],
+	parentKey?: string
+): Map< string, StatsReferrersItem > {
+	const lookup = new Map< string, StatsReferrersItem >();
+
+	items.forEach( item => {
+		const key = getItemKey( item, parentKey );
+		lookup.set( key, item );
+		buildReferrerItemLookup( item.children ?? [], key ).forEach( ( value, childKey ) => {
+			lookup.set( childKey, value );
+		} );
+	} );
+
+	return lookup;
+}
+
+function normalizeReferrerItem(
+	item: StatsReferrersItem,
+	comparisonLookup: Map< string, StatsReferrersItem >,
+	parent?: { key: string; icon?: string | null }
+): NormalizedReferrerItem {
+	const key = getItemKey( item, parent?.key );
+	const children = ( item.children ?? [] ).map( child =>
+		normalizeReferrerItem( child, comparisonLookup, { key, icon: item.icon ?? parent?.icon } )
+	);
+
+	return {
+		key,
+		label: getItemLabel( item ),
+		value: item.views,
+		previousValue: comparisonLookup.get( key )?.views ?? 0,
+		href: item.link ?? undefined,
+		icon: item.icon ?? parent?.icon,
+		children: children.length ? sortReferrerItems( children ) : undefined,
+	};
+}
+
+function sortReferrerItems( items: NormalizedReferrerItem[] ): NormalizedReferrerItem[] {
+	return [ ...items ].sort( ( a, b ) => b.value - a.value );
+}
+
+function toReferrerRow( item: NormalizedReferrerItem ): ReferrerRow {
+	return {
+		label: item.label,
+		value: item.value,
+		previousValue: item.previousValue,
+		href: item.href,
+		icon: item.icon,
+		children: item.children?.map( toReferrerRow ),
+	};
+}
+
+function getItems(
+	report: StatsNormalizedReport< StatsReferrersItem > | undefined
+): StatsReferrersItem[] {
+	return report?.data.flatMap( point => point.items ) ?? [];
+}
+
+/**
+ * Flattens a normalized referrers report into `ReferrerRow[]` and attaches
+ * matching comparison values when a comparison report is present.
+ *
+ * @param report           - Primary referrers report.
+ * @param comparisonReport - Comparison referrers report.
+ * @param max              - Maximum rows to keep. 0 keeps all rows.
+ * @return Rows ready for the leaderboard.
+ */
+export function toReferrerRows(
+	report: StatsNormalizedReport< StatsReferrersItem > | undefined,
+	comparisonReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
+	max: number
+): ReferrerRow[] {
+	const comparisonLookup = buildReferrerItemLookup( getItems( comparisonReport ) );
+	const sorted = sortReferrerItems(
+		getItems( report ).map( item => normalizeReferrerItem( item, comparisonLookup ) )
+	);
+	const sliced = max > 0 ? sorted.slice( 0, max ) : sorted;
+
+	return sliced.map( toReferrerRow );
+}
+
+function ReferrerLabel( { row }: { row: ReferrerRow } ) {
+	return (
+		<span className={ styles.labelContent }>
+			{ /* The fixed-size box (not the img) owns the favicon dimensions: the
+			     widget-picker preview grid stretches raw `img` elements to 100%,
+			     so sizing the parent keeps the icon 16px in both contexts. */ }
+			{ row.icon && (
+				<span className={ styles.labelIconBox }>
+					<img src={ row.icon } alt="" className={ styles.labelIcon } />
+				</span>
+			) }
+			<span className={ styles.labelTitle }>{ row.label }</span>
+		</span>
+	);
+}
+
+/**
+ * Maps normalized referrer rows onto the shape `LeaderboardChart` expects.
+ *
+ * @param rows           - Normalized referrer rows.
+ * @param withComparison - Whether to include comparison values and deltas.
+ * @param onDrillDown    - Callback fired when a row with child referrers is selected.
+ * @return Leaderboard chart data.
+ */
+function buildLeaderboardData(
+	rows: ReferrerRow[],
+	withComparison: boolean,
+	onDrillDown?: ( row: ReferrerRow ) => void
+): LeaderboardChartData {
+	const maxCurrentViews = Math.max( ...rows.map( row => row.value ), 1 );
+	const maxPreviousViews = Math.max( ...rows.map( row => row.previousValue ?? 0 ), 1 );
+
+	return rows.map( ( row, index ) => {
+		const previousValue = row.previousValue ?? 0;
+		const hasChildren = !! row.children?.length;
+
+		return {
+			id: `${ index }-${ row.href ?? row.label }`,
+			// Rows are display-only: label and favicon, never an outbound link.
+			label: (
+				<span className={ styles.labelText } title={ row.label }>
+					<ReferrerLabel row={ row } />
+				</span>
+			),
+			currentValue: row.value,
+			currentShare: ( row.value / maxCurrentViews ) * 100,
+			previousValue,
+			previousShare:
+				withComparison && previousValue > 0 ? ( previousValue / maxPreviousViews ) * 100 : 0,
+			delta: withComparison ? calculateDelta( row.value, previousValue ) : 0,
+			...( hasChildren &&
+				onDrillDown && {
+					onClick: () => onDrillDown( row ),
+					ariaLabel: sprintf(
+						/* translators: %s is the referrer group or domain label. */
+						__( 'View referrers for %s', 'jetpack-premium-analytics' ),
+						row.label
+					),
+				} ),
+		};
+	} );
+}
+
+export type ReferrersLeaderboardProps = {
+	rows?: ReferrerRow[];
+	isLoading?: boolean;
+	isError?: boolean;
+	withComparison?: boolean;
+	showLegend?: boolean;
+	legendLabels?: LegendLabels;
+	onDrillDown?: ( row: ReferrerRow ) => void;
+};
+
+/**
+ * Presentational leaderboard for the Referrers widget.
+ *
+ * @param props                - Component props.
+ * @param props.rows           - Normalized referrer rows.
+ * @param props.isLoading      - When true, show a loading overlay.
+ * @param props.isError        - When true, show an error message.
+ * @param props.withComparison - When true, render comparison deltas.
+ * @param props.showLegend     - When true, show the period legend below the chart.
+ * @param props.legendLabels   - Custom legend labels for the current/comparison periods.
+ * @param props.onDrillDown    - Callback fired when a row with child referrers is selected.
+ * @return The rendered leaderboard.
+ */
+export function ReferrersLeaderboard( {
+	rows = [],
+	isLoading = false,
+	isError = false,
+	withComparison = false,
+	showLegend = false,
+	legendLabels,
+	onDrillDown,
+}: ReferrersLeaderboardProps ) {
+	if ( isError ) {
+		return (
+			<Stack align="center" justify="center" className={ styles.placeholder }>
+				<Text>{ __( 'Unable to load referrers.', 'jetpack-premium-analytics' ) }</Text>
+			</Stack>
+		);
+	}
+
+	if ( isLoading && rows.length === 0 ) {
+		return <WidgetLoadingOverlay />;
+	}
+
+	return (
+		<LeaderboardChart
+			data={ buildLeaderboardData( rows, withComparison, onDrillDown ) }
+			loading={ isLoading }
+			withComparison={ withComparison }
+			withOverlayLabel
+			showLegend={ showLegend }
+			legendLabels={ legendLabels }
+			emptyStateText={ __( 'No referrers in this period.', 'jetpack-premium-analytics' ) }
+			dataFormat={ DATA_FORMAT }
+		/>
+	);
+}
+
+function ReferrersInner( { max }: { max: number } ) {
+	const { reportParams } = useWidgetRootContext();
+	const statsParams = {
+		...reportParams,
+		max,
+	} as StatsReportParams;
+	const { primary, comparison, hasComparison, isLoading, isFetching, hasData, isError } =
+		useStatsReferrers( statsParams );
+	const showLoading = isLoading || ( isFetching && hasData );
+
+	const comparisonReport = comparison.data as
+		| StatsNormalizedReport< StatsReferrersItem >
+		| undefined;
+
+	const rows = useMemo(
+		() =>
+			toReferrerRows(
+				primary.data as StatsNormalizedReport< StatsReferrersItem > | undefined,
+				comparisonReport,
+				max
+			),
+		[ primary.data, comparisonReport, max ]
+	);
+
+	// Referrer groups nest twice (group → source → domain), so the drill-down
+	// selection is a path of row labels rather than a single row. The shared
+	// hook stores the whole path; append/pop happens here.
+	const {
+		drillDownItem: drillPath,
+		drillDown: setDrillPath,
+		resetDrillDown,
+	} = useWidgetDrillDown< string[] >();
+
+	// Resolve the path against the current rows each render, so a refetch that
+	// drops a selected row falls back to the deepest level that still exists.
+	const trail = useMemo( () => {
+		const matched: ReferrerRow[] = [];
+		let level = rows;
+
+		for ( const label of drillPath ?? [] ) {
+			const row = level.find( candidate => candidate.label === label );
+
+			if ( ! row?.children?.length ) {
+				break;
+			}
+
+			matched.push( row );
+			level = row.children;
+		}
+
+		return matched;
+	}, [ rows, drillPath ] );
+
+	const activeRows = trail.length ? trail[ trail.length - 1 ].children ?? [] : rows;
+
+	const drillInto = useCallback(
+		( row: ReferrerRow ) => {
+			setDrillPath( [ ...( drillPath ?? [] ), row.label ] );
+		},
+		[ drillPath, setDrillPath ]
+	);
+
+	const goBack = useCallback( () => {
+		const nextPath = ( drillPath ?? [] ).slice( 0, -1 );
+
+		if ( nextPath.length ) {
+			setDrillPath( nextPath );
+		} else {
+			resetDrillDown();
+		}
+	}, [ drillPath, setDrillPath, resetDrillDown ] );
+
+	// The back link is labelled after the list it returns to: the parent row
+	// one level up, or the full top-level list.
+	const backLabel =
+		trail.length > 1
+			? trail[ trail.length - 2 ].label
+			: __( 'All referrers', 'jetpack-premium-analytics' );
+
+	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	return (
+		<>
+			{ trail.length > 0 && <WidgetBackLink label={ backLabel } onClick={ goBack } /> }
+			<ReferrersLeaderboard
+				rows={ activeRows }
+				isLoading={ showLoading }
+				isError={ isError }
+				withComparison={ hasComparison }
+				showLegend={ hasComparison }
+				legendLabels={ legendLabels }
+				onDrillDown={ drillInto }
+			/>
+		</>
+	);
+}
+
+/**
+ * Referrers widget render component.
+ *
+ * Shows the websites and search engines referring visitors as a ranked
+ * leaderboard. Date range comes from the shared dashboard date picker via
+ * WidgetRoot. Referrer groups drill down into their sources and domains.
+ *
+ * @param props            - Render props.
+ * @param props.attributes - Widget attributes.
+ * @return The rendered widget content.
+ */
+export default function ReferrersWidget( {
+	attributes = {},
+}: WidgetRenderProps< ReferrersRenderAttributes > ) {
+	const max = attributes?.max ?? 10;
+
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<div className={ styles.root }>
+				<ReferrersInner max={ max } />
+			</div>
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -82,7 +82,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Referrers" widget. Shows the websites and search engines referring visitors to the site as a ranked leaderboard, using the global dashboard date range. Referrer groups drill down into their sources and domains; rows are display-only (label and favicon, no outbound links).',
+					'The "Referrers" widget. Shows the websites and search engines referring visitors to the site as a ranked leaderboard, using the global dashboard date range. Referrer groups drill down into their sources and domains; URL-backed leaf rows (no children) render as outbound links that open in a new tab, while rows that drill down remain buttons.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import ReferrersRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+registerStatsMocks();
+
+const REFERRERS_RENDER_MODULE = 'storybook/referrers';
+
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+};
+
+interface ReferrersStoryControls {
+	withComparison: boolean;
+}
+
+interface ReferrersDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		ReferrersStoryControls {}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '340px' } }>
+		<Story />
+	</div>
+);
+
+function renderReferrersWidget( { withComparison }: ReferrersStoryControls ) {
+	return (
+		<ReferrersRender
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+function ReferrersDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: ReferrersDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ REFERRERS_RENDER_MODULE }
+			renderComponent={ ReferrersRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Referrers',
+	component: ReferrersRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Referrers" widget. Shows the websites and search engines referring visitors to the site as a ranked leaderboard, using the global dashboard date range. Referrer groups drill down into their sources and domains; rows are display-only (label and favicon, no outbound links).',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof ReferrersRender > & ReferrersStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< ReferrersStoryControls >;
+type DashboardStory = StoryObj< ReferrersDashboardStoryProps >;
+
+export const Default: Story = {
+	render: renderReferrersWidget,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+export const WithComparison: Story = {
+	render: renderReferrersWidget,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+export const WidgetDashboardWithWidget: DashboardStory = {
+	render: args => <ReferrersDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -19,8 +19,8 @@
 	object-fit: cover;
 }
 
+.labelLink,
 .labelText {
-	display: block;
 	padding-block: var(--wpds-dimension-padding-md, 12px);
 	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
 	overflow: hidden;
@@ -28,6 +28,21 @@
 	text-decoration: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.labelLink {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-xs, 4px);
+}
+
+.labelText {
+	display: block;
+}
+
+.labelLink:hover .labelTitle,
+.labelLink:focus .labelTitle {
+	text-decoration: underline;
 }
 
 .labelTitle {

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -1,0 +1,61 @@
+.labelContent {
+	display: inline-flex;
+	align-items: center;
+	min-inline-size: 0;
+	max-inline-size: 100%;
+	gap: var(--wpds-dimension-gap-xs, 4px);
+}
+
+.labelIconBox {
+	flex: 0 0 auto;
+	inline-size: 16px;
+	block-size: 16px;
+}
+
+.labelIcon {
+	inline-size: 16px;
+	block-size: 16px;
+	border-radius: var(--wpds-border-radius-sm);
+	object-fit: cover;
+}
+
+.labelText {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.labelTitle {
+	min-inline-size: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.placeholder {
+	flex: 1 1 0;
+	inline-size: 100%;
+	min-block-size: 200px;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	text-align: center;
+}
+
+.root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+}
+
+:global([inert]:not([inert="true"])) .root {
+	height: auto;
+	aspect-ratio: 4 / 3;
+	overflow: hidden;
+}
+

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -46,11 +46,20 @@
 }
 
 .root {
+	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
 	min-height: 0;
 	overflow: hidden;
+}
+
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
 }
 
 :global([inert]:not([inert="true"])) .root {

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -56,7 +56,7 @@
 	flex: 1 1 0;
 	inline-size: 100%;
 	min-block-size: 200px;
-	color: var(--wpds-color-fg-content-neutral-weak);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
 }
 

--- a/projects/packages/premium-analytics/widgets/referrers/widget.json
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/referrers",
+	"title": "Referrers",
+	"description": "Websites and search engines referring visitors to your site.",
+	"category": "traffic",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/referrers/widget.ts
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.ts
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+
+/**
+ * Configurable attributes for the Referrers widget.
+ */
+export type ReferrersAttributes = {
+	/**
+	 * Maximum rows to display. 0 means all rows returned by the API.
+	 */
+	max?: number;
+};
+
+/**
+ * Referrers widget type definition.
+ *
+ * Shows the websites and search engines referring visitors for the selected
+ * dashboard date range via the PA proxy at `stats/referrers`.
+ */
+export default {
+	name: 'jpa/referrers',
+	title: __( 'Referrers', 'jetpack-premium-analytics' ),
+	icon: globe,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer' as const,
+		},
+	],
+	example: {
+		attributes: {
+			max: 10,
+		},
+	},
+};


### PR DESCRIPTION
Fixes WOOA7S-1490

https://github.com/user-attachments/assets/50731ecd-979a-4776-b3f5-e9d23098aea0


## Proposed changes

Ports the Jetpack Stats **Referrers** module into Premium Analytics as the `jpa/referrers` widget.

- Adds the Referrers widget: a ranked leaderboard of websites and search engines referring visitors, backed by the Jetpack Stats API via the existing `useStatsReferrers` data hook.
- Supports two-level drill-down (e.g. Search Engines → Google Search → google.com), with scoped row keys so same-named rows at different levels don't collide.
- Consumes the shared `WidgetBackLink` component and `useWidgetDrillDown` hook already in `widgets-toolkit` for nested leaderboard widgets; the back link renders in the widget body while the host frame keeps the title static.
- Merges comparison-period values by scoped key before slicing primary rows, so deltas survive ordering differences between periods.
- Renders URL-backed childless referrers as outbound links that open in a new tab (matching legacy Stats), while rows that drill down remain buttons.
- Handles `max = 0` as "all rows", plus loading, empty, and error states per the widget guidelines.
- Adds Stats referrers fixtures to the Storybook mocks (`register-stats-mocks.ts`).
- Adds `Default`, `WithComparison`, and `WidgetDashboardWithWidget` stories.
- Adds JS unit coverage for drill-down navigation, URL-backed leaf links, comparison merging, and `max` semantics.

## Related product discussion/links

- WOOA7S-1490

## Does this pull request change what data or activity we track or use?

No. This reads existing Jetpack Stats referrers data through the existing Premium Analytics stats data layer.

## Testing instructions

Run focused checks:

```bash
pnpm --dir projects/packages/premium-analytics exec jest --config=tests/jest.config.cjs widgets/referrers/__tests__/referrers.test.tsx
pnpm --dir projects/packages/premium-analytics run typecheck
```

In Storybook:

1. Open `Packages/Premium Analytics/Widgets/Referrers`.
2. Confirm `Default`, `WithComparison`, and `WidgetDashboardWithWidget` render correctly.
3. Drill into a referrer group (e.g. Search Engines), then into a source, and use the back link to return each level.
4. Confirm comparison deltas appear in `WithComparison`.

On a Jetpack-connected test site with referrer traffic:

1. Open **Premium Analytics** and add the **Referrers** widget from the picker.
2. Confirm referrers render as ranked rows with view counts and favicons.
3. Drill into a group with nested sources and navigate back with the back link.
4. Confirm URL-backed childless referrers render as links that open in a new tab.
5. Select a date range with no referrer data and confirm the empty state appears.
