### PR TITLE
Forms: prevent mobile keyboard from opening on the date field

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-datepicker-mobile-keyboard
+++ b/projects/packages/forms/changelog/fix-forms-datepicker-mobile-keyboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date field: prevent the on-screen keyboard from appearing on mobile when tapping the date picker; show the date picker instead.

--- a/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
@@ -16,7 +16,15 @@ const views = {
 };
 
 function isMobileDevice() {
-	return /iPhone|iPad|iPod|Android/i.test( navigator.userAgent );
+	if ( /iPhone|iPad|iPod|Android/i.test( navigator.userAgent ) ) {
+		return true;
+	}
+
+	// iPadOS 13+ Safari requests desktop sites by default and reports a
+	// "Macintosh" user agent, so the check above misses it. A real Mac reports
+	// maxTouchPoints of 0, while an iPad reports a positive value — use that to
+	// detect touch-only iPads and still suppress the on-screen keyboard.
+	return /Macintosh/.test( navigator.userAgent ) && navigator.maxTouchPoints > 1;
 }
 
 function setReadonly( input: HTMLInputElement ) {
@@ -117,7 +125,10 @@ export default function BaseMode(
 			if ( becauseOfBlur && dp.shouldFocusOnBlur ) {
 				focusInput( input );
 			}
-			input.readOnly = false;
+			// Restore the device-appropriate read-only state: editable on
+			// desktop (so users can type), read-only on touch devices (so a
+			// re-focus after close does not pop the on-screen keyboard).
+			setReadonly( input );
 
 			// When we close, the input often gains refocus, which
 			// can then launch the date picker again, so we buffer
@@ -166,6 +177,12 @@ export default function BaseMode(
 	} as IDatePicker;
 
 	detatchInputEvents = attachInputEvents( input, dp );
+
+	// Apply the read-only state up front so that on touch devices the very
+	// first tap opens the date picker without triggering the on-screen
+	// keyboard. Doing this only on open() is too late: the input has already
+	// received focus by then and the keyboard has appeared.
+	setReadonly( input );
 
 	// Builds the initial view state
 	// selectedDate is a special case and causes changes to highlightedDate

--- a/projects/packages/forms/tests/js/contact-form/date-picker.test.js
+++ b/projects/packages/forms/tests/js/contact-form/date-picker.test.js
@@ -1,0 +1,130 @@
+/**
+ * Tests for the contact form date picker's mobile keyboard behavior.
+ *
+ * On mobile, tapping the date field should open the date picker without
+ * triggering the on-screen keyboard. We achieve this by marking the input
+ * read-only on touch devices, which suppresses the virtual keyboard while
+ * still allowing the field to receive focus and open the picker.
+ */
+import { DatePicker } from '../../../src/contact-form/libs/date-picker/date-picker.ts';
+
+const MOBILE_UA =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const DESKTOP_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+// iPadOS 13+ Safari requests desktop sites by default, reporting a "Macintosh"
+// user agent that is indistinguishable from a Mac except for maxTouchPoints.
+const IPADOS_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+
+/**
+ * Override the navigator user agent so isMobileDevice() can be exercised.
+ *
+ * @param {string} ua - The user agent string to report.
+ */
+function setUserAgent( ua ) {
+	Object.defineProperty( window.navigator, 'userAgent', {
+		value: ua,
+		configurable: true,
+	} );
+}
+
+/**
+ * Override navigator.maxTouchPoints to emulate touch vs non-touch hardware.
+ *
+ * @param {number} points - The number of simultaneous touch points to report.
+ */
+function setMaxTouchPoints( points ) {
+	Object.defineProperty( window.navigator, 'maxTouchPoints', {
+		value: points,
+		configurable: true,
+	} );
+}
+
+/**
+ * Create a contact form date input attached to the document body.
+ *
+ * @return {HTMLInputElement} The date input element.
+ */
+function createInput() {
+	const input = document.createElement( 'input' );
+	input.type = 'text';
+	input.className = 'jp-contact-form-date';
+	document.body.appendChild( input );
+	return input;
+}
+
+describe( 'contact form date picker', () => {
+	let picker;
+	let input;
+
+	afterEach( () => {
+		picker?.destroy();
+		picker = undefined;
+		input?.remove();
+		input = undefined;
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'on mobile devices', () => {
+		beforeEach( () => {
+			setUserAgent( MOBILE_UA );
+			setMaxTouchPoints( 5 );
+			input = createInput();
+		} );
+
+		it( 'marks the input read-only on init so the first tap does not open the keyboard', () => {
+			picker = DatePicker( input, {} );
+
+			expect( input.readOnly ).toBe( true );
+		} );
+
+		it( 'keeps the input read-only after opening and closing the picker', () => {
+			picker = DatePicker( input, {} );
+
+			picker.open();
+			picker.close();
+
+			expect( input.readOnly ).toBe( true );
+		} );
+	} );
+
+	describe( 'on iPadOS (desktop-class Safari user agent)', () => {
+		beforeEach( () => {
+			// iPadOS reports a Macintosh UA but, unlike a real Mac, exposes
+			// touch points. The field must still be treated as mobile.
+			setUserAgent( IPADOS_UA );
+			setMaxTouchPoints( 5 );
+			input = createInput();
+		} );
+
+		it( 'marks the input read-only on init despite the desktop-class user agent', () => {
+			picker = DatePicker( input, {} );
+
+			expect( input.readOnly ).toBe( true );
+		} );
+	} );
+
+	describe( 'on desktop devices', () => {
+		beforeEach( () => {
+			setUserAgent( DESKTOP_UA );
+			setMaxTouchPoints( 0 );
+			input = createInput();
+		} );
+
+		it( 'leaves the input editable on init so users can type a date', () => {
+			picker = DatePicker( input, {} );
+
+			expect( input.readOnly ).toBe( false );
+		} );
+
+		it( 'keeps the input editable after opening and closing the picker', () => {
+			picker = DatePicker( input, {} );
+
+			picker.open();
+			picker.close();
+
+			expect( input.readOnly ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes DSGCOM-548

## Proposed changes

On touch devices, tapping the Forms **Date field** opened the on-screen keyboard instead of (or on top of) the date picker. The picker is the only intended input on mobile, so the keyboard is unwanted noise.

Root cause: the date picker's `setReadonly()` helper (read-only inputs are focusable but don't summon the virtual keyboard) was only applied inside `open()` — which runs *after* the input has already been focused and the keyboard has appeared — and `close()` unconditionally reset the input back to editable.

Changes in `packages/forms` `date-picker/mode/base-mode.ts`:

* Apply the device-appropriate read-only state **at initialization**, so on touch devices the very first tap opens the picker without the keyboard.
* `close()` now restores state via `setReadonly()` instead of hardcoding `readOnly = false`, so mobile stays read-only across open/close cycles while desktop stays editable (typing a date still works).
* Harden mobile detection: iPadOS 13+ Safari reports a `Macintosh` user agent, so it's now also detected via `navigator.maxTouchPoints`. Without this the fix never engaged on iPad.

Added JS unit tests covering mobile, iPadOS (desktop-class UA), and desktop behavior on init and across open/close.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Add a **Form** block containing a **Date** field to a page and publish it.
* On a **mobile device** (or a real device — a desktop browser has no virtual keyboard to observe), open the published page and tap the date field.
  * **Expected:** the calendar date picker opens and **no on-screen keyboard appears**.
  * Pick a date, confirm it fills the field, submit the form, and confirm the value is saved (read-only inputs still submit).
* On **iPad** specifically, confirm the same (this is the case the UA-only check used to miss).
* On **desktop**, open the page and click the date field: the picker opens **and** you can still type a date manually.

<!-- Note for testers on a Jurassic Ninja / Atomic site: wp-content assets are served through a 10-year edge cache; after deploying, purge it (`wp edge-cache purge --domain=<domain>`) and load the page in a private/incognito tab so the device fetches the fresh bundle. -->
