### PR TITLE
AI Launchpad: temporarily lift the paid-plan eligibility gate

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-497-ai-launchpad-remove-paid-requirement
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-497-ai-launchpad-remove-paid-requirement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: temporarily make it available on all plans, including free.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -67,7 +67,8 @@ class AI_Launchpad {
 	/**
 	 * Whether the current site is eligible for the AI Launchpad.
 	 *
-	 * Gate: paid plan, not already AI-onboarded, and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled` option.
+	 * Gate: not already AI-onboarded, and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled` option.
+	 * The paid-plan requirement is temporarily lifted (see below).
 	 *
 	 * @return bool
 	 */
@@ -75,28 +76,13 @@ class AI_Launchpad {
 		static $eligible = null;
 
 		if ( null === $eligible ) {
-			// Cheapest gate first: the per-site option disqualifies most sites before the more expensive purchases lookup.
+			// TEMPORARY: the paid-plan gate is lifted so the AI Launchpad is available on all plans, including free.
+			// Revert this commit to re-require a paid bundle (the removed has_paid_plan() check).
 			$eligible = self::is_enabled_for_site()
-				&& ! self::was_ai_onboarded()
-				&& self::has_paid_plan();
+				&& ! self::was_ai_onboarded();
 		}
 
 		return $eligible;
-	}
-
-	/**
-	 * Whether the site has a paid plan (bundle purchase).
-	 *
-	 * @return bool
-	 */
-	private static function has_paid_plan() {
-		if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
-			return false;
-		}
-
-		$bundles = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
-
-		return ! empty( $bundles );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
-use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -44,7 +43,6 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
-	 * @param bool $has_paid_plan    Whether the site owns a bundle purchase.
 	 * @param bool $was_ai_onboarded Whether the site already went through AI onboarding.
 	 * @param bool $enabled          Whether the site has the wpcom_ai_launchpad_enabled option set.
 	 * @param bool $expected         Expected eligibility result.
@@ -52,11 +50,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	#[DataProvider( 'provide_eligibility_inputs' )]
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_is_eligible( $has_paid_plan, $was_ai_onboarded, $enabled, $expected ) {
-		Functions\when( 'wpcom_get_site_purchases' )->justReturn(
-			$has_paid_plan ? array( (object) array( 'product_type' => 'bundle' ) ) : array()
-		);
-
+	public function test_is_eligible( $was_ai_onboarded, $enabled, $expected ) {
 		if ( $was_ai_onboarded ) {
 			update_option( 'site_intent', 'ai-assembler' );
 		}
@@ -70,14 +64,16 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Data provider for test_is_eligible.
 	 *
+	 * The paid-plan requirement is temporarily lifted, so eligibility depends only on
+	 * the per-site enabled option and the site not already being AI-onboarded.
+	 *
 	 * @return array
 	 */
 	public static function provide_eligibility_inputs() {
 		return array(
-			'paid + enabled'       => array( true, false, true, true ),
-			'paid + not enabled'   => array( true, false, false, false ),
-			'enabled but not paid' => array( false, false, true, false ),
-			'onboarded blocks'     => array( true, true, true, false ),
+			'enabled'          => array( false, true, true ),
+			'not enabled'      => array( false, false, false ),
+			'onboarded blocks' => array( true, true, false ),
 		);
 	}
 }


### PR DESCRIPTION
## Proposed changes

* Temporarily makes the AI Launchpad available on **all plans, including free**, by dropping the `has_paid_plan()` check from `AI_Launchpad::is_eligible()`.
* Eligibility now depends only on the per-site `wpcom_ai_launchpad_enabled` option and the site not already being AI-onboarded.
* Updates the eligibility unit test to match (the paid-plan dimension is removed).

This is intentionally a temporary change — reverting this commit restores the paid-bundle requirement.

## Related product discussion/links

* DOTOBRD-497

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a **free-plan** site (Simple or Atomic), set the per-site option: `wp option update wpcom_ai_launchpad_enabled 1`.
* Confirm the **Site Setup** item appears in the wp-admin menu and the AI Launchpad page loads — previously this required a paid bundle.
* Confirm a site that has already been AI-onboarded (`site_intent = ai-assembler` or `site_creation_flow = ai-site-builder`) is still **not** eligible.
* Confirm a site without the enabled option set is still **not** eligible.
* `cd projects/packages/jetpack-mu-wpcom && composer phpunit -- --filter AI_Launchpad_Eligibility_Test` passes.
