### PR TITLE
Podcast: update package docs and description

### DIFF
--- a/projects/packages/podcast/AGENTS.md
+++ b/projects/packages/podcast/AGENTS.md
@@ -1,9 +1,14 @@
 # Podcast
 
-The wp-admin Podcast experience for the Jetpack plugin: the SPA, REST
-settings, and RSS feed customization for podcasting on Simple and Atomic
-sites. The package owns the experience outright now that the legacy stack
-it replaced has been removed.
+The wp-admin Podcast experience for Jetpack: the dashboard SPA, REST
+settings, and RSS feed customization for podcasting. The package owns the
+experience outright now that the legacy stack it replaced has been removed.
+
+Podcast ships as a Jetpack plugin module (`modules/podcast.php`,
+`Auto Activate: Yes`). It runs everywhere — WordPress.com Simple, WoA, and
+self-hosted Jetpack, where it auto-activates — and owns its own admin menu
+item (registered by `Admin_Page`, so it shows even when Calypso builds the
+nav over the `wpcom/v2/admin-menu` REST endpoint).
 
 ## UI primitives
 

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -2,4 +2,24 @@
 
 Hosts the wp-admin Podcast experience for Jetpack: the dashboard SPA, REST settings, and RSS feed customization for podcasting.
 
-Podcast ships as a Jetpack plugin module (`Auto Activate: Yes`) that auto-activates on self-hosted Jetpack sites and owns its own admin menu item. It runs everywhere — WordPress.com Simple, WordPress.com Atomic (WoA), and self-hosted Jetpack. The package owns the podcasting experience outright, now that the legacy stack it replaced has been removed.
+Podcast ships as a Jetpack plugin module (`Auto Activate: Yes`) that auto-activates on self-hosted Jetpack sites and owns its own admin menu item. It runs everywhere — WordPress.com Simple, WordPress.com Atomic (WoA), and self-hosted Jetpack — and owns the podcasting experience outright, now that the legacy stack it replaced has been removed.
+
+## What's in the box
+
+- **Dashboard SPA** — the wp-admin podcasting UI (`src/dashboard`, `src/admin-pages`).
+- **REST settings** — read/write podcast configuration over the REST API.
+- **RSS feed customization** — podcast-specific feed tags and metadata.
+
+See [`AGENTS.md`](./AGENTS.md) for architecture notes and the UI-primitive conventions to follow when adding React UI to this package.
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+jetpack-podcast is licensed under [GNU General Public License v2 (or later)](https://www.gnu.org/licenses/gpl-2.0.html).

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -4,13 +4,28 @@ Hosts the wp-admin Podcast experience for Jetpack: the dashboard SPA, REST setti
 
 Podcast ships as a Jetpack plugin module (`Auto Activate: Yes`) that auto-activates on self-hosted Jetpack sites and owns its own admin menu item. It runs everywhere — WordPress.com Simple, WordPress.com Atomic (WoA), and self-hosted Jetpack — and owns the podcasting experience outright, now that the legacy stack it replaced has been removed.
 
-## What's in the box
+## Hierarchy
 
-- **Dashboard SPA** — the wp-admin podcasting UI (`src/dashboard`, `src/admin-pages`).
-- **REST settings** — read/write podcast configuration over the REST API.
-- **RSS feed customization** — podcast-specific feed tags and metadata.
+```
+.
+├── routes/                                          - Client-side routes for the dashboard SPA.
+├── src/
+│   ├── admin-pages/                                 - Extra wp-admin pages (e.g. Create AI Podcast).
+│   ├── blocks/                                      - Editor blocks (Podcast Episode).
+│   ├── dashboard/                                   - The wp-admin podcasting dashboard SPA (React/TS).
+│   ├── editor/                                      - Post-editor integrations (post-publish promo).
+│   ├── endpoints/                                   - REST API endpoints (settings, distribution, stats).
+│   ├── feed/                                        - RSS feed customization and podcast feed tags.
+│   ├── class-podcast.php                            - Package entrypoint; self-gates and loads the module.
+│   ├── class-admin-page.php                         - Registers the "Jetpack > Podcast" admin menu + screen.
+│   ├── class-settings.php                           - Registers the `podcasting_*` options and REST settings.
+│   ├── class-podcast-gate.php                       - Premium podcast feature gate.
+│   └── class-tracks.php                             - Records podcast lifecycle analytics events.
+│
+└── tests/                                           - PHPUnit and JS tests.
+```
 
-See [`AGENTS.md`](./AGENTS.md) for architecture notes and the UI-primitive conventions to follow when adding React UI to this package.
+See the individual subdirectories for more information. For architecture notes and the UI-primitive conventions to follow when adding React UI, see [`AGENTS.md`](./AGENTS.md).
 
 ## Using this package in your WordPress plugin
 

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -37,4 +37,4 @@ Need to report a security vulnerability? Go to [https://automattic.com/security/
 
 ## License
 
-jetpack-podcast is licensed under [GNU General Public License v2 (or later)](https://www.gnu.org/licenses/gpl-2.0.html).
+jetpack-podcast is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)

--- a/projects/packages/podcast/README.md
+++ b/projects/packages/podcast/README.md
@@ -1,5 +1,5 @@
 # Podcast for Jetpack
 
-Hosts the wp-admin Podcast experience for the Jetpack plugin (Simple and Atomic only).
+Hosts the wp-admin Podcast experience for Jetpack: the dashboard SPA, REST settings, and RSS feed customization for podcasting.
 
-The package owns the wp-admin SPA, REST integration, and feed customization for podcasting on Simple and Atomic sites.
+Podcast ships as a Jetpack plugin module (`Auto Activate: Yes`) that auto-activates on self-hosted Jetpack sites and owns its own admin menu item. It runs everywhere — WordPress.com Simple, WordPress.com Atomic (WoA), and self-hosted Jetpack. The package owns the podcasting experience outright, now that the legacy stack it replaced has been removed.

--- a/projects/packages/podcast/changelog/update-podcast-package-docs
+++ b/projects/packages/podcast/changelog/update-podcast-package-docs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Docs: refresh README, AGENTS, and the package description now that Podcast runs everywhere — Simple, WoA, and self-hosted Jetpack, where it auto-activates and owns its own admin menu item.
+Podcast: update README and MD files

--- a/projects/packages/podcast/changelog/update-podcast-package-docs
+++ b/projects/packages/podcast/changelog/update-podcast-package-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Docs: refresh README, AGENTS, and the package description now that Podcast runs everywhere — Simple, WoA, and self-hosted Jetpack, where it auto-activates and owns its own admin menu item.

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack-podcast",
-	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
+	"description": "Jetpack Podcast: the wp-admin podcasting experience, REST settings, and RSS feed customization.",
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {

--- a/projects/plugins/jetpack/changelog/update-podcast-package-docs
+++ b/projects/plugins/jetpack/changelog/update-podcast-package-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2746,7 +2746,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "b8a52dce988b6970dd6e8012e6fa9642e0b1f60b"
+                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2811,7 +2811,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Podcast functionality (Simple and Atomic only).",
+            "description": "Jetpack Podcast: the wp-admin podcasting experience, REST settings, and RSS feed customization.",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-podcast-package-docs
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-podcast-package-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1520,7 +1520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "b8a52dce988b6970dd6e8012e6fa9642e0b1f60b"
+                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1585,7 +1585,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Podcast functionality (Simple and Atomic only).",
+            "description": "Jetpack Podcast: the wp-admin podcasting experience, REST settings, and RSS feed customization.",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/wpcomsh/changelog/update-podcast-package-docs
+++ b/projects/plugins/wpcomsh/changelog/update-podcast-package-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1707,7 +1707,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "b8a52dce988b6970dd6e8012e6fa9642e0b1f60b"
+                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1772,7 +1772,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Podcast functionality (Simple and Atomic only).",
+            "description": "Jetpack Podcast: the wp-admin podcasting experience, REST settings, and RSS feed customization.",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
Fixes PODS-180

## Proposed changes

Refreshes the Podcast package docs and description now that the module runs everywhere, not just Simple/Atomic (PODS-180).

* `composer.json` — drop "(Simple and Atomic only)" from the description; describe the actual surface (wp-admin experience, REST settings, RSS feed customization).
* `README.md` — Podcast is a Jetpack module (`Auto Activate: Yes`) that auto-activates on self-hosted, owns its own admin menu item, and runs on Simple, WoA, and self-hosted Jetpack.
* `AGENTS.md` — same framing, plus an agent-facing note on `modules/podcast.php` and how `Admin_Page` registers the menu (survives Calypso building nav over the `wpcom/v2/admin-menu` REST endpoint). UI primitives section unchanged.
* Changelog entry.

Docs-only; no code or behavior changes.

> **Note:** these docs describe the end state (auto-activates on self-hosted). Trunk still defaults `jetpack_podcast_for_the_world` to `false`; the flip that turns it on everywhere (PODS-174) hasn't shipped yet. Code docblocks in `class-podcast.php` are intentionally left describing the current default-off gate.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Read `projects/packages/podcast/README.md`, `AGENTS.md`, and the `composer.json` description — confirm they no longer say "Simple and Atomic only" and describe the module + self-hosted support.
* `pnpm jetpack changelog validate` (or CI) passes for the new changelog entry.
