### PR TITLE
Charts: add Bar and Line chart stories for a 2-item interactive comparison legend

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-238-comparison-legend-story
+++ b/projects/js-packages/charts/changelog/add-charts-238-comparison-legend-story
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Charts: add a Storybook story demonstrating a 2-item interactive legend for comparison bar charts.

--- a/projects/js-packages/charts/changelog/add-charts-238-comparison-legend-story
+++ b/projects/js-packages/charts/changelog/add-charts-238-comparison-legend-story
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Charts: add a Storybook story demonstrating a 2-item interactive legend for comparison bar charts.
+Charts: add Storybook stories demonstrating a 2-item interactive legend for comparison bar and line charts.

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -668,7 +668,9 @@ const ComparisonLegendItem = ( {
 					backgroundColor: color,
 				} }
 			/>
-			{ metric.label }
+			<span style={ { textDecoration: visible ? undefined : 'line-through' } }>
+				{ metric.label }
+			</span>
 		</button>
 	);
 };

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -13,9 +13,9 @@ import {
 	largeValuesData,
 	trafficData,
 	themeArgTypes,
+	viewsVisitorsComparisonData,
 } from '../../../stories';
 import BarChart from '../bar-chart';
-import type { SeriesData } from '../../../types';
 import type { Meta, StoryObj } from '@storybook/react';
 
 /**
@@ -417,31 +417,8 @@ export const Comparison: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		data: [
-			{
-				label: 'This period',
-				group: 'views',
-				data: [
-					{ label: 'Mon', value: 420 },
-					{ label: 'Tue', value: 580 },
-					{ label: 'Wed', value: 310 },
-					{ label: 'Thu', value: 750 },
-					{ label: 'Fri', value: 640 },
-				],
-			},
-			{
-				label: 'Previous period',
-				group: 'views',
-				options: { type: 'comparison' as const },
-				data: [
-					{ label: 'Mon', value: 510 },
-					{ label: 'Tue', value: 490 },
-					{ label: 'Wed', value: 430 },
-					{ label: 'Thu', value: 620 },
-					{ label: 'Fri', value: 700 },
-				],
-			},
-		],
+		// The Views group (primary + previous-period overlay) from the shared dataset.
+		data: viewsVisitorsComparisonData.slice( 0, 2 ),
 	},
 	parameters: {
 		docs: {
@@ -460,54 +437,7 @@ export const ComparisonGroups: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		data: [
-			{
-				label: 'Views — this period',
-				group: 'views',
-				data: [
-					{ label: 'Mon', value: 420 },
-					{ label: 'Tue', value: 580 },
-					{ label: 'Wed', value: 310 },
-					{ label: 'Thu', value: 750 },
-					{ label: 'Fri', value: 640 },
-				],
-			},
-			{
-				label: 'Views — previous period',
-				group: 'views',
-				options: { type: 'comparison' as const },
-				data: [
-					{ label: 'Mon', value: 510 },
-					{ label: 'Tue', value: 490 },
-					{ label: 'Wed', value: 430 },
-					{ label: 'Thu', value: 620 },
-					{ label: 'Fri', value: 700 },
-				],
-			},
-			{
-				label: 'Visitors — this period',
-				group: 'visitors',
-				data: [
-					{ label: 'Mon', value: 280 },
-					{ label: 'Tue', value: 390 },
-					{ label: 'Wed', value: 220 },
-					{ label: 'Thu', value: 500 },
-					{ label: 'Fri', value: 430 },
-				],
-			},
-			{
-				label: 'Visitors — previous period',
-				group: 'visitors',
-				options: { type: 'comparison' as const },
-				data: [
-					{ label: 'Mon', value: 340 },
-					{ label: 'Tue', value: 320 },
-					{ label: 'Wed', value: 290 },
-					{ label: 'Thu', value: 410 },
-					{ label: 'Fri', value: 460 },
-				],
-			},
-		],
+		data: viewsVisitorsComparisonData,
 	},
 	parameters: {
 		docs: {
@@ -569,55 +499,6 @@ export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 // metric and toggles each metric's current + previous-period series together.
 const INTERACTIVE_COMPARISON_CHART_ID = 'views-visitors-comparison';
 
-const comparisonLegendData: SeriesData[] = [
-	{
-		label: 'Views',
-		group: 'views',
-		data: [
-			{ label: 'Mon', value: 420 },
-			{ label: 'Tue', value: 580 },
-			{ label: 'Wed', value: 310 },
-			{ label: 'Thu', value: 750 },
-			{ label: 'Fri', value: 640 },
-		],
-	},
-	{
-		label: 'Views — previous',
-		group: 'views',
-		options: { type: 'comparison' as const },
-		data: [
-			{ label: 'Mon', value: 510 },
-			{ label: 'Tue', value: 490 },
-			{ label: 'Wed', value: 430 },
-			{ label: 'Thu', value: 620 },
-			{ label: 'Fri', value: 700 },
-		],
-	},
-	{
-		label: 'Visitors',
-		group: 'visitors',
-		data: [
-			{ label: 'Mon', value: 280 },
-			{ label: 'Tue', value: 390 },
-			{ label: 'Wed', value: 220 },
-			{ label: 'Thu', value: 500 },
-			{ label: 'Fri', value: 430 },
-		],
-	},
-	{
-		label: 'Visitors — previous',
-		group: 'visitors',
-		options: { type: 'comparison' as const },
-		data: [
-			{ label: 'Mon', value: 340 },
-			{ label: 'Tue', value: 320 },
-			{ label: 'Wed', value: 290 },
-			{ label: 'Thu', value: 410 },
-			{ label: 'Fri', value: 460 },
-		],
-	},
-];
-
 // One legend entry per metric; each entry controls its current + previous series together.
 const comparisonLegendMetrics = [
 	{ label: 'Views', current: 'Views', previous: 'Views — previous' },
@@ -677,7 +558,7 @@ const ComparisonLegendItem = ( {
 
 const ComparisonLegend = () => {
 	// Reuse the library's colour resolution so swatches match the primary bars.
-	const legendItems = useChartLegendItems( comparisonLegendData );
+	const legendItems = useChartLegendItems( viewsVisitorsComparisonData );
 	const colorByLabel = new Map( legendItems.map( item => [ item.label, item.color ] ) );
 
 	return (
@@ -703,7 +584,7 @@ export const ComparisonGroupsInteractiveLegend: Story = {
 			<div style={ { display: 'flex', flexDirection: 'column', gap: '16px', width: 700 } }>
 				<BarChart
 					chartId={ INTERACTIVE_COMPARISON_CHART_ID }
-					data={ comparisonLegendData }
+					data={ viewsVisitorsComparisonData }
 					legend={ { interactive: true } }
 					showLegend={ false }
 					withTooltips

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '@wordpress/ui';
 import { useCallback } from 'react';
 import { useChartLegendItems } from '../../../components/legend';
-import { useGlobalChartsContext } from '../../../providers';
+import { GlobalChartsProvider, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -692,25 +692,31 @@ const ComparisonLegend = () => {
 };
 
 export const ComparisonGroupsInteractiveLegend: Story = {
+	// The chart and the custom legend must share one GlobalChartsProvider so the legend's
+	// toggleSeriesVisibility calls reach the chart's visibility state. Storybook's decorator
+	// already provides one, but wrapping it explicitly here keeps the pattern copy-pasteable
+	// into a widget that has no such ambient provider.
 	render: () => (
-		<div style={ { display: 'flex', flexDirection: 'column', gap: '16px', width: 700 } }>
-			<BarChart
-				chartId={ INTERACTIVE_COMPARISON_CHART_ID }
-				data={ comparisonLegendData }
-				legend={ { interactive: true } }
-				showLegend={ false }
-				withTooltips
-				gridVisibility="x"
-				height={ 300 }
-			/>
-			<ComparisonLegend />
-		</div>
+		<GlobalChartsProvider>
+			<div style={ { display: 'flex', flexDirection: 'column', gap: '16px', width: 700 } }>
+				<BarChart
+					chartId={ INTERACTIVE_COMPARISON_CHART_ID }
+					data={ comparisonLegendData }
+					legend={ { interactive: true } }
+					showLegend={ false }
+					withTooltips
+					gridVisibility="x"
+					height={ 300 }
+				/>
+				<ComparisonLegend />
+			</div>
+		</GlobalChartsProvider>
 	),
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'A **2-item interactive legend** over a four-series comparison chart (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay). The built-in legend renders one item per series, so it is disabled here (`showLegend={ false }`) and replaced by a custom legend showing a single item per metric. Clicking a metric toggles **both** its current and previous-period series together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`) — one click hides or shows both bars, while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility even though it renders no legend of its own. This is the recommended pattern for comparison widgets (e.g. the Premium Analytics Views & Visitors chart) that need a grouped, interactive legend today.',
+					'A **2-item interactive legend** over a four-series comparison chart (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay). The built-in legend renders one item per series, so it is disabled here (`showLegend={ false }`) and replaced by a custom legend showing a single item per metric. Clicking a metric toggles **both** its current and previous-period series together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`) — one click hides or shows both bars, while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility even though it renders no legend of its own. The chart and the custom legend must be mounted inside the **same** `GlobalChartsProvider` so the toggle calls reach the chart\'s visibility state — Storybook supplies one via its decorator, and this story also wraps one explicitly so the snippet is self-contained. This is the recommended pattern for comparison widgets (e.g. the Premium Analytics Views & Visitors chart) that need a grouped, interactive legend today.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '@wordpress/ui';
 import { useCallback } from 'react';
 import { useChartLegendItems } from '../../../components/legend';
-import { GlobalChartsProvider, useGlobalChartsContext } from '../../../providers';
+import { useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -449,54 +449,10 @@ export const ComparisonGroups: Story = {
 	},
 };
 
-export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
-	render: () => (
-		<div style={ { display: 'grid', gap: '40px' } }>
-			<div>
-				<h3>Without labelOverflow (Default - Labels Overlap)</h3>
-				<p style={ { marginBottom: '20px', color: '#666' } }>
-					Default behavior: long labels overlap and become unreadable at narrow widths.
-				</p>
-				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
-					<BarChart data={ longLabelData } withTooltips={ true } gridVisibility="x" />
-				</div>
-			</div>
-			<div>
-				<h3>With labelOverflow: &apos;ellipsis&apos; (Labels Truncated)</h3>
-				<p style={ { marginBottom: '20px', color: '#666' } }>
-					With <code>labelOverflow: &apos;ellipsis&apos;</code>, labels are truncated to fit the
-					available bandwidth. <strong>Hover over a label to see the full text.</strong>
-				</p>
-				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
-					<BarChart
-						data={ longLabelData }
-						withTooltips={ true }
-						gridVisibility="x"
-						options={ {
-							axis: {
-								x: {
-									labelOverflow: 'ellipsis',
-								},
-							},
-						} }
-					/>
-				</div>
-			</div>
-		</div>
-	),
-	parameters: {
-		docs: {
-			description: {
-				story:
-					"Demonstrates the `labelOverflow: 'ellipsis'` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.",
-			},
-		},
-	},
-};
-
 // A 2-item interactive legend over a 4-series comparison chart. The built-in legend renders one
-// item per series; here it is disabled and replaced by a custom legend that shows one item per
-// metric and toggles each metric's current + previous-period series together.
+// item per series; here a custom legend is supplied through the composition API (a
+// <BarChart.Legend> child with a `render` prop), showing one item per metric and toggling each
+// metric's current + previous-period series together.
 const INTERACTIVE_COMPARISON_CHART_ID = 'views-visitors-comparison';
 
 // One legend entry per metric; each entry controls its current + previous series together.
@@ -574,32 +530,77 @@ const ComparisonLegend = () => {
 	);
 };
 
+// Passed to <BarChart.Legend>'s `render` prop; a module-level reference keeps the arrow out of the
+// JSX so it doesn't trip jsx-no-bind.
+const renderComparisonLegend = () => <ComparisonLegend />;
+
 export const ComparisonGroupsInteractiveLegend: Story = {
-	// The chart and the custom legend must share one GlobalChartsProvider so the legend's
-	// toggleSeriesVisibility calls reach the chart's visibility state. Storybook's decorator
-	// already provides one, but wrapping it explicitly here keeps the pattern copy-pasteable
-	// into a widget that has no such ambient provider.
+	// The custom legend is supplied through the composition API as a <BarChart.Legend> child, so it
+	// renders inside the chart's own layout — the chart stays responsive and fills its parent (no
+	// fixed dimensions), and the legend automatically shares the chart's GlobalChartsProvider, so
+	// its toggleSeriesVisibility calls reach the chart's visibility state.
 	render: () => (
-		<GlobalChartsProvider>
-			<div style={ { display: 'flex', flexDirection: 'column', gap: '16px', width: 700 } }>
-				<BarChart
-					chartId={ INTERACTIVE_COMPARISON_CHART_ID }
-					data={ viewsVisitorsComparisonData }
-					legend={ { interactive: true } }
-					showLegend={ false }
-					withTooltips
-					gridVisibility="x"
-					height={ 300 }
-				/>
-				<ComparisonLegend />
-			</div>
-		</GlobalChartsProvider>
+		<BarChart
+			chartId={ INTERACTIVE_COMPARISON_CHART_ID }
+			data={ viewsVisitorsComparisonData }
+			legend={ { interactive: true } }
+			withTooltips
+			gridVisibility="x"
+			maxWidth={ 1200 }
+		>
+			<BarChart.Legend position="bottom" render={ renderComparisonLegend } />
+		</BarChart>
 	),
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'A **2-item interactive legend** over a four-series comparison chart (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay). The built-in legend renders one item per series, so it is disabled here (`showLegend={ false }`) and replaced by a custom legend showing a single item per metric. Clicking a metric toggles **both** its current and previous-period series together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`) — one click hides or shows both bars, while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility even though it renders no legend of its own. The chart and the custom legend must be mounted inside the **same** `GlobalChartsProvider` so the toggle calls reach the chart\'s visibility state — Storybook supplies one via its decorator, and this story also wraps one explicitly so the snippet is self-contained. This is the recommended pattern for comparison widgets (e.g. the Premium Analytics Views & Visitors chart) that need a grouped, interactive legend today.',
+					'A **2-item interactive legend** over a four-series comparison chart (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay). The built-in legend renders one item per series, so a custom legend is supplied through the composition API — a `<BarChart.Legend>` child with a `render` prop — showing a single item per metric. Because the legend is a child of the chart it renders inside the chart layout, so the chart stays responsive and fills its parent (no fixed dimensions) and the legend automatically shares the chart\'s `GlobalChartsProvider`. Clicking a metric toggles **both** its current and previous-period series together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`) — one click hides or shows both bars and strikes through the item (matching the built-in legend\'s inactive styling), while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility. This is the recommended pattern for comparison widgets (e.g. the Premium Analytics Views & Visitors chart) that need a grouped, interactive legend today.',
+			},
+		},
+	},
+};
+
+export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '40px' } }>
+			<div>
+				<h3>Without labelOverflow (Default - Labels Overlap)</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					Default behavior: long labels overlap and become unreadable at narrow widths.
+				</p>
+				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
+					<BarChart data={ longLabelData } withTooltips={ true } gridVisibility="x" />
+				</div>
+			</div>
+			<div>
+				<h3>With labelOverflow: &apos;ellipsis&apos; (Labels Truncated)</h3>
+				<p style={ { marginBottom: '20px', color: '#666' } }>
+					With <code>labelOverflow: &apos;ellipsis&apos;</code>, labels are truncated to fit the
+					available bandwidth. <strong>Hover over a label to see the full text.</strong>
+				</p>
+				<div style={ { width: '350px', height: '250px', border: '1px solid #e0e0e0' } }>
+					<BarChart
+						data={ longLabelData }
+						withTooltips={ true }
+						gridVisibility="x"
+						options={ {
+							axis: {
+								x: {
+									labelOverflow: 'ellipsis',
+								},
+							},
+						} }
+					/>
+				</div>
+			</div>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Demonstrates the `labelOverflow: 'ellipsis'` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -1,3 +1,7 @@
+import { Stack } from '@wordpress/ui';
+import { useCallback } from 'react';
+import { useChartLegendItems } from '../../../components/legend';
+import { useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -11,6 +15,7 @@ import {
 	themeArgTypes,
 } from '../../../stories';
 import BarChart from '../bar-chart';
+import type { SeriesData } from '../../../types';
 import type { Meta, StoryObj } from '@storybook/react';
 
 /**
@@ -554,6 +559,158 @@ export const LabelOverflowEllipsis: StoryObj< typeof BarChart > = {
 			description: {
 				story:
 					"Demonstrates the `labelOverflow: 'ellipsis'` option that truncates long axis labels to fit the available bandwidth. The full label text is shown on hover via a native tooltip. This is useful for narrow widget contexts where space is limited.",
+			},
+		},
+	},
+};
+
+// A 2-item interactive legend over a 4-series comparison chart. The built-in legend renders one
+// item per series; here it is disabled and replaced by a custom legend that shows one item per
+// metric and toggles each metric's current + previous-period series together.
+const INTERACTIVE_COMPARISON_CHART_ID = 'views-visitors-comparison';
+
+const comparisonLegendData: SeriesData[] = [
+	{
+		label: 'Views',
+		group: 'views',
+		data: [
+			{ label: 'Mon', value: 420 },
+			{ label: 'Tue', value: 580 },
+			{ label: 'Wed', value: 310 },
+			{ label: 'Thu', value: 750 },
+			{ label: 'Fri', value: 640 },
+		],
+	},
+	{
+		label: 'Views — previous',
+		group: 'views',
+		options: { type: 'comparison' as const },
+		data: [
+			{ label: 'Mon', value: 510 },
+			{ label: 'Tue', value: 490 },
+			{ label: 'Wed', value: 430 },
+			{ label: 'Thu', value: 620 },
+			{ label: 'Fri', value: 700 },
+		],
+	},
+	{
+		label: 'Visitors',
+		group: 'visitors',
+		data: [
+			{ label: 'Mon', value: 280 },
+			{ label: 'Tue', value: 390 },
+			{ label: 'Wed', value: 220 },
+			{ label: 'Thu', value: 500 },
+			{ label: 'Fri', value: 430 },
+		],
+	},
+	{
+		label: 'Visitors — previous',
+		group: 'visitors',
+		options: { type: 'comparison' as const },
+		data: [
+			{ label: 'Mon', value: 340 },
+			{ label: 'Tue', value: 320 },
+			{ label: 'Wed', value: 290 },
+			{ label: 'Thu', value: 410 },
+			{ label: 'Fri', value: 460 },
+		],
+	},
+];
+
+// One legend entry per metric; each entry controls its current + previous series together.
+const comparisonLegendMetrics = [
+	{ label: 'Views', current: 'Views', previous: 'Views — previous' },
+	{ label: 'Visitors', current: 'Visitors', previous: 'Visitors — previous' },
+];
+
+type ComparisonMetric = ( typeof comparisonLegendMetrics )[ number ];
+
+const ComparisonLegendItem = ( {
+	metric,
+	color,
+}: {
+	metric: ComparisonMetric;
+	color?: string;
+} ) => {
+	const { toggleSeriesVisibility, isSeriesVisible } = useGlobalChartsContext();
+	const visible = isSeriesVisible( INTERACTIVE_COMPARISON_CHART_ID, metric.current );
+
+	const handleClick = useCallback( () => {
+		// One click toggles both the current and previous-period series for this metric.
+		toggleSeriesVisibility( INTERACTIVE_COMPARISON_CHART_ID, metric.current );
+		toggleSeriesVisibility( INTERACTIVE_COMPARISON_CHART_ID, metric.previous );
+	}, [ toggleSeriesVisibility, metric ] );
+
+	return (
+		<button
+			type="button"
+			aria-pressed={ visible }
+			aria-label={ `${ metric.label }: ${ visible ? 'visible' : 'hidden' }. Toggle visibility.` }
+			onClick={ handleClick }
+			style={ {
+				display: 'flex',
+				alignItems: 'center',
+				gap: '8px',
+				padding: 0,
+				border: 'none',
+				background: 'none',
+				cursor: 'pointer',
+				opacity: visible ? 1 : 0.4,
+			} }
+		>
+			<span
+				aria-hidden="true"
+				style={ {
+					width: '16px',
+					height: '16px',
+					borderRadius: '2px',
+					backgroundColor: color,
+				} }
+			/>
+			{ metric.label }
+		</button>
+	);
+};
+
+const ComparisonLegend = () => {
+	// Reuse the library's colour resolution so swatches match the primary bars.
+	const legendItems = useChartLegendItems( comparisonLegendData );
+	const colorByLabel = new Map( legendItems.map( item => [ item.label, item.color ] ) );
+
+	return (
+		<Stack direction="row" gap="lg" align="center" justify="center">
+			{ comparisonLegendMetrics.map( metric => (
+				<ComparisonLegendItem
+					key={ metric.label }
+					metric={ metric }
+					color={ colorByLabel.get( metric.current ) }
+				/>
+			) ) }
+		</Stack>
+	);
+};
+
+export const ComparisonGroupsInteractiveLegend: Story = {
+	render: () => (
+		<div style={ { display: 'flex', flexDirection: 'column', gap: '16px', width: 700 } }>
+			<BarChart
+				chartId={ INTERACTIVE_COMPARISON_CHART_ID }
+				data={ comparisonLegendData }
+				legend={ { interactive: true } }
+				showLegend={ false }
+				withTooltips
+				gridVisibility="x"
+				height={ 300 }
+			/>
+			<ComparisonLegend />
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A **2-item interactive legend** over a four-series comparison chart (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay). The built-in legend renders one item per series, so it is disabled here (`showLegend={ false }`) and replaced by a custom legend showing a single item per metric. Clicking a metric toggles **both** its current and previous-period series together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`) — one click hides or shows both bars, while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility even though it renders no legend of its own. This is the recommended pattern for comparison widgets (e.g. the Premium Analytics Views & Visitors chart) that need a grouped, interactive legend today.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -1,9 +1,14 @@
+import { Stack } from '@wordpress/ui';
+import { useCallback } from 'react';
+import { useChartLegendItems } from '../../../components/legend';
+import { useGlobalChartsContext } from '../../../providers';
 import {
 	ChartStoryArgs,
 	extractLegendConfig,
 	temperatureData as sampleData,
 	largeValuesData,
 	trafficData as webTrafficData,
+	viewsVisitorsComparisonTimeData,
 } from '../../../stories';
 import LineChart from '../line-chart';
 import { lineChartMetaArgs, lineChartStoryArgs } from './config';
@@ -558,4 +563,117 @@ Comparison.args = {
 			},
 		},
 	],
+};
+
+// A 2-item interactive legend over a 4-series comparison line chart. The built-in legend renders one
+// item per series; here a custom legend is supplied through the composition API (a
+// <LineChart.Legend> child with a `render` prop), showing one item per metric and toggling each
+// metric's current + previous-period series together.
+const INTERACTIVE_COMPARISON_CHART_ID = 'views-visitors-comparison-line';
+
+// One legend entry per metric; each entry controls its current + previous series together.
+const comparisonLegendMetrics = [
+	{ label: 'Views', current: 'Views', previous: 'Views — previous' },
+	{ label: 'Visitors', current: 'Visitors', previous: 'Visitors — previous' },
+];
+
+type ComparisonMetric = ( typeof comparisonLegendMetrics )[ number ];
+
+const ComparisonLegendItem = ( {
+	metric,
+	color,
+}: {
+	metric: ComparisonMetric;
+	color?: string;
+} ) => {
+	const { toggleSeriesVisibility, isSeriesVisible } = useGlobalChartsContext();
+	const visible = isSeriesVisible( INTERACTIVE_COMPARISON_CHART_ID, metric.current );
+
+	const handleClick = useCallback( () => {
+		// One click toggles both the current and previous-period series for this metric.
+		toggleSeriesVisibility( INTERACTIVE_COMPARISON_CHART_ID, metric.current );
+		toggleSeriesVisibility( INTERACTIVE_COMPARISON_CHART_ID, metric.previous );
+	}, [ toggleSeriesVisibility, metric ] );
+
+	return (
+		<button
+			type="button"
+			aria-pressed={ visible }
+			aria-label={ `${ metric.label }: ${ visible ? 'visible' : 'hidden' }. Toggle visibility.` }
+			onClick={ handleClick }
+			style={ {
+				display: 'flex',
+				alignItems: 'center',
+				gap: '8px',
+				padding: 0,
+				border: 'none',
+				background: 'none',
+				cursor: 'pointer',
+				opacity: visible ? 1 : 0.4,
+			} }
+		>
+			<span
+				aria-hidden="true"
+				style={ {
+					width: '16px',
+					height: '16px',
+					borderRadius: '2px',
+					backgroundColor: color,
+				} }
+			/>
+			<span style={ { textDecoration: visible ? undefined : 'line-through' } }>
+				{ metric.label }
+			</span>
+		</button>
+	);
+};
+
+const ComparisonLegend = () => {
+	// Reuse the library's colour resolution so swatches match the primary lines.
+	const legendItems = useChartLegendItems( viewsVisitorsComparisonTimeData );
+	const colorByLabel = new Map( legendItems.map( item => [ item.label, item.color ] ) );
+
+	return (
+		<Stack direction="row" gap="lg" align="center" justify="center">
+			{ comparisonLegendMetrics.map( metric => (
+				<ComparisonLegendItem
+					key={ metric.label }
+					metric={ metric }
+					color={ colorByLabel.get( metric.current ) }
+				/>
+			) ) }
+		</Stack>
+	);
+};
+
+// Passed to <LineChart.Legend>'s `render` prop; a module-level reference keeps the arrow out of the
+// JSX so it doesn't trip jsx-no-bind.
+const renderComparisonLegend = () => <ComparisonLegend />;
+
+export const ComparisonGroupsInteractiveLegend: StoryObj< typeof LineChart > = {
+	// The custom legend is supplied through the composition API as a <LineChart.Legend> child, so it
+	// renders inside the chart's own layout — the chart stays responsive and fills its parent (no
+	// fixed dimensions), and the legend automatically shares the chart's GlobalChartsProvider, so its
+	// toggleSeriesVisibility calls reach the chart's visibility state.
+	render: () => (
+		<LineChart
+			chartId={ INTERACTIVE_COMPARISON_CHART_ID }
+			data={ viewsVisitorsComparisonTimeData }
+			legend={ { interactive: true } }
+			withTooltips
+			withGradientFill={ false }
+			smoothing={ false }
+			maxWidth={ 1200 }
+		>
+			<LineChart.Legend position="bottom" render={ renderComparisonLegend } />
+		</LineChart>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The same 2-item interactive comparison legend pattern as the BarChart story, applied to a LineChart. Four series across two groups (`Views` / `Visitors`, each with a `type: "comparison"` previous-period overlay drawn as a dashed line) are shown behind a custom 2-item legend supplied through the composition API — a `<LineChart.Legend>` child with a `render` prop. Clicking a metric toggles **both** its current and previous-period lines together via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`), striking through the item to match the built-in legend\'s inactive styling, while tooltips keep distinct period labels. `legend={ { interactive: true } }` tells the chart to honour visibility. Note: with the current API the value axis rescales to the visible series when a metric is toggled (unlike the bar chart, whose axis stays fixed).',
+			},
+		},
+	},
 };

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -746,6 +746,75 @@ export const viewsVisitorsComparisonData: SeriesData[] = [
 ];
 
 /**
+ * Views & Visitors comparison time series
+ *
+ * Date-based sibling of `viewsVisitorsComparisonData` for the line chart: two metrics (Views,
+ * Visitors), each with a `type: 'comparison'` previous-period overlay sharing its `group`.
+ * - Category: comparative time series
+ * - Suitable for: LineChart, AreaChart
+ */
+export const viewsVisitorsComparisonTimeData: SeriesData[] = [
+	{
+		label: 'Views',
+		group: 'views',
+		data: [
+			{ date: new Date( '2024-01-01' ), value: 420 },
+			{ date: new Date( '2024-02-01' ), value: 580 },
+			{ date: new Date( '2024-03-01' ), value: 510 },
+			{ date: new Date( '2024-04-01' ), value: 690 },
+			{ date: new Date( '2024-05-01' ), value: 640 },
+			{ date: new Date( '2024-06-01' ), value: 760 },
+			{ date: new Date( '2024-07-01' ), value: 700 },
+			{ date: new Date( '2024-08-01' ), value: 830 },
+		],
+	},
+	{
+		label: 'Views — previous',
+		group: 'views',
+		options: { type: 'comparison' as const },
+		data: [
+			{ date: new Date( '2024-01-01' ), value: 510 },
+			{ date: new Date( '2024-02-01' ), value: 490 },
+			{ date: new Date( '2024-03-01' ), value: 470 },
+			{ date: new Date( '2024-04-01' ), value: 610 },
+			{ date: new Date( '2024-05-01' ), value: 620 },
+			{ date: new Date( '2024-06-01' ), value: 700 },
+			{ date: new Date( '2024-07-01' ), value: 660 },
+			{ date: new Date( '2024-08-01' ), value: 690 },
+		],
+	},
+	{
+		label: 'Visitors',
+		group: 'visitors',
+		data: [
+			{ date: new Date( '2024-01-01' ), value: 280 },
+			{ date: new Date( '2024-02-01' ), value: 390 },
+			{ date: new Date( '2024-03-01' ), value: 340 },
+			{ date: new Date( '2024-04-01' ), value: 470 },
+			{ date: new Date( '2024-05-01' ), value: 430 },
+			{ date: new Date( '2024-06-01' ), value: 510 },
+			{ date: new Date( '2024-07-01' ), value: 480 },
+			{ date: new Date( '2024-08-01' ), value: 560 },
+		],
+	},
+	{
+		label: 'Visitors — previous',
+		group: 'visitors',
+		options: { type: 'comparison' as const },
+		data: [
+			{ date: new Date( '2024-01-01' ), value: 340 },
+			{ date: new Date( '2024-02-01' ), value: 320 },
+			{ date: new Date( '2024-03-01' ), value: 360 },
+			{ date: new Date( '2024-04-01' ), value: 420 },
+			{ date: new Date( '2024-05-01' ), value: 440 },
+			{ date: new Date( '2024-06-01' ), value: 470 },
+			{ date: new Date( '2024-07-01' ), value: 470 },
+			{ date: new Date( '2024-08-01' ), value: 500 },
+		],
+	},
+];
+
+/**
  * Marketing channels by country data
  *
  * Sales performance by channel by country

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -688,6 +688,64 @@ export const marketingChannelsComparison: SeriesData[] = [
 ];
 
 /**
+ * Views & Visitors traffic with current vs previous-period comparison
+ *
+ * Two metric groups (views, visitors), each a primary series plus a
+ * type: 'comparison' previous-period overlay sharing the same group.
+ * - Category: time-series comparison
+ * - Data points: 5 per series
+ * - Suitable for: BarChart comparison groups, interactive legends
+ */
+export const viewsVisitorsComparisonData: SeriesData[] = [
+	{
+		label: 'Views',
+		group: 'views',
+		data: [
+			{ label: 'Mon', value: 420 },
+			{ label: 'Tue', value: 580 },
+			{ label: 'Wed', value: 310 },
+			{ label: 'Thu', value: 750 },
+			{ label: 'Fri', value: 640 },
+		],
+	},
+	{
+		label: 'Views — previous',
+		group: 'views',
+		options: { type: 'comparison' as const },
+		data: [
+			{ label: 'Mon', value: 510 },
+			{ label: 'Tue', value: 490 },
+			{ label: 'Wed', value: 430 },
+			{ label: 'Thu', value: 620 },
+			{ label: 'Fri', value: 700 },
+		],
+	},
+	{
+		label: 'Visitors',
+		group: 'visitors',
+		data: [
+			{ label: 'Mon', value: 280 },
+			{ label: 'Tue', value: 390 },
+			{ label: 'Wed', value: 220 },
+			{ label: 'Thu', value: 500 },
+			{ label: 'Fri', value: 430 },
+		],
+	},
+	{
+		label: 'Visitors — previous',
+		group: 'visitors',
+		options: { type: 'comparison' as const },
+		data: [
+			{ label: 'Mon', value: 340 },
+			{ label: 'Tue', value: 320 },
+			{ label: 'Wed', value: 290 },
+			{ label: 'Thu', value: 410 },
+			{ label: 'Fri', value: 460 },
+		],
+	},
+];
+
+/**
  * Marketing channels by country data
  *
  * Sales performance by channel by country


### PR DESCRIPTION
Fixes CHARTS-238

## Why

An upcoming Premium Analytics widget shows a Views & Visitors comparison chart (current period solid, previous period as a translucent "shadow" / dashed overlay) with a **2-item interactive legend** — one entry per metric, where clicking it toggles both that metric's current *and* previous-period series.

The charts library's built-in interactive legend can't express this: it emits one legend item per series (4 here, not 2) and toggles strictly one series per item by exact label, so a single "Views" click would leave the "Views — previous" overlay visible. This PR documents the supported way to build that legend **today**, using only public exports — a copy-pasteable pattern for widget authors, captured in Storybook for both the bar and line charts.

This is **Approach A** for CHARTS-238 — the ships-now, no-library-change option. The alternative, [#50194](https://github.com/Automattic/jetpack/pull/50194), teaches the library a group-aware legend so no custom legend is needed. The two PRs are alternatives; merging either closes the issue (see CHARTS-238 for the comparison).

## Proposed changes

* Add a `ComparisonGroupsInteractiveLegend` story to the BarChart stories (`projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx`).
* The chart uses four series across two groups (`views`, `visitors`), each a primary series plus a `type: "comparison"` previous-period overlay, with **distinct** labels so tooltips still separate the periods.
* Instead of the auto-derived legend, the custom legend is supplied through the composition API (a `<BarChart.Legend>` / `<LineChart.Legend>` child with a `render` prop) so it shares the chart's `GlobalChartsProvider` and stays inside the responsive layout. It renders one item per metric and, on click, toggles **both** the current and previous series for that metric via the public `useGlobalChartsContext()` (`toggleSeriesVisibility` / `isSeriesVisible`); `legend={ { interactive: true } }` keeps the chart honouring visibility. Swatch colours are pulled from `useChartLegendItems()` so they match the primary series.
* Add the matching `ComparisonGroupsInteractiveLegend` story to the LineChart stories, using the same composition-API custom legend. A date-based `viewsVisitorsComparisonTimeData` is added to the shared sample data as the time-series sibling of `viewsVisitorsComparisonData` (the line chart uses a time x-scale).
* No changes to core chart/legend/provider code and no public API changes — the stories rely solely on already-exported building blocks.

## Screenshots

### Bar chart

**All series visible** — the 2-item legend (Views / Visitors) over the comparison chart; each metric shows its current-period bar with the translucent previous-period shadow behind it.

<img width="832" height="436" alt="comparison-legend-all-visible" src="https://github.com/user-attachments/assets/edd2a8b8-80cd-4a63-b2a0-29c2a5de8dd5" />

**After clicking "Views"** — one click hides both the current and previous-period Views bars; the legend item dims and is struck through (matching the built-in interactive legend), while Visitors is unaffected.

<img width="832" height="436" alt="comparison-legend-views-hidden" src="https://github.com/user-attachments/assets/d316662d-37dd-4e5d-be74-37f7dbf59061" />

### Line chart

**All series visible** — the same 2-item legend over a comparison line chart; each metric is a solid current-period line with its dashed previous-period overlay.

<img width="832" height="436" alt="line-custom-legend-all-visible" src="https://github.com/user-attachments/assets/a678b148-1a15-445d-8d6c-e8ed3d670e2d" />

**After clicking "Views"** — one click hides both Views lines and the item is struck through, while Visitors is unaffected. (With the current API the value axis rescales to the visible series; the group-aware library legend in the alternative PR keeps it fixed.)

<img width="832" height="436" alt="line-custom-legend-views-hidden" src="https://github.com/user-attachments/assets/654d28fc-5374-4d83-8685-73ff5839bfa0" />

## Related product discussion/links

* Linear: CHARTS-238 (Premium Analytics project)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the Jetpack Storybook and open **JS Packages / Charts Library / Charts / Bar Chart → Comparison Groups Interactive Legend**.
* Confirm the legend below the chart shows exactly **two** items: *Views* and *Visitors*.
* Click **Views**: both the solid Views bars *and* the translucent previous-period shadow bars disappear; the item dims and `aria-pressed` becomes `false`. Click again to restore.
* Repeat for **Visitors** — same behaviour.
* Hover a bar and confirm the tooltip still labels the current and previous periods distinctly.
* Open **Line Chart → Comparison Groups Interactive Legend** and confirm the same: a 2-item legend, clicking a metric toggles both its solid current-period line and its dashed previous-period line, the other metric unaffected.

Automated checks (charts package): `pnpm run typecheck` and `pnpm exec eslint …` pass. Interactive behaviour verified in the browser via DOM assertions — bar chart: primary bars 10↔5 and shadow rects 10↔5 per metric toggle; line chart: line paths 8↔4 when a metric is toggled, the other metric unaffected.




