### PR TITLE
Podcast: save Pocket Casts show state on the submit

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-show-state
+++ b/projects/packages/podcast/changelog/fix-podcast-show-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast distribution: mirror the Pocket Casts submission verdict onto the local site options so the dashboard reflects show state on Jetpack/Atomic sites.

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -120,7 +120,7 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 	 *
 	 * @param mixed $data Decoded relay body.
 	 */
-	private function save_show_state( $data ): void {
+	protected function save_show_state( $data ): void {
 		$state = is_array( $data ) && isset( $data['state'] ) ? $data['state'] : '';
 
 		if ( ! in_array( $state, array( 'pending', 'active', 'rejected' ), true ) ) {

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -117,25 +117,23 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Mirror the Pocket Casts verdict from the relayed wpcom response onto the
-	 * local `podcasting_show_states` / `podcasting_show_urls` options.
-	 *
-	 * Writes raw partial patches keyed by `pocketcasts`; the registered
-	 * {@see Settings} sanitizers merge them into the stored maps without
-	 * disturbing the other podcatchers. `rejected` clears the entry.
+	 * Mirror the Pocket Casts verdict onto this site's local podcast options so
+	 * the dashboard reflects it (wpcom only persisted it to its own copy).
 	 *
 	 * @param mixed $data Decoded relay body.
 	 */
 	private function persist_distribution_state( $data ): void {
-		if ( ! is_array( $data ) || ! isset( $data['state'] )
-			|| ! in_array( $data['state'], array( 'pending', 'active', 'rejected' ), true ) ) {
+		$state = is_array( $data ) && isset( $data['state'] ) ? $data['state'] : '';
+
+		if ( ! in_array( $state, array( 'pending', 'active', 'rejected' ), true ) ) {
 			return;
 		}
 
-		$state = in_array( $data['state'], array( 'pending', 'active' ), true ) ? $data['state'] : '';
-		update_option( 'podcasting_show_states', array( 'pocketcasts' => $state ) );
+		// Partial patch: the registered Settings sanitizer merges it into the
+		// stored map, so the other podcatchers survive. 'rejected' clears it.
+		update_option( 'podcasting_show_states', array( 'pocketcasts' => 'rejected' === $state ? '' : $state ) );
 
-		if ( 'active' === $data['state'] && ! empty( $data['share_link'] ) && is_string( $data['share_link'] ) ) {
+		if ( 'active' === $state && ! empty( $data['share_link'] ) && is_string( $data['share_link'] ) ) {
 			update_option( 'podcasting_show_urls', array( 'pocketcasts' => $data['share_link'] ) );
 		}
 	}

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -107,8 +107,6 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 
 		$relayed = $this->relay_response( $response );
 
-		// wpcom persists the verdict to its own copy of the option, but the
-		// dashboard reads this site's local option, so mirror it here too.
 		if ( $relayed instanceof WP_REST_Response ) {
 			$this->save_show_state( $relayed->get_data() );
 		}
@@ -129,8 +127,6 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 			return;
 		}
 
-		// Partial patch: the registered Settings sanitizer merges it into the
-		// stored map, so the other podcatchers survive. 'rejected' clears it.
 		update_option( 'podcasting_show_states', array( 'pocketcasts' => 'rejected' === $state ? '' : $state ) );
 
 		if ( 'active' === $state && ! empty( $data['share_link'] ) && is_string( $data['share_link'] ) ) {

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -110,7 +110,7 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 		// wpcom persists the verdict to its own copy of the option, but the
 		// dashboard reads this site's local option, so mirror it here too.
 		if ( $relayed instanceof WP_REST_Response ) {
-			$this->store_show_state( $relayed->get_data() );
+			$this->save_show_state( $relayed->get_data() );
 		}
 
 		return $relayed;
@@ -122,7 +122,7 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 	 *
 	 * @param mixed $data Decoded relay body.
 	 */
-	private function store_show_state( $data ): void {
+	private function save_show_state( $data ): void {
 		$state = is_array( $data ) && isset( $data['state'] ) ? $data['state'] : '';
 
 		if ( ! in_array( $state, array( 'pending', 'active', 'rejected' ), true ) ) {

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -110,7 +110,7 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 		// wpcom persists the verdict to its own copy of the option, but the
 		// dashboard reads this site's local option, so mirror it here too.
 		if ( $relayed instanceof WP_REST_Response ) {
-			$this->persist_distribution_state( $relayed->get_data() );
+			$this->store_show_state( $relayed->get_data() );
 		}
 
 		return $relayed;
@@ -122,7 +122,7 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 	 *
 	 * @param mixed $data Decoded relay body.
 	 */
-	private function persist_distribution_state( $data ): void {
+	private function store_show_state( $data ): void {
 		$state = is_array( $data ) && isset( $data['state'] ) ? $data['state'] : '';
 
 		if ( ! in_array( $state, array( 'pending', 'active', 'rejected' ), true ) ) {

--- a/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-distribution-endpoint.php
@@ -105,6 +105,38 @@ class Podcast_Distribution_Endpoint extends WP_REST_Controller {
 			'wpcom'
 		);
 
-		return $this->relay_response( $response );
+		$relayed = $this->relay_response( $response );
+
+		// wpcom persists the verdict to its own copy of the option, but the
+		// dashboard reads this site's local option, so mirror it here too.
+		if ( $relayed instanceof WP_REST_Response ) {
+			$this->persist_distribution_state( $relayed->get_data() );
+		}
+
+		return $relayed;
+	}
+
+	/**
+	 * Mirror the Pocket Casts verdict from the relayed wpcom response onto the
+	 * local `podcasting_show_states` / `podcasting_show_urls` options.
+	 *
+	 * Writes raw partial patches keyed by `pocketcasts`; the registered
+	 * {@see Settings} sanitizers merge them into the stored maps without
+	 * disturbing the other podcatchers. `rejected` clears the entry.
+	 *
+	 * @param mixed $data Decoded relay body.
+	 */
+	private function persist_distribution_state( $data ): void {
+		if ( ! is_array( $data ) || ! isset( $data['state'] )
+			|| ! in_array( $data['state'], array( 'pending', 'active', 'rejected' ), true ) ) {
+			return;
+		}
+
+		$state = in_array( $data['state'], array( 'pending', 'active' ), true ) ? $data['state'] : '';
+		update_option( 'podcasting_show_states', array( 'pocketcasts' => $state ) );
+
+		if ( 'active' === $data['state'] && ! empty( $data['share_link'] ) && is_string( $data['share_link'] ) ) {
+			update_option( 'podcasting_show_urls', array( 'pocketcasts' => $data['share_link'] ) );
+		}
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Podcast_Distribution_Endpoint;
+use Automattic\Jetpack\Podcast\Settings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use ReflectionMethod;
+use WorDBless\BaseTestCase;
+
+/**
+ * Covers the local persistence the distribution proxy performs after relaying a
+ * Pocket Casts submission: the wpcom relay writes its own copy of the option,
+ * so the Jetpack side must mirror the verdict onto this site's local options or
+ * the dashboard (which reads them) stays empty.
+ *
+ * @covers \Automattic\Jetpack\Podcast\Podcast_Distribution_Endpoint
+ * @uses \Automattic\Jetpack\Podcast\Settings
+ */
+#[CoversClass( Podcast_Distribution_Endpoint::class )]
+#[UsesClass( Settings::class )]
+class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// The registered sanitize_callbacks are what merge partial patches into
+		// the stored maps, so persistence only behaves correctly once they exist.
+		Settings::register_settings();
+	}
+
+	protected function tearDown(): void {
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			delete_option( $name );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Invoke the private persist helper with a decoded relay body.
+	 *
+	 * @param mixed $data Relay body.
+	 */
+	private function persist( $data ): void {
+		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'persist_distribution_state' );
+		$method->invoke( new Podcast_Distribution_Endpoint(), $data );
+	}
+
+	public function test_active_persists_state_and_share_link() {
+		$this->persist(
+			array(
+				'state'      => 'active',
+				'share_link' => 'https://pca.st/abcd1234',
+			)
+		);
+
+		$this->assertSame( 'active', get_option( 'podcasting_show_states' )['pocketcasts'] );
+		$this->assertSame( 'https://pca.st/abcd1234', get_option( 'podcasting_show_urls' )['pocketcasts'] );
+	}
+
+	public function test_pending_persists_state_without_url() {
+		$this->persist( array( 'state' => 'pending' ) );
+
+		$this->assertSame( 'pending', get_option( 'podcasting_show_states' )['pocketcasts'] );
+		$this->assertArrayNotHasKey( 'pocketcasts', (array) get_option( 'podcasting_show_urls', array() ) );
+	}
+
+	public function test_rejected_clears_pocketcasts_but_preserves_other_podcatchers() {
+		update_option(
+			'podcasting_show_states',
+			array(
+				'apple'       => 'active',
+				'pocketcasts' => 'active',
+			)
+		);
+
+		$this->persist( array( 'state' => 'rejected' ) );
+
+		$states = get_option( 'podcasting_show_states' );
+		$this->assertArrayNotHasKey( 'pocketcasts', $states );
+		$this->assertSame( 'active', $states['apple'] );
+	}
+
+	public function test_pending_does_not_downgrade_an_active_state() {
+		update_option( 'podcasting_show_states', array( 'pocketcasts' => 'active' ) );
+
+		$this->persist( array( 'state' => 'pending' ) );
+
+		$this->assertSame( 'active', get_option( 'podcasting_show_states' )['pocketcasts'] );
+	}
+
+	public function test_disallowed_share_link_host_is_dropped() {
+		$this->persist(
+			array(
+				'state'      => 'active',
+				'share_link' => 'https://evil.example.com/abcd',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'pocketcasts', (array) get_option( 'podcasting_show_urls', array() ) );
+	}
+
+	/**
+	 * @param mixed $data Relay body that should not touch any option.
+	 */
+	#[DataProvider( 'provide_noop_bodies' )]
+	public function test_non_verdict_bodies_persist_nothing( $data ) {
+		$this->persist( $data );
+
+		$this->assertFalse( get_option( 'podcasting_show_states', false ) );
+		$this->assertFalse( get_option( 'podcasting_show_urls', false ) );
+	}
+
+	public static function provide_noop_bodies(): array {
+		return array(
+			'missing state'   => array( array( 'share_link' => 'https://pca.st/x' ) ),
+			'unknown state'   => array( array( 'state' => 'unreachable' ) ),
+			'string body'     => array( 'Bad Gateway' ),
+			'null body'       => array( null ),
+		);
+	}
+}

--- a/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
@@ -10,7 +10,6 @@ use Automattic\Jetpack\Podcast\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
-use ReflectionMethod;
 use WorDBless\BaseTestCase;
 
 /**
@@ -47,8 +46,12 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	 * @param mixed $data Relay body.
 	 */
 	private function save( $data ): void {
-		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'save_show_state' );
-		$method->invoke( new Podcast_Distribution_Endpoint(), $data );
+		$endpoint = new class() extends Podcast_Distribution_Endpoint {
+			public function save( $data ): void {
+				$this->save_show_state( $data );
+			}
+		};
+		$endpoint->save( $data );
 	}
 
 	public function test_active_persists_state_and_share_link() {

--- a/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
@@ -107,6 +107,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 
 	/**
 	 * @param mixed $data Relay body that should not touch any option.
+	 * @dataProvider provide_noop_bodies
 	 */
 	#[DataProvider( 'provide_noop_bodies' )]
 	public function test_non_verdict_bodies_persist_nothing( $data ) {
@@ -118,10 +119,10 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 
 	public static function provide_noop_bodies(): array {
 		return array(
-			'missing state'   => array( array( 'share_link' => 'https://pca.st/x' ) ),
-			'unknown state'   => array( array( 'state' => 'unreachable' ) ),
-			'string body'     => array( 'Bad Gateway' ),
-			'null body'       => array( null ),
+			'missing state' => array( array( 'share_link' => 'https://pca.st/x' ) ),
+			'unknown state' => array( array( 'state' => 'unreachable' ) ),
+			'string body'   => array( 'Bad Gateway' ),
+			'null body'     => array( null ),
 		);
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
@@ -42,17 +42,17 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Invoke the private persist helper with a decoded relay body.
+	 * Invoke the private store helper with a decoded relay body.
 	 *
 	 * @param mixed $data Relay body.
 	 */
-	private function persist( $data ): void {
-		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'persist_distribution_state' );
+	private function store( $data ): void {
+		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'store_show_state' );
 		$method->invoke( new Podcast_Distribution_Endpoint(), $data );
 	}
 
 	public function test_active_persists_state_and_share_link() {
-		$this->persist(
+		$this->store(
 			array(
 				'state'      => 'active',
 				'share_link' => 'https://pca.st/abcd1234',
@@ -64,7 +64,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	}
 
 	public function test_pending_persists_state_without_url() {
-		$this->persist( array( 'state' => 'pending' ) );
+		$this->store( array( 'state' => 'pending' ) );
 
 		$this->assertSame( 'pending', get_option( 'podcasting_show_states' )['pocketcasts'] );
 		$this->assertArrayNotHasKey( 'pocketcasts', (array) get_option( 'podcasting_show_urls', array() ) );
@@ -79,7 +79,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 			)
 		);
 
-		$this->persist( array( 'state' => 'rejected' ) );
+		$this->store( array( 'state' => 'rejected' ) );
 
 		$states = get_option( 'podcasting_show_states' );
 		$this->assertArrayNotHasKey( 'pocketcasts', $states );
@@ -89,13 +89,13 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	public function test_pending_does_not_downgrade_an_active_state() {
 		update_option( 'podcasting_show_states', array( 'pocketcasts' => 'active' ) );
 
-		$this->persist( array( 'state' => 'pending' ) );
+		$this->store( array( 'state' => 'pending' ) );
 
 		$this->assertSame( 'active', get_option( 'podcasting_show_states' )['pocketcasts'] );
 	}
 
 	public function test_disallowed_share_link_host_is_dropped() {
-		$this->persist(
+		$this->store(
 			array(
 				'state'      => 'active',
 				'share_link' => 'https://evil.example.com/abcd',
@@ -110,7 +110,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'provide_noop_bodies' )]
 	public function test_non_verdict_bodies_persist_nothing( $data ) {
-		$this->persist( $data );
+		$this->store( $data );
 
 		$this->assertFalse( get_option( 'podcasting_show_states', false ) );
 		$this->assertFalse( get_option( 'podcasting_show_urls', false ) );

--- a/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Distribution_Endpoint_Test.php
@@ -42,17 +42,17 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Invoke the private store helper with a decoded relay body.
+	 * Invoke the private save helper with a decoded relay body.
 	 *
 	 * @param mixed $data Relay body.
 	 */
-	private function store( $data ): void {
-		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'store_show_state' );
+	private function save( $data ): void {
+		$method = new ReflectionMethod( Podcast_Distribution_Endpoint::class, 'save_show_state' );
 		$method->invoke( new Podcast_Distribution_Endpoint(), $data );
 	}
 
 	public function test_active_persists_state_and_share_link() {
-		$this->store(
+		$this->save(
 			array(
 				'state'      => 'active',
 				'share_link' => 'https://pca.st/abcd1234',
@@ -64,7 +64,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	}
 
 	public function test_pending_persists_state_without_url() {
-		$this->store( array( 'state' => 'pending' ) );
+		$this->save( array( 'state' => 'pending' ) );
 
 		$this->assertSame( 'pending', get_option( 'podcasting_show_states' )['pocketcasts'] );
 		$this->assertArrayNotHasKey( 'pocketcasts', (array) get_option( 'podcasting_show_urls', array() ) );
@@ -79,7 +79,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 			)
 		);
 
-		$this->store( array( 'state' => 'rejected' ) );
+		$this->save( array( 'state' => 'rejected' ) );
 
 		$states = get_option( 'podcasting_show_states' );
 		$this->assertArrayNotHasKey( 'pocketcasts', $states );
@@ -89,13 +89,13 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	public function test_pending_does_not_downgrade_an_active_state() {
 		update_option( 'podcasting_show_states', array( 'pocketcasts' => 'active' ) );
 
-		$this->store( array( 'state' => 'pending' ) );
+		$this->save( array( 'state' => 'pending' ) );
 
 		$this->assertSame( 'active', get_option( 'podcasting_show_states' )['pocketcasts'] );
 	}
 
 	public function test_disallowed_share_link_host_is_dropped() {
-		$this->store(
+		$this->save(
 			array(
 				'state'      => 'active',
 				'share_link' => 'https://evil.example.com/abcd',
@@ -110,7 +110,7 @@ class Podcast_Distribution_Endpoint_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'provide_noop_bodies' )]
 	public function test_non_verdict_bodies_persist_nothing( $data ) {
-		$this->store( $data );
+		$this->save( $data );
 
 		$this->assertFalse( get_option( 'podcasting_show_states', false ) );
 		$this->assertFalse( get_option( 'podcasting_show_urls', false ) );


### PR DESCRIPTION
## Proposed changes

When you submit a podcast to Pocket Casts, the site needs to remember the result ("pending", "active", or "rejected") so the dashboard can show it.

* On **Simple** sites that already works — the save happens on wpcom, the same database the dashboard reads.
* On **Jetpack/Atomic** sites it didn't — the save landed in wpcom's database, but the dashboard reads this site's *own* database. Different box, so the dashboard stayed blank.

This teaches the Jetpack side to also write the result into the local site options, so the dashboard reflects it. The write reuses the existing settings sanitizers, so it safely patches just the Pocket Casts entry (keeps the other podcatchers, honors the "don't downgrade active → pending" rule).

## Testing instructions

Automated: `composer phpunit` in `projects/packages/podcast` — new `Podcast_Distribution_Endpoint_Test` covers active, pending, rejected, no-downgrade, bad host, and junk bodies.

Manual (on a Jetpack/Atomic site):

* Set a podcast category, then submit the show to Pocket Casts from the dashboard.
* Reload — the show state now appears (was blank before).
* `wp option get podcasting_show_states` shows the `pocketcasts` entry set locally.
