### PR TITLE
Donations block: update location of earnings link

### DIFF
--- a/projects/plugins/jetpack/changelog/update-payment-link-donations
+++ b/projects/plugins/jetpack/changelog/update-payment-link-donations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Donations block: update location of earnings link.

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -476,7 +476,7 @@ const Controls = props => {
 						</Flex>
 					) }
 					<p style={ { marginTop: 24 } }>
-						<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
+						<ExternalLink href={ `https://wordpress.com/earn/${ getSiteFragment() }` }>
 							{ __( 'View donation earnings', 'jetpack' ) }
 						</ExternalLink>
 					</p>


### PR DESCRIPTION
Fixes MON-80

## Proposed changes

The Donations block configuration has a link, View donation earnings, that opens in a new tab the following link: https://wordpress.com/earn/payments/{siteURL}. It doesn't contain any information about the earnings, or even a placeholder with a "Here you'll see your donations" or similar.

The correct link should be https://wordpress.com/earn/{siteURL}

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions

* In a connected Jetpack site, go to Posts > Add New, and insert a Donations block
* Check the link in the sidebar
