### PR TITLE
Premium Analytics: wire up the WooCommerce Analytics tracker (ClickHouse + proxy)

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1560-wire-up-woocommerce-analytics-tracker
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1560-wire-up-woocommerce-analytics-tracker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Wire up the WooCommerce Analytics front-end tracker with ClickHouse and proxy tracking enabled.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -10,7 +10,8 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-stats": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-wp-build-polyfills": "@dev"
+		"automattic/jetpack-wp-build-polyfills": "@dev",
+		"automattic/woocommerce-analytics": "^0.16"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -67,6 +67,9 @@ class Analytics {
 		Api_Proxy_Controller::register();
 		Notices_Controller::register();
 
+		// Emit WooCommerce store events into the Woo pipeline (ClickHouse + proxy).
+		WooCommerce_Analytics_Tracker::configure();
+
 		// Load the widget type registry: hydration routine, registry-time and
 		// runtime filters, and the registry accessors.
 		require_once __DIR__ . '/widget-types.php';

--- a/projects/packages/premium-analytics/src/class-woocommerce-analytics-tracker.php
+++ b/projects/packages/premium-analytics/src/class-woocommerce-analytics-tracker.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Wires up the WooCommerce Analytics front-end tracker for Premium Analytics.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use Automattic\Woocommerce_Analytics;
+
+/**
+ * Turns on the modern (ClickHouse + proxy) pipeline and triggers the vendored
+ * WooCommerce Analytics tracker, which self-gates on WooCommerce + connection
+ * and is idempotent.
+ */
+class WooCommerce_Analytics_Tracker {
+
+	/**
+	 * Register the tracker bootstrap.
+	 */
+	public static function configure() {
+		add_action( 'after_setup_theme', array( __CLASS__, 'bootstrap' ) );
+	}
+
+	/**
+	 * Enable the modern pipeline and trigger the tracker.
+	 *
+	 * On `after_setup_theme` the filters are in place before the package reads
+	 * them while localizing `window.wcAnalytics` at `wp_footer`.
+	 */
+	public static function bootstrap() {
+		add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
+		add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
+
+		// Guarded because the package ships with the Jetpack plugin or as a
+		// composer dependency, not with premium-analytics' own source.
+		if ( class_exists( Woocommerce_Analytics::class ) ) {
+			Woocommerce_Analytics::init();
+		}
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/WooCommerce_Analytics_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/WooCommerce_Analytics_Tracker_Test.php
@@ -43,8 +43,9 @@ class WooCommerce_Analytics_Tracker_Test extends TestCase {
 	}
 
 	public function test_bootstrap_is_safe_to_run_twice() {
-		WooCommerce_Analytics_Tracker::bootstrap();
-		WooCommerce_Analytics_Tracker::bootstrap();
+		for ( $i = 0; $i < 2; $i++ ) {
+			WooCommerce_Analytics_Tracker::bootstrap();
+		}
 
 		// Filters still resolve to true; the modern pipeline stays enabled and no
 		// error is raised by the second run.

--- a/projects/packages/premium-analytics/tests/php/WooCommerce_Analytics_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/WooCommerce_Analytics_Tracker_Test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for WooCommerce_Analytics_Tracker.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\WooCommerce_Analytics_Tracker
+ */
+#[CoversClass( WooCommerce_Analytics_Tracker::class )]
+class WooCommerce_Analytics_Tracker_Test extends TestCase {
+
+	/**
+	 * @after
+	 */
+	#[After]
+	public function tear_down() {
+		remove_all_actions( 'after_setup_theme' );
+		remove_all_filters( 'woocommerce_analytics_clickhouse_enabled' );
+		remove_all_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled' );
+	}
+
+	public function test_configure_registers_bootstrap_on_after_setup_theme() {
+		WooCommerce_Analytics_Tracker::configure();
+
+		$this->assertNotFalse(
+			has_action( 'after_setup_theme', array( WooCommerce_Analytics_Tracker::class, 'bootstrap' ) )
+		);
+	}
+
+	public function test_bootstrap_enables_clickhouse_and_proxy_filters() {
+		WooCommerce_Analytics_Tracker::bootstrap();
+
+		$this->assertTrue( apply_filters( 'woocommerce_analytics_clickhouse_enabled', false ) );
+		$this->assertTrue( apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false ) );
+	}
+
+	public function test_bootstrap_is_safe_to_run_twice() {
+		WooCommerce_Analytics_Tracker::bootstrap();
+		WooCommerce_Analytics_Tracker::bootstrap();
+
+		// Filters still resolve to true; the modern pipeline stays enabled and no
+		// error is raised by the second run.
+		$this->assertTrue( apply_filters( 'woocommerce_analytics_clickhouse_enabled', false ) );
+		$this->assertTrue( apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false ) );
+	}
+}

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1560-wire-up-woocommerce-analytics-tracker
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1560-wire-up-woocommerce-analytics-tracker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Wire up the WooCommerce Analytics front-end tracker with ClickHouse and proxy tracking enabled.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -7,6 +7,69 @@
     "content-hash": "26a28963f05fd6563512fc376bb7fced",
     "packages": [
         {
+            "name": "automattic/block-delimiter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/block-delimiter",
+                "reference": "e860d7feb6347341faad763d7e342cc6a5e8b449"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/block-delimiter/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/block-delimiter",
+                "textdomain": "jetpack-block-delimiter"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "classmap": [
+                    "tests/php/lib/"
+                ],
+                "psr-4": {
+                    "Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Efficiently work with block structure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-a8c-mc-stats",
             "version": "dev-trunk",
             "dist": {
@@ -606,6 +669,59 @@
             }
         },
         {
+            "name": "automattic/jetpack-device-detection",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/device-detection",
+                "reference": "060e4e98b1fb7351b6635c5c8c16a0a2f365ce90"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-device-detection",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A way to detect device types based on User-Agent header.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-ip",
             "version": "dev-trunk",
             "dist": {
@@ -724,7 +840,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "ece16351c0214699a18864e6745cc2f32a2a1ab4"
+                "reference": "2520bcc0d3875df8436b0fbef27888e00700b989"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -733,6 +849,7 @@
                 "automattic/jetpack-stats": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-wp-build-polyfills": "@dev",
+                "automattic/woocommerce-analytics": "^0.16",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -1224,6 +1341,58 @@
             "transport-options": {
                 "relative": true
             }
+        },
+        {
+            "name": "automattic/woocommerce-analytics",
+            "version": "0.16.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/woocommerce-analytics.git",
+                "reference": "92b67c5f12b3f9b3dcb34e1b668743cfbe552666"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/92b67c5f12b3f9b3dcb34e1b668743cfbe552666",
+                "reference": "92b67c5f12b3f9b3dcb34e1b668743cfbe552666",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/block-delimiter": "^0.3",
+                "automattic/jetpack-assets": "^4.3",
+                "automattic/jetpack-connection": "^8.1",
+                "automattic/jetpack-constants": "^3.0",
+                "automattic/jetpack-device-detection": "^3.4",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "3.3.0",
+                "automattic/wordbless": "^0.5",
+                "woocommerce/woocommerce-sniffs": "1.0.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "changelogger": {
+                    "changelog": "CHANGELOG.md"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Enhanced analytics for WooCommerce users.",
+            "support": {
+                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.6"
+            },
+            "time": "2026-06-17T08:21:41+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Proposed changes

Resolves WOOA7S-1560.

Premium Analytics reads from the Woo Analytics front-end pipeline but emitted no tracking of its own, so a store running only Premium Analytics produced no traffic data. This wires up the WooCommerce Analytics tracker with the modern pipeline (ClickHouse + proxy delivery) turned on.

* New `WooCommerce_Analytics_Tracker` class, wired from `Analytics::init()`. On `after_setup_theme` it enables the `woocommerce_analytics_clickhouse_enabled` and `woocommerce_analytics_experimental_proxy_tracking_enabled` filters, then calls `Woocommerce_Analytics::init()` behind a `class_exists()` guard.
* No extra dedup needed: the vendored package self-gates on WooCommerce + a live Jetpack connection and is idempotent (`did_action( 'woocommerce_analytics_init' )`), so running alongside the standalone Woo Analytics module (or WooCommerce core) is a harmless no-op. The proxy speed-module MU-plugin is intentionally left off.
* Adds `automattic/woocommerce-analytics: ^0.16` as a package dependency so standalone Premium Analytics installs can bootstrap the tracker.
* PHPUnit coverage for the hook registration and the two feature filters.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

* On a Jetpack-connected WooCommerce store, activate the Premium Analytics plugin.
* As a logged-out visitor, load a front-end store page (not wp-admin).
* Confirm `window.wcAnalytics` localization with `ch: true`, `sessionTracking: true`, `proxy: true`.

<img width="508"  alt="image" src="https://github.com/user-attachments/assets/0e5d0e0b-89a9-4078-855b-ff8f7c4ca864" />


* Trigger a tracked event (e.g. a product view) and confirm a single beacon/POST to the proxy `/track` route — and that it stays single when the standalone Woo Analytics module is also active.

<img width="904" height="372" alt="Screenshot 2026-07-03 at 6 22 31 PM" src="https://github.com/user-attachments/assets/8bb6dfe7-39ad-428b-9064-e08d3cbced27" />

* Package tests: `cd projects/packages/premium-analytics && composer phpunit`.
