### PR TITLE
Jetpack AI: add excerptSuggestion feature flag for the AI sidebar (FORNO-309)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-excerpt-suggestion-flag
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-excerpt-suggestion-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Add excerptSuggestion feature flag for the AI sidebar Generate Excerpt suggestion.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-excerpt-suggestion-flag
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-excerpt-suggestion-flag
@@ -1,4 +1,3 @@
 Significance: patch
 Type: other
-
-Jetpack AI: Add excerptSuggestion feature flag for the AI sidebar Generate Excerpt suggestion.
+Comment: Add the excerptSuggestion feature flag for the AI sidebar Generate Excerpt suggestion (FORNO-309). Exposed in internal testing environments only; no user-facing change, so the changelog entry is intentionally empty.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -351,6 +351,19 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * UI feature flag for the Generate Excerpt suggestion.
+	 *
+	 * Exposed only in internal testing environments while the feature is in development.
+	 * No plan gate: the excerpt is a core editorial field, and the ability's own
+	 * permission callback (edit_posts) gates execution server-side.
+	 *
+	 * @return bool
+	 */
+	private static function is_excerpt_suggestion_enabled(): bool {
+		return jetpack_is_internal_testing_environment();
+	}
+
+	/**
 	 * Whether the site's plan includes the Jetpack SEO feature.
 	 *
 	 * Same predicate the SEO editor panel uses to decide between the SEO fields and
@@ -439,6 +452,7 @@ class Jetpack_AI_Sidebar {
 			'blockToolbarButton'      => false,
 			'optimizeTitleSuggestion' => self::is_optimize_title_suggestion_enabled(),
 			'seoSuggestions'          => self::is_seo_suggestions_enabled(),
+			'excerptSuggestion'       => self::is_excerpt_suggestion_enabled(),
 			'chatHistory'             => false,
 			'supportGuides'           => false,
 		);
@@ -457,6 +471,7 @@ class Jetpack_AI_Sidebar {
 		$features['proofreadContent']        = self::is_proofread_content_enabled();
 		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && self::is_optimize_title_suggestion_enabled();
 		$features['seoSuggestions']          = (bool) $features['seoSuggestions'] && self::is_seo_suggestions_enabled();
+		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'] && self::is_excerpt_suggestion_enabled();
 
 		return array(
 			'enabled'  => self::is_jetpack_ai_sidebar_preview_enabled(),

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -696,11 +696,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
-		// generateFeedback, proofreadContent, optimizeTitleSuggestion and seoSuggestions are in development: off outside testing environments.
+		// generateFeedback, proofreadContent, optimizeTitleSuggestion, seoSuggestions and excerptSuggestion are in development: off outside testing environments.
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['chatHistory'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['supportGuides'] );
 	}
@@ -722,9 +723,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 	/**
 	 * In an internal testing environment, the in-development suggestions (Generate
-	 * Feedback, Proofreader, Optimize Title and SEO suggestions) are exposed. The test
-	 * plan supports advanced-seo, and the seo-tools module is activated so the SEO
-	 * suggestions gate is satisfied.
+	 * Feedback, Proofreader, Optimize Title, SEO suggestions and the excerpt
+	 * suggestion) are exposed. The test plan supports advanced-seo, and the
+	 * seo-tools module is activated so the SEO suggestions gate is satisfied.
 	 */
 	public function test_add_agents_manager_data_exposes_in_development_features_in_testing_environment() {
 		$this->set_block_editor_screen();
@@ -737,6 +738,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 	}
 
 	/**
@@ -752,6 +754,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 				$features['proofreadContent']        = true;
 				$features['optimizeTitleSuggestion'] = true;
 				$features['seoSuggestions']          = true;
+				$features['excerptSuggestion']       = true;
 				return $features;
 			}
 		);
@@ -762,6 +765,27 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+	}
+
+	/**
+	 * The generic preview features filter can still disable the excerpt suggestion
+	 * inside a testing environment (the gate raises the floor, not the ceiling).
+	 */
+	public function test_add_agents_manager_data_preview_features_filter_can_disable_excerpt_suggestion_in_testing_environment() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			function ( $features ) {
+				$features['excerptSuggestion'] = false;
+				return $features;
+			}
+		);
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add an `excerptSuggestion` preview feature flag to the Jetpack AI Sidebar config (`agentsManagerData.jetpackAiSidebar.features`), following the `optimizeTitleSuggestion` / `seoSuggestions` pattern: exposed only in internal testing environments while the feature is in development, with the post-filter re-assert so the generic `jetpack_ai_sidebar_preview_features` filter can disable it in testing but never enable it outside.
* No plan or module gate: the excerpt is a core editorial field, and the server-side ability's own permission callback (`edit_posts`) gates execution.
* The flag drives the "Generate Excerpt" suggestion chip and excerpt picker in the Calypso `jetpack-ai-sidebar` provider (companion PRs linked below); this PR alone changes nothing user-visible.

## Related product discussion/links
* Linear: FORNO-309 (migrate AI Excerpt / Content Lens to the orchestrator)
* Companion PRs: Calypso provider integration https://github.com/Automattic/wp-calypso/pull/112361 and wpcom PR 226823 (internal — the `jetpack-ai/generate-excerpt` ability).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `phpunit` (or CI): `Jetpack_AI_Sidebar_Test` covers the new flag — off outside testing environments, on inside them, filter cannot enable it outside a testing environment, filter can disable it inside one.
* Manually: in an internal testing environment with the AI sidebar preview enabled, `agentsManagerData.jetpackAiSidebar.features.excerptSuggestion` should be `true` in the post editor page source; on a production-like site it should be `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

