### PR TITLE
My Jetpack: reload the page when toggling certain modules

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -8,13 +8,20 @@ import { MyJetpackModule } from '../../types';
 import { getModuleActivationMessage } from '../../utils/module-benefit-messages';
 import { getSharingBlockEditorUrl } from '../../utils/sharing-block';
 import SecondaryButton from '../action-button/secondary-button';
+import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
 import { useProductFiltersContext } from '../my-jetpack-tab-panel/products/products-tracking-context';
+import { reloadPage } from '../my-jetpack-tab-panel/products/reload-page';
 import type { ChangeEvent } from 'react';
 
 export type ModuleToggleProps = {
 	module: MyJetpackModule;
 	describedby?: string;
 };
+
+// Modules that register a server-rendered wp-admin sidebar item. Toggling them
+// needs a full page reload for the sidebar to reflect the change; the success
+// notice is persisted so it survives the reload.
+const MODULES_REQUIRING_RELOAD = [ 'podcast' ];
 
 /**
  * Renders a toggle for a Jetpack module.
@@ -89,6 +96,20 @@ export function ModuleToggle( { module: $module, describedby }: ModuleToggleProp
 				name: $module.module,
 				active,
 			} );
+
+			if ( success && MODULES_REQUIRING_RELOAD.includes( $module.module ) ) {
+				setPendingSuccessNotice(
+					active
+						? getModuleActivationMessage( $module.module, $module.name )
+						: sprintf(
+								/* translators: %s is the module name */
+								__( '%s has been deactivated.', 'jetpack-my-jetpack' ),
+								$module.name
+						  )
+				);
+				reloadPage();
+				return;
+			}
 
 			await showToggleNotice( {
 				noticeType: success ? 'success' : 'error',

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -21,7 +21,7 @@ export type ModuleToggleProps = {
 // Modules that register a server-rendered wp-admin sidebar item. Toggling them
 // needs a full page reload for the sidebar to reflect the change; the success
 // notice is persisted so it survives the reload.
-const MODULES_REQUIRING_RELOAD = [ 'podcast' ];
+const MODULES_REQUIRING_RELOAD = [ 'podcast', 'subscriptions', 'wpcom-reader' ];
 
 /**
  * Renders a toggle for a Jetpack module.

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
@@ -139,12 +139,16 @@ describe( 'ModuleToggle', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'reloads the page after toggling a menu-registering module (Podcast)', async () => {
-		render( <ModuleToggle module={ buildModule() } /> );
+	it.each( [
+		[ 'podcast', 'Podcast' ],
+		[ 'subscriptions', 'Newsletter' ],
+		[ 'wpcom-reader', 'WordPress.com Reader' ],
+	] )( 'reloads the page after toggling the menu-registering %s module', async ( slug, name ) => {
+		render( <ModuleToggle module={ buildModule( { module: slug, name } ) } /> );
 
 		await userEvent.click( screen.getByRole( 'checkbox' ) );
 
-		expect( mockToggleModule ).toHaveBeenCalledWith( { name: 'podcast', active: false } );
+		expect( mockToggleModule ).toHaveBeenCalledWith( { name: slug, active: false } );
 		// Persists a notice so it survives the reload, then reloads. No inline notice.
 		expect( setPendingSuccessNotice ).toHaveBeenCalledWith(
 			expect.stringContaining( 'deactivated' )

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
@@ -1,14 +1,17 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MyJetpackModule } from '../../../types';
+import { setPendingSuccessNotice } from '../../my-jetpack-tab-panel/products/pending-notice';
+import { reloadPage } from '../../my-jetpack-tab-panel/products/reload-page';
 import { ModuleToggle } from '../index';
 
-const mockToggleModule = jest.fn();
+const mockToggleModule = jest.fn( () => Promise.resolve( true ) );
 const mockTrackProductAction = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
 
-jest.mock( '@automattic/jetpack-shared-stores', () => ( {
-	store: {},
-} ) );
+jest.mock( '@automattic/jetpack-shared-stores', () => ( { store: {} } ) );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { updateJetpackModuleStatus: mockToggleModule } ),
@@ -40,14 +43,22 @@ jest.mock( '@wordpress/ui', () => {
 
 jest.mock( '@automattic/jetpack-components', () => ( {
 	useGlobalNotices: () => ( {
-		createSuccessNotice: jest.fn(),
-		createErrorNotice: jest.fn(),
+		createSuccessNotice: mockCreateSuccessNotice,
+		createErrorNotice: mockCreateErrorNotice,
 	} ),
 } ) );
 
 jest.mock( '../../my-jetpack-tab-panel/products/products-tracking-context', () => ( {
 	useProductFiltersContext: () => ( { trackProductAction: mockTrackProductAction } ),
 } ) );
+
+jest.mock( '../../../utils/module-benefit-messages', () => ( {
+	getModuleActivationMessage: ( _slug: string, name: string ) => `${ name } activated.`,
+} ) );
+
+// window.location can't be mocked directly, so reloadPage is its own mockable wrapper.
+jest.mock( '../../my-jetpack-tab-panel/products/reload-page' );
+jest.mock( '../../my-jetpack-tab-panel/products/pending-notice' );
 
 const sharedaddyModule = {
 	module: 'sharedaddy',
@@ -58,6 +69,14 @@ const sharedaddyModule = {
 	long_description: '',
 	search_terms: '',
 };
+
+const buildModule = ( overrides = {} ) =>
+	( {
+		module: 'podcast',
+		name: 'Podcast',
+		activated: true,
+		...overrides,
+	} ) as unknown as MyJetpackModule;
 
 describe( 'ModuleToggle', () => {
 	beforeEach( () => {
@@ -118,5 +137,30 @@ describe( 'ModuleToggle', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Switch to Sharing Buttons block' } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'reloads the page after toggling a menu-registering module (Podcast)', async () => {
+		render( <ModuleToggle module={ buildModule() } /> );
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( mockToggleModule ).toHaveBeenCalledWith( { name: 'podcast', active: false } );
+		// Persists a notice so it survives the reload, then reloads. No inline notice.
+		expect( setPendingSuccessNotice ).toHaveBeenCalledWith(
+			expect.stringContaining( 'deactivated' )
+		);
+		expect( reloadPage ).toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not reload for a regular module and shows an inline notice instead', async () => {
+		render( <ModuleToggle module={ buildModule( { module: 'sitemaps', name: 'Sitemaps' } ) } /> );
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( mockToggleModule ).toHaveBeenCalledWith( { name: 'sitemaps', active: false } );
+		expect( reloadPage ).not.toHaveBeenCalled();
+		expect( setPendingSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/my-jetpack/changelog/fix-podcast-module-toggle-reload
+++ b/projects/packages/my-jetpack/changelog/fix-podcast-module-toggle-reload
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: reload the page after toggling the Podcast module in My Jetpack so the wp-admin sidebar reflects the change, matching the Forms toggle behavior.
+Reload the page after toggling a menu-registering module (Podcast, Newsletter, Reader) in My Jetpack so the wp-admin sidebar reflects the change, matching the Forms toggle behavior.

--- a/projects/packages/my-jetpack/changelog/fix-podcast-module-toggle-reload
+++ b/projects/packages/my-jetpack/changelog/fix-podcast-module-toggle-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: reload the page after toggling the Podcast module in My Jetpack so the wp-admin sidebar reflects the change, matching the Forms toggle behavior.


### PR DESCRIPTION
https://github.com/user-attachments/assets/5f734594-9033-40d5-9e99-b301c6fae926

## Proposed changes

Some modules in My Jetpack ⇢ Products register menu items that are not addressed when toggling on/off. By reloading the page we force the menu to update to gain or remove the item in the Jetpack list (or Reader in the top bar).

Modules rendered in the My Jetpack module list go through the generic `ModuleToggle`, which never reloaded. This teaches `ModuleToggle` the same behavior for menu-registering modules:

* Add a `MODULES_REQUIRING_RELOAD` allowlist: `podcast`, `subscriptions` (Newsletter), and `wpcom-reader` (Reader) — each registers a Jetpack submenu.
* On a successful toggle of an allowlisted module, persist the success notice via the existing `setPendingSuccessNotice` helper (so it survives the reload and replays through `useReplayPendingNotice`), then call `reloadPage()`.
* Regular modules keep the current inline-notice, no-reload behavior.

Reuses the exact utilities the Forms product card already uses, so behavior is consistent across the two surfaces. (`wpcom-reader` is already treated as reload-requiring in the classic Settings app's `RELOAD_FOR_OPTION_VALUES`.)

## Testing instructions

* In My Jetpack's Growth tab, toggle **Podcast**, **Newsletter**, or **Reader** on/off from the module list — the page should fully reload and the Jetpack admin sidebar should gain/lose the corresponding item, with a success notice shown after the reload.
* Toggle a regular module (e.g. Sitemaps) — it should **not** reload and should show the usual inline notice.

Unit tests cover both paths for all three reload modules plus a non-reload module (`_inc/components/module-toggle/test/index.test.tsx`).

## Does this pull request change what data or activity we track or use?

No