### PR TITLE
Premium Analytics: prevent clipped widget focus outlines

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-widget-focus-outline-clipping
+++ b/projects/packages/premium-analytics/changelog/fix-widget-focus-outline-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Prevent widget focus outlines from being clipped.

--- a/projects/packages/premium-analytics/changelog/fix-widget-focus-outline-clipping
+++ b/projects/packages/premium-analytics/changelog/fix-widget-focus-outline-clipping
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Dashboard: Prevent widget focus outlines from being clipped.
+Dashboard: Prevent widget focus outlines from being clipped in dashboard and post detail views.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
@@ -22,7 +22,7 @@
 		border-radius: var(--wpds-border-radius-sm, 2px);
 		outline:
 			var(--wpds-border-width-focus) solid
-			var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
+			var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
 		outline-offset: calc(-1 * var(--wpds-border-width-focus));
 	}
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
@@ -3,8 +3,30 @@
 }
 
 .chart {
+	--leaderboard-focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
+
 	height: 100%;
 	justify-content: space-between;
+
+	// Both wp-admin core (`a:focus` box-shadow in common.css) and the
+	// @wordpress/ui Link (`outset-ring--focus` outline) draw an outward ring on
+	// plain focus — mouse clicks included — which the chart's scroll container
+	// clips to a partial border. Suppress both; keyboard focus gets the inset
+	// ring below instead.
+	:global(a:focus) {
+		box-shadow: none;
+		outline: none;
+	}
+
+	// Row label links sit inside the chart's scroll container, which would clip
+	// an outward focus ring — draw it inset instead.
+	:global(a:focus-visible) {
+		border-radius: var(--wpds-border-radius-sm, 2px);
+		outline:
+			var(--leaderboard-focus-ring-width) solid
+			var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
+		outline-offset: calc(-1 * var(--leaderboard-focus-ring-width));
+	}
 
 	.legend {
 		flex-wrap: nowrap;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.module.scss
@@ -3,8 +3,6 @@
 }
 
 .chart {
-	--leaderboard-focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
-
 	height: 100%;
 	justify-content: space-between;
 
@@ -23,9 +21,9 @@
 	:global(a:focus-visible) {
 		border-radius: var(--wpds-border-radius-sm, 2px);
 		outline:
-			var(--leaderboard-focus-ring-width) solid
+			var(--wpds-border-width-focus) solid
 			var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
-		outline-offset: calc(-1 * var(--leaderboard-focus-ring-width));
+		outline-offset: calc(-1 * var(--wpds-border-width-focus));
 	}
 
 	.legend {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
@@ -1,4 +1,8 @@
 .backLink {
+	--back-link-focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
+	// Space between the button content and the inset focus ring.
+	--back-link-focus-ring-gap: var(--wpds-dimension-padding-xs, 4px);
+
 	position: relative;
 	z-index: 2;
 	align-self: flex-start;
@@ -7,7 +11,9 @@
 	gap: var(--wpds-dimension-gap-xs, 4px);
 	min-block-size: 20px;
 	margin-block-end: var(--wpds-dimension-gap-md, 12px);
-	padding: 0;
+	// Widget roots clip overflow, so the focus ring is drawn inset and the ring
+	// plus its gap must live inside the button's own box.
+	padding: calc(var(--back-link-focus-ring-gap) + var(--back-link-focus-ring-width));
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	font: inherit;
 	font-size: 13px;
@@ -21,6 +27,14 @@
 .backLink:focus {
 	color: var(--wp-admin-theme-color);
 	text-decoration: none;
+}
+
+.backLink:focus-visible {
+	border-radius: var(--wpds-border-radius-sm, 2px);
+	outline:
+		var(--back-link-focus-ring-width) solid
+		var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
+	outline-offset: calc(-1 * var(--back-link-focus-ring-width));
 }
 
 .icon {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
@@ -1,8 +1,4 @@
 .backLink {
-	--back-link-focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
-	// Space between the button content and the inset focus ring.
-	--back-link-focus-ring-gap: var(--wpds-dimension-padding-xs, 4px);
-
 	position: relative;
 	z-index: 2;
 	align-self: flex-start;
@@ -13,7 +9,7 @@
 	margin-block-end: var(--wpds-dimension-gap-md, 12px);
 	// Widget roots clip overflow, so the focus ring is drawn inset and the ring
 	// plus its gap must live inside the button's own box.
-	padding: calc(var(--back-link-focus-ring-gap) + var(--back-link-focus-ring-width));
+	padding: calc(var(--wpds-dimension-padding-xs) + var(--wpds-border-width-focus));
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	font: inherit;
 	font-size: 13px;
@@ -32,9 +28,9 @@
 .backLink:focus-visible {
 	border-radius: var(--wpds-border-radius-sm, 2px);
 	outline:
-		var(--back-link-focus-ring-width) solid
+		var(--wpds-border-width-focus) solid
 		var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
-	outline-offset: calc(-1 * var(--back-link-focus-ring-width));
+	outline-offset: calc(-1 * var(--wpds-border-width-focus));
 }
 
 .icon {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.module.scss
@@ -29,7 +29,7 @@
 	border-radius: var(--wpds-border-radius-sm, 2px);
 	outline:
 		var(--wpds-border-width-focus) solid
-		var(--wpds-color-stroke-focus-brand, var(--wp-admin-theme-color, #3858e9));
+		var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
 	outline-offset: calc(-1 * var(--wpds-border-width-focus));
 }
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -6,6 +6,8 @@
 	flex: 1 1 auto;
 	min-block-size: 0;
 	overflow-y: auto;
+	// Reserve paint space for the widget host's outer focus outline.
+	padding-block-start: calc(var(--wpds-border-width-focus, 2px) + 2px);
 	// Match the horizontal padding of the page header and the section tabs so the
 	// widget grid lines up with them instead of sitting flush to the edge.
 	padding-block-end: 24px;

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -6,6 +6,8 @@
 	flex: 1 1 auto;
 	min-block-size: 0;
 	overflow-y: auto;
+	// Reserve paint space for the widget host's outer focus outline.
+	padding-block-start: calc(var(--wpds-border-width-focus, 2px) + 2px);
 	// Match the horizontal padding of the tab bar and header so the widget grid
 	// lines up with them instead of sitting flush to the edge.
 	padding-block-end: 24px;


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Reserve top paint space in Premium Analytics widget tab panels so the widget-level focus outline is not clipped when controls inside a first-row widget receive focus.
* Apply the fix to the main dashboard and post-detail widget tab panels.
* Add a Premium Analytics changelog entry.

## Screenshots 

### Before

| | | | |
| --- | --- | --- | --- |
| <img alt="Google Chrome -2026-07-07 at 13 28 44@2x" src="https://github.com/user-attachments/assets/29a69628-8ca7-4d5a-ba13-92b36f2e2975" /> | <img alt="Google Chrome -2026-07-07 at 13 28 58@2x" src="https://github.com/user-attachments/assets/7f2496bd-6269-4fd4-bd0e-92dbdd9a5bbc" /> | <img alt="Google Chrome -2026-07-07 at 13 29 09@2x" src="https://github.com/user-attachments/assets/16a998fe-a9e3-4dfd-af32-0cd90338d09c" /> | <img alt="Google Chrome -2026-07-07 at 13 29 23@2x" src="https://github.com/user-attachments/assets/c520f2a4-5127-4fda-b0bb-cdc66487a43b" /> |

### After

| | | | |
| --- | --- | --- | --- |
| <img alt="Google Chrome -2026-07-07 at 13 30 29@2x" src="https://github.com/user-attachments/assets/a21c7997-7bc0-4976-a6e2-88328ef71e84" /> | <img alt="Google Chrome -2026-07-07 at 14 44 00@2x" src="https://github.com/user-attachments/assets/8e2c9d76-856b-4086-b4c2-6cda5313fcd0" /> | <img alt="Google Chrome -2026-07-07 at 14 44 28@2x" src="https://github.com/user-attachments/assets/f98385d1-6282-4c8c-ab9d-c3e1e9c17f91" /> | <img alt="Google Chrome -2026-07-07 at 14 48 35@2x" src="https://github.com/user-attachments/assets/a2308853-9777-408a-9ffd-0b9a8592cf70" /> |


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Build Premium Analytics:
  * `pnpm --dir projects/packages/premium-analytics run build:wp-build`
* Open the Premium Analytics dashboard in wp-admin.
* Focus a control inside a first-row widget, such as the UTM Insights select control.
* Confirm the blue widget focus outline is fully visible and no longer clipped at the top edge.
* Open a post-detail Premium Analytics route with widget tabs.
* Focus a control inside a first-row widget and confirm the widget focus outline is fully visible there too.


