### PR TITLE
Forms: fix duplicate field Name/IDs collapsing submissions (FORMS-724)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-724-duplicate-field-id
+++ b/projects/packages/forms/changelog/fix-forms-724-duplicate-field-id
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Forms: prevent duplicate field Name/IDs (from duplicating or copy/pasting a field) from collapsing into one another, which dropped fields from stored responses and email notifications.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -241,6 +241,23 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						break;
 					}
 				}
+			} elseif ( isset( $form->fields[ $id ] ) ) {
+				// A manually-set field ID (including the Name field's default IDs
+				// such as "name"/"first-name") is carried verbatim when a field is
+				// duplicated or copy/pasted, so two fields can end up sharing an ID.
+				// Duplicate IDs render the same input name: browsers mirror typing
+				// across the fields and only one value survives submission, dropping
+				// the rest from stored responses and emails. Suffix the later
+				// duplicates ("name" -> "name-2" -> "name-3", …) to keep every field
+				// ID unique, matching generateUniqueFormFieldId() on the editor side.
+				// See FORMS-724.
+				$base = $id;
+				$i    = 2;
+				$id   = $base . '-' . $i;
+				while ( isset( $form->fields[ $id ] ) ) {
+					++$i;
+					$id = $base . '-' . $i;
+				}
 			}
 
 			$attributes['id'] = $id;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4752,4 +4752,77 @@ class Contact_Form_Test extends BaseTestCase {
 			'image-select (hyphenated)'      => array( 'image-select' ),
 		);
 	}
+
+	/**
+	 * A manually-set field ID that collides with another field in the same form
+	 * (e.g. from duplicating or copy/pasting the block) should be suffixed so
+	 * each field keeps a unique input name. The suffix starts at -2 to match
+	 * generateUniqueFormFieldId() on the editor side. See FORMS-724.
+	 */
+	public function test_duplicate_manual_field_ids_are_made_unique() {
+		$form = new Contact_Form(
+			array(),
+			"[contact-field label='First' type='text' id='name'/][contact-field label='Second' type='text' id='name'/][contact-field label='Third' type='text' id='name'/]"
+		);
+
+		$this->assertSame(
+			array( 'name', 'name-2', 'name-3' ),
+			array_keys( $form->fields ),
+			'Duplicate manual field IDs should be suffixed so each field stays unique.'
+		);
+	}
+
+	/**
+	 * A single, non-colliding manual field ID must be preserved verbatim — the
+	 * de-duplication should only kick in on an actual collision.
+	 */
+	public function test_unique_manual_field_id_is_preserved() {
+		$form = new Contact_Form(
+			array(),
+			"[contact-field label='First' type='text' id='full_name'/][contact-field label='Second' type='email' id='contact_email'/]"
+		);
+
+		$this->assertSame(
+			array( 'full_name', 'contact_email' ),
+			array_keys( $form->fields ),
+			'Non-colliding manual field IDs should be left untouched.'
+		);
+	}
+
+	/**
+	 * Two distinct duplicated IDs in the same form must be de-duplicated
+	 * independently — the counter is per-ID, so "tel" collisions don't inherit
+	 * the "name" count. See FORMS-724.
+	 */
+	public function test_mixed_manual_field_ids_are_deduped_independently() {
+		$form = new Contact_Form(
+			array(),
+			"[contact-field label='First' type='text' id='name'/][contact-field label='Second' type='text' id='name'/][contact-field label='Third' type='text' id='name'/][contact-field label='Fourth' type='text' id='tel'/][contact-field label='Fifth' type='text' id='tel'/][contact-field label='Sixth' type='text' id='name'/]"
+		);
+
+		$this->assertSame(
+			array( 'name', 'name-2', 'name-3', 'tel', 'tel-2', 'name-4' ),
+			array_keys( $form->fields ),
+			'Each colliding ID should be suffixed against its own base, not a shared counter.'
+		);
+	}
+
+	/**
+	 * When a form already contains suffixed IDs, generated suffixes must skip the
+	 * ones already in use rather than collide with them. See FORMS-724.
+	 */
+	public function test_pre_suffixed_manual_field_ids_stay_unique() {
+		$form = new Contact_Form(
+			array(),
+			"[contact-field label='First' type='text' id='name'/][contact-field label='Second' type='text' id='name'/][contact-field label='Third' type='text' id='name'/][contact-field label='Fourth' type='text' id='name-2'/][contact-field label='Fifth' type='text' id='tel'/][contact-field label='Sixth' type='text' id='name-3'/]"
+		);
+
+		// The explicit "name-2"/"name-3" collide with generated ones and fall back
+		// to a further suffix, but every resulting ID stays unique.
+		$this->assertSame(
+			array( 'name', 'name-2', 'name-3', 'name-2-2', 'tel', 'name-3-2' ),
+			array_keys( $form->fields ),
+			'Explicit suffixed IDs that collide with generated ones should still resolve to unique IDs.'
+		);
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-forms-724-duplicate-field-id
+++ b/projects/plugins/jetpack/changelog/fix-forms-724-duplicate-field-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: prevent duplicate field Name/IDs (from duplicating or copy/pasting a field) from collapsing into one another, which dropped fields from stored responses and email notifications.


### PR DESCRIPTION
Fixes FORMS-724.

## Proposed changes

A field with a manually-set Name/ID that collides with another field in the same form was used verbatim, so duplicate fields rendered the same input `name`. Browsers then mirrored typing across the fields and only one value survived submission — the other fields were dropped entirely from stored responses and email notifications.

The most common trigger is the **Name field**: it is the only variation block, and its variations ship default IDs (`name`, `first-name`, `last-name`) where every other field leaves the ID empty and lets the server derive a unique one from the label. Those default IDs are carried verbatim when a field is **duplicated or copy/pasted**, producing the collision.

**Fix (server-side, at parse time):** a manually-set ID that collides with an already-registered field in the same form gets an incrementing suffix (`name` → `name-2` → `name-3`, …), keeping the first occurrence intact. Each ID is de-duplicated against its own base, so two distinct colliding IDs (e.g. `name` and `tel`) don't share a counter. The suffix numbering matches the editor-side `generateUniqueFormFieldId()` helper. The auto-derived (label-based) path is unchanged.

This repairs already-published forms at render time with no editing required, and render/submission stay consistent because both re-parse the same content in the same order.

## Review notes (from the FORMS-724 discussion)

* **Server-side only.** An editor-side dedup (mutating the Advanced Name/ID field on duplicate) was implemented first, then dropped: it can dirty the form / surface a confusing "unsaved changes" state, and it only helps once the form is re-saved. The server fix covers every render regardless.
* **Per-base counter, no bleed.** A concern was raised that distinct colliding IDs might share a counter. They don't — verified with `name, name, name, tel, tel, name` → `name, name-2, name-3, tel, tel-2, name-4` (`tel` dedupes to `tel-2`, not `tel-4`). Covered by `test_mixed_manual_field_ids_are_deduped_independently`.
* **Dropped the `max_tries` cap.** It was arbitrary; the loop advances on each iteration against an unbounded ID space, so it always terminates.
* **Known edge case.** A form that already stores explicit suffixed IDs which collide with generated ones (e.g. an explicit `name-2` alongside three `name`s) resolves to `name-2-2` — unique but not pretty. This matches `generateUniqueFormFieldId()` and is pinned in `test_pre_suffixed_manual_field_ids_stay_unique`; cleaner handling of pre-suffixed IDs could be a follow-up.

## Related product discussion/links

* FORMS-724

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated (`cd projects/packages/forms`):

* `composer phpunit -- --filter 'test_duplicate_manual_field_ids_are_made_unique|test_unique_manual_field_id_is_preserved|test_mixed_manual_field_ids_are_deduped_independently|test_pre_suffixed_manual_field_ids_stay_unique'`

Manual:

1. In the editor, add a Form block, add a **Name** field, then duplicate it (or paste a second copy) so two fields share `id="name"`.
2. Publish and submit the form on the front end with distinct values in each field.
3. Confirm both values are stored as **distinct** fields in **Jetpack → Forms** responses and in the email notification — no field is dropped or mirrored.
4. (Already-published form) A form whose saved markup already contains two fields with the same `id` is repaired the same way at render, with no editing needed.
