### PR TITLE
Write: add anon funnel Tracks events + is_anon on editor open

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-anon-funnel-events
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-anon-funnel-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: add anon funnel Tracks events (write-start, publish-click) and an is_anon flag on editor open, for the Write On Phase 1 fake-door funnel.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -37,6 +37,48 @@ function isAnon() {
 	return typeof window !== 'undefined' && window.wpcomWriteIsAnon === true;
 }
 
+// Approximates the anon editor open — the module loads immediately after the
+// server rendered the page (and fired `wpcom_write_editor_open`). Used as the
+// baseline for `time_to_publish_ms` on the anon publish-click event.
+const ANON_EDITOR_OPENED_AT = typeof Date !== 'undefined' ? Date.now() : 0;
+
+// Guards `wpcom_write_editor_anon_write_start` to once per session.
+let anonWriteStartTracked = false;
+
+/**
+ * Fire a client-side Tracks event via the `_tkq` queue. Anon callers share the
+ * `tk_ai` cookie, so these stitch to the eventual user at signup completion.
+ *
+ * @param {string} name    - Tracks event name.
+ * @param {object} [props] - Optional event properties.
+ */
+function recordTracksEvent( name, props ) {
+	try {
+		window._tkq = window._tkq || [];
+		window._tkq.push( [ 'recordEvent', name, props || {} ] );
+	} catch {
+		// Tracks unavailable — nothing useful to do; swallow.
+	}
+}
+
+/**
+ * Fire `wpcom_write_editor_anon_write_start` once, the first time an anon
+ * visitor types real content. Keeps the funnel's write-through step honest —
+ * an empty editor that's opened and abandoned shouldn't count as a write.
+ *
+ * @param {string} text - Current plain-text content of the editor.
+ */
+function maybeTrackAnonWriteStart( text ) {
+	if ( anonWriteStartTracked || ! isAnon() ) {
+		return;
+	}
+	if ( ! text || ! text.trim() ) {
+		return;
+	}
+	anonWriteStartTracked = true;
+	recordTracksEvent( 'wpcom_write_editor_anon_write_start' );
+}
+
 /**
  * Persist the current draft snapshot to localStorage under the anon key.
  *
@@ -3673,6 +3715,12 @@ const { state } = store( 'wpcom-write', {
 			promoteGapAtCursor();
 			ensureBlockStructure();
 			pushToUndoHistoryDebounced();
+
+			// First real keystroke in the anon funnel — fires once per session.
+			if ( isAnon() && ! anonWriteStartTracked ) {
+				const contentEl = getContent();
+				maybeTrackAnonWriteStart( contentEl ? contentEl.textContent : '' );
+			}
 		},
 
 		undo() {
@@ -5782,6 +5830,22 @@ const { state } = store( 'wpcom-write', {
 
 		async publish() {
 			if ( isAnon() ) {
+				// The publish-intent event — the moment an anon visitor hits the
+				// signup wall. Captured before navigating away so it isn't lost to
+				// the handoff. word_count / draft_size_bytes size the draft; the
+				// server open event and this share the tk_ai identity for stitching.
+				const contentEl = getContent();
+				const rawHtml = contentEl ? contentEl.innerHTML : '';
+				const plainText = contentEl ? contentEl.textContent || '' : '';
+				const words = plainText.trim() ? plainText.trim().split( /\s+/ ).length : 0;
+				const draftContent = rawHtml ? convertToBlocks( rawHtml ) : '';
+				recordTracksEvent( 'wpcom_write_editor_anon_publish_click', {
+					word_count: words,
+					time_to_publish_ms: Date.now() - ANON_EDITOR_OPENED_AT,
+					draft_size_bytes:
+						typeof Blob !== 'undefined' ? new Blob( [ draftContent ] ).size : draftContent.length,
+				} );
+
 				// Flush the latest draft snapshot before navigating — autosave is
 				// on a 30s tick, and a fast typer-then-clicker would otherwise
 				// hand off stale (or no) content to the signup flow.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3500,6 +3500,13 @@ const { state } = store( 'wpcom-write', {
 			el.ref.style.height = 'auto';
 			el.ref.style.height = el.ref.scrollHeight + 'px';
 
+			// Typing a title counts as the first anon write too — the title field
+			// binds to this action rather than repairStructure, so hook it here so
+			// a title-only author still registers a write-start before publish.
+			if ( isAnon() && ! anonWriteStartTracked ) {
+				maybeTrackAnonWriteStart( state.title );
+			}
+
 			// Dismiss the recovery banner once the user starts editing.
 			if ( state.showRecoveryBanner ) {
 				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -61,6 +61,43 @@ function recordTracksEvent( name, props ) {
 	}
 }
 
+// How long to let a Tracks pixel leave the browser before a redirect. wpcom's
+// Tracks client sends via `new Image()`, and the browser cancels in-flight
+// image GETs on unload — so an event fired immediately before navigation can be
+// dropped. 250ms is imperceptible ahead of a full-page handoff to the signup
+// flow, and well within the round-trip a fire-and-forget pixel needs.
+const TRACKS_BEACON_FLUSH_MS = 250;
+
+/**
+ * Fire a Tracks event, then resolve once the pixel has had time to leave the
+ * browser — for events recorded immediately before navigating away (e.g. the
+ * anon publish handoff), where a synchronous redirect would otherwise cancel
+ * the in-flight `new Image()` beacon. Best-effort and bounded: if the Tracks
+ * client hasn't upgraded the queue (nothing will send), it resolves at once so
+ * the handoff is never delayed for a beacon that won't fire.
+ *
+ * @param {string} name    - Tracks event name.
+ * @param {object} [props] - Optional event properties.
+ * @return {Promise<void>} Resolves when it is safe to navigate.
+ */
+function recordTracksEventBeforeUnload( name, props ) {
+	recordTracksEvent( name, props );
+
+	// The real Tracks client replaces `_tkq.push`; until it does, pushes just
+	// pile up in a plain array and no pixel is sent, so there's nothing to wait
+	// for. (This is exactly the pre-loader state we saw on the anon surface.)
+	const tracksActive =
+		typeof window !== 'undefined' && !! window._tkq && window._tkq.push !== Array.prototype.push;
+
+	if ( ! tracksActive || typeof setTimeout === 'undefined' ) {
+		return Promise.resolve();
+	}
+
+	return new Promise( resolve => {
+		setTimeout( resolve, TRACKS_BEACON_FLUSH_MS );
+	} );
+}
+
 /**
  * Fire `wpcom_write_editor_anon_write_start` once, the first time an anon
  * visitor types real content. Keeps the funnel's write-through step honest —
@@ -5846,12 +5883,6 @@ const { state } = store( 'wpcom-write', {
 				const plainText = contentEl ? contentEl.textContent || '' : '';
 				const words = plainText.trim() ? plainText.trim().split( /\s+/ ).length : 0;
 				const draftContent = rawHtml ? convertToBlocks( rawHtml ) : '';
-				recordTracksEvent( 'wpcom_write_editor_anon_publish_click', {
-					word_count: words,
-					time_to_publish_ms: Date.now() - ANON_EDITOR_OPENED_AT,
-					draft_size_bytes:
-						typeof Blob !== 'undefined' ? new Blob( [ draftContent ] ).size : draftContent.length,
-				} );
 
 				// Flush the latest draft snapshot before navigating — autosave is
 				// on a 30s tick, and a fast typer-then-clicker would otherwise
@@ -5861,6 +5892,18 @@ const { state } = store( 'wpcom-write', {
 				// Suppress the dirty-state leave prompt the way every other
 				// internal navigation in this file does (cf. openInBlockEditor).
 				allowLeave = true;
+
+				// Record publish-intent and let the pixel dispatch before the
+				// redirect. wpcom Tracks beacons via `new Image()`, whose in-flight
+				// GET the browser cancels on unload — so a synchronous navigate
+				// would drop this event. The wait is bounded (and skipped entirely
+				// when Tracks isn't loaded) so the handoff is never stalled.
+				await recordTracksEventBeforeUnload( 'wpcom_write_editor_anon_publish_click', {
+					word_count: words,
+					time_to_publish_ms: Date.now() - ANON_EDITOR_OPENED_AT,
+					draft_size_bytes:
+						typeof Blob !== 'undefined' ? new Blob( [ draftContent ] ).size : draftContent.length,
+				} );
 
 				// Anon visitors hand off to the signup flow, which reads the draft
 				// from localStorage and publishes after signup completes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -817,6 +817,11 @@ function wpcom_write_render_admin_page() {
 		$event_props = array(
 			'is_new_post' => (int) ( 0 === $edit_post_id ),
 			'source'      => $source,
+			// Anon entry is the only logged-out render of this editor (the wp-admin
+			// page requires auth), so logged-out is a reliable proxy for the anon
+			// fake-door funnel. Lets the funnel scope its top-of-funnel denominator
+			// to anon traffic without depending on the client-only wpcomWriteIsAnon flag.
+			'is_anon'     => (int) ! is_user_logged_in(),
 		);
 
 		if ( $edit_post_id > 0 ) {


### PR DESCRIPTION
Fixes READ-560

## Proposed changes
Adds the two funnel events that were missing between "land in the editor" and "enter signup" for the logged-out Write editor, plus a flag so the top-of-funnel open event can be scoped to anon traffic.

* **`wpcom_write_editor_anon_write_start`** — fires once per session on the first real keystroke in the anon editor. Guarded on non-empty text so an opened-then-abandoned empty editor doesn't count as a write.
* **`wpcom_write_editor_anon_publish_click`** — fires when a logged-out visitor hits the signup wall at Publish, captured before the handoff navigation so it isn't lost. Props: `word_count`, `time_to_publish_ms` (from editor open), `draft_size_bytes`.
* **`is_anon`** added to the existing server-side `wpcom_write_editor_open` event, as `(int) ! is_user_logged_in()` — the wp-admin editor page requires auth, so a logged-out render is a reliable proxy for the anon entry point, and it doesn't depend on the client-only `wpcomWriteIsAnon` flag.

Both JS events go through the `_tkq` queue and share the `tk_ai` cookie, so they attribute to the anon visitor and stitch to the new user at signup completion. They follow the same pattern as the existing `wpcom_write_editor_anon_draft_persist_failed` event.

## Related product discussion/links
* READ-560

## Does this pull request change what data or activity we track or use?
Yes — adds three Tracks events/props for the logged-out Write editor funnel: `wpcom_write_editor_anon_write_start`, `wpcom_write_editor_anon_publish_click` (`word_count`, `time_to_publish_ms`, `draft_size_bytes`), and an `is_anon` flag on the existing `wpcom_write_editor_open`. These are UI-interaction/counting events plus draft size; no new personal data is collected. Adding the "[Status] Needs Privacy Updates" label for review.

## Testing instructions
The anon events only fire on the logged-out Write editor entry point (where the host page sets `window.wpcomWriteIsAnon = true`), which is a wpcom-side surface — full live verification happens there.

Behaviour to confirm (with `window.wpcomWriteIsAnon = true` set before the module loads, watching `pixel.wp.com` requests in the Network panel):

* Open the editor, type into the content area → exactly one `wpcom_write_editor_anon_write_start` fires, on the first keystroke (not again on later keystrokes, not on an empty editor).
* Click Publish → one `wpcom_write_editor_anon_publish_click` with sensible `word_count`, a positive `time_to_publish_ms`, and a non-zero `draft_size_bytes`, immediately before the redirect to the signup flow.
* Load the editor logged out and logged in → `wpcom_write_editor_open` carries `is_anon: 1` and `is_anon: 0` respectively.

Note: `view.js` has no JS unit-test harness (the existing anon events are covered the same way), and the server-side Tracks call has no test seam, so this relies on the manual walk above; the live Trino stitch/funnel verification is tracked as follow-up in READ-560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)