### PR TITLE
Forms: update sidebar unread count live when reading a response

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-sidebar-unread-count-live-update
+++ b/projects/packages/forms/changelog/fix-forms-sidebar-unread-count-live-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update the unread response count in the admin sidebar immediately when a response is marked as read by viewing it, so the badge no longer requires a page refresh to reflect the change.

--- a/projects/packages/forms/changelog/fix-forms-sidebar-unread-count-live-update
+++ b/projects/packages/forms/changelog/fix-forms-sidebar-unread-count-live-update
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Update the unread response count in the admin sidebar immediately when a response is marked as read by viewing it, so the badge no longer requires a page refresh to reflect the change.
+Responses: update the unread response count in the admin sidebar immediately when a response is marked as read by viewing it, so the badge no longer requires a page refresh to reflect the change.

--- a/projects/packages/forms/routes/responses/response/index.tsx
+++ b/projects/packages/forms/routes/responses/response/index.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Modal,
 	Spinner,
@@ -9,7 +8,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -24,11 +23,12 @@ import PreviewFile from '../../../src/dashboard/components/inspector/preview-fil
 import ResponseFieldsIterator from '../../../src/dashboard/components/inspector/response-fields';
 import ResponseMeta from '../../../src/dashboard/components/inspector/response-meta';
 import useInboxData from '../../../src/dashboard/hooks/use-inbox-data.ts';
+import useMarkAsReadOnView from '../../../src/dashboard/hooks/use-mark-as-read-on-view';
 import { useMarkAsSpam } from '../../../src/dashboard/hooks/use-mark-as-spam.ts';
 import useConfigValue from '../../../src/hooks/use-config-value.ts';
 import { ResponseActions } from './actions';
 import { ResponseNavigation } from './navigation';
-import type { DispatchActions, SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
+import type { SelectActions } from '../../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../../src/types/index.ts';
 import './style.scss';
 
@@ -56,12 +56,10 @@ function SingleResponseView( {
 } ) {
 	const [ previewFile, setPreviewFile ] = useState< { url: string; name: string } | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
-	const [ hasMarkedAsRead, setHasMarkedAsRead ] = useState< number | null >( null );
 
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 	const isNotesEnabled = useConfigValue( 'isNotesEnabled' ) ?? false;
 
-	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
 	const navigate = useNavigate();
 	const searchParams = useSearch( { from: '/responses/$view' } );
 
@@ -149,31 +147,8 @@ function SingleResponseView( {
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
 	}, [ hasNext, hasPrevious, handleNext, handlePrevious, onClose ] );
 
-	// Mark as read when viewing
-	useEffect( () => {
-		if ( ! response || ! response.id || ! response.is_unread ) {
-			return;
-		}
-		if ( hasMarkedAsRead === response.id ) {
-			return;
-		}
-
-		setHasMarkedAsRead( response.id );
-
-		editEntityRecord( 'postType', 'feedback', response.id, {
-			is_unread: false,
-		} );
-
-		apiFetch( {
-			path: `/wp/v2/feedback/${ response.id }/read`,
-			method: 'POST',
-			data: { is_unread: false },
-		} ).catch( () => {
-			editEntityRecord( 'postType', 'feedback', response.id, {
-				is_unread: true,
-			} );
-		} );
-	}, [ response, editEntityRecord, hasMarkedAsRead ] );
+	// Mark as read when viewing, keeping the sidebar unread counter in sync.
+	useMarkAsReadOnView( response );
 
 	const handleFilePreview = useCallback(
 		( file: { url: string; name: string } ) => () => {

--- a/projects/packages/forms/src/dashboard/components/inspector/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/body.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Modal,
 	Tip,
@@ -16,9 +15,8 @@ import { useSearchParams } from 'react-router';
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value.ts';
-import useInboxData from '../../hooks/use-inbox-data.ts';
+import useMarkAsReadOnView from '../../hooks/use-mark-as-read-on-view';
 import { useMarkAsSpam } from '../../hooks/use-mark-as-spam.ts';
-import { updateMenuCounter, updateMenuCounterOptimistically } from '../../inbox/utils.js';
 import { store as dashboardStore } from '../../store/index.js';
 import FeedbackComments from '../feedback-comments/index.tsx';
 import PreviewFile from './preview-file/index';
@@ -48,14 +46,10 @@ const ResponseViewBody = ( {
 	isLoading,
 	onModalStateChange,
 }: ResponseViewBodyProps ): import('react').JSX.Element => {
-	const { currentQuery } = useInboxData();
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const [ previewFile, setPreviewFile ] = useState< { url: string; name: string } | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
-	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( 0 );
 	const [ searchParams, setSearchParams ] = useSearchParams();
-
-	const { editEntityRecord } = useDispatch( 'core' );
 
 	const emptyTrashDays = useConfigValue( 'emptyTrashDays' ) ?? 0;
 	const isNotesEnabled = useConfigValue( 'isNotesEnabled' ) ?? false;
@@ -120,61 +114,18 @@ const ResponseViewBody = ( {
 		ref.current.scrollTop = 0;
 	}, [ response ] );
 
-	// Mark feedback as read when viewing
-	useEffect( () => {
-		if ( ! response || ! response.id || ! response.is_unread ) {
-			setHasMarkedSelfAsRead( response.id );
-			return;
-		}
-		if ( hasMarkedSelfAsRead === response.id ) {
-			return;
-		}
+	// After the server confirms the read, refresh the list/tab counts so this
+	// dashboard's DataViews stay in sync.
+	const handleMarkedAsRead = useCallback(
+		( responseId: number ) => {
+			markRecordsAsInvalid( [ responseId ] );
+			invalidateCounts();
+		},
+		[ markRecordsAsInvalid, invalidateCounts ]
+	);
 
-		setHasMarkedSelfAsRead( response.id );
-
-		// Immediately update entity in store
-		editEntityRecord( 'postType', 'feedback', response.id, {
-			is_unread: false,
-		} );
-
-		// Immediately update menu counters optimistically to avoid delays
-		if ( response.status === 'publish' ) {
-			updateMenuCounterOptimistically( -1 );
-		}
-
-		// Then update on server
-		apiFetch( {
-			path: `/wp/v2/feedback/${ response.id }/read`,
-			method: 'POST',
-			data: { is_unread: false },
-		} )
-			.then( ( { count }: { count: number } ) => {
-				// Update menu counter with accurate count from server
-				updateMenuCounter( count );
-				// Mark record as invalid instead of removing from view
-				markRecordsAsInvalid( [ response.id ] );
-				// invalidate counts to refresh the counts across all status tabs
-				invalidateCounts();
-			} )
-			.catch( () => {
-				// Revert the change in the store
-				editEntityRecord( 'postType', 'feedback', response.id, {
-					is_unread: true,
-				} );
-
-				// Revert the change in the sidebar
-				if ( response.status === 'publish' ) {
-					updateMenuCounterOptimistically( 1 );
-				}
-			} );
-	}, [
-		response,
-		editEntityRecord,
-		hasMarkedSelfAsRead,
-		invalidateCounts,
-		markRecordsAsInvalid,
-		currentQuery,
-	] );
+	// Mark feedback as read when viewing, keeping the sidebar unread counter in sync.
+	useMarkAsReadOnView( response, handleMarkedAsRead );
 
 	const handelImageLoaded = useCallback( () => {
 		return setIsImageLoading( false );

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { markResponseAsRead } from '../inbox/mark-as-read';
+import type { FormResponse } from '../../types';
+import type { DispatchActions } from '../inbox/stage/types';
+
+/**
+ * Marks a feedback response as read the first time it is viewed, keeping the admin-menu unread counter in sync. No-ops for read or absent responses and marks each response at most once per mount.
+ *
+ * @param response  - The response currently being viewed, or null while loading.
+ * @param onSuccess - Optional callback run after the server confirms the read (e.g. to refresh list/tab counts); memoize it to avoid unnecessary effect churn.
+ */
+export default function useMarkAsReadOnView(
+	response: FormResponse | null | undefined,
+	onSuccess?: ( responseId: number ) => void
+): void {
+	const [ hasMarkedAsRead, setHasMarkedAsRead ] = useState< number | null >( null );
+	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
+
+	useEffect( () => {
+		if ( ! response || ! response.id || ! response.is_unread ) {
+			return;
+		}
+		if ( hasMarkedAsRead === response.id ) {
+			return;
+		}
+
+		setHasMarkedAsRead( response.id );
+		markResponseAsRead( response, editEntityRecord, onSuccess );
+	}, [ response, editEntityRecord, hasMarkedAsRead, onSuccess ] );
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
@@ -16,6 +16,8 @@ import type { DispatchActions } from '../inbox/stage/types';
  *
  * The guard is a ref rather than state so it also blocks React's synchronous double-invoke of effects (StrictMode/dev): a second `/read` request would otherwise recalculate the count on an already-read response and could clobber the badge with a stale value.
  *
+ * The id is latched even for responses that were already read when opened, so that a subsequent manual "Mark as unread" on the open response is not immediately undone: the flip to `is_unread` re-runs the effect, but the same-id guard now short-circuits it instead of re-marking the response as read.
+ *
  * @param response  - The response currently being viewed, or null while loading.
  * @param onSuccess - Optional callback run after the server confirms the read (e.g. to refresh list/tab counts); memoize it to avoid unnecessary effect churn.
  */
@@ -27,14 +29,23 @@ export default function useMarkAsReadOnView(
 	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
 
 	useEffect( () => {
-		if ( ! response || ! response.id || ! response.is_unread ) {
+		// No response to act on yet (still loading) — don't latch anything.
+		if ( ! response || ! response.id ) {
 			return;
 		}
+		// Already handled this response — don't re-mark it. This also covers the
+		// already-read-then-manually-unread case, since the id was latched below.
 		if ( lastMarkedId.current === response.id ) {
 			return;
 		}
 
 		lastMarkedId.current = response.id;
+
+		// Already read when opened — latch the id (above) but issue no request.
+		if ( ! response.is_unread ) {
+			return;
+		}
+
 		markResponseAsRead( response, editEntityRecord, onSuccess );
 	}, [ response, editEntityRecord, onSuccess ] );
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-read-on-view.ts
@@ -3,7 +3,7 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -12,7 +12,9 @@ import type { FormResponse } from '../../types';
 import type { DispatchActions } from '../inbox/stage/types';
 
 /**
- * Marks a feedback response as read the first time it is viewed, keeping the admin-menu unread counter in sync. No-ops for read or absent responses and marks each response at most once per mount.
+ * Marks a feedback response as read the first time it is viewed, keeping the admin-menu unread counter in sync. No-ops for read or absent responses and marks each response at most once.
+ *
+ * The guard is a ref rather than state so it also blocks React's synchronous double-invoke of effects (StrictMode/dev): a second `/read` request would otherwise recalculate the count on an already-read response and could clobber the badge with a stale value.
  *
  * @param response  - The response currently being viewed, or null while loading.
  * @param onSuccess - Optional callback run after the server confirms the read (e.g. to refresh list/tab counts); memoize it to avoid unnecessary effect churn.
@@ -21,18 +23,18 @@ export default function useMarkAsReadOnView(
 	response: FormResponse | null | undefined,
 	onSuccess?: ( responseId: number ) => void
 ): void {
-	const [ hasMarkedAsRead, setHasMarkedAsRead ] = useState< number | null >( null );
+	const lastMarkedId = useRef< number | null >( null );
 	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
 
 	useEffect( () => {
 		if ( ! response || ! response.id || ! response.is_unread ) {
 			return;
 		}
-		if ( hasMarkedAsRead === response.id ) {
+		if ( lastMarkedId.current === response.id ) {
 			return;
 		}
 
-		setHasMarkedAsRead( response.id );
+		lastMarkedId.current = response.id;
 		markResponseAsRead( response, editEntityRecord, onSuccess );
-	}, [ response, editEntityRecord, hasMarkedAsRead, onSuccess ] );
+	}, [ response, editEntityRecord, onSuccess ] );
 }

--- a/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
+++ b/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
@@ -17,10 +17,12 @@ type EditEntityRecord = DispatchActions[ 'editEntityRecord' ];
  * the sidebar badge, then reconciles with the authoritative server count, and
  * reverts both the store edit and the badge if the request fails.
  *
- * This is shared by the inbox inspectors (via `useMarkAsReadOnView`) and the
- * "Mark as read" row/bulk actions so the behaviour cannot drift between the
- * wp-build and legacy dashboards — the divergence that previously left the
- * sidebar badge stale until a page refresh.
+ * Used by both inbox inspectors (via `useMarkAsReadOnView`) so the "mark as read
+ * on view" behaviour cannot drift between the wp-build and legacy dashboards —
+ * the divergence that previously left the sidebar badge stale until a page
+ * refresh. It mirrors (but does not yet share) the equivalent per-item logic in
+ * the "Mark as read" row/bulk actions; consolidating those is a possible
+ * follow-up.
  *
  * @param response         - The response to mark as read.
  * @param editEntityRecord - The core-data `editEntityRecord` dispatcher.

--- a/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
+++ b/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { updateMenuCounter, updateMenuCounterOptimistically } from './utils';
+import type { DispatchActions } from './stage/types';
+import type { FormResponse } from '../../types';
+
+type EditEntityRecord = DispatchActions[ 'editEntityRecord' ];
+
+/**
+ * Marks a single feedback response as read, both on the server and in the store,
+ * and keeps the admin-menu unread counter in sync: it optimistically decrements
+ * the sidebar badge, then reconciles with the authoritative server count, and
+ * reverts both the store edit and the badge if the request fails.
+ *
+ * This is shared by the inbox inspectors (via `useMarkAsReadOnView`) and the
+ * "Mark as read" row/bulk actions so the behaviour cannot drift between the
+ * wp-build and legacy dashboards — the divergence that previously left the
+ * sidebar badge stale until a page refresh.
+ *
+ * @param response         - The response to mark as read.
+ * @param editEntityRecord - The core-data `editEntityRecord` dispatcher.
+ * @param onSuccess        - Optional callback run after the server confirms the read.
+ * @return A promise that resolves once the read has been persisted (or reverted).
+ */
+export function markResponseAsRead(
+	response: Pick< FormResponse, 'id' | 'status' >,
+	editEntityRecord: EditEntityRecord,
+	onSuccess?: ( responseId: number ) => void
+): Promise< void > {
+	const { id, status } = response;
+
+	// Immediately update the entity in the store.
+	editEntityRecord( 'postType', 'feedback', id, { is_unread: false } );
+
+	// Optimistically decrement the sidebar unread counter so it updates without
+	// waiting for the server (inbox/published responses only).
+	if ( status === 'publish' ) {
+		updateMenuCounterOptimistically( -1 );
+	}
+
+	return apiFetch< { count: number } >( {
+		path: `/wp/v2/feedback/${ id }/read`,
+		method: 'POST',
+		data: { is_unread: false },
+	} )
+		.then( ( { count } ) => {
+			// Sync the sidebar counter with the authoritative server count.
+			updateMenuCounter( count );
+			onSuccess?.( id );
+		} )
+		.catch( () => {
+			// Revert the store edit on failure.
+			editEntityRecord( 'postType', 'feedback', id, { is_unread: true } );
+
+			// Revert the optimistic sidebar decrement.
+			if ( status === 'publish' ) {
+				updateMenuCounterOptimistically( 1 );
+			}
+		} );
+}

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-mark-as-read-on-view.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-mark-as-read-on-view.test.jsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+// Mocks must be registered before importing the hook under test.
+const markResponseAsRead = jest.fn();
+const editEntityRecord = jest.fn();
+
+await jest.unstable_mockModule( '../../../../src/dashboard/inbox/mark-as-read', () => ( {
+	markResponseAsRead,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => ( { editEntityRecord } ) ),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+const useMarkAsReadOnView = (
+	await import( '../../../../src/dashboard/hooks/use-mark-as-read-on-view' )
+).default;
+
+describe( 'useMarkAsReadOnView', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does nothing while the response is null (still loading)', () => {
+		renderHook( () => useMarkAsReadOnView( null ) );
+
+		expect( markResponseAsRead ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not mark a response that is already read', () => {
+		renderHook( () => useMarkAsReadOnView( { id: 5, is_unread: false, status: 'publish' } ) );
+
+		expect( markResponseAsRead ).not.toHaveBeenCalled();
+	} );
+
+	it( 'marks an unread response as read on first view', () => {
+		const onSuccess = jest.fn();
+		const response = { id: 7, is_unread: true, status: 'publish' };
+
+		renderHook( () => useMarkAsReadOnView( response, onSuccess ) );
+
+		expect( markResponseAsRead ).toHaveBeenCalledTimes( 1 );
+		expect( markResponseAsRead ).toHaveBeenCalledWith( response, editEntityRecord, onSuccess );
+	} );
+
+	it( 'marks an unread response at most once across re-renders of the same id', () => {
+		const response = { id: 7, is_unread: true, status: 'publish' };
+		const { rerender } = renderHook( props => useMarkAsReadOnView( props ), {
+			initialProps: response,
+		} );
+
+		// A store update flips is_unread to false, producing a new response object
+		// for the same id — the hook must not fire a second request.
+		rerender( { id: 7, is_unread: false, status: 'publish' } );
+
+		expect( markResponseAsRead ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not re-mark an already-read response when it is manually set back to unread', () => {
+		// Open a response that was already read: the id is latched but no request fires.
+		const { rerender } = renderHook( props => useMarkAsReadOnView( props ), {
+			initialProps: { id: 9, is_unread: false, status: 'publish' },
+		} );
+
+		expect( markResponseAsRead ).not.toHaveBeenCalled();
+
+		// "Mark as unread" flips is_unread back to true on the open response.
+		// Because the id was latched on the first view, the hook must not bounce
+		// it back to read.
+		rerender( { id: 9, is_unread: true, status: 'publish' } );
+
+		expect( markResponseAsRead ).not.toHaveBeenCalled();
+	} );
+
+	it( 'marks a different response when navigating to a new unread id', () => {
+		const first = { id: 1, is_unread: true, status: 'publish' };
+		const second = { id: 2, is_unread: true, status: 'publish' };
+		const { rerender } = renderHook( props => useMarkAsReadOnView( props ), {
+			initialProps: first,
+		} );
+
+		rerender( second );
+
+		expect( markResponseAsRead ).toHaveBeenCalledTimes( 2 );
+		expect( markResponseAsRead ).toHaveBeenNthCalledWith( 1, first, editEntityRecord, undefined );
+		expect( markResponseAsRead ).toHaveBeenNthCalledWith( 2, second, editEntityRecord, undefined );
+	} );
+} );

--- a/projects/packages/forms/tests/js/dashboard/inbox/mark-as-read.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/mark-as-read.test.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+// Mocks must be registered before importing the module under test.
+const updateMenuCounter = jest.fn();
+const updateMenuCounterOptimistically = jest.fn();
+const apiFetch = jest.fn();
+
+await jest.unstable_mockModule( '../../../../src/dashboard/inbox/utils.js', () => ( {
+	updateMenuCounter,
+	updateMenuCounterOptimistically,
+	withTimeout: promise => promise,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
+	default: apiFetch,
+} ) );
+
+/**
+ * Internal dependencies
+ */
+const { markResponseAsRead } = await import( '../../../../src/dashboard/inbox/mark-as-read.ts' );
+
+describe( 'markResponseAsRead', () => {
+	let editEntityRecord;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		editEntityRecord = jest.fn();
+	} );
+
+	it( 'marks a published response read and syncs the sidebar counter', async () => {
+		apiFetch.mockResolvedValue( { count: 4 } );
+		const onSuccess = jest.fn();
+
+		await markResponseAsRead( { id: 7, status: 'publish' }, editEntityRecord, onSuccess );
+
+		expect( editEntityRecord ).toHaveBeenCalledWith( 'postType', 'feedback', 7, {
+			is_unread: false,
+		} );
+		// Optimistic decrement happens before the server responds.
+		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( -1 );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/wp/v2/feedback/7/read',
+				method: 'POST',
+				data: { is_unread: false },
+			} )
+		);
+		// The authoritative server count is applied on success.
+		expect( updateMenuCounter ).toHaveBeenCalledWith( 4 );
+		expect( onSuccess ).toHaveBeenCalledWith( 7 );
+	} );
+
+	it( 'does not optimistically decrement the counter for non-published responses', async () => {
+		apiFetch.mockResolvedValue( { count: 4 } );
+
+		await markResponseAsRead( { id: 8, status: 'spam' }, editEntityRecord );
+
+		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+		// The server count is still applied so the badge stays authoritative.
+		expect( updateMenuCounter ).toHaveBeenCalledWith( 4 );
+	} );
+
+	it( 'reverts the store edit and the optimistic counter when the request fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'network' ) );
+
+		await markResponseAsRead( { id: 9, status: 'publish' }, editEntityRecord );
+
+		expect( editEntityRecord ).toHaveBeenNthCalledWith( 1, 'postType', 'feedback', 9, {
+			is_unread: false,
+		} );
+		expect( editEntityRecord ).toHaveBeenNthCalledWith( 2, 'postType', 'feedback', 9, {
+			is_unread: true,
+		} );
+		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 1, -1 );
+		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 2, 1 );
+		expect( updateMenuCounter ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not revert the optimistic counter for non-published responses on failure', async () => {
+		apiFetch.mockRejectedValue( new Error( 'network' ) );
+
+		await markResponseAsRead( { id: 10, status: 'trash' }, editEntityRecord );
+
+		expect( editEntityRecord ).toHaveBeenNthCalledWith( 2, 'postType', 'feedback', 10, {
+			is_unread: true,
+		} );
+		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Fix the Jetpack Forms "needs a refresh" bug: viewing a response in the Responses inbox now updates the sidebar unread count (the **Forms** submenu badge and the top-level **Jetpack** badge) immediately, instead of only after a page reload.
* Root cause: the wp-build responses inspector (`routes/responses/response/index.tsx`) marked a response as read on view but never updated the admin-menu unread counter, while the legacy inspector and the "Mark as read" row/bulk actions already did. The two inspectors held independent, divergent copies of the "mark as read on view" effect.
* Extract the shared behaviour into `markResponseAsRead()` (`src/dashboard/inbox/mark-as-read.ts`) and a `useMarkAsReadOnView` hook (`src/dashboard/hooks/use-mark-as-read-on-view.ts`), now used by **both** inspectors so the counter update can't drift between dashboards again.
* The update is optimistic (decrements immediately), reconciled with the authoritative count returned by the server, and reverted on failure — matching the existing "Mark as read" action.
* Add unit tests for the extracted `markResponseAsRead()` logic.

## Related product discussion/links
* Reported by a user: the unread count in the left nav required a manual page refresh to update after reading responses.
* Related sidebar notification-count issues (duplicate "Jetpack" badges and the top-level count not matching the sum of the submenu counts) are tracked separately in FORMS-716 and are intentionally **out of scope** here — they'll be handled in a follow-up, ideally via a more declarative "a package declares its count and the menu follows" system.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the Jetpack Forms Responses dashboard, make sure you have some unread responses — the **Forms** item in the wp-admin sidebar shows an unread count and the top-level **Jetpack** item shows a matching badge.
* Go to **Jetpack → Forms → Responses** (the Inbox tab).
* Click an unread response (unread rows have a dot) to open it in the inspector.
* **Expected:** the **Forms** sidebar count (and the top-level **Jetpack** count) decrements **immediately**, without reloading the page. Before this change the badge stayed unchanged until a manual refresh.
* Open a couple more unread responses and confirm the count keeps decrementing and stays in sync with the actual number of unread responses.
* Confirm the "Mark as read" / "Mark as unread" row and bulk actions still update the count as before.
* Optional (failure path): with the network blocked so the `/read` request fails, open an unread response and confirm the optimistic decrement is reverted (no phantom drop in the count).
