### PR TITLE
Newsletter: rename modernized subscribers/stats proxy route to subscribers/individual-stats

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -140,7 +140,7 @@ export function fetchSubscriberDetails( params: IndividualParams ): Promise< Sub
  */
 export function fetchSubscriberStats( params: IndividualParams ): Promise< SubscriberStats > {
 	return apiFetch< SubscriberStats >( {
-		path: addQueryArgs( '/wpcom/v2/subscribers/stats', {
+		path: addQueryArgs( '/wpcom/v2/subscribers/individual-stats', {
 			subscription_id: params.subscription_id ?? 0,
 			user_id: params.user_id ?? 0,
 		} ),

--- a/projects/packages/newsletter/changelog/fix-newsletter-subscribers-individual-stats-route
+++ b/projects/packages/newsletter/changelog/fix-newsletter-subscribers-individual-stats-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Point fetchSubscriberStats at the renamed subscribers/individual-stats route (JETPACK-1774). Flag-gated; no user-facing change.
+
+

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -130,7 +130,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/subscribers/stats',
+			'/subscribers/individual-stats',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/projects/plugins/jetpack/changelog/fix-newsletter-subscribers-individual-stats-route
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-subscribers-individual-stats-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Rename the modernized Newsletter proxy route to subscribers/individual-stats so it no longer shadows the aggregate subscribers/stats endpoint on WordPress.com (JETPACK-1774). Flag-gated; no user-facing change.
+
+

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -448,10 +448,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	}
 
 	/**
-	 * Same contract on `/subscribers/stats`.
+	 * Same contract on `/subscribers/individual-stats`.
 	 */
 	public function test_stats_rejects_missing_ids() {
-		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/subscribers/stats' );
+		$request = new WP_REST_Request( Requests::GET, '/wpcom/v2/subscribers/individual-stats' );
 
 		$response = $this->server->dispatch( $request );
 


### PR DESCRIPTION
Fixes # <!-- JETPACK-1774 (Linear); no public GitHub issue -->

> ⚠️ **Do not merge before the wpcom-side PR1 is deployed.** This is PR2 of a coordinated 3-PR rename (expand → migrate → contract). PR1 (wpcom) adds the new-name route; this PR repoints Jetpack's proxy + client to it; PR3 (wpcom) removes the old shadowing route. Merging/deploying this ahead of PR1 would leave a12s' Newsletter dashboard calling a route that doesn't yet exist on WordPress.com.

## Proposed changes
* Rename the modernized Newsletter dashboard's individual-subscriber-stats route from `wpcom/v2/subscribers/stats` to `wpcom/v2/subscribers/individual-stats`. On WordPress.com the old path collided with the pre-existing **aggregate** `subscribers/stats` endpoint that the Newsletter dashboard widget relies on; the individual route loads first and shadowed it, hiding the widget for the modernization rollout cohort (a12s).
* Update the self-hosted proxy registration (`class-wpcom-rest-api-v2-endpoint-subscribers-list.php`), the shared JS client `fetchSubscriberStats` (`packages/newsletter/…/data/api.ts`), and the proxy's PHPUnit test to the new path. The upstream call to `individual-subscriber-stats` is unchanged.
* Aggregate consumers are intentionally left untouched: the dashboard widget (`class-jetpack-newsletter-dashboard-widget.php`) and the newsletter ability (`class-newsletter-abilities.php`) both call the aggregate `/sites/{id}/subscribers/stats` and must keep doing so.
* Flag-gated (`rsm_jetpack_ui_modernization_newsletter`); no user-facing change, so changelog entries are recorded as `Comment:` (no public changelog line).

## Related product discussion/links
* Linear: JETPACK-1774 — Newsletter widget disappears for Automatticians due to route collision

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Self-hosted Jetpack (works standalone, no wpcom PR needed):**
* On a Jetpack-connected self-hosted site with the newsletter modernization filter enabled, open the modernized Subscribers dashboard and view a single subscriber's detail.
* Confirm the engagement-stats panel still loads (the client now calls `/wpcom/v2/subscribers/individual-stats`, which the local proxy forwards to wpcom's unchanged `individual-subscriber-stats`).
* Confirm `GET /wp-json/wpcom/v2/subscribers/individual-stats` (no `subscription_id`/`user_id`) returns `400 subscriber_stats_missing_id`, and the old `/wpcom/v2/subscribers/stats` now returns `rest_no_route`.

**Simple / Atomic (after wpcom PR1 is deployed):**
* As an a12s on a Simple test blog with the rollout on, open the Subscribers dashboard subscriber detail and confirm individual stats load against `subscribers/individual-stats`.
* Confirm the wp-admin Dashboard "Jetpack Newsletter" widget reappears (its aggregate `subscribers/stats` is no longer shadowed once PR3 removes the old route).
