### PR TITLE
AI Launchpad: drop the WooCommerce Launch Store task for the canonical Launch Site task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-507-ai-launchpad-launch-store-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-507-ai-launchpad-launch-store-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: replace the WooCommerce "Launch your store" task with the canonical "Launch your site" task, whose CTA opens a working launch flow and completes reliably (the old task dead-ended in the WooCommerce onboarding task list and could not complete when the guided setup was skipped).

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -729,15 +729,17 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					),
 					true
 				);
-				// build_tasks runs per id here, so its own dedup can't see this collision: the catalog holds both
-				// `woo_launch_site` and `site_launched`, and the former is remapped onto the latter. Keep the first.
-				if ( ! empty( $one ) && ! in_array( $one[0]['id'], $seen_ids, true ) ) {
-					$seen_ids[] = $one[0]['id'];
-					$built[]    = $one[0];
-				}
 			} catch ( \Throwable $e ) {
 				continue;
 			}
+			// build_tasks runs per id here, so its own dedup can't see this collision: the catalog holds both
+			// `woo_launch_site` and `site_launched`, and the former is remapped onto the latter. Keep the first.
+			$card = $one[0] ?? null;
+			if ( null === $card || isset( $seen_ids[ $card['id'] ] ) ) {
+				continue;
+			}
+			$seen_ids[ $card['id'] ] = true;
+			$built[]                 = $card;
 		}
 		return $built;
 	}
@@ -770,9 +772,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			}
 
 			// The WooCommerce launch task deep-links into the WC onboarding task list, which renders blank when the
-			// guided setup was skipped, and only completes via a WC option that skip never writes. Normalize it to the
-			// canonical site-launch task, which reads the real launch signal and self-completes. The prompt no longer
-			// offers it, so this only catches a stray AI emission.
+			// guided setup was skipped, and only completes via a WC option the skipped-setup flow never writes. Normalize
+			// it to the canonical site-launch task, which reads the real launch signal and self-completes. The prompt no
+			// longer offers it, so this only catches a stray AI emission.
 			if ( 'woo_launch_site' === $task['id'] ) {
 				$task['id'] = 'site_launched';
 			}
@@ -784,7 +786,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// One card per id — the client keys cards by id. The woo_launch_site→site_launched remap above can collide
 			// with a real site_launched (notably the ?all_tasks=1 view, which enumerates every catalog id), so collapse
 			// any repeat to the first occurrence.
-			if ( in_array( $task['id'], $seen_ids, true ) ) {
+			if ( isset( $seen_ids[ $task['id'] ] ) ) {
 				continue;
 			}
 
@@ -855,8 +857,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// Title follows our precise in-progress signal so it, the icon, and the CTA agree.
 			$title = $this->get_task_title( $task['id'], $in_progress, $title );
 
-			$seen_ids[] = $task['id'];
-			$built[]    = array(
+			$seen_ids[ $task['id'] ] = true;
+			$built[]                 = array(
 				'id'           => $task['id'],
 				'subtitle'     => $task['subtitle'],
 				'title'        => $title,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -21,6 +21,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 	const MIN_VALID_TASKS = 4;
 
+	// `woo_launch_site` stays a valid launch task so a stray AI emission passes PUT validation and is normalized to
+	// `site_launched` on read (see build_tasks), rather than failing the whole list into the deterministic fallback.
 	const LAUNCH_TASK_IDS = array( 'site_launched', 'blog_launched', 'woo_launch_site', 'link_in_bio_launched', 'videopress_launched' );
 
 	/**
@@ -72,7 +74,6 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		'woo_customize_store',
 		'woo_products',
 		'set_up_payments',
-		'woo_launch_site',
 	);
 
 	/**
@@ -715,7 +716,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function build_all_catalog_tasks() {
-		$built = array();
+		$built    = array();
+		$seen_ids = array();
 		foreach ( array_keys( wpcom_launchpad_get_task_definitions() ) as $task_id ) {
 			try {
 				$one = $this->build_tasks(
@@ -727,8 +729,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					),
 					true
 				);
-				if ( ! empty( $one ) ) {
-					$built[] = $one[0];
+				// build_tasks runs per id here, so its own dedup can't see this collision: the catalog holds both
+				// `woo_launch_site` and `site_launched`, and the former is remapped onto the latter. Keep the first.
+				if ( ! empty( $one ) && ! in_array( $one[0]['id'], $seen_ids, true ) ) {
+					$seen_ids[] = $one[0]['id'];
+					$built[]    = $one[0];
 				}
 			} catch ( \Throwable $e ) {
 				continue;
@@ -750,6 +755,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	private function build_tasks( $tasks, $bypass_visibility = false, $niche = '', $disable_hidden_woo = false ) {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
+		$seen_ids    = array();
 
 		// Some catalog visibility callbacks call is_plugin_active(), which is not loaded during a REST request.
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -763,7 +769,22 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				continue;
 			}
 
+			// The WooCommerce launch task deep-links into the WC onboarding task list, which renders blank when the
+			// guided setup was skipped, and only completes via a WC option that skip never writes. Normalize it to the
+			// canonical site-launch task, which reads the real launch signal and self-completes. The prompt no longer
+			// offers it, so this only catches a stray AI emission.
+			if ( 'woo_launch_site' === $task['id'] ) {
+				$task['id'] = 'site_launched';
+			}
+
 			if ( ! isset( $definitions[ $task['id'] ] ) ) {
+				continue;
+			}
+
+			// One card per id — the client keys cards by id. The woo_launch_site→site_launched remap above can collide
+			// with a real site_launched (notably the ?all_tasks=1 view, which enumerates every catalog id), so collapse
+			// any repeat to the first occurrence.
+			if ( in_array( $task['id'], $seen_ids, true ) ) {
 				continue;
 			}
 
@@ -834,7 +855,8 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			// Title follows our precise in-progress signal so it, the icon, and the CTA agree.
 			$title = $this->get_task_title( $task['id'], $in_progress, $title );
 
-			$built[] = array(
+			$seen_ids[] = $task['id'];
+			$built[]    = array(
 				'id'           => $task['id'],
 				'subtitle'     => $task['subtitle'],
 				'title'        => $title,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
@@ -11,7 +11,7 @@
 			"type": "array",
 			"minItems": 6,
 			"maxItems": 6,
-			"description": "Exactly six task selections. The last task MUST be a launch task (canonical: `site_launched`; flow-specific alternatives: `blog_launched`, `woo_launch_site`, `link_in_bio_launched`, `videopress_launched`); server enforces. Order follows the STEP rules from the system prompt: first-creation → niche-specific → foundation → launch. Catalog uses snake_case IDs.",
+			"description": "Exactly six task selections. The last task MUST be a launch task (canonical: `site_launched`; flow-specific alternatives: `blog_launched`, `link_in_bio_launched`, `videopress_launched`); server enforces. Order follows the STEP rules from the system prompt: first-creation → niche-specific → foundation → launch. Catalog uses snake_case IDs.",
 			"items": {
 				"type": "object",
 				"required": [ "id", "subtitle" ],

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.test.mts
@@ -17,7 +17,6 @@ const fileSchema = JSON.parse(
 const LAUNCH_TASKS = new Set( [
 	'site_launched',
 	'blog_launched',
-	'woo_launch_site',
 	'link_in_bio_launched',
 	'videopress_launched',
 ] );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -20,7 +20,6 @@ const TASK_SUBTITLES: Record< string, string > = {
 	drive_traffic: 'Help people find your site.',
 	site_launched: 'Launch your site for the world to see.',
 	blog_launched: 'Launch your blog for the world to see.',
-	woo_launch_site: 'Launch your store and start selling.',
 	link_in_bio_launched: 'Launch your link-in-bio page.',
 };
 
@@ -52,7 +51,7 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'set_up_payments',
 		'site_theme_selected',
 		'complete_profile',
-		'woo_launch_site',
+		'site_launched',
 	],
 	newsletter: [
 		'first_post_published_newsletter',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -24,7 +24,6 @@ export const TASK_MENU: readonly string[] = [
 	'setup_general',
 	'site_launched',
 	'blog_launched',
-	'woo_launch_site',
 	'link_in_bio_launched',
 	'set_up_payments',
 	'stripe_connected',
@@ -101,7 +100,7 @@ HARD RULES (do not break - the server rejects output that violates these):
 - Every "id" MUST come from the menu below, verbatim. Never invent IDs. Drop any task you cannot map to a menu ID.
 - Return exactly 6 tasks.
 - At least one task must create content (e.g. "first_post_published", "first_post_published_newsletter", "woo_products", or "add_about_page").
-- The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", "woo_launch_site", or "link_in_bio_launched".
+- The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", or "link_in_bio_launched".
 - Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
 - For the sell goal, order the commerce tasks store-first: "woo_customize_store", then "woo_products", then "set_up_payments", keeping the launch task last. Installing WooCommerce is added automatically as the first step, so do not include a task for it.
 - Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -33,7 +33,7 @@ const fixture: TailoredOutput = {
 		{ id: 'set_up_payments', subtitle: 'Set up checkout so customers can buy.' },
 		{ id: 'site_theme_selected', subtitle: 'Pick a theme that suits a ceramics studio.' },
 		{ id: 'complete_profile', subtitle: 'Tell shoppers the story behind Terra Ceramics.' },
-		{ id: 'woo_launch_site', subtitle: 'Launch the shop and start selling.' },
+		{ id: 'site_launched', subtitle: 'Launch the shop and start selling.' },
 	],
 	inferred: {
 		goal: 'sell',
@@ -96,7 +96,8 @@ describe( 'ctaKind', () => {
 
 	it( 'routes everything else to a deeplink', () => {
 		assert.equal( ctaKind( 'site_theme_selected' ), 'deeplink' );
-		// woo_launch_site has its own wc-admin deeplink, so it is not a launch kind.
+		// woo_launch_site is dropped server-side (remapped to site_launched), but guard the client too: were a stray
+		// one to reach here it must not be treated as a launch task.
 		assert.equal( ctaKind( 'woo_launch_site' ), 'deeplink' );
 		// The synthetic store tasks navigate to their wp-admin CTAs.
 		assert.equal( ctaKind( 'install_woocommerce' ), 'deeplink' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -53,8 +53,7 @@ export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
 const PATTERN_PAGE_TASK_IDS = [ 'add_about_page', 'add_gallery_page' ];
-// Launch tasks with no catalog deeplink: they open the wordpress.com launch
-// flow. woo_launch_site is excluded — it has its own deeplink.
+// Launch tasks with no catalog deeplink: they open the wordpress.com launch flow.
 const LAUNCH_TASK_IDS = [
 	'site_launched',
 	'blog_launched',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -752,15 +752,63 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->seed_sell_output_with_commerce_tasks();
 		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
 
-		foreach ( array( 'woo_customize_store', 'woo_products', 'set_up_payments', 'woo_launch_site' ) as $id ) {
+		foreach ( array( 'woo_customize_store', 'woo_products', 'set_up_payments' ) as $id ) {
 			$this->assertArrayHasKey( $id, $tasks, "$id should be kept as a disabled preview" );
 			$this->assertTrue( $tasks[ $id ]['disabled'], "$id should be disabled" );
 			$this->assertNull( $tasks[ $id ]['calypso_path'], "$id should have no CTA" );
 		}
 
+		// The WooCommerce launch task is normalized to the canonical site-launch task, which is not WooCommerce-gated.
+		$this->assertArrayNotHasKey( 'woo_launch_site', $tasks );
+		$this->assertArrayHasKey( 'site_launched', $tasks );
+		$this->assertFalse( $tasks['site_launched']['disabled'] );
+
 		// A non-commerce task in the same list stays actionable, not swept into the disabled treatment.
 		$this->assertArrayHasKey( 'site_theme_selected', $tasks );
 		$this->assertFalse( $tasks['site_theme_selected']['disabled'] );
+	}
+
+	/**
+	 * A stray `woo_launch_site` (whose CTA dead-ends in the WC onboarding task list and whose completion depends on a
+	 * WC option the skipped setup never writes) is normalized on read to the canonical `site_launched` launch task.
+	 */
+	public function test_get_remaps_woo_launch_site_to_site_launched() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'site_theme_selected', 'woo_launch_site' ) );
+
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertArrayNotHasKey( 'woo_launch_site', $tasks );
+		$this->assertArrayHasKey( 'site_launched', $tasks );
+		// The canonical launch task has no wc-admin deeplink CTA.
+		$this->assertStringNotContainsString( 'wc-admin', (string) $tasks['site_launched']['calypso_path'] );
+	}
+
+	/**
+	 * The remap must not produce two `site_launched` cards when a list already carries it alongside a stray
+	 * `woo_launch_site`: the tailored list keys cards by id, so a repeat has to collapse to a single card.
+	 */
+	public function test_get_dedupes_site_launched_when_remap_collides() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'woo_launch_site', 'site_theme_selected', 'site_launched' ) );
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertCount( 1, array_keys( $ids, 'site_launched', true ), 'exactly one site_launched card' );
+		$this->assertNotContains( 'woo_launch_site', $ids );
+	}
+
+	/**
+	 * The full-catalog testing view (?all_tasks=1) enumerates every id, so it builds both `site_launched` and the
+	 * remapped `woo_launch_site`. The result must still contain a single `site_launched` card.
+	 */
+	public function test_all_tasks_view_has_single_site_launched_despite_remap() {
+		wp_set_current_user( $this->admin_id );
+
+		$ids = array_column( $this->call_api( Requests::GET, '', null, array( 'all_tasks' => '1' ) )->get_data()['tasks'], 'id' );
+
+		$this->assertCount( 1, array_keys( $ids, 'site_launched', true ), 'exactly one site_launched card' );
+		$this->assertNotContains( 'woo_launch_site', $ids );
 	}
 
 	/**


### PR DESCRIPTION
Related to DOTOBRD-507

## Proposed changes

Replaces the AI Launchpad's WooCommerce "Launch your store" task (`woo_launch_site`) with the canonical "Launch your site" task (`site_launched`) for the sell goal (DOTOBRD-507).

`woo_launch_site` was broken two ways on WordPress.com:

* **Its CTA opened a blank page.** It deep-linked to `admin.php?page=wc-admin&task=launch_site`, a task inside WooCommerce's onboarding task-list UI. That UI only renders while the guided setup/profiler is active, so on a site where the merchant *skipped* the guided setup the link lands on an empty WooCommerce Admin screen. (The link is also stale — modern WooCommerce moved this to `page=wc-admin&path=/launch-your-store`.)
* **It could never complete.** Its completion callback reads the `launch_site` key out of WooCommerce's `woocommerce_task_list_tracked_completed_tasks` option, which only that same onboarding flow writes — so if the setup was skipped, the task stays stuck incomplete even after the site is launched.

`site_launched` — the prompt's own "canonical" launch task — reads the real WordPress.com `launch-status` signal, self-completes via a launch listener, and has no CTA quirk. Launching the site is what makes the store public anyway.

What changed (all AI-Launchpad-side; the shared catalog is untouched):

* **Client:** removed `woo_launch_site` from the AI prompt's task menu and launch-task rule (`prompts.ts`), and pointed the `sell` goal's deterministic fallback at `site_launched` (`fallback.ts`).
* **Server:** a read-side remap normalizes any stray `woo_launch_site` (a non-deterministic AI could still emit it) to `site_launched` before it reaches the UI. `woo_launch_site` stays a valid launch task for PUT validation so such a payload is accepted and normalized rather than rejected into the fallback. Removed it from `WOO_TASK_IDS`.
* **Dedup:** built tasks are now deduped by id — in `build_tasks` and in the per-id `?all_tasks=1` catalog view — so the remap can't yield two identical "Launch your site" cards (the client keys cards by id).
* Cosmetic: updated a stale `model.ts` comment and the schema-contract description.

## Related product discussion/links

* DOTOBRD-507

## Does this pull request change what data or activity we track or use?

No. No tracking or data collection changes.

## Testing instructions

The AI Launchpad is off by default. On a test site, enable it (visit any wp-admin page with `?enable-ai-launchpad=1`, then open **Site Setup**; `?reset-ai-launchpad=1` starts fresh).

1. **Sell goal ends with "Launch your site".** Run the wizard with the **sell** goal and tailor the list. The final task is **Launch your site**, and its CTA opens the WordPress.com launch flow (not a `wc-admin` page). Confirm there is no "Launch your store" task.
2. **No blank page.** On a site where the guided WooCommerce setup was skipped, the launch task no longer opens an empty WooCommerce Admin screen.
3. **Full-catalog view is clean.** Open the Site Setup page with `?all_tasks=1` and confirm there is exactly one "Launch your site" card (no duplicate) and no "Launch your store" card.
