### PR TITLE
Stylelint: disable with null instead of false

### DIFF
--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -14,7 +14,7 @@ const baseConfig = {
 	rules: {
 		'plugin-wpds/no-unknown-ds-tokens': true,
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
-		'plugin-wpds/no-token-fallback-values': false, // Disabled because `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` is not configured yet.
+		'plugin-wpds/no-token-fallback-values': null, // Disabled because `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` is not configured yet.
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/50110

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Disable `plugin-wpds/no-token-fallback-values` rule with `null` rather than `false` as [per Stylelint docs](https://stylelint.io/user-guide/configure/#rules).

Otherwise, you might see:

```
$ stylelint --allow-empty-input --globby-options '{"gitignore":true,"ignore":["tools/docker/data","**/vendor/**","**/jetpack_vendor/**"]}' --fix projects/packages/search/src/instant-search/components/tabbed-search-filters.scss

Invalid Option: Invalid option value "false" for rule "plugin-wpds/no-token-fallback-values". Are you trying to disable this rule? If so use "null" instead
```

It'll get flipped to `true` later, after https://github.com/Automattic/jetpack/pull/50108 is done.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI passing, above example command passing
