### PR TITLE
Connection: cache wpcom.getUser XML-RPC failures in get_connected_user_data()

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
+++ b/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: cache wpcom.getUser XML-RPC failures briefly in get_connected_user_data() so a failing request is not retried synchronously on every admin page load.

--- a/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
+++ b/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Connection: cache wpcom.getUser XML-RPC failures briefly in get_connected_user_data() so a failing request is not retried synchronously on every admin page load.
+Connection: cache wpcom.getUser XML-RPC failures briefly in get_connected_user_data().

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -868,6 +868,10 @@ class Manager {
 		$transient_key    = "jetpack_connected_user_data_$user_id";
 		$cached_user_data = get_transient( $transient_key );
 
+		if ( 'error' === $cached_user_data ) {
+			return false;
+		}
+
 		if ( $cached_user_data ) {
 			return $cached_user_data;
 		}
@@ -884,6 +888,11 @@ class Manager {
 			set_transient( $transient_key, $xml->getResponse(), DAY_IN_SECONDS );
 			return $user_data;
 		}
+
+		// Cache errors briefly so a failing remote request doesn't result in
+		// a blocking XML-RPC request on every call, e.g. on each admin page
+		// load via Initial_State::set_connection_script_data().
+		set_transient( $transient_key, 'error', 5 * MINUTE_IN_SECONDS );
 
 		return false;
 	}

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -443,6 +443,84 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * Test that `get_connected_user_data` caches XML-RPC failures so a failing
+	 * request is not repeated on every call.
+	 */
+	public function test_get_connected_user_data_caches_error_responses() {
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/' );
+		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
+		Jetpack_Options::update_option( 'id', 1234 );
+		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
+
+		$http_request_count = 0;
+		$intercept          = function () use ( &$http_request_count ) {
+			++$http_request_count;
+			return new WP_Error( 'http_request_failed', 'Request blocked in test.' );
+		};
+		add_filter( 'pre_http_request', $intercept );
+
+		try {
+			$manager = new Manager();
+
+			$this->assertFalse( $manager->get_connected_user_data( $this->user_id ) );
+			$this->assertSame( 1, $http_request_count );
+			$this->assertSame( 'error', get_transient( 'jetpack_connected_user_data_' . $this->user_id ) );
+
+			// A repeated call must not trigger another remote request.
+			$this->assertFalse( $manager->get_connected_user_data( $this->user_id ) );
+			$this->assertSame( 1, $http_request_count );
+		} finally {
+			remove_filter( 'pre_http_request', $intercept );
+		}
+	}
+
+	/**
+	 * Test that `get_connected_user_data` returns and caches the user data on success.
+	 */
+	public function test_get_connected_user_data_returns_and_caches_user_data() {
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/' );
+		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
+		Jetpack_Options::update_option( 'id', 1234 );
+		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
+
+		$body = '<?xml version="1.0"?><methodResponse><params><param><value><struct>'
+			. '<member><name>ID</name><value><int>7</int></value></member>'
+			. '<member><name>email</name><value><string>user@example.com</string></value></member>'
+			. '</struct></value></param></params></methodResponse>';
+
+		$http_request_count = 0;
+		$intercept          = function () use ( &$http_request_count, $body ) {
+			++$http_request_count;
+			return array(
+				'headers'  => array(),
+				'body'     => $body,
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $intercept );
+
+		try {
+			$manager   = new Manager();
+			$user_data = $manager->get_connected_user_data( $this->user_id );
+
+			$this->assertSame( 7, $user_data['ID'] );
+			$this->assertSame( 'user@example.com', $user_data['email'] );
+			$this->assertSame( $user_data, get_transient( 'jetpack_connected_user_data_' . $this->user_id ) );
+
+			// A repeated call must be served from the cache.
+			$this->assertSame( $user_data, $manager->get_connected_user_data( $this->user_id ) );
+			$this->assertSame( 1, $http_request_count );
+		} finally {
+			remove_filter( 'pre_http_request', $intercept );
+		}
+	}
+
+	/**
 	 * Unit test for the "Delete all tokens" functionality.
 	 */
 	public function test_delete_all_connection_tokens() {


### PR DESCRIPTION
## Proposed changes

* Cache `wpcom.getUser` XML-RPC failures in `Manager::get_connected_user_data()` with a short-lived `error` transient (5 minutes). Successful responses are already cached for a day, but failures never were, so a site with a broken user connection makes a fresh blocking request to `jetpack.wordpress.com` on every wp-admin page load.
* Repeated calls within the window return `false` immediately, the same value they would get today, just without the round-trip. The success path is unchanged, and the connection recovers within 5 minutes of the underlying problem being fixed.

**Why this matters**

* The call runs on effectively every wp-admin page load (`Initial_State::set_connection_script_data()` on the `jetpack_admin_js_script_data` filter), for every plugin that bundles the connection package.
* Broken user connections are common: stale or revoked tokens, staging clones, identity crisis, blocked egress, or a [WordPress.com](<http://WordPress.com>) incident. The failing call blocks the page for a full network round-trip each time; see the linked issue below for measurements.

## Related product discussion/links

* Found while investigating admin page load performance for WooPayments: Automattic/woocommerce-payments#8090. Measured there: WooCommerce → Settings → Payments median TTFB went from 821ms to 530ms with a failing user token, on par with the plugin deactivated.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Failures are cached**

1. On a connected site, block the outgoing call, e.g. an mu-plugin returning a `WP_Error` from `pre_http_request` for URLs containing `jetpack.wordpress.com/xmlrpc.php`.
2. Delete the `jetpack_connected_user_data_{user_id}` transient.
3. Log outbound requests (e.g. via `http_request_args`) and load a few wp-admin pages.
4. Only the first load makes an XML-RPC request. The transient holds `error` and later loads skip the request for 5 minutes. Before this change, every load made a fresh request.

**Regression: success path still works**

5. Unblock the request and delete the transient (or wait 5 minutes). User data is fetched and cached for a day, as before.
6. Unit tests: `cd projects/packages/connection && composer phpunit -- --filter get_connected_user_data`