### PR TITLE
Charts: support missing leaderboard comparison rows

### DIFF
--- a/projects/js-packages/charts/changelog/fix-leaderboard-missing-comparison-rows
+++ b/projects/js-packages/charts/changelog/fix-leaderboard-missing-comparison-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Leaderboard Chart: Avoid fabricated deltas for rows without matching comparison data.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -69,7 +69,19 @@
 }
 
 .valueContainer {
+	align-items: center;
 	justify-content: flex-end;
+}
+
+.deltaValue {
+	display: inline-block;
+	font-variant-numeric: tabular-nums;
+	min-width: 3ch;
+	text-align: right;
+}
+
+.deltaPlaceholder {
+	text-align: center;
 }
 
 .overlayLabel {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -65,6 +65,15 @@ const defaultDeltaFormatter = ( value: number ): string => {
 const getBarWidth = ( share: number ): string =>
 	`calc(${ share }% - var(--a8c--charts--leaderboard--bar--hover-inset, 0px) * ${ share } / 100)`;
 
+const hasComparisonValue = (
+	entry: LeaderboardEntry
+): entry is LeaderboardEntry & {
+	previousValue: number;
+	previousShare: number;
+	delta: number;
+} =>
+	entry.previousValue != null && entry.previousShare != null && entry.delta != null;
+
 const BarLabel = ( { label }: { label: LeaderboardEntry[ 'label' ] } ) => (
 	<>{ typeof label === 'string' ? <Text className={ styles.label }>{ label }</Text> : label }</>
 );
@@ -87,39 +96,43 @@ const BarWithLabel = ( {
 	isPrimaryVisible?: boolean;
 	isComparisonVisible?: boolean;
 	animation?: boolean;
-} ) => (
-	<div
-		className={ clsx( styles.barWithLabelContainer, {
-			[ styles[ 'is-overlay' ] ]: withOverlayLabel,
-		} ) }
-	>
-		<BarLabel label={ entry.label } />
+} ) => {
+	const showComparisonBar = withComparison && ! withOverlayLabel && isComparisonVisible;
 
-		{ isPrimaryVisible && (
-			<div
-				className={ clsx( styles.bar, {
-					[ styles[ 'bar--animated' ] ]: animation,
-				} ) }
-				style={ {
-					width: getBarWidth( entry.currentShare ),
-					backgroundColor: primaryColor,
-				} }
-			></div>
-		) }
+	return (
+		<div
+			className={ clsx( styles.barWithLabelContainer, {
+				[ styles[ 'is-overlay' ] ]: withOverlayLabel,
+			} ) }
+		>
+			<BarLabel label={ entry.label } />
 
-		{ withComparison && ! withOverlayLabel && isComparisonVisible && (
-			<div
-				className={ clsx( styles.bar, {
-					[ styles[ 'bar--animated' ] ]: animation,
-				} ) }
-				style={ {
-					width: getBarWidth( entry.previousShare ),
-					backgroundColor: secondaryColor,
-				} }
-			></div>
-		) }
-	</div>
-);
+			{ isPrimaryVisible && (
+				<div
+					className={ clsx( styles.bar, {
+						[ styles[ 'bar--animated' ] ]: animation,
+					} ) }
+					style={ {
+						width: getBarWidth( entry.currentShare ),
+						backgroundColor: primaryColor,
+					} }
+				></div>
+			) }
+
+			{ showComparisonBar && hasComparisonValue( entry ) && (
+				<div
+					className={ clsx( styles.bar, {
+						[ styles[ 'bar--animated' ] ]: animation,
+					} ) }
+					style={ {
+						width: getBarWidth( entry.previousShare ),
+						backgroundColor: secondaryColor,
+					} }
+				></div>
+			) }
+		</div>
+	);
+};
 
 /**
  * LeaderboardChart component displays a ranked list of data with progress bars
@@ -335,7 +348,9 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					) : (
 						<Grid templateColumns="minmax(0, 1fr) auto" rowGap={ rowGap } columnGap={ columnGap }>
 							{ data.map( entry => {
-								const colorIndex = Math.sign( entry.delta ) + 1;
+								const showComparisonColumn = withComparison && isComparisonVisible;
+								const showComparisonValue = showComparisonColumn && hasComparisonValue( entry );
+								const colorIndex = showComparisonValue ? Math.sign( entry.delta ) + 1 : 1;
 								const deltaColor = deltaColors[ colorIndex ];
 
 								const rowCells = (
@@ -362,9 +377,18 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 										>
 											{ isPrimaryVisible && <Text>{ valueFormatter( entry.currentValue ) }</Text> }
 
-											{ withComparison && isComparisonVisible && (
-												<Text style={ { color: deltaColor } }>
+											{ showComparisonValue && (
+												<Text className={ styles.deltaValue } style={ { color: deltaColor } }>
 													{ deltaFormatter( entry.delta ) }
+												</Text>
+											) }
+
+											{ showComparisonColumn && ! showComparisonValue && (
+												<Text
+													className={ clsx( styles.deltaValue, styles.deltaPlaceholder ) }
+													style={ { color: deltaColor } }
+												>
+													-
 												</Text>
 											) }
 										</Stack>

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -78,6 +78,29 @@ describe( 'LeaderboardChart', () => {
 		expect( screen.getByText( '-8%' ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows a placeholder when a row has no previous value', () => {
+		render(
+			<LeaderboardChart
+				data={ [
+					...mockData,
+					{
+						id: 'new',
+						label: 'New Source',
+						currentValue: 100,
+						currentShare: 1,
+					},
+				] }
+				withComparison={ true }
+			/>
+		);
+
+		expect( screen.getByText( '+25%' ) ).toBeInTheDocument();
+		expect( screen.getByText( '-8%' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New Source' ) ).toBeInTheDocument();
+		expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '+100%' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'shows custom label when provided', () => {
 		render(
 			<LeaderboardChart

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -191,9 +191,10 @@ export type LeaderboardEntry = {
 	currentValue: number;
 
 	/**
-	 * Value of the entry in the previous period
+	 * Value of the entry in the previous period. Omit when this row has no
+	 * matching comparison-period value.
 	 */
-	previousValue: number;
+	previousValue?: number;
 
 	/**
 	 * Width of current bar, as % of the current value
@@ -201,14 +202,16 @@ export type LeaderboardEntry = {
 	currentShare: number;
 
 	/**
-	 * Width of previous bar, as % of the current value
+	 * Width of previous bar, as % of the current value. Omit when this row has
+	 * no matching comparison-period value.
 	 */
-	previousShare: number;
+	previousShare?: number;
 
 	/**
-	 * Delta of the entry
+	 * Delta of the entry. Omit when this row has no matching comparison-period
+	 * value.
 	 */
-	delta: number;
+	delta?: number;
 
 	/**
 	 * Optional color for the entry's image/icon


### PR DESCRIPTION
Fixes #

## Proposed changes
* Allow `LeaderboardChart` rows to omit `previousValue`, `previousShare`, and `delta` when a row has no matching comparison-period value.
* Render a neutral `-` placeholder for rows missing comparison data, keeping the value/delta columns aligned without showing a fabricated `+100%`.
* Skip the previous-period bar for rows without comparison data.

## Related product discussion/links
* CHARTS-239

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm --dir projects/js-packages/charts run test src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx`.
* Run `pnpm --dir projects/js-packages/charts run typecheck`.
* Run `pnpm --dir projects/js-packages/charts run build`.
