### PR TITLE
Write editor: add save/publish failure telemetry

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-failure-telemetry
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-failure-telemetry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Write editor: add diagnostic Tracks events for save/publish failures and stalled requests to aid root-cause analysis.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5978,13 +5978,135 @@ function showPostPickerModal() {
 	} );
 }
 
+// --- Save failure telemetry (RSM-4323) ---
+//
+// Diagnostic Tracks events for save/publish failures. Today a throw during
+// content preparation, or a request stalled by a proxy/VPN/ad blocker, leaves
+// the Publish and Save buttons disabled with no error surfaced and nothing in
+// Tracks — so we can't see it happening. These events add observability only;
+// they intentionally do not change the save behavior. view.js is served
+// unminified, so error_code + error_message read against real line numbers,
+// and `phase` localizes which stage failed without needing a full stack trace.
+
+// Report a save that has neither resolved nor rejected within this window.
+const SAVE_STALL_THRESHOLD_MS = 30000;
+// Cap free-text error strings so a pathological message can't bloat the payload.
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+
+/**
+ * Normalize an unknown thrown value into a small, Tracks-friendly descriptor.
+ *
+ * Handles the shapes `wp.apiFetch` actually rejects with: WP REST errors
+ * ( `{ code, message, data: { status } }` ), native/AbortError ( `{ name,
+ * message }` ), and non-object throws as a last resort.
+ *
+ * @param {*} err - The thrown value.
+ * @return {{ code: string, status: (number|null), message: string }} Descriptor.
+ */
+function describeSaveError( err ) {
+	if ( ! err || typeof err !== 'object' ) {
+		const raw = err === undefined ? '' : String( err );
+		return { code: 'unknown', status: null, message: raw.slice( 0, MAX_ERROR_MESSAGE_LENGTH ) };
+	}
+	// Prefer the specific REST `code`; fall back to `name` ('AbortError', 'TypeError', …).
+	const code = err.code || err.name || 'unknown';
+	const status = err.data && typeof err.data.status === 'number' ? err.data.status : null;
+	const message = String( err.message || '' ).slice( 0, MAX_ERROR_MESSAGE_LENGTH );
+	return { code: String( code ), status, message };
+}
+
+/**
+ * Fire the `wpcom_write_editor_save_failed` Tracks event.
+ *
+ * @param {*}       err                - The thrown value.
+ * @param {object}  context            - Save context.
+ * @param {string}  context.postStatus - The attempted status ('publish' or 'draft').
+ * @param {boolean} context.isAutosave - Whether the failed save was a periodic autosave.
+ * @param {boolean} context.isUpdate   - Whether this was an update to a published post.
+ * @param {boolean} context.isEditing  - Whether an existing post was being edited.
+ * @param {string}  context.phase      - Stage that failed ('prepare' | 'save_request').
+ */
+function recordSaveFailed( err, { postStatus, isAutosave, isUpdate, isEditing, phase } ) {
+	const { code, status, message } = describeSaveError( err );
+	window._tkq = window._tkq || [];
+	window._tkq.push( [
+		'recordEvent',
+		'wpcom_write_editor_save_failed',
+		{
+			post_status: postStatus,
+			is_autosave: !! isAutosave,
+			is_update: !! isUpdate,
+			is_new_post: ! isEditing,
+			phase,
+			error_code: code,
+			error_status: status,
+			error_message: message,
+		},
+	] );
+}
+
+/**
+ * Fire the `wpcom_write_editor_save_stalled` Tracks event for a save request
+ * that never settled within the watchdog window.
+ *
+ * @param {object}  context            - Save context.
+ * @param {string}  context.postStatus - The attempted status ('publish' or 'draft').
+ * @param {boolean} context.isAutosave - Whether the stalled save was a periodic autosave.
+ * @param {boolean} context.isUpdate   - Whether this was an update to a published post.
+ * @param {boolean} context.isEditing  - Whether an existing post was being edited.
+ * @param {number}  context.elapsedMs  - The watchdog threshold that elapsed, in ms.
+ */
+function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, elapsedMs } ) {
+	window._tkq = window._tkq || [];
+	window._tkq.push( [
+		'recordEvent',
+		'wpcom_write_editor_save_stalled',
+		{
+			post_status: postStatus,
+			is_autosave: !! isAutosave,
+			is_update: !! isUpdate,
+			is_new_post: ! isEditing,
+			elapsed_ms: elapsedMs,
+		},
+	] );
+}
+
 /**
  * Save or publish the current post via the REST API.
+ *
+ * Thin wrapper around performSave() that reports any throw during content
+ * preparation or tag resolution — code that runs before the save request's own
+ * try/catch and today surfaces as a silent unhandled rejection. It re-throws to
+ * preserve current behavior; this is an observability-only change (RSM-4323).
  *
  * @param {string}  postStatus - The desired post status ('publish' or 'draft').
  * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
  */
 async function savePost( postStatus, isAutosave = false ) {
+	try {
+		await performSave( postStatus, isAutosave );
+	} catch ( err ) {
+		// Save-request failures are handled inside performSave; anything caught
+		// here threw during content prep / tag resolution. Report, then re-throw
+		// so behavior is unchanged.
+		recordSaveFailed( err, {
+			postStatus,
+			isAutosave,
+			isUpdate: state.editPostId > 0 && state.postStatus === 'publish',
+			isEditing: state.editPostId > 0,
+			phase: 'prepare',
+		} );
+		throw err;
+	}
+}
+
+/**
+ * Perform the save/publish request. See savePost() for the failure-telemetry wrapper.
+ *
+ * @param {string}  postStatus - The desired post status ('publish' or 'draft').
+ * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
+ */
+async function performSave( postStatus, isAutosave = false ) {
 	if ( ! isAutosave ) {
 		// Use textContent rather than innerHTML so structural-only markup
 		// (e.g. <p><br></p> left over from clearing the editor) doesn't
@@ -6125,6 +6247,19 @@ async function savePost( postStatus, isAutosave = false ) {
 	// If editing, PUT to the existing post. If new, POST to create.
 	const path = isEditing ? state.postsPath + '/' + state.editPostId : state.postsPath;
 
+	// Watchdog: report (without aborting) a save request that neither resolves
+	// nor rejects within the threshold — e.g. one held open by a proxy, VPN, or
+	// ad blocker. Cleared as soon as the request settles.
+	const stallWatchdog = setTimeout( () => {
+		recordSaveStalled( {
+			postStatus,
+			isAutosave,
+			isUpdate,
+			isEditing,
+			elapsedMs: SAVE_STALL_THRESHOLD_MS,
+		} );
+	}, SAVE_STALL_THRESHOLD_MS );
+
 	try {
 		const post = await window.wp.apiFetch( {
 			path,
@@ -6139,6 +6274,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				wpcom_write_editor_used: true,
 			},
 		} );
+		clearTimeout( stallWatchdog );
 
 		// Store the post ID so subsequent saves update the same post.
 		if ( ! isEditing ) {
@@ -6217,6 +6353,8 @@ async function savePost( postStatus, isAutosave = false ) {
 			}, 2500 );
 		}
 	} catch ( err ) {
+		clearTimeout( stallWatchdog );
+		recordSaveFailed( err, { postStatus, isAutosave, isUpdate, isEditing, phase: 'save_request' } );
 		state.isSaving = false;
 		if ( ! isAutosave ) {
 			state.message = ( i18n.error || 'Error: %s' ).replace( '%s', err.message );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6054,9 +6054,10 @@ function recordSaveFailed( err, { postStatus, isAutosave, isUpdate, isEditing, p
  * @param {boolean} context.isAutosave - Whether the stalled save was a periodic autosave.
  * @param {boolean} context.isUpdate   - Whether this was an update to a published post.
  * @param {boolean} context.isEditing  - Whether an existing post was being edited.
+ * @param {string}  context.phase      - Stage that stalled ('prepare' | 'save_request').
  * @param {number}  context.elapsedMs  - The watchdog threshold that elapsed, in ms.
  */
-function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, elapsedMs } ) {
+function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, phase, elapsedMs } ) {
 	window._tkq = window._tkq || [];
 	window._tkq.push( [
 		'recordEvent',
@@ -6066,6 +6067,7 @@ function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, elaps
 			is_autosave: !! isAutosave,
 			is_update: !! isUpdate,
 			is_new_post: ! isEditing,
+			phase,
 			elapsed_ms: elapsedMs,
 		},
 	] );
@@ -6083,12 +6085,17 @@ function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, elaps
  * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
  */
 async function savePost( postStatus, isAutosave = false ) {
+	// Shared with performSave so a prep-stage throw here can clear the stall
+	// watchdog performSave armed — otherwise it would fire a spurious
+	// save_stalled ~30s after a save that already failed.
+	const saveCtx = {};
 	try {
-		await performSave( postStatus, isAutosave );
+		await performSave( postStatus, isAutosave, saveCtx );
 	} catch ( err ) {
 		// Save-request failures are handled inside performSave; anything caught
 		// here threw during content prep / tag resolution. Report, then re-throw
 		// so behavior is unchanged.
+		clearTimeout( saveCtx.stallWatchdog );
 		recordSaveFailed( err, {
 			postStatus,
 			isAutosave,
@@ -6105,8 +6112,9 @@ async function savePost( postStatus, isAutosave = false ) {
  *
  * @param {string}  postStatus - The desired post status ('publish' or 'draft').
  * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
+ * @param {object}  saveCtx    - Cross-call scratch; receives the stall watchdog handle.
  */
-async function performSave( postStatus, isAutosave = false ) {
+async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 	if ( ! isAutosave ) {
 		// Use textContent rather than innerHTML so structural-only markup
 		// (e.g. <p><br></p> left over from clearing the editor) doesn't
@@ -6134,6 +6142,24 @@ async function performSave( postStatus, isAutosave = false ) {
 		}
 		state.message = savingMessage;
 	}
+
+	// Watchdog: report (without aborting) a save that neither resolves nor rejects
+	// within the threshold — e.g. one held open by a proxy, VPN, or ad blocker.
+	// Armed here, before the pre-save awaits below (media-size swaps, tag
+	// resolution), so a hang in either of those is caught too — not just a hang
+	// in the main save request. `stallPhase` narrows the report to prep vs. the
+	// request. Cleared as soon as the flow settles or early-returns.
+	let stallPhase = 'prepare';
+	const stallWatchdog = ( saveCtx.stallWatchdog = setTimeout( () => {
+		recordSaveStalled( {
+			postStatus,
+			isAutosave,
+			isUpdate,
+			isEditing,
+			phase: stallPhase,
+			elapsedMs: SAVE_STALL_THRESHOLD_MS,
+		} );
+	}, SAVE_STALL_THRESHOLD_MS ) );
 
 	// Wait for any in-flight image size swaps to finish so the saved
 	// content's img.src matches its size-* class. Without this, a save
@@ -6187,6 +6213,7 @@ async function performSave( postStatus, isAutosave = false ) {
 	// Safety net: if stripping editor-only elements left the clone
 	// empty, treat it the same as no content.
 	if ( ! clone.innerHTML.trim() ) {
+		clearTimeout( stallWatchdog );
 		state.message = i18n.pleaseWriteSomething || 'Please write something';
 		state.isSaving = false;
 		setTimeout( () => {
@@ -6247,18 +6274,8 @@ async function performSave( postStatus, isAutosave = false ) {
 	// If editing, PUT to the existing post. If new, POST to create.
 	const path = isEditing ? state.postsPath + '/' + state.editPostId : state.postsPath;
 
-	// Watchdog: report (without aborting) a save request that neither resolves
-	// nor rejects within the threshold — e.g. one held open by a proxy, VPN, or
-	// ad blocker. Cleared as soon as the request settles.
-	const stallWatchdog = setTimeout( () => {
-		recordSaveStalled( {
-			postStatus,
-			isAutosave,
-			isUpdate,
-			isEditing,
-			elapsedMs: SAVE_STALL_THRESHOLD_MS,
-		} );
-	}, SAVE_STALL_THRESHOLD_MS );
+	// Prep is done; a stall from here on is the main save request itself.
+	stallPhase = 'save_request';
 
 	try {
 		const post = await window.wp.apiFetch( {


### PR DESCRIPTION
## Proposed changes

Failed or stalled saves in the Write editor currently leave the Publish and Save buttons disabled with no error surfaced to the user and nothing recorded in Tracks, so the failures are invisible. This adds **observability only** — it does not change save behavior.

* `savePost()` is now a thin wrapper that reports throws during content preparation / tag resolution (today silent unhandled rejections) as `wpcom_write_editor_save_failed` with `phase: "prepare"`, then re-throws so behavior is unchanged.
* The save-request `catch` fires the same event with `phase: "save_request"`.
* A non-aborting 30s watchdog fires `wpcom_write_editor_save_stalled` for a save that never settles (e.g. one held open by a proxy, VPN, or ad blocker). It is armed before the pre-save requests (media-size swaps, tag resolution), so a hang in those is caught too — not just a hang in the main save request — and carries a `phase` (`prepare` | `save_request`) to localize where the stall occurred.
* Events carry `error_code`, HTTP `error_status`, a truncated `error_message`, and `is_autosave` / `is_update` / `is_new_post` to localize the root cause.

The behavioral fix (reset the saving flag on failure, add a request timeout, surface an error) is intentionally deferred to a follow-up so we can first confirm the actual failure mode from this data.

## Related product discussion/links

* RSM-4323

## Does this pull request change what data or activity we track or use?

Yes — it adds two new client-side Tracks events for Write editor save diagnostics:

* `wpcom_write_editor_save_failed` — props: `post_status`, `is_autosave`, `is_update`, `is_new_post`, `phase` (`prepare` | `save_request`), `error_code`, `error_status`, `error_message`.
* `wpcom_write_editor_save_stalled` — props: `post_status`, `is_autosave`, `is_update`, `is_new_post`, `phase` (`prepare` | `save_request`), `elapsed_ms` (the watchdog threshold that elapsed, i.e. 30000, not a measured latency).

`error_code` / `error_status` / `phase` are bounded codes or enums. `error_message` is free text taken from the `apiFetch` rejection (typically a WordPress REST error string such as "The title field is required."), truncated to 200 characters. No post content, title, or personally identifying information is recorded. The `[Status] Needs Privacy Updates` label has been applied.

## Testing instructions

* Open the Write editor (`wp-admin/admin.php?page=write`), add a title and some body content.
* In DevTools, force a failing save: `window.wp.apiFetch = () => Promise.reject( { code: 'rest_cannot_create', message: 'Simulated', data: { status: 503 } } );`
* Clear the queue with `window._tkq = [];`, then click **Publish**.
* Confirm `window._tkq` contains a `wpcom_write_editor_save_failed` entry with `phase: "save_request"`, `error_code: "rest_cannot_create"`, `error_status: 503`. The existing error message and button re-enable behavior should be unchanged.
* **Prepare-stage failure:** add a `#tag` line to the content and set `window.wp.apiFetch = () => { throw new TypeError('boom'); };` — the event should fire with `phase: "prepare"`.
* **Stalled pre-save request:** add a `#tag` line, then hang only the tag endpoint — `const _o = window.wp.apiFetch; window.wp.apiFetch = o => o?.path?.includes('/wp/v2/tags') ? new Promise(() => {}) : _o(o);` — click **Save draft** and wait ~30s. Confirm a `wpcom_write_editor_save_stalled` entry fires with `phase: "prepare"` (before this watchdog placement it produced no event).
