### PR TITLE
premium-analytics: Temporarily disable wp-build build in CI

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-disable-premium-analytics-build
+++ b/projects/packages/premium-analytics/changelog/fix-disable-premium-analytics-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Temporarily disable build in CI, it seems like it's breaking Actions due to resource usage. See p1783074995036859-slack-C05Q5HSS013 for discussion.
+
+

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -9,7 +9,7 @@
 		"build:assets-production": "pnpm --dir ../assets run build-production",
 		"build:boot-asset": "provide-boot-asset-file",
 		"build:strip-unminified-prod": "strip-unminified-prod",
-		"build:wp-build": "wp-build",
+		"build:wp-build": "if [ -n \"$CI\" ]; then echo '::notice:: Premium Analytics build is temporarily disabled in CI, see p1783074995036859-slack-C05Q5HSS013'; else wp-build; fi",
 		"build-production": "pnpm run build:assets-production && NODE_ENV=production BABEL_ENV=production pnpm run build:wp-build && pnpm run build:strip-unminified-prod && pnpm run build:boot-asset && pnpm run validate",
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "jest --config=tests/jest.config.cjs",


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems that this may be using so much RAM that it's causing the GitHub Actions runners to be killed. Disable the build temporarily while that can be looked into.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1783074995036859-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI build happy now?