### PR TITLE
Menu badges: central notification-count registry for the Jetpack admin menu

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3249,6 +3249,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.107.2)
 
+  projects/packages/menu-badges: {}
+
   projects/packages/my-jetpack:
     dependencies:
       '@automattic/babel-plugin-replace-textdomain':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3249,7 +3249,11 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.107.2)
 
-  projects/packages/menu-badges: {}
+  projects/packages/menu-badges:
+    devDependencies:
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2
 
   projects/packages/my-jetpack:
     dependencies:

--- a/projects/packages/forms/changelog/update-forms-menu-badges-registry
+++ b/projects/packages/forms/changelog/update-forms-menu-badges-registry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms now reports its unread count to the central menu-badges registry instead of writing admin-menu markup directly.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -13,6 +13,7 @@
 		"automattic/jetpack-external-connections": "@dev",
 		"automattic/jetpack-jwt": "@dev",
 		"automattic/jetpack-logo": "@dev",
+		"automattic/jetpack-menu-badges": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -15,10 +15,7 @@ import * as React from 'react';
  */
 import { notSpam, spam } from '../../src/dashboard/icons';
 import { defaultView } from '../../src/dashboard/inbox/stage/views.js';
-import {
-	updateMenuCounter,
-	updateMenuCounterOptimistically,
-} from '../../src/dashboard/inbox/utils';
+import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from '../../src/dashboard/inbox/utils';
 import { store as dashboardStore } from '../../src/dashboard/store';
 /**
  * Types
@@ -1028,7 +1025,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 						// Immediately update menu counters optimistically to avoid delays, but only for inbox
 						if ( status === 'publish' ) {
-							updateMenuCounterOptimistically( -1 );
+							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
 						}
 					}
 
@@ -1041,7 +1038,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 						.then( ( response: unknown ) => {
 							const { count } = response as { count: number };
 							// Update menu counter with accurate count from server.
-							updateMenuCounter( count );
+							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
 						} )
 						.catch( () => {
 							// Revert the change in the store if the server update fails.
@@ -1052,7 +1049,10 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 								// Revert the optimistic change in the sidebar.
 								if ( status === 'publish' ) {
-									updateMenuCounterOptimistically( 1 );
+									window.jetpackMenuBadges?.setCount(
+										FORMS_MENU_BADGE_SLUG,
+										getMenuBadgeCount() + 1
+									);
 								}
 							}
 
@@ -1144,7 +1144,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 						// Immediately update menu counters optimistically to avoid delays, but only for inbox
 						if ( status === 'publish' ) {
-							updateMenuCounterOptimistically( 1 );
+							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
 						}
 					}
 
@@ -1157,7 +1157,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 						.then( ( response: unknown ) => {
 							const { count } = response as { count: number };
 							// Update menu counter with accurate count from server.
-							updateMenuCounter( count );
+							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
 						} )
 						.catch( () => {
 							// Revert the change in the store if the server update fails.
@@ -1168,7 +1168,10 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 								// Revert the optimistic change in the sidebar.
 								if ( status === 'publish' ) {
-									updateMenuCounterOptimistically( -1 );
+									window.jetpackMenuBadges?.setCount(
+										FORMS_MENU_BADGE_SLUG,
+										getMenuBadgeCount() - 1
+									);
 								}
 							}
 

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
  */
 import { notSpam, spam } from '../../src/dashboard/icons';
 import { defaultView } from '../../src/dashboard/inbox/stage/views.js';
-import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from '../../src/dashboard/inbox/utils';
+import { getFormsMenuBadgeSlug, getMenuBadgeCount } from '../../src/dashboard/inbox/utils';
 import { store as dashboardStore } from '../../src/dashboard/store';
 /**
  * Types
@@ -1025,7 +1025,10 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 						// Immediately update menu counters optimistically to avoid delays, but only for inbox
 						if ( status === 'publish' ) {
-							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
+							window.jetpackMenuBadges?.setCount(
+								getFormsMenuBadgeSlug(),
+								getMenuBadgeCount() - 1
+							);
 						}
 					}
 
@@ -1038,7 +1041,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 						.then( ( response: unknown ) => {
 							const { count } = response as { count: number };
 							// Update menu counter with accurate count from server.
-							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
+							window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), count );
 						} )
 						.catch( () => {
 							// Revert the change in the store if the server update fails.
@@ -1050,7 +1053,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 								// Revert the optimistic change in the sidebar.
 								if ( status === 'publish' ) {
 									window.jetpackMenuBadges?.setCount(
-										FORMS_MENU_BADGE_SLUG,
+										getFormsMenuBadgeSlug(),
 										getMenuBadgeCount() + 1
 									);
 								}
@@ -1144,7 +1147,10 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 
 						// Immediately update menu counters optimistically to avoid delays, but only for inbox
 						if ( status === 'publish' ) {
-							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
+							window.jetpackMenuBadges?.setCount(
+								getFormsMenuBadgeSlug(),
+								getMenuBadgeCount() + 1
+							);
 						}
 					}
 
@@ -1157,7 +1163,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 						.then( ( response: unknown ) => {
 							const { count } = response as { count: number };
 							// Update menu counter with accurate count from server.
-							window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
+							window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), count );
 						} )
 						.catch( () => {
 							// Revert the change in the store if the server update fails.
@@ -1169,7 +1175,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 								// Revert the optimistic change in the sidebar.
 								if ( status === 'publish' ) {
 									window.jetpackMenuBadges?.setCount(
-										FORMS_MENU_BADGE_SLUG,
+										getFormsMenuBadgeSlug(),
 										getMenuBadgeCount() - 1
 									);
 								}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -237,7 +237,9 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-		add_action( 'current_screen', array( $this, 'unread_count' ) );
+		// Priority 1000: after Dashboard::add_admin_submenu() (999) registers the Forms submenu,
+		// but well before the menu-badges renderer (100000) reads the registry.
+		add_action( 'admin_menu', array( $this, 'unread_count' ), 1000 );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
 		add_filter( 'use_block_editor_for_post_type', array( $this, 'use_block_editor_for_post_type' ), 10, 2 );
@@ -1530,83 +1532,25 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
+	 * Report the count of new feedback entries received to the central menu-badges
+	 * registry. It's reset when the user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
 	 */
 	public function unread_count() {
-
-		global $submenu, $menu;
-		if ( current_user_can( 'edit_pages' ) ) {
-			// show the count on Jetpack and Jetpack → Forms
-			$unread = self::get_unread_count();
-
-			if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
-				$forms_unread_count_tag = $this->get_unread_count_badge_markup( $unread );
-				$jetpack_badge_count    = $unread;
-
-				// Main menu entries
-				foreach ( $menu as $index => $main_menu_item ) {
-					if ( isset( $main_menu_item[1] ) && 'jetpack_admin_page' === $main_menu_item[1] ) {
-						// Parse the menu item
-						$jetpack_menu_item = $this->parse_menu_item( $menu[ $index ][0] );
-
-						if ( isset( $jetpack_menu_item['badge'] ) && is_numeric( $jetpack_menu_item['badge'] ) && intval( $jetpack_menu_item['badge'] ) ) {
-							$jetpack_badge_count += intval( $jetpack_menu_item['badge'] );
-						}
-
-						if ( isset( $jetpack_menu_item['count'] ) && is_numeric( $jetpack_menu_item['count'] ) && intval( $jetpack_menu_item['count'] ) ) {
-							$jetpack_badge_count += intval( $jetpack_menu_item['count'] );
-						}
-
-						if ( $unread > 0 ) {
-							$jetpack_unread_tag = $this->get_unread_count_badge_markup(
-								$jetpack_badge_count,
-								$jetpack_badge_count - $unread
-							);
-
-							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$menu[ $index ][0] = $jetpack_menu_item['title'] . ' ' . $jetpack_unread_tag;
-						}
-					}
-				}
-
-				// Jetpack submenu entries
-				if ( $unread > 0 ) {
-					foreach ( $submenu['jetpack'] as $index => $menu_item ) {
-						/** This filter is documented in class-dashboard.php::init */
-						$admin_slug = apply_filters( 'jetpack_forms_alpha', true ) ? Dashboard::FORMS_WPBUILD_ADMIN_SLUG : Dashboard::ADMIN_SLUG;
-						if ( $admin_slug === $menu_item[2] ) {
-							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$submenu['jetpack'][ $index ][0] .= $forms_unread_count_tag;
-						}
-					}
-				}
-			}
+		if ( ! current_user_can( 'edit_pages' ) ) {
 			return;
 		}
-	}
-
-	/**
-	 * Build the admin menu unread count badge markup.
-	 *
-	 * Uses the `menu-counter` markup expected by admin color schemes so bubble
-	 * colors render correctly in the sidebar.
-	 *
-	 * @since 7.21.3
-	 *
-	 * @param int      $count         Badge count to display.
-	 * @param int|null $unread_diff   Optional diff for combined Jetpack menu badges.
-	 * @return string Badge HTML.
-	 */
-	private function get_unread_count_badge_markup( $count, $unread_diff = null ) {
-		$attributes = "class='menu-counter jp-feedback-unread-counter count-" . (int) $count . "'";
-
-		if ( null !== $unread_diff ) {
-			$attributes = "data-unread-diff='" . (int) $unread_diff . "' " . $attributes;
-		}
-
-		return " <span {$attributes}><span class='count'>" . number_format_i18n( $count ) . '</span></span>';
+		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
+		$slug = apply_filters( 'jetpack_forms_alpha', true ) ? Dashboard::FORMS_WPBUILD_ADMIN_SLUG : Dashboard::ADMIN_SLUG;
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'jetpack-forms',
+			array(
+				'menu_slug' => $slug,
+				'count'     => self::get_unread_count(),
+				'type'      => 'count',
+			)
+		);
 	}
 
 	/**
@@ -3936,71 +3880,6 @@ class Contact_Form_Plugin {
 		$should_enable_tracking = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
 
 		return $is_wpcom || $should_enable_tracking;
-	}
-
-	/**
-	 * Jetpack menu item might have a count badge when there are updates available.
-	 * This method parses that information, removes the associated markup and adds it to the response.
-	 * Copied verbatim from WPCOM_REST_API_V2_Endpoint_Admin_Menu::prepare_menu_item.
-	 *
-	 * Also sanitizes the titles from remaining unexpected markup.
-	 *
-	 * @param string $title Title to parse.
-	 * @return array
-	 */
-	private function parse_menu_item( $title ) {
-		$item = array();
-
-		if (
-			str_contains( $title, 'count-' )
-			&& preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches )
-		) {
-
-			$count = (int) ( $matches[1] );
-			if ( $count > 0 ) {
-				// Keep the counter in the item array.
-				$item['count'] = $count;
-			}
-
-			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
-		}
-
-		if (
-			str_contains( $title, 'inline-text' )
-			&& preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches )
-		) {
-
-			$text = $matches[1];
-			if ( $text ) {
-				// Keep the text in the item array.
-				$item['inlineText'] = $text;
-			}
-
-			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
-		}
-
-		if (
-			str_contains( $title, 'awaiting-mod' )
-			&& preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches )
-		) {
-
-			$text = $matches[1];
-			if ( $text ) {
-				// Keep the text in the item array.
-				$item['badge'] = $text;
-			}
-
-			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
-		}
-
-		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.
-		// We are also capitalizing the first letter in case there was a counter (now parsed) in front of the title.
-		$item['title'] = ucfirst( wp_strip_all_tags( $title ) );
-
-		return $item;
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
+++ b/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from './utils';
+import { getFormsMenuBadgeSlug, getMenuBadgeCount } from './utils';
 import type { DispatchActions } from './stage/types';
 import type { FormResponse } from '../../types';
 
@@ -43,7 +43,7 @@ export function markResponseAsRead(
 	// Optimistically decrement the sidebar unread counter so it updates without
 	// waiting for the server (inbox/published responses only).
 	if ( status === 'publish' ) {
-		window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
+		window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() - 1 );
 	}
 
 	return apiFetch< { count: number } >( {
@@ -53,7 +53,7 @@ export function markResponseAsRead(
 	} )
 		.then( ( { count } ) => {
 			// Sync the sidebar counter with the authoritative server count.
-			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
+			window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), count );
 			onSuccess?.( id );
 		} )
 		.catch( () => {
@@ -62,7 +62,7 @@ export function markResponseAsRead(
 
 			// Revert the optimistic sidebar decrement.
 			if ( status === 'publish' ) {
-				window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
+				window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() + 1 );
 			}
 		} );
 }

--- a/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
+++ b/projects/packages/forms/src/dashboard/inbox/mark-as-read.ts
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { updateMenuCounter, updateMenuCounterOptimistically } from './utils';
+import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from './utils';
 import type { DispatchActions } from './stage/types';
 import type { FormResponse } from '../../types';
 
@@ -13,9 +13,10 @@ type EditEntityRecord = DispatchActions[ 'editEntityRecord' ];
 
 /**
  * Marks a single feedback response as read, both on the server and in the store,
- * and keeps the admin-menu unread counter in sync: it optimistically decrements
- * the sidebar badge, then reconciles with the authoritative server count, and
- * reverts both the store edit and the badge if the request fails.
+ * and keeps the admin-menu unread counter in sync via the shared menu-badges
+ * client: it optimistically decrements the sidebar badge, then reconciles with
+ * the authoritative server count, and reverts both the store edit and the badge
+ * if the request fails.
  *
  * Used by both inbox inspectors (via `useMarkAsReadOnView`) so the "mark as read
  * on view" behaviour cannot drift between the wp-build and legacy dashboards —
@@ -42,7 +43,7 @@ export function markResponseAsRead(
 	// Optimistically decrement the sidebar unread counter so it updates without
 	// waiting for the server (inbox/published responses only).
 	if ( status === 'publish' ) {
-		updateMenuCounterOptimistically( -1 );
+		window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
 	}
 
 	return apiFetch< { count: number } >( {
@@ -52,7 +53,7 @@ export function markResponseAsRead(
 	} )
 		.then( ( { count } ) => {
 			// Sync the sidebar counter with the authoritative server count.
-			updateMenuCounter( count );
+			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
 			onSuccess?.( id );
 		} )
 		.catch( () => {
@@ -61,7 +62,7 @@ export function markResponseAsRead(
 
 			// Revert the optimistic sidebar decrement.
 			if ( status === 'publish' ) {
-				updateMenuCounterOptimistically( 1 );
+				window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
 			}
 		} );
 }

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -13,7 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { notSpam, spam } from '../../icons/index.ts';
 import { store as dashboardStore } from '../../store/index.js';
-import { updateMenuCounter, updateMenuCounterOptimistically, withTimeout } from '../utils.js';
+import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount, withTimeout } from '../utils.js';
 import { optimisticallyUpdateUnreadCount, processStatusChange } from './process-status-change';
 import { defaultView } from './views.js';
 /**
@@ -867,7 +867,7 @@ export const markAsReadAction: Action = {
 
 					// Immediately update menu counters optimistically to avoid delays, but only for inbox
 					if ( status === 'publish' ) {
-						updateMenuCounterOptimistically( -1 );
+						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
 					}
 				}
 
@@ -879,7 +879,7 @@ export const markAsReadAction: Action = {
 				} )
 					.then( ( { count } ) => {
 						// Update menu counter with accurate count from server.
-						updateMenuCounter( count );
+						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
 					} )
 					.catch( () => {
 						// Revert the change in the store if the server update fails.
@@ -890,7 +890,10 @@ export const markAsReadAction: Action = {
 
 							// Revert the optimistic change in the sidebar.
 							if ( status === 'publish' ) {
-								updateMenuCounterOptimistically( 1 );
+								window.jetpackMenuBadges?.setCount(
+									FORMS_MENU_BADGE_SLUG,
+									getMenuBadgeCount() + 1
+								);
 							}
 						}
 
@@ -982,7 +985,7 @@ export const markAsUnreadAction: Action = {
 
 					// Immediately update menu counters optimistically to avoid delays, but only for inbox
 					if ( status === 'publish' ) {
-						updateMenuCounterOptimistically( 1 );
+						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
 					}
 				}
 
@@ -994,7 +997,7 @@ export const markAsUnreadAction: Action = {
 				} )
 					.then( ( { count } ) => {
 						// Update menu counter with accurate count from server.
-						updateMenuCounter( count );
+						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
 					} )
 					.catch( () => {
 						// Revert the change in the store if the server update fails.
@@ -1005,7 +1008,10 @@ export const markAsUnreadAction: Action = {
 
 							// Revert the optimistic change in the sidebar.
 							if ( status === 'publish' ) {
-								updateMenuCounterOptimistically( -1 );
+								window.jetpackMenuBadges?.setCount(
+									FORMS_MENU_BADGE_SLUG,
+									getMenuBadgeCount() - 1
+								);
 							}
 						}
 

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -13,7 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { notSpam, spam } from '../../icons/index.ts';
 import { store as dashboardStore } from '../../store/index.js';
-import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount, withTimeout } from '../utils.js';
+import { getFormsMenuBadgeSlug, getMenuBadgeCount, withTimeout } from '../utils.js';
 import { optimisticallyUpdateUnreadCount, processStatusChange } from './process-status-change';
 import { defaultView } from './views.js';
 /**
@@ -867,7 +867,7 @@ export const markAsReadAction: Action = {
 
 					// Immediately update menu counters optimistically to avoid delays, but only for inbox
 					if ( status === 'publish' ) {
-						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
+						window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() - 1 );
 					}
 				}
 
@@ -879,7 +879,7 @@ export const markAsReadAction: Action = {
 				} )
 					.then( ( { count } ) => {
 						// Update menu counter with accurate count from server.
-						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
+						window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), count );
 					} )
 					.catch( () => {
 						// Revert the change in the store if the server update fails.
@@ -891,7 +891,7 @@ export const markAsReadAction: Action = {
 							// Revert the optimistic change in the sidebar.
 							if ( status === 'publish' ) {
 								window.jetpackMenuBadges?.setCount(
-									FORMS_MENU_BADGE_SLUG,
+									getFormsMenuBadgeSlug(),
 									getMenuBadgeCount() + 1
 								);
 							}
@@ -985,7 +985,7 @@ export const markAsUnreadAction: Action = {
 
 					// Immediately update menu counters optimistically to avoid delays, but only for inbox
 					if ( status === 'publish' ) {
-						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
+						window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() + 1 );
 					}
 				}
 
@@ -997,7 +997,7 @@ export const markAsUnreadAction: Action = {
 				} )
 					.then( ( { count } ) => {
 						// Update menu counter with accurate count from server.
-						window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, count );
+						window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), count );
 					} )
 					.catch( () => {
 						// Revert the change in the store if the server update fails.
@@ -1009,7 +1009,7 @@ export const markAsUnreadAction: Action = {
 							// Revert the optimistic change in the sidebar.
 							if ( status === 'publish' ) {
 								window.jetpackMenuBadges?.setCount(
-									FORMS_MENU_BADGE_SLUG,
+									getFormsMenuBadgeSlug(),
 									getMenuBadgeCount() - 1
 								);
 							}

--- a/projects/packages/forms/src/dashboard/inbox/stage/process-status-change.ts
+++ b/projects/packages/forms/src/dashboard/inbox/stage/process-status-change.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount, withTimeout } from '../utils';
+import { getFormsMenuBadgeSlug, getMenuBadgeCount, withTimeout } from '../utils';
 import type { QueryParams } from './types.tsx';
 import type { FormResponse } from '../../../types/index.ts';
 
@@ -126,11 +126,11 @@ export const optimisticallyUpdateUnreadCount = (
 
 	if ( newStatus === 'spam' || newStatus === 'trash' ) {
 		if ( oldStatus === 'publish' ) {
-			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
+			window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() - 1 );
 		}
 	} else if ( oldStatus === 'spam' || oldStatus === 'trash' ) {
 		if ( newStatus === 'publish' ) {
-			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
+			window.jetpackMenuBadges?.setCount( getFormsMenuBadgeSlug(), getMenuBadgeCount() + 1 );
 		}
 	}
 };

--- a/projects/packages/forms/src/dashboard/inbox/stage/process-status-change.ts
+++ b/projects/packages/forms/src/dashboard/inbox/stage/process-status-change.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { updateMenuCounterOptimistically, withTimeout } from '../utils';
+import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount, withTimeout } from '../utils';
 import type { QueryParams } from './types.tsx';
 import type { FormResponse } from '../../../types/index.ts';
 
@@ -126,11 +126,11 @@ export const optimisticallyUpdateUnreadCount = (
 
 	if ( newStatus === 'spam' || newStatus === 'trash' ) {
 		if ( oldStatus === 'publish' ) {
-			updateMenuCounterOptimistically( -1 );
+			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() - 1 );
 		}
 	} else if ( oldStatus === 'spam' || oldStatus === 'trash' ) {
 		if ( newStatus === 'publish' ) {
-			updateMenuCounterOptimistically( 1 );
+			window.jetpackMenuBadges?.setCount( FORMS_MENU_BADGE_SLUG, getMenuBadgeCount() + 1 );
 		}
 	}
 };

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -1,5 +1,3 @@
-import { formatNumber } from '@automattic/number-formatters';
-
 // Function to get the URL of the page or post where the form was submitted.
 export const getPath = item => {
 	try {
@@ -11,65 +9,26 @@ export const getPath = item => {
 };
 
 /**
- * Update `count-0` style CSS class in the unread menu badge with new count like `count-1`.
- *
- * @param {HTMLElement} element - Counter badge element
- * @param {number}      count   - Count to use in new CSS class
+ * Slug the Forms wp-admin submenu badge is registered under. Must match
+ * `Dashboard::FORMS_WPBUILD_ADMIN_SLUG` in the PHP class of the same name, and
+ * the `data-jp-menu-badge` attribute the shared menu-badges renderer tags the
+ * Forms badge with.
  */
-function updateBadge( element, count ) {
-	const oldClass = [ ...element.classList ].find( c => c.startsWith( 'count-' ) );
-	if ( oldClass ) {
-		element.classList.replace( oldClass, `count-${ count }` );
-	} else {
-		element.classList.add( `count-${ count }` );
-	}
-
-	element.ariaHidden = count > 0 ? 'false' : 'true';
-
-	const countElement = element.querySelector( '.count' );
-	if ( countElement ) {
-		countElement.textContent = formatNumber( count );
-	} else {
-		element.textContent = formatNumber( count );
-	}
-}
+export const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
 
 /**
- * Update the unread count in the admin menu to specific count.
+ * Read the current Forms submenu badge count from the DOM, so callers can
+ * compute an optimistic delta (e.g. -1 on mark-as-read) without waiting for
+ * the authoritative server count.
  *
- * @param {number} count - The new unread count.
+ * @return {number} The current badge count, or 0 if the badge isn't rendered (e.g. the count is already 0).
  */
-export const updateMenuCounter = count => {
-	// Iterate over all badges with the class 'jp-feedback-unread-counter' and update their count
-	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
-		// Jetpack menu item has combined count and forms unread counter
-		if ( item.dataset.unreadDiff ) {
-			const unreadDiff = parseInt( item.dataset.unreadDiff, 10 ) + count;
-			updateBadge( item, unreadDiff );
-		} else {
-			updateBadge( item, count );
-		}
-	} );
-};
-
-/**
- * Update the unread count in the admin menu by addition or substraction, not by knowing the actual count.
- *
- * @param {number} count - By how much we should add or substract from the current sidebar menu count; either positive or negative integer.
- */
-export const updateMenuCounterOptimistically = count => {
-	// Iterate over all badges with the class 'jp-feedback-unread-counter' and update their count
-	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
-		let optimisticCount = 0;
-		if ( item.textContent !== '' ) {
-			// Ensure large formatted numbers like "1,000" are converted to integers properly
-			optimisticCount = parseInt( item.textContent.replace( /\D/g, '' ), 10 ) + count;
-		}
-
-		if ( optimisticCount >= 0 ) {
-			updateBadge( item, optimisticCount );
-		}
-	} );
+export const getMenuBadgeCount = () => {
+	const badge = document.querySelector( `[data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }"]` );
+	if ( ! badge ) {
+		return 0;
+	}
+	return parseInt( badge.getAttribute( 'data-jp-menu-count' ), 10 ) || 0;
 };
 
 /**

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -9,12 +9,22 @@ export const getPath = item => {
 };
 
 /**
- * Slug the Forms wp-admin submenu badge is registered under. Must match
- * `Dashboard::FORMS_WPBUILD_ADMIN_SLUG` in the PHP class of the same name, and
- * the `data-jp-menu-badge` attribute the shared menu-badges renderer tags the
- * Forms badge with.
+ * The Forms wp-admin submenu badge can be registered under either of two
+ * slugs, depending on the `jetpack_forms_alpha` filter: the wp-build slug
+ * (`jetpack-forms-responses-wp-admin`), or the legacy slug
+ * (`jetpack-forms-admin`, i.e. `Dashboard::ADMIN_SLUG`) when the filter
+ * returns false. This selector matches whichever one is actually rendered so
+ * callers don't have to hardcode (and potentially mismatch) the active slug.
  */
-export const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
+const FORMS_MENU_BADGE_SELECTOR =
+	'[data-jp-menu-badge="jetpack-forms-responses-wp-admin"],[data-jp-menu-badge="jetpack-forms-admin"]';
+
+/**
+ * Fallback slug to use when no Forms menu badge is present in the DOM
+ * (e.g. the count is already 0, or the badge simply hasn't rendered yet).
+ * This matches the default wp-build slug.
+ */
+const DEFAULT_FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
 
 /**
  * Read the current Forms submenu badge count from the DOM, so callers can
@@ -24,11 +34,26 @@ export const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
  * @return {number} The current badge count, or 0 if the badge isn't rendered (e.g. the count is already 0).
  */
 export const getMenuBadgeCount = () => {
-	const badge = document.querySelector( `[data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }"]` );
+	const badge = document.querySelector( FORMS_MENU_BADGE_SELECTOR );
 	if ( ! badge ) {
 		return 0;
 	}
 	return parseInt( badge.getAttribute( 'data-jp-menu-count' ), 10 ) || 0;
+};
+
+/**
+ * Resolve the slug the Forms wp-admin submenu badge is currently registered
+ * under, by reading it off the rendered `data-jp-menu-badge` attribute rather
+ * than assuming a fixed slug. This is needed because the active slug depends
+ * on the `jetpack_forms_alpha` filter (see `FORMS_MENU_BADGE_SELECTOR`
+ * above), and using the wrong slug means `window.jetpackMenuBadges.setCount()`
+ * silently no-ops against a badge element that doesn't exist.
+ *
+ * @return {string} The active Forms menu badge slug, or the default wp-build slug if no badge is rendered.
+ */
+export const getFormsMenuBadgeSlug = () => {
+	const badge = document.querySelector( FORMS_MENU_BADGE_SELECTOR );
+	return badge?.getAttribute( 'data-jp-menu-badge' ) ?? DEFAULT_FORMS_MENU_BADGE_SLUG;
 };
 
 /**

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -239,6 +239,10 @@ declare global {
 		jetpackForms?: {
 			generateStyleVariables: ( formNode: HTMLElement ) => Record< string, string >;
 		};
+		/** Shared client for live-updating Jetpack admin-menu notification badges (automattic/jetpack-menu-badges). */
+		jetpackMenuBadges?: {
+			setCount: ( menuSlug: string, count: number ) => void;
+		};
 	}
 }
 

--- a/projects/packages/forms/tests/js/dashboard/inbox/actions-menu-counter.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/actions-menu-counter.test.js
@@ -1,17 +1,7 @@
 /**
  * External dependencies
  */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-
-// Create mock function
-const updateMenuCounterOptimistically = jest.fn();
-
-// Mock the utils module before importing
-await jest.unstable_mockModule( '../../../../src/dashboard/inbox/utils.js', () => ( {
-	updateMenuCounterOptimistically,
-	updateMenuCounter: jest.fn(),
-	withTimeout: promise => promise,
-} ) );
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 
 /**
  * Internal dependencies
@@ -19,6 +9,20 @@ await jest.unstable_mockModule( '../../../../src/dashboard/inbox/utils.js', () =
 const { processStatusChange } = await import(
 	'../../../../src/dashboard/inbox/stage/process-status-change.ts'
 );
+
+const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
+
+/**
+ * A `setCount` stand-in that mirrors the real shared client: it writes the new
+ * count back onto the badge's `data-jp-menu-count` attribute, so sequential
+ * optimistic updates (e.g. across a bulk operation) compound correctly.
+ */
+const setCount = jest.fn( ( menuSlug, count ) => {
+	const badge = document.querySelector( `[data-jp-menu-badge="${ menuSlug }"]` );
+	if ( badge ) {
+		badge.setAttribute( 'data-jp-menu-count', String( count ) );
+	}
+} );
 
 describe( 'processStatusChange menu counter', () => {
 	let editEntityRecord;
@@ -28,6 +32,12 @@ describe( 'processStatusChange menu counter', () => {
 		jest.clearAllMocks();
 		editEntityRecord = jest.fn();
 		updateCountsOptimistically = jest.fn();
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
+		window.jetpackMenuBadges = { setCount };
+	} );
+
+	afterEach( () => {
+		delete window.jetpackMenuBadges;
 	} );
 
 	it( 'decrements counter when moving unread publish item to spam', async () => {
@@ -43,7 +53,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( -1 );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 4 );
 	} );
 
 	it( 'decrements counter when moving unread publish item to trash', async () => {
@@ -59,7 +69,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( -1 );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 4 );
 	} );
 
 	it( 'increments counter when restoring unread spam item to publish', async () => {
@@ -75,7 +85,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( 1 );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 6 );
 	} );
 
 	it( 'increments counter when restoring unread trash item to publish', async () => {
@@ -91,7 +101,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( 1 );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 6 );
 	} );
 
 	it( 'does not update counter for read items', async () => {
@@ -107,7 +117,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not update counter when moving spam to trash', async () => {
@@ -123,7 +133,7 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 
 	it( 'updates counter once per item in bulk operations', async () => {
@@ -147,8 +157,11 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledTimes( 3 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( -1 );
+		// Each item decrements the shared badge count in turn: 5 -> 4 -> 3 -> 2.
+		expect( setCount ).toHaveBeenCalledTimes( 3 );
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 4 );
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 3 );
+		expect( setCount ).toHaveBeenNthCalledWith( 3, FORMS_MENU_BADGE_SLUG, 2 );
 	} );
 
 	it( 'reverts counter when API call fails', async () => {
@@ -164,10 +177,10 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		// Should be called twice: once to decrement, once to revert
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledTimes( 2 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 1, -1 ); // Initial optimistic update
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 2, 1 ); // Revert
+		// Should be called twice: once to decrement (5 -> 4), once to revert (4 -> 5).
+		expect( setCount ).toHaveBeenCalledTimes( 2 );
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 4 ); // Initial optimistic update
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 5 ); // Revert
 	} );
 
 	it( 'reverts counter when restoring from spam fails', async () => {
@@ -183,10 +196,10 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		// Should be called twice: once to increment, once to revert
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledTimes( 2 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 1, 1 ); // Initial optimistic update
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 2, -1 ); // Revert
+		// Should be called twice: once to increment (5 -> 6), once to revert (6 -> 5).
+		expect( setCount ).toHaveBeenCalledTimes( 2 );
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 6 ); // Initial optimistic update
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 5 ); // Revert
 	} );
 
 	it( 'reverts only failed items in bulk operations', async () => {
@@ -210,12 +223,12 @@ describe( 'processStatusChange menu counter', () => {
 			queryParams: {},
 		} );
 
-		// Called 3 times for optimistic updates, 1 time to revert the failed item
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledTimes( 4 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 1, -1 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 2, -1 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 3, -1 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 4, 1 ); // Revert for item 2
+		// 3 optimistic decrements (5 -> 4 -> 3 -> 2), then 1 revert for the failed item (2 -> 3).
+		expect( setCount ).toHaveBeenCalledTimes( 4 );
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 4 );
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 3 );
+		expect( setCount ).toHaveBeenNthCalledWith( 3, FORMS_MENU_BADGE_SLUG, 2 );
+		expect( setCount ).toHaveBeenNthCalledWith( 4, FORMS_MENU_BADGE_SLUG, 3 ); // Revert for item 2
 	} );
 
 	it( 'does not revert counter for read items when API fails', async () => {
@@ -232,6 +245,6 @@ describe( 'processStatusChange menu counter', () => {
 		} );
 
 		// Should not be called at all since item is read
-		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/inbox/mark-as-read.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/mark-as-read.test.js
@@ -1,18 +1,10 @@
 /**
  * External dependencies
  */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 
 // Mocks must be registered before importing the module under test.
-const updateMenuCounter = jest.fn();
-const updateMenuCounterOptimistically = jest.fn();
 const apiFetch = jest.fn();
-
-await jest.unstable_mockModule( '../../../../src/dashboard/inbox/utils.js', () => ( {
-	updateMenuCounter,
-	updateMenuCounterOptimistically,
-	withTimeout: promise => promise,
-} ) );
 
 await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
 	default: apiFetch,
@@ -23,15 +15,36 @@ await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
  */
 const { markResponseAsRead } = await import( '../../../../src/dashboard/inbox/mark-as-read.ts' );
 
+const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
+
+/**
+ * A `setCount` stand-in that mirrors the real shared client: it writes the new
+ * count back onto the badge's `data-jp-menu-count` attribute, so a later
+ * `getMenuBadgeCount()` read (e.g. to compute a revert) sees the latest value.
+ */
+const setCount = jest.fn( ( menuSlug, count ) => {
+	const badge = document.querySelector( `[data-jp-menu-badge="${ menuSlug }"]` );
+	if ( badge ) {
+		badge.setAttribute( 'data-jp-menu-count', String( count ) );
+	}
+} );
+
 describe( 'markResponseAsRead', () => {
 	let editEntityRecord;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 		editEntityRecord = jest.fn();
+		document.body.innerHTML = '';
+		window.jetpackMenuBadges = { setCount };
+	} );
+
+	afterEach( () => {
+		delete window.jetpackMenuBadges;
 	} );
 
 	it( 'marks a published response read and syncs the sidebar counter', async () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
 		apiFetch.mockResolvedValue( { count: 4 } );
 		const onSuccess = jest.fn();
 
@@ -40,8 +53,8 @@ describe( 'markResponseAsRead', () => {
 		expect( editEntityRecord ).toHaveBeenCalledWith( 'postType', 'feedback', 7, {
 			is_unread: false,
 		} );
-		// Optimistic decrement happens before the server responds.
-		expect( updateMenuCounterOptimistically ).toHaveBeenCalledWith( -1 );
+		// Optimistic decrement happens before the server responds, based on the DOM count (5 - 1 = 4).
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 4 );
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/wp/v2/feedback/7/read',
@@ -50,7 +63,7 @@ describe( 'markResponseAsRead', () => {
 			} )
 		);
 		// The authoritative server count is applied on success.
-		expect( updateMenuCounter ).toHaveBeenCalledWith( 4 );
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 4 );
 		expect( onSuccess ).toHaveBeenCalledWith( 7 );
 	} );
 
@@ -59,12 +72,13 @@ describe( 'markResponseAsRead', () => {
 
 		await markResponseAsRead( { id: 8, status: 'spam' }, editEntityRecord );
 
-		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
 		// The server count is still applied so the badge stays authoritative.
-		expect( updateMenuCounter ).toHaveBeenCalledWith( 4 );
+		expect( setCount ).toHaveBeenCalledTimes( 1 );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 4 );
 	} );
 
 	it( 'reverts the store edit and the optimistic counter when the request fails', async () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
 		apiFetch.mockRejectedValue( new Error( 'network' ) );
 
 		await markResponseAsRead( { id: 9, status: 'publish' }, editEntityRecord );
@@ -75,9 +89,9 @@ describe( 'markResponseAsRead', () => {
 		expect( editEntityRecord ).toHaveBeenNthCalledWith( 2, 'postType', 'feedback', 9, {
 			is_unread: true,
 		} );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 1, -1 );
-		expect( updateMenuCounterOptimistically ).toHaveBeenNthCalledWith( 2, 1 );
-		expect( updateMenuCounter ).not.toHaveBeenCalled();
+		// Optimistic decrement (5 - 1 = 4), then reverted back to 5 on failure.
+		expect( setCount ).toHaveBeenNthCalledWith( 1, FORMS_MENU_BADGE_SLUG, 4 );
+		expect( setCount ).toHaveBeenNthCalledWith( 2, FORMS_MENU_BADGE_SLUG, 5 );
 	} );
 
 	it( 'does not revert the optimistic counter for non-published responses on failure', async () => {
@@ -88,6 +102,6 @@ describe( 'markResponseAsRead', () => {
 		expect( editEntityRecord ).toHaveBeenNthCalledWith( 2, 'postType', 'feedback', 10, {
 			is_unread: true,
 		} );
-		expect( updateMenuCounterOptimistically ).not.toHaveBeenCalled();
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
@@ -5,7 +5,10 @@ import { describe, expect, it, beforeEach } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from '../../../../src/dashboard/inbox/utils';
+import { getFormsMenuBadgeSlug, getMenuBadgeCount } from '../../../../src/dashboard/inbox/utils';
+
+const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
+const FORMS_LEGACY_MENU_BADGE_SLUG = 'jetpack-forms-admin';
 
 describe( 'getMenuBadgeCount', () => {
 	beforeEach( () => {
@@ -16,6 +19,12 @@ describe( 'getMenuBadgeCount', () => {
 		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
 
 		expect( getMenuBadgeCount() ).toBe( 5 );
+	} );
+
+	it( 'reads the count when the legacy (jetpack_forms_alpha=false) badge slug is rendered instead', () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_LEGACY_MENU_BADGE_SLUG }" data-jp-menu-count="7"></span>`;
+
+		expect( getMenuBadgeCount() ).toBe( 7 );
 	} );
 
 	it( 'returns 0 when the badge is not rendered (e.g. count is already 0)', () => {
@@ -33,5 +42,27 @@ describe( 'getMenuBadgeCount', () => {
 		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="not-a-number"></span>`;
 
 		expect( getMenuBadgeCount() ).toBe( 0 );
+	} );
+} );
+
+describe( 'getFormsMenuBadgeSlug', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'returns the wp-build slug when that badge is rendered', () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
+
+		expect( getFormsMenuBadgeSlug() ).toBe( FORMS_MENU_BADGE_SLUG );
+	} );
+
+	it( 'returns the legacy slug when jetpack_forms_alpha=false renders that badge instead', () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_LEGACY_MENU_BADGE_SLUG }" data-jp-menu-count="7"></span>`;
+
+		expect( getFormsMenuBadgeSlug() ).toBe( FORMS_LEGACY_MENU_BADGE_SLUG );
+	} );
+
+	it( 'falls back to the wp-build slug when no badge is rendered', () => {
+		expect( getFormsMenuBadgeSlug() ).toBe( FORMS_MENU_BADGE_SLUG );
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
@@ -5,45 +5,33 @@ import { describe, expect, it, beforeEach } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import {
-	updateMenuCounter,
-	updateMenuCounterOptimistically,
-} from '../../../../src/dashboard/inbox/utils';
+import { FORMS_MENU_BADGE_SLUG, getMenuBadgeCount } from '../../../../src/dashboard/inbox/utils';
 
-describe( 'Menu counter updates', () => {
+describe( 'getMenuBadgeCount', () => {
 	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'reads the count from the Forms badge data attribute', () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
+
+		expect( getMenuBadgeCount() ).toBe( 5 );
+	} );
+
+	it( 'returns 0 when the badge is not rendered (e.g. count is already 0)', () => {
+		expect( getMenuBadgeCount() ).toBe( 0 );
+	} );
+
+	it( 'ignores badges for other menu slugs', () => {
 		document.body.innerHTML =
-			'<span class="menu-counter jp-feedback-unread-counter count-5"><span class="count">5</span></span>';
+			'<span data-jp-menu-badge="some-other-plugin" data-jp-menu-count="9"></span>';
+
+		expect( getMenuBadgeCount() ).toBe( 0 );
 	} );
 
-	it( 'updates counter from server', () => {
-		updateMenuCounter( 10 );
+	it( 'returns 0 for a non-numeric count attribute', () => {
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="not-a-number"></span>`;
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '10' );
-		expect( counter ).toHaveClass( 'count-10' );
-	} );
-
-	it( 'increments counter optimistically', () => {
-		updateMenuCounterOptimistically( 1 );
-
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '6' );
-	} );
-
-	it( 'decrements counter optimistically', () => {
-		updateMenuCounterOptimistically( -1 );
-
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '4' );
-	} );
-
-	it( 'server count overrides optimistic updates', () => {
-		updateMenuCounterOptimistically( 1 ); // Now 6
-		updateMenuCounterOptimistically( 1 ); // Now 7
-		updateMenuCounter( 10 ); // Server says 10
-
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '10' );
+		expect( getMenuBadgeCount() ).toBe( 0 );
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/inbox/optimistically-update-unread-count.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/optimistically-update-unread-count.test.js
@@ -1,50 +1,63 @@
 /**
  * External dependencies
  */
-import { describe, expect, it, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 /**
  * Internal dependencies
  */
 import { optimisticallyUpdateUnreadCount } from '../../../../src/dashboard/inbox/stage/process-status-change';
 
+const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
+
+/**
+ * A `setCount` stand-in that mirrors the real shared client: it writes the new
+ * count back onto the badge's `data-jp-menu-count` attribute.
+ */
+const setCount = jest.fn( ( menuSlug, count ) => {
+	const badge = document.querySelector( `[data-jp-menu-badge="${ menuSlug }"]` );
+	if ( badge ) {
+		badge.setAttribute( 'data-jp-menu-count', String( count ) );
+	}
+} );
+
 describe( 'optimisticallyUpdateUnreadCount', () => {
 	beforeEach( () => {
-		document.body.innerHTML =
-			'<span class="menu-counter jp-feedback-unread-counter count-5"><span class="count">5</span></span>';
+		jest.clearAllMocks();
+		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
+		window.jetpackMenuBadges = { setCount };
+	} );
+
+	afterEach( () => {
+		delete window.jetpackMenuBadges;
 	} );
 
 	it( 'does not change counter for read items', () => {
 		optimisticallyUpdateUnreadCount( 'spam', 'publish', false );
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '5' );
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 
 	it( 'decrements counter when moving unread item from publish to spam', () => {
 		optimisticallyUpdateUnreadCount( 'spam', 'publish', true );
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '4' );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 4 );
 	} );
 
 	it( 'decrements counter when moving unread item from publish to trash', () => {
 		optimisticallyUpdateUnreadCount( 'trash', 'publish', true );
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '4' );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 4 );
 	} );
 
 	it( 'increments counter when restoring unread item to publish', () => {
 		optimisticallyUpdateUnreadCount( 'publish', 'spam', true );
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '6' );
+		expect( setCount ).toHaveBeenCalledWith( FORMS_MENU_BADGE_SLUG, 6 );
 	} );
 
 	it( 'does not change counter when moving between spam and trash', () => {
 		optimisticallyUpdateUnreadCount( 'trash', 'spam', true );
 
-		const counter = document.querySelector( '.jp-feedback-unread-counter' );
-		expect( counter ).toHaveTextContent( '5' );
+		expect( setCount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
+use Automattic\Jetpack\Menu_Badges\Notification_Counts;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -1161,14 +1162,19 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Clean up menu globals and options after each unread_count test.
+	 * Reset the menu-badges registry before each unread_count test so entries
+	 * left by other test classes in the same PHPUnit process don't leak in.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Notification_Counts::reset();
+	}
+
+	/**
+	 * Clean up the menu-badges registry and options after each unread_count test.
 	 */
 	public function tearDown(): void {
-		global $menu, $submenu;
-		if ( isset( $menu ) || isset( $submenu ) ) {
-			$menu    = array();
-			$submenu = array();
-		}
+		Notification_Counts::reset();
 		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 		delete_option( 'jetpack_feedback_unread_count' );
 		wp_set_current_user( 0 );
@@ -1176,37 +1182,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Helper: set up $menu and $submenu globals for unread_count() tests.
-	 *
-	 * @param string $jetpack_title The title for the Jetpack menu item.
-	 * @return array { menu_index: int, submenu_index: int } Indices of the Jetpack and Forms entries.
-	 */
-	private function setup_menu_globals( $jetpack_title = 'Jetpack' ) {
-		global $menu, $submenu;
-
-		$menu    = array();
-		$submenu = array();
-
-		// Jetpack top-level menu entry at index 2.
-		$menu[2] = array( $jetpack_title, 'jetpack_admin_page', 'jetpack', 'Jetpack', 'menu-top' );
-
-		// Forms submenu entry.
-		$admin_slug             = Dashboard::ADMIN_SLUG;
-		$submenu['jetpack']     = array();
-		$submenu['jetpack'][0]  = array( 'Dashboard', 'manage_options', 'jetpack' );
-		$submenu['jetpack'][10] = array( 'Form Responses', 'edit_pages', $admin_slug );
-
-		// Ensure the alpha filter returns false so ADMIN_SLUG is used.
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		return array(
-			'menu_index'    => 2,
-			'submenu_index' => 10,
-		);
-	}
-
-	/**
-	 * Helper: create an admin user and set as current user.
+	 * Helper: create an admin user (with edit_pages capability) and set as current user.
 	 *
 	 * @return int The user ID.
 	 */
@@ -1223,118 +1199,37 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * When Forms unread count is 0 and the Jetpack menu has no existing badge,
-	 * unread_count() should not add a jp-feedback-unread-counter badge.
+	 * Unread_count() should register the unread count with the central
+	 * menu-badges registry, under the Forms wp-build dashboard slug (the
+	 * default, since jetpack_forms_alpha defaults to true).
 	 */
-	public function test_unread_count_zero_does_not_add_forms_badge() {
+	public function test_unread_count_registers_with_menu_badges() {
 		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack' );
-		update_option( 'jetpack_feedback_unread_count', 0 );
-
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
-
-		global $menu, $submenu;
-
-		$this->assertSame( 'Jetpack', $menu[ $indices['menu_index'] ][0], 'Menu title should remain unchanged.' );
-		$this->assertSame( 'Form Responses', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu title should remain unchanged.' );
-	}
-
-	/**
-	 * When Forms unread count is 0 but the Jetpack menu already has a My Jetpack
-	 * awaiting-mod badge, unread_count() should leave it untouched and not wrap it
-	 * in a jp-feedback-unread-counter span.
-	 */
-	public function test_unread_count_zero_preserves_existing_my_jetpack_badge() {
-		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack <span class="awaiting-mod">1</span>' );
-		update_option( 'jetpack_feedback_unread_count', 0 );
-
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
-
-		global $menu;
-
-		$this->assertStringContainsString( 'awaiting-mod', $menu[ $indices['menu_index'] ][0], 'My Jetpack badge should be preserved.' );
-		$this->assertStringNotContainsString( 'jp-feedback-unread-counter', $menu[ $indices['menu_index'] ][0], 'Forms should not re-wrap the badge.' );
-	}
-
-	/**
-	 * When Forms has unread submissions and no existing Jetpack badge,
-	 * unread_count() should add a jp-feedback-unread-counter badge to the menu.
-	 */
-	public function test_unread_count_nonzero_adds_forms_badge_to_menu() {
-		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack' );
 		update_option( 'jetpack_feedback_unread_count', 3 );
 
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
+		Contact_Form_Plugin::init()->unread_count();
 
-		global $menu;
-
-		$this->assertStringContainsString( 'menu-counter', $menu[ $indices['menu_index'] ][0], 'Should use menu-counter badge markup.' );
-		$this->assertStringContainsString( 'jp-feedback-unread-counter', $menu[ $indices['menu_index'] ][0], 'Should contain Forms badge class.' );
-		$this->assertStringContainsString( 'count-3', $menu[ $indices['menu_index'] ][0], 'Should show count of 3.' );
-		$this->assertStringContainsString( "data-unread-diff='0'", $menu[ $indices['menu_index'] ][0], 'Diff should be 0 when no other badges exist.' );
+		$this->assertSame( 3, Notification_Counts::get_for_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG ) );
 	}
 
 	/**
-	 * When Forms has unread submissions and the Jetpack menu already has a My Jetpack
-	 * awaiting-mod badge, unread_count() should combine both counts.
+	 * Unread_count() should register against the legacy ADMIN_SLUG instead when
+	 * the jetpack_forms_alpha filter is disabled.
 	 */
-	public function test_unread_count_nonzero_combines_with_existing_badge() {
+	public function test_unread_count_registers_legacy_slug_when_alpha_disabled() {
 		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack <span class="awaiting-mod">1</span>' );
-		update_option( 'jetpack_feedback_unread_count', 2 );
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+		update_option( 'jetpack_feedback_unread_count', 4 );
 
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
+		Contact_Form_Plugin::init()->unread_count();
 
-		global $menu;
-
-		$this->assertStringContainsString( 'jp-feedback-unread-counter', $menu[ $indices['menu_index'] ][0], 'Should contain Forms badge class.' );
-		$this->assertStringContainsString( 'count-3', $menu[ $indices['menu_index'] ][0], 'Should show combined count of 3 (2 unread + 1 existing).' );
-		$this->assertStringContainsString( "data-unread-diff='1'", $menu[ $indices['menu_index'] ][0], 'Diff should be 1 (3 - 2).' );
-	}
-
-	/**
-	 * When Forms has unread submissions, the Forms submenu item should get a badge.
-	 */
-	public function test_unread_count_nonzero_adds_badge_to_submenu() {
-		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack' );
-		update_option( 'jetpack_feedback_unread_count', 5 );
-
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
-
-		global $submenu;
-
-		$this->assertStringContainsString( 'menu-counter', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu should use menu-counter badge markup.' );
-		$this->assertStringContainsString( 'jp-feedback-unread-counter', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu should contain Forms badge.' );
-		$this->assertStringContainsString( 'count-5', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu badge should show count of 5.' );
-	}
-
-	/**
-	 * When Forms has 0 unread submissions, the Forms submenu item should not get a badge.
-	 */
-	public function test_unread_count_zero_does_not_add_badge_to_submenu() {
-		$this->create_admin_user();
-		$indices = $this->setup_menu_globals( 'Jetpack' );
-		update_option( 'jetpack_feedback_unread_count', 0 );
-
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
-
-		global $submenu;
-
-		$this->assertStringNotContainsString( 'jp-feedback-unread-counter', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu should not contain Forms badge when unread is 0.' );
+		$this->assertSame( 4, Notification_Counts::get_for_menu( Dashboard::ADMIN_SLUG ) );
+		$this->assertSame( 0, Notification_Counts::get_for_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG ) );
 	}
 
 	/**
 	 * When the current user lacks edit_pages capability, unread_count() should
-	 * not modify the menu globals at all.
+	 * not register anything with the menu-badges registry.
 	 */
 	public function test_unread_count_skips_for_user_without_edit_pages() {
 		// Create a subscriber (no edit_pages capability).
@@ -1346,40 +1241,11 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			)
 		);
 		wp_set_current_user( $user_id );
-
-		$indices = $this->setup_menu_globals( 'Jetpack' );
 		update_option( 'jetpack_feedback_unread_count', 5 );
 
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
+		Contact_Form_Plugin::init()->unread_count();
 
-		global $menu, $submenu;
-
-		$this->assertSame( 'Jetpack', $menu[ $indices['menu_index'] ][0], 'Menu title should remain unchanged for users without edit_pages.' );
-		$this->assertSame( 'Form Responses', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu title should remain unchanged for users without edit_pages.' );
-	}
-
-	/**
-	 * When $submenu['jetpack'] is not set, unread_count() should not modify the
-	 * menu and should complete without errors.
-	 */
-	public function test_unread_count_handles_missing_submenu() {
-		$this->create_admin_user();
-
-		global $menu, $submenu;
-		$menu    = array();
-		$submenu = array();
-
-		// Set up only the main menu, no submenu.
-		$menu[2] = array( 'Jetpack', 'jetpack_admin_page', 'jetpack', 'Jetpack', 'menu-top' );
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		update_option( 'jetpack_feedback_unread_count', 3 );
-
-		$plugin = Contact_Form_Plugin::init();
-		$plugin->unread_count();
-
-		$this->assertSame( 'Jetpack', $menu[2][0], 'Menu title should remain unchanged when submenu is missing.' );
+		$this->assertSame( 0, Notification_Counts::get_for_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG ) );
 	}
 
 	/**

--- a/projects/packages/menu-badges/.gitattributes
+++ b/projects/packages/menu-badges/.gitattributes
@@ -1,0 +1,9 @@
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+build/**          production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# (see also entries in the monorepo root .gitattributes)
+# Remember to end all directories with `/**` to properly tag every file.
+src/**.scss       production-exclude

--- a/projects/packages/menu-badges/.gitignore
+++ b/projects/packages/menu-badges/.gitignore
@@ -1,0 +1,5 @@
+build/
+vendor/
+node_modules/
+wordpress
+.cache

--- a/projects/packages/menu-badges/.phan/config.php
+++ b/projects/packages/menu-badges/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-menu-badges
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/menu-badges/CHANGELOG.md
+++ b/projects/packages/menu-badges/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/projects/packages/menu-badges/README.md
+++ b/projects/packages/menu-badges/README.md
@@ -1,0 +1,17 @@
+# Menu Badges
+
+Central registry and renderer for Jetpack admin-menu notification-count badges.
+
+This package is currently scaffold-only (no registry or renderer behavior yet); that code is introduced in follow-up tasks.
+
+## Usage
+
+`\Automattic\Jetpack\Menu_Badges\Menu_Badges::init();`
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+menu-badges is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)

--- a/projects/packages/menu-badges/README.md
+++ b/projects/packages/menu-badges/README.md
@@ -2,11 +2,39 @@
 
 Central registry and renderer for Jetpack admin-menu notification-count badges.
 
-This package is currently scaffold-only (no registry or renderer behavior yet); that code is introduced in follow-up tasks.
+Products report a count against a Jetpack menu item to the `Notification_Counts`
+registry; `Menu_Renderer` (wired by `Menu_Badges::init()`) is the sole writer of
+those badges into the wp-admin `$menu`/`$submenu` globals, and it also feeds the
+top-level total into the WP.com admin-menu REST response. This replaces every
+feature poking at `$menu`/`$submenu` on its own.
 
 ## Usage
 
-`\Automattic\Jetpack\Menu_Badges\Menu_Badges::init();`
+Wire the renderer (idempotent — call it from every consumer that registers a
+count), then register your count:
+
+```php
+\Automattic\Jetpack\Menu_Badges\Menu_Badges::init();
+
+\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+	'jetpack-forms', // Unique id for your entry.
+	array(
+		'menu_slug' => 'jetpack-forms-responses', // Submenu item slug to badge; null for top-level total only.
+		'count'     => 3,                          // Magnitude for 'count' entries.
+		'type'      => 'count',                    // 'count' (uses `count`) or 'attention' (contributes 1).
+	)
+);
+```
+
+Guard the `register()` call on the same capability as the menu item it badges
+(e.g. `current_user_can( 'manage_options' )`), so the top-level total never
+includes counts the current user can't act on.
+
+To live-update a badge after a client-side change, without a page reload:
+
+```js
+window.jetpackMenuBadges.setCount( 'jetpack-forms-responses', 2 );
+```
 
 ## Security
 

--- a/projects/packages/menu-badges/changelog/add-menu-badges-package
+++ b/projects/packages/menu-badges/changelog/add-menu-badges-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Initial release: central registry and renderer for Jetpack admin-menu notification-count badges.

--- a/projects/packages/menu-badges/composer.json
+++ b/projects/packages/menu-badges/composer.json
@@ -1,0 +1,60 @@
+{
+	"name": "automattic/jetpack-menu-badges",
+	"description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2",
+		"automattic/jetpack-assets": "@dev"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-test-environment": "@dev",
+		"automattic/phpunit-select-config": "@dev"
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-php": "@composer phpunit",
+		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-menu-badges",
+		"textdomain": "jetpack-menu-badges",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+		},
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-menu-badges.php"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"roots/wordpress-core-installer": true
+		}
+	}
+}

--- a/projects/packages/menu-badges/jest.config.js
+++ b/projects/packages/menu-badges/jest.config.js
@@ -1,0 +1,7 @@
+const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
+
+module.exports = {
+	...baseConfig,
+	rootDir: __dirname,
+	testMatch: [ '**/tests/js/**/*.test.js' ],
+};

--- a/projects/packages/menu-badges/package.json
+++ b/projects/packages/menu-badges/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-menu-badges",
-	"version": "0.1.0",
+	"version": "0.1.0-alpha",
 	"description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
 	"private": true,
 	"scripts": {

--- a/projects/packages/menu-badges/package.json
+++ b/projects/packages/menu-badges/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@automattic/jetpack-menu-badges",
+	"version": "0.1.0",
+	"description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+	"private": true,
+	"scripts": {
+		"test-js": "jest"
+	}
+}

--- a/projects/packages/menu-badges/package.json
+++ b/projects/packages/menu-badges/package.json
@@ -5,5 +5,8 @@
 	"private": true,
 	"scripts": {
 		"test-js": "jest"
+	},
+	"devDependencies": {
+		"jest": "30.4.2"
 	}
 }

--- a/projects/packages/menu-badges/phpunit.11.xml.dist
+++ b/projects/packages/menu-badges/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/menu-badges/phpunit.12.xml.dist
+++ b/projects/packages/menu-badges/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/menu-badges/phpunit.8.xml.dist
+++ b/projects/packages/menu-badges/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/menu-badges/phpunit.9.xml.dist
+++ b/projects/packages/menu-badges/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/menu-badges/src/class-menu-badges.php
+++ b/projects/packages/menu-badges/src/class-menu-badges.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Bootstrap for the Jetpack menu-badges package.
+ *
+ * @package automattic/jetpack-menu-badges
+ */
+
+namespace Automattic\Jetpack\Menu_Badges;
+
+/**
+ * Wires the notification-count registry into the admin menu and enqueues the client.
+ */
+class Menu_Badges {
+
+	const PACKAGE_VERSION = '0.1.0';
+
+	/**
+	 * Initialize the package. Idempotent.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		static $done = false;
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+		// Renderer + client wiring added in later tasks.
+	}
+}

--- a/projects/packages/menu-badges/src/class-menu-badges.php
+++ b/projects/packages/menu-badges/src/class-menu-badges.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Menu_Badges;
  */
 class Menu_Badges {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.1.0-alpha';
 
 	/**
 	 * Initialize the package. Idempotent.

--- a/projects/packages/menu-badges/src/class-menu-badges.php
+++ b/projects/packages/menu-badges/src/class-menu-badges.php
@@ -25,6 +25,28 @@ class Menu_Badges {
 			return;
 		}
 		$done = true;
-		// Renderer + client wiring added in later tasks.
+
+		// Render badges late, after products have registered their menus and counts.
+		add_action( 'admin_menu', array( Menu_Renderer::class, 'render' ), 100000 );
+
+		// Client live-update API.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_client' ) );
+	}
+
+	/**
+	 * Enqueue the vanilla client that owns live badge updates.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_client() {
+		\Automattic\Jetpack\Assets::register_script(
+			'jetpack-menu-badges',
+			'../src/js/menu-badges.js',
+			__FILE__,
+			array(
+				'enqueue'   => true,
+				'in_footer' => true,
+			)
+		);
 	}
 }

--- a/projects/packages/menu-badges/src/class-menu-renderer.php
+++ b/projects/packages/menu-badges/src/class-menu-renderer.php
@@ -74,10 +74,19 @@ class Menu_Renderer {
 			}
 		}
 
-		// Top-level total on the Jetpack parent (found by capability).
+		// Top-level total on the Jetpack parent. Match by menu slug (item[2]), which is
+		// portable across self-hosted, Atomic, and WP.com Simple — where jetpack-mu-wpcom
+		// builds the parent with a different capability, so the plugin's 'jetpack_admin_page'
+		// capability (kept as a fallback) is absent.
 		$total = Notification_Counts::get_total();
 		foreach ( $menu as $i => $item ) {
-			if ( isset( $item[1] ) && 'jetpack_admin_page' === $item[1] && isset( $item[0] ) ) {
+			if (
+				isset( $item[0] )
+				&& (
+					( isset( $item[2] ) && 'jetpack' === $item[2] )
+					|| ( isset( $item[1] ) && 'jetpack_admin_page' === $item[1] )
+				)
+			) {
 				$title = self::strip( $item[0] );
 				if ( $total > 0 ) {
 					$title .= self::badge_markup( 'total', $total, true );

--- a/projects/packages/menu-badges/src/class-menu-renderer.php
+++ b/projects/packages/menu-badges/src/class-menu-renderer.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Renders notification-count badges into the wp-admin $menu/$submenu globals.
+ *
+ * @package automattic/jetpack-menu-badges
+ */
+
+namespace Automattic\Jetpack\Menu_Badges;
+
+/**
+ * Reads the Notification_Counts registry and writes the top-level and submenu
+ * badges. Sole writer of Jetpack menu badges in wp-admin. Idempotent.
+ */
+class Menu_Renderer {
+
+	/**
+	 * Build a single badge span.
+	 *
+	 * @param string $id       Owning entry id (or 'total').
+	 * @param int    $count    Count to show.
+	 * @param bool   $is_total Whether this is the top-level total badge.
+	 * @return string
+	 */
+	public static function badge_markup( $id, $count, $is_total = false ) {
+		$attrs = sprintf(
+			'class="menu-counter count-%1$d" data-jp-menu-badge="%2$s" data-jp-menu-count="%1$d"%3$s',
+			(int) $count,
+			esc_attr( $id ),
+			$is_total ? ' data-jp-menu-badge-total="1"' : ''
+		);
+		return sprintf(
+			' <span %1$s><span class="count">%2$s</span></span>',
+			$attrs,
+			number_format_i18n( $count )
+		);
+	}
+
+	/**
+	 * Strip any badge this renderer previously wrote from a menu title (idempotency).
+	 *
+	 * @param string $title Menu title.
+	 * @return string
+	 */
+	private static function strip( $title ) {
+		return trim( (string) preg_replace( '/\s*<span class="menu-counter count-\d+" data-jp-menu-badge=.*$/s', '', (string) $title ) );
+	}
+
+	/**
+	 * Render badges into the current $menu/$submenu globals.
+	 *
+	 * @return void
+	 */
+	public static function render() {
+		global $menu, $submenu;
+
+		if ( ! is_array( $menu ) ) {
+			return;
+		}
+
+		// Submenu badges: one per registered menu_slug with a positive count.
+		if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) ) {
+			foreach ( $submenu['jetpack'] as $i => $item ) {
+				if ( ! isset( $item[2] ) || ! isset( $item[0] ) ) {
+					continue;
+				}
+				$slug  = $item[2];
+				$count = Notification_Counts::get_for_menu( $slug );
+				$title = self::strip( $item[0] );
+				if ( $count > 0 ) {
+					$title .= self::badge_markup( $slug, $count );
+				}
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu['jetpack'][ $i ][0] = $title;
+			}
+		}
+
+		// Top-level total on the Jetpack parent (found by capability).
+		$total = Notification_Counts::get_total();
+		foreach ( $menu as $i => $item ) {
+			if ( isset( $item[1] ) && 'jetpack_admin_page' === $item[1] && isset( $item[0] ) ) {
+				$title = self::strip( $item[0] );
+				if ( $total > 0 ) {
+					$title .= self::badge_markup( 'total', $total, true );
+				}
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$menu[ $i ][0] = $title;
+				break;
+			}
+		}
+	}
+}

--- a/projects/packages/menu-badges/src/class-menu-renderer.php
+++ b/projects/packages/menu-badges/src/class-menu-renderer.php
@@ -22,11 +22,17 @@ class Menu_Renderer {
 	 * @return string
 	 */
 	public static function badge_markup( $id, $count, $is_total = false ) {
-		$attrs = sprintf(
-			'class="menu-counter count-%1$d" data-jp-menu-badge="%2$s" data-jp-menu-count="%1$d"%3$s',
-			(int) $count,
+		$count = (int) $count;
+		// A zero-count badge still renders (so client live-updates have an element to
+		// target) but ships hidden. The inline style trails the data-jp-* attributes so
+		// strip()'s idempotency regex still matches; setBadgeCount() clears it to reveal.
+		$hidden = $count > 0 ? '' : ' style="display:none"';
+		$attrs  = sprintf(
+			'class="menu-counter count-%1$d" data-jp-menu-badge="%2$s" data-jp-menu-count="%1$d"%3$s%4$s',
+			$count,
 			esc_attr( $id ),
-			$is_total ? ' data-jp-menu-badge-total="1"' : ''
+			$is_total ? ' data-jp-menu-badge-total="1"' : '',
+			$hidden
 		);
 		return sprintf(
 			' <span %1$s><span class="count">%2$s</span></span>',
@@ -57,44 +63,78 @@ class Menu_Renderer {
 			return;
 		}
 
-		// Submenu badges: one per registered menu_slug with a positive count.
+		$entries = Notification_Counts::all();
+
+		// Submenu badges: one per registered menu_slug. A registered slug always gets a
+		// badge span — even at count 0 — so a later client live-update (0 -> positive)
+		// has an element to reveal. badge_markup() ships the zero case hidden.
 		if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) ) {
 			foreach ( $submenu['jetpack'] as $i => $item ) {
 				if ( ! isset( $item[2] ) || ! isset( $item[0] ) ) {
 					continue;
 				}
 				$slug  = $item[2];
-				$count = Notification_Counts::get_for_menu( $slug );
 				$title = self::strip( $item[0] );
-				if ( $count > 0 ) {
-					$title .= self::badge_markup( $slug, $count );
+				if ( self::has_registered_slug( $entries, $slug ) ) {
+					$title .= self::badge_markup( $slug, Notification_Counts::get_for_menu( $slug ) );
 				}
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$submenu['jetpack'][ $i ][0] = $title;
 			}
 		}
 
-		// Top-level total on the Jetpack parent. Match by menu slug (item[2]), which is
-		// portable across self-hosted, Atomic, and WP.com Simple — where jetpack-mu-wpcom
-		// builds the parent with a different capability, so the plugin's 'jetpack_admin_page'
-		// capability (kept as a fallback) is absent.
-		$total = Notification_Counts::get_total();
-		foreach ( $menu as $i => $item ) {
-			if (
-				isset( $item[0] )
-				&& (
-					( isset( $item[2] ) && 'jetpack' === $item[2] )
-					|| ( isset( $item[1] ) && 'jetpack_admin_page' === $item[1] )
-				)
-			) {
-				$title = self::strip( $item[0] );
-				if ( $total > 0 ) {
-					$title .= self::badge_markup( 'total', $total, true );
-				}
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$menu[ $i ][0] = $title;
-				break;
+		// Nothing registered: leave the Jetpack parent untouched (no badge to write or strip).
+		if ( empty( $entries ) ) {
+			return;
+		}
+
+		// Top-level total on the Jetpack parent. Rendered even at 0 (hidden) so a live
+		// update can reveal it without a reload.
+		$parent_index = self::find_parent_index( $menu );
+		if ( null === $parent_index ) {
+			return;
+		}
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$menu[ $parent_index ][0] = self::strip( $menu[ $parent_index ][0] ) . self::badge_markup( 'total', Notification_Counts::get_total(), true );
+	}
+
+	/**
+	 * Whether any registered entry badges the given submenu slug.
+	 *
+	 * @param array<string,array> $entries Registry entries (from Notification_Counts::all()).
+	 * @param string              $slug    Submenu slug.
+	 * @return bool
+	 */
+	private static function has_registered_slug( array $entries, $slug ) {
+		foreach ( $entries as $entry ) {
+			if ( isset( $entry['menu_slug'] ) && $entry['menu_slug'] === $slug ) {
+				return true;
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * Locate the Jetpack top-level menu row to carry the total badge.
+	 *
+	 * Prefers the row whose slug (item[2]) is 'jetpack' — portable across self-hosted,
+	 * Atomic, and WP.com Simple, where jetpack-mu-wpcom builds the parent with a different
+	 * capability. Falls back to the plugin's 'jetpack_admin_page' capability (item[1]).
+	 *
+	 * @param array $menu The wp-admin $menu global.
+	 * @return int|string|null Matching key, or null when no Jetpack parent is present.
+	 */
+	private static function find_parent_index( array $menu ) {
+		foreach ( $menu as $i => $item ) {
+			if ( isset( $item[0] ) && isset( $item[2] ) && 'jetpack' === $item[2] ) {
+				return $i;
+			}
+		}
+		foreach ( $menu as $i => $item ) {
+			if ( isset( $item[0] ) && isset( $item[1] ) && 'jetpack_admin_page' === $item[1] ) {
+				return $i;
+			}
+		}
+		return null;
 	}
 }

--- a/projects/packages/menu-badges/src/class-notification-counts.php
+++ b/projects/packages/menu-badges/src/class-notification-counts.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Central registry of admin-menu notification counts.
+ *
+ * @package automattic/jetpack-menu-badges
+ */
+
+namespace Automattic\Jetpack\Menu_Badges;
+
+/**
+ * Passive source of truth for admin-menu notification counts. Products register
+ * a count against a menu item; renderers read the aggregate. No rendering here.
+ */
+class Notification_Counts {
+
+	/**
+	 * Registered entries, keyed by id.
+	 *
+	 * @var array<string,array>
+	 */
+	private static $entries = array();
+
+	/**
+	 * Register (or overwrite) a notification count for a product.
+	 *
+	 * @param string $id   Unique id (e.g. 'jetpack-forms').
+	 * @param array  $args {
+	 *     Notification count entry arguments.
+	 *
+	 *     @type string|null $menu_slug Submenu item slug to badge; null → top-level only.
+	 *     @type int         $count     Magnitude for 'count' entries. Default 0.
+	 *     @type string      $type      'count' | 'attention'. Default 'count'.
+	 *     @type bool        $is_silent Exclude from totals/display. Default false.
+	 * }
+	 * @return void
+	 */
+	public static function register( $id, array $args ) {
+		self::$entries[ $id ] = array(
+			'menu_slug' => isset( $args['menu_slug'] ) ? (string) $args['menu_slug'] : null,
+			'count'     => isset( $args['count'] ) ? (int) $args['count'] : 0,
+			'type'      => ( isset( $args['type'] ) && 'attention' === $args['type'] ) ? 'attention' : 'count',
+			'is_silent' => ! empty( $args['is_silent'] ),
+		);
+	}
+
+	/**
+	 * All non-silent entries, after applying the extension filter.
+	 *
+	 * @return array<string,array>
+	 */
+	public static function all() {
+		/**
+		 * Filters the registered menu notification counts.
+		 *
+		 * @since 0.1.0
+		 * @param array<string,array> $entries Map of id => entry.
+		 */
+		$entries = apply_filters( 'jetpack_menu_notification_counts', self::$entries );
+
+		return array_filter(
+			$entries,
+			function ( $entry ) {
+				return empty( $entry['is_silent'] );
+			}
+		);
+	}
+
+	/**
+	 * The magnitude an entry contributes to a total: its count, or 1 for attention.
+	 *
+	 * @param array $entry Entry.
+	 * @return int
+	 */
+	private static function magnitude( array $entry ) {
+		if ( isset( $entry['type'] ) && 'attention' === $entry['type'] ) {
+			return 1;
+		}
+		return isset( $entry['count'] ) ? (int) $entry['count'] : 0;
+	}
+
+	/**
+	 * Summed count for a specific submenu item.
+	 *
+	 * @param string $menu_slug Submenu slug.
+	 * @return int
+	 */
+	public static function get_for_menu( $menu_slug ) {
+		$total = 0;
+		foreach ( self::all() as $entry ) {
+			if ( isset( $entry['menu_slug'] ) && $entry['menu_slug'] === $menu_slug ) {
+				$total += self::magnitude( $entry );
+			}
+		}
+		return $total;
+	}
+
+	/**
+	 * Top-level total across all non-silent entries.
+	 *
+	 * @return int
+	 */
+	public static function get_total() {
+		$total = 0;
+		foreach ( self::all() as $entry ) {
+			$total += self::magnitude( $entry );
+		}
+		return $total;
+	}
+
+	/**
+	 * Clear all registered entries (test helper).
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		self::$entries = array();
+	}
+}

--- a/projects/packages/menu-badges/src/class-notification-counts.php
+++ b/projects/packages/menu-badges/src/class-notification-counts.php
@@ -21,6 +21,13 @@ class Notification_Counts {
 	private static $entries = array();
 
 	/**
+	 * Memoized result of all(), or null when stale. Invalidated on register()/reset().
+	 *
+	 * @var array<string,array>|null
+	 */
+	private static $visible_cache = null;
+
+	/**
 	 * Register (or overwrite) a notification count for a product.
 	 *
 	 * @param string $id   Unique id (e.g. 'jetpack-forms').
@@ -41,6 +48,7 @@ class Notification_Counts {
 			'type'      => ( isset( $args['type'] ) && 'attention' === $args['type'] ) ? 'attention' : 'count',
 			'is_silent' => ! empty( $args['is_silent'] ),
 		);
+		self::$visible_cache  = null;
 	}
 
 	/**
@@ -49,6 +57,10 @@ class Notification_Counts {
 	 * @return array<string,array>
 	 */
 	public static function all() {
+		if ( null !== self::$visible_cache ) {
+			return self::$visible_cache;
+		}
+
 		/**
 		 * Filters the registered menu notification counts.
 		 *
@@ -57,12 +69,15 @@ class Notification_Counts {
 		 */
 		$entries = apply_filters( 'jetpack_menu_notification_counts', self::$entries );
 
-		return array_filter(
-			$entries,
-			function ( $entry ) {
-				return empty( $entry['is_silent'] );
+		$visible = array();
+		foreach ( $entries as $id => $entry ) {
+			if ( empty( $entry['is_silent'] ) ) {
+				$visible[ $id ] = $entry;
 			}
-		);
+		}
+
+		self::$visible_cache = $visible;
+		return $visible;
 	}
 
 	/**
@@ -113,6 +128,7 @@ class Notification_Counts {
 	 * @return void
 	 */
 	public static function reset() {
-		self::$entries = array();
+		self::$entries       = array();
+		self::$visible_cache = null;
 	}
 }

--- a/projects/packages/menu-badges/src/js/menu-badges.js
+++ b/projects/packages/menu-badges/src/js/menu-badges.js
@@ -1,0 +1,63 @@
+/**
+ * Client live-update API for Jetpack admin-menu notification badges.
+ *
+ * Products call window.jetpackMenuBadges.setCount( menuSlug, count ) after a
+ * state change; this updates that badge and recomputes the top-level total from
+ * the DOM (each badge carries its own data-jp-menu-count).
+ */
+/* eslint-disable no-var -- shipped as-is with no build step, so it stays ES5-compatible */
+( function () {
+	/**
+	 * Update a single badge element's count, in its DOM attribute, class, and visible text.
+	 *
+	 * @param {Element} el    - The badge element.
+	 * @param {number}  count - The new count.
+	 */
+	function setBadgeCount( el, count ) {
+		el.setAttribute( 'data-jp-menu-count', String( count ) );
+		var oldClass = ( el.className.match( /count-\d+/ ) || [] )[ 0 ];
+		if ( oldClass ) {
+			el.className = el.className.replace( oldClass, 'count-' + count );
+		}
+		var inner = el.querySelector( '.count' );
+		if ( inner ) {
+			inner.textContent = String( count );
+		}
+	}
+
+	/**
+	 * Recompute the top-level total badge as the sum of all non-total badge counts.
+	 */
+	function recomputeTotal() {
+		var total = 0;
+		var badges = document.querySelectorAll( '[data-jp-menu-count]' );
+		badges.forEach( function ( el ) {
+			if ( el.getAttribute( 'data-jp-menu-badge-total' ) === '1' ) {
+				return;
+			}
+			total += parseInt( el.getAttribute( 'data-jp-menu-count' ), 10 ) || 0;
+		} );
+		var totalEl = document.querySelector( '[data-jp-menu-badge-total="1"]' );
+		if ( totalEl ) {
+			setBadgeCount( totalEl, total );
+		}
+	}
+
+	/**
+	 * Set the count for the badge matching the given menu slug, then recompute the total.
+	 *
+	 * @param {string} menuSlug - The menu slug the badge was registered with, i.e. `data-jp-menu-badge`.
+	 * @param {number} count    - The new count. Clamped to >= 0.
+	 */
+	function setCount( menuSlug, count ) {
+		count = Math.max( 0, parseInt( count, 10 ) || 0 );
+		var el = document.querySelector( '[data-jp-menu-badge="' + menuSlug + '"]' );
+		if ( el ) {
+			setBadgeCount( el, count );
+		}
+		recomputeTotal();
+	}
+
+	window.jetpackMenuBadges = window.jetpackMenuBadges || {};
+	window.jetpackMenuBadges.setCount = setCount;
+} )();

--- a/projects/packages/menu-badges/src/js/menu-badges.js
+++ b/projects/packages/menu-badges/src/js/menu-badges.js
@@ -27,6 +27,10 @@
 
 	/**
 	 * Recompute the top-level total badge as the sum of all non-total badge counts.
+	 *
+	 * WordPress clones the top-level menu title (badge included) into a
+	 * `li.wp-submenu-head` flyout header, so more than one element can carry
+	 * `data-jp-menu-badge-total="1"`; update all of them, not just the first.
 	 */
 	function recomputeTotal() {
 		var total = 0;
@@ -37,10 +41,10 @@
 			}
 			total += parseInt( el.getAttribute( 'data-jp-menu-count' ), 10 ) || 0;
 		} );
-		var totalEl = document.querySelector( '[data-jp-menu-badge-total="1"]' );
-		if ( totalEl ) {
+		var totalEls = document.querySelectorAll( '[data-jp-menu-badge-total="1"]' );
+		totalEls.forEach( function ( totalEl ) {
 			setBadgeCount( totalEl, total );
-		}
+		} );
 	}
 
 	/**

--- a/projects/packages/menu-badges/src/js/menu-badges.js
+++ b/projects/packages/menu-badges/src/js/menu-badges.js
@@ -23,6 +23,10 @@
 		if ( inner ) {
 			inner.textContent = String( count );
 		}
+		// Server-rendered zero-count badges ship hidden (inline display:none) so an element
+		// exists for this update. Reveal it when the count is positive, hide it again at zero;
+		// clearing the inline style hands display back to the stylesheet.
+		el.style.display = count > 0 ? '' : 'none';
 	}
 
 	/**

--- a/projects/packages/menu-badges/src/js/menu-badges.js
+++ b/projects/packages/menu-badges/src/js/menu-badges.js
@@ -55,7 +55,9 @@
 	 */
 	function setCount( menuSlug, count ) {
 		count = Math.max( 0, parseInt( count, 10 ) || 0 );
-		var el = document.querySelector( '[data-jp-menu-badge="' + menuSlug + '"]' );
+		// Escape the slug so an unusual character can't break the selector; feature-detected since this file ships without a build step.
+		var escaped = window.CSS && window.CSS.escape ? window.CSS.escape( menuSlug ) : menuSlug;
+		var el = document.querySelector( '[data-jp-menu-badge="' + escaped + '"]' );
 		if ( el ) {
 			setBadgeCount( el, count );
 		}

--- a/projects/packages/menu-badges/tests/.phpcs.dir.xml
+++ b/projects/packages/menu-badges/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/menu-badges/tests/js/menu-badges.test.js
+++ b/projects/packages/menu-badges/tests/js/menu-badges.test.js
@@ -1,0 +1,43 @@
+require( '../../src/js/menu-badges.js' );
+
+/**
+ * Build the markup for a single menu-counter badge, matching Menu_Renderer's output.
+ *
+ * @param {string}  slug    - The menu slug, i.e. `data-jp-menu-badge`.
+ * @param {number}  count   - The badge's count.
+ * @param {boolean} isTotal - Whether this is the top-level total badge.
+ * @return {string} The badge's HTML markup.
+ */
+function badge( slug, count, isTotal ) {
+	return `<span class="menu-counter count-${ count }" data-jp-menu-badge="${ slug }" data-jp-menu-count="${ count }"${
+		isTotal ? ' data-jp-menu-badge-total="1"' : ''
+	}><span class="count">${ count }</span></span>`;
+}
+
+describe( 'jetpackMenuBadges.setCount', () => {
+	beforeEach( () => {
+		document.body.innerHTML =
+			`<div id="forms">${ badge( 'jetpack-forms-responses-wp-admin', 15 ) }</div>` +
+			`<div id="protect">${ badge( 'jetpack-protect', 1 ) }</div>` +
+			`<div id="total">${ badge( 'total', 16, true ) }</div>`;
+	} );
+
+	it( 'updates the target badge and recomputes the total', () => {
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 14 );
+
+		const forms = document.querySelector(
+			'[data-jp-menu-badge="jetpack-forms-responses-wp-admin"]'
+		);
+		const total = document.querySelector( '[data-jp-menu-badge-total="1"]' );
+		expect( forms ).toHaveAttribute( 'data-jp-menu-count', '14' );
+		expect( forms.querySelector( '.count' ) ).toHaveTextContent( '14' );
+		expect( total.querySelector( '.count' ) ).toHaveTextContent( '15' ); // 14 + 1
+	} );
+
+	it( 'clears a badge number at zero and drops it from the total', () => {
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 0 );
+
+		const total = document.querySelector( '[data-jp-menu-badge-total="1"]' );
+		expect( total.querySelector( '.count' ) ).toHaveTextContent( '1' ); // just protect
+	} );
+} );

--- a/projects/packages/menu-badges/tests/js/menu-badges.test.js
+++ b/projects/packages/menu-badges/tests/js/menu-badges.test.js
@@ -9,9 +9,10 @@ require( '../../src/js/menu-badges.js' );
  * @return {string} The badge's HTML markup.
  */
 function badge( slug, count, isTotal ) {
+	const hidden = count > 0 ? '' : ' style="display:none"';
 	return `<span class="menu-counter count-${ count }" data-jp-menu-badge="${ slug }" data-jp-menu-count="${ count }"${
 		isTotal ? ' data-jp-menu-badge-total="1"' : ''
-	}><span class="count">${ count }</span></span>`;
+	}${ hidden }><span class="count">${ count }</span></span>`;
 }
 
 describe( 'jetpackMenuBadges.setCount', () => {
@@ -39,6 +40,42 @@ describe( 'jetpackMenuBadges.setCount', () => {
 
 		const total = document.querySelector( '[data-jp-menu-badge-total="1"]' );
 		expect( total.querySelector( '.count' ) ).toHaveTextContent( '1' ); // just protect
+	} );
+} );
+
+describe( 'jetpackMenuBadges.setCount reveals and hides zero-count badges', () => {
+	beforeEach( () => {
+		// Forms and the total start at 0, so they ship hidden from the server.
+		document.body.innerHTML =
+			`<div id="forms">${ badge( 'jetpack-forms-responses-wp-admin', 0 ) }</div>` +
+			`<div id="total">${ badge( 'total', 0, true ) }</div>`;
+	} );
+
+	it( 'reveals a hidden zero badge and its total when the count becomes positive', () => {
+		const forms = document.querySelector(
+			'[data-jp-menu-badge="jetpack-forms-responses-wp-admin"]'
+		);
+		const total = document.querySelector( '[data-jp-menu-badge-total="1"]' );
+		expect( forms ).toHaveStyle( 'display: none' );
+
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 2 );
+
+		expect( forms ).toHaveAttribute( 'data-jp-menu-count', '2' );
+		expect( forms ).not.toHaveStyle( 'display: none' );
+		expect( total ).not.toHaveStyle( 'display: none' );
+		expect( total.querySelector( '.count' ) ).toHaveTextContent( '2' );
+	} );
+
+	it( 'hides a badge and total again when the count returns to zero', () => {
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 2 );
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 0 );
+
+		const forms = document.querySelector(
+			'[data-jp-menu-badge="jetpack-forms-responses-wp-admin"]'
+		);
+		const total = document.querySelector( '[data-jp-menu-badge-total="1"]' );
+		expect( forms ).toHaveStyle( 'display: none' );
+		expect( total ).toHaveStyle( 'display: none' );
 	} );
 } );
 

--- a/projects/packages/menu-badges/tests/js/menu-badges.test.js
+++ b/projects/packages/menu-badges/tests/js/menu-badges.test.js
@@ -41,3 +41,27 @@ describe( 'jetpackMenuBadges.setCount', () => {
 		expect( total.querySelector( '.count' ) ).toHaveTextContent( '1' ); // just protect
 	} );
 } );
+
+describe( 'jetpackMenuBadges.setCount with a cloned flyout-header total badge', () => {
+	beforeEach( () => {
+		// WordPress clones the top-level menu title (badge included) into a
+		// `li.wp-submenu-head` flyout header, so two elements can carry
+		// data-jp-menu-badge-total="1" at once.
+		document.body.innerHTML =
+			`<div id="forms">${ badge( 'jetpack-forms-responses-wp-admin', 15 ) }</div>` +
+			`<div id="protect">${ badge( 'jetpack-protect', 1 ) }</div>` +
+			`<li id="toplevel_page_jetpack">${ badge( 'total', 16, true ) }</li>` +
+			`<li class="wp-submenu-head">${ badge( 'total', 16, true ) }</li>`;
+	} );
+
+	it( 'updates every total-badge clone, not just the first', () => {
+		window.jetpackMenuBadges.setCount( 'jetpack-forms-responses-wp-admin', 14 );
+
+		const totals = document.querySelectorAll( '[data-jp-menu-badge-total="1"]' );
+		expect( totals ).toHaveLength( 2 );
+		totals.forEach( totalEl => {
+			expect( totalEl ).toHaveAttribute( 'data-jp-menu-count', '15' );
+			expect( totalEl.querySelector( '.count' ) ).toHaveTextContent( '15' ); // 14 + 1
+		} );
+	} );
+} );

--- a/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
+++ b/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
@@ -72,6 +72,8 @@ class Menu_Renderer_Test extends TestCase {
 			)
 		);
 		Menu_Renderer::render();
+		// Rendering a second time must be idempotent: strip() removes the prior badge before re-adding.
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentional repeat render.
 		Menu_Renderer::render();
 		// Only one badge on the Forms item.
 		$this->assertSame( 1, substr_count( $GLOBALS['submenu']['jetpack'][0][0], 'menu-counter' ) );

--- a/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
+++ b/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
@@ -62,6 +62,73 @@ class Menu_Renderer_Test extends TestCase {
 		$this->assertSame( 'Forms', $GLOBALS['submenu']['jetpack'][0][0] );
 	}
 
+	public function test_registered_zero_count_renders_hidden_anchor() {
+		$this->seed_menu();
+		// A registered-but-zero count still renders an element (hidden), so a later
+		// client live-update from 0 to positive has something to reveal.
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 0,
+			)
+		);
+
+		Menu_Renderer::render();
+
+		$forms_title = $GLOBALS['submenu']['jetpack'][0][0];
+		$this->assertStringContainsString( 'data-jp-menu-badge="jetpack-forms-responses-wp-admin"', $forms_title );
+		$this->assertStringContainsString( 'count-0', $forms_title );
+		$this->assertStringContainsString( 'style="display:none"', $forms_title );
+
+		// The top-level total is present but hidden too (there is a registered entry).
+		$total_title = $GLOBALS['menu'][3][0];
+		$this->assertStringContainsString( 'data-jp-menu-badge-total="1"', $total_title );
+		$this->assertStringContainsString( 'style="display:none"', $total_title );
+	}
+
+	public function test_parent_match_prefers_slug_over_capability() {
+		// A capability-only row appears before the slug row. The renderer must badge
+		// the row whose slug is 'jetpack', not the first capability match.
+		$GLOBALS['menu']    = array(
+			2 => array( 'Decoy', 'jetpack_admin_page', 'not-jetpack' ),
+			5 => array( 'Jetpack', 'read', 'jetpack' ),
+		);
+		$GLOBALS['submenu'] = array();
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 3,
+			)
+		);
+
+		Menu_Renderer::render();
+
+		$this->assertSame( 'Decoy', $GLOBALS['menu'][2][0] );
+		$this->assertStringContainsString( 'data-jp-menu-badge-total="1"', $GLOBALS['menu'][5][0] );
+		$this->assertStringContainsString( 'count-3', $GLOBALS['menu'][5][0] );
+	}
+
+	public function test_parent_match_falls_back_to_capability() {
+		// No slug row: fall back to the plugin's 'jetpack_admin_page' capability.
+		$GLOBALS['menu']    = array(
+			4 => array( 'Jetpack', 'jetpack_admin_page', 'jetpack-custom-slug' ),
+		);
+		$GLOBALS['submenu'] = array();
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 2,
+			)
+		);
+
+		Menu_Renderer::render();
+
+		$this->assertStringContainsString( 'data-jp-menu-badge-total="1"', $GLOBALS['menu'][4][0] );
+	}
+
 	public function test_render_is_idempotent() {
 		$this->seed_menu();
 		Notification_Counts::register(

--- a/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
+++ b/projects/packages/menu-badges/tests/php/Menu_Renderer_Test.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package automattic/jetpack-menu-badges
+ */
+
+namespace Automattic\Jetpack\Menu_Badges;
+
+use PHPUnit\Framework\TestCase;
+
+class Menu_Renderer_Test extends TestCase {
+
+	protected function tearDown(): void {
+		Notification_Counts::reset();
+		unset( $GLOBALS['menu'], $GLOBALS['submenu'] );
+		parent::tearDown();
+	}
+
+	private function seed_menu() {
+		// Mimic the Jetpack top-level menu + a Forms submenu item.
+		$GLOBALS['menu']    = array(
+			3 => array( 'Jetpack', 'jetpack_admin_page', 'jetpack' ),
+		);
+		$GLOBALS['submenu'] = array(
+			'jetpack' => array(
+				array( 'Forms', 'edit_pages', 'jetpack-forms-responses-wp-admin' ),
+				array( 'Protect', 'manage_options', 'jetpack-protect' ),
+			),
+		);
+	}
+
+	public function test_renders_submenu_and_total_badges() {
+		$this->seed_menu();
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+			)
+		);
+		Notification_Counts::register(
+			'protect',
+			array(
+				'menu_slug' => 'jetpack-protect',
+				'count'     => 1,
+			)
+		);
+
+		Menu_Renderer::render();
+
+		$this->assertStringContainsString( 'count-15', $GLOBALS['submenu']['jetpack'][0][0] );
+		$this->assertStringContainsString( 'data-jp-menu-count="15"', $GLOBALS['submenu']['jetpack'][0][0] );
+		$this->assertStringContainsString( 'count-1', $GLOBALS['submenu']['jetpack'][1][0] );
+		// Top-level total = 15 + 1 = 16.
+		$this->assertStringContainsString( 'count-16', $GLOBALS['menu'][3][0] );
+		$this->assertStringContainsString( 'data-jp-menu-badge-total="1"', $GLOBALS['menu'][3][0] );
+	}
+
+	public function test_no_badges_when_registry_empty() {
+		$this->seed_menu();
+		Menu_Renderer::render();
+		$this->assertSame( 'Jetpack', $GLOBALS['menu'][3][0] );
+		$this->assertSame( 'Forms', $GLOBALS['submenu']['jetpack'][0][0] );
+	}
+
+	public function test_render_is_idempotent() {
+		$this->seed_menu();
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+			)
+		);
+		Menu_Renderer::render();
+		Menu_Renderer::render();
+		// Only one badge on the Forms item.
+		$this->assertSame( 1, substr_count( $GLOBALS['submenu']['jetpack'][0][0], 'menu-counter' ) );
+		$this->assertSame( 1, substr_count( $GLOBALS['menu'][3][0], 'menu-counter' ) );
+	}
+}

--- a/projects/packages/menu-badges/tests/php/Notification_Counts_Test.php
+++ b/projects/packages/menu-badges/tests/php/Notification_Counts_Test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @package automattic/jetpack-menu-badges
+ */
+
+namespace Automattic\Jetpack\Menu_Badges;
+
+use PHPUnit\Framework\TestCase;
+
+class Notification_Counts_Test extends TestCase {
+
+	protected function tearDown(): void {
+		Notification_Counts::reset();
+		remove_all_filters( 'jetpack_menu_notification_counts' );
+		parent::tearDown();
+	}
+
+	public function test_total_sums_counts_and_counts_attention_as_one() {
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+				'type'      => 'count',
+			)
+		);
+		Notification_Counts::register(
+			'protect',
+			array(
+				'menu_slug' => 'jetpack-protect',
+				'count'     => 3,
+				'type'      => 'count',
+			)
+		);
+		Notification_Counts::register(
+			'plan-expiring',
+			array(
+				'menu_slug' => 'my-jetpack',
+				'type'      => 'attention',
+			)
+		);
+
+		$this->assertSame( 19, Notification_Counts::get_total() ); // 15 + 3 + 1
+	}
+
+	public function test_get_for_menu_returns_that_items_count() {
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+				'type'      => 'count',
+			)
+		);
+		Notification_Counts::register(
+			'protect',
+			array(
+				'menu_slug' => 'jetpack-protect',
+				'count'     => 3,
+				'type'      => 'count',
+			)
+		);
+
+		$this->assertSame( 15, Notification_Counts::get_for_menu( 'jetpack-forms-responses-wp-admin' ) );
+		$this->assertSame( 3, Notification_Counts::get_for_menu( 'jetpack-protect' ) );
+		$this->assertSame( 0, Notification_Counts::get_for_menu( 'nonexistent' ) );
+	}
+
+	public function test_silent_entries_are_excluded() {
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'x',
+				'count'     => 5,
+			)
+		);
+		Notification_Counts::register(
+			'welcome',
+			array(
+				'menu_slug' => 'my-jetpack',
+				'type'      => 'attention',
+				'is_silent' => true,
+			)
+		);
+
+		$this->assertSame( 5, Notification_Counts::get_total() );
+		$this->assertArrayNotHasKey( 'welcome', Notification_Counts::all() );
+	}
+
+	public function test_reregistering_same_id_overwrites() {
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'x',
+				'count'     => 15,
+			)
+		);
+		Notification_Counts::register(
+			'forms',
+			array(
+				'menu_slug' => 'x',
+				'count'     => 14,
+			)
+		);
+
+		$this->assertSame( 14, Notification_Counts::get_total() );
+	}
+
+	public function test_filter_can_add_entries() {
+		add_filter(
+			'jetpack_menu_notification_counts',
+			function ( $entries ) {
+				$entries['third-party'] = array(
+					'menu_slug' => 'x',
+					'count'     => 2,
+					'type'      => 'count',
+				);
+				return $entries;
+			}
+		);
+
+		$this->assertSame( 2, Notification_Counts::get_total() );
+	}
+}

--- a/projects/packages/menu-badges/tests/php/bootstrap.php
+++ b/projects/packages/menu-badges/tests/php/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-menu-badges
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+define( 'WP_DEBUG', true );
+
+\Automattic\Jetpack\Test_Environment::init();

--- a/projects/packages/my-jetpack/_inc/utils/async-notification-bubble.ts
+++ b/projects/packages/my-jetpack/_inc/utils/async-notification-bubble.ts
@@ -2,25 +2,40 @@
  * My Jetpack Notification Bubble async loader.
  *
  * `Initializer::maybe_show_red_bubble()` enqueues this script only when the
- * red-bubble transient is cold, which also means it registered nothing with
- * the menu-badges `Notification_Counts` registry for this request. Menu_Renderer
- * has therefore already rendered the page's menu with a zero contribution from
- * My Jetpack, and no `[data-jp-menu-badge="my-jetpack"]` element exists on the
- * page for `window.jetpackMenuBadges.setCount()` to update.
+ * red-bubble transient is cold. On that path it registers a hidden zero-count
+ * placeholder with the menu-badges `Notification_Counts` registry, so
+ * Menu_Renderer emits a hidden `[data-jp-menu-badge="my-jetpack"]` element on
+ * the current page.
  *
- * This request's only job is to warm the red-bubble transient (the REST
- * callback recomputes and re-caches it, see
- * `Red_Bubble_Notifications::get_red_bubble_alerts()`) so the *next* page load
- * takes the cached-alerts path and registers My Jetpack's contribution with
- * the registry in time for Menu_Renderer to badge it. It intentionally does
- * not write any badge into the current page's DOM.
+ * This request warms the red-bubble transient (the REST callback recomputes and
+ * re-caches it, see `Red_Bubble_Notifications::get_red_bubble_alerts()`) and,
+ * with the fresh alerts it gets back, lights up that placeholder via
+ * `window.jetpackMenuBadges.setCount()` — so the badge appears on the current
+ * page without waiting for a reload. The next page load takes the cached-alerts
+ * path and re-registers the authoritative per-alert counts server-side.
  */
 import apiFetch from '@wordpress/api-fetch';
 
-apiFetch( {
+apiFetch< RedBubbleAlerts >( {
 	path: 'my-jetpack/v1/red-bubble-notifications',
 	method: 'POST',
-} ).catch( error => {
-	// eslint-disable-next-line no-console
-	console.log( '[Jetpack] Red bubble notification fetch failed:', error );
-} );
+} )
+	.then( alerts => {
+		if ( typeof window.jetpackMenuBadges?.setCount !== 'function' ) {
+			return;
+		}
+		// Count the alerts that would show a badge (server-side registration skips
+		// `is_silent` ones). This is a transient client-side estimate; the next page
+		// load re-registers the authoritative count server-side, which also handles
+		// the Protect-standalone de-dup this can't see.
+		const count = alerts
+			? Object.values( alerts ).filter(
+					alert => ! ( alert as { is_silent?: boolean } | null )?.is_silent
+			  ).length
+			: 0;
+		window.jetpackMenuBadges.setCount( 'my-jetpack', count );
+	} )
+	.catch( error => {
+		// eslint-disable-next-line no-console
+		console.log( '[Jetpack] Red bubble notification fetch failed:', error );
+	} );

--- a/projects/packages/my-jetpack/_inc/utils/async-notification-bubble.ts
+++ b/projects/packages/my-jetpack/_inc/utils/async-notification-bubble.ts
@@ -1,46 +1,26 @@
 /**
  * My Jetpack Notification Bubble async loader.
- * Fetches fresh alert data via REST API without blocking page load.
+ *
+ * `Initializer::maybe_show_red_bubble()` enqueues this script only when the
+ * red-bubble transient is cold, which also means it registered nothing with
+ * the menu-badges `Notification_Counts` registry for this request. Menu_Renderer
+ * has therefore already rendered the page's menu with a zero contribution from
+ * My Jetpack, and no `[data-jp-menu-badge="my-jetpack"]` element exists on the
+ * page for `window.jetpackMenuBadges.setCount()` to update.
+ *
+ * This request's only job is to warm the red-bubble transient (the REST
+ * callback recomputes and re-caches it, see
+ * `Red_Bubble_Notifications::get_red_bubble_alerts()`) so the *next* page load
+ * takes the cached-alerts path and registers My Jetpack's contribution with
+ * the registry in time for Menu_Renderer to badge it. It intentionally does
+ * not write any badge into the current page's DOM.
  */
 import apiFetch from '@wordpress/api-fetch';
 
-// Minimal type for counting non-silent alerts.
-type Alert = {
-	is_silent?: boolean;
-};
-
-type AlertsResponse = Record< string, Alert >;
-
-apiFetch< AlertsResponse >( {
+apiFetch( {
 	path: 'my-jetpack/v1/red-bubble-notifications',
 	method: 'POST',
-} )
-	.then( alerts => {
-		const count = Object.values( alerts || {} ).filter( a => ! a.is_silent ).length;
-		const menuItem = document.querySelector( '#toplevel_page_jetpack .wp-menu-name' );
-
-		if ( ! menuItem ) {
-			return;
-		}
-
-		const bubble = menuItem.querySelector( '.awaiting-mod' );
-
-		if ( count > 0 ) {
-			if ( bubble ) {
-				bubble.className = 'awaiting-mod';
-				bubble.textContent = String( count );
-			} else {
-				const span = document.createElement( 'span' );
-				span.className = 'awaiting-mod';
-				span.textContent = String( count );
-				menuItem.appendChild( document.createTextNode( ' ' ) );
-				menuItem.appendChild( span );
-			}
-		} else if ( bubble ) {
-			bubble.remove();
-		}
-	} )
-	.catch( error => {
-		// eslint-disable-next-line no-console
-		console.log( '[Jetpack] Red bubble notification fetch failed:', error );
-	} );
+} ).catch( error => {
+	// eslint-disable-next-line no-console
+	console.log( '[Jetpack] Red bubble notification fetch failed:', error );
+} );

--- a/projects/packages/my-jetpack/changelog/add-central-menu-notification-counts
+++ b/projects/packages/my-jetpack/changelog/add-central-menu-notification-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack now reports its red-bubble alerts to the central menu-badges registry instead of writing admin-menu markup directly; the Protect alert is skipped there since Protect reports its own count.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -13,6 +13,7 @@
 		"automattic/jetpack-explat": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-licensing": "@dev",
+		"automattic/jetpack-menu-badges": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-constants": "@dev",

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -658,4 +658,8 @@ interface Window {
 		apiRoot: string;
 		apiNonce: string;
 	};
+	/** Shared client for live-updating Jetpack admin-menu notification badges (automattic/jetpack-menu-badges). */
+	jetpackMenuBadges?: {
+		setCount: ( menuSlug: string, count: number ) => void;
+	};
 }

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -767,7 +767,18 @@ class Initializer {
 			$cached_alerts = Red_Bubble_Notifications::get_cached_alerts();
 
 			if ( false === $cached_alerts ) {
-				// No cache - fetch asynchronously via JS.
+				// No cache: warm it asynchronously via JS. Register a hidden zero-count
+				// placeholder so Menu_Renderer emits a `my-jetpack` badge element the
+				// warmer can reveal (see async-notification-bubble.ts) without a reload.
+				Menu_Badges::init(); // idempotent; wires the renderer.
+				Notification_Counts::register(
+					'my-jetpack',
+					array(
+						'menu_slug' => 'my-jetpack',
+						'count'     => 0,
+						'type'      => 'count',
+					)
+				);
 				add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_red_bubble_script' ) );
 				return;
 			}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -20,6 +20,8 @@ use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\ExPlat;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Licensing;
+use Automattic\Jetpack\Menu_Badges\Menu_Badges;
+use Automattic\Jetpack\Menu_Badges\Notification_Counts;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Status;
@@ -96,8 +98,9 @@ class Initializer {
 		add_action( 'admin_menu', array( __CLASS__, 'add_my_jetpack_menu_item' ) );
 
 		add_action( 'admin_init', array( __CLASS__, 'setup_historically_active_jetpack_modules_sync' ) );
-		// This is later than the admin-ui package, which runs on 1000
-		add_action( 'admin_init', array( __CLASS__, 'maybe_show_red_bubble' ), 1001 );
+		// Registered on admin_menu (not admin_init) and well before priority 100000, so the
+		// counts it registers exist before the menu-badges renderer runs on admin_menu 100000.
+		add_action( 'admin_menu', array( __CLASS__, 'maybe_show_red_bubble' ), 30 );
 
 		// Set up the ExPlat package endpoints
 		ExPlat::init();
@@ -735,7 +738,7 @@ class Initializer {
 	 * @return void
 	 */
 	public static function maybe_show_red_bubble() {
-		global $menu, $pagenow;
+		global $pagenow;
 
 		// Don't show red bubble alerts for non-admin users
 		// These alerts are generally only actionable for admins
@@ -780,14 +783,22 @@ class Initializer {
 			}
 		);
 
-		// The Jetpack menu item should be on index 3
-		if (
-			! empty( $red_bubble_alerts ) &&
-			isset( $menu[3] ) &&
-			$menu[3][0] === 'Jetpack'
-		) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$menu[3][0] .= sprintf( ' <span class="awaiting-mod">%d</span>', count( $red_bubble_alerts ) );
+		// Report each non-silent alert to the central menu-badges registry as an
+		// attention entry (count 1). The registry + renderer own the badge.
+		Menu_Badges::init(); // idempotent; wires the renderer.
+		foreach ( array_keys( $red_bubble_alerts ) as $slug ) {
+			// Protect now reports its own count directly to the registry; skip it here
+			// so it isn't counted twice in the top-level menu total.
+			if ( 'protect_has_threats' === $slug ) {
+				continue;
+			}
+			Notification_Counts::register(
+				'my-jetpack-' . $slug,
+				array(
+					'menu_slug' => 'my-jetpack',
+					'type'      => 'attention',
+				)
+			);
 		}
 	}
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -787,9 +787,11 @@ class Initializer {
 		// attention entry (count 1). The registry + renderer own the badge.
 		Menu_Badges::init(); // idempotent; wires the renderer.
 		foreach ( array_keys( $red_bubble_alerts ) as $slug ) {
-			// Protect now reports its own count directly to the registry; skip it here
-			// so it isn't counted twice in the top-level menu total.
-			if ( 'protect_has_threats' === $slug ) {
+			// Protect reports its own count directly to the registry, but only when its
+			// standalone plugin is active (see class-jetpack-protect.php::admin_page_init()).
+			// If the standalone plugin isn't active, nobody else registers this count, so we
+			// must not skip it here or the alert silently disappears from the menu total.
+			if ( 'protect_has_threats' === $slug && Products\Protect::is_standalone_plugin_active() ) {
 				continue;
 			}
 			Notification_Counts::register(

--- a/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack\My_Jetpack;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
+use Automattic\Jetpack\My_Jetpack\Products\Protect;
 use Jetpack_Options;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -85,6 +86,21 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 	}
 
 	/**
+	 * Installs and activates a mock jetpack-protect standalone plugin so
+	 * Products\Protect::is_standalone_plugin_active() reports true, mirroring the
+	 * scenario where the standalone Protect plugin registers its own count.
+	 */
+	private function activate_standalone_protect_plugin() {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . Protect::$plugin_slug;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+		copy( __DIR__ . '/assets/protect-mock-plugin.txt', $plugin_dir . '/jetpack-protect.php' );
+		wp_cache_delete( 'plugins', 'plugins' );
+		activate_plugins( Protect::get_installed_plugin_filename() );
+	}
+
+	/**
 	 * Non-silent alerts should each register as an 'attention' entry against the
 	 * 'my-jetpack' submenu, keyed uniquely so they don't overwrite one another.
 	 */
@@ -110,11 +126,18 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 	}
 
 	/**
-	 * Protect now reports its own count directly to the registry (Task 8); My Jetpack
-	 * must skip it in the menu-count registration loop to avoid double-counting the
-	 * top-level menu total.
+	 * Protect reports its own count directly to the registry when its standalone
+	 * plugin is active (Task 8); My Jetpack must skip it in the menu-count
+	 * registration loop in that case, to avoid double-counting the top-level menu
+	 * total.
 	 */
-	public function test_skips_protect_has_threats_to_avoid_double_counting() {
+	public function test_skips_protect_has_threats_when_standalone_plugin_active() {
+		$this->activate_standalone_protect_plugin();
+		$this->assertTrue(
+			Protect::is_standalone_plugin_active(),
+			'Precondition: the mock standalone Protect plugin should be active.'
+		);
+
 		$this->seed_cached_alerts(
 			array(
 				'protect_has_threats' => array( 'count' => 3 ),
@@ -128,10 +151,42 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 	}
 
 	/**
+	 * When the standalone Protect plugin is NOT active, nothing else registers the
+	 * protect_has_threats count (class-jetpack-protect.php::admin_page_init() only
+	 * runs from the standalone plugin). My Jetpack must NOT skip it in that case,
+	 * or a security-relevant alert silently disappears from the top-level menu
+	 * total on full Jetpack + Scan installs.
+	 */
+	public function test_registers_protect_has_threats_when_standalone_plugin_inactive() {
+		$this->assertFalse(
+			Protect::is_standalone_plugin_active(),
+			'Precondition: the standalone Protect plugin should not be installed/active.'
+		);
+
+		$this->seed_cached_alerts(
+			array(
+				'protect_has_threats' => array( 'count' => 3 ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$entries = Notification_Counts::all();
+		$this->assertArrayHasKey( 'my-jetpack-protect_has_threats', $entries );
+		$this->assertSame( 'my-jetpack', $entries['my-jetpack-protect_has_threats']['menu_slug'] );
+		$this->assertSame( 'attention', $entries['my-jetpack-protect_has_threats']['type'] );
+		$this->assertSame( 1, Notification_Counts::get_for_menu( 'my-jetpack' ) );
+		$this->assertSame( 1, Notification_Counts::get_total() );
+	}
+
+	/**
 	 * The registered total for the my-jetpack submenu should equal the number of
-	 * non-silent, non-Protect alerts (each attention entry contributes 1 to the total).
+	 * non-silent alerts (each attention entry contributes 1 to the total), excluding
+	 * Protect's alert when the standalone plugin is active and reports it directly.
 	 */
 	public function test_total_reflects_non_silent_non_protect_alert_count() {
+		$this->activate_standalone_protect_plugin();
+
 		$this->seed_cached_alerts(
 			array(
 				'backup_failure'           => array( 'message' => 'Backup failed' ),

--- a/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
@@ -230,6 +230,28 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 	}
 
 	/**
+	 * On a cold red-bubble cache (no transient) off the My Jetpack page, the alert
+	 * data is fetched asynchronously. maybe_show_red_bubble() must still register a
+	 * hidden zero-count 'my-jetpack' placeholder so Menu_Renderer emits a badge
+	 * element the async warmer (async-notification-bubble.ts) can reveal without a
+	 * reload, and it must enqueue that warmer script.
+	 */
+	public function test_cold_cache_registers_hidden_placeholder_and_enqueues_warmer() {
+		// No transient seeded in setUp(): get_cached_alerts() returns false -> cold path.
+		Initializer::maybe_show_red_bubble();
+
+		$entries = Notification_Counts::all();
+		$this->assertArrayHasKey( 'my-jetpack', $entries );
+		$this->assertSame( 'my-jetpack', $entries['my-jetpack']['menu_slug'] );
+		$this->assertSame( 0, Notification_Counts::get_for_menu( 'my-jetpack' ) );
+		$this->assertSame( 0, Notification_Counts::get_total() );
+		$this->assertNotFalse(
+			has_action( 'admin_enqueue_scripts', array( Initializer::class, 'enqueue_red_bubble_script' ) ),
+			'The async warmer script should be enqueued on a cold cache.'
+		);
+	}
+
+	/**
 	 * Disconnected sites should not have anything registered.
 	 */
 	public function test_skips_registration_when_disconnected() {

--- a/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
@@ -97,7 +97,10 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 		}
 		copy( __DIR__ . '/assets/protect-mock-plugin.txt', $plugin_dir . '/jetpack-protect.php' );
 		wp_cache_delete( 'plugins', 'plugins' );
-		activate_plugins( Protect::get_installed_plugin_filename() );
+		$plugin_file = Protect::get_installed_plugin_filename();
+		if ( $plugin_file ) {
+			activate_plugins( $plugin_file );
+		}
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
@@ -188,4 +188,27 @@ class Red_Bubble_Menu_Badge_Test extends TestCase {
 
 		$this->assertSame( array(), Notification_Counts::all() );
 	}
+
+	/**
+	 * Notification_Counts registration must happen on `admin_menu` (not `admin_init`),
+	 * and at a priority earlier than the menu-badges Menu_Renderer, which runs on
+	 * `admin_menu` at priority 100000. Getting the hook or priority wrong here is
+	 * exactly how the renderer would silently miss My Jetpack's contribution to the
+	 * top-level badge total: registering on `admin_init` runs too early (before
+	 * `admin_menu` fires at all), while a priority at or after 100000 on `admin_menu`
+	 * would run after the renderer already read the registry.
+	 */
+	public function test_registers_on_admin_menu_at_priority_30_not_admin_init() {
+		Initializer::init();
+
+		$this->assertSame(
+			30,
+			has_action( 'admin_menu', array( Initializer::class, 'maybe_show_red_bubble' ) ),
+			'maybe_show_red_bubble must be registered on admin_menu at priority 30, well before the menu-badges renderer at priority 100000.'
+		);
+		$this->assertFalse(
+			has_action( 'admin_init', array( Initializer::class, 'maybe_show_red_bubble' ) ),
+			'maybe_show_red_bubble must not be registered on admin_init.'
+		);
+	}
 }

--- a/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Red_Bubble_Menu_Badge_Test.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Menu_Badges\Notification_Counts;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Tests that Initializer::maybe_show_red_bubble() reports alerts to the central
+ * menu-badges registry instead of writing the legacy `$menu[3]` "awaiting-mod" markup.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Initializer::maybe_show_red_bubble
+ */
+class Red_Bubble_Menu_Badge_Test extends TestCase {
+
+	/**
+	 * The red bubble transient key, mirrored from Red_Bubble_Notifications
+	 * (private there) so tests can seed the cached-alerts code path directly.
+	 *
+	 * @var string
+	 */
+	const RED_BUBBLE_TRANSIENT_KEY = 'my-jetpack-red-bubble-transient';
+
+	/**
+	 * The admin user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Notification_Counts::reset();
+
+		global $pagenow;
+		$pagenow = 'index.php';
+		unset( $_GET['page'] );
+
+		// Mock site connection so maybe_show_red_bubble() doesn't bail out early.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		Notification_Counts::reset();
+		wp_set_current_user( 0 );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Seed the red-bubble transient cache the same way Red_Bubble_Notifications does,
+	 * so maybe_show_red_bubble() takes the cached (non-blocking) code path instead of
+	 * recomputing real product alerts.
+	 *
+	 * @param array $alerts Alerts keyed by slug.
+	 */
+	private function seed_cached_alerts( array $alerts ) {
+		set_transient( self::RED_BUBBLE_TRANSIENT_KEY, $alerts, 3600 );
+	}
+
+	/**
+	 * Non-silent alerts should each register as an 'attention' entry against the
+	 * 'my-jetpack' submenu, keyed uniquely so they don't overwrite one another.
+	 */
+	public function test_registers_non_silent_alerts_as_attention_entries() {
+		$this->seed_cached_alerts(
+			array(
+				'backup_failure'           => array( 'message' => 'Backup failed' ),
+				'plan--plan_expiring_soon' => array( 'product_name' => 'Plan' ),
+				'silent-thing'             => array( 'is_silent' => true ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$entries = Notification_Counts::all();
+
+		$this->assertArrayHasKey( 'my-jetpack-backup_failure', $entries );
+		$this->assertArrayHasKey( 'my-jetpack-plan--plan_expiring_soon', $entries );
+		$this->assertArrayNotHasKey( 'my-jetpack-silent-thing', $entries, 'Silent alerts should not be registered.' );
+
+		$this->assertSame( 'my-jetpack', $entries['my-jetpack-backup_failure']['menu_slug'] );
+		$this->assertSame( 'attention', $entries['my-jetpack-backup_failure']['type'] );
+	}
+
+	/**
+	 * Protect now reports its own count directly to the registry (Task 8); My Jetpack
+	 * must skip it in the menu-count registration loop to avoid double-counting the
+	 * top-level menu total.
+	 */
+	public function test_skips_protect_has_threats_to_avoid_double_counting() {
+		$this->seed_cached_alerts(
+			array(
+				'protect_has_threats' => array( 'count' => 3 ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$this->assertArrayNotHasKey( 'my-jetpack-protect_has_threats', Notification_Counts::all() );
+		$this->assertSame( 0, Notification_Counts::get_for_menu( 'my-jetpack' ) );
+	}
+
+	/**
+	 * The registered total for the my-jetpack submenu should equal the number of
+	 * non-silent, non-Protect alerts (each attention entry contributes 1 to the total).
+	 */
+	public function test_total_reflects_non_silent_non_protect_alert_count() {
+		$this->seed_cached_alerts(
+			array(
+				'backup_failure'           => array( 'message' => 'Backup failed' ),
+				'protect_has_threats'      => array( 'count' => 3 ),
+				'plan--plan_expiring_soon' => array( 'product_name' => 'Plan' ),
+				'silent-thing'             => array( 'is_silent' => true ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$this->assertSame( 2, Notification_Counts::get_for_menu( 'my-jetpack' ) );
+		$this->assertSame( 2, Notification_Counts::get_total() );
+	}
+
+	/**
+	 * Users without manage_options should not have anything registered.
+	 */
+	public function test_skips_registration_for_non_admin_users() {
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => '123',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $editor_id );
+
+		$this->seed_cached_alerts(
+			array(
+				'backup_failure' => array( 'message' => 'Backup failed' ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$this->assertSame( array(), Notification_Counts::all() );
+	}
+
+	/**
+	 * Disconnected sites should not have anything registered.
+	 */
+	public function test_skips_registration_when_disconnected() {
+		Jetpack_Options::delete_option( 'id' );
+		( new Connection_Manager() )->reset_connection_status();
+
+		$this->seed_cached_alerts(
+			array(
+				'backup_failure' => array( 'message' => 'Backup failed' ),
+			)
+		);
+
+		Initializer::maybe_show_red_bubble();
+
+		$this->assertSame( array(), Notification_Counts::all() );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/assets/protect-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/protect-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Jetpack Protect Plugin
+ *
+ * Plugin Name:       Protect
+ * Description:       Jetpack Protect mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */

--- a/projects/plugins/backup/changelog/add-central-menu-notification-counts
+++ b/projects/plugins/backup/changelog/add-central-menu-notification-counts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1260,12 +1260,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1277,6 +1336,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -43,14 +43,19 @@ class Admin {
 		 * @since   1.0.0
 		 */
 		$total_problems = apply_filters( 'jetpack_boost_total_problem_count', 0 );
-		$menu_label     = 'Boost'; // "Boost" is a product name, do not translate.
-		if ( $total_problems ) {
-			$menu_label .= sprintf( ' <span class="menu-counter count-%d"><span class="count">%d</span></span>', $total_problems, $total_problems );
-		}
+		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'jetpack-boost',
+			array(
+				'menu_slug' => JETPACK_BOOST_SLUG,
+				'count'     => (int) $total_problems,
+				'type'      => 'count',
+			)
+		);
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),
-			$menu_label,
+			'Boost', // "Boost" is a product name, do not translate.
 			'manage_options',
 			JETPACK_BOOST_SLUG,
 			array( $this, 'render_settings' ),

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -42,16 +42,21 @@ class Admin {
 		 *
 		 * @since   1.0.0
 		 */
-		$total_problems = apply_filters( 'jetpack_boost_total_problem_count', 0 );
-		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
-		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
-			'jetpack-boost',
-			array(
-				'menu_slug' => JETPACK_BOOST_SLUG,
-				'count'     => (int) $total_problems,
-				'type'      => 'count',
-			)
-		);
+		// Only report the count to users who can actually reach the Boost menu
+		// (added below with the 'manage_options' cap). Otherwise the central
+		// menu-badges total would include problems the current user can't see.
+		if ( current_user_can( 'manage_options' ) ) {
+			$total_problems = apply_filters( 'jetpack_boost_total_problem_count', 0 );
+			\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
+			\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+				'jetpack-boost',
+				array(
+					'menu_slug' => JETPACK_BOOST_SLUG,
+					'count'     => (int) $total_problems,
+					'type'      => 'count',
+				)
+			);
+		}
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),

--- a/projects/plugins/boost/changelog/update-boost-menu-badges-registry
+++ b/projects/plugins/boost/changelog/update-boost-menu-badges-registry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost now reports its problem count to the central menu-badges registry instead of writing admin-menu markup directly.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -24,6 +24,7 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-image-cdn": "@dev",
+		"automattic/jetpack-menu-badges": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-plugin-deactivation": "@dev",
 		"automattic/jetpack-schema": "@dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1241,7 +1241,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1253,6 +1253,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "290271cf45d484993b4fec793522e45f",
+    "content-hash": "24816340f4972b5618ae2363e6e298b6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1172,6 +1172,65 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A logo for Jetpack",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
             "transport-options": {
                 "relative": true
             }
@@ -4331,6 +4390,7 @@
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-image-cdn": 20,
+        "automattic/jetpack-menu-badges": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-plugin-deactivation": 20,
         "automattic/jetpack-schema": 20,

--- a/projects/plugins/boost/tests/php/admin/Admin_Test.php
+++ b/projects/plugins/boost/tests/php/admin/Admin_Test.php
@@ -22,6 +22,10 @@ class Admin_Test extends Base_TestCase {
 
 		Functions\when( '__' )->returnArg();
 
+		// Boost only reports its count to users who can reach the menu; default the
+		// capability to true so the registration path runs. Overridden per-test below.
+		Functions\when( 'current_user_can' )->justReturn( true );
+
 		// Start each test with a clean registry; other suites registering
 		// under different ids don't matter here since we only assert on
 		// the 'jetpack-boost' menu slug.
@@ -56,5 +60,15 @@ class Admin_Test extends Base_TestCase {
 		( new Admin() )->handle_admin_menu();
 
 		$this->assertSame( 3, Notification_Counts::get_for_menu( JETPACK_BOOST_SLUG ) );
+	}
+
+	public function test_skips_registration_for_users_without_manage_options() {
+		// A user who can't reach the Boost menu (added with 'manage_options') must not
+		// contribute to the central menu-badges total.
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		( new Admin() )->handle_admin_menu();
+
+		$this->assertSame( array(), Notification_Counts::all() );
 	}
 }

--- a/projects/plugins/boost/tests/php/admin/Admin_Test.php
+++ b/projects/plugins/boost/tests/php/admin/Admin_Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Admin;
+
+use Automattic\Jetpack\Menu_Badges\Notification_Counts;
+use Automattic\Jetpack_Boost\Admin\Admin;
+use Automattic\Jetpack_Boost\Tests\Base_TestCase;
+use Brain\Monkey\Functions;
+
+if ( ! defined( 'JETPACK_BOOST_SLUG' ) ) {
+	define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
+}
+
+/**
+ * Verifies that Admin::handle_admin_menu() reports the Boost problem count to
+ * the central menu-badges registry, rather than hand-writing a menu-counter
+ * span into the submenu label.
+ */
+class Admin_Test extends Base_TestCase {
+	protected function set_up() {
+		parent::set_up();
+
+		Functions\when( '__' )->returnArg();
+
+		// Start each test with a clean registry; other suites registering
+		// under different ids don't matter here since we only assert on
+		// the 'jetpack-boost' menu slug.
+		Notification_Counts::reset();
+	}
+
+	protected function tear_down() {
+		Notification_Counts::reset();
+		parent::tear_down();
+	}
+
+	public function test_registers_zero_count_when_no_problems() {
+		( new Admin() )->handle_admin_menu();
+
+		$this->assertSame( 0, Notification_Counts::get_for_menu( JETPACK_BOOST_SLUG ) );
+	}
+
+	public function test_registers_filtered_problem_count() {
+		// Only override the Boost problem-count filter; pass every other
+		// apply_filters() call through unchanged (e.g. the registry's own
+		// 'jetpack_menu_notification_counts' filter, invoked below via
+		// Notification_Counts::get_for_menu()).
+		Functions\when( 'apply_filters' )->alias(
+			function ( $hook_name, $value = null ) {
+				if ( 'jetpack_boost_total_problem_count' === $hook_name ) {
+					return 3;
+				}
+				return $value;
+			}
+		);
+
+		( new Admin() )->handle_admin_menu();
+
+		$this->assertSame( 3, Notification_Counts::get_for_menu( JETPACK_BOOST_SLUG ) );
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -809,6 +809,16 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$item = array_merge( $item, $parsed_item );
 		}
 
+		// Additive: authoritative top-level total from the central menu-badges
+		// registry, when the package is loaded. Overlays any count parsed from
+		// title markup above.
+		if ( 'jetpack' === $menu_item[2] && class_exists( '\Automattic\Jetpack\Menu_Badges\Notification_Counts' ) ) {
+			$registry_total = \Automattic\Jetpack\Menu_Badges\Notification_Counts::get_total();
+			if ( $registry_total > 0 ) {
+				$item['count'] = $registry_total;
+			}
+		}
+
 		// Additive: classifier-derived `group_id` + `signal` for the redesigned
 		// sidebar. Match key is the raw menu slug (`$menu_item[2]`), which is
 		// what the public plugin's `Sidebar_Classifier` keys nav items by.
@@ -846,6 +856,16 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		$parsed_item = $this->parse_menu_item( $item['title'] );
 		if ( ! empty( $parsed_item ) ) {
 			$item = array_merge( $item, $parsed_item );
+		}
+
+		// Additive: authoritative count from the central menu-badges registry,
+		// when the package is loaded. Overlays any count parsed from title
+		// markup above.
+		if ( class_exists( '\Automattic\Jetpack\Menu_Badges\Notification_Counts' ) ) {
+			$registry_count = \Automattic\Jetpack\Menu_Badges\Notification_Counts::get_for_menu( $submenu_item[2] );
+			if ( $registry_count > 0 ) {
+				$item['count'] = $registry_count;
+			}
 		}
 
 		// Additive: classifier-derived fields. Same lookup contract as the

--- a/projects/plugins/jetpack/changelog/add-admin-menu-registry-counts
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-registry-counts
@@ -1,4 +1,4 @@
 Significance: patch
-Type: added
+Type: enhancement
 
 Admin-menu REST endpoint now surfaces notification counts from the central menu-badges registry, so Calypso/Simple sidebars get authoritative Jetpack menu counts.

--- a/projects/plugins/jetpack/changelog/add-admin-menu-registry-counts
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-registry-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Admin-menu REST endpoint now surfaces notification counts from the central menu-badges registry, so Calypso/Simple sidebars get authoritative Jetpack menu counts.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -41,6 +41,7 @@
 		"automattic/jetpack-licensing": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
+		"automattic/jetpack-menu-badges": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-newsletter": "@dev",
 		"automattic/jetpack-paypal-payments": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64a7e3f6111300cfc62f31285fa1fff3",
+    "content-hash": "caea7600eeca649122fb8ab7843df34b",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2232,65 +2232,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-menu-badges",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/menu-badges",
-                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-menu-badges",
-                "textdomain": "jetpack-menu-badges",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
-                },
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
             "transport-options": {
                 "relative": true
             }
@@ -6128,7 +6069,6 @@
         "automattic/jetpack-licensing": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-masterbar": 20,
-        "automattic/jetpack-menu-badges": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-newsletter": 20,
         "automattic/jetpack-paypal-payments": 20,

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "caea7600eeca649122fb8ab7843df34b",
+    "content-hash": "64a7e3f6111300cfc62f31285fa1fff3",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2232,6 +2232,65 @@
                 "GPL-2.0-or-later"
             ],
             "description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
             "transport-options": {
                 "relative": true
             }
@@ -6069,6 +6128,7 @@
         "automattic/jetpack-licensing": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-masterbar": 20,
+        "automattic/jetpack-menu-badges": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-newsletter": 20,
         "automattic/jetpack-paypal-payments": 20,

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "caea7600eeca649122fb8ab7843df34b",
+    "content-hash": "64a7e3f6111300cfc62f31285fa1fff3",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1648,7 +1648,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "4b58670eb9082f7397320a436d7a4c27db5a411d"
+                "reference": "bd3156378fe8d7ac37f51fb36af372242b4c9c4d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1659,6 +1659,7 @@
                 "automattic/jetpack-external-connections": "@dev",
                 "automattic/jetpack-jwt": "@dev",
                 "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
@@ -2237,12 +2238,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2254,6 +2314,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",
@@ -6069,6 +6130,7 @@
         "automattic/jetpack-licensing": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-masterbar": 20,
+        "automattic/jetpack-menu-badges": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-newsletter": 20,
         "automattic/jetpack-paypal-payments": 20,

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -367,6 +367,53 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
+	 * Mirrors test_prepare_submenu_item_overlays_registry_count() but for the
+	 * top-level branch: the central menu-badges registry's authoritative grand
+	 * total overlays the top-level "Jetpack" menu item's `count`, so the total
+	 * reflects every registered menu_slug (e.g. both jetpack-forms and
+	 * my-jetpack contributions), not just one submenu's contribution.
+	 */
+	public function test_prepare_menu_item_overlays_registry_total() {
+		if ( ! class_exists( '\Automattic\Jetpack\Menu_Badges\Notification_Counts' ) ) {
+			$this->markTestSkipped( 'menu-badges package not loaded' );
+		}
+
+		global $submenu;
+		$old_submenu        = $submenu;
+		$submenu['jetpack'] = array();
+
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::reset();
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'jetpack-forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+			)
+		);
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'my-jetpack-protect_has_threats',
+			array(
+				'menu_slug' => 'my-jetpack',
+				'type'      => 'attention',
+			)
+		);
+
+		$class  = new \ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+		$method = $class->getMethod( 'prepare_menu_item' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$menu_item = array( 'Jetpack', 'read', 'jetpack', 'Jetpack', 'menu-top', 'toplevel_page_jetpack', 'dashicons-admin-generic' );
+
+		$result = $method->invokeArgs( new \WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $menu_item ) );
+
+		$submenu = $old_submenu;
+
+		$this->assertSame( \Automattic\Jetpack\Menu_Badges\Notification_Counts::get_total(), $result['count'] );
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::reset();
+	}
+
+	/**
 	 * Check if the menu URL is properly generated from the first submenu slug.
 	 */
 	public function test_if_the_first_submenu_url_is_used_for_menu_url() {

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -335,6 +335,38 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
+	 * Tests that the central menu-badges registry's authoritative count
+	 * overlays the submenu item's `count`, so Calypso/Simple sidebars get
+	 * registry-backed counts without relying on title-markup scraping.
+	 */
+	public function test_prepare_submenu_item_overlays_registry_count() {
+		if ( ! class_exists( '\Automattic\Jetpack\Menu_Badges\Notification_Counts' ) ) {
+			$this->markTestSkipped( 'menu-badges package not loaded' );
+		}
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::reset();
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'jetpack-forms',
+			array(
+				'menu_slug' => 'jetpack-forms-responses-wp-admin',
+				'count'     => 15,
+			)
+		);
+
+		$class  = new \ReflectionClass( 'WPCOM_REST_API_V2_Endpoint_Admin_Menu' );
+		$method = $class->getMethod( 'prepare_submenu_item' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$submenu_item = array( 'Forms', 'edit_pages', 'jetpack-forms-responses-wp-admin', 'Forms', '' );
+		$menu_item    = array( 'Jetpack', 'jetpack_admin_page', 'jetpack', 'Jetpack', 'menu-top' );
+
+		$result = $method->invokeArgs( new \WPCOM_REST_API_V2_Endpoint_Admin_Menu(), array( $submenu_item, $menu_item ) );
+
+		$this->assertSame( 15, $result['count'] );
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::reset();
+	}
+
+	/**
 	 * Check if the menu URL is properly generated from the first submenu slug.
 	 */
 	public function test_if_the_first_submenu_url_is_used_for_menu_url() {

--- a/projects/plugins/protect/changelog/update-protect-menu-badges-registry
+++ b/projects/plugins/protect/changelog/update-protect-menu-badges-registry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect now reports its threat count to the central menu-badges registry instead of writing admin-menu markup directly.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -10,6 +10,7 @@
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",
+		"automattic/jetpack-menu-badges": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
 		"automattic/jetpack-sync": "@dev",

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acf4bf4f963d8f0b65e00c8bd18ac443",
+    "content-hash": "dd02dd33ab120e08d0d0d8bc839fda14",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1234,6 +1234,65 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A logo for Jetpack",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
             "transport-options": {
                 "relative": true
             }
@@ -3909,6 +3968,7 @@
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
+        "automattic/jetpack-menu-badges": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-plans": 20,
         "automattic/jetpack-plugins-installer": 20,

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1303,7 +1303,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1315,6 +1315,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -149,15 +149,20 @@ class Jetpack_Protect {
 	 * Initialize the admin page resources.
 	 */
 	public function admin_page_init() {
-		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
-		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
-			'jetpack-protect',
-			array(
-				'menu_slug' => 'jetpack-protect',
-				'count'     => Status::get_total_threats(),
-				'type'      => 'count',
-			)
-		);
+		// Only report the threat count to users who can actually reach the Protect
+		// menu (added below with the 'manage_options' cap). Otherwise the central
+		// menu-badges total would include threats the current user can't see.
+		if ( current_user_can( 'manage_options' ) ) {
+			\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
+			\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+				'jetpack-protect',
+				array(
+					'menu_slug' => 'jetpack-protect',
+					'count'     => Status::get_total_threats(),
+					'type'      => 'count',
+				)
+			);
+		}
 
 		$page_suffix = Admin_Menu::add_menu(
 			'Jetpack Protect', // "Jetpack Protect" is a product name, do not translate.

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -149,15 +149,19 @@ class Jetpack_Protect {
 	 * Initialize the admin page resources.
 	 */
 	public function admin_page_init() {
-		$total_threats = Status::get_total_threats();
-		$menu_label    = 'Protect'; // "Protect" is a product name, do not translate.
-		if ( $total_threats ) {
-			$menu_label .= sprintf( ' <span class="update-plugins">%d</span>', $total_threats );
-		}
+		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
+		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
+			'jetpack-protect',
+			array(
+				'menu_slug' => 'jetpack-protect',
+				'count'     => Status::get_total_threats(),
+				'type'      => 'count',
+			)
+		);
 
 		$page_suffix = Admin_Menu::add_menu(
 			'Jetpack Protect', // "Jetpack Protect" is a product name, do not translate.
-			$menu_label,
+			'Protect', // "Protect" is a product name, do not translate.
 			'manage_options',
 			'jetpack-protect',
 			array( $this, 'plugin_settings_page' ),

--- a/projects/plugins/search/changelog/add-central-menu-notification-counts
+++ b/projects/plugins/search/changelog/add-central-menu-notification-counts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1117,12 +1117,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1134,6 +1193,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/social/changelog/add-central-menu-notification-counts
+++ b/projects/plugins/social/changelog/add-central-menu-notification-counts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1240,12 +1240,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1257,6 +1316,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/starter-plugin/changelog/add-central-menu-notification-counts
+++ b/projects/plugins/starter-plugin/changelog/add-central-menu-notification-counts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1117,12 +1117,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1134,6 +1193,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",

--- a/projects/plugins/videopress/changelog/add-central-menu-notification-counts
+++ b/projects/plugins/videopress/changelog/add-central-menu-notification-counts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1117,12 +1117,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-my-jetpack",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d892112ea87492bd73daf094dab0fa937559935"
+                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1134,6 +1193,7 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-plugins-installer": "@dev",
                 "automattic/jetpack-protect-status": "@dev",


### PR DESCRIPTION
Part of FORMS-716

<!-- Stacked on #50187 (Forms sidebar live-update fix) — base is that branch, so this diff is only the menu-badges work; GitHub will retarget to trunk when #50187 merges. -->

## Proposed changes

Introduces a **central notification-count system** for the Jetpack admin-menu badges (the red count bubbles on the top-level "Jetpack" menu and its submenu items), replacing the previous approach where each product poked the `$menu`/`$submenu` markup independently in three different CSS conventions, coordinated by nothing. That approach produced the reported problems: a top-level number that didn't reconcile with the submenu numbers ("17" vs Forms 15 + Protect 1), an unstable top-level count across page loads, duplicate badges (FORMS-716), and per-product live-update code that left counts stale until a refresh.

* **New `jetpack-menu-badges` package** — a low-level package with:
  * `Notification_Counts` — passive registry + aggregation. Products call `register( $id, [ 'menu_slug' => …, 'count' => N, 'type' => 'count'|'attention' ] )`. Top-level total = Σ(count magnitudes) + 1 per non-silent `attention` entry, so it reconciles with the visible submenu badges.
  * `Menu_Renderer` — the sole writer of the top-level and submenu badges, in one consistent markup (`menu-counter count-N` + `data-jp-menu-*` attributes), hooked late on `admin_menu`.
  * A small vanilla-JS client — `window.jetpackMenuBadges.setCount( slug, count )` — that updates a badge and recomputes the top-level total from the DOM (incl. WordPress's flyout-header clone), so products no longer hand-roll DOM updates.
* **REST/Calypso** — the `wpcom/v2/admin-menu` endpoint now overlays authoritative counts from the registry (guarded by `class_exists`), so Calypso/Simple sidebars get registry-sourced counts, not title-markup scraping.
* **Migrated all four producers onto the registry** (no legacy markup writers remain):
  * **Forms** — reports its unread count; the inbox live-update goes through the shared `setCount` client (keeping the single-request ref guard from #50187); slug resolves dynamically to support the `jetpack_forms_alpha=false` legacy dashboard.
  * **Protect** — reports its threat count.
  * **Boost** — reports its problem count.
  * **My Jetpack** — its red-bubble alerts become `attention` registry entries (the alert *data* is unchanged for the dashboard cards). Protect is **de-duplicated**: My Jetpack skips the `protect_has_threats` alert only when the standalone Protect plugin is active (which registers its own count); otherwise it still contributes, so Scan-threat notifications aren't lost on full-Jetpack-plus-Scan sites without the standalone plugin.

Every provider registers before the renderer runs, and each modified project has a changelog entry.

## Related product discussion/links

* FORMS-716 (duplicate Forms notification badges) and the user reports of the top-level count not matching the submenu counts / requiring a refresh motivated this.
* Follow-up/coordination: the WP.com `wp-admin-sidebar` classifier owns the structured `signal` model on Simple — feeding it directly (vs. the markup-scraping path this PR relies on) is a cross-repo follow-up.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with several Jetpack products active (e.g. Forms with unread responses, Protect with a Scan plan), open **wp-admin** and confirm the sidebar:
  * The **top-level "Jetpack"** badge equals the **sum of the submenu badges** (Forms unread + Protect threats + Boost problems + any My Jetpack alerts), and stays stable across reloads.
  * There is a **single** badge on the "Jetpack" item (no duplicate bubble).
* **Reproduce the FORMS-716 double badge on `trunk`, then confirm it's fixed here.** The duplicate only appears on a *cold* red-bubble cache (a warm cache consolidates to one badge), so it must be forced:
  * Use a **self-hosted or Atomic** site (not Simple — My Jetpack isn't loaded there), **connected**, as an admin, with **≥1 unread Forms response** and **≥1 non-silent My Jetpack red-bubble alert** (e.g. a Protect/Scan threat).
  * Drop a mu-plugin so the cache is cold on every load (on `trunk`, My Jetpack reads the cache on `admin_init` priority 1001):
    ```php
    <?php // wp-content/mu-plugins/force-cold-red-bubble.php
    add_action( 'admin_init', function () {
        delete_transient( 'my-jetpack-red-bubble-transient' );
    }, 1000 );
    ```
  * **On `trunk`:** load a non–My-Jetpack admin page (e.g. Dashboard) and wait ~2s. The top-level "Jetpack" shows **two** bubbles — Forms' `.menu-counter.jp-feedback-unread-counter` (unread count) **plus** an `.awaiting-mod` bubble that My Jetpack's async script adds client-side (different CSS class, so neither dedups the other).
  * **On this branch:** same site/state → the top-level shows a **single** badge (`.menu-counter[data-jp-menu-badge-total="1"]`) equal to the sum of the submenu counts, no `.awaiting-mod`, stable across reloads. (The mu-plugin has no effect here — My Jetpack now registers on `admin_menu`, before the renderer, so there is no cold-cache client-side writer.)
* **Live update:** go to **Jetpack → Forms → Responses**, open an unread response. The Forms and top-level counts decrement **immediately, without a page refresh**, and stay consistent (open a few more to confirm).
* **De-dup:** on a site with a Scan plan but **without** the standalone Protect plugin, confirm the Scan-threat notification still contributes to the top-level count (it must not silently drop). With the standalone Protect plugin active, confirm Protect is counted **once** (no double-count).
* **Calypso/Simple:** on a nav-unified/Simple site, confirm the Jetpack menu counts render (sourced from the registry via the `wpcom/v2/admin-menu` endpoint). Note the top-level total badge renders here too — the renderer matches the Jetpack parent by menu slug, not the plugin capability that Simple lacks.
* Run the affected test suites: `jetpack test php packages/menu-badges`, `packages/forms`, `plugins/boost`, `packages/my-jetpack`, and the `WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test`; plus the menu-badges + forms JS suites.

| Before | After |
| - | - |
| <img width="219" height="140" alt="Screenshot from 2026-07-03 20-02-10" src="https://github.com/user-attachments/assets/b0085ec3-4149-4583-8020-9f0918e8a5df" /> | <img width="219" height="140" alt="Screenshot from 2026-07-03 20-07-58" src="https://github.com/user-attachments/assets/187d13eb-d3bf-4b59-9a0f-f21f66f6ef26" /> |
