### PR TITLE
SEO dashboard: migrate to `@wordpress/ui` Button

### DIFF
--- a/projects/packages/seo/_inc/components/dashboard-load-error.tsx
+++ b/projects/packages/seo/_inc/components/dashboard-load-error.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import './dashboard-load-error.scss';
 import type { FC } from 'react';
 
@@ -25,9 +25,7 @@ const DashboardLoadError: FC< Props > = ( { onRetry } ) => (
 		<p className="jetpack-seo-load-error__body">
 			{ __( 'This is usually temporary. Give it another try.', 'jetpack-seo' ) }
 		</p>
-		<Button variant="primary" onClick={ onRetry }>
-			{ __( 'Try again', 'jetpack-seo' ) }
-		</Button>
+		<Button onClick={ onRetry }>{ __( 'Try again', 'jetpack-seo' ) }</Button>
 	</div>
 );
 

--- a/projects/packages/seo/_inc/components/enable-seo-card.tsx
+++ b/projects/packages/seo/_inc/components/enable-seo-card.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card, Stack } from '@wordpress/ui';
+import { Button, Card, Stack } from '@wordpress/ui';
 import useSeoToolsToggle from '../data/use-seo-tools-toggle';
 import type { FC } from 'react';
 
@@ -31,9 +30,8 @@ const EnableSeoCard: FC = () => {
 					</p>
 					<div>
 						<Button
-							variant="primary"
 							onClick={ () => setActive( true ) }
-							isBusy={ isToggling }
+							loading={ isToggling }
 							disabled={ isToggling }
 						>
 							{ __( 'Enable SEO tools', 'jetpack-seo' ) }

--- a/projects/packages/seo/_inc/components/test/enable-seo-card.test.tsx
+++ b/projects/packages/seo/_inc/components/test/enable-seo-card.test.tsx
@@ -41,6 +41,9 @@ describe( 'EnableSeoCard', () => {
 
 		render( <EnableSeoCard /> );
 
-		expect( screen.getByRole( 'button', { name: 'Enable SEO tools' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Enable SEO tools' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -1,10 +1,9 @@
-import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
-import { Badge, Link } from '@wordpress/ui';
+import { Badge, IconButton, Link } from '@wordpress/ui';
 import useSeoPosts from '../../data/use-seo-posts';
 import './style.scss';
 import type { ContentRow } from '../../data/content-types';
@@ -61,7 +60,16 @@ interface EditButtonProps {
 
 const EditButton: FC< EditButtonProps > = ( { item, onEdit } ) => {
 	const handleClick = useCallback( () => onEdit( item ), [ item, onEdit ] );
-	return <Button icon={ pencil } label={ editSeoLabel } size="small" onClick={ handleClick } />;
+	return (
+		<IconButton
+			icon={ pencil }
+			label={ editSeoLabel }
+			size="small"
+			variant="minimal"
+			tone="neutral"
+			onClick={ handleClick }
+		/>
+	);
 };
 
 /**

--- a/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
+++ b/projects/packages/seo/_inc/screens/content/seo-inspector.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
-import {
-	Button,
-	SelectControl,
-	TextControl,
-	TextareaControl,
-	ToggleControl,
-} from '@wordpress/components';
+import { SelectControl, TextControl, TextareaControl, ToggleControl } from '@wordpress/components';
 import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
@@ -14,6 +8,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { Button, IconButton } from '@wordpress/ui';
 import { coverageStore } from '../../data/coverage-store';
 import SerpPreview from './serp-preview';
 import type { ContentPostType, SchemaType, SeoPostMeta } from '../../data/content-types';
@@ -179,12 +174,14 @@ const SeoInspector: FC< Props > = ( { postId, postType, onClose } ) => {
 				<h2 className="jetpack-seo-content__inspector-title">
 					{ __( 'Edit SEO', 'jetpack-seo' ) }
 				</h2>
-				<Button
+				<IconButton
 					icon={ close }
 					label={ __( 'Close', 'jetpack-seo' ) }
 					onClick={ onClose }
 					disabled={ isSaving }
 					size="small"
+					variant="minimal"
+					tone="neutral"
 				/>
 			</div>
 			<div className="jetpack-seo-content__inspector-body">
@@ -237,15 +234,10 @@ const SeoInspector: FC< Props > = ( { postId, postType, onClose } ) => {
 				/>
 			</div>
 			<div className="jetpack-seo-content__inspector-actions">
-				<Button variant="tertiary" onClick={ onClose } disabled={ isSaving }>
+				<Button variant="minimal" tone="neutral" onClick={ onClose } disabled={ isSaving }>
 					{ __( 'Cancel', 'jetpack-seo' ) }
 				</Button>
-				<Button
-					variant="primary"
-					onClick={ onSave }
-					isBusy={ isSaving }
-					disabled={ isSaving || isResolving }
-				>
+				<Button onClick={ onSave } loading={ isSaving } disabled={ isSaving || isResolving }>
 					{ __( 'Save', 'jetpack-seo' ) }
 				</Button>
 			</div>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -1,7 +1,6 @@
 import { DonutMeter } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card } from '@wordpress/ui';
+import { Button, Card } from '@wordpress/ui';
 import type { ContentCoverage } from '../../data/overview-types';
 import type { FC } from 'react';
 
@@ -90,7 +89,7 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
 					</div>
 				) }
 				<div className="jetpack-seo-overview__card-footer">
-					<Button variant="secondary" onClick={ onManage }>
+					<Button variant="outline" tone="neutral" onClick={ onManage }>
 						{ __( 'Manage content', 'jetpack-seo' ) }
 					</Button>
 				</div>

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/ui';
+import { Button, Card } from '@wordpress/ui';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
 import StatusDot from './status-dot';
 import type { SiteVerification } from '../../data/overview-types';
@@ -29,7 +28,7 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 				</div>
 			) ) }
 			<div className="jetpack-seo-overview__card-footer">
-				<Button variant="secondary" onClick={ onManage }>
+				<Button variant="outline" tone="neutral" onClick={ onManage }>
 					{ __( 'Manage verification', 'jetpack-seo' ) }
 				</Button>
 			</div>

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card, Stack } from '@wordpress/ui';
+import { Button, Card, Stack } from '@wordpress/ui';
 import StatusDot from './status-dot';
 import type { OverviewResponse } from '../../data/overview-types';
 import type { FC } from 'react';
@@ -47,7 +46,7 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 					/>
 				</Stack>
 				<div className="jetpack-seo-overview__card-footer">
-					<Button variant="secondary" onClick={ onManage }>
+					<Button variant="outline" tone="neutral" onClick={ onManage }>
 						{ __( 'Manage visibility', 'jetpack-seo' ) }
 					</Button>
 				</div>

--- a/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { Button, TextControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Badge, Link, Stack } from '@wordpress/ui';
+import { Badge, Button, Link, Stack } from '@wordpress/ui';
 import { useGoogleVerify } from '../../data/use-google-verify';
 import type { FC } from 'react';
 
@@ -104,16 +104,16 @@ const GoogleVerificationField: FC< Props > = ( { value, onChange, onCommit, disa
 			{ state !== 'verified' && (
 				<Stack direction="row" gap="sm" align="center">
 					<Button
-						variant="primary"
 						onClick={ autoVerify }
-						isBusy={ isVerifying }
+						loading={ isVerifying }
 						disabled={ disabled || isVerifying || state === 'loading' }
 					>
 						{ __( 'Verify with Google', 'jetpack-seo' ) }
 					</Button>
 					{ ! manualVisible && (
 						<Button
-							variant="tertiary"
+							variant="minimal"
+							tone="neutral"
 							onClick={ () => setManualOpen( true ) }
 							disabled={ disabled }
 						>

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { Button, TextareaControl, ToggleControl } from '@wordpress/components';
+import { TextareaControl, ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSearch } from '@wordpress/route';
-import { Badge, Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import { Badge, Button, Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
 import SchemaCard from './schema-card';
 import SocialPreviewsCard from './social-previews-card';
 import TitleStructureField from './title-structure-field';
@@ -243,7 +243,6 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						/>
 						<div className="jetpack-seo-settings__save">
 							<Button
-								variant="primary"
 								onClick={ () => commitFields( [ 'front_page_description' ] ) }
 								disabled={ isSaving || ! isDirty( [ 'front_page_description' ] ) }
 							>

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { TextControl, TextareaControl } from '@wordpress/components';
+import { Button as WPButton, TextControl, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
 import { normalizeProfileUrl } from '../../../data/schema-settings-utils';
@@ -122,14 +122,15 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 									__nextHasNoMarginBottom
 								/>
 							</div>
-							<Button
-								variant="minimal"
-								tone="destructive"
+							<WPButton
+								variant="tertiary"
+								isDestructive
 								onClick={ () => removeProfile( index ) }
 								disabled={ isSaving }
+								__next40pxDefaultSize
 							>
 								{ __( 'Remove profile', 'jetpack-seo' ) }
-							</Button>
+							</WPButton>
 						</Stack>
 					);
 				} ) }

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { Button, TextControl, TextareaControl } from '@wordpress/components';
+import { TextControl, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
+import { Button, Stack } from '@wordpress/ui';
 import { normalizeProfileUrl } from '../../../data/schema-settings-utils';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 import type { FC } from 'react';
@@ -123,11 +123,10 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 								/>
 							</div>
 							<Button
-								variant="tertiary"
-								isDestructive
+								variant="minimal"
+								tone="destructive"
 								onClick={ () => removeProfile( index ) }
 								disabled={ isSaving }
-								__next40pxDefaultSize
 							>
 								{ __( 'Remove profile', 'jetpack-seo' ) }
 							</Button>
@@ -135,12 +134,7 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 					);
 				} ) }
 				<div>
-					<Button
-						variant="secondary"
-						onClick={ addProfile }
-						disabled={ isSaving }
-						__next40pxDefaultSize
-					>
+					<Button variant="outline" tone="neutral" onClick={ addProfile } disabled={ isSaving }>
 						{ __( 'Add profile', 'jetpack-seo' ) }
 					</Button>
 				</div>
@@ -158,11 +152,7 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 			/>
 
 			<div className="jetpack-seo-settings__save">
-				<Button
-					variant="primary"
-					onClick={ save }
-					disabled={ isSaving || ! isDirty || hasProfileErrors }
-				>
+				<Button onClick={ save } disabled={ isSaving || ! isDirty || hasProfileErrors }>
 					{ saveLabel }
 				</Button>
 			</div>

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -89,7 +89,10 @@ describe( 'SchemaCard', () => {
 		expect(
 			screen.getByText( 'Enter a valid URL that starts with http:// or https://.' )
 		).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'allows full social profile URLs', () => {
@@ -108,7 +111,10 @@ describe( 'SchemaCard', () => {
 		expect(
 			screen.queryByText( 'Enter a valid URL that starts with http:// or https://.' )
 		).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toBeEnabled();
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'disables saving when social profile URLs are duplicated', () => {
@@ -128,7 +134,10 @@ describe( 'SchemaCard', () => {
 		expand();
 
 		expect( screen.getAllByText( 'This profile URL is already listed.' ) ).toHaveLength( 1 );
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'shows the configured-field count in the header', () => {

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -2,10 +2,10 @@
 
 /* eslint-disable react/jsx-no-bind */
 
-import { Button, TextControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Card, CollapsibleCard, Stack } from '@wordpress/ui';
+import { Badge, Button, Card, CollapsibleCard, Stack } from '@wordpress/ui';
 import {
 	PAGE_TYPES,
 	PAGE_TYPE_SUGGESTIONS,
@@ -107,8 +107,9 @@ const TitleStructureRow: FC< RowProps > = ( {
 					{ PAGE_TYPE_SUGGESTIONS[ pageTypeId ].map( tokenId => (
 						<Button
 							key={ tokenId }
-							variant="secondary"
-							size="small"
+							variant="outline"
+							tone="neutral"
+							size="compact"
 							disabled={ disabled }
 							onClick={ () => insertToken( tokenId ) }
 						>
@@ -124,7 +125,7 @@ const TitleStructureRow: FC< RowProps > = ( {
 					</div>
 				) }
 				<div className="jetpack-seo-settings__save">
-					<Button variant="primary" onClick={ onSave } disabled={ disabled || ! canSave }>
+					<Button onClick={ onSave } disabled={ disabled || ! canSave }>
 						{ saveLabel }
 					</Button>
 				</div>

--- a/projects/packages/seo/changelog/update-seo-ui-button
+++ b/projects/packages/seo/changelog/update-seo-ui-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Migrate SEO dashboard buttons from @wordpress/components to @wordpress/ui (Button/IconButton).


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->

Migrate SEO dashboard buttons from `@wordpress/components` [`Button`](https://wordpress.github.io/gutenberg/?path=/docs/components-button--docs) to `@wordpress/ui` [`Button`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) / [`IconButton`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-iconbutton--docs) to align with the rest of Jetpack.

- **Overview cards** — secondary actions use `variant="outline" tone="neutral"`.
- **Settings** — primary saves, verification, schema, and title-structure controls use WPDS `Button`; icon-only actions (close, edit) use `IconButton`.
- **Content inspector** — save/cancel and close button migrated.
- **Enable / error states** — primary actions use WPDS `Button` with `loading` instead of `isBusy`.
- **Tests** — disabled-state assertions updated for WPDS (`aria-disabled` instead of native `disabled`).

**Exception:** `disable-seo-tools.tsx` still uses `@wordpress/components` `Button variant="link"`. That can move to `@wordpress/ui` once [`LinkButton`](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) ships in the next UI package (https://github.com/WordPress/gutenberg/issues/77098).

Checked that there are no style overrides for previous Button component  (`.components-button`, `.is-primary`, `.is-secondary`, etc.)


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Smoke test SEO UI; things should look more or less the same for all buttons.

AI-generated steps:

- Open **Jetpack → SEO → Overview** — confirm card footer buttons, enable/disable SEO tools link, and coverage rings render correctly.
- Open **Settings** — exercise verification, schema (add/remove profile, save), title structure (insert tokens, per-row save), and front-page description save.
- Open **Content** — open the SEO inspector, edit fields, save/cancel; confirm the edit (pencil) action in the table.


## Screenshots

### Before
<img width="693" height="306" alt="Screenshot 2026-07-09 at 12 22 18" src="https://github.com/user-attachments/assets/a25b2ab1-a772-4f22-8771-667d566d5135" />
<img width="738" height="196" alt="Screenshot 2026-07-09 at 12 22 22" src="https://github.com/user-attachments/assets/3009e576-0166-4375-ac15-7a47e14d960b" />
<img width="713" height="471" alt="Screenshot 2026-07-09 at 12 22 37" src="https://github.com/user-attachments/assets/30a697c8-0473-4ff2-aff5-a2e1053a02ce" />
<img width="698" height="174" alt="Screenshot 2026-07-09 at 12 22 46" src="https://github.com/user-attachments/assets/8d08d9a5-e442-453f-84c2-ff41351bdc07" />
<img width="453" height="91" alt="image" src="https://github.com/user-attachments/assets/27709386-cab5-4007-9bc4-719b8816688f" />
<img width="1397" height="1010" alt="image" src="https://github.com/user-attachments/assets/be2e1474-b68f-4fa2-80e1-404c82e32933" />




### After
<img width="408" height="98" alt="Screenshot 2026-07-09 at 11 39 05" src="https://github.com/user-attachments/assets/e44f907f-2f78-4abe-aa10-4c8226fb7f0e" />
<img width="709" height="167" alt="Screenshot 2026-07-09 at 11 38 45" src="https://github.com/user-attachments/assets/31776d46-6258-4da2-b24f-452ce67de1fa" />
<img width="725" height="511" alt="Screenshot 2026-07-09 at 11 38 33" src="https://github.com/user-attachments/assets/ebc2488e-bd98-49b0-9d10-a032658ae87d" />
<img width="792" height="223" alt="Screenshot 2026-07-09 at 11 38 22" src="https://github.com/user-attachments/assets/3fe18266-fcaa-4813-872e-69fd1e857b29" />
<img width="1570" height="1017" alt="Screenshot 2026-07-09 at 11 38 15" src="https://github.com/user-attachments/assets/e2f55340-a94c-4eaf-ac1e-9bcdac43d8b4" />
