### PR TITLE
Paid content: preserve non-ASCII characters in subscriber login redirect

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-273-paid-content-emoji-redirect
+++ b/projects/plugins/jetpack/changelog/fix-nl-273-paid-content-emoji-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paid content: preserve non-ASCII characters (emoji, Chinese, etc.) in the post URL when a subscriber logs in via "Already a paid subscriber?", so they are redirected back to the correct post instead of a 404.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -61,9 +61,14 @@ function get_subscriber_login_url( $redirect ) {
 		return wpcom_logmein_redirect_url( $redirect, false, null, 'link', get_current_blog_id() );
 	}
 
-	// On self-hosted we will save and hide the token
+	// On self-hosted we will save and hide the token.
+	// rawurlencode the redirect before nesting it: it is already percent-encoded
+	// (e.g. an emoji or non-ASCII slug comes through as %F0%9F%8C%91), and add_query_arg
+	// does not encode the values it inserts. Without this extra layer the value is
+	// over-decoded to raw bytes by the time it reaches the subscribers/auth endpoint,
+	// which strips it and 404s. See NL-273.
 	$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
-	$redirect_url = add_query_arg( 'redirect_url', $redirect, $redirect_url );
+	$redirect_url = add_query_arg( 'redirect_url', rawurlencode( $redirect ), $redirect_url );
 
 	return add_query_arg(
 		array(

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -94,9 +94,14 @@ function get_subscriber_login_url( $redirect ) {
 		return wpcom_logmein_redirect_url( $redirect, false, null, 'link', get_current_blog_id() );
 	}
 
-	// On self-hosted we will save and hide the token
+	// On self-hosted we will save and hide the token.
+	// rawurlencode the redirect before nesting it: it is already percent-encoded
+	// (e.g. an emoji or non-ASCII slug comes through as %F0%9F%8C%91), and add_query_arg
+	// does not encode the values it inserts. Without this extra layer the value is
+	// over-decoded to raw bytes by the time it reaches the subscribers/auth endpoint,
+	// which strips it and 404s. See NL-273.
 	$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
-	$redirect_url = add_query_arg( 'redirect_url', $redirect, $redirect_url );
+	$redirect_url = add_query_arg( 'redirect_url', rawurlencode( $redirect ), $redirect_url );
 
 	return add_query_arg(
 		array(

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Login_Button_Redirect_Encoding_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Login_Button_Redirect_Encoding_Test.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Premium Content Login Button redirect-URL encoding tests.
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/login-button/login-button.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Verifies get_subscriber_login_url() preserves non-ASCII (percent-encoded) post
+ * URLs through the nested redirect it builds for the self-hosted JWT login flow.
+ *
+ * Regression test for NL-273: an emoji or other non-ASCII character in the post
+ * permalink was being over-decoded to raw bytes by the time it reached the
+ * subscribers/auth endpoint, stripping it and 404ing the subscriber.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Premium_Content\get_subscriber_login_url
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Premium_Content\get_subscriber_login_url' )]
+class Login_Button_Redirect_Encoding_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Peel the two nested `redirect_url` query parameters that
+	 * get_subscriber_login_url() wraps around the original destination,
+	 * mimicking the single urldecode each hop applies when parsing $_GET.
+	 *
+	 * @param string $login_url The URL returned by get_subscriber_login_url().
+	 *
+	 * @return string The recovered innermost redirect URL.
+	 */
+	private function recover_redirect_url( string $login_url ) {
+		// Layer 1: the subscribe.wordpress.com/memberships/jwt URL wraps the auth endpoint URL.
+		wp_parse_str( (string) wp_parse_url( $login_url, PHP_URL_QUERY ), $outer_args );
+		$auth_url = $outer_args['redirect_url'];
+
+		// Layer 2: the subscribers/auth URL wraps the real post URL.
+		wp_parse_str( (string) wp_parse_url( $auth_url, PHP_URL_QUERY ), $inner_args );
+		return $inner_args['redirect_url'];
+	}
+
+	/**
+	 * A percent-encoded emoji slug must survive the round trip unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_emoji_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/%F0%9F%8C%91-the-black-moon-rises/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Premium_Content\get_subscriber_login_url( $post_url );
+
+		$this->assertSame(
+			$post_url,
+			$this->recover_redirect_url( $login_url ),
+			'Emoji percent-encoding must be preserved so the auth endpoint redirects to the real post.'
+		);
+	}
+
+	/**
+	 * Percent-encoded multibyte (e.g. Chinese) slugs must survive too.
+	 *
+	 * @return void
+	 */
+	public function test_non_ascii_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/%E4%B8%AD%E6%96%87-post/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Premium_Content\get_subscriber_login_url( $post_url );
+
+		$this->assertSame( $post_url, $this->recover_redirect_url( $login_url ) );
+	}
+
+	/**
+	 * Plain ASCII URLs (the previously-working case) must be unaffected.
+	 *
+	 * @return void
+	 */
+	public function test_ascii_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/hello-world/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Premium_Content\get_subscriber_login_url( $post_url );
+
+		$this->assertSame( $post_url, $this->recover_redirect_url( $login_url ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/subscriber-login/Subscriber_Login_Redirect_Encoding_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/subscriber-login/Subscriber_Login_Redirect_Encoding_Test.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Subscriber Login block redirect-URL encoding tests.
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriber-login/subscriber-login.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Verifies get_subscriber_login_url() preserves non-ASCII (percent-encoded) post
+ * URLs through the nested redirect it builds for the self-hosted JWT login flow.
+ *
+ * This is the block rendered by the paywall behind the "Already a paid subscriber?"
+ * link. Regression test for NL-273: an emoji or other non-ASCII character in the
+ * post permalink was being over-decoded to raw bytes by the time it reached the
+ * subscribers/auth endpoint, stripping it and 404ing the subscriber.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Subscriber_Login\get_subscriber_login_url
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Subscriber_Login\get_subscriber_login_url' )]
+class Subscriber_Login_Redirect_Encoding_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Peel the two nested `redirect_url` query parameters that
+	 * get_subscriber_login_url() wraps around the original destination,
+	 * mimicking the single urldecode each hop applies when parsing $_GET.
+	 *
+	 * @param string $login_url The URL returned by get_subscriber_login_url().
+	 *
+	 * @return string The recovered innermost redirect URL.
+	 */
+	private function recover_redirect_url( string $login_url ) {
+		// Layer 1: the subscribe.wordpress.com/memberships/jwt URL wraps the auth endpoint URL.
+		wp_parse_str( (string) wp_parse_url( $login_url, PHP_URL_QUERY ), $outer_args );
+		$auth_url = $outer_args['redirect_url'];
+
+		// Layer 2: the subscribers/auth URL wraps the real post URL.
+		wp_parse_str( (string) wp_parse_url( $auth_url, PHP_URL_QUERY ), $inner_args );
+		return $inner_args['redirect_url'];
+	}
+
+	/**
+	 * A percent-encoded emoji slug must survive the round trip unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_emoji_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/%F0%9F%8C%91-the-black-moon-rises/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Subscriber_Login\get_subscriber_login_url( $post_url );
+
+		$this->assertSame(
+			$post_url,
+			$this->recover_redirect_url( $login_url ),
+			'Emoji percent-encoding must be preserved so the auth endpoint redirects to the real post.'
+		);
+	}
+
+	/**
+	 * Percent-encoded multibyte (e.g. Chinese) slugs must survive too.
+	 *
+	 * @return void
+	 */
+	public function test_non_ascii_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/%E4%B8%AD%E6%96%87-post/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Subscriber_Login\get_subscriber_login_url( $post_url );
+
+		$this->assertSame( $post_url, $this->recover_redirect_url( $login_url ) );
+	}
+
+	/**
+	 * Plain ASCII URLs (the previously-working case) must be unaffected.
+	 *
+	 * @return void
+	 */
+	public function test_ascii_url_is_preserved_through_nested_redirect() {
+		$post_url = 'https://example.org/2025/08/22/hello-world/';
+
+		$login_url = \Automattic\Jetpack\Extensions\Subscriber_Login\get_subscriber_login_url( $post_url );
+
+		$this->assertSame( $post_url, $this->recover_redirect_url( $login_url ) );
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> **Defense-in-depth follow-up.** The root cause of the non-ASCII redirect bug was on the WordPress.com platform side (the login handler was dropping the URL's percent-encoding), and that fix has now shipped separately. This PR is hardening on the Jetpack side: it keeps the nested redirect value percent-encoded end-to-end so the round trip never has to rely on raw-byte handling. Safe to land on its own.

## Proposed changes

Hardens the paid-content subscriber login redirect against non-ASCII characters (emoji, Chinese, accented slugs, etc.) in a post permalink.

**Background:** When a paid subscriber clicks **"Already a paid subscriber?"** (or a Premium Content login button) on a paywalled post, the login helper nests the current post URL into the JWT login URL. That URL is already percent-encoded (an emoji slug arrives as `%F0%9F%8C%91`). The platform-side fix ensures that encoding is preserved through login; this change adds the matching encode layer on the Jetpack side so the value stays percent-encoded through the auth endpoint's own decode step, rather than depending on raw bytes being re-encoded correctly downstream.

**Change:** `rawurlencode()` the redirect before nesting it, so the value stays cleanly encoded across every hop. Pure-ASCII URLs are unaffected. The same helper exists in both `subscriber-login` and `premium-content/login-button`, so both are updated.

## Related product discussion/links

* NL-273

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated (added in this PR), run with `jetpack docker phpunit jetpack -- --filter Redirect_Encoding`:
* `Subscriber_Login_Redirect_Encoding_Test` and `Login_Button_Redirect_Encoding_Test` assert that an emoji URL, a Chinese-character URL, and a plain ASCII URL each round-trip back to the exact original permalink through the two nested `redirect_url` layers. The three non-ASCII assertions fail on `trunk` and pass with this change; ASCII passes both ways.

Manual:
* Create a post with an emoji or non-ASCII character in its slug and mark it paid/premium.
* View it logged out and click "Already a paid subscriber?", then complete login.
* Confirm you land back on the original post (with the emoji intact) rather than a 404.
