### PR TITLE
pr-is-up-to-date: Work around a new git bug

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-git-bug
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-git-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Work around a new `git` bug that results in "fatal: error in object: unshallow <sha>" errors.

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -84,6 +84,13 @@ function git_clean_shallow {
 	for REV in "${REVS[@]}"; do
 		# Read parents. If any are missing, put the rev back in .git/shallow. If not all are missing, queue the missing ones to be fetched.
 		mapfile -t PP < <(/usr/bin/git rev-parse "$REV^@" 2>/dev/null)
+
+		# It seems the file now starts containing refs that don't exist, which breaks later `git fetch --deepen=N` calls.
+		# `git rev-parse` returns the input in that case, so drop them.
+		if [[ "${PP[0]}" == "$REV^@" ]]; then
+			continue
+		fi
+
 		PPM=()
 		for P in "${PP[@]}"; do
 			if ! /usr/bin/git cat-file -e "$P" &>/dev/null; then


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Today we started seeing processes fail with an error

    fatal: error in object: unshallow <sha>

It seems that git somehow is putting unfetched shas into `.git/shallow` and then choking on them when trying to deepen later. I don't know if the new bug is the putting or just the choking, but either way we can avoid it by filtering those out.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷