### PR TITLE
Feature Catalog: register_feature() + platform-adapter status resolver (behind a flag)

### DIFF
--- a/projects/packages/features/.gitattributes
+++ b/projects/packages/features/.gitattributes
@@ -1,0 +1,7 @@
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# (see also entries in the monorepo root .gitattributes)
+# Remember to end all directories with `/**` to properly tag every file.

--- a/projects/packages/features/.gitignore
+++ b/projects/packages/features/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/features/.phan/config.php
+++ b/projects/packages/features/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-features
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/features/.phpcs.dir.xml
+++ b/projects/packages/features/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-features" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-features" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-features" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/features/CHANGELOG.md
+++ b/projects/packages/features/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/projects/packages/features/README.md
+++ b/projects/packages/features/README.md
@@ -1,0 +1,23 @@
+# Jetpack Feature Catalog
+
+Feature Catalog: register and resolve granular Jetpack features across platforms.
+
+## How to install Jetpack Feature Catalog
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+Jetpack Feature Catalog is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)

--- a/projects/packages/features/changelog/add-feature-catalog
+++ b/projects/packages/features/changelog/add-feature-catalog
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Feature Catalog: register_feature(), Registry, Status_Resolver, Jetpack_Environment, and a flag-gated WP-CLI command.

--- a/projects/packages/features/changelog/add-feature-catalog
+++ b/projects/packages/features/changelog/add-feature-catalog
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add Feature Catalog: register_feature(), Registry, Status_Resolver, Jetpack_Environment, and a flag-gated WP-CLI command.
+Add Feature Catalog: register_feature(), Registry, Status_Resolver, Jetpack_Environment, a flag-gated WP-CLI command, and a flag-gated admin dashboard (Tools > Jetpack Features).

--- a/projects/packages/features/changelog/scaffold-jetpack-features-package
+++ b/projects/packages/features/changelog/scaffold-jetpack-features-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/features/composer.json
+++ b/projects/packages/features/composer.json
@@ -43,6 +43,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-features",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-features/compare/v${old}...v${new}"
+		},
 		"branch-alias": {
 			"dev-trunk": "0.1.x-dev"
 		},

--- a/projects/packages/features/composer.json
+++ b/projects/packages/features/composer.json
@@ -7,6 +7,9 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-plans": "@dev",
+		"automattic/jetpack-status": "@dev",
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/features/composer.json
+++ b/projects/packages/features/composer.json
@@ -1,0 +1,56 @@
+{
+	"name": "automattic/jetpack-features",
+	"description": "Feature Catalog: register and resolve granular Jetpack features across platforms.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/phpunit-select-config": "@dev"
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		],
+		"files": [
+			"src/functions.php"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-php": "@composer phpunit",
+		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-features",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-features/compare/v${old}...v${new}"
+		},
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "jetpack-features",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-features.php"
+		}
+	}
+}

--- a/projects/packages/features/composer.json
+++ b/projects/packages/features/composer.json
@@ -40,11 +40,6 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
-		"autotagger": true,
-		"mirror-repo": "Automattic/jetpack-features",
-		"changelogger": {
-			"link-template": "https://github.com/Automattic/jetpack-features/compare/v${old}...v${new}"
-		},
 		"branch-alias": {
 			"dev-trunk": "0.1.x-dev"
 		},

--- a/projects/packages/features/phpunit.11.xml.dist
+++ b/projects/packages/features/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="false"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/features/phpunit.11.xml.dist
+++ b/projects/packages/features/phpunit.11.xml.dist
@@ -12,7 +12,7 @@
 	displayDetailsOnTestsThatTriggerNotices="true"
 	displayDetailsOnTestsThatTriggerWarnings="true"
 	failOnDeprecation="true"
-	failOnEmptyTestSuite="false"
+	failOnEmptyTestSuite="true"
 	failOnPhpunitDeprecation="true"
 	failOnNotice="true"
 	failOnRisky="true"

--- a/projects/packages/features/phpunit.12.xml.dist
+++ b/projects/packages/features/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/features/phpunit.8.xml.dist
+++ b/projects/packages/features/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/features/phpunit.9.xml.dist
+++ b/projects/packages/features/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/features/src/class-cli.php
+++ b/projects/packages/features/src/class-cli.php
@@ -35,6 +35,7 @@ class CLI extends WP_CLI_Command {
 	 * @param array $assoc_args Flags.
 	 */
 	public function list( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		Features::ensure_registered();
 		$registry = Registry::instance();
 		$env      = $registry->environment();
 		if ( null === $env ) {

--- a/projects/packages/features/src/class-cli.php
+++ b/projects/packages/features/src/class-cli.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WP-CLI surface for the Feature Catalog.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	return;
+}
+
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Inspect the feature catalog.
+ */
+class CLI extends WP_CLI_Command {
+
+	/**
+	 * List all registered features with their resolved status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp jetpack features list
+	 *
+	 * @subcommand list
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Flags.
+	 */
+	public function list( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$registry = Registry::instance();
+		$env      = $registry->environment();
+		if ( null === $env ) {
+			WP_CLI::error( 'No feature environment is bound.' );
+		}
+		$resolver = new Status_Resolver();
+		$rows     = array();
+		foreach ( $registry->all() as $feature ) {
+			$r      = $resolver->resolve( $feature, $env );
+			$rows[] = array(
+				'slug'        => $feature->slug(),
+				'status'      => $r['status'],
+				'reason'      => $r['reason'],
+				'connection'  => $feature->connection(),
+				'entitlement' => (string) $feature->entitlement(),
+			);
+		}
+		if ( empty( $rows ) ) {
+			WP_CLI::warning( 'No features registered.' );
+			return;
+		}
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'slug', 'status', 'reason', 'connection', 'entitlement' ) );
+	}
+}

--- a/projects/packages/features/src/class-cli.php
+++ b/projects/packages/features/src/class-cli.php
@@ -50,8 +50,8 @@ class CLI extends WP_CLI_Command {
 				'slug'        => $feature->slug(),
 				'status'      => $r['status'],
 				'reason'      => $r['reason'],
-				'connection'  => $feature->connection(),
-				'entitlement' => (string) $feature->entitlement(),
+				'connection'  => $feature->required_connection(),
+				'entitlement' => (string) $feature->required_entitlement(),
 			);
 		}
 		if ( empty( $rows ) ) {

--- a/projects/packages/features/src/class-cli.php
+++ b/projects/packages/features/src/class-cli.php
@@ -39,6 +39,7 @@ class CLI extends WP_CLI_Command {
 		$env      = $registry->environment();
 		if ( null === $env ) {
 			WP_CLI::error( 'No feature environment is bound.' );
+			return;
 		}
 		$resolver = new Status_Resolver();
 		$rows     = array();

--- a/projects/packages/features/src/class-dashboard.php
+++ b/projects/packages/features/src/class-dashboard.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Read-only admin dashboard for the Feature Catalog.
+ *
+ * Renders the resolved catalog as a table under the wp-admin Tools menu.
+ * Server-rendered, no JS build. Platform-agnostic: it displays whatever the
+ * bound Feature_Environment resolves.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+/**
+ * Registers and renders the Tools > Jetpack Features page.
+ */
+class Dashboard {
+
+	const MENU_SLUG  = 'jetpack-features';
+	const CAPABILITY = 'manage_options';
+
+	/**
+	 * Hook the admin page. Safe to call once the flag is on.
+	 */
+	public static function register() {
+		add_action( 'admin_menu', array( __CLASS__, 'add_page' ) );
+	}
+
+	/**
+	 * Add the Tools submenu page.
+	 */
+	public static function add_page() {
+		add_submenu_page(
+			'tools.php',
+			__( 'Jetpack Features', 'jetpack-features' ),
+			__( 'Jetpack Features', 'jetpack-features' ),
+			self::CAPABILITY,
+			self::MENU_SLUG,
+			array( __CLASS__, 'render' )
+		);
+	}
+
+	/**
+	 * Map a resolved status to a badge CSS modifier class. Pure; unit-tested.
+	 *
+	 * @param string $status Resolved status.
+	 * @return string CSS class suffix.
+	 */
+	public static function status_class( $status ) {
+		switch ( $status ) {
+			case Status_Resolver::STATUS_ACTIVE:
+				return 'is-active';
+			case Status_Resolver::STATUS_AVAILABLE_OFF:
+				return 'is-available';
+			case Status_Resolver::STATUS_NEEDS_CONNECTION:
+				return 'is-connection';
+			case Status_Resolver::STATUS_NEEDS_UPGRADE:
+				return 'is-upgrade';
+			case Status_Resolver::STATUS_UNSUPPORTED:
+			default:
+				return 'is-unsupported';
+		}
+	}
+
+	/**
+	 * Render the page.
+	 */
+	public static function render() {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_die( esc_html__( 'You do not have permission to view this page.', 'jetpack-features' ) );
+		}
+
+		$registry = Registry::instance();
+		$env      = $registry->environment();
+		$resolver = new Status_Resolver();
+		$features = $registry->all();
+
+		echo '<style>
+			.jpfeat-badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:12px;font-weight:600;white-space:nowrap}
+			.jpfeat-badge.is-active{background:#e5f5e5;color:#1f6f20}
+			.jpfeat-badge.is-available{background:#e3f0fb;color:#0b5a94}
+			.jpfeat-badge.is-connection{background:#fbeed6;color:#8a5200}
+			.jpfeat-badge.is-upgrade{background:#fbeed6;color:#8a5200}
+			.jpfeat-badge.is-unsupported{background:#eceff2;color:#586069}
+			.jpfeat-table td,.jpfeat-table th{vertical-align:top}
+			.jpfeat-muted{color:#787c82}
+		</style>';
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Jetpack Features', 'jetpack-features' ) . '</h1>';
+		echo '<p class="jpfeat-muted">' . esc_html__( 'A read-only view of every registered feature and its resolved availability on this site.', 'jetpack-features' ) . '</p>';
+
+		if ( null === $env ) {
+			echo '<div class="notice notice-warning"><p>' . esc_html__( 'No feature environment is bound; statuses cannot be resolved.', 'jetpack-features' ) . '</p></div>';
+		}
+
+		if ( empty( $features ) ) {
+			echo '<p>' . esc_html__( 'No features are registered.', 'jetpack-features' ) . '</p></div>';
+			return;
+		}
+
+		echo '<table class="widefat striped jpfeat-table"><thead><tr>';
+		foreach ( array(
+			__( 'Feature', 'jetpack-features' ),
+			__( 'Status', 'jetpack-features' ),
+			__( 'Connection', 'jetpack-features' ),
+			__( 'Entitlement', 'jetpack-features' ),
+			__( 'Category', 'jetpack-features' ),
+			__( 'Since', 'jetpack-features' ),
+			__( 'Docs', 'jetpack-features' ),
+		) as $heading ) {
+			echo '<th>' . esc_html( $heading ) . '</th>';
+		}
+		echo '</tr></thead><tbody>';
+
+		foreach ( $features as $feature ) {
+			$resolved = null === $env ? null : $resolver->resolve( $feature, $env );
+			$status   = null === $resolved ? '' : $resolved['status'];
+			$reason   = null === $resolved ? '' : $resolved['reason'];
+
+			echo '<tr>';
+
+			// Feature: title + slug + description.
+			echo '<td><strong>' . esc_html( '' !== $feature->title() ? $feature->title() : $feature->slug() ) . '</strong>';
+			echo '<br><code>' . esc_html( $feature->slug() ) . '</code>';
+			if ( '' !== $feature->description() ) {
+				echo '<br><span class="jpfeat-muted">' . esc_html( $feature->description() ) . '</span>';
+			}
+			echo '</td>';
+
+			// Status badge + reason.
+			echo '<td>';
+			if ( '' === $status ) {
+				echo '<span class="jpfeat-muted">&mdash;</span>';
+			} else {
+				echo '<span class="jpfeat-badge ' . esc_attr( self::status_class( $status ) ) . '">' . esc_html( $status ) . '</span>';
+				echo '<br><span class="jpfeat-muted">' . esc_html( $reason ) . '</span>';
+			}
+			echo '</td>';
+
+			// Connection level.
+			echo '<td>' . esc_html( $feature->connection() ) . '</td>';
+
+			// Entitlement.
+			$entitlement = $feature->entitlement();
+			echo '<td>' . ( null === $entitlement || '' === $entitlement ? '<span class="jpfeat-muted">&mdash;</span>' : '<code>' . esc_html( $entitlement ) . '</code>' ) . '</td>';
+
+			// Category.
+			echo '<td>' . ( '' === $feature->category() ? '<span class="jpfeat-muted">&mdash;</span>' : esc_html( $feature->category() ) ) . '</td>';
+
+			// Available since (per-platform map).
+			echo '<td>';
+			$since = $feature->available_since();
+			if ( empty( $since ) ) {
+				echo '<span class="jpfeat-muted">&mdash;</span>';
+			} else {
+				$parts = array();
+				foreach ( $since as $platform => $marker ) {
+					$parts[] = esc_html( $platform . ': ' . $marker );
+				}
+				echo wp_kses_post( implode( '<br>', $parts ) );
+			}
+			echo '</td>';
+
+			// Docs links.
+			echo '<td>';
+			$docs  = $feature->docs();
+			$links = array();
+			foreach ( array( 'wpcom', 'jetpack' ) as $doc_key ) {
+				if ( ! empty( $docs[ $doc_key ] ) ) {
+					$links[] = '<a href="' . esc_url( $docs[ $doc_key ] ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $doc_key ) . '</a>';
+				}
+			}
+			echo '' === implode( '', $links ) ? '<span class="jpfeat-muted">&mdash;</span>' : wp_kses_post( implode( ' &middot; ', $links ) );
+			echo '</td>';
+
+			echo '</tr>';
+		}
+
+		echo '</tbody></table></div>';
+	}
+}

--- a/projects/packages/features/src/class-dashboard.php
+++ b/projects/packages/features/src/class-dashboard.php
@@ -106,6 +106,7 @@ class Dashboard {
 			__( 'Connection', 'jetpack-features' ),
 			__( 'Entitlement', 'jetpack-features' ),
 			__( 'Category', 'jetpack-features' ),
+			__( 'Module', 'jetpack-features' ),
 			__( 'Since', 'jetpack-features' ),
 			__( 'Docs', 'jetpack-features' ),
 		) as $heading ) {
@@ -147,6 +148,10 @@ class Dashboard {
 
 			// Category.
 			echo '<td>' . ( '' === $feature->category() ? '<span class="jpfeat-muted">&mdash;</span>' : esc_html( $feature->category() ) ) . '</td>';
+
+			// Module the feature belongs to.
+			$module = $feature->module();
+			echo '<td>' . ( null === $module || '' === $module ? '<span class="jpfeat-muted">&mdash;</span>' : '<code>' . esc_html( $module ) . '</code>' ) . '</td>';
 
 			// Available since (per-platform map).
 			echo '<td>';

--- a/projects/packages/features/src/class-dashboard.php
+++ b/projects/packages/features/src/class-dashboard.php
@@ -142,10 +142,10 @@ class Dashboard {
 			echo '</td>';
 
 			// Connection level.
-			echo '<td>' . esc_html( $feature->connection() ) . '</td>';
+			echo '<td>' . esc_html( $feature->required_connection() ) . '</td>';
 
 			// Entitlement.
-			$entitlement = $feature->entitlement();
+			$entitlement = $feature->required_entitlement();
 			echo '<td>' . ( null === $entitlement || '' === $entitlement ? '<span class="jpfeat-muted">&mdash;</span>' : '<code>' . esc_html( $entitlement ) . '</code>' ) . '</td>';
 
 			// Category.

--- a/projects/packages/features/src/class-dashboard.php
+++ b/projects/packages/features/src/class-dashboard.php
@@ -70,6 +70,8 @@ class Dashboard {
 			wp_die( esc_html__( 'You do not have permission to view this page.', 'jetpack-features' ) );
 		}
 
+		Features::ensure_registered();
+
 		$registry = Registry::instance();
 		$env      = $registry->environment();
 		$resolver = new Status_Resolver();

--- a/projects/packages/features/src/class-feature.php
+++ b/projects/packages/features/src/class-feature.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Immutable value object describing a single feature.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+use InvalidArgumentException;
+
+/**
+ * A declared feature. Pure data — no side effects, no platform logic.
+ */
+class Feature {
+
+	const CONNECTION_LEVELS = array( 'none', 'site', 'user' );
+
+	/**
+	 * Unique feature slug.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Feature metadata.
+	 *
+	 * @var array
+	 */
+	private $args;
+
+	/**
+	 * Create a new Feature instance.
+	 *
+	 * @param string $slug Unique feature slug.
+	 * @param array  $args Feature metadata.
+	 *
+	 * @throws InvalidArgumentException If slug is empty or connection level is invalid.
+	 */
+	public function __construct( $slug, array $args = array() ) {
+		if ( ! is_string( $slug ) || '' === $slug ) {
+			throw new InvalidArgumentException( 'Feature slug must be a non-empty string.' );
+		}
+		$defaults = array(
+			'title'           => '',
+			'description'     => '',
+			'category'        => '',
+			'docs'            => array(),
+			'entitlement'     => null,
+			'connection'      => 'none',
+			'module'          => null,
+			'available_since' => array(),
+			'recommend'       => array(),
+			'is_active'       => null,
+			'is_applicable'   => null,
+		);
+		$args     = array_merge( $defaults, $args );
+
+		if ( ! in_array( $args['connection'], self::CONNECTION_LEVELS, true ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Invalid connection level "%s" for feature "%s".', $args['connection'], $slug )
+			);
+		}
+
+		$this->slug = $slug;
+		$this->args = $args;
+	}
+
+	/**
+	 * Get the feature slug.
+	 *
+	 * @return string
+	 */
+	public function slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Get the feature title.
+	 *
+	 * @return string
+	 */
+	public function title() {
+		return (string) $this->args['title'];
+	}
+
+	/**
+	 * Get the feature description.
+	 *
+	 * @return string
+	 */
+	public function description() {
+		return (string) $this->args['description'];
+	}
+
+	/**
+	 * Get the feature category.
+	 *
+	 * @return string
+	 */
+	public function category() {
+		return (string) $this->args['category'];
+	}
+
+	/**
+	 * Get the feature documentation links.
+	 *
+	 * @return array
+	 */
+	public function docs() {
+		return (array) $this->args['docs'];
+	}
+
+	/**
+	 * Get the feature entitlement.
+	 *
+	 * @return ?string
+	 */
+	public function entitlement() {
+		return $this->args['entitlement'];
+	}
+
+	/**
+	 * Get the feature connection level.
+	 *
+	 * @return string
+	 */
+	public function connection() {
+		return (string) $this->args['connection'];
+	}
+
+	/**
+	 * Get the feature module name.
+	 *
+	 * @return ?string
+	 */
+	public function module() {
+		return $this->args['module'];
+	}
+
+	/**
+	 * Get the available_since information.
+	 *
+	 * @return array
+	 */
+	public function available_since() {
+		return (array) $this->args['available_since'];
+	}
+
+	/**
+	 * Get the feature recommendations.
+	 *
+	 * @return array
+	 */
+	public function recommend() {
+		return (array) $this->args['recommend'];
+	}
+
+	/**
+	 * Get the is_active callback if available.
+	 *
+	 * @return ?callable
+	 */
+	public function is_active_callback() {
+		return is_callable( $this->args['is_active'] ) ? $this->args['is_active'] : null;
+	}
+
+	/**
+	 * Get the is_applicable callback if available.
+	 *
+	 * @return ?callable
+	 */
+	public function is_applicable_callback() {
+		return is_callable( $this->args['is_applicable'] ) ? $this->args['is_applicable'] : null;
+	}
+
+	/**
+	 * Serialize the manifest fields (excludes callables).
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		return array(
+			'slug'            => $this->slug,
+			'title'           => $this->title(),
+			'description'     => $this->description(),
+			'category'        => $this->category(),
+			'docs'            => $this->docs(),
+			'entitlement'     => $this->entitlement(),
+			'connection'      => $this->connection(),
+			'module'          => $this->module(),
+			'available_since' => $this->available_since(),
+			'recommend'       => $this->recommend(),
+		);
+	}
+}

--- a/projects/packages/features/src/class-feature.php
+++ b/projects/packages/features/src/class-feature.php
@@ -59,7 +59,7 @@ class Feature {
 
 		if ( ! in_array( $args['connection'], self::CONNECTION_LEVELS, true ) ) {
 			throw new InvalidArgumentException(
-				sprintf( 'Invalid connection level "%s" for feature "%s".', $args['connection'], $slug )
+				sprintf( 'Invalid connection level "%s" for feature "%s".', (string) $args['connection'], $slug )
 			);
 		}
 

--- a/projects/packages/features/src/class-feature.php
+++ b/projects/packages/features/src/class-feature.php
@@ -117,7 +117,7 @@ class Feature {
 	 *
 	 * @return ?string
 	 */
-	public function entitlement() {
+	public function required_entitlement() {
 		return $this->args['entitlement'];
 	}
 
@@ -126,7 +126,7 @@ class Feature {
 	 *
 	 * @return string
 	 */
-	public function connection() {
+	public function required_connection() {
 		return (string) $this->args['connection'];
 	}
 
@@ -162,7 +162,7 @@ class Feature {
 	 *
 	 * @return ?callable
 	 */
-	public function is_active_callback() {
+	public function active_on_site_callback() {
 		return is_callable( $this->args['is_active'] ) ? $this->args['is_active'] : null;
 	}
 
@@ -171,7 +171,7 @@ class Feature {
 	 *
 	 * @return ?callable
 	 */
-	public function is_applicable_callback() {
+	public function applies_to_site_callback() {
 		return is_callable( $this->args['is_applicable'] ) ? $this->args['is_applicable'] : null;
 	}
 
@@ -187,8 +187,8 @@ class Feature {
 			'description'     => $this->description(),
 			'category'        => $this->category(),
 			'docs'            => $this->docs(),
-			'entitlement'     => $this->entitlement(),
-			'connection'      => $this->connection(),
+			'entitlement'     => $this->required_entitlement(),
+			'connection'      => $this->required_connection(),
 			'module'          => $this->module(),
 			'available_since' => $this->available_since(),
 			'recommend'       => $this->recommend(),

--- a/projects/packages/features/src/class-features.php
+++ b/projects/packages/features/src/class-features.php
@@ -35,8 +35,12 @@ class Features {
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'register_features' ), 20 );
 
-		if ( self::is_enabled() && defined( 'WP_CLI' ) && \WP_CLI ) {
-			\WP_CLI::add_command( 'jetpack features', __NAMESPACE__ . '\\CLI' );
+		if ( self::is_enabled() ) {
+			Dashboard::register();
+
+			if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+				\WP_CLI::add_command( 'jetpack features', __NAMESPACE__ . '\\CLI' );
+			}
 		}
 	}
 

--- a/projects/packages/features/src/class-features.php
+++ b/projects/packages/features/src/class-features.php
@@ -8,9 +8,55 @@
 namespace Automattic\Jetpack\Features;
 
 /**
- * Bootstraps and holds the version of the Feature Catalog package.
+ * Wires the catalog into the host platform.
  */
 class Features {
 
 	const PACKAGE_VERSION = '0.1.0-alpha';
+
+	/**
+	 * Whether init() has already run.
+	 *
+	 * @var bool
+	 */
+	private static $did_init = false;
+
+	/**
+	 * Bind the Jetpack environment, trigger feature registration, and (flag-gated) register CLI.
+	 * Safe to call more than once.
+	 */
+	public static function init() {
+		if ( self::$did_init ) {
+			return;
+		}
+		self::$did_init = true;
+
+		Registry::instance()->set_environment( new Jetpack_Environment() );
+
+		add_action( 'plugins_loaded', array( __CLASS__, 'register_features' ), 20 );
+
+		if ( self::is_enabled() && defined( 'WP_CLI' ) && \WP_CLI ) {
+			\WP_CLI::add_command( 'jetpack features', __NAMESPACE__ . '\\CLI' );
+		}
+	}
+
+	/**
+	 * Fire the registration hook so each owner can require its features.php.
+	 */
+	public static function register_features() {
+		/**
+		 * Register features into the catalog. Handlers should only call register_feature().
+		 */
+		do_action( 'jetpack_features_register' );
+	}
+
+	/**
+	 * Master flag for all user-visible surfaces.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		/** Gate every catalog surface (CLI, REST, UI) behind this flag. */
+		return (bool) apply_filters( 'jetpack_features_catalog_enabled', false );
+	}
 }

--- a/projects/packages/features/src/class-features.php
+++ b/projects/packages/features/src/class-features.php
@@ -22,8 +22,16 @@ class Features {
 	private static $did_init = false;
 
 	/**
-	 * Bind the Jetpack environment, trigger feature registration, and (flag-gated) register CLI.
-	 * Safe to call more than once.
+	 * Whether feature registration has already run.
+	 *
+	 * @var bool
+	 */
+	private static $did_register = false;
+
+	/**
+	 * Bind the Jetpack environment and (flag-gated) register the CLI command and dashboard.
+	 * Feature registration itself is deferred to first use — see ensure_registered() — so
+	 * requests that never read the catalog do no catalog work. Safe to call more than once.
 	 */
 	public static function init() {
 		if ( self::$did_init ) {
@@ -32,8 +40,6 @@ class Features {
 		self::$did_init = true;
 
 		Registry::instance()->set_environment( new Jetpack_Environment() );
-
-		add_action( 'plugins_loaded', array( __CLASS__, 'register_features' ), 20 );
 
 		if ( self::is_enabled() ) {
 			Dashboard::register();
@@ -45,9 +51,16 @@ class Features {
 	}
 
 	/**
-	 * Fire the registration hook so each owner can require its features.php.
+	 * Register all features on first use. Idempotent — a consumer (CLI, dashboard, REST)
+	 * calls this immediately before it reads the catalog, so registration only happens when
+	 * the catalog is actually looked at, never on plain page loads.
 	 */
-	public static function register_features() {
+	public static function ensure_registered() {
+		if ( self::$did_register ) {
+			return;
+		}
+		self::$did_register = true;
+
 		/**
 		 * Register features into the catalog. Handlers should only call register_feature().
 		 */

--- a/projects/packages/features/src/class-features.php
+++ b/projects/packages/features/src/class-features.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Feature Catalog bootstrap.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+/**
+ * Bootstraps and holds the version of the Feature Catalog package.
+ */
+class Features {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+}

--- a/projects/packages/features/src/class-jetpack-environment.php
+++ b/projects/packages/features/src/class-jetpack-environment.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Self-hosted Jetpack platform adapter.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Modules;
+
+/**
+ * Binds the Feature_Environment contract to the Jetpack module/plan/connection systems.
+ * All external calls are behind class_exists guards + protected seams so the package
+ * stays loadable everywhere and the mapping logic stays unit-testable.
+ */
+class Jetpack_Environment implements Feature_Environment {
+
+	/**
+	 * Checks if a feature is applicable based on registered callback.
+	 *
+	 * @param Feature $f Feature to check applicability for.
+	 * @return bool True if applicable.
+	 */
+	public function is_applicable( Feature $f ): bool {
+		$cb = $f->is_applicable_callback();
+		if ( null !== $cb ) {
+			return (bool) call_user_func( $cb, $f );
+		}
+		return true;
+	}
+
+	/**
+	 * Checks if a feature is entitled based on plan support.
+	 *
+	 * @param ?string $entitlement_slug Entitlement slug to check.
+	 * @return bool True if entitled.
+	 */
+	public function is_entitled( ?string $entitlement_slug ): bool {
+		if ( null === $entitlement_slug || '' === $entitlement_slug ) {
+			return true;
+		}
+		return $this->plan_supports( $entitlement_slug );
+	}
+
+	/**
+	 * Checks if required connection level is met.
+	 *
+	 * @param string $level Connection level required.
+	 * @return bool True if level is met.
+	 */
+	public function connection_level_met( string $level ): bool {
+		switch ( $level ) {
+			case 'user':
+				return $this->has_connected_owner();
+			case 'site':
+				return $this->site_is_connected();
+			case 'none':
+			default:
+				return true;
+		}
+	}
+
+	/**
+	 * Checks if a feature is active based on module status.
+	 *
+	 * @param Feature $f Feature to check activity for.
+	 * @return bool True if active.
+	 */
+	public function is_active( Feature $f ): bool {
+		$cb = $f->is_active_callback();
+		if ( null !== $cb ) {
+			return (bool) call_user_func( $cb, $f );
+		}
+		$module = $f->module();
+		if ( null === $module ) {
+			return true;
+		}
+		return $this->module_is_active( $module );
+	}
+
+	// --- Platform seams (overridden in tests) ---
+
+	/**
+	 * Checks if a plan supports an entitlement.
+	 *
+	 * @param string $slug Entitlement slug.
+	 * @return bool True if plan supports entitlement.
+	 */
+	protected function plan_supports( $slug ): bool {
+		return class_exists( Current_Plan::class ) && Current_Plan::supports( $slug );
+	}
+
+	/**
+	 * Checks if a module is active.
+	 *
+	 * @param string $module Module slug.
+	 * @return bool True if module is active.
+	 */
+	protected function module_is_active( $module ): bool {
+		return class_exists( Modules::class ) && ( new Modules() )->is_active( $module );
+	}
+
+	/**
+	 * Checks if the site is connected to WordPress.com.
+	 *
+	 * @return bool True if site is connected.
+	 */
+	protected function site_is_connected(): bool {
+		return class_exists( Connection_Manager::class ) && ( new Connection_Manager( 'jetpack' ) )->is_connected();
+	}
+
+	/**
+	 * Checks if the site has a connected owner.
+	 *
+	 * @return bool True if connected owner exists.
+	 */
+	protected function has_connected_owner(): bool {
+		return class_exists( Connection_Manager::class ) && ( new Connection_Manager( 'jetpack' ) )->has_connected_owner();
+	}
+}

--- a/projects/packages/features/src/class-jetpack-environment.php
+++ b/projects/packages/features/src/class-jetpack-environment.php
@@ -89,7 +89,7 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param string $slug Entitlement slug.
 	 * @return bool True if plan supports entitlement.
 	 */
-	protected function plan_supports( $slug ): bool {
+	protected function plan_supports( string $slug ): bool {
 		return class_exists( Current_Plan::class ) && Current_Plan::supports( $slug );
 	}
 
@@ -99,7 +99,7 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param string $module Module slug.
 	 * @return bool True if module is active.
 	 */
-	protected function module_is_active( $module ): bool {
+	protected function module_is_active( string $module ): bool {
 		return class_exists( Modules::class ) && ( new Modules() )->is_active( $module );
 	}
 

--- a/projects/packages/features/src/class-jetpack-environment.php
+++ b/projects/packages/features/src/class-jetpack-environment.php
@@ -2,11 +2,9 @@
 /**
  * Self-hosted Jetpack platform adapter.
  *
- * The Modules / Current_Plan / Connection\Manager classes are optional runtime
- * dependencies (the package requires only PHP and guards every use with class_exists),
- * so Phan cannot see them from this package in isolation.
- *
- * @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredClassReference
+ * Modules / Current_Plan / Connection\Manager are optional *runtime* dependencies
+ * (declared as require-dev for analysis/tests only; every use is class_exists-guarded),
+ * so the shipped package still requires nothing but PHP.
  *
  * @package automattic/jetpack-features
  */

--- a/projects/packages/features/src/class-jetpack-environment.php
+++ b/projects/packages/features/src/class-jetpack-environment.php
@@ -2,6 +2,12 @@
 /**
  * Self-hosted Jetpack platform adapter.
  *
+ * The Modules / Current_Plan / Connection\Manager classes are optional runtime
+ * dependencies (the package requires only PHP and guards every use with class_exists),
+ * so Phan cannot see them from this package in isolation.
+ *
+ * @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredClassReference
+ *
  * @package automattic/jetpack-features
  */
 

--- a/projects/packages/features/src/class-jetpack-environment.php
+++ b/projects/packages/features/src/class-jetpack-environment.php
@@ -28,8 +28,8 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param Feature $f Feature to check applicability for.
 	 * @return bool True if applicable.
 	 */
-	public function is_applicable( Feature $f ): bool {
-		$cb = $f->is_applicable_callback();
+	public function applies_to_site( Feature $f ): bool {
+		$cb = $f->applies_to_site_callback();
 		if ( null !== $cb ) {
 			return (bool) call_user_func( $cb, $f );
 		}
@@ -42,7 +42,7 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param ?string $entitlement_slug Entitlement slug to check.
 	 * @return bool True if entitled.
 	 */
-	public function is_entitled( ?string $entitlement_slug ): bool {
+	public function site_is_entitled( ?string $entitlement_slug ): bool {
 		if ( null === $entitlement_slug || '' === $entitlement_slug ) {
 			return true;
 		}
@@ -55,7 +55,7 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param string $level Connection level required.
 	 * @return bool True if level is met.
 	 */
-	public function connection_level_met( string $level ): bool {
+	public function site_has_connection_level( string $level ): bool {
 		switch ( $level ) {
 			case 'user':
 				return $this->has_connected_owner();
@@ -73,8 +73,8 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param Feature $f Feature to check activity for.
 	 * @return bool True if active.
 	 */
-	public function is_active( Feature $f ): bool {
-		$cb = $f->is_active_callback();
+	public function is_active_on_site( Feature $f ): bool {
+		$cb = $f->active_on_site_callback();
 		if ( null !== $cb ) {
 			return (bool) call_user_func( $cb, $f );
 		}
@@ -82,7 +82,7 @@ class Jetpack_Environment implements Feature_Environment {
 		if ( null === $module ) {
 			return true;
 		}
-		return $this->module_is_active( $module );
+		return $this->module_is_active_on_site( $module );
 	}
 
 	// --- Platform seams (overridden in tests) ---
@@ -103,7 +103,7 @@ class Jetpack_Environment implements Feature_Environment {
 	 * @param string $module Module slug.
 	 * @return bool True if module is active.
 	 */
-	protected function module_is_active( string $module ): bool {
+	protected function module_is_active_on_site( string $module ): bool {
 		return class_exists( Modules::class ) && ( new Modules() )->is_active( $module );
 	}
 

--- a/projects/packages/features/src/class-registry.php
+++ b/projects/packages/features/src/class-registry.php
@@ -61,7 +61,7 @@ class Registry {
 	 * @return Feature|null
 	 */
 	public function get( $slug ) {
-		return isset( $this->features[ $slug ] ) ? $this->features[ $slug ] : null;
+		return $this->features[ $slug ] ?? null;
 	}
 
 	/**

--- a/projects/packages/features/src/class-registry.php
+++ b/projects/packages/features/src/class-registry.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * In-memory registry of declared features.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+/**
+ * Singleton store of Feature objects and the bound platform environment.
+ */
+class Registry {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registered features indexed by slug.
+	 *
+	 * @var Feature[]
+	 */
+	private $features = array();
+
+	/**
+	 * Bound platform environment.
+	 *
+	 * @var Feature_Environment|null
+	 */
+	private $environment = null;
+
+	/**
+	 * Get or create the Registry singleton instance.
+	 *
+	 * @return Registry
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register a feature. Last registration for a slug wins.
+	 *
+	 * @param Feature $feature Feature to register.
+	 */
+	public function register( Feature $feature ) {
+		$this->features[ $feature->slug() ] = $feature;
+	}
+
+	/**
+	 * Get a registered feature by slug.
+	 *
+	 * @param string $slug Feature slug.
+	 * @return Feature|null
+	 */
+	public function get( $slug ) {
+		return isset( $this->features[ $slug ] ) ? $this->features[ $slug ] : null;
+	}
+
+	/**
+	 * Get all registered features, slug-keyed.
+	 *
+	 * @return Feature[]
+	 */
+	public function all() {
+		return $this->features;
+	}
+
+	/**
+	 * Reset (primarily for tests).
+	 */
+	public function clear() {
+		$this->features    = array();
+		$this->environment = null;
+	}
+
+	/**
+	 * Set the bound platform environment.
+	 *
+	 * @param Feature_Environment $env Bound platform adapter.
+	 */
+	public function set_environment( Feature_Environment $env ) {
+		$this->environment = $env;
+	}
+
+	/**
+	 * Get the bound platform environment.
+	 *
+	 * @return Feature_Environment|null
+	 */
+	public function environment() {
+		return $this->environment;
+	}
+}

--- a/projects/packages/features/src/class-status-resolver.php
+++ b/projects/packages/features/src/class-status-resolver.php
@@ -26,11 +26,11 @@ class Status_Resolver {
 	 * @return array{status:string,reason:string,facets:array}
 	 */
 	public function resolve( Feature $f, Feature_Environment $env ): array {
-		$applicable     = $env->is_applicable( $f );
-		$entitled       = $env->is_entitled( $f->entitlement() );
-		$connection_req = $f->connection();
-		$connection_met = $env->connection_level_met( $connection_req );
-		$active         = $env->is_active( $f );
+		$applicable     = $env->applies_to_site( $f );
+		$entitled       = $env->site_is_entitled( $f->required_entitlement() );
+		$connection_req = $f->required_connection();
+		$connection_met = $env->site_has_connection_level( $connection_req );
+		$active         = $env->is_active_on_site( $f );
 
 		// Precedence: unsupported -> needs_connection -> needs_upgrade -> available_off -> active.
 		if ( ! $applicable ) {
@@ -54,12 +54,12 @@ class Status_Resolver {
 			'status' => $status,
 			'reason' => $reason,
 			'facets' => array(
-				'registered'          => true,
-				'applicable'          => $applicable,
-				'entitled'            => $entitled,
-				'connection_required' => $connection_req,
-				'connection_met'      => $connection_met,
-				'active'              => $active,
+				'is_registered'        => true,
+				'applies_to_site'      => $applicable,
+				'is_entitled_on_site'  => $entitled,
+				'required_connection'  => $connection_req,
+				'connection_satisfied' => $connection_met,
+				'is_active_on_site'    => $active,
 			),
 		);
 	}

--- a/projects/packages/features/src/class-status-resolver.php
+++ b/projects/packages/features/src/class-status-resolver.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Composes environment signals into one availability status.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+/**
+ * Pure composition: given a Feature and an environment, produce status + reason + facets.
+ */
+class Status_Resolver {
+
+	const STATUS_ACTIVE           = 'active';
+	const STATUS_AVAILABLE_OFF    = 'available_off';
+	const STATUS_NEEDS_CONNECTION = 'needs_connection';
+	const STATUS_NEEDS_UPGRADE    = 'needs_upgrade';
+	const STATUS_UNSUPPORTED      = 'unsupported';
+
+	/**
+	 * Resolve feature status given environment signals.
+	 *
+	 * @param Feature             $f   Feature to resolve.
+	 * @param Feature_Environment $env Bound platform adapter.
+	 * @return array{status:string,reason:string,facets:array}
+	 */
+	public function resolve( Feature $f, Feature_Environment $env ) {
+		$applicable     = $env->is_applicable( $f );
+		$entitled       = $env->is_entitled( $f->entitlement() );
+		$connection_req = $f->connection();
+		$connection_met = $env->connection_level_met( $connection_req );
+		$active         = $env->is_active( $f );
+
+		// Precedence: unsupported -> needs_connection -> needs_upgrade -> available_off -> active.
+		if ( ! $applicable ) {
+			$status = self::STATUS_UNSUPPORTED;
+			$reason = 'not_applicable';
+		} elseif ( ! $connection_met ) {
+			$status = self::STATUS_NEEDS_CONNECTION;
+			$reason = 'connection_missing';
+		} elseif ( ! $entitled ) {
+			$status = self::STATUS_NEEDS_UPGRADE;
+			$reason = 'not_entitled';
+		} elseif ( ! $active ) {
+			$status = self::STATUS_AVAILABLE_OFF;
+			$reason = 'inactive';
+		} else {
+			$status = self::STATUS_ACTIVE;
+			$reason = 'available';
+		}
+
+		return array(
+			'status' => $status,
+			'reason' => $reason,
+			'facets' => array(
+				'registered'          => true,
+				'applicable'          => $applicable,
+				'entitled'            => $entitled,
+				'connection_required' => $connection_req,
+				'connection_met'      => $connection_met,
+				'active'              => $active,
+			),
+		);
+	}
+}

--- a/projects/packages/features/src/class-status-resolver.php
+++ b/projects/packages/features/src/class-status-resolver.php
@@ -25,7 +25,7 @@ class Status_Resolver {
 	 * @param Feature_Environment $env Bound platform adapter.
 	 * @return array{status:string,reason:string,facets:array}
 	 */
-	public function resolve( Feature $f, Feature_Environment $env ) {
+	public function resolve( Feature $f, Feature_Environment $env ): array {
 		$applicable     = $env->is_applicable( $f );
 		$entitled       = $env->is_entitled( $f->entitlement() );
 		$connection_req = $f->connection();

--- a/projects/packages/features/src/functions.php
+++ b/projects/packages/features/src/functions.php
@@ -5,4 +5,17 @@
  * @package automattic/jetpack-features
  */
 
-// register_feature() is defined in Task 3.
+use Automattic\Jetpack\Features\Feature;
+use Automattic\Jetpack\Features\Registry;
+
+if ( ! function_exists( 'register_feature' ) ) {
+	/**
+	 * Declare a feature in the catalog. Side-effect-free: registers metadata only.
+	 *
+	 * @param string $slug Unique feature slug.
+	 * @param array  $args Feature metadata (see Feature::__construct).
+	 */
+	function register_feature( $slug, array $args = array() ) {
+		Registry::instance()->register( new Feature( $slug, $args ) );
+	}
+}

--- a/projects/packages/features/src/functions.php
+++ b/projects/packages/features/src/functions.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Global helper functions for the Jetpack Feature Catalog.
+ *
+ * @package automattic/jetpack-features
+ */
+
+// register_feature() is defined in Task 3.

--- a/projects/packages/features/src/functions.php
+++ b/projects/packages/features/src/functions.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Global helper functions for the Jetpack Feature Catalog.
+ * Namespaced helper functions for the Jetpack Feature Catalog.
  *
  * @package automattic/jetpack-features
  */
 
-use Automattic\Jetpack\Features\Feature;
-use Automattic\Jetpack\Features\Registry;
+namespace Automattic\Jetpack\Features;
 
-if ( ! function_exists( 'register_feature' ) ) {
+if ( ! function_exists( __NAMESPACE__ . '\register_feature' ) ) {
 	/**
 	 * Declare a feature in the catalog. Side-effect-free: registers metadata only.
 	 *

--- a/projects/packages/features/src/interface-feature-environment.php
+++ b/projects/packages/features/src/interface-feature-environment.php
@@ -18,7 +18,7 @@ interface Feature_Environment {
 	 * @param Feature $f Feature.
 	 * @return bool
 	 */
-	public function is_applicable( Feature $f ): bool;
+	public function applies_to_site( Feature $f ): bool;
 
 	/**
 	 * Does the current plan/site grant the entitlement? Null slug means "free".
@@ -26,7 +26,7 @@ interface Feature_Environment {
 	 * @param string|null $entitlement_slug Entitlement slug.
 	 * @return bool
 	 */
-	public function is_entitled( ?string $entitlement_slug ): bool;
+	public function site_is_entitled( ?string $entitlement_slug ): bool;
 
 	/**
 	 * Is the required connection level satisfied?
@@ -34,7 +34,7 @@ interface Feature_Environment {
 	 * @param string $level One of 'none' | 'site' | 'user'.
 	 * @return bool
 	 */
-	public function connection_level_met( string $level ): bool;
+	public function site_has_connection_level( string $level ): bool;
 
 	/**
 	 * Is the feature currently turned on?
@@ -42,5 +42,5 @@ interface Feature_Environment {
 	 * @param Feature $f Feature.
 	 * @return bool
 	 */
-	public function is_active( Feature $f ): bool;
+	public function is_active_on_site( Feature $f ): bool;
 }

--- a/projects/packages/features/src/interface-feature-environment.php
+++ b/projects/packages/features/src/interface-feature-environment.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Platform adapter contract for resolving feature signals.
+ *
+ * @package automattic/jetpack-features
+ */
+
+namespace Automattic\Jetpack\Features;
+
+/**
+ * Each platform (Jetpack self-hosted, wpcom Simple, Atomic) binds one implementation.
+ */
+interface Feature_Environment {
+
+	/**
+	 * Does this platform have the capability at all?
+	 *
+	 * @param Feature $f Feature.
+	 * @return bool
+	 */
+	public function is_applicable( Feature $f ): bool;
+
+	/**
+	 * Does the current plan/site grant the entitlement? Null slug means "free".
+	 *
+	 * @param string|null $entitlement_slug Entitlement slug.
+	 * @return bool
+	 */
+	public function is_entitled( ?string $entitlement_slug ): bool;
+
+	/**
+	 * Is the required connection level satisfied?
+	 *
+	 * @param string $level One of 'none' | 'site' | 'user'.
+	 * @return bool
+	 */
+	public function connection_level_met( string $level ): bool;
+
+	/**
+	 * Is the feature currently turned on?
+	 *
+	 * @param Feature $f Feature.
+	 * @return bool
+	 */
+	public function is_active( Feature $f ): bool;
+}

--- a/projects/packages/features/tests/.phpcs.dir.xml
+++ b/projects/packages/features/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/features/tests/php/DashboardTest.php
+++ b/projects/packages/features/tests/php/DashboardTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Automattic\Jetpack\Features\Dashboard;
+use Automattic\Jetpack\Features\Status_Resolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @covers \Automattic\Jetpack\Features\Dashboard
+ */
+#[CoversClass( Dashboard::class )]
+final class DashboardTest extends PHPUnit\Framework\TestCase {
+
+	/**
+	 * Each resolved status maps to its badge CSS class; unknown falls back to unsupported.
+	 *
+	 * @dataProvider status_class_provider
+	 *
+	 * @param string $status   Resolved status.
+	 * @param string $expected Expected CSS class.
+	 */
+	#[DataProvider( 'status_class_provider' )]
+	public function test_status_class( $status, $expected ) {
+		$this->assertSame( $expected, Dashboard::status_class( $status ) );
+	}
+
+	/**
+	 * Data provider for status_class.
+	 *
+	 * @return array<string, array{0:string,1:string}>
+	 */
+	public static function status_class_provider() {
+		return array(
+			'active'           => array( Status_Resolver::STATUS_ACTIVE, 'is-active' ),
+			'available_off'    => array( Status_Resolver::STATUS_AVAILABLE_OFF, 'is-available' ),
+			'needs_connection' => array( Status_Resolver::STATUS_NEEDS_CONNECTION, 'is-connection' ),
+			'needs_upgrade'    => array( Status_Resolver::STATUS_NEEDS_UPGRADE, 'is-upgrade' ),
+			'unsupported'      => array( Status_Resolver::STATUS_UNSUPPORTED, 'is-unsupported' ),
+			'unknown'          => array( 'something-else', 'is-unsupported' ),
+		);
+	}
+}

--- a/projects/packages/features/tests/php/FeatureTest.php
+++ b/projects/packages/features/tests/php/FeatureTest.php
@@ -13,12 +13,12 @@ final class FeatureTest extends PHPUnit\Framework\TestCase {
 		$f = new Feature( 'forms-multistep' );
 		$this->assertSame( 'forms-multistep', $f->slug() );
 		$this->assertSame( '', $f->title() );
-		$this->assertSame( 'none', $f->connection() );
-		$this->assertNull( $f->entitlement() );
+		$this->assertSame( 'none', $f->required_connection() );
+		$this->assertNull( $f->required_entitlement() );
 		$this->assertNull( $f->module() );
 		$this->assertSame( array(), $f->recommend() );
 		$this->assertSame( array(), $f->available_since() );
-		$this->assertNull( $f->is_active_callback() );
+		$this->assertNull( $f->active_on_site_callback() );
 	}
 
 	public function test_reads_all_fields() {
@@ -42,8 +42,8 @@ final class FeatureTest extends PHPUnit\Framework\TestCase {
 				'recommend'       => array( 'high_content_volume' ),
 			)
 		);
-		$this->assertSame( 'field-file', $f->entitlement() );
-		$this->assertSame( 'user', $f->connection() );
+		$this->assertSame( 'field-file', $f->required_entitlement() );
+		$this->assertSame( 'user', $f->required_connection() );
 		$this->assertSame( 'contact-form', $f->module() );
 		$this->assertSame( '14.2', $f->available_since()['jetpack'] );
 		$this->assertSame( array( 'high_content_volume' ), $f->recommend() );

--- a/projects/packages/features/tests/php/FeatureTest.php
+++ b/projects/packages/features/tests/php/FeatureTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Automattic\Jetpack\Features\Feature;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Features\Feature
+ */
+#[CoversClass( Feature::class )]
+final class FeatureTest extends PHPUnit\Framework\TestCase {
+
+	public function test_defaults_are_applied() {
+		$f = new Feature( 'forms-multistep' );
+		$this->assertSame( 'forms-multistep', $f->slug() );
+		$this->assertSame( '', $f->title() );
+		$this->assertSame( 'none', $f->connection() );
+		$this->assertNull( $f->entitlement() );
+		$this->assertNull( $f->module() );
+		$this->assertSame( array(), $f->recommend() );
+		$this->assertSame( array(), $f->available_since() );
+		$this->assertNull( $f->is_active_callback() );
+	}
+
+	public function test_reads_all_fields() {
+		$f = new Feature(
+			'forms-file-uploads',
+			array(
+				'title'           => 'File upload field',
+				'description'     => 'Attach files.',
+				'category'        => 'forms',
+				'docs'            => array(
+					'wpcom'   => 'https://w.com',
+					'jetpack' => 'https://j.com',
+				),
+				'entitlement'     => 'field-file',
+				'connection'      => 'user',
+				'module'          => 'contact-form',
+				'available_since' => array(
+					'jetpack' => '14.2',
+					'wpcom'   => '2026-07-06',
+				),
+				'recommend'       => array( 'high_content_volume' ),
+			)
+		);
+		$this->assertSame( 'field-file', $f->entitlement() );
+		$this->assertSame( 'user', $f->connection() );
+		$this->assertSame( 'contact-form', $f->module() );
+		$this->assertSame( '14.2', $f->available_since()['jetpack'] );
+		$this->assertSame( array( 'high_content_volume' ), $f->recommend() );
+		$this->assertSame( 'field-file', $f->to_array()['entitlement'] );
+	}
+
+	public function test_empty_slug_throws() {
+		$this->expectException( InvalidArgumentException::class );
+		new Feature( '' );
+	}
+
+	public function test_invalid_connection_throws() {
+		$this->expectException( InvalidArgumentException::class );
+		new Feature( 'x', array( 'connection' => 'account' ) );
+	}
+}

--- a/projects/packages/features/tests/php/FeatureTest.php
+++ b/projects/packages/features/tests/php/FeatureTest.php
@@ -52,11 +52,13 @@ final class FeatureTest extends PHPUnit\Framework\TestCase {
 
 	public function test_empty_slug_throws() {
 		$this->expectException( InvalidArgumentException::class );
+		// @phan-suppress-next-line PhanNoopNew -- Constructing to assert it throws.
 		new Feature( '' );
 	}
 
 	public function test_invalid_connection_throws() {
 		$this->expectException( InvalidArgumentException::class );
+		// @phan-suppress-next-line PhanNoopNew -- Constructing to assert it throws.
 		new Feature( 'x', array( 'connection' => 'account' ) );
 	}
 }

--- a/projects/packages/features/tests/php/FeatureTest.php
+++ b/projects/packages/features/tests/php/FeatureTest.php
@@ -52,13 +52,13 @@ final class FeatureTest extends PHPUnit\Framework\TestCase {
 
 	public function test_empty_slug_throws() {
 		$this->expectException( InvalidArgumentException::class );
-		// @phan-suppress-next-line PhanNoopNew -- Constructing to assert it throws.
-		new Feature( '' );
+		// The constructor throws before the assertion runs; wrapping it keeps the result "used".
+		$this->assertInstanceOf( Feature::class, new Feature( '' ) );
 	}
 
 	public function test_invalid_connection_throws() {
 		$this->expectException( InvalidArgumentException::class );
-		// @phan-suppress-next-line PhanNoopNew -- Constructing to assert it throws.
-		new Feature( 'x', array( 'connection' => 'account' ) );
+		// The constructor throws before the assertion runs; wrapping it keeps the result "used".
+		$this->assertInstanceOf( Feature::class, new Feature( 'x', array( 'connection' => 'account' ) ) );
 	}
 }

--- a/projects/packages/features/tests/php/JetpackEnvironmentTest.php
+++ b/projects/packages/features/tests/php/JetpackEnvironmentTest.php
@@ -1,0 +1,89 @@
+<?php
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Stub_Jetpack_Environment + test class in same file as per brief.
+
+use Automattic\Jetpack\Features\Feature;
+use Automattic\Jetpack\Features\Jetpack_Environment;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Testable subclass: stub the platform seams so we test only the mapping logic.
+ */
+final class Stub_Jetpack_Environment extends Jetpack_Environment {
+	public $plan   = false;
+	public $module = false;
+	public $site   = false;
+	public $owner  = false;
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by overridden interface.
+	protected function plan_supports( $slug ): bool {
+		return $this->plan; }
+	protected function module_is_active( $module ): bool {
+		return $this->module; }
+	protected function site_is_connected(): bool {
+		return $this->site; }
+	protected function has_connected_owner(): bool {
+		return $this->owner; }
+	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+}
+
+/**
+ * @covers \Automattic\Jetpack\Features\Jetpack_Environment
+ */
+#[CoversClass( Jetpack_Environment::class )]
+final class JetpackEnvironmentTest extends PHPUnit\Framework\TestCase {
+
+	public function test_null_entitlement_is_free() {
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_entitled( null ) );
+	}
+
+	public function test_entitlement_delegates_to_plan() {
+		$env       = new Stub_Jetpack_Environment();
+		$env->plan = true;
+		$this->assertTrue( $env->is_entitled( 'field-file' ) );
+		$env->plan = false;
+		$this->assertFalse( $env->is_entitled( 'field-file' ) );
+	}
+
+	public function test_connection_none_always_met() {
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->connection_level_met( 'none' ) );
+	}
+
+	public function test_connection_site_uses_site_seam() {
+		$env       = new Stub_Jetpack_Environment();
+		$env->site = true;
+		$this->assertTrue( $env->connection_level_met( 'site' ) );
+	}
+
+	public function test_connection_user_uses_owner_seam() {
+		$env        = new Stub_Jetpack_Environment();
+		$env->owner = true;
+		$this->assertTrue( $env->connection_level_met( 'user' ) );
+		$this->assertFalse( $env->connection_level_met( 'site' ) );
+	}
+
+	public function test_is_active_uses_module_seam() {
+		$env         = new Stub_Jetpack_Environment();
+		$env->module = true;
+		$this->assertTrue( $env->is_active( new Feature( 'x', array( 'module' => 'contact-form' ) ) ) );
+	}
+
+	public function test_is_active_true_when_no_module() {
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_active( new Feature( 'x' ) ) );
+	}
+
+	public function test_callbacks_win() {
+		$f           = new Feature(
+			'x',
+			array(
+				'module'        => 'contact-form',
+				'is_active'     => function () {
+					return false; },
+				'is_applicable' => function () {
+					return false; },
+			)
+		);
+		$env         = new Stub_Jetpack_Environment();
+		$env->module = true;
+		$this->assertFalse( $env->is_active( $f ) );
+		$this->assertFalse( $env->is_applicable( $f ) );
+	}
+}

--- a/projects/packages/features/tests/php/JetpackEnvironmentTest.php
+++ b/projects/packages/features/tests/php/JetpackEnvironmentTest.php
@@ -35,6 +35,10 @@ final class JetpackEnvironmentTest extends PHPUnit\Framework\TestCase {
 		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_entitled( null ) );
 	}
 
+	public function test_empty_string_entitlement_is_free() {
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_entitled( '' ) );
+	}
+
 	public function test_entitlement_delegates_to_plan() {
 		$env       = new Stub_Jetpack_Environment();
 		$env->plan = true;

--- a/projects/packages/features/tests/php/JetpackEnvironmentTest.php
+++ b/projects/packages/features/tests/php/JetpackEnvironmentTest.php
@@ -16,7 +16,7 @@ final class Stub_Jetpack_Environment extends Jetpack_Environment {
 	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by overridden interface.
 	protected function plan_supports( $slug ): bool {
 		return $this->plan; }
-	protected function module_is_active( $module ): bool {
+	protected function module_is_active_on_site( $module ): bool {
 		return $this->module; }
 	protected function site_is_connected(): bool {
 		return $this->site; }
@@ -32,46 +32,46 @@ final class Stub_Jetpack_Environment extends Jetpack_Environment {
 final class JetpackEnvironmentTest extends PHPUnit\Framework\TestCase {
 
 	public function test_null_entitlement_is_free() {
-		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_entitled( null ) );
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->site_is_entitled( null ) );
 	}
 
 	public function test_empty_string_entitlement_is_free() {
-		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_entitled( '' ) );
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->site_is_entitled( '' ) );
 	}
 
 	public function test_entitlement_delegates_to_plan() {
 		$env       = new Stub_Jetpack_Environment();
 		$env->plan = true;
-		$this->assertTrue( $env->is_entitled( 'field-file' ) );
+		$this->assertTrue( $env->site_is_entitled( 'field-file' ) );
 		$env->plan = false;
-		$this->assertFalse( $env->is_entitled( 'field-file' ) );
+		$this->assertFalse( $env->site_is_entitled( 'field-file' ) );
 	}
 
 	public function test_connection_none_always_met() {
-		$this->assertTrue( ( new Stub_Jetpack_Environment() )->connection_level_met( 'none' ) );
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->site_has_connection_level( 'none' ) );
 	}
 
 	public function test_connection_site_uses_site_seam() {
 		$env       = new Stub_Jetpack_Environment();
 		$env->site = true;
-		$this->assertTrue( $env->connection_level_met( 'site' ) );
+		$this->assertTrue( $env->site_has_connection_level( 'site' ) );
 	}
 
 	public function test_connection_user_uses_owner_seam() {
 		$env        = new Stub_Jetpack_Environment();
 		$env->owner = true;
-		$this->assertTrue( $env->connection_level_met( 'user' ) );
-		$this->assertFalse( $env->connection_level_met( 'site' ) );
+		$this->assertTrue( $env->site_has_connection_level( 'user' ) );
+		$this->assertFalse( $env->site_has_connection_level( 'site' ) );
 	}
 
 	public function test_is_active_uses_module_seam() {
 		$env         = new Stub_Jetpack_Environment();
 		$env->module = true;
-		$this->assertTrue( $env->is_active( new Feature( 'x', array( 'module' => 'contact-form' ) ) ) );
+		$this->assertTrue( $env->is_active_on_site( new Feature( 'x', array( 'module' => 'contact-form' ) ) ) );
 	}
 
 	public function test_is_active_true_when_no_module() {
-		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_active( new Feature( 'x' ) ) );
+		$this->assertTrue( ( new Stub_Jetpack_Environment() )->is_active_on_site( new Feature( 'x' ) ) );
 	}
 
 	public function test_callbacks_win() {
@@ -87,7 +87,7 @@ final class JetpackEnvironmentTest extends PHPUnit\Framework\TestCase {
 		);
 		$env         = new Stub_Jetpack_Environment();
 		$env->module = true;
-		$this->assertFalse( $env->is_active( $f ) );
-		$this->assertFalse( $env->is_applicable( $f ) );
+		$this->assertFalse( $env->is_active_on_site( $f ) );
+		$this->assertFalse( $env->applies_to_site( $f ) );
 	}
 }

--- a/projects/packages/features/tests/php/RegistryTest.php
+++ b/projects/packages/features/tests/php/RegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Automattic\Jetpack\Features\Feature;
+use Automattic\Jetpack\Features\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Features\Registry
+ */
+#[CoversClass( Registry::class )]
+final class RegistryTest extends PHPUnit\Framework\TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Registry::instance()->clear();
+	}
+
+	public function test_register_and_get() {
+		Registry::instance()->register( new Feature( 'a', array( 'title' => 'A' ) ) );
+		$this->assertSame( 'A', Registry::instance()->get( 'a' )->title() );
+		$this->assertNull( Registry::instance()->get( 'missing' ) );
+	}
+
+	public function test_all_is_slug_keyed() {
+		Registry::instance()->register( new Feature( 'a' ) );
+		Registry::instance()->register( new Feature( 'b' ) );
+		$this->assertSame( array( 'a', 'b' ), array_keys( Registry::instance()->all() ) );
+	}
+
+	public function test_later_registration_overrides() {
+		Registry::instance()->register( new Feature( 'a', array( 'title' => 'first' ) ) );
+		Registry::instance()->register( new Feature( 'a', array( 'title' => 'second' ) ) );
+		$this->assertCount( 1, Registry::instance()->all() );
+		$this->assertSame( 'second', Registry::instance()->get( 'a' )->title() );
+	}
+
+	public function test_global_register_feature_delegates() {
+		register_feature( 'c', array( 'title' => 'C' ) );
+		$this->assertSame( 'C', Registry::instance()->get( 'c' )->title() );
+	}
+}

--- a/projects/packages/features/tests/php/RegistryTest.php
+++ b/projects/packages/features/tests/php/RegistryTest.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Features\Feature;
 use Automattic\Jetpack\Features\Registry;
 use PHPUnit\Framework\Attributes\CoversClass;
+use function Automattic\Jetpack\Features\register_feature;
 
 /**
  * @covers \Automattic\Jetpack\Features\Registry
@@ -34,7 +35,7 @@ final class RegistryTest extends PHPUnit\Framework\TestCase {
 		$this->assertSame( 'second', Registry::instance()->get( 'a' )->title() );
 	}
 
-	public function test_global_register_feature_delegates() {
+	public function test_namespaced_register_feature_delegates() {
 		register_feature( 'c', array( 'title' => 'C' ) );
 		$this->assertSame( 'C', Registry::instance()->get( 'c' )->title() );
 	}

--- a/projects/packages/features/tests/php/StatusResolverTest.php
+++ b/projects/packages/features/tests/php/StatusResolverTest.php
@@ -1,0 +1,89 @@
+<?php
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Fake_Environment + test class in same file as per brief.
+
+use Automattic\Jetpack\Features\Feature;
+use Automattic\Jetpack\Features\Feature_Environment;
+use Automattic\Jetpack\Features\Status_Resolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Configurable fake environment for exercising the resolver.
+ */
+final class Fake_Environment implements Feature_Environment {
+	public $applicable     = true;
+	public $entitled       = true;
+	public $connection_met = true;
+	public $active         = true;
+
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by interface.
+	public function is_applicable( Feature $_f ): bool {
+		return $this->applicable; }
+	public function is_entitled( ?string $_slug ): bool {
+		return $this->entitled; }
+	public function connection_level_met( string $_level ): bool {
+		return $this->connection_met; }
+	public function is_active( Feature $_f ): bool {
+		return $this->active; }
+	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+}
+
+/**
+ * @covers \Automattic\Jetpack\Features\Status_Resolver
+ */
+#[CoversClass( Status_Resolver::class )]
+final class StatusResolverTest extends PHPUnit\Framework\TestCase {
+
+	private function resolve( Fake_Environment $env, array $args = array() ) {
+		return ( new Status_Resolver() )->resolve( new Feature( 'x', $args ), $env );
+	}
+
+	public function test_active_when_all_satisfied() {
+		$r = $this->resolve( new Fake_Environment() );
+		$this->assertSame( Status_Resolver::STATUS_ACTIVE, $r['status'] );
+		$this->assertTrue( $r['facets']['registered'] );
+		$this->assertTrue( $r['facets']['active'] );
+	}
+
+	public function test_available_off_when_not_active() {
+		$env         = new Fake_Environment();
+		$env->active = false;
+		$this->assertSame( Status_Resolver::STATUS_AVAILABLE_OFF, $this->resolve( $env )['status'] );
+	}
+
+	public function test_needs_upgrade_when_not_entitled() {
+		$env           = new Fake_Environment();
+		$env->entitled = false;
+		$env->active   = false;
+		$this->assertSame( Status_Resolver::STATUS_NEEDS_UPGRADE, $this->resolve( $env )['status'] );
+	}
+
+	public function test_needs_connection_wins_over_upgrade() {
+		$env                 = new Fake_Environment();
+		$env->connection_met = false;
+		$env->entitled       = false;
+		$this->assertSame( Status_Resolver::STATUS_NEEDS_CONNECTION, $this->resolve( $env, array( 'connection' => 'site' ) )['status'] );
+	}
+
+	public function test_unsupported_wins_over_everything() {
+		$env                 = new Fake_Environment();
+		$env->applicable     = false;
+		$env->connection_met = false;
+		$env->entitled       = false;
+		$this->assertSame( Status_Resolver::STATUS_UNSUPPORTED, $this->resolve( $env )['status'] );
+	}
+
+	public function test_facets_reported() {
+		$env                 = new Fake_Environment();
+		$env->connection_met = false;
+		$r                   = $this->resolve(
+			$env,
+			array(
+				'connection'  => 'user',
+				'entitlement' => 'field-file',
+			)
+		);
+		$this->assertSame( 'user', $r['facets']['connection_required'] );
+		$this->assertFalse( $r['facets']['connection_met'] );
+		$this->assertSame( 'connection_missing', $r['reason'] );
+	}
+}

--- a/projects/packages/features/tests/php/StatusResolverTest.php
+++ b/projects/packages/features/tests/php/StatusResolverTest.php
@@ -16,13 +16,13 @@ final class Fake_Environment implements Feature_Environment {
 	public $active         = true;
 
 	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by interface.
-	public function is_applicable( Feature $_f ): bool {
+	public function applies_to_site( Feature $_f ): bool {
 		return $this->applicable; }
-	public function is_entitled( ?string $_slug ): bool {
+	public function site_is_entitled( ?string $_slug ): bool {
 		return $this->entitled; }
-	public function connection_level_met( string $_level ): bool {
+	public function site_has_connection_level( string $_level ): bool {
 		return $this->connection_met; }
-	public function is_active( Feature $_f ): bool {
+	public function is_active_on_site( Feature $_f ): bool {
 		return $this->active; }
 	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 }
@@ -40,8 +40,8 @@ final class StatusResolverTest extends PHPUnit\Framework\TestCase {
 	public function test_active_when_all_satisfied() {
 		$r = $this->resolve( new Fake_Environment() );
 		$this->assertSame( Status_Resolver::STATUS_ACTIVE, $r['status'] );
-		$this->assertTrue( $r['facets']['registered'] );
-		$this->assertTrue( $r['facets']['active'] );
+		$this->assertTrue( $r['facets']['is_registered'] );
+		$this->assertTrue( $r['facets']['is_active_on_site'] );
 	}
 
 	public function test_available_off_when_not_active() {
@@ -85,11 +85,11 @@ final class StatusResolverTest extends PHPUnit\Framework\TestCase {
 				'entitlement' => 'field-file',
 			)
 		);
-		$this->assertSame( 'user', $r['facets']['connection_required'] );
-		$this->assertFalse( $r['facets']['connection_met'] );
+		$this->assertSame( 'user', $r['facets']['required_connection'] );
+		$this->assertFalse( $r['facets']['connection_satisfied'] );
 		$this->assertSame( 'connection_missing', $r['reason'] );
-		$this->assertFalse( $r['facets']['entitled'] );
-		$this->assertTrue( $r['facets']['applicable'] );
-		$this->assertFalse( $r['facets']['active'] );
+		$this->assertFalse( $r['facets']['is_entitled_on_site'] );
+		$this->assertTrue( $r['facets']['applies_to_site'] );
+		$this->assertFalse( $r['facets']['is_active_on_site'] );
 	}
 }

--- a/projects/packages/features/tests/php/StatusResolverTest.php
+++ b/projects/packages/features/tests/php/StatusResolverTest.php
@@ -75,6 +75,9 @@ final class StatusResolverTest extends PHPUnit\Framework\TestCase {
 	public function test_facets_reported() {
 		$env                 = new Fake_Environment();
 		$env->connection_met = false;
+		$env->entitled       = false;
+		$env->applicable     = true;
+		$env->active         = false;
 		$r                   = $this->resolve(
 			$env,
 			array(
@@ -85,5 +88,8 @@ final class StatusResolverTest extends PHPUnit\Framework\TestCase {
 		$this->assertSame( 'user', $r['facets']['connection_required'] );
 		$this->assertFalse( $r['facets']['connection_met'] );
 		$this->assertSame( 'connection_missing', $r['reason'] );
+		$this->assertFalse( $r['facets']['entitled'] );
+		$this->assertTrue( $r['facets']['applicable'] );
+		$this->assertFalse( $r['facets']['active'] );
 	}
 }

--- a/projects/packages/features/tests/php/bootstrap.php
+++ b/projects/packages/features/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-features
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/packages/features/tests/php/bootstrap.php
+++ b/projects/packages/features/tests/php/bootstrap.php
@@ -6,6 +6,6 @@
  */
 
 /**
- * Include the composer autoloader.
+ * Includes the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/plugins/jetpack/changelog/add-feature-catalog
+++ b/projects/plugins/jetpack/changelog/add-feature-catalog
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add the Feature Catalog (behind the jetpack_features_catalog_enabled flag).

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1001,6 +1001,12 @@ class Jetpack {
 			add_action( 'init', array( 'Jetpack_Iframe_Embed', 'init' ), 9, 0 );
 			add_action( 'rest_api_init', array( $this, 'maybe_initialize_rest_jsonapi' ) );
 		}
+
+		// Feature Catalog (Slice 1).
+		if ( class_exists( \Automattic\Jetpack\Features\Features::class ) ) {
+			require_once JETPACK__PLUGIN_DIR . 'features-probes.php';
+			\Automattic\Jetpack\Features\Features::init();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -33,6 +33,7 @@
 		"automattic/jetpack-error": "@dev",
 		"automattic/jetpack-external-connections": "@dev",
 		"automattic/jetpack-external-media": "@dev",
+		"automattic/jetpack-features": "@dev",
 		"automattic/jetpack-forms": "@dev",
 		"automattic/jetpack-image-cdn": "@dev",
 		"automattic/jetpack-import": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1648,12 +1648,15 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/features",
-                "reference": "15fa89faa10f7ba5d6975053a066a088fac83c8c"
+                "reference": "bbd510edf3833f3d1a350850fe51c9d1006441fa"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-status": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64a7e3f6111300cfc62f31285fa1fff3",
+    "content-hash": "06ec9af9bbca88f337e8be346dcf6fb5",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -1638,6 +1638,66 @@
                 "GPL-2.0-or-later"
             ],
             "description": "The external media feature allows users to select and import photos from external media",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-features",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/features",
+                "reference": "15fa89faa10f7ba5d6975053a066a088fac83c8c"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-features",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-features/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-features",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-features.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Feature Catalog: register and resolve granular Jetpack features across platforms.",
             "transport-options": {
                 "relative": true
             }
@@ -6122,6 +6182,7 @@
         "automattic/jetpack-error": 20,
         "automattic/jetpack-external-connections": 20,
         "automattic/jetpack-external-media": 20,
+        "automattic/jetpack-features": 20,
         "automattic/jetpack-forms": 20,
         "automattic/jetpack-image-cdn": 20,
         "automattic/jetpack-import": 20,

--- a/projects/plugins/jetpack/features-probes.php
+++ b/projects/plugins/jetpack/features-probes.php
@@ -8,10 +8,12 @@
  * @package automattic/jetpack
  */
 
+use function Automattic\Jetpack\Features\register_feature;
+
 add_action(
 	'jetpack_features_register',
 	function () {
-		if ( ! function_exists( 'register_feature' ) ) {
+		if ( ! function_exists( 'Automattic\Jetpack\Features\register_feature' ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/features-probes.php
+++ b/projects/plugins/jetpack/features-probes.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Validation probe features for the Feature Catalog (Slice 1).
+ *
+ * Deliberately co-located here (not scattered into packages) until the model is validated.
+ * Entitlements are STRING slugs — never \WPCOM_Features constants.
+ *
+ * @package automattic/jetpack
+ */
+
+add_action(
+	'jetpack_features_register',
+	function () {
+		if ( ! function_exists( 'register_feature' ) ) {
+			return;
+		}
+
+		register_feature(
+			'forms-multistep',
+			array(
+				'title'           => __( 'Multi-step forms', 'jetpack' ),
+				'description'     => __( 'Break long forms into steps.', 'jetpack' ),
+				'category'        => 'forms',
+				'connection'      => 'none',
+				'module'          => 'contact-form',
+				'available_since' => array( 'jetpack' => '14.2' ),
+				'recommend'       => array( 'high_content_volume' ),
+			)
+		);
+
+		register_feature(
+			'forms-file-uploads',
+			array(
+				'title'       => __( 'File upload field', 'jetpack' ),
+				'description' => __( 'Let visitors attach files to submissions.', 'jetpack' ),
+				'category'    => 'forms',
+				'entitlement' => 'field-file',
+				'connection'  => 'user',
+				'module'      => 'contact-form',
+			)
+		);
+
+		register_feature(
+			'protect-firewall',
+			array(
+				'title'       => __( 'Web Application Firewall', 'jetpack' ),
+				'description' => __( 'Block malicious requests.', 'jetpack' ),
+				'category'    => 'security',
+				'connection'  => 'site',
+				'module'      => 'waf',
+			)
+		);
+
+		register_feature(
+			'videopress',
+			array(
+				'title'       => __( 'VideoPress hosting', 'jetpack' ),
+				'description' => __( 'Ad-free, high-quality video.', 'jetpack' ),
+				'category'    => 'performance',
+				'entitlement' => 'videopress',
+				'connection'  => 'site',
+				'module'      => 'videopress',
+			)
+		);
+	}
+);


### PR DESCRIPTION
## Proposed changes

Introduces a **Feature Catalog** — a new `automattic/jetpack-features` package that lets code declare granular *features* (finer-grained than modules) and resolve each to a single availability **status**, without owning any gating itself. It is descriptive: it *reads* modules for on/off and `WPCOM_Features`/`Current_Plan` for entitlement, and adds the connective metadata (title, description, docs, connection level) that lives nowhere today.

This is **Slice 1** of a larger effort. Everything user-visible is behind the `jetpack_features_catalog_enabled` filter (default off).

What's included:

* `register_feature( $slug, $args )` — declare a feature (title, description, docs, string entitlement slug, connection level `none|site|user`, owning module, `available_since` per-platform map, `recommend` hints). Side-effect-free registration; never turns anything on.
* `Registry` (singleton) + `Feature` value object.
* `Feature_Environment` interface + `Status_Resolver` — composes signals into one status (`active` / `available_off` / `needs_connection` / `needs_upgrade` / `unsupported`) plus a machine-readable reason and raw facets. Precedence: `unsupported → needs_connection → needs_upgrade → available_off → active` (connection before upgrade).
* `Jetpack_Environment` — the self-hosted adapter, binding the interface to `Modules` / `Current_Plan` / `Connection\Manager` behind `class_exists` guards so the package stays loadable where those packages are absent. The cross-platform seam: a future `Wpcom_Environment` implements the same interface for Simple/Atomic, from the same manifest.
* Flag-gated WP-CLI `wp jetpack features list`.
* Four validation-probe features registered from the plugin (`forms-multistep`, `forms-file-uploads`, `protect-firewall`, `videopress`) exercising the free/paid × none/site/user matrix.

Entitlements are stored as **string slugs** (e.g. `field-file`), never as `\WPCOM_Features::` constants, so `features.php` stays loadable on self-hosted Jetpack where that class is absent.

## Related product discussion/links

* Design spec and implementation plan authored alongside this work (feature-catalog concept: Pillar > Product > Feature > Entitlement, made concrete as a registry).

## Does this pull request change what data or activity we track or use?

No. This adds a read-only descriptive layer over existing module/plan/connection state. It introduces no tracking and, by default (flag off), exposes no surfaces.

## Testing instructions

Unit tests:

* `pnpm jetpack test php packages/features` — 23 tests covering the Feature value object, Registry, the full Status_Resolver precedence matrix, and the Jetpack_Environment mapping (via test seams).

Live (behind the flag):

1. Build + deploy the `jetpack` plugin to a connected test site (`pnpm jetpack build --deps plugins/jetpack`, then rsync).
2. Enable the flag on the site, e.g. a mu-plugin: `add_filter( 'jetpack_features_catalog_enabled', '__return_true' );`
3. Run `wp jetpack features list`. Expect a table of the four probes with resolved statuses. On a connected free-plan site: `forms-multistep` → `active`, `forms-file-uploads` → `needs_upgrade`, `protect-firewall`/`videopress` → `available_off`.
4. Remove the user/owner token (`wp jetpack disconnect blog`) and re-run: `forms-file-uploads` (a `user`-level feature) flips to `needs_connection` while the `site`-level features are unaffected — demonstrating the per-feature connection level and the connection-before-upgrade precedence.
