### PR TITLE
premium-analytics: Add dummy dev-dep on device-detection

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-trunk-build-sigh
+++ b/projects/packages/premium-analytics/changelog/fix-trunk-build-sigh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add dummy dev-require on automattic/jetpack-device-detection to fix trunk build. Otherwise the indirect dep via automattic/woocommerce-analytics confuses things.
+
+

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -15,6 +15,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-device-detection": "@dev",
 		"automattic/phpunit-select-config": "@dev",
 		"automattic/jetpack-test-environment": "@dev"
 	},

--- a/projects/plugins/premium-analytics/changelog/fix-trunk-build-sigh
+++ b/projects/plugins/premium-analytics/changelog/fix-trunk-build-sigh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lock file update
+
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "2520bcc0d3875df8436b0fbef27888e00700b989"
+                "reference": "91fd5f530d94b4ac1eb5f0a5dc4633175559ab47"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -854,6 +854,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The trunk build is getting confused by the indirect dep via automattic/woocommerce-analytics.

This is a quick fix to (hopefully) make the trunk build pass again. A followup will try to fix this more reliably (or at least break it more reliably in CI so it breaks PRs too 😅).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1783398194703009-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷