### PR TITLE
Stylelint: report & clean needless disables

### DIFF
--- a/projects/js-packages/components/changelog/update-stylelint-report-needless-disables
+++ b/projects/js-packages/components/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/js-packages/components/components/number-slider/style.scss
+++ b/projects/js-packages/components/components/number-slider/style.scss
@@ -5,7 +5,7 @@ $track-height: 8px;
 
 @mixin adjust-track-rail-styles {
 	height: $track-height;
-	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	border-radius: 8px;
 }
 
 // On holding thumb styling

--- a/projects/js-packages/social-previews/changelog/update-stylelint-report-needless-disables
+++ b/projects/js-packages/social-previews/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/js-packages/social-previews/src/bluesky-preview/post/header/styles.scss
+++ b/projects/js-packages/social-previews/src/bluesky-preview/post/header/styles.scss
@@ -7,7 +7,6 @@
 
 	margin-bottom: 0.625rem;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem;
 	line-height: 1.47;
 

--- a/projects/js-packages/social-previews/src/bluesky-preview/styles.scss
+++ b/projects/js-packages/social-previews/src/bluesky-preview/styles.scss
@@ -23,7 +23,6 @@
 	color: vars.$bluesky-preview-text-color;
 
 	font-family: vars.$bluesky-preview-font-family;
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem;
 	line-height: 1.47;
 

--- a/projects/js-packages/social-previews/src/facebook-preview/post/actions/styles.scss
+++ b/projects/js-packages/social-previews/src/facebook-preview/post/actions/styles.scss
@@ -13,7 +13,6 @@
 	color: vars.$facebook-preview-light-text-color;
 	list-style-type: none;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem; // 15px
 	font-weight: 600;
 	line-height: 1.33;

--- a/projects/js-packages/social-previews/src/facebook-preview/post/header/styles.scss
+++ b/projects/js-packages/social-previews/src/facebook-preview/post/header/styles.scss
@@ -28,7 +28,6 @@
 .facebook-preview__post-header-name {
 	color: vars.$facebook-preview-text-color;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem; // 15px
 	font-weight: 600;
 	line-height: 1.33;
@@ -42,7 +41,6 @@
 }
 
 .facebook-preview__post-header-time {
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.8125rem; // 13px
 	line-height: 1.23;
 }

--- a/projects/js-packages/social-previews/src/facebook-preview/style.scss
+++ b/projects/js-packages/social-previews/src/facebook-preview/style.scss
@@ -27,7 +27,6 @@
 
 	color: vars.$facebook-preview-text-color;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem; // 15px
 	line-height: 1.33;
 	overflow-wrap: break-word;
@@ -78,7 +77,6 @@
 
 	color: vars.$facebook-preview-light-text-color;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.8125rem; // 13px
 	line-height: 1;
 	text-transform: uppercase;
@@ -87,7 +85,6 @@
 .facebook-preview__title {
 	margin: 0.25rem 0 0.125rem;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9444rem; // 17px
 	font-weight: 600;
 	line-height: 1.18;
@@ -96,7 +93,6 @@
 .facebook-preview__description {
 	color: vars.$facebook-preview-light-text-color;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem; // 15px
 	line-height: 1.33;
 

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/card/styles.scss
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/card/styles.scss
@@ -56,7 +56,6 @@
 .mastodon-preview__card-title {
 	color: #282c37;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 1.187rem;
 	font-weight: 700;
 	line-height: 1.4;

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/header/styles.scss
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/header/styles.scss
@@ -5,7 +5,6 @@
 
 	margin-bottom: 0.625rem;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem;
 	line-height: 1.47;
 }

--- a/projects/js-packages/social-previews/src/mastodon-preview/styles.scss
+++ b/projects/js-packages/social-previews/src/mastodon-preview/styles.scss
@@ -17,7 +17,6 @@
 	color: vars.$mastodon-preview-text-color;
 
 	font-family: vars.$mastodon-preview-font-family;
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem;
 	line-height: 1.47;
 

--- a/projects/js-packages/social-previews/src/threads-preview/style.scss
+++ b/projects/js-packages/social-previews/src/threads-preview/style.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable scales/radii */
 @use "./variables" as vars;
 
 .threads-preview {

--- a/projects/js-packages/social-previews/src/tumblr-preview/styles.scss
+++ b/projects/js-packages/social-previews/src/tumblr-preview/styles.scss
@@ -48,7 +48,6 @@
 	margin: 0 0 1rem 0;
 	padding: 0 vars.$tumblr-preview-card-inline-padding;
 
-	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 1.625rem; // 26px
 	font-weight: 400;
 	line-height: 1.3;

--- a/projects/js-packages/social-previews/src/tumblr-preview/variables.scss
+++ b/projects/js-packages/social-previews/src/tumblr-preview/variables.scss
@@ -5,7 +5,6 @@ $tumblr-preview-background-color: #fff;
 $tumblr-preview-action-text-color: rgba(0, 0, 0, 0.65);
 $tumblr-preview-font-family: "Favorit", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
 $tumblr-preview-border-radius: 8px;
-/* stylelint-disable-next-line scales/radii */
 $tumblr-preview-window-border-radius: 6px;
 $tumblr-preview-border: solid 1px rgba(194, 123, 123, 0.15);
 $tumblr-preview-card-inline-padding: 1.25rem;

--- a/projects/js-packages/social-previews/src/twitter-preview/style.scss
+++ b/projects/js-packages/social-previews/src/twitter-preview/style.scss
@@ -96,7 +96,7 @@
 		}
 
 		.twitter-preview__media {
-			border-radius: 15px; /* stylelint-disable-line scales/radii */
+			border-radius: 15px;
 			overflow: hidden;
 			display: grid;
 			gap: 2px;
@@ -163,7 +163,7 @@
 			margin-bottom: 12px;
 			overflow: hidden;
 			border: 1px solid #e1e8ed;
-			border-radius: 12px; /* stylelint-disable-line scales/radii */
+			border-radius: 12px;
 
 			.twitter-preview__card-summary {
 				display: grid;

--- a/projects/packages/backup/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/backup/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/style.scss
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/style.scss
@@ -8,14 +8,13 @@
 	> div {
 		height: 100%;
 		width: 100%;
-		border-radius: 12px; /* stylelint-disable-line scales/radii */
+		border-radius: 12px;
 		background-color: var(--jp-gray-5);
 
 		// WP ProgressBar Indicator (the progress fill)
 		> div {
 			// Unless we're 100% full, the left side of the bar
 			// is rounded and the right side is flat
-			/* stylelint-disable-next-line scales/radii */
 			border-radius: 12px 0 0 12px;
 
 			// We always expect some amount of used storage,
@@ -46,7 +45,7 @@
 		&.full-warning > div {
 			max-width: initial;
 			background-color: var(--jp-red-40);
-			border-radius: 12px; /* stylelint-disable-line scales/radii */
+			border-radius: 12px;
 		}
 	}
 }

--- a/projects/packages/forms/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/forms/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -864,9 +864,6 @@
 				border-radius: unset !important;
 				padding: 0 4px;
 				transition: border 150ms linear;
-				// For some reason, when keeping the rule below together with the above
-				// selector, on production builds, the attributes are being reordered,
-				// causing side-effects.
 				border-left: none !important;
 				border-right: none !important;
 				box-sizing: content-box;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -867,7 +867,6 @@
 				// For some reason, when keeping the rule below together with the above
 				// selector, on production builds, the attributes are being reordered,
 				// causing side-effects.
-				// stylelint-disable-next-line no-duplicate-selectors
 				border-left: none !important;
 				border-right: none !important;
 				box-sizing: content-box;

--- a/projects/packages/forms/src/dashboard/_mixins.scss
+++ b/projects/packages/forms/src/dashboard/_mixins.scss
@@ -14,7 +14,6 @@
 	margin-bottom: 97px;
 
 	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		margin-bottom: 57px;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-global-styles/src/global-styles-sidebar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-global-styles/src/global-styles-sidebar.scss
@@ -2,7 +2,6 @@
 	// Make the font dropdown a bit more spacy.
 	.components-select-control__input {
 		line-height: 1;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 18px;
 		height: 36px;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/style.scss
@@ -28,7 +28,6 @@
 
 		h1 {
 			margin-top: 0;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 2.25rem;
 
 			@include mixins.break-small {
@@ -73,7 +72,6 @@
 			}
 
 			> p {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				font-size: 1rem;
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/event-countdown/event-countdown.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/event-countdown/event-countdown.scss
@@ -5,7 +5,6 @@
 
 	.event-countdown__counter {
 		text-transform: uppercase;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 16px;
 		font-weight: 600;
 	}
@@ -18,14 +17,12 @@
 
 	.event-countdown__counter span strong {
 		margin-right: 8px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 24px;
 	}
 
 	.event-countdown__day {
 		line-height: 1;
-		font-weight: 900; /* stylelint-disable-line scales/font-weights */
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-weight: 900;
 		font-size: 56px;
 		display: block;
 	}
@@ -47,7 +44,6 @@
 	.event-countdown__counter.event-countdown__counter-stopped p,
 	.event-countdown__counter.event-countdown__counter-stopped span,
 	.event-countdown__counter.event-countdown__counter-stopped strong {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 100%;
 		display: inline;
 
@@ -64,7 +60,6 @@
 	}
 
 	.event-countdown__event-title {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 36px;
 	}
 }
@@ -75,17 +70,14 @@
 	.wp-block-jetpack-event-countdown {
 
 		.event-countdown__counter span strong {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 36px;
 		}
 
 		.event-countdown__day {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 96px;
 		}
 
 		.event-countdown__event-title {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 48px;
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notice.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notice.scss
@@ -87,7 +87,6 @@
 	&.wpcom-global-styles-action-is-external::after {
 		content: "";
 		margin-left: 4px;
-		/* stylelint-disable-next-line function-url-quotes */
 		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='15' height='15' aria-hidden='true' focusable='false'%3E%3Cpath d='M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z'%3E%3C/path%3E%3C/svg%3E");
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -119,7 +119,6 @@
 				bottom: 0;
 				background-color: #ccc;
 				transition: 0.4s;
-				/* stylelint-disable-next-line scales/radii */
 				border-radius: 18px;
 
 				&::before {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/_mixins.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/_mixins.scss
@@ -18,7 +18,6 @@
 	gap: calc(var(--spacing-base) * 6);
 
 	@media only screen and (max-width: 1366px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		padding-inline: calc(var(--spacing-base) * 3);
 	}
 }
@@ -30,7 +29,6 @@
 	flex: 1;
 
 	@media screen and (min-width: 960px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		max-width: 70%;
 	}
 
@@ -57,7 +55,6 @@
 	justify-content: flex-end;
 
 	@media only screen and (max-width: 430px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		flex: 1;
 	}
 }
@@ -75,14 +72,11 @@
 	width: 168px;
 
 	@media only screen and (max-width: 960px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		width: 30vw;
 	}
 
 	@media only screen and (max-width: 430px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		width: 100%;
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		min-width: 168px;
 	}
 
@@ -130,9 +124,7 @@
 		padding-bottom: calc(var(--spacing-base) * 8);
 
 		@media only screen and (max-width: 960px) {
-			/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 			padding-top: calc(var(--spacing-base) * 6);
-			/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 			padding-bottom: calc(var(--spacing-base) * 6);
 		}
 	}
@@ -150,7 +142,6 @@
 	margin: 0 auto;
 
 	@media only screen and (max-width: 1366px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		padding-inline: calc(var(--spacing-base) * 3);
 	}
 }
@@ -163,7 +154,6 @@
 	margin: 0 auto;
 
 	@media only screen and (max-width: 1366px) {
-		/* stylelint-disable-next-line no-invalid-position-declaration -- Ok in a sass mixin. */
 		padding-inline: calc(var(--spacing-base) * 3);
 	}
 }

--- a/projects/packages/my-jetpack/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/my-jetpack/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/premium-analytics/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/premium-analytics/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.scss
@@ -14,7 +14,6 @@
 }
 
 /* disable animation for the date range popover */
-/* stylelint-disable property-no-unknown, selector-pseudo-element-no-unknown */
 @media not ( prefers-reduced-motion: reduce ) {
 
 	.date-comparison-dropdown__popover {
@@ -33,4 +32,3 @@
 ::view-transition-old(jp-premium-analytics--date-comparison-dropdown) {
 	animation: none;
 }
-/* stylelint-enable property-no-unknown, selector-pseudo-element-no-unknown */

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
@@ -85,7 +85,6 @@
 }
 
 /* disable animation for the date range popover */
-/* stylelint-disable property-no-unknown, selector-pseudo-element-no-unknown */
 @media not ( prefers-reduced-motion: reduce ) {
 
 	.date-filters-panel__popover {
@@ -103,4 +102,3 @@
 ::view-transition-old(jp-premium-analytics--date-range-popover) {
 	animation: none;
 }
-/* stylelint-enable property-no-unknown, selector-pseudo-element-no-unknown */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.module.scss
@@ -1,7 +1,6 @@
 .chart {
 	// Override visx-bar default styles that break the layout
 	// Todo: address upstream in Charts package.
-	/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 	:global(.visx-bar) {
 		// All corners rounded to handle both positive and negative bar
 		// values consistently.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.module.scss
@@ -18,7 +18,6 @@
 // Override visx-tooltip ONLY when our custom tooltip components are used.
 // This applies to ChartTooltip (line/bar) and PieChartTooltip
 // (pie/semi-circle).
-/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 :global(.visx-tooltip):has(.tooltip) {
 	max-width: none !important;
 	box-shadow: none !important;

--- a/projects/packages/search/changelog/update-stylelint-report-needless-disables
+++ b/projects/packages/search/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Stylelint: Remove needless disables.

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
@@ -188,8 +188,8 @@
 		// Reset everything browsers add by default — !important fights theme
 		// styles that try to re-style native inputs.
 		margin: 0;
-		padding: 0 !important; // stylelint-disable-line declaration-no-important
-		border: 0 !important; // stylelint-disable-line declaration-no-important
+		padding: 0 !important;
+		border: 0 !important;
 		outline: none;
 		background: transparent;
 		-webkit-appearance: none;

--- a/projects/plugins/jetpack/changelog/update-stylelint-report-needless-disables
+++ b/projects/plugins/jetpack/changelog/update-stylelint-report-needless-disables
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Stylelint: Remove needless disables.

--- a/projects/plugins/jetpack/extensions/shared/memberships.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships.scss
@@ -1,5 +1,4 @@
 /* Additional styling to thickbox that displays modal */
-/* stylelint-disable selector-max-id */
 
 @keyframes jetpack-memberships_button__spinner-animation {
 

--- a/projects/plugins/jetpack/extensions/shared/memberships.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships.scss
@@ -1,5 +1,3 @@
-/* Additional styling to thickbox that displays modal */
-
 @keyframes jetpack-memberships_button__spinner-animation {
 
 	100% {

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
  */
 const baseConfig = {
 	extends: fileURLToPath( import.meta.resolve( '@wordpress/stylelint-config/scss-stylistic' ) ),
+	reportNeedlessDisables: true,
 	rules: {
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Enable `reportNeedlessDisables: true` for Stylelint: it turns these stale comments into CI failures instead of letting them accumulate.
* Clean out needless disables

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->


<details>
  <summary>See an AI-produced summary for each rule.</summary>
Here is a rule-by-rule breakdown of why those disables were added originally, and why `reportNeedlessDisables` correctly flagged them as dead weight.

The common thread matches [Gutenberg #79788](https://github.com/WordPress/gutenberg/pull/79788): most were workarounds for **older Stylelint versions or older `@wordpress/stylelint-config` rules that no longer fire** on the current toolchain (Stylelint 17 + `@wordpress/stylelint-config` 23.x).

---

### `scales/radii`

**Why added:** A legacy WordPress Stylelint plugin (`scales/radii`) required `border-radius` values to match the Gutenberg design scale (`$radius-small`, `$radius-medium`, etc.). Raw values like `8px`, `12px`, or `15px` were flagged.

**Where it showed up:** number-slider, social previews (threads/tumblr/twitter), backup storage meter, wpcom-global-styles toggle.

**Why not needed anymore:** The `scales/*` plugin rules were **removed from `@wordpress/stylelint-config`** during the Stylelint 15→17 migration. Jetpack extends `scss-stylistic`, which no longer enables them. The comments outlived the rule.

---

### `scales/font-sizes`

**Why added:** Same `scales/*` family — enforced the WordPress admin typography scale. Social preview components intentionally use platform-specific sizes (e.g. Facebook’s 15px / `0.9375rem`) that don’t match Gutenberg tokens.

**Where it showed up:** bluesky, facebook, mastodon, tumblr previews.

**Why not needed anymore:** Same as `scales/radii` — the rule is **gone from the active config**. Those pixel-perfect sizes are still valid CSS; only the lint enforcement disappeared.

---

### `scales/font-weights`

**Why added:** Enforced allowed font-weight values from the design scale. `font-weight: 900` on the event-countdown block was outside what the rule accepted.

**Where it showed up:** `event-countdown.scss`.

**Why not needed anymore:** Another retired `scales/*` rule — no longer part of the config.

---

### `no-invalid-position-declaration`

**Why added:** A relatively new core Stylelint rule (added in v16.11) that flags declarations in invalid positions within a rule block. It **false-positived heavily in SCSS mixins**, where properties inside `@media` blocks get expanded into output Stylelint couldn’t reason about correctly. Comments explicitly said “Ok in a sass mixin.”

**Where it showed up:** forms `_mixins.scss`, my-jetpack product-interstitial `_mixins.scss` (10 instances).

**Why not needed anymore:** Stylelint fixed mixin false positives ([#9120](https://github.com/stylelint/stylelint/pull/9120)). Declarations like `margin-bottom` inside a mixin’s `@media` block are now understood correctly.

---

### `selector-max-id`

**Why added:** Limits ID selectors (`#foo`), which WordPress coding standards discourage. `memberships.scss` had a **file-level** disable, likely from when it styled Thickbox modal IDs (`#TB_*`).

**Where it showed up:** `memberships.scss`.

**Why not needed anymore:** The file was refactored to classes and `<dialog>` — **there are no ID selectors left**. The blanket disable was leftover from old Thickbox integration.

---

### `no-duplicate-selectors`

**Why added:** Flags when the same selector appears twice in a file. In the contact-form editor, `border-left: none !important` was split into a **separate nested rule** as a workaround for production CSS attribute reordering (comment in the file explains this). That structural split created a duplicate-selector pattern Stylelint flagged.

**Where it showed up:** `contact-form/editor.scss`.

**Why not needed anymore:** Stylelint 17 improved `no-duplicate-selectors` handling (including `ignoreSelectors` support and fewer false positives). The workaround structure no longer triggers the rule.

---

### `function-url-quotes`

**Why added:** `@wordpress/stylelint-config` sets `function-url-quotes: 'never'`. Disables were added for **quoted `url()` values** in inline SVG data URLs (`mask-image: url("data:image/svg+xml,...")`), where quotes are often required for parsing.

**Where it showed up:** `wpcom-global-styles/notice.scss`.

**Why not needed anymore:** Newer Stylelint / config versions handle quoted data URLs correctly, or the specific `mask-image` usage no longer violates the rule. Gutenberg removed the same disable in [#79788](https://github.com/WordPress/gutenberg/pull/79788) for identical `mask-image` patterns.

---

### `declaration-property-unit-allowed-list`

**Why added:** WordPress config restricts units on certain properties (historically centered on `line-height: px` only). Disables were sprinkled on `font-size` declarations using `px`, `rem`, or `%` in wpcom blocks — likely copied from an era when the rule was broader, or from a misunderstanding of which properties it targets.

**Where it showed up:** event-countdown, global-styles-sidebar, recommended-tags-modal.

**Why not needed anymore:** The current `@wordpress/stylelint-config` only restricts **`line-height`**, not `font-size`. Those `font-size` disables were suppressing a rule that **never applied to those declarations**.

---

### `property-no-unknown` + `selector-pseudo-element-no-unknown`

**Why added:** Stylelint didn’t recognize **View Transitions API** syntax when premium-analytics added popover animations:
- `view-transition-name`
- `::view-transition-group()`, `::view-transition-new()`, `::view-transition-old()`

**Where it showed up:** `date-comparison-dropdown.scss`, `date-range-filter.scss`.

**Why not needed anymore:** Stylelint’s built-in known-property and pseudo-element lists were updated to include View Transitions. The same change landed in Gutenberg core around the same time.

---

### `declaration-no-important`

**Why added:** Stylelint discourages `!important` as a maintainability smell. The WC price filter slider uses `!important` on `padding` and `border` to **reset native range input styles** that themes override.

**Where it showed up:** `filter-wc-price/style.scss`.

**Why not needed anymore:** `declaration-no-important` is **not enabled** in Jetpack’s effective config chain (`@wordpress/stylelint-config/scss-stylistic` + Jetpack overrides). The inline disables were guarding a rule that isn’t active.

---

### `selector-pseudo-class-no-unknown`

**Why added:** Flags unrecognized pseudo-classes. **CSS Modules’ `:global()`** pseudo-class isn’t standard CSS, so Stylelint flagged `:global(.visx-bar)` and `:global(.visx-tooltip):has(.tooltip)`.

**Where it showed up:** premium-analytics chart-bar and chart-tooltip modules.

**Why not needed anymore:** Jetpack’s base config already whitelists it:

```63:68:tools/js-tools/stylelint.config.base.mjs
		'selector-pseudo-class-no-unknown': [
			true,
			{
				ignorePseudoClasses: [ 'export', 'global' ], // Ignore pseudo-classes used by CSS Modules.
			},
		],
```

The per-file disables predated (or duplicated) that central config.

---

### Summary table

| Rule | Original reason | Why obsolete now |
|---|---|---|
| `scales/radii` | Enforce Gutenberg radius tokens | Rule removed from `@wordpress/stylelint-config` |
| `scales/font-sizes` | Enforce typography scale | Rule removed; social previews need custom sizes anyway |
| `scales/font-weights` | Enforce weight scale | Rule removed |
| `no-invalid-position-declaration` | Mixin false positives | Fixed in Stylelint for `@mixin` |
| `selector-max-id` | Discourage `#id` selectors | Code refactored; no IDs remain |
| `no-duplicate-selectors` | Split-rule workaround in editor | Stylelint 17 fewer false positives |
| `function-url-quotes` | Quoted data URLs in `mask-image` | Rule/parser now accepts the pattern |
| `declaration-property-unit-allowed-list` | Unit restrictions | Only applies to `line-height`, not `font-size` |
| `property-no-unknown` | View Transitions properties | Added to Stylelint’s known list |
| `selector-pseudo-element-no-unknown` | `::view-transition-*` | Added to Stylelint’s known list |
| `declaration-no-important` | Discourage `!important` | Rule not enabled in Jetpack config |
| `selector-pseudo-class-no-unknown` | CSS Modules `:global()` | Globally ignored in `stylelint.config.base.mjs` |


</details>

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->


## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI lint passing?