### PR TITLE
Jetpack Analytics: Add dashboard section layout persistence API

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-dashboard-section-layout-api
+++ b/projects/packages/premium-analytics/changelog/add-dashboard-section-layout-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Add dashboard section layout persistence endpoints.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -33,6 +33,11 @@ const DASHBOARD_LAYOUT_SCOPE = 'jetpack-premium-analytics/dashboard';
 const DASHBOARD_LAYOUT_KEY = 'dashboardLayout';
 
 /**
+ * Preferences key under DASHBOARD_LAYOUT_SCOPE that holds per-section layouts.
+ */
+const DASHBOARD_SECTION_LAYOUTS_KEY = 'dashboardSectionLayouts';
+
+/**
  * Identifier of the Premium Analytics dashboard, formatted as `<plugin>_<page>`
  * to match the underscore form produced by the wp-build pipeline. Used as the
  * `{name}` segment of the REST route and as the seed filter's target.

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 require_once __DIR__ . '/dashboard-layout.php';
+require_once __DIR__ . '/dashboard-grammar.php';
 require_once __DIR__ . '/class-dashboard-section.php';
 require_once __DIR__ . '/class-dashboard-section-registry.php';
 
@@ -100,30 +101,255 @@ function check_dashboard_sections_permission() {
 }
 
 /**
- * REST callback returning available dashboard sections.
+ * Gets the user meta key used by the WordPress preferences store.
  *
- * @param \WP_REST_Request $request REST request carrying the dashboard name.
- * @return \WP_REST_Response
+ * @global \wpdb $wpdb WordPress database abstraction object.
+ *
+ * @return string Persisted preferences user meta key.
  */
-function get_dashboard_sections_response( $request ) {
-	$sections = array_map(
-		static function ( Dashboard_Section $section ) {
-			return $section->to_array();
-		},
-		get_available_dashboard_sections( $request['name'] )
-	);
+function get_persisted_preferences_meta_key() {
+	global $wpdb;
 
-	return rest_ensure_response( $sections );
+	return $wpdb->get_blog_prefix() . 'persisted_preferences';
 }
 
 /**
- * REST callback returning a section's default layout.
+ * Reads the raw stored preferences for a user.
  *
- * @param \WP_REST_Request $request REST request carrying dashboard and section identifiers.
- * @return \WP_REST_Response|\WP_Error
+ * The dashboard default layout is injected through the same user meta key at
+ * read time. Section layout writes need the committed value only, otherwise a
+ * section-only update can accidentally persist that synthetic default layout.
+ *
+ * @param int $user_id User ID.
+ * @return array Preferences array.
  */
-function get_dashboard_section_default_layout_response( $request ) {
-	$section = get_registered_dashboard_section( $request['name'], $request['section'] );
+function get_stored_persisted_preferences_for_user( $user_id ) {
+	$default_layout_filter = __NAMESPACE__ . '\\inject_dashboard_default_layout';
+	$removed_filter        = remove_filter( 'get_user_metadata', $default_layout_filter, 99 );
+
+	$preferences = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
+
+	if ( $removed_filter ) {
+		add_filter( 'get_user_metadata', $default_layout_filter, 99, 3 );
+	}
+
+	return is_array( $preferences ) ? $preferences : array();
+}
+
+/**
+ * Reads stored dashboard section layouts for a user.
+ *
+ * Invalid or stale section layout entries are ignored while preserving the
+ * missing-key semantics used by the section API.
+ *
+ * @param int $user_id User ID.
+ * @return array<string,array> Map of section IDs to custom layouts.
+ */
+function get_dashboard_section_layouts_for_user( $user_id ) {
+	$preferences = get_stored_persisted_preferences_for_user( $user_id );
+	$scope       = $preferences[ DASHBOARD_LAYOUT_SCOPE ] ?? array();
+
+	if ( ! is_array( $scope ) ) {
+		return array();
+	}
+
+	$layouts = $scope[ DASHBOARD_SECTION_LAYOUTS_KEY ] ?? array();
+
+	if ( ! is_array( $layouts ) ) {
+		return array();
+	}
+
+	$normalized = array();
+
+	foreach ( $layouts as $section_id => $layout ) {
+		if (
+			is_string( $section_id )
+			&& 1 === preg_match( '/^' . get_dashboard_section_id_pattern() . '$/', $section_id )
+			&& is_dashboard_section_layout( $layout )
+		) {
+			$normalized[ $section_id ] = array_values( $layout );
+		}
+	}
+
+	return $normalized;
+}
+
+/**
+ * Persists a custom dashboard section layout for a user.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $section_id Section identifier.
+ * @param array  $layout     Widget layout.
+ * @return bool True when the write completed or the stored value was unchanged.
+ */
+function update_dashboard_section_layout_for_user( $user_id, $section_id, $layout ) {
+	$preferences = get_stored_persisted_preferences_for_user( $user_id );
+	$original    = $preferences;
+
+	if ( ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) ) {
+		$preferences[ DASHBOARD_LAYOUT_SCOPE ] = array();
+	}
+
+	if (
+		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
+		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
+	) {
+		$preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] = array();
+	}
+
+	$preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ][ $section_id ] = array_values( $layout );
+
+	if ( $preferences === $original ) {
+		return true;
+	}
+
+	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
+
+	return false !== $updated;
+}
+
+/**
+ * Removes a custom dashboard section layout for a user.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $section_id Section identifier.
+ * @return bool True when the reset completed or there was nothing to reset.
+ */
+function delete_dashboard_section_layout_for_user( $user_id, $section_id ) {
+	$preferences = get_stored_persisted_preferences_for_user( $user_id );
+
+	if (
+		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
+		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
+		|| ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
+		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
+	) {
+		return true;
+	}
+
+	if ( ! array_key_exists( $section_id, $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] ) ) {
+		return true;
+	}
+
+	unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ][ $section_id ] );
+
+	if ( empty( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] ) ) {
+		unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] );
+	}
+
+	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
+
+	return false !== $updated;
+}
+
+/**
+ * Removes all custom dashboard section layouts for a user.
+ *
+ * @param int $user_id User ID.
+ * @return bool True when the reset completed or there was nothing to reset.
+ */
+function delete_dashboard_section_layouts_for_user( $user_id ) {
+	$preferences = get_stored_persisted_preferences_for_user( $user_id );
+
+	if (
+		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
+		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
+		|| ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
+	) {
+		return true;
+	}
+
+	unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] );
+
+	if ( empty( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) ) {
+		unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] );
+	}
+
+	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
+
+	return false !== $updated;
+}
+
+/**
+ * Checks whether a value is a valid dashboard section layout.
+ *
+ * @param mixed $layout Candidate layout.
+ * @return bool True when the value is a list of widget instances.
+ */
+function is_dashboard_section_layout( $layout ) {
+	if ( ! is_array( $layout ) ) {
+		return false;
+	}
+
+	$expected_key = 0;
+
+	foreach ( $layout as $key => $widget ) {
+		if ( $key !== $expected_key ) {
+			return false;
+		}
+
+		++$expected_key;
+
+		if ( ! is_array( $widget ) ) {
+			return false;
+		}
+
+		if ( ! isset( $widget['uuid'] ) || ! is_string( $widget['uuid'] ) || '' === $widget['uuid'] ) {
+			return false;
+		}
+
+		if ( ! isset( $widget['type'] ) || ! is_string( $widget['type'] ) || '' === $widget['type'] ) {
+			return false;
+		}
+
+		if ( isset( $widget['placement'] ) && ! is_array( $widget['placement'] ) ) {
+			return false;
+		}
+
+		if ( isset( $widget['attributes'] ) && ! is_array( $widget['attributes'] ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Validates a dashboard section layout REST argument.
+ *
+ * @param mixed $value Candidate layout.
+ * @return true|\WP_Error True when valid, otherwise an error.
+ */
+function validate_dashboard_section_layout( $value ) {
+	if ( is_dashboard_section_layout( $value ) ) {
+		return true;
+	}
+
+	return new \WP_Error(
+		'invalid_dashboard_section_layout',
+		__( 'Dashboard section layout must be an array of widget instances.', 'jetpack-premium-analytics' )
+	);
+}
+
+/**
+ * Sanitizes a dashboard section layout REST argument.
+ *
+ * @param mixed $value Candidate layout.
+ * @return array Layout array.
+ */
+function sanitize_dashboard_section_layout( $value ) {
+	return is_array( $value ) ? array_values( $value ) : array();
+}
+
+/**
+ * Resolves a route section, including availability checks.
+ *
+ * @param string $dashboard_name Dashboard identifier.
+ * @param string $section_id     Section identifier.
+ * @return Dashboard_Section|\WP_Error Registered available section, or error.
+ */
+function get_available_dashboard_section_for_route( $dashboard_name, $section_id ) {
+	$section = get_registered_dashboard_section( $dashboard_name, $section_id );
 
 	if ( ! $section ) {
 		return new \WP_Error(
@@ -141,7 +367,139 @@ function get_dashboard_section_default_layout_response( $request ) {
 		);
 	}
 
+	return $section;
+}
+
+/**
+ * Builds the public REST representation for a dashboard section.
+ *
+ * @param Dashboard_Section $section         Dashboard section.
+ * @param array             $section_layouts Map of section IDs to custom layouts.
+ * @return array REST response data.
+ */
+function get_dashboard_section_response_data( Dashboard_Section $section, $section_layouts ) {
+	$has_custom_layout = array_key_exists( $section->id, $section_layouts );
+	$data              = $section->to_array();
+
+	$data['layout']          = $has_custom_layout ? $section_layouts[ $section->id ] : $section->get_default_layout();
+	$data['hasCustomLayout'] = $has_custom_layout;
+
+	return $data;
+}
+
+/**
+ * REST callback returning available dashboard sections.
+ *
+ * @param \WP_REST_Request $request REST request carrying the dashboard name.
+ * @return \WP_REST_Response
+ */
+function get_dashboard_sections_response( $request ) {
+	$section_layouts = get_dashboard_section_layouts_for_user( get_current_user_id() );
+	$sections        = array_map(
+		static function ( Dashboard_Section $section ) use ( $section_layouts ) {
+			return get_dashboard_section_response_data( $section, $section_layouts );
+		},
+		get_available_dashboard_sections( $request['name'] )
+	);
+
+	return rest_ensure_response( $sections );
+}
+
+/**
+ * REST callback returning a section's default layout.
+ *
+ * @param \WP_REST_Request $request REST request carrying dashboard and section identifiers.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function get_dashboard_section_default_layout_response( $request ) {
+	$section = get_available_dashboard_section_for_route( $request['name'], $request['section'] );
+
+	if ( is_wp_error( $section ) ) {
+		return $section;
+	}
+
 	return rest_ensure_response( $section->get_default_layout() );
+}
+
+/**
+ * REST callback persisting a dashboard section layout for the current user.
+ *
+ * @param \WP_REST_Request $request REST request carrying dashboard, section, and layout.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function update_dashboard_section_layout_response( $request ) {
+	$section = get_available_dashboard_section_for_route( $request['name'], $request['section'] );
+
+	if ( is_wp_error( $section ) ) {
+		return $section;
+	}
+
+	$layout = sanitize_dashboard_section_layout( $request['layout'] );
+	$user   = get_current_user_id();
+
+	if ( ! update_dashboard_section_layout_for_user( $user, $section->id, $layout ) ) {
+		return new \WP_Error(
+			'dashboard_section_layout_update_failed',
+			__( 'Could not update dashboard section layout.', 'jetpack-premium-analytics' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return rest_ensure_response(
+		get_dashboard_section_response_data(
+			$section,
+			array( $section->id => $layout )
+		)
+	);
+}
+
+/**
+ * REST callback removing a dashboard section layout customization for the current user.
+ *
+ * @param \WP_REST_Request $request REST request carrying dashboard and section identifiers.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function delete_dashboard_section_layout_response( $request ) {
+	$section = get_available_dashboard_section_for_route( $request['name'], $request['section'] );
+
+	if ( is_wp_error( $section ) ) {
+		return $section;
+	}
+
+	$user = get_current_user_id();
+
+	if ( ! delete_dashboard_section_layout_for_user( $user, $section->id ) ) {
+		return new \WP_Error(
+			'dashboard_section_layout_delete_failed',
+			__( 'Could not reset dashboard section layout.', 'jetpack-premium-analytics' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return rest_ensure_response(
+		get_dashboard_section_response_data(
+			$section,
+			get_dashboard_section_layouts_for_user( $user )
+		)
+	);
+}
+
+/**
+ * REST callback removing all dashboard section layout customizations for the current user.
+ *
+ * @param \WP_REST_Request $request REST request carrying the dashboard identifier.
+ * @return \WP_REST_Response|\WP_Error
+ */
+function delete_dashboard_sections_layouts_response( $request ) {
+	if ( ! delete_dashboard_section_layouts_for_user( get_current_user_id() ) ) {
+		return new \WP_Error(
+			'dashboard_section_layout_delete_failed',
+			__( 'Could not reset dashboard section layouts.', 'jetpack-premium-analytics' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return get_dashboard_sections_response( $request );
 }
 
 /**
@@ -168,10 +526,73 @@ function register_dashboard_sections_rest_routes() {
 
 	register_rest_route(
 		DASHBOARD_REST_NAMESPACE,
+		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections',
+		array(
+			'methods'             => \WP_REST_Server::DELETABLE,
+			'callback'            => __NAMESPACE__ . '\\delete_dashboard_sections_layouts_response',
+			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
+			'args'                => array(
+				'name' => array(
+					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		DASHBOARD_REST_NAMESPACE,
 		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/default-layout',
 		array(
 			'methods'             => \WP_REST_Server::READABLE,
 			'callback'            => __NAMESPACE__ . '\\get_dashboard_section_default_layout_response',
+			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
+			'args'                => array(
+				'name'    => array(
+					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+				),
+				'section' => array(
+					'description' => __( 'Dashboard section identifier.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		DASHBOARD_REST_NAMESPACE,
+		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/layout',
+		array(
+			'methods'             => 'PUT',
+			'callback'            => __NAMESPACE__ . '\\update_dashboard_section_layout_response',
+			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
+			'args'                => array(
+				'name'    => array(
+					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+				),
+				'section' => array(
+					'description' => __( 'Dashboard section identifier.', 'jetpack-premium-analytics' ),
+					'type'        => 'string',
+				),
+				'layout'  => array(
+					'description'       => __( 'Widget layout to persist for the dashboard section.', 'jetpack-premium-analytics' ),
+					'type'              => 'array',
+					'required'          => true,
+					'validate_callback' => __NAMESPACE__ . '\\validate_dashboard_section_layout',
+					'sanitize_callback' => __NAMESPACE__ . '\\sanitize_dashboard_section_layout',
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		DASHBOARD_REST_NAMESPACE,
+		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/layout',
+		array(
+			'methods'             => \WP_REST_Server::DELETABLE,
+			'callback'            => __NAMESPACE__ . '\\delete_dashboard_section_layout_response',
 			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
 			'args'                => array(
 				'name'    => array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -203,9 +203,11 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'analytics/traffic',
-					'label' => 'Traffic',
-					'order' => 10,
+					'id'              => 'analytics/traffic',
+					'label'           => 'Traffic',
+					'order'           => 10,
+					'layout'          => array(),
+					'hasCustomLayout' => false,
 				),
 			),
 			$response->get_data()
@@ -392,14 +394,108 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'example/first',
-					'label' => 'First',
-					'order' => 10,
+					'id'              => 'example/first',
+					'label'           => 'First',
+					'order'           => 10,
+					'layout'          => array(),
+					'hasCustomLayout' => false,
 				),
 				array(
-					'id'    => 'example/later',
-					'label' => 'Later',
-					'order' => 20,
+					'id'              => 'example/later',
+					'label'           => 'Later',
+					'order'           => 20,
+					'layout'          => array(),
+					'hasCustomLayout' => false,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Sections route includes resolved default layouts.
+	 */
+	public function test_sections_route_resolves_default_layouts() {
+		$default_layout = array(
+			array(
+				'uuid' => 'default-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_sections_dashboard',
+			'analytics/traffic',
+			array(
+				'label'          => 'Traffic',
+				'order'          => 10,
+				'default_layout' => $default_layout,
+			)
+		);
+
+		$this->set_admin_user();
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/jetpack/v4/dashboards/route_sections_dashboard/sections' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'id'              => 'analytics/traffic',
+					'label'           => 'Traffic',
+					'order'           => 10,
+					'layout'          => $default_layout,
+					'hasCustomLayout' => false,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Sections route treats an empty stored layout as a deliberate customization.
+	 */
+	public function test_sections_route_resolves_customized_empty_layouts() {
+		$default_layout = array(
+			array(
+				'uuid' => 'default-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_sections_dashboard',
+			'analytics/traffic',
+			array(
+				'label'          => 'Traffic',
+				'order'          => 10,
+				'default_layout' => $default_layout,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+		$this->set_section_layouts_preference(
+			$user_id,
+			array(
+				'analytics/traffic' => array(),
+			)
+		);
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/jetpack/v4/dashboards/route_sections_dashboard/sections' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'id'              => 'analytics/traffic',
+					'label'           => 'Traffic',
+					'order'           => 10,
+					'layout'          => array(),
+					'hasCustomLayout' => true,
 				),
 			),
 			$response->get_data()
@@ -491,9 +587,507 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Layout route persists a custom layout for the current user.
+	 */
+	public function test_update_layout_route_persists_current_user_layout() {
+		$custom_layout = array(
+			array(
+				'uuid'       => 'custom-route-widget',
+				'type'       => 'example/widget',
+				'attributes' => array(
+					'example' => true,
+				),
+				'placement'  => array(
+					'width'  => 2,
+					'height' => 1,
+					'order'  => 0,
+				),
+			),
+		);
+
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param( 'layout', $custom_layout );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'id'              => 'analytics/traffic',
+				'label'           => 'Traffic',
+				'order'           => 10,
+				'layout'          => $custom_layout,
+				'hasCustomLayout' => true,
+			),
+			$response->get_data()
+		);
+
+		$stored = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
+
+		$this->assertSame(
+			$custom_layout,
+			$stored[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ]['analytics/traffic']
+		);
+	}
+
+	/**
+	 * Layout route does not persist the injected dashboard default layout.
+	 */
+	public function test_update_layout_route_does_not_persist_injected_dashboard_layout() {
+		$custom_layout = array(
+			array(
+				'uuid' => 'custom-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param( 'layout', $custom_layout );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$stored = get_stored_persisted_preferences_for_user( $user_id );
+
+		$this->assertArrayHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
+		$this->assertSame(
+			$custom_layout,
+			$stored[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ]['analytics/traffic']
+		);
+		$this->assertArrayNotHasKey( DASHBOARD_LAYOUT_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
+	}
+
+	/**
+	 * Layout route accepts an empty custom layout.
+	 */
+	public function test_update_layout_route_persists_empty_layout_as_custom() {
+		$default_layout = array(
+			array(
+				'uuid' => 'default-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label'          => 'Traffic',
+				'order'          => 10,
+				'default_layout' => $default_layout,
+			)
+		);
+
+		$this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param( 'layout', array() );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'id'              => 'analytics/traffic',
+				'label'           => 'Traffic',
+				'order'           => 10,
+				'layout'          => array(),
+				'hasCustomLayout' => true,
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Layout route rejects invalid widget layout entries.
+	 */
+	public function test_update_layout_route_rejects_invalid_layout() {
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		$this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param(
+			'layout',
+			array(
+				array(
+					'uuid' => 'missing-type-widget',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Layout route rejects non-array widget attributes.
+	 */
+	public function test_update_layout_route_rejects_invalid_attributes() {
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		$this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param(
+			'layout',
+			array(
+				array(
+					'uuid'       => 'invalid-attributes-widget',
+					'type'       => 'example/widget',
+					'attributes' => 'oops',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Layout route requires manage_options.
+	 */
+	public function test_update_layout_route_requires_manage_options() {
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
+		$request->set_param( 'layout', array() );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Layout route returns 404 for unknown sections.
+	 */
+	public function test_update_layout_route_returns_404_for_unknown_section() {
+		$this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/missing/layout' );
+		$request->set_param( 'layout', array() );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'dashboard_section_not_found', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Layout route returns 404 for unavailable sections.
+	 */
+	public function test_update_layout_route_returns_404_for_unavailable_section() {
+		register_dashboard_section(
+			'route_unavailable_dashboard',
+			'analytics/insights',
+			array(
+				'label'        => 'Insights',
+				'order'        => 10,
+				'is_available' => '__return_false',
+			)
+		);
+
+		$this->set_admin_user();
+
+		$request = new WP_REST_Request( 'PUT', '/jetpack/v4/dashboards/route_unavailable_dashboard/sections/analytics/insights/layout' );
+		$request->set_param( 'layout', array() );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'dashboard_section_unavailable', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Delete layout route resets a section to its default layout.
+	 */
+	public function test_delete_layout_route_resets_to_default_layout() {
+		$default_layout = array(
+			array(
+				'uuid' => 'default-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+		$custom_layout  = array(
+			array(
+				'uuid' => 'custom-route-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label'          => 'Traffic',
+				'order'          => 10,
+				'default_layout' => $default_layout,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+		$this->set_section_layouts_preference(
+			$user_id,
+			array(
+				'analytics/traffic' => $custom_layout,
+			)
+		);
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'id'              => 'analytics/traffic',
+				'label'           => 'Traffic',
+				'order'           => 10,
+				'layout'          => $default_layout,
+				'hasCustomLayout' => false,
+			),
+			$response->get_data()
+		);
+
+		$stored = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
+
+		$this->assertArrayNotHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
+		$this->assertSame( 'keep-me', $stored[ DASHBOARD_LAYOUT_SCOPE ]['unrelatedPreference'] );
+	}
+
+	/**
+	 * Delete layout route returns 404 for unknown sections.
+	 */
+	public function test_delete_layout_route_returns_404_for_unknown_section() {
+		$this->set_admin_user();
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_layout_dashboard/sections/analytics/missing/layout' )
+		);
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'dashboard_section_not_found', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Delete layout route returns 404 for unavailable sections.
+	 */
+	public function test_delete_layout_route_returns_404_for_unavailable_section() {
+		register_dashboard_section(
+			'route_unavailable_dashboard',
+			'analytics/insights',
+			array(
+				'label'        => 'Insights',
+				'order'        => 10,
+				'is_available' => '__return_false',
+			)
+		);
+
+		$this->set_admin_user();
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_unavailable_dashboard/sections/analytics/insights/layout' )
+		);
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'dashboard_section_unavailable', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Delete sections route resets every custom section layout.
+	 */
+	public function test_delete_sections_route_resets_all_section_layouts() {
+		$traffic_default  = array(
+			array(
+				'uuid' => 'default-traffic-widget',
+				'type' => 'example/widget',
+			),
+		);
+		$insights_default = array(
+			array(
+				'uuid' => 'default-insights-widget',
+				'type' => 'example/widget',
+			),
+		);
+		$traffic_custom   = array(
+			array(
+				'uuid' => 'custom-traffic-widget',
+				'type' => 'example/widget',
+			),
+		);
+		$insights_custom  = array(
+			array(
+				'uuid' => 'custom-insights-widget',
+				'type' => 'example/widget',
+			),
+		);
+
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label'          => 'Traffic',
+				'order'          => 10,
+				'default_layout' => $traffic_default,
+			)
+		);
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/insights',
+			array(
+				'label'          => 'Insights',
+				'order'          => 20,
+				'default_layout' => $insights_default,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+		$this->set_section_layouts_preference(
+			$user_id,
+			array(
+				'analytics/traffic'  => $traffic_custom,
+				'analytics/insights' => $insights_custom,
+			)
+		);
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_layout_dashboard/sections' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'id'              => 'analytics/traffic',
+					'label'           => 'Traffic',
+					'order'           => 10,
+					'layout'          => $traffic_default,
+					'hasCustomLayout' => false,
+				),
+				array(
+					'id'              => 'analytics/insights',
+					'label'           => 'Insights',
+					'order'           => 20,
+					'layout'          => $insights_default,
+					'hasCustomLayout' => false,
+				),
+			),
+			$response->get_data()
+		);
+
+		$stored = get_stored_persisted_preferences_for_user( $user_id );
+
+		$this->assertArrayNotHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
+		$this->assertSame( 'keep-me', $stored[ DASHBOARD_LAYOUT_SCOPE ]['unrelatedPreference'] );
+	}
+
+	/**
+	 * Delete sections route removes the empty dashboard scope.
+	 */
+	public function test_delete_sections_route_removes_empty_dashboard_scope() {
+		register_dashboard_section(
+			'route_layout_dashboard',
+			'analytics/traffic',
+			array(
+				'label' => 'Traffic',
+				'order' => 10,
+			)
+		);
+
+		$user_id = $this->set_admin_user();
+		update_user_meta(
+			$user_id,
+			get_persisted_preferences_meta_key(),
+			array(
+				DASHBOARD_LAYOUT_SCOPE => array(
+					DASHBOARD_SECTION_LAYOUTS_KEY => array(
+						'analytics/traffic' => array(
+							array(
+								'uuid' => 'custom-traffic-widget',
+								'type' => 'example/widget',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_layout_dashboard/sections' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$stored = get_stored_persisted_preferences_for_user( $user_id );
+
+		$this->assertArrayNotHasKey( DASHBOARD_LAYOUT_SCOPE, $stored );
+	}
+
+	/**
+	 * Delete sections route requires manage_options.
+	 */
+	public function test_delete_sections_route_requires_manage_options() {
+		wp_set_current_user( 0 );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'DELETE', '/jetpack/v4/dashboards/route_layout_dashboard/sections' )
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
 	 * Set current user to an administrator.
 	 *
-	 * @return void
+	 * @return int User ID.
 	 */
 	private function set_admin_user() {
 		++self::$user_count;
@@ -507,5 +1101,27 @@ class Dashboard_Section_Test extends BaseTestCase {
 		);
 
 		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	/**
+	 * Store section layout preferences for a user.
+	 *
+	 * @param int   $user_id         User ID.
+	 * @param array $section_layouts Section layout map.
+	 * @return void
+	 */
+	private function set_section_layouts_preference( $user_id, $section_layouts ) {
+		update_user_meta(
+			$user_id,
+			get_persisted_preferences_meta_key(),
+			array(
+				DASHBOARD_LAYOUT_SCOPE => array(
+					'unrelatedPreference'         => 'keep-me',
+					DASHBOARD_SECTION_LAYOUTS_KEY => $section_layouts,
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
## Proposed changes
* Extend the Premium Analytics dashboard sections response with resolved section layouts and `hasCustomLayout` metadata.
* Add `PUT` and `DELETE` section layout endpoints for current-user layout persistence and per-section or all-section reset behavior.
* Store section layouts under the dashboard preferences scope while preserving default-vs-empty custom layout semantics.
* Add PHP tests and a changelog entry for the new section layout persistence API.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `PATH=/Users/lourensschep/.nvm/versions/node/v24.15.0/bin:$PATH /Users/lourensschep/.nvm/versions/node/v24.15.0/bin/node /Users/lourensschep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules/pnpm/bin/pnpm.mjs jetpack test php packages/premium-analytics`.
* Confirm the Premium Analytics PHP test suite passes.
* With Jetpack and Premium Analytics active on a local test site, open wp-admin while logged in as an administrator.
* In the browser console, fetch the sections and confirm the traffic section includes `layout` and `hasCustomLayout`:

```js
await window.wp.apiFetch( {
	path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections',
} );
```

* Persist a custom layout for the traffic section:

```js
await window.wp.apiFetch( {
	path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections/analytics/traffic/layout',
	method: 'PUT',
	data: {
		layout: [
			{
				uuid: 'manual-test-widget-instance',
				type: 'jpa/hello-world',
				placement: {
					width: 1,
					height: 1,
					order: 0,
				},
			},
		],
	},
} );
```

* Fetch the sections again and confirm `analytics/traffic` now has `hasCustomLayout: true` and returns the custom `manual-test-widget-instance` layout.
* Reset just the traffic section layout:

```js
await window.wp.apiFetch( {
	path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections/analytics/traffic/layout',
	method: 'DELETE',
} );
```

* Fetch the sections again and confirm `analytics/traffic` has `hasCustomLayout: false` and its default layout is restored.
* Persist one or more custom section layouts again, then reset all section layouts for the dashboard:

```js
await window.wp.apiFetch( {
	path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections',
	method: 'DELETE',
} );
```

* Fetch the sections one more time and confirm every returned section has `hasCustomLayout: false`.
* Note: `pnpm jetpack phan packages/premium-analytics --allow-polyfill-parser` was attempted and still reports the existing package-wide PHPUnit/test-stub issues noted on the foundation branch.
