### PR TITLE
AI Launchpad: rework the sell goal to lead with store setup

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: rework the "sell" goal to lead with a store-setup task that installs WooCommerce, so the commerce tasks no longer collapse on a fresh site.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: rework the "sell" goal to lead with a store-setup task that installs WooCommerce, so the commerce tasks no longer collapse on a fresh site.
+AI Launchpad: rework the "sell" goal to lead with install-WooCommerce and store-setup tasks, so the commerce tasks no longer collapse on a fresh site.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-launchpad-store-setup-task
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: rework the "sell" goal to lead with install-WooCommerce and store-setup tasks, so the commerce tasks no longer collapse on a fresh site.
+AI Launchpad: rework the "sell" goal to lead with install-WooCommerce and store-setup tasks, and show the commerce tasks as a disabled roadmap until WooCommerce is active, so the list no longer collapses on a fresh site.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -295,10 +295,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
 			// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
 			if ( 'sell' === $goal ) {
-				// The store-setup tasks lead the sell list; prepend in reverse so they keep their display order.
-				foreach ( array_reverse( $this->build_store_tasks() ) as $lead ) {
-					$tasks = $this->insert_lead_task( $tasks, $lead );
-				}
+				// The store-setup tasks lead the sell list. Their synthetic ids never appear in the AI payload, so a
+				// plain prepend is safe.
+				$tasks = array_merge( $this->build_store_tasks(), $tasks );
 			} else {
 				$gallery = $this->build_gallery_task( $inferred );
 				if ( null !== $gallery ) {
@@ -852,24 +851,6 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		}
 
 		array_splice( $tasks, $insert_at, 0, array( $task ) );
-		return $tasks;
-	}
-
-	/**
-	 * Inserts a synthetic task at the head of the list, idempotently by id.
-	 *
-	 * @param array $tasks The enriched task list.
-	 * @param array $task  The synthetic task entry.
-	 * @return array
-	 */
-	private function insert_lead_task( $tasks, $task ) {
-		foreach ( $tasks as $existing ) {
-			if ( isset( $existing['id'] ) && $existing['id'] === $task['id'] ) {
-				return $tasks;
-			}
-		}
-
-		array_unshift( $tasks, $task );
 		return $tasks;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -294,6 +294,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			if ( null !== $gallery ) {
 				$tasks = $this->insert_before_launch_task( $tasks, $gallery );
 			}
+
+			$store = $this->build_store_task( $inferred );
+			if ( null !== $store ) {
+				$tasks = $this->insert_lead_task( $tasks, $store );
+			}
 		}
 
 		// The membership tasks' completion is recomputed in build_tasks(), so overlay it to keep
@@ -744,6 +749,48 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
+	 * Whether the synthetic "Set up your store" task should be offered, based on the inferred goal.
+	 *
+	 * @param array $inferred The AI output's `inferred` block.
+	 * @return bool
+	 */
+	private function should_offer_store_task( $inferred ) {
+		return isset( $inferred['goal'] ) && 'sell' === $inferred['goal'];
+	}
+
+	/**
+	 * Builds the synthetic store-setup task, or null when it should not be offered.
+	 *
+	 * The commerce (`woo_*`) tasks are visibility-gated on WooCommerce being active, so a fresh sell site would
+	 * otherwise collapse to almost nothing. This task leads the sell sequence with a WooCommerce install CTA and
+	 * completes — letting the woo_* tasks surface — once the plugin is active. Completion is read live, so no
+	 * marker or listener is needed.
+	 *
+	 * @param array $inferred The AI output's `inferred` block.
+	 * @return array|null
+	 */
+	private function build_store_task( $inferred ) {
+		if ( ! $this->should_offer_store_task( $inferred ) ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$completed = is_plugin_active( 'woocommerce/woocommerce.php' );
+
+		return array(
+			'id'           => 'install_woocommerce',
+			'subtitle'     => __( 'Add WooCommerce so you can start selling.', 'jetpack-mu-wpcom' ),
+			'title'        => __( 'Set up your store', 'jetpack-mu-wpcom' ),
+			'completed'    => $completed,
+			'in_progress'  => false,
+			// Install-and-activate from wp-admin; once WooCommerce is active the woo_* tasks take over and the CTA drops.
+			'calypso_path' => $completed ? null : admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ),
+		);
+	}
+
+	/**
 	 * Inserts a synthetic task immediately before the trailing launch task (or appends it), idempotently by id.
 	 *
 	 * @param array $tasks The enriched task list.
@@ -766,6 +813,24 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		}
 
 		array_splice( $tasks, $insert_at, 0, array( $task ) );
+		return $tasks;
+	}
+
+	/**
+	 * Inserts a synthetic task at the head of the list, idempotently by id.
+	 *
+	 * @param array $tasks The enriched task list.
+	 * @param array $task  The synthetic task entry.
+	 * @return array
+	 */
+	private function insert_lead_task( $tasks, $task ) {
+		foreach ( $tasks as $existing ) {
+			if ( isset( $existing['id'] ) && $existing['id'] === $task['id'] ) {
+				return $tasks;
+			}
+		}
+
+		array_unshift( $tasks, $task );
 		return $tasks;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -295,9 +295,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
 			// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
 			if ( 'sell' === $goal ) {
-				$store = $this->build_store_task();
-				if ( null !== $store ) {
-					$tasks = $this->insert_lead_task( $tasks, $store );
+				// The store-setup tasks lead the sell list; prepend in reverse so they keep their display order.
+				foreach ( array_reverse( $this->build_store_tasks() ) as $lead ) {
+					$tasks = $this->insert_lead_task( $tasks, $lead );
 				}
 			} else {
 				$gallery = $this->build_gallery_task( $inferred );
@@ -755,30 +755,77 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * Builds the synthetic store-setup task that leads the sell sequence, or null once WooCommerce is active.
+	 * Builds the synthetic store-setup lead tasks for the sell goal: an "install WooCommerce" task, plus a "set up
+	 * your store" task once WooCommerce is active.
 	 *
 	 * The commerce (`woo_*`) tasks are visibility-gated on WooCommerce being active, so a fresh sell site would
-	 * otherwise collapse to almost nothing. This task offers a WooCommerce install CTA until the plugin is active,
-	 * at which point the woo_* tasks take over and it drops out (rather than lingering as a completed lead card).
-	 * The active check is read live, so no marker or listener is needed. Callers gate this on the sell goal.
+	 * otherwise collapse to almost nothing. These tasks are read live (installed/active/profiler options), so no
+	 * marker or listener is needed. Callers gate this on the sell goal.
 	 *
-	 * @return array|null
+	 * @return array The lead tasks in display order.
 	 */
-	private function build_store_task() {
+	private function build_store_tasks() {
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-			return null;
+
+		$active = is_plugin_active( 'woocommerce/woocommerce.php' );
+		$tasks  = array( $this->build_install_woocommerce_task( $active ) );
+
+		// The setup wizard needs WooCommerce running, so its task only appears once the plugin is active.
+		if ( $active ) {
+			$tasks[] = $this->build_setup_store_task();
+		}
+
+		return $tasks;
+	}
+
+	/**
+	 * The "Install the WooCommerce plugin" lead task: to-do until the plugin exists, in-progress while it is
+	 * installed-but-inactive, and complete once active.
+	 *
+	 * @param bool $active Whether WooCommerce is active.
+	 * @return array
+	 */
+	private function build_install_woocommerce_task( $active ) {
+		$in_progress = ! $active && array_key_exists( 'woocommerce/woocommerce.php', get_plugins() );
+
+		$calypso_path = null;
+		if ( ! $active ) {
+			$calypso_path = $in_progress
+				? admin_url( 'plugins.php?plugin_status=inactive' )
+				: admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' );
 		}
 
 		return array(
 			'id'           => 'install_woocommerce',
-			'subtitle'     => __( 'Add WooCommerce so you can start selling.', 'jetpack-mu-wpcom' ),
+			'subtitle'     => $in_progress
+				? __( 'Activate the WooCommerce plugin to continue.', 'jetpack-mu-wpcom' )
+				: __( 'Add the WooCommerce plugin to start selling.', 'jetpack-mu-wpcom' ),
+			'title'        => __( 'Install the WooCommerce plugin', 'jetpack-mu-wpcom' ),
+			'completed'    => $active,
+			'in_progress'  => $in_progress,
+			'calypso_path' => $calypso_path,
+		);
+	}
+
+	/**
+	 * The "Set up your store" lead task: to-do until the WooCommerce setup wizard (core profiler) is completed or
+	 * skipped, then complete. Only offered while WooCommerce is active.
+	 *
+	 * @return array
+	 */
+	private function build_setup_store_task() {
+		$profile   = (array) get_option( 'woocommerce_onboarding_profile', array() );
+		$completed = ! empty( $profile['completed'] ) || ! empty( $profile['skipped'] );
+
+		return array(
+			'id'           => 'setup_woocommerce_store',
+			'subtitle'     => __( 'Complete or skip the WooCommerce setup wizard.', 'jetpack-mu-wpcom' ),
 			'title'        => __( 'Set up your store', 'jetpack-mu-wpcom' ),
-			'completed'    => false,
+			'completed'    => $completed,
 			'in_progress'  => false,
-			'calypso_path' => admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ),
+			'calypso_path' => $completed ? null : admin_url( 'admin.php?page=wc-admin&path=%2Fsetup-wizard' ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -290,14 +290,20 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				$tasks = $this->build_tasks( $payload['tasks'], false, $niche );
 			}
 
-			$gallery = $this->build_gallery_task( $inferred );
-			if ( null !== $gallery ) {
-				$tasks = $this->insert_before_launch_task( $tasks, $gallery );
-			}
+			$goal = isset( $inferred['goal'] ) && is_string( $inferred['goal'] ) ? $inferred['goal'] : '';
 
-			$store = $this->build_store_task( $inferred );
-			if ( null !== $store ) {
-				$tasks = $this->insert_lead_task( $tasks, $store );
+			// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
+			// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
+			if ( 'sell' === $goal ) {
+				$store = $this->build_store_task();
+				if ( null !== $store ) {
+					$tasks = $this->insert_lead_task( $tasks, $store );
+				}
+			} else {
+				$gallery = $this->build_gallery_task( $inferred );
+				if ( null !== $gallery ) {
+					$tasks = $this->insert_before_launch_task( $tasks, $gallery );
+				}
 			}
 		}
 
@@ -749,44 +755,30 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * Whether the synthetic "Set up your store" task should be offered, based on the inferred goal.
-	 *
-	 * @param array $inferred The AI output's `inferred` block.
-	 * @return bool
-	 */
-	private function should_offer_store_task( $inferred ) {
-		return isset( $inferred['goal'] ) && 'sell' === $inferred['goal'];
-	}
-
-	/**
-	 * Builds the synthetic store-setup task, or null when it should not be offered.
+	 * Builds the synthetic store-setup task that leads the sell sequence, or null once WooCommerce is active.
 	 *
 	 * The commerce (`woo_*`) tasks are visibility-gated on WooCommerce being active, so a fresh sell site would
-	 * otherwise collapse to almost nothing. This task leads the sell sequence with a WooCommerce install CTA and
-	 * completes — letting the woo_* tasks surface — once the plugin is active. Completion is read live, so no
-	 * marker or listener is needed.
+	 * otherwise collapse to almost nothing. This task offers a WooCommerce install CTA until the plugin is active,
+	 * at which point the woo_* tasks take over and it drops out (rather than lingering as a completed lead card).
+	 * The active check is read live, so no marker or listener is needed. Callers gate this on the sell goal.
 	 *
-	 * @param array $inferred The AI output's `inferred` block.
 	 * @return array|null
 	 */
-	private function build_store_task( $inferred ) {
-		if ( ! $this->should_offer_store_task( $inferred ) ) {
-			return null;
-		}
-
+	private function build_store_task() {
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		$completed = is_plugin_active( 'woocommerce/woocommerce.php' );
+		if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			return null;
+		}
 
 		return array(
 			'id'           => 'install_woocommerce',
 			'subtitle'     => __( 'Add WooCommerce so you can start selling.', 'jetpack-mu-wpcom' ),
 			'title'        => __( 'Set up your store', 'jetpack-mu-wpcom' ),
-			'completed'    => $completed,
+			'completed'    => false,
 			'in_progress'  => false,
-			// Install-and-activate from wp-admin; once WooCommerce is active the woo_* tasks take over and the CTA drops.
-			'calypso_path' => $completed ? null : admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ),
+			'calypso_path' => admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -619,27 +619,30 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				}
 			}
 
-			// The membership tasks' catalog callbacks are always false on Atomic; recompute from local signals instead.
-			$completed = AI_Launchpad_Memberships::has_override( $task['id'] )
-				? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
-				: wpcom_launchpad_checklists()->is_task_complete( $definition );
-
-			$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $niche );
-			if ( null !== $theme_showcase_path ) {
-				$calypso_path = $theme_showcase_path;
-			} elseif ( isset( self::CTA_OVERRIDES[ $task['id'] ] ) ) {
-				$calypso_path = admin_url( self::CTA_OVERRIDES[ $task['id'] ] );
+			if ( $disabled ) {
+				// A disabled preview always renders as the locked card: never resolve its completion (the woo
+				// completion callback marks the task complete as a side effect, which must not fire on a read) and
+				// never resolve a CTA path (it has no reachable action).
+				$completed    = false;
+				$calypso_path = null;
 			} else {
-				$calypso_path = wpcom_launchpad_checklists()->load_calypso_path( $definition );
+				// The membership tasks' catalog callbacks are always false on Atomic; recompute from local signals.
+				$completed = AI_Launchpad_Memberships::has_override( $task['id'] )
+					? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
+					: wpcom_launchpad_checklists()->is_task_complete( $definition );
+
+				$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $niche );
+				if ( null !== $theme_showcase_path ) {
+					$calypso_path = $theme_showcase_path;
+				} elseif ( isset( self::CTA_OVERRIDES[ $task['id'] ] ) ) {
+					$calypso_path = admin_url( self::CTA_OVERRIDES[ $task['id'] ] );
+				} else {
+					$calypso_path = wpcom_launchpad_checklists()->load_calypso_path( $definition );
+				}
 			}
 
 			$title       = isset( $definition['get_title'] ) ? $definition['get_title']() : '';
 			$in_progress = false;
-
-			// A disabled preview task has no reachable CTA and can't be in progress, so drop its path.
-			if ( $disabled ) {
-				$calypso_path = null;
-			}
 
 			// A saved-but-unpublished draft (found by marker meta) puts a site-editor task "in progress": reopen that
 			// draft instead of creating a new one, and surface the drafts icon + a "Continue…" prompt in the card.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -46,6 +46,19 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
+	 * Commerce tasks whose catalog visibility gate requires WooCommerce to be active.
+	 *
+	 * On a fresh sell site these would be dropped, collapsing the list. Instead the sell branch keeps them as a
+	 * disabled preview of the store roadmap until WooCommerce is active. See build_tasks()'s $disable_hidden_woo mode.
+	 */
+	const WOO_TASK_IDS = array(
+		'woo_customize_store',
+		'woo_products',
+		'set_up_payments',
+		'woo_launch_site',
+	);
+
+	/**
 	 * CTA destinations the AI Launchpad repoints to wp-admin, keyed by task id, each mapping to an `admin_url()` path.
 	 *
 	 * The catalog sends these to Calypso flows that are a poor fit for wp-admin. Overridden on read so the shared
@@ -285,19 +298,28 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				? trim( $inferred['niche'] )
 				: '';
 
+			$goal = isset( $inferred['goal'] ) && is_string( $inferred['goal'] ) ? $inferred['goal'] : '';
+
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+			$woo_active = is_plugin_active( 'woocommerce/woocommerce.php' );
+
+			// On a sell site without WooCommerce, keep the gated commerce tasks as a disabled preview of the store
+			// roadmap instead of dropping them (which would collapse the list to almost nothing).
+			$disable_hidden_woo = 'sell' === $goal && ! $woo_active;
+
 			$tasks = array();
 			if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
-				$tasks = $this->build_tasks( $payload['tasks'], false, $niche );
+				$tasks = $this->build_tasks( $payload['tasks'], false, $niche, $disable_hidden_woo );
 			}
-
-			$goal = isset( $inferred['goal'] ) && is_string( $inferred['goal'] ) ? $inferred['goal'] : '';
 
 			// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
 			// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
 			if ( 'sell' === $goal ) {
 				// The store-setup tasks lead the sell list. Their synthetic ids never appear in the AI payload, so a
 				// plain prepend is safe.
-				$tasks = array_merge( $this->build_store_tasks(), $tasks );
+				$tasks = array_merge( $this->build_store_tasks( $woo_active ), $tasks );
 			} else {
 				$gallery = $this->build_gallery_task( $inferred );
 				if ( null !== $gallery ) {
@@ -545,12 +567,14 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	/**
 	 * Enriches the persisted tasks with title, completion state, and CTA path from the catalog.
 	 *
-	 * @param array  $tasks             The persisted `payload.tasks` array.
-	 * @param bool   $bypass_visibility Skip the catalog visibility gate (for the all-tasks testing view).
-	 * @param string $niche             The AI-inferred niche, used to pre-filter the theme-picker CTAs.
+	 * @param array  $tasks              The persisted `payload.tasks` array.
+	 * @param bool   $bypass_visibility  Skip the catalog visibility gate (for the all-tasks testing view).
+	 * @param string $niche              The AI-inferred niche, used to pre-filter the theme-picker CTAs.
+	 * @param bool   $disable_hidden_woo Keep WOO_TASK_IDS that fail the visibility gate as disabled preview cards
+	 *                                   instead of dropping them (sell goal while WooCommerce is inactive).
 	 * @return array
 	 */
-	private function build_tasks( $tasks, $bypass_visibility = false, $niche = '' ) {
+	private function build_tasks( $tasks, $bypass_visibility = false, $niche = '', $disable_hidden_woo = false ) {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
 
@@ -577,6 +601,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 			$definition       = $definitions[ $task['id'] ];
 			$definition['id'] = $task['id'];
+			$disabled         = false;
 
 			// Honor the catalog's own visibility gate: a task the catalog would hide here must not render, since its
 			// CTA would 404 and it could never complete. Filtered on read so the deterministic fallback stays usable.
@@ -585,7 +610,13 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				&& ! in_array( $task['id'], self::FORCE_VISIBLE_TASK_IDS, true )
 				&& ! wpcom_launchpad_checklists()->is_visible( $definition )
 			) {
-				continue;
+				// On a sell site without WooCommerce, keep the commerce tasks as a disabled preview of the store
+				// roadmap rather than dropping them and collapsing the list. Everything else stays hidden.
+				if ( $disable_hidden_woo && in_array( $task['id'], self::WOO_TASK_IDS, true ) ) {
+					$disabled = true;
+				} else {
+					continue;
+				}
 			}
 
 			// The membership tasks' catalog callbacks are always false on Atomic; recompute from local signals instead.
@@ -605,9 +636,14 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			$title       = isset( $definition['get_title'] ) ? $definition['get_title']() : '';
 			$in_progress = false;
 
+			// A disabled preview task has no reachable CTA and can't be in progress, so drop its path.
+			if ( $disabled ) {
+				$calypso_path = null;
+			}
+
 			// A saved-but-unpublished draft (found by marker meta) puts a site-editor task "in progress": reopen that
 			// draft instead of creating a new one, and surface the drafts icon + a "Continue…" prompt in the card.
-			if ( ! $completed ) {
+			if ( ! $completed && ! $disabled ) {
 				$draft_url = $this->get_in_progress_draft_url( $task['id'] );
 				if ( null !== $draft_url ) {
 					$in_progress  = true;
@@ -624,6 +660,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				'title'        => $title,
 				'completed'    => $completed,
 				'in_progress'  => $in_progress,
+				'disabled'     => $disabled,
 				'calypso_path' => $calypso_path,
 			);
 		}
@@ -749,34 +786,27 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'title'        => $this->get_task_title( 'add_gallery_page', $in_progress, __( 'Create your first gallery', 'jetpack-mu-wpcom' ) ),
 			'completed'    => $completed,
 			'in_progress'  => $in_progress,
+			'disabled'     => false,
 			'calypso_path' => $calypso_path,
 		);
 	}
 
 	/**
-	 * Builds the synthetic store-setup lead tasks for the sell goal: an "install WooCommerce" task, plus a "set up
-	 * your store" task once WooCommerce is active.
+	 * Builds the synthetic store-setup lead tasks for the sell goal: an "install WooCommerce" task and a "set up
+	 * your store" task.
 	 *
-	 * The commerce (`woo_*`) tasks are visibility-gated on WooCommerce being active, so a fresh sell site would
-	 * otherwise collapse to almost nothing. These tasks are read live (installed/active/profiler options), so no
-	 * marker or listener is needed. Callers gate this on the sell goal.
+	 * Both are read live (installed/active/profiler options), so no marker or listener is needed. While WooCommerce
+	 * is inactive the setup task shows as a disabled preview, matching the disabled commerce tasks below it. Callers
+	 * gate this on the sell goal.
 	 *
+	 * @param bool $active Whether WooCommerce is active.
 	 * @return array The lead tasks in display order.
 	 */
-	private function build_store_tasks() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$active = is_plugin_active( 'woocommerce/woocommerce.php' );
-		$tasks  = array( $this->build_install_woocommerce_task( $active ) );
-
-		// The setup wizard needs WooCommerce running, so its task only appears once the plugin is active.
-		if ( $active ) {
-			$tasks[] = $this->build_setup_store_task();
-		}
-
-		return $tasks;
+	private function build_store_tasks( $active ) {
+		return array(
+			$this->build_install_woocommerce_task( $active ),
+			$this->build_setup_store_task( $active ),
+		);
 	}
 
 	/**
@@ -804,19 +834,21 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'title'        => __( 'Install the WooCommerce plugin', 'jetpack-mu-wpcom' ),
 			'completed'    => $active,
 			'in_progress'  => $in_progress,
+			'disabled'     => false,
 			'calypso_path' => $calypso_path,
 		);
 	}
 
 	/**
 	 * The "Set up your store" lead task: to-do until the WooCommerce setup wizard (core profiler) is completed or
-	 * skipped, then complete. Only offered while WooCommerce is active.
+	 * skipped, then complete. Shown as a disabled preview until WooCommerce is active, since the wizard needs it.
 	 *
+	 * @param bool $active Whether WooCommerce is active.
 	 * @return array
 	 */
-	private function build_setup_store_task() {
+	private function build_setup_store_task( $active ) {
 		$profile   = (array) get_option( 'woocommerce_onboarding_profile', array() );
-		$completed = ! empty( $profile['completed'] ) || ! empty( $profile['skipped'] );
+		$completed = $active && ( ! empty( $profile['completed'] ) || ! empty( $profile['skipped'] ) );
 
 		return array(
 			'id'           => 'setup_woocommerce_store',
@@ -824,7 +856,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'title'        => __( 'Set up your store', 'jetpack-mu-wpcom' ),
 			'completed'    => $completed,
 			'in_progress'  => false,
-			'calypso_path' => $completed ? null : admin_url( 'admin.php?page=wc-admin&path=%2Fsetup-wizard' ),
+			'disabled'     => ! $active,
+			'calypso_path' => $completed || ! $active ? null : admin_url( 'admin.php?page=wc-admin&path=%2Fsetup-wizard' ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.test.mts
@@ -62,6 +62,11 @@ describe( 'selectFallback', () => {
 		} );
 	}
 
+	it( 'leads the sell sequence with store customization then products', () => {
+		const ids = selectFallback( inputFor( 'sell' ) ).tasks.map( task => task.id );
+		assert.deepEqual( ids.slice( 0, 2 ), [ 'woo_customize_store', 'woo_products' ] );
+	} );
+
 	it( 'clamps an over-long site name to stay schema-valid', () => {
 		const longName = 'X'.repeat( 200 );
 		const output = selectFallback( {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -47,8 +47,8 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'site_launched',
 	],
 	sell: [
-		'woo_products',
 		'woo_customize_store',
+		'woo_products',
 		'set_up_payments',
 		'site_theme_selected',
 		'complete_profile',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -103,6 +103,7 @@ HARD RULES (do not break - the server rejects output that violates these):
 - At least one task must create content (e.g. "first_post_published", "first_post_published_newsletter", "woo_products", or "add_about_page").
 - The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", "woo_launch_site", or "link_in_bio_launched".
 - Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
+- For the sell goal, order the commerce tasks store-first: "woo_customize_store", then "woo_products", then "set_up_payments", keeping the launch task last. Installing WooCommerce is added automatically as the first step, so do not include a task for it.
 - Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
 - For the social tasks "connect_social_media", "drive_traffic", and "post_sharing_enabled", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
 - Subtitles must be plain text: no URLs, no HTML, and no template syntax such as {{ }} or [[ ]].

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -97,6 +97,8 @@ describe( 'ctaKind', () => {
 		assert.equal( ctaKind( 'site_theme_selected' ), 'deeplink' );
 		// woo_launch_site has its own wc-admin deeplink, so it is not a launch kind.
 		assert.equal( ctaKind( 'woo_launch_site' ), 'deeplink' );
+		// The synthetic store task navigates to its wp-admin install CTA.
+		assert.equal( ctaKind( 'install_woocommerce' ), 'deeplink' );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -66,6 +66,7 @@ function task( overrides: Partial< EnrichedTask > = {} ): EnrichedTask {
 		title: 'Choose a design',
 		completed: false,
 		in_progress: false,
+		disabled: false,
 		calypso_path: '/themes/example.com',
 		...overrides,
 	};
@@ -184,6 +185,17 @@ describe( 'isTaskActionable', () => {
 		assert.equal(
 			isTaskActionable(
 				task( { id: 'add_about_page', in_progress: true, calypso_path: null } ),
+				null
+			),
+			false
+		);
+	} );
+
+	it( 'is never actionable for a disabled preview task', () => {
+		// Even with an otherwise-actionable shape, disabled short-circuits to false.
+		assert.equal(
+			isTaskActionable(
+				task( { id: 'woo_products', disabled: true, calypso_path: '/themes/example.com' } ),
 				null
 			),
 			false
@@ -398,6 +410,21 @@ describe( 'nextIncompleteId', () => {
 	it( 'returns null when the given id was the only incomplete task', () => {
 		const tasks = [ task( { id: 'a', completed: true } ), task( { id: 'b', completed: true } ) ];
 		assert.equal( nextIncompleteId( tasks, 'b' ), null );
+	} );
+
+	it( 'skips disabled preview tasks as auto-expand targets', () => {
+		const tasks = [
+			task( { id: 'a', disabled: true } ),
+			task( { id: 'b', disabled: true } ),
+			task( { id: 'c', completed: false } ),
+		];
+		// The two disabled cards are passed over in favor of the first actionable one.
+		assert.equal( nextIncompleteId( tasks ), 'c' );
+	} );
+
+	it( 'returns null when only disabled tasks remain', () => {
+		const tasks = [ task( { id: 'a', completed: true } ), task( { id: 'b', disabled: true } ) ];
+		assert.equal( nextIncompleteId( tasks ), null );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -97,8 +97,9 @@ describe( 'ctaKind', () => {
 		assert.equal( ctaKind( 'site_theme_selected' ), 'deeplink' );
 		// woo_launch_site has its own wc-admin deeplink, so it is not a launch kind.
 		assert.equal( ctaKind( 'woo_launch_site' ), 'deeplink' );
-		// The synthetic store task navigates to its wp-admin install CTA.
+		// The synthetic store tasks navigate to their wp-admin CTAs.
 		assert.equal( ctaKind( 'install_woocommerce' ), 'deeplink' );
+		assert.equal( ctaKind( 'setup_woocommerce_store' ), 'deeplink' );
 	} );
 } );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -13,6 +13,10 @@ export interface EnrichedTask {
 	// True when a site-editor task has a saved-but-unpublished draft: the card shows
 	// the drafts icon + a "Continue" CTA, and `calypso_path` reopens that draft.
 	in_progress: boolean;
+	// True for a task shown as a locked preview of the roadmap (e.g. a sell site's
+	// commerce tasks before WooCommerce is active): it renders muted, expands to its
+	// subtitle, but offers no CTA or Skip until its prerequisite is met.
+	disabled: boolean;
 	calypso_path: string | null;
 }
 
@@ -210,6 +214,10 @@ export function isTaskActionable(
 	output: TailoredOutput | null,
 	siteUrl: string | null = null
 ): boolean {
+	// A disabled preview task has no reachable action until its prerequisite is met.
+	if ( task.disabled ) {
+		return false;
+	}
 	// An in-progress task reopens its existing draft via calypso_path, so it stays actionable.
 	if ( task.in_progress && task.calypso_path ) {
 		return true;
@@ -226,16 +234,17 @@ export function isTaskActionable(
 }
 
 /**
- * The id of the next incomplete task to auto-expand. With no `afterId`, the first
- * incomplete task; with `afterId`, the first incomplete task after it, falling
- * back to any remaining incomplete task. Returns null when every task is complete.
+ * The id of the next actionable task to auto-expand. With no `afterId`, the first
+ * such task; with `afterId`, the first one after it, falling back to any remaining
+ * one. Disabled preview tasks are never targets (they can't be acted on yet, though
+ * they stay manually expandable). Returns null when nothing is left to act on.
  *
  * @param tasks   - The enriched tasks (skipped tasks already coerced to completed).
  * @param afterId - The id to advance past, or undefined to take the first.
- * @return The next incomplete task id, or null.
+ * @return The next actionable task id, or null.
  */
 export function nextIncompleteId( tasks: EnrichedTask[], afterId?: string ): string | null {
-	const incomplete = tasks.filter( task => ! task.completed );
+	const incomplete = tasks.filter( task => ! task.completed && ! task.disabled );
 	if ( incomplete.length === 0 ) {
 		return null;
 	}
@@ -261,6 +270,7 @@ export function tasksFromFixture( output: TailoredOutput ): EnrichedTask[] {
 		title: humanizeTaskId( task.id ),
 		completed: false,
 		in_progress: false,
+		disabled: false,
 		calypso_path: null,
 	} ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -10,8 +10,10 @@ export interface EnrichedTask {
 	subtitle: string;
 	title: string;
 	completed: boolean;
-	// True when a site-editor task has a saved-but-unpublished draft: the card shows
-	// the drafts icon + a "Continue" CTA, and `calypso_path` reopens that draft.
+	// True when a task is mid-way through its prerequisite. For a site-editor task that
+	// means a saved-but-unpublished draft (drafts icon + "Continue" CTA, `calypso_path`
+	// reopens it); for the synthetic `install_woocommerce` task it means the plugin is
+	// installed but not yet active (the CTA activates it).
 	in_progress: boolean;
 	// True for a task shown as a locked preview of the roadmap (e.g. a sell site's
 	// commerce tasks before WooCommerce is active): it renders muted, expands to its

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -115,6 +115,23 @@
 		gap: 8px;
 	}
 
+	// A locked preview of a task that isn't reachable yet: title and lock icon are
+	// dimmed (no line-through — it isn't done) to read as "coming later".
+	&__card.is-disabled {
+
+		.ai-launchpad-tailored-list__title,
+		.ai-launchpad-tailored-list__icon {
+			color: var(--wpds-color-fg-interactive-neutral-disabled, #8d8d8d);
+		}
+	}
+
+	// The "available once…" line shown in place of the actions on a disabled card.
+	&__hint {
+		margin: 0 0 8px;
+		font-style: italic;
+		color: #757575;
+	}
+
 	// The site-preview card in the right column.
 	&__preview {
 		display: flex;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -29,6 +29,12 @@ interface Props {
  * @return The translated CTA label.
  */
 function getCtaLabel( taskId: string, inProgress: boolean ): string {
+	// The install task's in-progress state means "installed but inactive", so its CTA activates the plugin rather
+	// than resuming a draft.
+	if ( inProgress && taskId === 'install_woocommerce' ) {
+		return __( 'Activate WooCommerce', 'jetpack-mu-wpcom' );
+	}
+
 	// An in-progress task reopens its existing draft, so the CTA invites the user to pick up where they left off.
 	if ( inProgress ) {
 		return __( 'Continue', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { border, drafts, published } from '@wordpress/icons';
+import { border, drafts, lock, published } from '@wordpress/icons';
 import { Button, Card, CollapsibleCard } from '@wordpress/ui';
 import { ctaKind, type EnrichedTask } from './model.ts';
 
@@ -119,6 +119,34 @@ export function TaskCard( {
 					</span>
 				</Card.Header>
 			</Card.Root>
+		);
+	}
+
+	// A disabled task is a locked preview of a task that isn't reachable yet (a sell site's
+	// commerce tasks before WooCommerce is active). It still expands to its subtitle, but
+	// shows a lock glyph and a hint in place of any CTA / Skip actions.
+	if ( task.disabled ) {
+		return (
+			<CollapsibleCard.Root
+				className="ai-launchpad-tailored-list__card is-disabled"
+				open={ isOpen }
+				onOpenChange={ onOpenChange }
+			>
+				<CollapsibleCard.Header>
+					<span className="ai-launchpad-tailored-list__header-inner">
+						<span className="ai-launchpad-tailored-list__icon">
+							<Icon icon={ lock } size={ 24 } />
+						</span>
+						<span className="ai-launchpad-tailored-list__title">{ task.title }</span>
+					</span>
+				</CollapsibleCard.Header>
+				<CollapsibleCard.Content>
+					<p className="ai-launchpad-tailored-list__subtitle">{ task.subtitle }</p>
+					<p className="ai-launchpad-tailored-list__hint">
+						{ __( 'Available once WooCommerce is active.', 'jetpack-mu-wpcom' ) }
+					</p>
+				</CollapsibleCard.Content>
+			</CollapsibleCard.Root>
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -40,6 +40,8 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 		case 'add_gallery_page':
 			return __( 'Create gallery', 'jetpack-mu-wpcom' );
 		case 'install_woocommerce':
+			return __( 'Install WooCommerce', 'jetpack-mu-wpcom' );
+		case 'setup_woocommerce_store':
 			return __( 'Set up store', 'jetpack-mu-wpcom' );
 		case 'woo_products':
 			return __( 'Add products', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -39,6 +39,8 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 			return __( 'Browse themes', 'jetpack-mu-wpcom' );
 		case 'add_gallery_page':
 			return __( 'Create gallery', 'jetpack-mu-wpcom' );
+		case 'install_woocommerce':
+			return __( 'Set up store', 'jetpack-mu-wpcom' );
 		case 'woo_products':
 			return __( 'Add products', 'jetpack-mu-wpcom' );
 		case 'woo_customize_store':

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -107,24 +107,10 @@ export function TaskCard( {
 	onMarkComplete,
 	onSkip,
 }: Props ) {
-	if ( task.completed ) {
-		return (
-			<Card.Root className="ai-launchpad-tailored-list__card is-completed">
-				<Card.Header>
-					<span className="ai-launchpad-tailored-list__header-inner">
-						<span className="ai-launchpad-tailored-list__icon is-done">
-							<Icon icon={ published } size={ 24 } />
-						</span>
-						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
-					</span>
-				</Card.Header>
-			</Card.Root>
-		);
-	}
-
 	// A disabled task is a locked preview of a task that isn't reachable yet (a sell site's
 	// commerce tasks before WooCommerce is active). It still expands to its subtitle, but
-	// shows a lock glyph and a hint in place of any CTA / Skip actions.
+	// shows a lock glyph and a hint in place of any CTA / Skip actions. Checked before
+	// `completed` so a stale completion flag can never render it as a struck-through "done".
 	if ( task.disabled ) {
 		return (
 			<CollapsibleCard.Root
@@ -147,6 +133,21 @@ export function TaskCard( {
 					</p>
 				</CollapsibleCard.Content>
 			</CollapsibleCard.Root>
+		);
+	}
+
+	if ( task.completed ) {
+		return (
+			<Card.Root className="ai-launchpad-tailored-list__card is-completed">
+				<Card.Header>
+					<span className="ai-launchpad-tailored-list__header-inner">
+						<span className="ai-launchpad-tailored-list__icon is-done">
+							<Icon icon={ published } size={ 24 } />
+						</span>
+						<span className="ai-launchpad-tailored-list__title is-done">{ task.title }</span>
+					</span>
+				</Card.Header>
+			</Card.Root>
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -702,6 +702,61 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The store-setup task leads the sell sequence and offers an install CTA while WooCommerce is inactive.
+	 */
+	public function test_get_injects_store_task_leading_for_sell_goal() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
+
+		$tasks = $this->call_api( Requests::GET )->get_data()['tasks'];
+		$ids   = array_column( $tasks, 'id' );
+		$this->assertContains( 'install_woocommerce', $ids );
+		$this->assertSame( 'install_woocommerce', $ids[0] );
+
+		$store = null;
+		foreach ( $tasks as $task ) {
+			if ( 'install_woocommerce' === $task['id'] ) {
+				$store = $task;
+			}
+		}
+		$this->assertSame( 'Set up your store', $store['title'] );
+		$this->assertFalse( $store['completed'] );
+		$this->assertStringContainsString( 'plugin-install.php?s=woocommerce', $store['calypso_path'] );
+	}
+
+	/**
+	 * The store-setup task shows complete with no CTA once WooCommerce is active.
+	 */
+	public function test_get_marks_store_task_complete_when_woocommerce_active() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
+		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
+
+		$store = null;
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			if ( 'install_woocommerce' === $task['id'] ) {
+				$store = $task;
+			}
+		}
+		update_option( 'active_plugins', array() );
+
+		$this->assertNotNull( $store );
+		$this->assertTrue( $store['completed'] );
+		$this->assertNull( $store['calypso_path'] );
+	}
+
+	/**
+	 * The store-setup task is not injected for a non-sell goal.
+	 */
+	public function test_get_omits_store_task_for_non_sell_goal() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_gallery_output( 'build', 'organic coffee beans' );
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertNotContains( 'install_woocommerce', $ids );
+	}
+
+	/**
 	 * The gallery task is not injected on the ?all_tasks=1 catalog view.
 	 */
 	public function test_get_all_tasks_param_omits_gallery_task() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -726,24 +726,17 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The store-setup task shows complete with no CTA once WooCommerce is active.
+	 * The store-setup task drops out once WooCommerce is active, letting the woo_* tasks take over.
 	 */
-	public function test_get_marks_store_task_complete_when_woocommerce_active() {
+	public function test_get_omits_store_task_when_woocommerce_active() {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
 		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
 
-		$store = null;
-		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
-			if ( 'install_woocommerce' === $task['id'] ) {
-				$store = $task;
-			}
-		}
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 		update_option( 'active_plugins', array() );
 
-		$this->assertNotNull( $store );
-		$this->assertTrue( $store['completed'] );
-		$this->assertNull( $store['calypso_path'] );
+		$this->assertNotContains( 'install_woocommerce', $ids );
 	}
 
 	/**
@@ -754,6 +747,19 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->seed_gallery_output( 'build', 'organic coffee beans' );
 		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 		$this->assertNotContains( 'install_woocommerce', $ids );
+	}
+
+	/**
+	 * A sell site whose niche matches a gallery keyword gets the store task, not the off-target gallery task.
+	 */
+	public function test_get_prefers_store_over_gallery_for_sell_goal() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		$this->seed_gallery_output( 'sell', 'handmade art' );
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertContains( 'install_woocommerce', $ids );
+		$this->assertNotContains( 'add_gallery_page', $ids );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -702,62 +702,103 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The store-setup task leads the sell sequence and offers an install CTA while WooCommerce is inactive.
+	 * Returns the sell task list keyed by id (WooCommerce state controlled by the caller beforehand).
+	 *
+	 * @param string $niche The inferred niche.
+	 * @return array<string, array> Tasks keyed by id.
 	 */
-	public function test_get_injects_store_task_leading_for_sell_goal() {
-		wp_set_current_user( $this->admin_id );
-		update_option( 'active_plugins', array() );
-		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
-
+	private function sell_tasks_by_id( $niche = 'organic coffee beans' ) {
+		$this->seed_gallery_output( 'sell', $niche );
 		$tasks = $this->call_api( Requests::GET )->get_data()['tasks'];
-		$ids   = array_column( $tasks, 'id' );
-		$this->assertContains( 'install_woocommerce', $ids );
-		$this->assertSame( 'install_woocommerce', $ids[0] );
-
-		$store = null;
-		foreach ( $tasks as $task ) {
-			if ( 'install_woocommerce' === $task['id'] ) {
-				$store = $task;
-			}
-		}
-		$this->assertSame( 'Set up your store', $store['title'] );
-		$this->assertFalse( $store['completed'] );
-		$this->assertStringContainsString( 'plugin-install.php?s=woocommerce', $store['calypso_path'] );
+		return array_column( $tasks, null, 'id' );
 	}
 
 	/**
-	 * The store-setup task drops out once WooCommerce is active, letting the woo_* tasks take over.
+	 * With WooCommerce missing, the install task leads with the plugin-install CTA and the setup task is absent.
 	 */
-	public function test_get_omits_store_task_when_woocommerce_active() {
+	public function test_get_leads_sell_with_install_task_when_woocommerce_missing() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+
+		$tasks = $this->sell_tasks_by_id();
+		$this->assertSame( 'install_woocommerce', array_key_first( $tasks ) );
+		$this->assertArrayNotHasKey( 'setup_woocommerce_store', $tasks );
+
+		$install = $tasks['install_woocommerce'];
+		$this->assertFalse( $install['completed'] );
+		$this->assertFalse( $install['in_progress'] );
+		$this->assertStringContainsString( 'Add the WooCommerce plugin', $install['subtitle'] );
+		$this->assertStringContainsString( 'plugin-install.php?s=woocommerce', $install['calypso_path'] );
+	}
+
+	/**
+	 * With WooCommerce installed but not active, the install task is in progress and points at the plugins screen.
+	 */
+	public function test_get_marks_install_task_in_progress_when_inactive() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		wp_cache_set( 'plugins', array( '' => array( 'woocommerce/woocommerce.php' => array( 'Name' => 'WooCommerce' ) ) ), 'plugins' );
+
+		$install = $this->sell_tasks_by_id()['install_woocommerce'];
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		$this->assertTrue( $install['in_progress'] );
+		$this->assertFalse( $install['completed'] );
+		$this->assertStringContainsString( 'Activate the WooCommerce plugin', $install['subtitle'] );
+		$this->assertStringContainsString( 'plugins.php?plugin_status=inactive', $install['calypso_path'] );
+	}
+
+	/**
+	 * Once WooCommerce is active the install task shows complete and the setup task appears with the wizard CTA.
+	 */
+	public function test_get_completes_install_and_offers_setup_when_active() {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
-		$this->seed_gallery_output( 'sell', 'organic coffee beans' );
 
-		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$tasks = $this->sell_tasks_by_id();
 		update_option( 'active_plugins', array() );
 
-		$this->assertNotContains( 'install_woocommerce', $ids );
+		$this->assertTrue( $tasks['install_woocommerce']['completed'] );
+		$this->assertArrayHasKey( 'setup_woocommerce_store', $tasks );
+		$setup = $tasks['setup_woocommerce_store'];
+		$this->assertFalse( $setup['completed'] );
+		$this->assertStringContainsString( 'page=wc-admin&path=%2Fsetup-wizard', $setup['calypso_path'] );
 	}
 
 	/**
-	 * The store-setup task is not injected for a non-sell goal.
+	 * The setup task completes once the WooCommerce core profiler is completed or skipped.
 	 */
-	public function test_get_omits_store_task_for_non_sell_goal() {
+	public function test_get_completes_setup_when_profiler_done() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array( 'woocommerce/woocommerce.php' ) );
+		update_option( 'woocommerce_onboarding_profile', array( 'skipped' => true ) );
+
+		$setup = $this->sell_tasks_by_id()['setup_woocommerce_store'];
+		update_option( 'active_plugins', array() );
+
+		$this->assertTrue( $setup['completed'] );
+		$this->assertNull( $setup['calypso_path'] );
+	}
+
+	/**
+	 * The store tasks are not injected for a non-sell goal.
+	 */
+	public function test_get_omits_store_tasks_for_non_sell_goal() {
 		wp_set_current_user( $this->admin_id );
 		$this->seed_gallery_output( 'build', 'organic coffee beans' );
 		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 		$this->assertNotContains( 'install_woocommerce', $ids );
+		$this->assertNotContains( 'setup_woocommerce_store', $ids );
 	}
 
 	/**
-	 * A sell site whose niche matches a gallery keyword gets the store task, not the off-target gallery task.
+	 * A sell site whose niche matches a gallery keyword gets the store tasks, not the off-target gallery task.
 	 */
 	public function test_get_prefers_store_over_gallery_for_sell_goal() {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'active_plugins', array() );
-		$this->seed_gallery_output( 'sell', 'handmade art' );
 
-		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$ids = array_keys( $this->sell_tasks_by_id( 'handmade art' ) );
 		$this->assertContains( 'install_woocommerce', $ids );
 		$this->assertNotContains( 'add_gallery_page', $ids );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -714,7 +714,8 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * With WooCommerce missing, the install task leads with the plugin-install CTA and the setup task is absent.
+	 * With WooCommerce missing, the install task leads with the plugin-install CTA and stays actionable, while the
+	 * setup task follows as a disabled preview.
 	 */
 	public function test_get_leads_sell_with_install_task_when_woocommerce_missing() {
 		wp_set_current_user( $this->admin_id );
@@ -722,13 +723,42 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$tasks = $this->sell_tasks_by_id();
 		$this->assertSame( 'install_woocommerce', array_key_first( $tasks ) );
-		$this->assertArrayNotHasKey( 'setup_woocommerce_store', $tasks );
 
 		$install = $tasks['install_woocommerce'];
 		$this->assertFalse( $install['completed'] );
 		$this->assertFalse( $install['in_progress'] );
+		$this->assertFalse( $install['disabled'] );
 		$this->assertStringContainsString( 'Add the WooCommerce plugin', $install['subtitle'] );
 		$this->assertStringContainsString( 'plugin-install.php?s=woocommerce', $install['calypso_path'] );
+
+		// The setup task is still listed, but as a disabled preview with no CTA until WooCommerce is active.
+		$this->assertArrayHasKey( 'setup_woocommerce_store', $tasks );
+		$setup = $tasks['setup_woocommerce_store'];
+		$this->assertTrue( $setup['disabled'] );
+		$this->assertFalse( $setup['completed'] );
+		$this->assertNull( $setup['calypso_path'] );
+	}
+
+	/**
+	 * On a fresh sell site the gated commerce tasks are kept as disabled previews (with no CTA) instead of being
+	 * dropped, so the full store roadmap is visible.
+	 */
+	public function test_get_keeps_commerce_tasks_disabled_when_woocommerce_inactive() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+
+		$this->seed_sell_output_with_commerce_tasks();
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		foreach ( array( 'woo_customize_store', 'woo_products', 'set_up_payments', 'woo_launch_site' ) as $id ) {
+			$this->assertArrayHasKey( $id, $tasks, "$id should be kept as a disabled preview" );
+			$this->assertTrue( $tasks[ $id ]['disabled'], "$id should be disabled" );
+			$this->assertNull( $tasks[ $id ]['calypso_path'], "$id should have no CTA" );
+		}
+
+		// A non-commerce task in the same list stays actionable, not swept into the disabled treatment.
+		$this->assertArrayHasKey( 'site_theme_selected', $tasks );
+		$this->assertFalse( $tasks['site_theme_selected']['disabled'] );
 	}
 
 	/**
@@ -1251,6 +1281,50 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 					'inferred' => array(
 						'goal'  => $goal,
 						'niche' => $niche,
+					),
+				),
+			),
+			false
+		);
+	}
+
+	/**
+	 * Seeds a sell payload whose tasks include the WooCommerce-gated commerce tasks plus a non-commerce task, so the
+	 * disabled-preview behavior can be asserted.
+	 */
+	private function seed_sell_output_with_commerce_tasks() {
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'woo_customize_store',
+							'subtitle' => 'Make it yours.',
+						),
+						array(
+							'id'       => 'woo_products',
+							'subtitle' => 'Add products.',
+						),
+						array(
+							'id'       => 'set_up_payments',
+							'subtitle' => 'Get paid.',
+						),
+						array(
+							'id'       => 'site_theme_selected',
+							'subtitle' => 'Pick a theme.',
+						),
+						array(
+							'id'       => 'woo_launch_site',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array(
+						'goal'  => 'sell',
+						'niche' => 'organic coffee beans',
 					),
 				),
 			),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -762,6 +762,28 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * A commerce task previously completed in WooCommerce renders as a disabled preview (not "done") while
+	 * WooCommerce is inactive, and building the list must not persist a launchpad completion as a side effect.
+	 */
+	public function test_get_disabled_commerce_task_is_not_completed_and_does_not_write_status() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		// Simulate a task WooCommerce recorded as complete during a prior active period.
+		update_option( 'woocommerce_task_list_tracked_completed_tasks', array( 'products' ) );
+		delete_option( 'launchpad_checklist_tasks_statuses' );
+
+		$this->seed_sell_output_with_commerce_tasks();
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertTrue( $tasks['woo_products']['disabled'] );
+		$this->assertFalse( $tasks['woo_products']['completed'] );
+
+		// The completion callback (which writes launchpad status) must not have fired for the disabled preview.
+		$statuses = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$this->assertArrayNotHasKey( 'woo_products', $statuses );
+	}
+
+	/**
 	 * With WooCommerce installed but not active, the install task is in progress and points at the plugins screen.
 	 */
 	public function test_get_marks_install_task_in_progress_when_inactive() {


### PR DESCRIPTION
## Proposed changes

Reworks the AI Launchpad **"sell"** goal so it leads with store setup and shows the full commerce roadmap instead of collapsing to a couple of tasks on a fresh site.

* Prepends two synthetic lead tasks: **Install the WooCommerce plugin** (to-do → installed-but-inactive "Activate" → complete-when-active) and **Set up your store** (completes when the WooCommerce core profiler is completed/skipped).
* When WooCommerce is **inactive**, the `woo_*` commerce tasks that the catalog visibility gate would otherwise drop are kept as a **disabled preview of the roadmap** (muted, lock icon, expandable to the subtitle + an "Available once WooCommerce is active." hint, no CTA/Skip). They become actionable once WooCommerce is active.
* Reorders the deterministic `sell` fallback list and the tailoring prompt to lead store-first.
* Disabled previews never resolve completion or a CTA path — this avoids the WooCommerce completion callback's side-effect write firing during a read, and keeps a stale completion flag from rendering a locked task as "done".

Synthetic tasks are injected read-side in `AI_Launchpad_REST`; the shared launchpad catalog is untouched.

This is the third and last of the AI Launchpad first-pass design-feedback follow-ups, stacked on the gallery-task PR (#50166). **Merge order: #50127 → #50166 → this.**

## Related product discussion/links

* [DOTCOM-17738](https://linear.app/a8c/issue/DOTCOM-17738/ai-launchpad-rework-the-sell-goal-sequence-lead-with-store-setup)
* Follow-up refactor filed: [DOTCOM-17758](https://linear.app/a8c/issue/DOTCOM-17758/ai-launchpad-extract-task-building-out-of-ai-launchpad-rest-into-a)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The AI Launchpad is behind a feature flag and off in production; test on an Atomic site where it's enabled (e.g. a WoA dev site with the mu-wpcom build synced).

1. Ensure the site has a persisted **sell** tailored output (goal `sell`), with WooCommerce **not active**.
2. Open **wp-admin → AI Launchpad**. You should see the full roadmap: **Install the WooCommerce plugin** and **Choose a theme** actionable; **Set up your store**, **Customize your store**, **Add your products**, **Set up payment method**, **Launch your store** shown as muted, locked cards that expand to their subtitle + "Available once WooCommerce is active." with no CTA/Skip.
3. Install + activate WooCommerce. Reload — the commerce tasks become actionable, **Install the WooCommerce plugin** shows complete, and **Set up your store** links to the WooCommerce setup wizard.
4. Complete or skip the WooCommerce setup wizard, reload — **Set up your store** shows complete.
5. Edge case: with WooCommerce inactive but a commerce task previously marked complete in `woocommerce_task_list_tracked_completed_tasks`, the task still renders as a locked preview (not "done"), and loading the list does not write `launchpad_checklist_tasks_statuses`.
