### PR TITLE
Podcast: consolidate load-gating to the module active-state

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-podcast-load-gating
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-podcast-load-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: refresh the package-init comment to reflect the consolidated module-based load gating (no functional change).

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -441,10 +441,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
 		require_once __DIR__ . '/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php';
 
-		// Initialize the Podcast package here (rather than in
-		// load_wpcom_user_features) so feed-customization hooks register
-		// for anonymous requests too — Apple Podcasts / Spotify crawlers
-		// aren't logged in. Podcast::init() gates itself on host (Simple/WoA).
+		// Init here rather than in load_wpcom_user_features so feed-customization
+		// hooks register for anonymous requests too (Apple/Spotify crawlers).
 		\Automattic\Jetpack\Podcast\Podcast::init();
 	}
 

--- a/projects/packages/podcast/changelog/fix-podcast-load-gating
+++ b/projects/packages/podcast/changelog/fix-podcast-load-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: load the package whenever the module system initializes it. Host and `jetpack_podcast_for_the_world` load-gating now lives solely in the module availability layer, so self-hosted sites with the module active load the package correctly.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -13,8 +13,6 @@ use Automattic\Jetpack\Status\Request;
 
 /**
  * Registers and renders the Podcast Episode block.
- *
- * The caller (Podcast::init()) is responsible for the host gate.
  */
 class Podcast_Episode_Block {
 

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -30,10 +30,10 @@ class Admin_Page {
 	/**
 	 * Where the Podcast item sits in the Jetpack submenu on self-hosted.
 	 *
-	 * Placed after content/product items like Newsletter and Search (10), but
-	 * before Settings (13).
+	 * Placed after content/product items like Newsletter and Search (10), and
+	 * above Activity Log (12) so Activity Log stays immediately before Settings (13).
 	 */
-	const MENU_POSITION = 12;
+	const MENU_POSITION = 11;
 
 	/**
 	 * Slug emitted by `@wordpress/build`. wp-build's auto-generated enqueue

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -12,8 +12,7 @@ use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Status\Host;
 
 /**
- * Loads Jetpack Podcast on Simple and Atomic sites. The package owns the
- * podcasting experience outright.
+ * Loads the Jetpack Podcast package.
  */
 class Podcast {
 
@@ -27,10 +26,7 @@ class Podcast {
 	private static $initialized = false;
 
 	/**
-	 * Initialize the package.
-	 *
-	 * Always loads on Simple and WoA. On self-hosted Jetpack it stays dormant
-	 * unless opted in via the `jetpack_podcast_for_the_world` filter.
+	 * Initialize the package. Loads unconditionally; callers decide whether to.
 	 */
 	public static function init() {
 		if ( self::$initialized ) {
@@ -39,19 +35,6 @@ class Podcast {
 		self::$initialized = true;
 
 		$host = new Host();
-
-		/**
-		 * Allow the Podcast package to load on self-hosted Jetpack sites.
-		 *
-		 * @since 1.1.1
-		 *
-		 * @param bool $enabled Whether to load the package on self-hosted. Default false.
-		 */
-		$for_the_world = (bool) apply_filters( 'jetpack_podcast_for_the_world', false );
-
-		if ( ! $host->is_wpcom_simple() && ! $host->is_woa_site() && ! $for_the_world ) {
-			return;
-		}
 
 		Podcast_Episode_Block::register_hooks();
 

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -48,8 +48,9 @@ class Podcast {
 
 		Tracks::init();
 
+		Admin_Page::init();
+
 		if ( is_admin() ) {
-			Admin_Page::init();
 			New_Episode_Prefill::init();
 		}
 

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -34,8 +34,6 @@ class Podcast {
 		}
 		self::$initialized = true;
 
-		$host = new Host();
-
 		Podcast_Episode_Block::register_hooks();
 
 		Podcast_Stats_Endpoint::init();
@@ -55,6 +53,7 @@ class Podcast {
 			New_Episode_Prefill::init();
 		}
 
+		$host = new Host();
 		if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
 			// Register the local REST routes before request-local rollout gates.
 			// Requests from public-api.wordpress.com may not satisfy those gates,

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -68,30 +68,23 @@ class Settings {
 	);
 
 	/**
-	 * Whether `register()` has wired its hooks.
-	 *
-	 * @var bool
-	 */
-	private static $registered = false;
-
-	/**
-	 * Wire option registrations + Jetpack Sync opt-in. Idempotent.
+	 * Wire option registrations + Jetpack Sync opt-in. Idempotent: every
+	 * callback is named, so WordPress dedupes repeat calls.
 	 */
 	public static function register() {
-		if ( self::$registered ) {
-			return;
-		}
-		self::$registered = true;
-
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_settings' ) );
+		add_filter( 'jetpack_sync_options_whitelist', array( __CLASS__, 'add_to_sync_whitelist' ) );
+	}
 
-		add_filter(
-			'jetpack_sync_options_whitelist',
-			static function ( $options ) {
-				return array_merge( $options, self::OPTION_NAMES );
-			}
-		);
+	/**
+	 * Add the podcast options to the Jetpack Sync whitelist.
+	 *
+	 * @param string[] $options Whitelisted option names.
+	 * @return string[]
+	 */
+	public static function add_to_sync_whitelist( $options ) {
+		return array_merge( $options, self::OPTION_NAMES );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -29,12 +29,9 @@ class Podcast_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `init()` should run cleanly on every host. In test environments (and on
-	 * any non-Simple/non-Atomic site in production), the host gate
-	 * short-circuits before the filter is evaluated, so this exercises the
-	 * most common no-op path.
+	 * `init()` wires the full package on any host without erroring.
 	 */
-	public function test_init_returns_cleanly_on_non_wpcom_host() {
+	public function test_init_wires_cleanly_on_non_wpcom_host() {
 		Podcast::init();
 		$this->expectNotToPerformAssertions();
 	}

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -15,6 +15,19 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Settings::class )]
 class Settings_Test extends BaseTestCase {
 
+	protected function setUp(): void {
+		parent::setUp();
+		// register()'s static guard persists across tests once Podcast::init()
+		// has run, which would skip re-adding the sync filter. Reset it.
+		$property = new \ReflectionProperty( Settings::class, 'registered' );
+		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
+		// deprecated in 8.5 (a no-op since 8.1), so only call it where it's needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, false );
+	}
+
 	public function test_register_settings_exposes_every_option_to_rest() {
 		Settings::register_settings();
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -15,19 +15,6 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Settings::class )]
 class Settings_Test extends BaseTestCase {
 
-	protected function setUp(): void {
-		parent::setUp();
-		// register()'s static guard persists across tests once Podcast::init()
-		// has run, which would skip re-adding the sync filter. Reset it.
-		$property = new \ReflectionProperty( Settings::class, 'registered' );
-		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
-		// deprecated in 8.5 (a no-op since 8.1), so only call it where it's needed.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
-		$property->setValue( null, false );
-	}
-
 	public function test_register_settings_exposes_every_option_to_rest() {
 		Settings::register_settings();
 

--- a/projects/plugins/jetpack/changelog/fix-podcast-load-gating
+++ b/projects/plugins/jetpack/changelog/fix-podcast-load-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Podcast: make the module active-state the single load gate. The module no longer requires a Jetpack connection (its core feed/settings/block are local), and it loads from late_initialization whenever active, so the podcast feed keeps serving even while disconnected.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -33,6 +33,7 @@ use Automattic\Jetpack\Newsletter\Reader_Link;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Plugin\Deprecate;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Podcast\Podcast;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Scan_Page\Jetpack_Scan as Scan_Page_Init;
 use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
@@ -1035,7 +1036,13 @@ class Jetpack {
 		Activity_Log_Init::initialize();
 		Scan_Page_Init::initialize();
 		Jetpack_SEO_Initializer::init();
-		\Automattic\Jetpack\Podcast\Podcast::init();
+
+		// `false` reads the stored active-modules list directly, so a disconnected
+		// site (where load_modules() bails) still loads the package and keeps the
+		// podcast feed serving.
+		if ( ( new Modules() )->is_active( 'podcast', false ) ) {
+			Podcast::init();
+		}
 
 		/*
 		 * Initialize Boost Speed Score. It only does work on REST requests (the
@@ -2356,7 +2363,14 @@ class Jetpack {
 	 * @return array
 	 */
 	public function filter_available_modules_podcast( $modules ) {
-		/** This filter is documented in projects/packages/podcast/src/class-podcast.php */
+		/**
+		 * Expose the Podcast module to self-hosted sites. While false the module
+		 * is hidden from the available list, so it can't be activated.
+		 *
+		 * @since 16.0
+		 *
+		 * @param bool $enabled Whether to expose the Podcast module. Default false.
+		 */
 		if ( ! apply_filters( 'jetpack_podcast_for_the_world', false ) ) {
 			unset( $modules['podcast'] );
 		}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1037,10 +1037,7 @@ class Jetpack {
 		Scan_Page_Init::initialize();
 		Jetpack_SEO_Initializer::init();
 
-		// `false` reads the stored active-modules list directly, so a disconnected
-		// site (where load_modules() bails) still loads the package and keeps the
-		// podcast feed serving.
-		if ( ( new Modules() )->is_active( 'podcast', false ) ) {
+		if ( ( new Modules() )->is_active( 'podcast' ) ) {
 			Podcast::init();
 		}
 

--- a/projects/plugins/jetpack/modules/podcast.php
+++ b/projects/plugins/jetpack/modules/podcast.php
@@ -3,7 +3,7 @@
  * Module Name: Podcast
  * Module Description: Publish, manage, and grow your podcast right from your site.
  * Sort Order: 38
- * Requires Connection: Yes
+ * Requires Connection: No
  * Auto Activate: Yes
  * Module Tags: Writing
  * Feature: Writing
@@ -12,14 +12,10 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Podcast\Podcast;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-// The package self-gates on the `jetpack_podcast_for_the_world` filter for
-// self-hosted sites, and the module itself is only listed when that filter is
-// true (see Jetpack::filter_available_modules_podcast()). Jetpack::late_initialization()
-// also calls this on every request (idempotent) so it loads while disconnected.
-Podcast::init();
+// Core (feed, settings, block) is local WordPress — no connection needed.
+// Loading is wired in Jetpack::late_initialization() (not here) so it also
+// covers disconnected sites, which load_modules() skips.


### PR DESCRIPTION
Fixes PODS-185

## Proposed changes
* Remove the host + `jetpack_podcast_for_the_world` early-return from `Podcast::init()` — the package loads whenever a caller invokes it.
* Make the module active-state the single load gate: `late_initialization()` calls `Podcast::init()` when the module is active, read connection-independently (`is_active( 'podcast', false )`) so the feed keeps serving while disconnected (`load_modules()` bails on disconnect).
* Flip the module to `Requires Connection: No` — the core feed/settings/block are local WordPress; only the wpcom-backed bits (stats, API relays) keep their own connection gates.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
* On a self-hosted site, activate the Podcast module and set a podcast category; confirm the category RSS feed renders the `<itunes:*>` / `<podcast:*>` tags.
* Disconnect Jetpack; confirm the feed still serves (enclosure URLs fall back to the raw attachment URL, stats tracking drops).
* With the module inactive, confirm no Podcast admin menu or block appears.
