### PR TITLE
Sharing: show legacy settings on block themes so users can disable sharing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-block-theme-toggle
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-block-theme-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sharing: ensure legacy sharing settings remain accessible on block themes so users can disable sharing buttons appended to content.

--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-block-theme-toggle
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-block-theme-toggle
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Sharing: ensure legacy sharing settings remain accessible on block themes so users can disable sharing buttons appended to content.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -367,9 +367,13 @@ class Sharing_Admin {
 			$is_simple_site     = defined( 'IS_WPCOM' ) && IS_WPCOM;
 			$show_block_message = $this->should_use_site_editor() && ! $is_simple_site;
 
-			// We either show old services config or the sharing block message.
+			// Show the block theme message (if applicable) and always show
+			// the services config so users can manage/disable legacy sharing.
 		if ( current_user_can( 'manage_options' ) ) :
-			$show_block_message ? $this->sharing_block_display() : $this->services_config_display();
+			if ( $show_block_message ) :
+				$this->sharing_block_display();
+			endif;
+			$this->services_config_display();
 			endif;
 		?>
 	</div>


### PR DESCRIPTION
## What
Fixes #49495

## Why
When a block-based theme is active on a self-hosted Jetpack site, the Sharing settings page (`Settings > Sharing`) replaces the full services configuration UI with only a Site Editor prompt. This hides all controls for managing legacy sharing buttons, making it impossible for users to disable the sharing buttons that are automatically appended to post content via `the_content` filter.

Users have to switch back to a classic theme, disable sharing, then switch back to their block theme — which is a poor UX.

## How
Instead of replacing `services_config_display()` with `sharing_block_display()`, show both:
1. The block theme message/prompt (encouraging use of the Sharing block)
2. The full legacy services config (so users can manage/disable existing sharing buttons)

## Testing Instructions
1. Activate a block-based theme (e.g., Twenty Twenty-Four)
2. Enable Jetpack Sharing module
3. Go to **Settings > Sharing**
4. **Before:** Only see a "Go to the site editor" prompt with no way to disable legacy sharing buttons
5. **After:** See the block theme prompt AND the full services configuration below it, including the ability to remove sharing services and disable content-appended buttons
6. Disable all sharing services and verify buttons no longer appear on posts

## Changelog
> Sharing: ensure legacy sharing settings remain accessible on block themes so users can disable sharing buttons appended to content.

## Does this pull request change what data or activity we track or use?
No. This change only modifies what UI is shown on the Sharing settings page — no data collection or tracking changes.

## Testing instructions
1. Activate a block-based theme (e.g., Twenty Twenty-Four)
2. Enable the Jetpack Sharing module
3. Go to **Settings > Sharing**
4. **Before:** Only a "Go to the site editor" prompt is shown with no way to disable legacy sharing buttons
5. **After:** The block theme prompt appears AND the full services configuration is displayed below it — you can remove sharing services and disable content-appended buttons
6. Disable all sharing services and verify that buttons no longer appear on posts