### PR TITLE
VideoPress: fix Wide width and Full alignment not rendering in editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-wide-width-editor
+++ b/projects/plugins/jetpack/changelog/fix-videopress-wide-width-editor
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 VideoPress: ensure "Wide width" and "Full" alignments render correctly in the editor when the VideoPress block replaces the core video block.

--- a/projects/plugins/jetpack/changelog/fix-videopress-wide-width-editor
+++ b/projects/plugins/jetpack/changelog/fix-videopress-wide-width-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: ensure "Wide width" and "Full" alignments render correctly in the editor when the VideoPress block replaces the core video block.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -1105,6 +1105,8 @@ export const VpBlock = props => {
 		setAttributes( { maxWidth: newMaxWidth } );
 	};
 
+	const isAligned = align === 'wide' || align === 'full';
+
 	return (
 		<figure { ...blockProps }>
 			<div className="wp-block-embed__wrapper">
@@ -1112,11 +1114,11 @@ export const VpBlock = props => {
 					enable={ {
 						top: false,
 						bottom: false,
-						left: true,
-						right: true,
+						left: ! isAligned,
+						right: ! isAligned,
 					} }
 					maxWidth="100%"
-					size={ { width: maxWidth } }
+					size={ { width: isAligned ? '100%' : maxWidth } }
 					style={ { margin: 'auto' } }
 					onResizeStop={ onBlockResize }
 				>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.scss
@@ -26,6 +26,19 @@
 	display: none;
 }
 
+// Ensure wide and full alignments render correctly in the editor
+// when VideoPress wraps the video in a ResizableBox.
+.wp-block-video {
+
+	&.alignwide,
+	&.alignfull {
+
+		.wp-block-embed__wrapper {
+			width: 100%;
+		}
+	}
+}
+
 .seekbar-color-settings__panel {
 
 	.components-panel__body.is-opened {


### PR DESCRIPTION
## What
Fixes #43807

## Why
When VideoPress is enabled, it replaces the core video block's edit component and wraps the video preview in a `ResizableBox` with explicit width constraints. This overrides the editor's wide/full alignment styles, causing the block to render at normal width even when "Wide width" or "Full" alignment is selected.

## How
- **Disable resize handles** when the block has `align: 'wide'` or `align: 'full'` — resizing doesn't make sense for these alignments
- **Set `ResizableBox` width to `100%`** when aligned, so the content fills the wider figure element
- **Add editor CSS** to ensure `.wp-block-embed__wrapper` expands to fill the aligned figure

## Testing Instructions
1. Activate the VideoPress module
2. Add a Video block to a post
3. Upload/select a video and wait for the VideoPress preview to load
4. Change alignment to "Wide width" — block should render wide in the editor
5. Change alignment to "Full" — block should render full-width in the editor
6. Change back to default alignment — resize handles should reappear and block should respect the custom maxWidth

## Changelog
> VideoPress: ensure "Wide width" and "Full" alignments render correctly in the editor.

## Does this pull request change what data or activity we track or use?
No. This change only affects the visual rendering of the VideoPress block in the editor — it does not collect, log, or transmit any new data.

## Testing instructions
1. Activate the VideoPress module
2. Add a Video block to a post
3. Upload/select a video and wait for the VideoPress preview to load
4. Change the alignment to "Wide width" — the block should render wide in the editor
5. Change the alignment to "Full" — the block should render full-width in the editor
6. Change back to default alignment — resize handles should reappear and the block should still respect the custom width

## Does this pull request change what data or activity we track or use?
No. This change only affects the visual rendering of the VideoPress block in the editor — it does not collect, log, or transmit any new data.

## Testing instructions
1. Activate the VideoPress module
2. Add a Video block to a post
3. Upload/select a video and wait for the VideoPress preview to load
4. Change the alignment to "Wide width" — the block should render wide in the editor
5. Change the alignment to "Full" — the block should render full-width in the editor
6. Change back to default alignment — resize handles should reappear and the block should still respect the custom width