### PR TITLE
SEO: use the site's real name and tagline in the title-structure preview

### DIFF
--- a/projects/packages/seo/_inc/data/get-site.ts
+++ b/projects/packages/seo/_inc/data/get-site.ts
@@ -5,6 +5,7 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 // Used to render the homepage search/social previews on the Settings tab.
 export interface SiteData {
 	title: string;
+	tagline: string;
 	url: string;
 	icon: string;
 	image: string;

--- a/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
+++ b/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
@@ -129,6 +129,29 @@ describe( 'buildPreview', () => {
 	it( 'falls back to the raw value for an unknown token id', () => {
 		expect( buildPreview( [ { type: 'token', value: 'mystery' } ] ) ).toBe( 'mystery' );
 	} );
+
+	it( 'uses real override values for tokens when provided', () => {
+		const tokens: TitleFormatToken[] = [
+			{ type: 'token', value: 'site_name' },
+			{ type: 'string', value: ' | ' },
+			{ type: 'token', value: 'tagline' },
+		];
+		expect( buildPreview( tokens, { site_name: 'Acme Co', tagline: 'We make things' } ) ).toBe(
+			'Acme Co | We make things'
+		);
+	} );
+
+	it( 'falls back to sample text when an override is missing or empty', () => {
+		const tokens: TitleFormatToken[] = [
+			{ type: 'token', value: 'site_name' },
+			{ type: 'string', value: ' | ' },
+			{ type: 'token', value: 'tagline' },
+		];
+		// site_name has a real value; tagline is empty, so it uses the sample.
+		expect( buildPreview( tokens, { site_name: 'Acme Co', tagline: '' } ) ).toBe(
+			'Acme Co | Your tagline'
+		);
+	} );
 } );
 
 describe( 'tokensToString', () => {

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -132,17 +132,25 @@ export const fromDisplay = ( display: string, allowedTokenIds?: string[] ): Titl
 };
 
 /**
- * Render an ordered token list into a human-readable preview string, swapping
- * placeholders for representative sample text and passing literal fragments
- * through unchanged.
+ * Render an ordered token list into a human-readable preview string. A placeholder
+ * is swapped for its real value from `overrides` when one is supplied and non-empty
+ * (e.g. the site's actual name/tagline), otherwise for representative sample text;
+ * literal fragments pass through unchanged.
  *
- * @param tokens - The ordered token list.
+ * @param tokens    - The ordered token list.
+ * @param overrides - Real values keyed by token id; an absent or empty value falls
+ *                  back to the token's sample text.
  * @return The preview string.
  */
-export const buildPreview = ( tokens: TitleFormatToken[] ): string =>
+export const buildPreview = (
+	tokens: TitleFormatToken[],
+	overrides: Partial< Record< string, string > > = {}
+): string =>
 	tokens
 		.map( token =>
-			token.type === 'string' ? token.value : TOKEN_PREVIEW_SAMPLES[ token.value ] ?? token.value
+			token.type === 'string'
+				? token.value
+				: overrides[ token.value ] || TOKEN_PREVIEW_SAMPLES[ token.value ] || token.value
 		)
 		.join( '' );
 

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -169,11 +169,13 @@ const TitleStructureField: FC< Props > = ( {
 	const customizedCount = PAGE_TYPES.filter( pt => ( formats[ pt.id ]?.length ?? 0 ) > 0 ).length;
 
 	// Fill the site-wide placeholders in each row's preview with the site's real
-	// name and tagline (bootstrapped in `seo.site`). Per-page tokens like
-	// [Post title] keep their representative samples since they vary per page.
+	// name and tagline (bootstrapped in `seo.site`). Coalesce to '' when the site
+	// data is absent so the empty value falls through to the sample text in
+	// `buildPreview`. Per-page tokens like [Post title] keep their representative
+	// samples since they vary per page.
 	const site = getSite();
 	const previewOverrides = useMemo(
-		() => ( { site_name: site?.title, tagline: site?.tagline } ),
+		() => ( { site_name: site?.title ?? '', tagline: site?.tagline ?? '' } ),
 		[ site?.title, site?.tagline ]
 	);
 

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -6,6 +6,7 @@ import { TextControl } from '@wordpress/components';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Badge, Button, Card, CollapsibleCard, Stack } from '@wordpress/ui';
+import getSite from '../../data/get-site';
 import {
 	PAGE_TYPES,
 	PAGE_TYPE_SUGGESTIONS,
@@ -34,6 +35,7 @@ interface RowProps {
 	onChange: ( next: TitleFormatToken[] ) => void;
 	onSave: () => void;
 	canSave: boolean;
+	previewOverrides: Partial< Record< string, string > >;
 	disabled?: boolean;
 }
 
@@ -59,12 +61,16 @@ const TitleStructureRow: FC< RowProps > = ( {
 	onChange,
 	onSave,
 	canSave,
+	previewOverrides,
 	disabled,
 } ) => {
 	const inputRef = useRef< HTMLInputElement | null >( null );
 	const value = useMemo( () => tokensToString( tokens ), [ tokens ] );
 	const allowed = PAGE_TYPE_TOKENS[ pageTypeId ];
-	const preview = useMemo( () => buildPreview( tokens ), [ tokens ] );
+	const preview = useMemo(
+		() => buildPreview( tokens, previewOverrides ),
+		[ tokens, previewOverrides ]
+	);
 
 	const setFromString = useCallback(
 		( next: string ) => onChange( stringToTokens( next, allowed ) ),
@@ -162,6 +168,15 @@ const TitleStructureField: FC< Props > = ( {
 } ) => {
 	const customizedCount = PAGE_TYPES.filter( pt => ( formats[ pt.id ]?.length ?? 0 ) > 0 ).length;
 
+	// Fill the site-wide placeholders in each row's preview with the site's real
+	// name and tagline (bootstrapped in `seo.site`). Per-page tokens like
+	// [Post title] keep their representative samples since they vary per page.
+	const site = getSite();
+	const previewOverrides = useMemo(
+		() => ( { site_name: site?.title, tagline: site?.tagline } ),
+		[ site?.title, site?.tagline ]
+	);
+
 	return (
 		<CollapsibleCard.Root defaultOpen={ false }>
 			<CollapsibleCard.Header>
@@ -190,6 +205,7 @@ const TitleStructureField: FC< Props > = ( {
 							onChange={ next => onChange( pt.id, next ) }
 							onSave={ () => onSaveFormat( pt.id ) }
 							canSave={ isFormatDirty( pt.id ) }
+							previewOverrides={ previewOverrides }
 							disabled={ disabled }
 						/>
 					) ) }

--- a/projects/packages/seo/changelog/add-seo-title-preview-real-site-values
+++ b/projects/packages/seo/changelog/add-seo-title-preview-real-site-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-SEO: the title-structure preview now uses the site's real name and tagline instead of placeholder samples.
+SEO: use the site's real name and tagline in the title-structure preview instead of placeholder samples.

--- a/projects/packages/seo/changelog/add-seo-title-preview-real-site-values
+++ b/projects/packages/seo/changelog/add-seo-title-preview-real-site-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SEO: the title-structure preview now uses the site's real name and tagline instead of placeholder samples.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -833,7 +833,7 @@ class Initializer {
 
 	/**
 	 * Site identity used to render the homepage search/social previews on the
-	 * Settings tab: title, URL, and representative images. The front-page
+	 * Settings tab: title, tagline, URL, and representative images. The front-page
 	 * description that completes the preview is read from the Settings form
 	 * (it's editable there), not bootstrapped here.
 	 *
@@ -846,10 +846,11 @@ class Initializer {
 		$logo_url = $logo_id ? (string) wp_get_attachment_image_url( $logo_id, 'full' ) : '';
 
 		return array(
-			'title' => (string) get_bloginfo( 'name' ),
-			'url'   => (string) home_url(),
-			'icon'  => $icon_url,
-			'image' => $logo_url ? $logo_url : $icon_url,
+			'title'   => (string) get_bloginfo( 'name' ),
+			'tagline' => (string) get_bloginfo( 'description' ),
+			'url'     => (string) home_url(),
+			'icon'    => $icon_url,
+			'image'   => $logo_url ? $logo_url : $icon_url,
 		);
 	}
 

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -567,7 +567,7 @@ class InitializerTest extends TestCase {
 
 	/**
 	 * The site-identity bootstrap (used by the Settings search/social previews)
-	 * exposes title, url, icon and image, all as strings. With no site icon or
+	 * exposes title, tagline, url, icon and image, all as strings. With no site icon or
 	 * custom logo in the test environment the image falls back to the (empty)
 	 * icon.
 	 */
@@ -575,10 +575,12 @@ class InitializerTest extends TestCase {
 		$site = Initializer::get_site_data();
 
 		$this->assertArrayHasKey( 'title', $site );
+		$this->assertArrayHasKey( 'tagline', $site );
 		$this->assertArrayHasKey( 'url', $site );
 		$this->assertArrayHasKey( 'icon', $site );
 		$this->assertArrayHasKey( 'image', $site );
 		$this->assertIsString( $site['title'] );
+		$this->assertIsString( $site['tagline'] );
 		$this->assertIsString( $site['url'] );
 		$this->assertIsString( $site['icon'] );
 		$this->assertIsString( $site['image'] );


### PR DESCRIPTION
## Proposed changes

* The **Title Structure** editor preview filled the `[Site name]` and `[Tagline]` tokens with placeholder samples ("Your site" / "Your tagline") even though the site's real values are known.
* Bootstrap the tagline (`get_bloginfo('description')`) alongside the existing site title in the `seo.site` script data.
* `buildPreview()` now takes an optional `overrides` map; the Title Structure field fills `site_name`/`tagline` from the real site identity, falling back to the sample when a value is empty (e.g. no tagline set). Per-page tokens (post/page/tag/date) keep their representative samples since they vary per page.

## Related product discussion/links

* [JETPACK-1828](https://linear.app/a8c/issue/JETPACK-1828) — surfaced during the [JETPACK-1814](https://linear.app/a8c/issue/JETPACK-1814) preview verification.

## Does this pull request change what data or activity we track or use?

No new tracking. Adds the site tagline (already-public site metadata) to the admin-only SEO page bootstrap.

## Testing instructions

* On a site with the new Jetpack &gt; SEO page (`rsm_jetpack_seo` flag on), set a **Site Title** and **Tagline** under Settings → General.
* Go to **Jetpack → SEO → Settings** and expand **Title structure**.
* Confirm each row's **Preview** shows your real site name and tagline in place of "Your site" / "Your tagline", while per-page tokens still show samples (e.g. "Hello World" for Post title).
* Clear the site Tagline and confirm the preview falls back to the "Your tagline" sample (no empty gap).
