### PR TITLE
Upgrade nudge: replace  CSS class to avoid Gutenberg editor iframe warning

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Upgrade nudge: replace `.wp-block` CSS class with `.jetpack-nudge-canvas` to avoid Gutenberg iframe compatibility warnings in the block editor.

--- a/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Upgrade nudge: replace `.wp-block` CSS class with `.jetpack-nudge-canvas` to avoid Gutenberg iframe compatibility warnings in the block editor.

--- a/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-wp-block-css-warning
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Upgrade nudge: replace `.wp-block` CSS class with `.jetpack-nudge-canvas` to avoid Gutenberg iframe compatibility warnings in the block editor.

--- a/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/index.jsx
@@ -19,7 +19,7 @@ export const Nudge = ( {
 	target = '_top',
 } ) => {
 	const cssClasses = clsx( className, 'jetpack-upgrade-plan-banner', {
-		'wp-block': context === 'editor-canvas',
+		'jetpack-nudge-canvas': context === 'editor-canvas',
 		'block-editor-block-list__block': context === 'editor-canvas',
 		'jetpack-upgrade-plan__hidden': ! visible,
 	} );

--- a/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/style.scss
+++ b/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/style.scss
@@ -47,8 +47,8 @@
 	margin-bottom: 0;
 }
 
-.jetpack-upgrade-plan-banner.wp-block[data-align="right"] .jetpack-upgrade-plan-banner__wrapper,
-.jetpack-upgrade-plan-banner.wp-block[data-align="left"] .jetpack-upgrade-plan-banner__wrapper {
+.jetpack-upgrade-plan-banner.jetpack-nudge-canvas[data-align="right"] .jetpack-upgrade-plan-banner__wrapper,
+.jetpack-upgrade-plan-banner.jetpack-nudge-canvas[data-align="left"] .jetpack-upgrade-plan-banner__wrapper {
 	max-width: 580px;
 	width: 100%;
 }


### PR DESCRIPTION
## What
Fixes #46416

## Why
The upgrade-nudge component adds a  CSS class when rendered in the `editor-canvas` context. The Gutenberg iframe compatibility checker ([get-compatibility-styles.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/iframe/get-compatibility-styles.js)) scans all stylesheets injected into the editor iframe for content matching the string `.wp-block`. When it finds it in a stylesheet that wasn't properly enqueued via `block.json`, it emits warnings:

> `editor-jetpack-sidebar-css was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.`

This CSS is pulled into multiple bundles (Social sidebar, external media) through a barrel-file re-export chain in `shared-extension-utils`, where unused components like `Nudge` are still evaluated due to side-effect CSS imports — JavaScript tree-shaking can't eliminate the module because the CSS import in `index.jsx` is a side-effect.

## How
Replace the generic `.wp-block` class with a custom `.jetpack-nudge-canvas` class. This:
- Removes the `.wp-block` string from the stylesheet entirely
- Gutenberg's compatibility checker no longer flags it
- Preserves the same left/right alignment styling for paid plan upgrade nudges in the editor canvas

## Testing Instructions
1. Open any post in the block editor
2. Open the browser DevTools console
3. **Before:** One or more warnings like `editor-jetpack-sidebar-css was added to the iframe incorrectly`
4. **After:** No such warnings — the upgrade nudge banner still renders with correct left/right alignment

## Changelog
> Upgrade nudge: replace `.wp-block` CSS class with `.jetpack-nudge-canvas` to avoid Gutenberg iframe compatibility warnings in the block editor.

## Does this pull request change what data or activity we track or use?
No. This change only renames a CSS class from `.wp-block` to `.jetpack-nudge-canvas` — no data collection or tracking changes.

## Testing instructions
1. Open any post in the block editor
2. Open the browser DevTools console
3. **Before:** One or more warnings like `editor-jetpack-sidebar-css was added to the iframe incorrectly`
4. **After:** No such warnings — the upgrade nudge banner still renders with correct left/right alignment