### PR TITLE
Forms: don't load legacy dashboard bundle on the wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-drop-legacy-bundle
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-drop-legacy-bundle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: stop loading the unused legacy dashboard SPA bundle on the new (wp-build) Forms dashboard, removing a large amount of unnecessary JavaScript from the page.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -280,23 +280,36 @@ class Dashboard {
 			return;
 		}
 
-		Assets::register_script(
-			self::SCRIPT_HANDLE,
-			'../../dist/dashboard/jetpack-forms-dashboard.js',
-			__FILE__,
-			array(
-				'in_footer'  => true,
-				'textdomain' => 'jetpack-forms',
-				'enqueue'    => true,
-			)
-		);
+		// The wp-build (script-module) dashboard renders its own UI from build/pages/…,
+		// so the legacy SPA bundle is dead weight there. Only enqueue it on the legacy
+		// dashboard. The shared inline data below (connection initial state + REST
+		// preload) is instead attached to the always-present wp-api-fetch handle so the
+		// wp-build app still receives it.
+		if ( self::is_wp_build_dashboard_page() ) {
+			$inline_handle    = 'wp-api-fetch';
+			$preload_position = 'after';
+		} else {
+			$inline_handle    = self::SCRIPT_HANDLE;
+			$preload_position = 'before';
+
+			Assets::register_script(
+				self::SCRIPT_HANDLE,
+				'../../dist/dashboard/jetpack-forms-dashboard.js',
+				__FILE__,
+				array(
+					'in_footer'  => true,
+					'textdomain' => 'jetpack-forms',
+					'enqueue'    => true,
+				)
+			);
+		}
 
 		if ( Contact_Form_Plugin::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
 
 		// Adds Connection package initial state.
-		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
+		Connection_Initial_State::render_script( $inline_handle );
 
 		// Preload Forms endpoints needed in dashboard context.
 		// Pre-fetch the first inbox page so the UI renders instantly on first load.
@@ -364,13 +377,28 @@ class Dashboard {
 		}
 
 		wp_add_inline_script(
-			self::SCRIPT_HANDLE,
+			$inline_handle,
 			sprintf(
 				'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
 				wp_json_encode( $preload_data, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 			),
-			'before'
+			$preload_position
 		);
+	}
+
+	/**
+	 * Whether the current request targets the wp-build (script-module) Forms dashboard,
+	 * as opposed to the legacy SPA dashboard.
+	 *
+	 * When true, the legacy dashboard bundle should not be enqueued: the wp-build page
+	 * (build/pages/jetpack-forms-responses/…) provides its own UI and asset loading.
+	 *
+	 * @return bool
+	 */
+	public static function is_wp_build_dashboard_page() {
+		/** This filter is documented in class-dashboard.php::init */
+		return apply_filters( 'jetpack_forms_alpha', true )
+			&& self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -232,6 +232,56 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The wp-build dashboard page is detected when the alpha flag is on and the
+	 * wp-build slug is requested (so the legacy SPA bundle is skipped there).
+	 */
+	public function test_is_wp_build_dashboard_page_true_on_wpbuild_slug() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+
+		$this->assertTrue( Dashboard::is_wp_build_dashboard_page() );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+	}
+
+	/**
+	 * The legacy SPA bundle must still load when the alpha flag is off, even on the
+	 * wp-build slug (the cross-variant redirect sends the user to the legacy page).
+	 */
+	public function test_is_wp_build_dashboard_page_false_when_alpha_off() {
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+
+		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+	}
+
+	/**
+	 * The legacy dashboard slug is not treated as the wp-build page.
+	 */
+	public function test_is_wp_build_dashboard_page_false_on_legacy_slug() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+		$_GET['page'] = Dashboard::ADMIN_SLUG;
+
+		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+	}
+
+	/**
+	 * With no page requested, this is not the wp-build dashboard page.
+	 */
+	public function test_is_wp_build_dashboard_page_false_without_page() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+		unset( $_GET['page'] );
+
+		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+	}
+
+	/**
 	 * Test is_jetpack_forms_admin_page when get_current_screen is not available
 	 */
 	public function test_is_jetpack_forms_admin_page_no_get_current_screen() {


### PR DESCRIPTION
## Proposed changes

The new **wp-build (script-module) Forms dashboard** was also loading the **legacy SPA dashboard bundle** (`dist/dashboard/jetpack-forms-dashboard.js`) on every visit, even though the wp-build page renders its own UI and never uses it.

`Dashboard::load_admin_scripts()` enqueued that bundle whenever `is_jetpack_forms_admin_page()` was true — which matches **both** the legacy slug and the new wp-build slug (`jetpack-forms-responses-wp-admin`). So the browser downloaded and parsed ~2.4 MB of unused JavaScript (plus its CSS) on the modern dashboard.

This PR only enqueues the legacy bundle on the legacy dashboard. The two pieces of inline data that were attached to the legacy script handle — the **connection initial state** (used by the Google Drive export via `useConnection`) and the **REST preload middleware** (feedback list / counts / filters, so the table renders without a round-trip) — are re-homed to the always-present `wp-api-fetch` handle so the wp-build app still receives them.

### Measured impact (live JN site, Jetpack `16.0-a.7`, `/forms` + `/responses/inbox`)

| | Before | After | Δ |
|---|---|---|---|
| HTTP requests | 99 | 96 | −3 |
| Transferred (gzip) | 1.38 MB | 957 KB | **−433 KB (−31%)** |
| JS parsed (decoded) | 8.81 MB | 6.32 MB | **−2.49 MB (−28%)** |

This is the first of a set of Forms-dashboard load improvements; a follow-up will address the block editor (`editor.min.js`/`block-editor.min.js`) still loading eagerly on the list views.

## Does this pull request change what data or activity we track or use?

No. Tracking and connection initial state behave exactly as before; only the script handle they attach to changed on the wp-build page.

## Testing instructions

1. On a site running the wp-build Forms dashboard (default; `jetpack_forms_alpha` on), open **Jetpack → Forms**.
2. Open DevTools → Network, filter for `jetpack-forms-dashboard.js`.
   * **Before:** the ~433 KB `dist/dashboard/jetpack-forms-dashboard.js` (and its `.css`) load.
   * **After:** they no longer load.
3. Confirm the dashboard still works end-to-end:
   * The responses table renders (with preloaded data — no visible fetch delay for the first inbox page).
   * `window.JP_CONNECTION_INITIAL_STATE` is defined in the console.
   * **Export → Google Drive** (which relies on `useConnection`) still detects the connection.
4. Set `add_filter( 'jetpack_forms_alpha', '__return_false' );` to force the legacy dashboard and confirm `jetpack-forms-dashboard.js` **does** still load there (unchanged behavior).
