### PR TITLE
ci: Avoid concurrent update-jetpack-staging-sites.yml runs

### DIFF
--- a/.github/workflows/update-jetpack-staging-sites.yml
+++ b/.github/workflows/update-jetpack-staging-sites.yml
@@ -9,6 +9,10 @@ permissions:
   # actions/checkout
   contents: read
 
+concurrency:
+  group: update-jetpack-staging-sites-all
+  cancel-in-progress: true
+
 jobs:
   run_shell_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Each run just updates the staging sites to trunk anyway. Use GitHub's concurrency to make sure only one runs at a time.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1783097911424419-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷