### PR TITLE
jetpack-mu-wpcom: add Stats link under Dashboard in site-name menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/sage-stats-287-stats-in-omnibar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/sage-stats-287-stats-in-omnibar
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a Stats link beneath Dashboard in the site-name admin bar menu
+Add a Stats link to the site-name admin bar menu, alongside Dashboard.

--- a/projects/packages/jetpack-mu-wpcom/changelog/sage-stats-287-stats-in-omnibar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/sage-stats-287-stats-in-omnibar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a Stats link beneath Dashboard in the site-name admin bar menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -497,13 +497,11 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
 
 /**
- * Adds a "Stats" link directly beneath "Dashboard" in the site-name submenu (STATS-287).
+ * Adds a "Stats" link to the site-name submenu, alongside "Dashboard" (STATS-287).
  *
  * Hooks `wp_before_admin_bar_render`, the last point before WP_Admin_Bar builds
  * its render tree, so core's `dashboard` node (added during `admin_bar_menu`) is
- * guaranteed to exist. Sibling order in the rendered menu follows the order
- * nodes were registered, and core exposes no public API to insert at a given
- * position, so the new node is spliced into place directly.
+ * guaranteed to exist.
  */
 function wpcom_add_stats_to_site_menu() {
 	global $wp_admin_bar;
@@ -525,21 +523,5 @@ function wpcom_add_stats_to_site_menu() {
 			'href'   => $stats_url,
 		)
 	);
-
-	$nodes_property = new ReflectionProperty( WP_Admin_Bar::class, 'nodes' );
-	$nodes_property->setAccessible( true );
-	$nodes = $nodes_property->getValue( $wp_admin_bar );
-
-	$stats = $nodes['wpcom-stats'];
-	unset( $nodes['wpcom-stats'] );
-
-	$reordered = array();
-	foreach ( $nodes as $id => $node ) {
-		$reordered[ $id ] = $node;
-		if ( 'dashboard' === $id ) {
-			$reordered['wpcom-stats'] = $stats;
-		}
-	}
-	$nodes_property->setValue( $wp_admin_bar, $reordered );
 }
 add_action( 'wp_before_admin_bar_render', 'wpcom_add_stats_to_site_menu' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -495,3 +495,51 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	}
 }
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
+
+/**
+ * Adds a "Stats" link directly beneath "Dashboard" in the site-name submenu (STATS-287).
+ *
+ * Hooks `wp_before_admin_bar_render`, the last point before WP_Admin_Bar builds
+ * its render tree, so core's `dashboard` node (added during `admin_bar_menu`) is
+ * guaranteed to exist. Sibling order in the rendered menu follows the order
+ * nodes were registered, and core exposes no public API to insert at a given
+ * position, so the new node is spliced into place directly.
+ */
+function wpcom_add_stats_to_site_menu() {
+	global $wp_admin_bar;
+
+	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) ) {
+		return;
+	}
+
+	$site_slug = wpcom_get_site_slug();
+	$stats_url = $site_slug
+		? 'https://wordpress.com/stats/day/' . $site_slug
+		: admin_url( 'admin.php?page=stats' );
+
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'site-name',
+			'id'     => 'wpcom-stats',
+			'title'  => __( 'Stats', 'jetpack-mu-wpcom' ),
+			'href'   => $stats_url,
+		)
+	);
+
+	$nodes_property = new ReflectionProperty( WP_Admin_Bar::class, 'nodes' );
+	$nodes_property->setAccessible( true );
+	$nodes = $nodes_property->getValue( $wp_admin_bar );
+
+	$stats = $nodes['wpcom-stats'];
+	unset( $nodes['wpcom-stats'] );
+
+	$reordered = array();
+	foreach ( $nodes as $id => $node ) {
+		$reordered[ $id ] = $node;
+		if ( 'dashboard' === $id ) {
+			$reordered['wpcom-stats'] = $stats;
+		}
+	}
+	$nodes_property->setValue( $wp_admin_bar, $reordered );
+}
+add_action( 'wp_before_admin_bar_render', 'wpcom_add_stats_to_site_menu' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -497,16 +497,17 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
 
 /**
- * Adds a "Stats" link to the site-name submenu, alongside "Dashboard" (STATS-287).
+ * Adds a "Stats" link to the site-name submenu, in both wp-admin and the
+ * front end (STATS-287).
  *
  * Hooks `wp_before_admin_bar_render`, the last point before WP_Admin_Bar builds
- * its render tree, so core's `dashboard` node (added during `admin_bar_menu`) is
+ * its render tree, so core's `site-name` node (added during `admin_bar_menu`) is
  * guaranteed to exist.
  */
 function wpcom_add_stats_to_site_menu() {
 	global $wp_admin_bar;
 
-	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) ) {
+	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'site-name' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -497,17 +497,16 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
 
 /**
- * Adds a "Stats" link to the site-name submenu, in both wp-admin and the
- * front end (STATS-287).
+ * Adds a "Stats" link to the site-name submenu, alongside "Dashboard" (STATS-287).
  *
  * Hooks `wp_before_admin_bar_render`, the last point before WP_Admin_Bar builds
- * its render tree, so core's `site-name` node (added during `admin_bar_menu`) is
+ * its render tree, so core's `dashboard` node (added during `admin_bar_menu`) is
  * guaranteed to exist.
  */
 function wpcom_add_stats_to_site_menu() {
 	global $wp_admin_bar;
 
-	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'site-name' ) ) {
+	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -506,21 +506,16 @@ add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
 function wpcom_add_stats_to_site_menu() {
 	global $wp_admin_bar;
 
-	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) ) {
+	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) || ! current_user_can( 'view_stats' ) ) {
 		return;
 	}
-
-	$site_slug = wpcom_get_site_slug();
-	$stats_url = $site_slug
-		? 'https://wordpress.com/stats/day/' . $site_slug
-		: admin_url( 'admin.php?page=stats' );
 
 	$wp_admin_bar->add_node(
 		array(
 			'parent' => 'site-name',
 			'id'     => 'wpcom-stats',
 			'title'  => __( 'Stats', 'jetpack-mu-wpcom' ),
-			'href'   => $stats_url,
+			'href'   => admin_url( 'admin.php?page=stats' ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -142,4 +142,104 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		}
 		$property->setValue( null, null );
 	}
+
+	/**
+	 * Builds an admin bar with a 'dashboard' child of 'site-name' (as core adds
+	 * on the front end) and fires `wp_before_admin_bar_render`, the hook our
+	 * Stats node listens on.
+	 */
+	private static function make_test_admin_bar_with_dashboard() {
+		global $wp_admin_bar;
+
+		$admin_bar = self::make_test_admin_bar();
+		$admin_bar->add_node(
+			array(
+				'id'    => 'site-name',
+				'title' => 'Test Site',
+			)
+		);
+		$admin_bar->add_node(
+			array(
+				'id'     => 'dashboard',
+				'parent' => 'site-name',
+				'title'  => 'Dashboard',
+				'href'   => 'https://example.com/wp-admin/',
+			)
+		);
+
+		$wp_admin_bar = $admin_bar;
+		do_action( 'wp_before_admin_bar_render' );
+
+		return $admin_bar;
+	}
+
+	/**
+	 * Clears the `$wp_admin_bar` global so it doesn't leak between tests.
+	 */
+	private static function reset_admin_bar_global(): void {
+		global $wp_admin_bar;
+		$wp_admin_bar = null;
+	}
+
+	/**
+	 * Forces `current_user_can( 'view_stats' )` to true for the test's duration.
+	 *
+	 * @param array $allcaps All capabilities of the user.
+	 * @return array
+	 */
+	public function grant_view_stats( $allcaps ) {
+		$allcaps['view_stats'] = true;
+		return $allcaps;
+	}
+
+	/**
+	 * Forces `current_user_can( 'view_stats' )` to false for the test's duration.
+	 *
+	 * @param array $allcaps All capabilities of the user.
+	 * @return array
+	 */
+	public function deny_view_stats( $allcaps ) {
+		$allcaps['view_stats'] = false;
+		return $allcaps;
+	}
+
+	public function test_stats_link_shown_when_user_can_view_stats() {
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_dashboard();
+		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+
+		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
+		self::reset_admin_bar_global();
+
+		$this->assertNotNull( $stats_node );
+		$this->assertSame( 'site-name', $stats_node->parent );
+		$this->assertSame( 'Stats', $stats_node->title );
+		$this->assertSame( admin_url( 'admin.php?page=stats' ), $stats_node->href );
+	}
+
+	public function test_stats_link_hidden_when_user_cannot_view_stats() {
+		add_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_dashboard();
+		remove_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
+
+		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
+		self::reset_admin_bar_global();
+
+		$this->assertNull( $stats_node );
+	}
+
+	public function test_stats_link_hidden_when_dashboard_node_absent() {
+		global $wp_admin_bar;
+
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar    = self::make_test_admin_bar();
+		$wp_admin_bar = $admin_bar;
+		do_action( 'wp_before_admin_bar_render' );
+		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+
+		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
+		self::reset_admin_bar_global();
+
+		$this->assertNull( $stats_node );
+	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/STATS-287

## Why
Matt pointed out that Stats should live in the omnibar (the site-name dropdown), alongside Dashboard, so people can jump to Stats without leaving the current page. It's labelled "Stats" for now and will be renamed to "Analytics" at launch.

## Proposed changes
* Add a `wpcom-stats` node to the `site-name` admin bar submenu, linking to `admin.php?page=stats`.
* Gated behind `current_user_can( 'view_stats' )` — the same capability used by every other Stats entry point — so it never shows to users who can't actually open Stats.
* Hooked on `wp_before_admin_bar_render` so core's `dashboard` node (added earlier during `admin_bar_menu`) is guaranteed to exist by the time we check for it. No-ops when `dashboard` isn't present (e.g. in wp-admin, where core shows "Visit Site" instead).

## Verification
* `phpcs`: 0 errors/warnings.
* New PHPUnit coverage in `WPCOM_Admin_Bar_Test.php`: node shown when the user can view stats, hidden when they can't, and hidden when the `dashboard` node isn't present.
* Note: `wpcom-admin-bar.php` is only loaded via `Jetpack_Mu_Wpcom::load_wpcom_user_features()`, gated behind `is_wpcom_user()` — this feature only runs for WordPress.com-connected users, so it can't be exercised end-to-end in a local, disconnected docker environment. Live verification to be done directly on WordPress.com.

<details>
<summary>phpunit output</summary>

```
OK (5 tests, 21 assertions)
```

</details>

## Related product discussion/links
* https://linear.app/a8c/issue/STATS-287

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Visit any front-end page while logged in as a user who can view Stats.
* Click the site name in the top-left of the admin bar.
* Confirm a "Stats" link now appears in the dropdown alongside "Dashboard", linking to `admin.php?page=stats`.
* Confirm the link does **not** appear for a user who can't view Stats, or in the wp-admin site-name dropdown (where "Dashboard" isn't shown).
