### PR TITLE
Stats: detect clicks on relocated upload directories (multisite /files/)

### DIFF
--- a/projects/packages/stats/changelog/fix-uploads-path-click-tracking
+++ b/projects/packages/stats/changelog/fix-uploads-path-click-tracking
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Stats: detect clicks on relocated upload directories (e.g. multisite /files/) by passing the effective uploads path to the tracker.

--- a/projects/packages/stats/changelog/fix-uploads-path-click-tracking
+++ b/projects/packages/stats/changelog/fix-uploads-path-click-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: detect clicks on relocated upload directories (e.g. multisite /files/) by passing the effective uploads path to the tracker.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -125,10 +125,11 @@ class Tracking_Pixel {
 
 		// Pass the effective uploads URL path so the click tracker can match
 		// relocated upload directories (e.g. multisite /files/).
-		$upload_dir  = wp_get_upload_dir();
-		$upload_path = $upload_dir['baseurl'] ?? '';
-		$upload_path = trailingslashit( $upload_path );
-		$upload_path = wp_parse_url( $upload_path, PHP_URL_PATH ) ?: '/wp-content/uploads/';
+		$upload_dir      = wp_get_upload_dir();
+		$upload_path     = $upload_dir['baseurl'] ?? '';
+		$upload_path     = trailingslashit( $upload_path );
+		$upload_url_path = wp_parse_url( $upload_path, PHP_URL_PATH );
+		$upload_path     = $upload_url_path ? $upload_url_path : '/wp-content/uploads/';
 		$view_data['nu'] = $upload_path;
 
 		return $view_data;
@@ -191,9 +192,10 @@ class Tracking_Pixel {
 
 		// Derive the site's uploads URL path so the click tracker can match
 		// relocated upload directories (e.g. multisite /files/).
-		$upload_path = wp_get_upload_dir()['baseurl'] ?? '';
-		$upload_path = trailingslashit( $upload_path );
-		$upload_path = wp_parse_url( $upload_path, PHP_URL_PATH ) ?: '/wp-content/uploads/';
+		$upload_baseurl = wp_get_upload_dir()['baseurl'] ?? '';
+		$upload_baseurl = trailingslashit( $upload_baseurl );
+		$upload_url     = wp_parse_url( $upload_baseurl, PHP_URL_PATH );
+		$upload_path    = $upload_url ? $upload_url : '/wp-content/uploads/';
 
 		$output = sprintf(
 			'_stq = window._stq || [];
@@ -209,18 +211,17 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 		// are still captured. The WPCOM tracker only matches /wp-content/uploads/
 		// by default, so we supplement it here via event delegation.
 		if ( '/wp-content/uploads/' !== $upload_path ) {
-			$escaped_path = esc_js( $upload_path );
 			$output .= sprintf(
 				"\n( function() {\n" .
-				"\tvar uploadUrl = '%1\$s';\n" .
+				"\tvar uploadUrl = %1\$s;\n" .
 				"\tdocument.addEventListener( 'click', function( e ) {\n" .
 				"\t\tvar el = e.target.closest( 'a' );\n" .
 				"\t\tif ( ! el || ! el.href ) return;\n" .
 				"\t\tif ( ! el.href.includes( uploadUrl ) ) return;\n" .
 				"\t\twindow._stq && _stq.push( [ 'click', { s: '2', u: el.href, r: document.referrer, b: '%2\$s', p: '%3\$s' } ] );\n" .
 				"\t} );\n" .
-				"} )();",
-				$escaped_path,
+				'}();',
+				wp_json_encode( $upload_path, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ),
 				$blog_id,
 				$post_id
 			);

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -122,6 +122,15 @@ class Tracking_Pixel {
 				$view_data['arch_other'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			}
 		}
+
+		// Pass the effective uploads URL path so the click tracker can match
+		// relocated upload directories (e.g. multisite /files/).
+		$upload_dir  = wp_get_upload_dir();
+		$upload_path = $upload_dir['baseurl'] ?? '';
+		$upload_path = trailingslashit( $upload_path );
+		$upload_path = wp_parse_url( $upload_path, PHP_URL_PATH ) ?: '/wp-content/uploads/';
+		$view_data['nu'] = $upload_path;
+
 		return $view_data;
 	}
 
@@ -177,14 +186,47 @@ class Tracking_Pixel {
 	private static function build_stats_details( $data ) {
 		$data_stats_array = self::stats_array_to_string( $data );
 
-		return sprintf(
+		$blog_id = $data['blog'];
+		$post_id = $data['post'];
+
+		// Derive the site's uploads URL path so the click tracker can match
+		// relocated upload directories (e.g. multisite /files/).
+		$upload_path = wp_get_upload_dir()['baseurl'] ?? '';
+		$upload_path = trailingslashit( $upload_path );
+		$upload_path = wp_parse_url( $upload_path, PHP_URL_PATH ) ?: '/wp-content/uploads/';
+
+		$output = sprintf(
 			'_stq = window._stq || [];
 _stq.push([ "view", %1$s ]);
 _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 			$data_stats_array,
-			$data['blog'],
-			$data['post']
+			$blog_id,
+			$post_id
 		);
+
+		// When the uploads path differs from the default /wp-content/uploads/,
+		// add a click-tracker patch so links to the relocated upload directory
+		// are still captured. The WPCOM tracker only matches /wp-content/uploads/
+		// by default, so we supplement it here via event delegation.
+		if ( '/wp-content/uploads/' !== $upload_path ) {
+			$escaped_path = esc_js( $upload_path );
+			$output .= sprintf(
+				"\n( function() {\n" .
+				"\tvar uploadUrl = '%1\$s';\n" .
+				"\tdocument.addEventListener( 'click', function( e ) {\n" .
+				"\t\tvar el = e.target.closest( 'a' );\n" .
+				"\t\tif ( ! el || ! el.href ) return;\n" .
+				"\t\tif ( ! el.href.includes( uploadUrl ) ) return;\n" .
+				"\t\twindow._stq && _stq.push( [ 'click', { s: '2', u: el.href, r: document.referrer, b: '%2\$s', p: '%3\$s' } ] );\n" .
+				"\t} );\n" .
+				"} )();",
+				$escaped_path,
+				$blog_id,
+				$post_id
+			);
+		}
+
+		return $output;
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -60,6 +60,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'srv'        => 'example.org',
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -80,6 +81,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
 			'arch_home'  => '1',
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -104,6 +106,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source'   => 'a_source',
 			'arch_author'  => 'some_author',
 			'arch_results' => 0,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -122,6 +125,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source'   => 'a_source',
 			'arch_date'    => '2019/12/31',
 			'arch_results' => 0,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -140,6 +144,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source'   => 'a_source',
 			'arch_cat'     => 'testcategory',
 			'arch_results' => 0,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -158,6 +163,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source'   => 'a_source',
 			'arch_tag'     => 'testtag',
 			'arch_results' => 0,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -177,6 +183,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source'       => 'a_source',
 			'arch_tax_testtax' => 'testterm',
 			'arch_results'     => 3,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -197,6 +204,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
 			'arch_err'   => $_SERVER['REQUEST_URI'],
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -215,6 +223,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
 			'arch_other' => $_SERVER['REQUEST_URI'],
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -240,6 +249,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'arch_search'  => 'term',
 			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC&author_name=author&terms=' . wp_json_encode( array( 'testtax' => array( 'testterm' ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ),
 			'arch_results' => 2,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -259,6 +269,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'arch_search'  => 'term',
 			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC',
 			'arch_results' => 3,
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -278,6 +289,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
 			'arch_other' => $_SERVER['REQUEST_URI'],
+			'nu'          => '/wp-content/uploads/',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -408,6 +420,86 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		);
 		$this->assertNotContains( '//stats.wp.com', $resource_hints );
 		$this->assertContains( '//example.com', $resource_hints );
+	}
+
+	/**
+	 * Test that build_view_data includes the uploads URL path.
+	 */
+	public function test_build_view_data_includes_uploads_path() {
+		global $wp_the_query;
+		$wp_the_query->is_home = true;
+		$view_data             = Tracking_Pixel::build_view_data();
+
+		$this->assertArrayHasKey( 'nu', $view_data );
+		$this->assertNotEmpty( $view_data['nu'] );
+	}
+
+	/**
+	 * Test that build_stats_details does not add inline click handler
+	 * when the uploads path is the default /wp-content/uploads/.
+	 */
+	public function test_build_stats_details_no_inline_handler_for_default_uploads() {
+		$data = array(
+			'v'    => 'ext',
+			'blog' => 1234,
+			'post' => 0,
+			'tz'   => false,
+			'srv'  => 'example.org',
+		);
+
+		$method = new \ReflectionMethod( Tracking_Pixel::class, 'build_stats_details' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$output = $method->invoke( new Tracking_Pixel(), $data );
+
+		// The default uploads path should not produce an inline click handler.
+		$this->assertStringNotContainsString( 'uploadUrl', $output );
+		$this->assertStringNotContainsString( 'addEventListener', $output );
+	}
+
+	/**
+	 * Test that build_stats_details adds inline click handler
+	 * when the uploads path differs from the default.
+	 */
+	public function test_build_stats_details_adds_inline_handler_for_custom_uploads() {
+		// Simulate a custom uploads path (e.g. multisite /files/).
+		add_filter( 'upload_dir', array( $this, 'filter_custom_upload_dir' ) );
+
+		$data = array(
+			'v'    => 'ext',
+			'blog' => 1234,
+			'post' => 0,
+			'tz'   => false,
+			'srv'  => 'example.org',
+		);
+
+		$method = new \ReflectionMethod( Tracking_Pixel::class, 'build_stats_details' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$output = $method->invoke( new Tracking_Pixel(), $data );
+
+		remove_filter( 'upload_dir', array( $this, 'filter_custom_upload_dir' ) );
+
+		// The custom uploads path should produce an inline click handler.
+		$this->assertStringContainsString( 'uploadUrl', $output );
+		$this->assertStringContainsString( 'addEventListener', $output );
+		$this->assertStringContainsString( "/files/", $output );
+	}
+
+	/**
+	 * Filter callback to simulate a custom uploads directory.
+	 *
+	 * @param array $uploads Upload directory data.
+	 * @return array
+	 */
+	public function filter_custom_upload_dir( $uploads ) {
+		$uploads['baseurl'] = 'http://example.org/files';
+		$uploads['basedir'] = '/tmp/files';
+		$uploads['url']     = 'http://example.org/files';
+		$uploads['path']    = '/tmp/files';
+		return $uploads;
 	}
 
 	/**


### PR DESCRIPTION
## What
Fixes #49478

## Why
The WPCOM Stats click tracker only matches same-host links containing the hardcoded string `/wp-content/uploads`. On WordPress multisite installs that serve uploads from `/files/` (the `ms_files_rewriting` mechanism), and any site using a custom `UPLOADS` constant or `upload_path`/`upload_url_path` option, media file clicks are never tracked — they silently fall through the same-host guard because the path prefix doesn't match.

## How

Two changes in `Tracking_Pixel`:

1. **View data** (`build_view_data`): Derive the effective uploads URL path via `wp_get_upload_dir()['baseurl']` and pass it as key `nu` in the view data object, so a future WPCOM tracker version can use it instead of hardcoding `/wp-content/uploads/`.

2. **Inline click handler** (`build_stats_details`): When the actual upload path differs from `/wp-content/uploads/`, inject a lightweight (~300 byte) event delegation handler that catches clicks on links pointing to the relocated upload directory and pushes them to `_stq` as click events. This handler is only present when uploads are relocated, has zero overhead for the default configuration.

The handler uses `document.addEventListener('click')` with `e.target.closest('a')` to handle dynamically added links and avoid interfering with the WPCOM tracker's own click handling for `/wp-content/uploads/` paths (both can coexist).

## Testing Instructions
1. Set up a WordPress multisite with `define('WP_CONTENT_URL', '/wp-content');` and `uploads` served from `/files/` (or use a single-site install with a custom `UPLOADS` constant)
2. Create a post containing download links to media files (e.g. `<a href="https://example.org/files/2024/01/doc.pdf">Download</a>`)
3. Visit the post from a logged-out browser, open the Network tab, and click the download link
4. **Before:** No beacon to `pixel.wp.com/g.gif` is fired
5. **After:** A beacon is fired containing the click data (`s=2`, the URL, referrer, blog, and post)
6. Verify that default-configuration sites (`/wp-content/uploads/`) are unaffected — no additional handler is injected

## Changelog
> Stats: detect clicks on relocated upload directories (e.g. multisite /files/) by passing the effective uploads path to the tracker.

## Does this pull request change what data or activity we track or use?
Yes — this change improves tracking of click events on media file downloads:
- On multisite installs using the `/files/` upload mechanism, clicks on download links to uploaded files are now tracked (previously missed because the tracker hardcoded `/wp-content/uploads/`)
- For sites with custom upload paths, the effective path is passed to the Stats view data (`nu` key), and click events are captured via inline event delegation
- No new personal data is collected — only standard click tracking data (URL, referrer, blog ID, post ID) is captured for previously missed upload paths

## Testing instructions
1. Set up a WordPress multisite with uploads served from `/files/` (or use a single-site with a custom `UPLOADS` constant)
2. Create a post containing download links to media files
3. Visit the post from a logged-out browser, open the Network tab, and click the download link
4. **Before:** No beacon to `pixel.wp.com/g.gif` is fired
5. **After:** A beacon is fired containing the click data
6. Verify that default sites using `/wp-content/uploads/` are unaffected