### PR TITLE
Premium Analytics: take over the Stats menu (top slot, "Stats" label, replace Jetpack Stats)

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Move the Premium Analytics admin menu to the top position, directly under Dashboard, and remove the Jetpack Stats menu so Premium Analytics replaces it.
+Move the Premium Analytics admin menu to the top position, directly under Dashboard, and remove the Jetpack Stats menu (when present) so Premium Analytics replaces it.

--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Move the Premium Analytics admin menu to the top position, directly under Dashboard, and remove the Jetpack Stats menu so Premium Analytics replaces it.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -118,6 +118,9 @@ class Analytics {
 		}
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
+		// Remove the standalone Jetpack "Stats" menu so Premium Analytics takes its
+		// place. Runs after Stats registers itself (admin_menu priority 999).
+		add_action( 'admin_menu', array( static::class, 'remove_stats_menu' ), 1001 );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'ensure_script_data' ) );
 	}
@@ -173,8 +176,22 @@ class Analytics {
 			'jetpack-premium-analytics-wp-admin',
 			$render_callback,
 			'dashicons-chart-bar',
-			30
+			2
 		);
+	}
+
+	/**
+	 * Remove the standalone Jetpack "Stats" top-level menu.
+	 *
+	 * Premium Analytics registers at the same position Stats used (2, right under
+	 * Dashboard) and replaces it, so the two do not sit side by side. Hooked on
+	 * admin_menu at priority 1001 — after Stats registers itself at priority 999 —
+	 * so the menu exists to be removed. No-op when Stats is not present.
+	 *
+	 * @return void
+	 */
+	public static function remove_stats_menu() {
+		remove_menu_page( 'stats' );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -181,17 +181,8 @@ class Analytics {
 	}
 
 	/**
-	 * Remove the standalone Jetpack "Stats" top-level menu.
-	 *
-	 * Premium Analytics registers at the same position Stats used (2, right under
-	 * Dashboard) and replaces it, so the two do not sit side by side. Hooked on
-	 * admin_menu at priority 1001 — after Stats registers itself at priority 999 —
-	 * so the menu exists to be removed.
-	 *
-	 * Only removes the menu when it is actually registered: $admin_page_hooks has a
-	 * 'stats' entry only when the Stats module added its top-level page. This keeps
-	 * the replacement a no-op on sites where Stats is inactive and avoids touching
-	 * a menu Premium Analytics is not responsible for.
+	 * Remove the standalone Jetpack "Stats" top-level menu so Premium Analytics
+	 * replaces it, but only when Stats actually registered its menu.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -186,11 +186,20 @@ class Analytics {
 	 * Premium Analytics registers at the same position Stats used (2, right under
 	 * Dashboard) and replaces it, so the two do not sit side by side. Hooked on
 	 * admin_menu at priority 1001 — after Stats registers itself at priority 999 —
-	 * so the menu exists to be removed. No-op when Stats is not present.
+	 * so the menu exists to be removed.
+	 *
+	 * Only removes the menu when it is actually registered: $admin_page_hooks has a
+	 * 'stats' entry only when the Stats module added its top-level page. This keeps
+	 * the replacement a no-op on sites where Stats is inactive and avoids touching
+	 * a menu Premium Analytics is not responsible for.
 	 *
 	 * @return void
 	 */
 	public static function remove_stats_menu() {
+		if ( ! isset( $GLOBALS['admin_page_hooks']['stats'] ) ) {
+			return;
+		}
+
 		remove_menu_page( 'stats' );
 	}
 

--- a/projects/plugins/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
+++ b/projects/plugins/premium-analytics/changelog/update-premium-analytics-replace-stats-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Rename the admin menu label from "Premium Analytics" to "Stats".

--- a/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
+++ b/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
@@ -25,7 +25,7 @@ class Jetpack_Premium_Analytics {
 	 * Constructor.
 	 */
 	public function __construct() {
-		Analytics::init( array( 'menu_title' => 'Premium Analytics' ) );
+		Analytics::init( array( 'menu_title' => 'Stats' ) );
 		Cookie_Consent::init();
 	}
 }


### PR DESCRIPTION
## Proposed changes

Makes the **Premium Analytics** dashboard take over the top-of-sidebar "Stats" slot in wp-admin:

* **Position** — the menu moves to position `2`, directly under **Dashboard** (was `30`). `Analytics::register_admin_menu()`.
* **Label** — the menu is renamed from "Premium Analytics" to **"Stats"**. `Jetpack_Premium_Analytics::__construct()` now calls `Analytics::init( array( 'menu_title' => 'Stats' ) )`.
* **Replace Jetpack Stats** — the standalone Jetpack **Stats** top-level menu is removed so the two do not sit side by side. New `Analytics::remove_stats_menu()` is hooked on `admin_menu` at priority `1001` (Stats registers itself at priority `999`).
* **Guarded removal** — removal only runs when the Stats menu is actually registered (`isset( $GLOBALS['admin_page_hooks']['stats'] )`), which is the case only when the Stats module added its top-level page. On sites without Stats the replacement is a no-op, and Premium Analytics never touches a menu it is not responsible for.

Files: `projects/packages/premium-analytics/src/class-analytics.php`, `projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php`.

<img width="1447" height="820" alt="Screenshot 2026-07-07 at 12 01 36" src="https://github.com/user-attachments/assets/86c98ef6-a129-4a0e-8233-f842ee2cdd1b" />


## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the Premium Analytics plugin and standalone Jetpack Stats both active.
2. Load `wp-admin`.
3. **Before:** the sidebar shows a top-level **Stats** menu (`admin.php?page=stats`) at position 2 under Dashboard, and **Stats** further down the list.
4. **After this change:** a **Stats** menu at position 2 directly under **Dashboard** opens the Premium Analytics dashboard (`admin.php?page=jetpack-premium-analytics-wp-admin`), and the Jetpack **Stats** top-level menu (`page=stats`) is gone.
5. Deactivate the Stats module and reload `wp-admin`: the Premium Analytics "Stats" menu still appears at position 2, and nothing errors (removal is a no-op).

Verified end-to-end with Playwright against a local Jetpack Docker env: top-level menu order is `Dashboard → Stats (Premium Analytics) → …`, the menu label is "Stats", and no `page=stats` menu is present.
