### PR TITLE
Premium Analytics: add drill-down into an author's posts in the Authors widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-authors-widget-drilldown
+++ b/projects/packages/premium-analytics/changelog/add-authors-widget-drilldown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Authors widget: label rows with the author name and avatar, and let a row click drill down into that author's posts with comparison deltas and a back link to all authors.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
@@ -16,6 +16,7 @@ describe( 'Stats top authors normalizer', () => {
 		} );
 		expect( result.data[ 0 ].items[ 0 ] ).toEqual(
 			expect.objectContaining( {
+				id: 196411292,
 				label: 'Jetpack Team',
 				views: 4166,
 				icon: 'https://example.com/avatar.png',
@@ -51,6 +52,7 @@ describe( 'Stats top authors normalizer', () => {
 				date_end: '2026-06-16T23:59:59+00:00',
 				items: [
 					expect.objectContaining( {
+						id: 196411292,
 						label: 'Jetpack Team',
 						views: 64,
 						children: [

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
@@ -10,11 +10,18 @@ import type { StatsNormalizedItemBase, StatsNormalizedReport } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
 export type StatsTopAuthorsItem = StatsNormalizedItemBase< StatsTopPostsItem > & {
+	id?: string | number;
 	views: number;
 	icon: string | null;
 	iconClassName?: string;
 	className?: string | null;
 };
+
+function getAuthorId( item: Record< string, unknown > ): string | number | undefined {
+	const id = item.author_id ?? item.authorId;
+
+	return typeof id === 'string' || typeof id === 'number' ? id : undefined;
+}
 
 export function sanitizeStatsTopAuthorsResponse(
 	response: unknown,
@@ -23,6 +30,7 @@ export function sanitizeStatsTopAuthorsResponse(
 	return {
 		summary: normalizeStatsReportSummary( response, query, [ 'authors' ] ),
 		data: mapStatsReportDataPoints( response, query, [ 'authors' ], item => ( {
+			id: getAuthorId( item ),
 			label: item.name || 'Untracked Authors',
 			views: safeParseFloat( item.views ),
 			icon: typeof item.avatar === 'string' ? item.avatar : null,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -77,9 +77,9 @@ export function useChartTheme(): WooChartTheme {
 				labelSpacing: 'xs',
 				barBorderRadius: 'var(--wpds-border-radius-md)',
 				deltaColors: [
-					'var(--wpds-color-fg-content-error-weak)',
-					'var(--wpds-color-fg-content-neutral)',
-					'var(--wpds-color-fg-content-success-weak)',
+					'var(--wpds-color-stroke-surface-error-strong)',
+					'var(--wpds-color-fg-content-neutral-weak)',
+					'var(--wpds-color-stroke-surface-success-strong)',
 				] as [ string, string, string ], // [ negative, neutral, positive ]
 			},
 			conversionFunnelChart: {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -63,6 +63,7 @@ export {
 } from './customers';
 
 export { mockSearchTermsData, mockSearchTermsComparisonData } from './search-terms';
+export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors';
 
 export { mockSiteSummary } from './site-summary';
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-authors.ts
@@ -1,0 +1,143 @@
+const avatar = ( seed: string ) =>
+	`https://www.gravatar.com/avatar/${ encodeURIComponent( seed ) }?d=identicon&s=48`;
+
+const post = ( id: number, title: string, views: number ) => ( {
+	id,
+	title,
+	url: `https://example.com/posts/${ id }`,
+	views,
+	video: false,
+} );
+
+export const mockTopAuthorsData = {
+	date: '2026-06-22',
+	period: 'month',
+	summary: {
+		authors: [
+			{
+				author_id: 101,
+				name: 'Jane Cooper',
+				avatar: avatar( 'Jane Cooper' ),
+				views: 4820,
+				posts: [
+					post( 1001, 'Jane Cooper: Getting started', 2410 ),
+					post( 1002, 'Jane Cooper: A deeper dive', 1446 ),
+					post( 1003, 'Jane Cooper: Lessons learned', 964 ),
+				],
+			},
+			{
+				author_id: 102,
+				name: 'Wade Warren',
+				avatar: avatar( 'Wade Warren' ),
+				views: 3110,
+				posts: [
+					post( 2001, 'Wade Warren: Getting started', 1555 ),
+					post( 2002, 'Wade Warren: A deeper dive', 933 ),
+					post( 2003, 'Wade Warren: Lessons learned', 622 ),
+				],
+			},
+			{
+				author_id: 103,
+				name: 'Esther Howard',
+				avatar: avatar( 'Esther Howard' ),
+				views: 2540,
+				posts: [
+					post( 3001, 'Esther Howard: Getting started', 1270 ),
+					post( 3002, 'Esther Howard: A deeper dive', 762 ),
+					post( 3003, 'Esther Howard: Lessons learned', 508 ),
+				],
+			},
+			{
+				author_id: 104,
+				name: 'Cameron Williamson',
+				avatar: avatar( 'Cameron Williamson' ),
+				views: 1890,
+				posts: [
+					post( 4001, 'Cameron Williamson: Getting started', 945 ),
+					post( 4002, 'Cameron Williamson: A deeper dive', 567 ),
+					post( 4003, 'Cameron Williamson: Lessons learned', 378 ),
+				],
+			},
+			{
+				author_id: 105,
+				name: 'Brooklyn Simmons',
+				avatar: avatar( 'Brooklyn Simmons' ),
+				views: 1320,
+				posts: [
+					post( 5001, 'Brooklyn Simmons: Getting started', 660 ),
+					post( 5002, 'Brooklyn Simmons: A deeper dive', 396 ),
+					post( 5003, 'Brooklyn Simmons: Lessons learned', 264 ),
+				],
+			},
+			{
+				author_id: 106,
+				name: 'Leslie Alexander',
+				avatar: avatar( 'Leslie Alexander' ),
+				views: 760,
+				posts: [
+					post( 6001, 'Leslie Alexander: Getting started', 380 ),
+					post( 6002, 'Leslie Alexander: A deeper dive', 228 ),
+					post( 6003, 'Leslie Alexander: Lessons learned', 152 ),
+				],
+			},
+			{
+				name: '',
+				views: 410,
+				posts: [],
+			},
+		],
+	},
+};
+
+export const mockTopAuthorsComparisonData = {
+	date: '2026-05-22',
+	period: 'month',
+	summary: {
+		authors: [
+			{
+				author_id: 101,
+				name: 'Jane Cooper',
+				avatar: avatar( 'Jane Cooper' ),
+				views: 3900,
+				posts: [
+					post( 1001, 'Jane Cooper: Getting started', 2145 ),
+					post( 1002, 'Jane Cooper: A deeper dive', 1170 ),
+					post( 1099, 'Jane Cooper: Earlier update', 585 ),
+				],
+			},
+			{
+				author_id: 102,
+				name: 'Wade Warren',
+				avatar: avatar( 'Wade Warren' ),
+				views: 3540,
+				posts: [
+					post( 2001, 'Wade Warren: Getting started', 1770 ),
+					post( 2002, 'Wade Warren: A deeper dive', 1062 ),
+					post( 2003, 'Wade Warren: Lessons learned', 708 ),
+				],
+			},
+			{
+				author_id: 103,
+				name: 'Esther Howard',
+				avatar: avatar( 'Esther Howard' ),
+				views: 1980,
+				posts: [
+					post( 3001, 'Esther Howard: Getting started', 990 ),
+					post( 3002, 'Esther Howard: A deeper dive', 594 ),
+					post( 3003, 'Esther Howard: Lessons learned', 396 ),
+				],
+			},
+			{
+				author_id: 104,
+				name: 'Cameron Williamson',
+				avatar: avatar( 'Cameron Williamson' ),
+				views: 2010,
+				posts: [
+					post( 4001, 'Cameron Williamson: Getting started', 1005 ),
+					post( 4002, 'Cameron Williamson: A deeper dive', 603 ),
+					post( 4003, 'Cameron Williamson: Lessons learned', 402 ),
+				],
+			},
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-authors.ts
@@ -1,5 +1,13 @@
-const avatar = ( seed: string ) =>
-	`https://www.gravatar.com/avatar/${ encodeURIComponent( seed ) }?d=identicon&s=48`;
+// Inline SVG avatar so stories stay deterministic and offline (no network
+// request to Gravatar). A hue derived from the seed keeps each author distinct.
+const avatar = ( seed: string ) => {
+	let hue = 0;
+	for ( let i = 0; i < seed.length; i++ ) {
+		hue = ( hue * 31 + seed.charCodeAt( i ) ) % 360;
+	}
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" fill="hsl(${ hue } 55% 65%)"/></svg>`;
+	return `data:image/svg+xml,${ encodeURIComponent( svg ) }`;
+};
 
 const post = ( id: number, title: string, views: number ) => ( {
 	id,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -47,6 +47,8 @@ import {
 	mockCustomersByDateComparisonData,
 	mockSearchTermsData,
 	mockSearchTermsComparisonData,
+	mockTopAuthorsData,
+	mockTopAuthorsComparisonData,
 	mockSiteSummary,
 	mockStatsInsightsData,
 } from './data';
@@ -721,6 +723,10 @@ function routeStatsReport( subPath: string ): unknown {
 			return nextIsComparison( 'stats/search-terms' )
 				? mockSearchTermsComparisonData
 				: mockSearchTermsData;
+		case '/top-authors':
+			return nextIsComparison( 'stats/top-authors' )
+				? mockTopAuthorsComparisonData
+				: mockTopAuthorsData;
 		case '/insights':
 			return mockStatsInsightsData;
 		default:

--- a/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
@@ -4,27 +4,57 @@
 import { buildTopAuthorsData } from '../build-top-authors-data';
 import type { StatsNormalizedReport, StatsTopAuthorsItem } from '@jetpack-premium-analytics/data';
 
+type PostSeed = {
+	id?: string | number;
+	title: string;
+	views: number;
+	link?: string | null;
+};
+
 type AuthorSeed = {
+	id?: string | number;
 	label?: string;
 	views: number;
+	avatar?: string | null;
+	posts?: PostSeed[];
 };
 
 /**
  * Builds a single normalized top-authors item from a compact seed.
  *
- * @param seed       - The author seed.
- * @param seed.label - Display label (defaults to `Author`).
- * @param seed.views - View count for the period.
+ * @param seed        - The author seed.
+ * @param seed.id     - Stable author id.
+ * @param seed.label  - Display label (defaults to `Author`).
+ * @param seed.views  - View count for the period.
+ * @param seed.avatar - Avatar URL (defaults to none).
+ * @param seed.posts  - The author's posts (defaults to none).
  * @return A normalized top-authors item.
  */
-function makeAuthor( { label = 'Author', views }: AuthorSeed ): StatsTopAuthorsItem {
+function makeAuthor( {
+	id,
+	label = 'Author',
+	views,
+	avatar = null,
+	posts,
+}: AuthorSeed ): StatsTopAuthorsItem {
 	return {
+		id,
 		label,
 		views,
-		icon: null,
+		icon: avatar,
 		iconClassName: 'avatar-user',
 		className: 'module-content-list-item-large',
-		children: null,
+		children: posts
+			? posts.map( post => ( {
+					id: post.id,
+					label: post.title,
+					views: post.views,
+					link: post.link ?? null,
+					page: null,
+					actions: [],
+					children: null,
+			  } ) )
+			: null,
 	};
 }
 
@@ -67,7 +97,7 @@ describe( 'buildTopAuthorsData', () => {
 
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ] ).toMatchObject( {
-			id: 'Alice',
+			id: 'Alice-0',
 			label: 'Alice',
 			currentValue: 10,
 			previousValue: 0,
@@ -91,10 +121,10 @@ describe( 'buildTopAuthorsData', () => {
 		expect( result.map( author => author.label ) ).toEqual( [ 'Bob', 'Carol', 'Alice' ] );
 	} );
 
-	it( 'aligns comparison values by author label', () => {
+	it( 'aligns comparison values by author id', () => {
 		const result = buildTopAuthorsData(
-			makeReport( [ { label: 'Alice', views: 150 } ] ),
-			makeReport( [ { label: 'Alice', views: 100 } ] )
+			makeReport( [ { id: 1, label: 'Alice', views: 150 } ] ),
+			makeReport( [ { id: 1, label: 'Alice', views: 100 } ] )
 		);
 
 		expect( result[ 0 ] ).toMatchObject( {
@@ -107,10 +137,10 @@ describe( 'buildTopAuthorsData', () => {
 	it( 'treats authors missing from the comparison period as zero', () => {
 		const result = buildTopAuthorsData(
 			makeReport( [
-				{ label: 'Alice', views: 10 },
-				{ label: 'Bob', views: 8 },
+				{ id: 1, label: 'Alice', views: 10 },
+				{ id: 2, label: 'Bob', views: 8 },
 			] ),
-			makeReport( [ { label: 'Alice', views: 5 } ] )
+			makeReport( [ { id: 1, label: 'Alice', views: 5 } ] )
 		);
 
 		const bob = result.find( author => author.label === 'Bob' );
@@ -124,5 +154,164 @@ describe( 'buildTopAuthorsData', () => {
 		);
 
 		expect( result[ 0 ].label ).toBe( 'Untracked authors' );
+	} );
+
+	it( 'carries the author avatar and an empty posts list when there are no children', () => {
+		const result = buildTopAuthorsData(
+			makeReport( [ { label: 'Alice', views: 10, avatar: 'https://example.com/a.png' } ] ),
+			undefined
+		);
+
+		expect( result[ 0 ] ).toMatchObject( {
+			avatarUrl: 'https://example.com/a.png',
+			posts: [],
+		} );
+	} );
+
+	it( 'maps the author children into drill-down posts', () => {
+		const result = buildTopAuthorsData(
+			makeReport( [
+				{
+					label: 'Alice',
+					views: 30,
+					posts: [
+						{ id: 12, title: 'Hello world', views: 20, link: 'https://example.com/hello' },
+						{ title: 'Second post', views: 10 },
+					],
+				},
+			] ),
+			undefined
+		);
+
+		expect( result[ 0 ].posts ).toEqual( [
+			{
+				id: '12',
+				title: 'Hello world',
+				link: 'https://example.com/hello',
+				currentValue: 20,
+				previousValue: 0,
+				currentShare: 100,
+				previousShare: 0,
+				delta: 100,
+			},
+			{
+				id: 'title:Second post',
+				title: 'Second post',
+				link: null,
+				currentValue: 10,
+				previousValue: 0,
+				currentShare: 50,
+				previousShare: 0,
+				delta: 100,
+			},
+		] );
+	} );
+
+	it( 'uses author ids to keep same-name authors distinct', () => {
+		const result = buildTopAuthorsData(
+			makeReport( [
+				{
+					id: 1,
+					label: 'Alex',
+					views: 30,
+					posts: [ { id: 101, title: 'First Alex post', views: 30 } ],
+				},
+				{
+					id: 2,
+					label: 'Alex',
+					views: 20,
+					posts: [ { id: 201, title: 'Second Alex post', views: 20 } ],
+				},
+			] ),
+			makeReport( [
+				{
+					id: 1,
+					label: 'Alex',
+					views: 10,
+					posts: [ { id: 101, title: 'First Alex post', views: 10 } ],
+				},
+				{
+					id: 2,
+					label: 'Alex',
+					views: 15,
+					posts: [ { id: 201, title: 'Second Alex post', views: 15 } ],
+				},
+			] )
+		);
+
+		expect(
+			result.map( author => ( { id: author.id, previousValue: author.previousValue } ) )
+		).toEqual( [
+			{ id: '1', previousValue: 10 },
+			{ id: '2', previousValue: 15 },
+		] );
+		expect( result[ 0 ].posts[ 0 ] ).toMatchObject( {
+			id: '101',
+			title: 'First Alex post',
+			previousValue: 10,
+		} );
+		expect( result[ 1 ].posts[ 0 ] ).toMatchObject( {
+			id: '201',
+			title: 'Second Alex post',
+			previousValue: 15,
+		} );
+	} );
+
+	it( 'aligns author posts across comparison periods and includes dropped posts', () => {
+		const result = buildTopAuthorsData(
+			makeReport( [
+				{
+					label: 'Alice',
+					views: 30,
+					posts: [
+						{ id: 1, title: 'Still popular', views: 20 },
+						{ id: 2, title: 'New post', views: 10 },
+					],
+				},
+			] ),
+			makeReport( [
+				{
+					label: 'Alice',
+					views: 40,
+					posts: [
+						{ id: 1, title: 'Still popular', views: 30 },
+						{ id: 3, title: 'Dropped post', views: 10 },
+					],
+				},
+			] )
+		);
+
+		expect( result[ 0 ].posts ).toEqual( [
+			{
+				id: '1',
+				title: 'Still popular',
+				link: null,
+				currentValue: 20,
+				previousValue: 30,
+				currentShare: 66.66666666666666,
+				previousShare: 100,
+				delta: -33.33333333333333,
+			},
+			{
+				id: '2',
+				title: 'New post',
+				link: null,
+				currentValue: 10,
+				previousValue: 0,
+				currentShare: 33.33333333333333,
+				previousShare: 0,
+				delta: 100,
+			},
+			{
+				id: '3',
+				title: 'Dropped post',
+				link: null,
+				currentValue: 0,
+				previousValue: 10,
+				currentShare: 0,
+				previousShare: 33.33333333333333,
+				delta: -100,
+			},
+		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/authors/__tests__/build-top-authors-data.test.ts
@@ -97,7 +97,7 @@ describe( 'buildTopAuthorsData', () => {
 
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ] ).toMatchObject( {
-			id: 'Alice-0',
+			id: 'label:Alice|',
 			label: 'Alice',
 			currentValue: 10,
 			previousValue: 0,

--- a/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
+++ b/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
@@ -63,12 +63,16 @@ function getAuthorLabel( author: StatsTopAuthorsItem ) {
 	return label;
 }
 
-function getAuthorKey( author: StatsTopAuthorsItem, index: number ) {
+function getAuthorKey( author: StatsTopAuthorsItem ) {
 	if ( author.id != null ) {
 		return String( author.id );
 	}
 
-	return `${ getAuthorLabel( author ) }-${ index }`;
+	// No id from the endpoint: build a period-independent key so the same author
+	// aligns across the primary and comparison periods even when their rank (and
+	// thus array position) differs. The avatar keeps same-named authors distinct
+	// where one is available.
+	return `label:${ getAuthorLabel( author ) }|${ author.icon ?? '' }`;
 }
 
 type NormalizedAuthorPost = {
@@ -172,10 +176,11 @@ function toAuthorItems(
  * Builds leaderboard rows for the Authors widget.
  *
  * Transforms Jetpack Stats top-authors data into normalized rows, with
- * comparison values aligned by author display label (authors missing from the
- * comparison period count as zero). Each row also carries the author's avatar
- * and posts so the render layer can show a name + picture label and drill down
- * into the author's posts.
+ * comparison values aligned by a stable author key — the author id when the
+ * endpoint provides one, otherwise the display label plus avatar (authors
+ * missing from the comparison period count as zero). Each row also carries the
+ * author's avatar and posts so the render layer can show a name + picture label
+ * and drill down into the author's posts.
  *
  * @param primary    - Primary period top-authors report
  * @param comparison - Comparison period top-authors report
@@ -192,24 +197,21 @@ export function buildTopAuthorsData(
 	}
 
 	const comparisonAuthors = new Map(
-		toAuthorItems( comparison ).map( ( author, index ) => [
-			getAuthorKey( author, index ),
-			author,
-		] )
+		toAuthorItems( comparison ).map( author => [ getAuthorKey( author ), author ] )
 	);
 
 	// Share each value against the largest of either period so the overlay bars
 	// stay proportional; `1` guards against division by zero.
 	const maxValue = Math.max(
-		...authors.map( ( author, index ) =>
-			Math.max( author.views, comparisonAuthors.get( getAuthorKey( author, index ) )?.views ?? 0 )
+		...authors.map( author =>
+			Math.max( author.views, comparisonAuthors.get( getAuthorKey( author ) )?.views ?? 0 )
 		),
 		1
 	);
 
-	return authors.map( ( author, index ) => {
+	return authors.map( author => {
 		const label = getAuthorLabel( author );
-		const authorKey = getAuthorKey( author, index );
+		const authorKey = getAuthorKey( author );
 		const currentValue = author.views;
 		const comparisonAuthor = comparisonAuthors.get( authorKey );
 		const previousValue = comparisonAuthor?.views ?? 0;

--- a/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
+++ b/projects/packages/premium-analytics/widgets/authors/build-top-authors-data.ts
@@ -1,17 +1,50 @@
 /**
  * External dependencies
  */
-import {
-	calculateDelta,
-	type LeaderboardChartData,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { calculateDelta } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import type { StatsNormalizedReport, StatsTopAuthorsItem } from '@jetpack-premium-analytics/data';
+import type {
+	StatsNormalizedReport,
+	StatsTopAuthorsItem,
+	StatsTopPostsItem,
+} from '@jetpack-premium-analytics/data';
 
 // The Stats sanitizer substitutes this untranslated sentinel for authors with
 // no name (see `sanitizeStatsTopAuthorsResponse`), so match it here to surface a
 // localized label.
 const UNTRACKED_AUTHORS_SENTINEL = 'Untracked Authors';
+
+/**
+ * A single post by an author, used to drill down from the author leaderboard
+ * into that author's posts.
+ */
+export interface AuthorPost {
+	id: string;
+	title: string;
+	link: string | null;
+	currentValue: number;
+	previousValue: number;
+	currentShare: number;
+	previousShare: number;
+	delta: number;
+}
+
+/**
+ * A normalized author row for the leaderboard. Carries the display name and
+ * avatar so the render layer can compose the `LeaderboardLabel`, plus the
+ * author's `posts` so a row click can drill down without another fetch.
+ */
+export interface AuthorLeaderboardRow {
+	id: string;
+	label: string;
+	avatarUrl: string | null;
+	currentValue: number;
+	previousValue: number;
+	currentShare: number;
+	previousShare: number;
+	delta: number;
+	posts: AuthorPost[];
+}
 
 /**
  * Resolve a display label for an author, translating the untracked-authors
@@ -28,6 +61,95 @@ function getAuthorLabel( author: StatsTopAuthorsItem ) {
 	}
 
 	return label;
+}
+
+function getAuthorKey( author: StatsTopAuthorsItem, index: number ) {
+	if ( author.id != null ) {
+		return String( author.id );
+	}
+
+	return `${ getAuthorLabel( author ) }-${ index }`;
+}
+
+type NormalizedAuthorPost = {
+	key: string;
+	id: string;
+	title: string;
+	views: number;
+	link: string | null;
+};
+
+function getPostKey( post: StatsTopPostsItem, fallbackId: string ) {
+	if ( post.id != null ) {
+		return `id:${ String( post.id ) }`;
+	}
+
+	if ( post.link ) {
+		return `link:${ post.link }`;
+	}
+
+	return `title:${ typeof post.label === 'string' ? post.label : fallbackId }`;
+}
+
+function getPostId( post: StatsTopPostsItem, fallbackId: string ) {
+	return post.id != null ? String( post.id ) : getPostKey( post, fallbackId );
+}
+
+/**
+ * Map an author's nested posts (the report's `children`) into a normalized
+ * period-specific shape used to align primary and comparison values.
+ *
+ * @param author - The top-authors item.
+ * @return The author's posts for one period.
+ */
+function toNormalizedAuthorPosts( author: StatsTopAuthorsItem ): NormalizedAuthorPost[] {
+	const children = ( author.children ?? [] ) as StatsTopPostsItem[];
+
+	return children.map( ( post, index ) => {
+		const fallbackId = `post-${ index }`;
+
+		return {
+			key: getPostKey( post, fallbackId ),
+			id: getPostId( post, fallbackId ),
+			title: typeof post.label === 'string' ? post.label : String( post.label ?? '' ),
+			views: post.views,
+			link: post.link ?? null,
+		};
+	} );
+}
+
+function toAuthorPostRows(
+	primaryAuthor: StatsTopAuthorsItem,
+	comparisonAuthor: StatsTopAuthorsItem | undefined
+): AuthorPost[] {
+	const primaryPosts = toNormalizedAuthorPosts( primaryAuthor );
+	const comparisonPosts = comparisonAuthor ? toNormalizedAuthorPosts( comparisonAuthor ) : [];
+	const comparisonByKey = new Map( comparisonPosts.map( post => [ post.key, post ] ) );
+	const primaryKeys = new Set( primaryPosts.map( post => post.key ) );
+	const droppedPosts = comparisonPosts.filter( post => ! primaryKeys.has( post.key ) );
+	const posts = [ ...primaryPosts, ...droppedPosts ];
+
+	const maxValue = Math.max(
+		...posts.map( post => Math.max( post.views, comparisonByKey.get( post.key )?.views ?? 0 ) ),
+		1
+	);
+
+	return posts.map( post => {
+		const comparisonPost = comparisonByKey.get( post.key );
+		const currentValue = primaryKeys.has( post.key ) ? post.views : 0;
+		const previousValue = comparisonPost?.views ?? 0;
+
+		return {
+			id: post.id,
+			title: post.title,
+			link: post.link,
+			currentValue,
+			previousValue,
+			currentShare: ( currentValue / maxValue ) * 100,
+			previousShare: ( previousValue / maxValue ) * 100,
+			delta: calculateDelta( currentValue, previousValue ),
+		};
+	} );
 }
 
 /**
@@ -47,52 +169,61 @@ function toAuthorItems(
 }
 
 /**
- * Builds leaderboard chart data for the Authors widget.
+ * Builds leaderboard rows for the Authors widget.
  *
- * Transforms Jetpack Stats top-authors data into the format required by
- * LeaderboardChart, with comparison values aligned by author display label
- * (authors missing from the comparison period count as zero).
+ * Transforms Jetpack Stats top-authors data into normalized rows, with
+ * comparison values aligned by author display label (authors missing from the
+ * comparison period count as zero). Each row also carries the author's avatar
+ * and posts so the render layer can show a name + picture label and drill down
+ * into the author's posts.
  *
  * @param primary    - Primary period top-authors report
  * @param comparison - Comparison period top-authors report
- * @return Processed data ready for the LeaderboardChart component
+ * @return Normalized author rows ready for the render layer
  */
 export function buildTopAuthorsData(
 	primary: StatsNormalizedReport< StatsTopAuthorsItem > | undefined,
 	comparison: StatsNormalizedReport< StatsTopAuthorsItem > | undefined
-): LeaderboardChartData {
+): AuthorLeaderboardRow[] {
 	const authors = toAuthorItems( primary );
 
 	if ( authors.length === 0 ) {
 		return [];
 	}
 
-	const comparisonViews = new Map(
-		toAuthorItems( comparison ).map( author => [ getAuthorLabel( author ), author.views ] )
+	const comparisonAuthors = new Map(
+		toAuthorItems( comparison ).map( ( author, index ) => [
+			getAuthorKey( author, index ),
+			author,
+		] )
 	);
 
 	// Share each value against the largest of either period so the overlay bars
 	// stay proportional; `1` guards against division by zero.
 	const maxValue = Math.max(
-		...authors.map( author =>
-			Math.max( author.views, comparisonViews.get( getAuthorLabel( author ) ) ?? 0 )
+		...authors.map( ( author, index ) =>
+			Math.max( author.views, comparisonAuthors.get( getAuthorKey( author, index ) )?.views ?? 0 )
 		),
 		1
 	);
 
-	return authors.map( author => {
+	return authors.map( ( author, index ) => {
 		const label = getAuthorLabel( author );
+		const authorKey = getAuthorKey( author, index );
 		const currentValue = author.views;
-		const previousValue = comparisonViews.get( label ) ?? 0;
+		const comparisonAuthor = comparisonAuthors.get( authorKey );
+		const previousValue = comparisonAuthor?.views ?? 0;
 
 		return {
-			id: label,
+			id: authorKey,
 			label,
+			avatarUrl: author.icon ?? null,
 			currentValue,
 			previousValue,
 			currentShare: ( currentValue / maxValue ) * 100,
 			previousShare: ( previousValue / maxValue ) * 100,
 			delta: calculateDelta( currentValue, previousValue ),
+			posts: toAuthorPostRows( author, comparisonAuthor ),
 		};
 	} );
 }

--- a/projects/packages/premium-analytics/widgets/authors/package.json
+++ b/projects/packages/premium-analytics/widgets/authors/package.json
@@ -8,6 +8,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/widget-primitives": "next",
 		"react": "18.3.1"
 	}

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -26,8 +26,8 @@ import type { ComponentProps } from 'react';
 
 const DEFAULT_MAX = 7;
 
-// The host injects report params (date range / comparison) through `attributes`
-// alongside the widget's own `max`, so compose the render-only shape from both.
+// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
+// also pass them via `attributes`. Compose the render-only shape to cover both.
 type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAttributes >;
 
 type AuthorsRenderProps = WidgetRenderProps< AuthorsRenderAttributes > & {

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -9,6 +9,7 @@ import {
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	formatLegendLabels,
+	useWidgetDrillDown,
 	useWidgetError,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -17,7 +18,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { postAuthor } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -101,11 +102,15 @@ export function AuthorsLeaderboard( {
 	withComparison = false,
 	legendLabels,
 }: AuthorsLeaderboardProps ) {
-	const [ selectedAuthorId, setSelectedAuthorId ] = useState< string | null >( null );
-	const clearSelectedAuthor = useCallback( () => setSelectedAuthorId( null ), [] );
+	// Store only the author id and resolve the row fresh from the current rows,
+	// so a background refetch that drops the author cleanly falls back to the
+	// top view instead of pinning a stale snapshot.
+	const {
+		drillDownItem: selectedAuthorId,
+		drillDown: selectAuthor,
+		resetDrillDown: clearSelectedAuthor,
+	} = useWidgetDrillDown< string >();
 
-	// Resolve the drilled-into author from the current rows so a background
-	// refetch that drops the author cleanly falls back to the top view.
 	const selectedAuthor = useMemo(
 		() => ( selectedAuthorId ? rows.find( row => row.id === selectedAuthorId ) ?? null : null ),
 		[ rows, selectedAuthorId ]
@@ -113,9 +118,9 @@ export function AuthorsLeaderboard( {
 
 	useEffect( () => {
 		if ( selectedAuthorId && ! selectedAuthor ) {
-			setSelectedAuthorId( null );
+			clearSelectedAuthor();
 		}
-	}, [ selectedAuthorId, selectedAuthor ] );
+	}, [ selectedAuthorId, selectedAuthor, clearSelectedAuthor ] );
 
 	const chartData: LeaderboardChartData = useMemo( () => {
 		// Drilled-in: show the selected author's posts. Rows are not interactive;
@@ -177,7 +182,7 @@ export function AuthorsLeaderboard( {
 			previousShare: row.previousShare,
 			delta: row.delta,
 			...( row.posts.length > 0 && {
-				onClick: () => setSelectedAuthorId( row.id ),
+				onClick: () => selectAuthor( row.id ),
 				// The label already renders the name as text; without an explicit
 				// action name the button would announce the avatar alt ("Avatar of
 				// X") plus the name. Give it a concise, deterministic name instead.
@@ -188,7 +193,7 @@ export function AuthorsLeaderboard( {
 				),
 			} ),
 		} ) );
-	}, [ rows, selectedAuthor ] );
+	}, [ rows, selectedAuthor, selectAuthor ] );
 
 	if ( isLoading ) {
 		return <WidgetLoadingOverlay />;

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -26,8 +26,8 @@ import type { ComponentProps } from 'react';
 
 const DEFAULT_MAX = 7;
 
-// Report params are usually URL-driven (WidgetRoot's fallback), but callers may
-// also pass them via `attributes`. Compose the render-only shape to cover both.
+// The host injects report params (date range / comparison) through `attributes`
+// alongside the widget's own `max`, so compose the render-only shape from both.
 type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAttributes >;
 
 type AuthorsRenderProps = WidgetRenderProps< AuthorsRenderAttributes > & {
@@ -171,11 +171,12 @@ function AuthorsReport( { max }: { max: number } ) {
 /**
  * Authors widget render entry point.
  *
- * Passes host `attributes` into `WidgetRoot`, which resolves the report params:
- * the dashboard leaves `reportParams` out of `attributes`, so it falls back to
- * the date-range URL search params the picker writes to; Storybook injects
- * `attributes.reportParams` directly. The widget's own `max` is forwarded to
- * the inner component.
+ * WidgetRoot resolves the report params from the dashboard date range (the URL
+ * search params the date picker writes to), the same way the other Stats
+ * widgets read them. We intentionally don't pass `attributes` here: the host
+ * injects a `reportParams` into them, and `WidgetRoot` would prefer that shadow
+ * copy over the live URL — so the date picker would never reach the query. The
+ * widget's own `max` attribute is forwarded to the inner component instead.
  *
  * @param props            - Render props.
  * @param props.attributes - Widget attributes.
@@ -184,7 +185,7 @@ function AuthorsReport( { max }: { max: number } ) {
  */
 export default function Authors( { attributes = {}, setError }: AuthorsRenderProps ) {
 	return (
-		<WidgetRoot attributes={ attributes } setError={ setError }>
+		<WidgetRoot setError={ setError }>
 			<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -171,12 +171,11 @@ function AuthorsReport( { max }: { max: number } ) {
 /**
  * Authors widget render entry point.
  *
- * WidgetRoot resolves the report params from the dashboard date range (the URL
- * search params the date picker writes to), the same way the other Stats
- * widgets read them. We intentionally don't pass `attributes` here: the host
- * injects a `reportParams` into them, and `WidgetRoot` would prefer that shadow
- * copy over the live URL — so the date picker would never reach the query. The
- * widget's own `max` attribute is forwarded to the inner component instead.
+ * Passes host `attributes` into `WidgetRoot`, which resolves the report params:
+ * the dashboard leaves `reportParams` out of `attributes`, so it falls back to
+ * the date-range URL search params the picker writes to; Storybook injects
+ * `attributes.reportParams` directly. The widget's own `max` is forwarded to
+ * the inner component.
  *
  * @param props            - Render props.
  * @param props.attributes - Widget attributes.
@@ -185,7 +184,7 @@ function AuthorsReport( { max }: { max: number } ) {
  */
 export default function Authors( { attributes = {}, setError }: AuthorsRenderProps ) {
 	return (
-		<WidgetRoot setError={ setError }>
+		<WidgetRoot attributes={ attributes } setError={ setError }>
 			<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -196,13 +196,17 @@ export function AuthorsLeaderboard( {
 	}, [ rows, selectedAuthor, selectAuthor ] );
 
 	if ( isLoading ) {
-		return <WidgetLoadingOverlay />;
+		return (
+			<div className={ styles.content }>
+				<WidgetLoadingOverlay />
+			</div>
+		);
 	}
 
 	const isDrilled = Boolean( selectedAuthor );
 
 	return (
-		<>
+		<div className={ styles.content }>
 			{ selectedAuthor && (
 				<WidgetBackLink
 					label={ __( 'All authors', 'jetpack-premium-analytics' ) }
@@ -233,7 +237,7 @@ export function AuthorsLeaderboard( {
 				}
 			/>
 			{ isRefetching && <WidgetLoadingOverlay /> }
-		</>
+		</div>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -4,6 +4,8 @@
 import { useStatsTopAuthors } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardLabel,
+	WidgetBackLink,
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	formatLegendLabels,
@@ -13,13 +15,15 @@ import {
 	type LegendLabels,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { postAuthor } from '@wordpress/icons';
-import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { buildTopAuthorsData } from './build-top-authors-data';
+import { buildTopAuthorsData, type AuthorLeaderboardRow } from './build-top-authors-data';
+import styles from './style.module.css';
 import type { AuthorsAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
@@ -42,10 +46,12 @@ const toPositiveInt = ( value: string | number | undefined, fallback: number ) =
 
 export type AuthorsLeaderboardProps = {
 	/**
-	 * Leaderboard rows to render, already built from the top-authors report.
+	 * Author rows to render, already built from the top-authors report. Each row
+	 * carries its avatar and posts so the leaderboard can show a name + picture
+	 * label and drill down into that author's posts on click.
 	 * When omitted, the empty state is shown (unless `isLoading` is set).
 	 */
-	data?: LeaderboardChartData;
+	rows?: AuthorLeaderboardRow[];
 	/**
 	 * When `true`, the initial loading overlay is rendered instead of the chart.
 	 */
@@ -67,15 +73,21 @@ export type AuthorsLeaderboardProps = {
 
 /**
  * Presentational leaderboard for the Authors widget. Renders the site's top
- * authors by views, and is responsible only for the loading, empty, and
- * populated states.
+ * authors by views — each row labelled with the author's name and avatar — and
+ * lets a click drill down into that author's posts, with a back link to return.
+ *
+ * Both the interactive row affordance (chevron, hover, keyboard access) and the
+ * name + picture label come from the shared `@automattic/charts` leaderboard
+ * primitives via the toolkit's `LeaderboardChart` / `LeaderboardLabel`; only the
+ * drill-down navigation state lives here.
  *
  * Takes already-built rows via props (and is exported) so Storybook can
- * exercise those states with fixture data — there is no Stats backend in
- * Storybook, so the data-connected entry point would only ever show chrome.
+ * exercise these states — including the drill-down — with fixture data; there
+ * is no Stats backend in Storybook, so the data-connected entry point would
+ * only ever show chrome.
  *
  * @param props                - Component props.
- * @param props.data           - Leaderboard rows to render.
+ * @param props.rows           - Author rows to render.
  * @param props.isLoading      - Whether to render the initial loading overlay.
  * @param props.isRefetching   - Whether to layer a loading overlay over the chart.
  * @param props.withComparison - Whether to render previous-period deltas.
@@ -83,31 +95,137 @@ export type AuthorsLeaderboardProps = {
  * @return The rendered leaderboard.
  */
 export function AuthorsLeaderboard( {
-	data = [],
+	rows = [],
 	isLoading = false,
 	isRefetching = false,
 	withComparison = false,
 	legendLabels,
 }: AuthorsLeaderboardProps ) {
+	const [ selectedAuthorId, setSelectedAuthorId ] = useState< string | null >( null );
+	const clearSelectedAuthor = useCallback( () => setSelectedAuthorId( null ), [] );
+
+	// Resolve the drilled-into author from the current rows so a background
+	// refetch that drops the author cleanly falls back to the top view.
+	const selectedAuthor = useMemo(
+		() => ( selectedAuthorId ? rows.find( row => row.id === selectedAuthorId ) ?? null : null ),
+		[ rows, selectedAuthorId ]
+	);
+
+	useEffect( () => {
+		if ( selectedAuthorId && ! selectedAuthor ) {
+			setSelectedAuthorId( null );
+		}
+	}, [ selectedAuthorId, selectedAuthor ] );
+
+	const chartData: LeaderboardChartData = useMemo( () => {
+		// Drilled-in: show the selected author's posts. Rows are not interactive;
+		// the data builder already aligned current/comparison values, including
+		// posts that only existed in the comparison period.
+		if ( selectedAuthor ) {
+			return selectedAuthor.posts.map( post => {
+				// A custom label element bypasses the chart's default overlay
+				// `.label` inset, so mirror top-posts: pad the block (sets the bar
+				// height, since there is no avatar to size the row) and inset the
+				// text from the bar's rounded left edge.
+				const label = post.link ? (
+					<Link
+						className={ styles.postLabel }
+						href={ post.link }
+						variant="unstyled"
+						openInNewTab
+						title={ post.title }
+					>
+						{ post.title }
+					</Link>
+				) : (
+					<span className={ styles.postLabel } title={ post.title }>
+						{ post.title }
+					</span>
+				);
+
+				return {
+					id: post.id,
+					label,
+					currentValue: post.currentValue,
+					previousValue: post.previousValue,
+					currentShare: post.currentShare,
+					previousShare: post.previousShare,
+					delta: post.delta,
+				};
+			} );
+		}
+
+		// Top authors: name + avatar label, and a click drills into the author's
+		// posts. Authors without posts stay inert (no onClick).
+		return rows.map( row => ( {
+			id: row.id,
+			label: (
+				<LeaderboardLabel
+					label={ row.label }
+					imageUrl={ row.avatarUrl ?? undefined }
+					imageAlt={ sprintf(
+						/* translators: %s is the author name */
+						__( 'Avatar of %s', 'jetpack-premium-analytics' ),
+						row.label
+					) }
+					imageClassName={ styles.avatar }
+				/>
+			),
+			currentValue: row.currentValue,
+			previousValue: row.previousValue,
+			currentShare: row.currentShare,
+			previousShare: row.previousShare,
+			delta: row.delta,
+			...( row.posts.length > 0 && {
+				onClick: () => setSelectedAuthorId( row.id ),
+				// The label already renders the name as text; without an explicit
+				// action name the button would announce the avatar alt ("Avatar of
+				// X") plus the name. Give it a concise, deterministic name instead.
+				ariaLabel: sprintf(
+					/* translators: %s is the author name */
+					__( 'View posts by %s', 'jetpack-premium-analytics' ),
+					row.label
+				),
+			} ),
+		} ) );
+	}, [ rows, selectedAuthor ] );
+
 	if ( isLoading ) {
 		return <WidgetLoadingOverlay />;
 	}
 
+	const isDrilled = Boolean( selectedAuthor );
+
 	return (
 		<>
+			{ selectedAuthor && (
+				<WidgetBackLink
+					label={ __( 'All authors', 'jetpack-premium-analytics' ) }
+					onClick={ clearSelectedAuthor }
+				/>
+			) }
 			<LeaderboardChart
-				data={ data }
+				data={ chartData }
 				withComparison={ withComparison }
+				withOverlayLabel
+				showLegend={ false }
 				legendLabels={ legendLabels }
 				dataFormat={ {
 					type: 'number',
-					options: { useMultipliers: false, decimals: 0 },
+					options: { useMultipliers: true, decimals: 0 },
 				} }
 				emptyStateIcon={ postAuthor }
-				emptyStateText={ __(
-					'Learn about your most popular authors to better understand how they contribute to growing your site.',
-					'jetpack-premium-analytics'
-				) }
+				emptyStateText={
+					isDrilled
+						? __(
+								'This author has no posts with views for the selected period.',
+								'jetpack-premium-analytics'
+						  )
+						: __(
+								'Learn about your most popular authors to better understand how they contribute to growing your site.',
+								'jetpack-premium-analytics'
+						  )
+				}
 			/>
 			{ isRefetching && <WidgetLoadingOverlay /> }
 		</>
@@ -145,7 +263,7 @@ function AuthorsReport( { max }: { max: number } ) {
 	const primaryData = primary.data;
 	const comparisonData = comparison.data;
 
-	const chartData = useMemo(
+	const rows = useMemo(
 		() => buildTopAuthorsData( primaryData, comparisonData ),
 		[ primaryData, comparisonData ]
 	);
@@ -159,7 +277,7 @@ function AuthorsReport( { max }: { max: number } ) {
 
 	return (
 		<AuthorsLeaderboard
-			data={ chartData }
+			rows={ rows }
 			isLoading={ isInitialLoading }
 			isRefetching={ isRefetching }
 			withComparison={ hasComparison }
@@ -185,7 +303,9 @@ function AuthorsReport( { max }: { max: number } ) {
 export default function Authors( { attributes = {}, setError }: AuthorsRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError }>
-			<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
+			<div className={ styles.root }>
+				<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
+			</div>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -60,7 +60,10 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< AuthorsStoryControls >;
+	// The story args are the widget-specific controls, but `component` is the
+	// render component (host `WidgetRenderProps`). Intersect the two so
+	// `component` type-checks against the meta while the controls drive argTypes.
+} satisfies Meta< ComponentProps< typeof AuthorsRender > & AuthorsStoryControls >;
 
 export default meta;
 

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -1,241 +1,107 @@
-/**
- * Internal dependencies
- */
-import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
-import { AuthorsLeaderboard } from '../render';
-import type { LeaderboardChartData } from '@jetpack-premium-analytics/widgets-toolkit';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import AuthorsRender from '../render';
+import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
 
-const meta: Meta< typeof AuthorsLeaderboard > = {
+registerReportMocks();
+
+const AUTHORS_RENDER_MODULE = 'storybook/authors';
+
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+};
+
+interface AuthorsStoryControls {
+	withComparison: boolean;
+}
+
+function renderAuthors( { withComparison }: AuthorsStoryControls ) {
+	return (
+		<AuthorsRender
+			attributes={ { max: 7, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+function AuthorsDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <AuthorsRender { ...( props as ComponentProps< typeof AuthorsRender > ) } />;
+}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '360px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Authors',
-	component: AuthorsLeaderboard,
+	component: AuthorsRender,
 	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					"The Authors widget. Renders the site's top authors by views as a leaderboard, sourced from the Jetpack Stats API, with optional period-over-period comparison. This is the presentational component — it takes already-built leaderboard rows via props and handles the loading, empty, and populated states.",
+					'The "Authors" widget. Displays top authors by views from the Jetpack Stats top-authors endpoint. Rows show author avatars and drill down into linked post rows; comparison mode carries period-over-period deltas into both author and post views.',
 			},
 		},
 	},
-	decorators: [ withChartTheme ],
-};
+} satisfies Meta< AuthorsStoryControls >;
 
 export default meta;
 
-type Story = StoryObj< typeof AuthorsLeaderboard >;
+type Story = StoryObj< AuthorsStoryControls >;
 
-const MAX_VIEWS = 4820;
-
-/**
- * Compute the share (0–100) of a value relative to the most-viewed author, so
- * the overlay bars stay proportional — mirroring `buildTopAuthorsData`.
- *
- * @param value - The view count.
- * @return The share as a percentage of the top author's views.
- */
-const share = ( value: number ) => ( value / MAX_VIEWS ) * 100;
-
-const mockAuthors: LeaderboardChartData = [
-	{
-		id: 'Jane Cooper',
-		label: 'Jane Cooper',
-		currentValue: 4820,
-		previousValue: 0,
-		currentShare: share( 4820 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Wade Warren',
-		label: 'Wade Warren',
-		currentValue: 3110,
-		previousValue: 0,
-		currentShare: share( 3110 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Esther Howard',
-		label: 'Esther Howard',
-		currentValue: 2540,
-		previousValue: 0,
-		currentShare: share( 2540 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Cameron Williamson',
-		label: 'Cameron Williamson',
-		currentValue: 1890,
-		previousValue: 0,
-		currentShare: share( 1890 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Brooklyn Simmons',
-		label: 'Brooklyn Simmons',
-		currentValue: 1320,
-		previousValue: 0,
-		currentShare: share( 1320 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Leslie Alexander',
-		label: 'Leslie Alexander',
-		currentValue: 760,
-		previousValue: 0,
-		currentShare: share( 760 ),
-		previousShare: 0,
-		delta: 0,
-	},
-	{
-		id: 'Untracked authors',
-		label: 'Untracked authors',
-		currentValue: 410,
-		previousValue: 0,
-		currentShare: share( 410 ),
-		previousShare: 0,
-		delta: 0,
-	},
-];
-
-const mockAuthorsWithComparison: LeaderboardChartData = [
-	{
-		id: 'Jane Cooper',
-		label: 'Jane Cooper',
-		currentValue: 4820,
-		previousValue: 3900,
-		currentShare: share( 4820 ),
-		previousShare: share( 3900 ),
-		delta: 23.6,
-	},
-	{
-		id: 'Wade Warren',
-		label: 'Wade Warren',
-		currentValue: 3110,
-		previousValue: 3540,
-		currentShare: share( 3110 ),
-		previousShare: share( 3540 ),
-		delta: -12.1,
-	},
-	{
-		id: 'Esther Howard',
-		label: 'Esther Howard',
-		currentValue: 2540,
-		previousValue: 1980,
-		currentShare: share( 2540 ),
-		previousShare: share( 1980 ),
-		delta: 28.3,
-	},
-	{
-		id: 'Cameron Williamson',
-		label: 'Cameron Williamson',
-		currentValue: 1890,
-		previousValue: 2010,
-		currentShare: share( 1890 ),
-		previousShare: share( 2010 ),
-		delta: -6,
-	},
-	{
-		id: 'Brooklyn Simmons',
-		label: 'Brooklyn Simmons',
-		currentValue: 1320,
-		previousValue: 0,
-		currentShare: share( 1320 ),
-		previousShare: 0,
-		delta: 100,
-	},
-];
-
-/**
- * Default populated state — top authors ranked by views for the period.
- */
 export const Default: Story = {
-	args: {
-		data: mockAuthors,
-	},
+	render: renderAuthors,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
 };
 
-/**
- * Comparison state — each value shows its change versus the previous period
- * (green for gains, red for losses), driven by each row's `previousValue`.
- */
 export const WithComparison: Story = {
-	args: {
-		data: mockAuthorsWithComparison,
-		withComparison: true,
-		legendLabels: {
-			primary: 'Jun 1 – 18, 2026',
-			comparison: 'May 14 – 31, 2026',
-		},
-	},
+	render: renderAuthors,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
 };
 
-/**
- * Loading state — the initial loading overlay renders while data is fetched.
- */
-export const Loading: Story = {
-	args: {
-		data: [],
-		isLoading: true,
-	},
-};
+interface AuthorsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		AuthorsStoryControls {}
 
-/**
- * Empty state — no authors recorded any views for the selected period.
- */
-export const Empty: Story = {
-	args: {
-		data: [],
-	},
-};
-
-/**
- * Creates a decorator that wraps the story in a fixed-size container so the
- * widget's responsiveness can be inspected at a given width.
- *
- * @param width    - The container width (any CSS length).
- * @param [height] - The container height; defaults to `auto`.
- * @return A Storybook decorator.
- */
-const createSizeDecorator = ( width: string, height = 'auto' ): Decorator => {
-	return Story => (
-		<div
-			style={ {
-				width,
-				height,
-				border: '1px dashed #ccc',
-				borderRadius: '8px',
-				padding: '16px',
-				background: '#fafafa',
-				containerType: 'inline-size',
-				containerName: 'widget',
-			} }
-		>
-			<Story />
-		</div>
+function AuthorsDashboardStory( { withComparison, ...dashboardArgs }: AuthorsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ AUTHORS_RENDER_MODULE }
+			renderComponent={ AuthorsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: 7, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
 	);
-};
+}
 
-/**
- * Medium container (448px / md breakpoint).
- */
-export const SizeMedium: Story = {
+export const WidgetDashboardWithWidget: StoryObj< AuthorsDashboardStoryProps > = {
+	render: args => <AuthorsDashboardStory { ...args } />,
 	args: {
-		data: mockAuthors,
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
 	},
-	decorators: [ createSizeDecorator( '448px' ) ],
-};
-
-/**
- * Large container (576px / xl breakpoint).
- */
-export const SizeLarge: Story = {
-	args: {
-		data: mockAuthors,
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
 	},
-	decorators: [ createSizeDecorator( '576px' ) ],
 };

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -1,0 +1,55 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+/* Round the author avatar; a fixed size keeps the leaderboard row height
+   stable. */
+.avatar {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+/* Drilled-in post rows have no avatar, so the post label sizes the row.
+   Mirror top-posts: pad the block to set the overlay bar height and inset the
+   text from the bar's rounded left edge. */
+.postLabel {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+a.postLabel:hover,
+a.postLabel:focus {
+	text-decoration: underline;
+}
+
+/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
+ * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
+ * on .root also resolves to auto, leaving aspect-ratio with no anchor.
+ * Setting height: auto here lets aspect-ratio derive the height from the known
+ * inline size and overflow: hidden clips the chart content. Targets only the
+ * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
+ * tile supplies a real height. */
+:global([inert]:not([inert="true"])) .root {
+	height: auto;
+	aspect-ratio: 4 / 3;
+	overflow: hidden;
+}
+
+/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
+ * to all images inside the media cell, overriding our 20px avatar size.
+ * Restore correct sizing for avatar images in any inert context. */
+:global([inert]) .avatar {
+	width: 20px;
+	height: 20px;
+	object-fit: cover;
+}

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -4,6 +4,7 @@
 	flex-direction: column;
 	height: 100%;
 	overflow: hidden;
+	position: relative;
 }
 
 /* Round the author avatar; a fixed size keeps the leaderboard row height

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -4,7 +4,16 @@
 	flex-direction: column;
 	height: 100%;
 	overflow: hidden;
+}
+
+/* Positioned anchor so WidgetLoadingOverlay (position: absolute; inset: 0)
+   resolves against the widget body, not the host frame. */
+.content {
 	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
 }
 
 /* Round the author avatar; a fixed size keeps the leaderboard row height


### PR DESCRIPTION
Fixes #


https://github.com/user-attachments/assets/db6f52e1-e9da-460d-9398-6a3f12e78bc6


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Authors widget rows now show the author's name and avatar (via the shared `LeaderboardLabel`), and clicking a row drills into that author's posts with comparison deltas; a new `WidgetBackLink` toolkit component returns to the all-authors view. Authors without posts stay inert.
* Comparison alignment now keys on stable author/post ids instead of display labels, so same-name authors stay distinct; the top-authors sanitizer carries the author id through.
* `AuthorsAttributes` is now typed and the widget no longer shadows the URL-driven report params; `attributes` keep flowing to `WidgetRoot` per the widget render contract (with a clarified comment explaining why).
* Delta colors in the shared chart theme switch to the stronger stroke tokens (`stroke-surface-error/success-strong`) for better contrast.
* Stories move to the shared widget-dashboard harness with mocked top-authors report data, and the data builder tests cover the new drill-down rows.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Follow-ups to the Authors widget port.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build and serve Premium Analytics on a site with multiple post authors, and open the dashboard with the Authors widget.
* Confirm each row shows the author's name with their avatar.
* Click an author row: the chart should switch to that author's posts (with previous-period deltas when comparison is on), and an "All authors" back link should appear; clicking it returns to the top-authors view.
* Confirm an author with no posts in the period is not clickable, and post labels link to the post in a new tab.
* With a screen reader or by inspecting the DOM, confirm clickable rows are announced as "View posts by {author}".
* Storybook: run the widgets-toolkit Storybook and check the Authors widget stories (loading, empty, populated, drill-down) render against the mocked top-authors report.
* Tests: `pnpm test` in `projects/packages/premium-analytics` (see `widgets/authors/__tests__/build-top-authors-data.test.ts` and `packages/data/src/processing/stats/__tests__/top-authors.test.ts`).