### PR TITLE
Premium Analytics: move Emails widget selector onto the header row

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1654-emails-header-row
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1654-emails-header-row
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emails widget: Move the metric selector onto the header row, next to the title.

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -12,12 +12,12 @@ import {
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Stack, Text } from '@wordpress/ui';
+import { Icon, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
-import type { EmailsAttributes } from './widget';
+import widgetDefinition, { type EmailsAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 type EmailsRenderAttributes = EmailsAttributes & Partial< ReportParamsFieldAttributes >;
@@ -89,6 +89,23 @@ function buildLeaderboardData( rows: EmailRow[], metric: EmailMetric ): Leaderbo
 	} );
 }
 
+/**
+ * Widget header title: the envelope icon plus the "Emails" label. Rendered by
+ * the widget itself (not the host) because the widget is `full-bleed`, so the
+ * header sits on the same row as the metric selector — matching the Locations
+ * widget's layout.
+ *
+ * @return The header title.
+ */
+function EmailsHeaderTitle() {
+	return (
+		<span className={ styles.headerTitle }>
+			<Icon icon={ widgetDefinition.icon } size={ 20 } className={ styles.headerIcon } />
+			<span>{ __( 'Emails', 'jetpack-premium-analytics' ) }</span>
+		</span>
+	);
+}
+
 type EmailsLeaderboardProps = {
 	/**
 	 * Normalized email rows to render. When omitted, the empty state is shown
@@ -146,9 +163,9 @@ export const EmailsLeaderboard = ( {
 	let body;
 	if ( isError ) {
 		body = (
-			<Text className={ styles.placeholder }>
-				{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }
-			</Text>
+			<Stack align="center" justify="center" className={ styles.placeholder }>
+				<Text>{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }</Text>
+			</Stack>
 		);
 	} else if ( isLoading && rows.length === 0 ) {
 		body = <WidgetLoadingOverlay />;
@@ -175,7 +192,10 @@ export const EmailsLeaderboard = ( {
 
 	return (
 		<Stack className={ styles.root }>
-			<Stack direction="row" justify="flex-end" align="center" className={ styles.header }>
+			<Stack direction="row" justify="space-between" align="center" className={ styles.header }>
+				<Text className={ styles.title }>
+					<EmailsHeaderTitle />
+				</Text>
 				<SelectControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
@@ -190,7 +210,7 @@ export const EmailsLeaderboard = ( {
 					className={ styles.metricSelect }
 				/>
 			</Stack>
-			{ body }
+			<div className={ styles.content }>{ body }</div>
 		</Stack>
 	);
 };

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -101,12 +101,23 @@ const mockLongLabelRows: EmailRow[] = [
 ];
 
 /**
+ * Close-up canvas so the widget fills a real body area outside the dashboard
+ * grid — the loading overlay and empty state need a sized container to render in.
+ */
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '320px' } }>
+		<Story />
+	</div>
+);
+
+/**
  * Default populated state — latest emails (newest first) with their open rate.
  */
 export const Default: Story = {
 	args: {
 		rows: mockRows,
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -117,6 +128,7 @@ export const ByClickRate: Story = {
 		rows: mockRows,
 		initialMetric: 'clicks',
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -127,6 +139,7 @@ export const Loading: Story = {
 		rows: [],
 		isLoading: true,
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -136,6 +149,7 @@ export const Empty: Story = {
 	args: {
 		rows: [],
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -145,6 +159,7 @@ export const ErrorState: Story = {
 	args: {
 		isError: true,
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -154,6 +169,7 @@ export const LongLabels: Story = {
 	args: {
 		rows: mockLongLabelRows,
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
 /**
@@ -203,7 +219,7 @@ export const SizeLarge: Story = {
 
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
- * appears exactly as it does in product (framed card, sizing, edit mode).
+ * appears exactly as it does in product (full-bleed framing, sizing, edit mode).
  *
  * @param props - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
@@ -216,7 +232,10 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 				name: widgetDefinition.name,
 				title: widgetDefinition.title,
 				icon: widgetDefinition.icon,
-				presentation: 'framed',
+				// Matches widget.json so the host hides its card title (full-bleed),
+				// exactly as it does on the real dashboard — the widget renders its
+				// own header with the title next to the metric selector.
+				presentation: 'full-bleed',
 			} }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }

--- a/projects/packages/premium-analytics/widgets/emails/style.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/style.module.css
@@ -3,13 +3,40 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	min-height: 0;
 	overflow: hidden;
 }
 
 .header {
 	flex-wrap: wrap;
 	gap: var(--wpds-dimension-gap-sm, 8px);
-	margin-block-end: var(--wpds-dimension-gap-sm, 8px);
+	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+	min-height: 32px;
+}
+
+.title {
+	flex: 1 1 0;
+	min-inline-size: 0;
+	font-size: 13px;
+	line-height: 20px;
+	font-weight: 500; /* design spec was 499; 500 is the nearest valid CSS value */
+	color: inherit;
+}
+
+.title * {
+	font-weight: inherit;
+}
+
+.headerTitle {
+	display: inline-flex;
+	align-items: center;
+	min-inline-size: 0;
+	gap: var(--wpds-dimension-gap-xs, 4px);
+	line-height: inherit;
+}
+
+.headerIcon {
+	flex: 0 0 auto;
 }
 
 .metricSelect {
@@ -17,6 +44,15 @@
 	inline-size: min(100%, 220px);
 	max-inline-size: 100%;
 	min-inline-size: 0;
+}
+
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	padding: 0 var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-lg);
+	flex: 1 1 0;
+	min-height: 0;
 }
 
 .leaderboard {
@@ -39,7 +75,11 @@
 }
 
 .placeholder {
+	flex: 1 1 0;
+	inline-size: 100%;
+	min-block-size: 200px;
 	color: var(--wpds-color-fg-content-neutral-weak);
+	text-align: center;
 }
 
 /* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -3,5 +3,5 @@
 	"title": "Emails",
 	"description": "Open and click rates for your latest emails.",
 	"category": "stats",
-	"presentation": "framed"
+	"presentation": "full-bleed"
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1654

## Why

On the Premium Analytics dashboard, the Emails widget showed its metric dropdown ("Open rate" / "Click rate") on its own row below the widget title, wasting vertical space and reading as two separate header rows. This puts the dropdown on the same row as the widget title, so the header reads as one compact line — the same way the Locations widget already lays out its "View by" selector next to its title.

## Proposed changes

* Switch the Emails widget from `framed` to `full-bleed` presentation so the widget owns its header instead of the host rendering a separate card title.
* Render the widget's own header row: envelope icon + "Emails" title on the left, metric selector on the right (`Stack` `justify="space-between"`), mirroring the Locations/Clicks widgets.
* Restore the body padding that the framed host chrome used to supply, and give loading / empty / error states a real, centered body area (the `.content` flex sizing contract used by the sibling Stats widgets).
* Update the Storybook stories to render through `full-bleed` and add a fixed-height close-up canvas so the loading and empty states render in a sized frame.

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/12cb2e4d-8735-4ee9-b73e-064816715896) | ![after](https://github.com/user-attachments/assets/08758341-26b6-4705-a905-15f63b11ff15) |

## Related product discussion/links

* https://linear.app/a8c/issue/WOOA7S-1654

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard (or the widget's Storybook: `Packages/Premium Analytics/Widgets/Emails`).
* Verify the metric dropdown renders on the **same row** as the "Emails" header/title, matching the Locations widget.
* Verify the header shows the envelope icon + "Emails" on the left and the metric dropdown on the right, with no duplicate title.
* Verify the leaderboard rows and the loading, empty, and error states keep correct padding and sit in a centered body area.
* Narrow the widget and confirm the title and dropdown wrap gracefully without colliding.
* Confirm the Storybook `WidgetDashboardWithWidget` story renders as it does in product (full-bleed).
