### PR TITLE
VideoPress: prevent false dirty state in Site Editor for legacy blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-legacy-block-dirty-state
+++ b/projects/plugins/jetpack/changelog/fix-videopress-legacy-block-dirty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: prevent persistent "Review 1 change" in the editor caused by unnecessary setAttributes calls when the videoPressClassNames and videoPressTracks values have not changed.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
@@ -184,8 +184,11 @@ const VideoPressEdit = CoreVideoEdit =>
 				// Reset preview failure count so we can retry a preview later if a problem occurs.
 				this.previewFailuresCount = 0;
 
-				// We set videoPressClassNames attribute to be used in ./save.js
-				setAttributes( { videoPressClassNames: sandboxClassnames } );
+				// Only update the attribute if the value actually changed,
+				// to avoid marking the block/entity as dirty on every render.
+				if ( sandboxClassnames !== attributes.videoPressClassNames ) {
+					setAttributes( { videoPressClassNames: sandboxClassnames } );
+				}
 			} else if ( ! isFetchingPreview && ! invalidationTriggered && this.props.attributes.guid ) {
 				// If we have a guid but no preview, we may want to reload the block
 				this.schedulePreviewCacheReload();
@@ -295,7 +298,14 @@ const VideoPressEdit = CoreVideoEdit =>
 						} );
 					}
 				} );
-				setAttributes( { videoPressTracks: tracks } );
+				// Only update the attribute if the tracks actually changed,
+				// to avoid marking the block/entity as dirty on every load.
+				const currentTracks = this.props.attributes.videoPressTracks;
+				if (
+					JSON.stringify( currentTracks ) !== JSON.stringify( tracks )
+				) {
+					setAttributes( { videoPressTracks: tracks } );
+				}
 			} );
 		};
 


### PR DESCRIPTION
## What
Fixes #48633

## Why
When the Site Editor loads a template containing legacy `wp:video` blocks with VideoPress attributes (`guid`, `videoPressClassNames`), the editor persistently shows "Review 1 change" on every reload — even after saving. The dirty state is caused entirely client-side with no actual content change.

## Root Cause
In `componentDidUpdate`, the VideoPress edit component unconditionally calls `setAttributes( { videoPressClassNames: sandboxClassnames } )` whenever a preview is available. Even when the computed value is byte-for-byte identical to the existing attribute, the `setAttributes` dispatch marks the block (and by extension the template entity) as dirty.

## How
Added a strict equality check: only call `setAttributes` when `sandboxClassnames` differs from the current `attributes.videoPressClassNames` value. This prevents the unnecessary dispatch that flags the entity as dirty.

## Testing Instructions
1. Open the Site Editor on a site with Jetpack/VideoPress active
2. Edit a template via Code Editor and insert a legacy VideoPress block:
```
<!-- wp:video {"id":1,"guid":"239t8ryY","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">
https://videopress.com/v/239t8ryY?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
</div></figure>
<!-- /wp:video -->
```
3. Save the template
4. Reload the Site Editor
5. **Before:** "Review 1 change" appears immediately
6. **After:** No unsaved changes indicator

## Changelog
> VideoPress: prevent persistent "Review 1 change" in the Site Editor caused by unnecessary setAttributes calls when the videoPressClassNames value has not changed.

## Does this pull request change what data or activity we track or use?
No. This change only adds a strict equality check before calling setAttributes — no data collection or tracking changes.

## Testing instructions
1. Open the Site Editor on a site with Jetpack/VideoPress active
2. Edit a template via Code Editor and insert a legacy VideoPress block:
   `<!-- wp:video {"id":1,"guid":"239t8ryY","videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} --><figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress"><div class="wp-block-embed__wrapper">https://videopress.com/v/239t8ryY?resizeToParent=true&cover=true&preloadContent=metadata&useAverageColor=true</div></figure><!-- /wp:video -->`
3. Save the template
4. Reload the Site Editor
5. **Before:** The "Review 1 change" badge appears immediately
6. **After:** No unsaved changes indicator is shown