### PR TITLE
Agents Manager: restore the AI chat on the Site Editor navigation view

### DIFF
--- a/projects/packages/agents-manager/changelog/update-agents-manager-restore-site-editor-navigation-chat
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-restore-site-editor-navigation-chat
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Site Editor: Restore the AI chat on the navigation view.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -269,12 +269,10 @@ class Agents_Manager {
 			}
 		}
 
-		// When Gutenberg's admin-bar-in-editor experiment is active, register the editor omnibar
-		// entry points. CIAB is excluded because it has its own Site Hub UI. The Help dropdown
-		// shows only in the full unified experience, and the Ask AI button shows whenever Agents
-		// Manager is enabled here. They stay registered on the navigation view too, because the
-		// Site Editor toggles the canvas on the client without a reload, so the frontend controls
-		// visibility there.
+		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, add the entry
+		// points to that editor admin bar. CIAB is excluded — it has its own Site Hub UI.
+		// Mirroring wp-admin: the Help "?" dropdown shows only in the full unified experience;
+		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
 			if ( self::is_unified_experience() ) {
@@ -945,23 +943,6 @@ class Agents_Manager {
 			&& function_exists( 'gutenberg_is_experiment_enabled' )
 			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
 			&& \gutenberg_is_experiment_enabled( 'gutenberg-admin-bar-in-editor' );
-	}
-
-	/**
-	 * Whether the current request is the Site Editor navigation view, as opposed to
-	 * the editing canvas (`?canvas=edit`) where the chat can dock.
-	 *
-	 * @return bool
-	 */
-	public static function is_site_editor_navigation() {
-		if ( 'site-editor.php' !== ( $GLOBALS['pagenow'] ?? '' ) ) {
-			return false;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only layout hint; changes no state.
-		$canvas = isset( $_GET['canvas'] ) ? sanitize_text_field( wp_unslash( $_GET['canvas'] ) ) : '';
-
-		return 'edit' !== $canvas;
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
+++ b/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
@@ -143,21 +143,15 @@ class Sidebar_Open_Preservation {
 	/**
 	 * Whether the docked-open shell should be pre-rendered on this request.
 	 *
-	 * True only when the app is loading (so the shell will be reconciled by the
-	 * app that mounts to manage it) and the cached state is both open and docked
-	 * — the only state that reshapes the admin layout. A cold session (no cache),
-	 * a closed sidebar, a floating (undocked) chat, or the Site Editor navigation
-	 * view all pre-render nothing.
+	 * True only when the app is loading (so it will take over the shell once
+	 * mounted) and the cached state is both open and docked — the only state
+	 * that reshapes the admin layout. A cold session (no cache), a closed
+	 * sidebar, or a floating (undocked) chat all pre-render nothing.
 	 *
 	 * @return bool
 	 */
 	private function should_pre_render_docked_shell(): bool {
 		if ( ! $this->should_preserve_sidebar_open_state() ) {
-			return false;
-		}
-
-		// Skip the pre-render on the Site Editor navigation view, where the chat can't dock.
-		if ( Agents_Manager::is_site_editor_navigation() ) {
 			return false;
 		}
 

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -150,10 +150,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			$GLOBALS['current_screen'] = $this->original_current_screen;
 		}
 
-		// Clear Site Editor context that individual tests set, so a failed
-		// assertion can't leak it into later tests.
-		unset( $GLOBALS['pagenow'], $_GET['canvas'] );
-
 		// Reset the REST server to clear any registered routes.
 		global $wp_rest_server;
 		$wp_rest_server = null;
@@ -761,65 +757,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) )
 		);
 
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the editor omnibar entry points stay registered on the Site Editor
-	 * navigation view (`site-editor.php` without `?canvas=edit`); the frontend hides them there.
-	 */
-	public function test_omnibar_entry_points_registered_on_site_editor_navigation() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-
-		$GLOBALS['pagenow'] = 'site-editor.php';
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) ),
-			'The Ask AI button must stay registered on the Site Editor navigation view.'
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) ),
-			'The Help menu must stay registered on the Site Editor navigation view.'
-		);
-
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the editor omnibar entry points are registered in the Site Editor editing
-	 * canvas (`?canvas=edit`), where the chat can dock.
-	 */
-	public function test_omnibar_entry_points_registered_in_site_editor_canvas() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-
-		$GLOBALS['pagenow'] = 'site-editor.php';
-		$_GET['canvas']     = 'edit';
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) ),
-			'The Ask AI button must be registered in the Site Editor canvas.'
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) ),
-			'The Help menu must be registered in the Site Editor canvas.'
-		);
-
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
 	}
 

--- a/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
+++ b/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
@@ -95,7 +95,7 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 		if ( function_exists( 'set_current_screen' ) ) {
 			set_current_screen( 'front' );
 		}
-		unset( $GLOBALS['current_screen'], $GLOBALS['pagenow'], $_GET['canvas'] );
+		unset( $GLOBALS['current_screen'], $GLOBALS['pagenow'] );
 
 		parent::tear_down();
 	}
@@ -433,40 +433,17 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the shell is pre-rendered in the Site Editor editing canvas
-	 * (`?canvas=edit`), where the chat docks.
+	 * Tests that the shell is still pre-rendered on an editor screen when
+	 * fullscreen mode is on (the default), where the chat docks.
 	 */
-	public function test_pre_renders_on_site_editor_canvas() {
+	public function test_pre_renders_on_fullscreen_editor() {
 		$this->enable_preservation();
 		$this->cache_open_state( true );
 		$GLOBALS['pagenow'] = 'site-editor.php';
-		$_GET['canvas']     = 'edit';
 		$this->set_fullscreen_preference( 'core/edit-site', true );
 
 		$result = $this->preservation->add_preopen_body_classes( 'foo bar' );
 
 		$this->assertStringContainsString( self::SIDEBAR_OPEN_CLASS, $result );
-	}
-
-	/**
-	 * Tests that nothing is pre-rendered on the Site Editor navigation view (no
-	 * `?canvas=edit`), where the chat can't dock.
-	 */
-	public function test_does_not_pre_render_on_site_editor_navigation() {
-		$this->enable_preservation();
-		$this->cache_open_state( true );
-		$GLOBALS['pagenow'] = 'site-editor.php';
-
-		$this->assertSame( 'foo bar', $this->preservation->add_preopen_body_classes( 'foo bar' ) );
-
-		// Stub the gate script so the empty output proves the navigation-view gate
-		// suppresses it, not a missing build file.
-		$gate_script   = '/* gate */';
-		$expected_path = dirname( __DIR__, 2 ) . '/src/../build/sidebar-docking-gate.js';
-		$this->stub_filesystem( $gate_script, $expected_path );
-
-		ob_start();
-		$this->preservation->print_sidebar_docking_gate_script();
-		$this->assertSame( '', ob_get_clean() );
 	}
 }


### PR DESCRIPTION
Fixes N/A — related to AI-1056

## Proposed changes
* Revert the Site Editor navigation-view gating added in #50120, restoring the AI chat there:
  * Remove `Agents_Manager::is_site_editor_navigation()`.
  * Remove the docked-sidebar pre-render skip in `Sidebar_Open_Preservation`, so the shell pre-renders on the navigation view again when the chat was left open and docked.
  * Revert the related test changes (navigation-view omnibar/pre-render tests and the `$_GET['canvas']` teardown cleanup).
* Changelog entry is `Significance: major` because this removes a public method that shipped in the released 0.7.0 package.

## Related product discussion/links
* AI-1056
* wp-calypso frontend counterpart (removes the client-side hiding): https://github.com/Automattic/wp-calypso/pull/112372

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This is the backend half; the visible behavior comes from the wp-calypso counterpart. Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/112372 with both PRs applied to your sandbox:

* Sync this package's `src/*.php` changes to the sandbox plugin copies (`{jetpack-plugin, jetpack-mu-wpcom-plugin} × {moon, sun}` under `jetpack_vendor/automattic/jetpack-agents-manager/`), and deploy the wp-calypso PR's frontend bundle (`cd apps/agents-manager && yarn dev --sync`).
* On a Simple site with the unified experience enabled, open the chat on any wp-admin screen and dock it, then visit `/wp-admin/site-editor.php` (the navigation view, no `?canvas=edit`): the docked sidebar shell should pre-render on load (no layout flash), and the Ask AI button and Help menu should show in the admin bar.
* Enter the editing canvas (`?canvas=edit`) and go back: the chat keeps working in both views.
* `composer phpunit` in `projects/packages/agents-manager` passes.
