### PR TITLE
VideoPress: Allow presentation in player iframes

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-presentation-allow
+++ b/projects/packages/videopress/changelog/add-videopress-presentation-allow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add presentation to the player iframe allow list to enable casting from embeds

--- a/projects/packages/videopress/changelog/add-videopress-presentation-allow
+++ b/projects/packages/videopress/changelog/add-videopress-presentation-allow
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add presentation to the player iframe allow list to enable casting from embeds
+Add presentation to the player iframe allow list to enable casting from embeds.

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -126,7 +126,7 @@ class Block_Editor_Content {
 					'title="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
 					'aria-label="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
 					'src="%s" ' .
-					'width="%s"' .
+					'width="%s" ' .
 					'height="%s" ' .
 					'frameborder="0" ' .
 					'allowfullscreen%s allow="clipboard-write; presentation">' .

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -129,7 +129,7 @@ class Block_Editor_Content {
 					'width="%s"' .
 					'height="%s" ' .
 					'frameborder="0" ' .
-					'allowfullscreen%s allow="clipboard-write">' .
+					'allowfullscreen%s allow="clipboard-write; presentation">' .
 				'</iframe>' .
 			'</div>' .
 		'</figure>';

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -350,7 +350,7 @@ class Initializer {
 				}
 
 				return sprintf(
-					'<iframe title="%1$s" aria-label="%1$s" src="%2$s" width="640" height="360" allowfullscreen data-resize-to-parent="true" allow="clipboard-write"></iframe>',
+					'<iframe title="%1$s" aria-label="%1$s" src="%2$s" width="640" height="360" allowfullscreen data-resize-to-parent="true" allow="clipboard-write; presentation"></iframe>',
 					esc_attr__( 'VideoPress Video Player', 'jetpack-videopress-pkg' ),
 					esc_url( preg_replace( '#/v/#', '/embed/', $url, 1 ) )
 				);

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -107,7 +107,7 @@ class Initializer_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( 'allowfullscreen', $html );
 		$this->assertStringContainsString( 'data-resize-to-parent="true"', $html );
-		$this->assertStringContainsString( 'allow="clipboard-write"', $html );
+		$this->assertStringContainsString( 'allow="clipboard-write; presentation"', $html );
 		$this->assertStringContainsString( 'width="640"', $html );
 		$this->assertStringContainsString( 'height="360"', $html );
 	}

--- a/projects/plugins/jetpack/changelog/add-videopress-presentation-allow
+++ b/projects/plugins/jetpack/changelog/add-videopress-presentation-allow
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-VideoPress: Add presentation to the player iframe allow list to enable casting from embeds
+VideoPress: Add presentation to the player iframe allow list to enable casting from embeds.

--- a/projects/plugins/jetpack/changelog/add-videopress-presentation-allow
+++ b/projects/plugins/jetpack/changelog/add-videopress-presentation-allow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Add presentation to the player iframe allow list to enable casting from embeds

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -723,7 +723,7 @@ class VideoPress_Player {
 				. "' src='" . esc_attr( $iframe_url )
 				. "' frameborder='0' allowfullscreen"
 				. $cover
-				. " allow='clipboard-write'></iframe>";
+				. " allow='clipboard-write; presentation'></iframe>";
 
 		} else {
 			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -57,13 +57,13 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 				array(
 					'cover' => true,
 				),
-				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=1&amp;hd=0' frameborder='0' allowfullscreen data-resize-to-parent=\"true\" allow='clipboard-write'></iframe>",
+				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=1&amp;hd=0' frameborder='0' allowfullscreen data-resize-to-parent=\"true\" allow='clipboard-write; presentation'></iframe>",
 			),
 			'cover_disabled' => array(
 				array(
 					'cover' => false,
 				),
-				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=0&amp;hd=0' frameborder='0' allowfullscreen allow='clipboard-write'></iframe>",
+				"<iframe title='VideoPress Video Player' aria-label='VideoPress Video Player' width='0' height='0' src='https://videopress.com/embed/testguid?cover=0&amp;hd=0' frameborder='0' allowfullscreen allow='clipboard-write; presentation'></iframe>",
 			),
 		);
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Adds `presentation` to the `allow` list of every VideoPress player iframe this repo generates, so the player can use the Presentation API for Chromecast casting when embedded in an iframe (companion to Automattic/videopress#1361).
* Updated iframes: the `videopress/video` block's oEmbed fallback iframe (`class-initializer.php`), the block content renderer (`class-block-editor-content.php`), and the legacy `[videopress]`/`[wpvideo]` shortcode player (`class.videopress-player.php`).
* Updates the corresponding assertions in `Initializer_Test` and `VideoPress_Player_Test`.

## Related product discussion/links
* Automattic/videopress#1361

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* With a build of Automattic/videopress#1361 serving the player, embed a VideoPress video on a page via the VideoPress video block and via the legacy `[videopress <guid>]` shortcode.
* View the page source and confirm the player iframes include `presentation` in their `allow` attribute.
* On a Chromecast-capable network in Chrome, confirm the cast button in the player works inside the embedded iframe.
* Run the unit tests: `composer phpunit -- --filter Initializer_Test` in `projects/packages/videopress` and `--filter VideoPress_Player_Test` in `projects/plugins/jetpack`.



https://claude.ai/code/session_01MDh3gtYSrZ5xSzq9GhaNaF
