### PR TITLE
Forms: remove unused react-redux, redux, and redux-thunk dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2742,21 +2742,12 @@ importers:
       photon:
         specifier: 4.1.1
         version: 4.1.1
-      react-redux:
-        specifier: 7.2.8
-        version: 7.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router:
         specifier: 7.15.1
         version: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      redux:
-        specifier: 4.2.1
-        version: 4.2.1
-      redux-thunk:
-        specifier: 2.3.0
-        version: 2.3.0(redux@4.2.1)
       semver:
         specifier: 7.7.3
         version: 7.7.3

--- a/projects/packages/forms/changelog/update-forms-redux-deps
+++ b/projects/packages/forms/changelog/update-forms-redux-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove unused react-redux, redux, and redux-thunk dependencies

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -86,11 +86,8 @@
 		"libphonenumber-js": "1.13.3",
 		"lodash": "4.18.1",
 		"photon": "4.1.1",
-		"react-redux": "7.2.8",
 		"react-router": "7.15.1",
 		"react-transition-group": "^4.4.5",
-		"redux": "4.2.1",
-		"redux-thunk": "2.3.0",
 		"semver": "7.7.3",
 		"webpack": "5.107.2",
 		"webpack-cli": "6.0.1"

--- a/projects/packages/forms/src/dashboard/store/index.js
+++ b/projects/packages/forms/src/dashboard/store/index.js
@@ -1,4 +1,3 @@
-// import { createStore, applyMiddleware, compose } from 'redux';
 import { createReduxStore, register } from '@wordpress/data';
 import * as actions from './actions.js';
 import reducer from './reducer.js';


### PR DESCRIPTION
## Proposed changes

Follow-up to #50246 (which bumped the Jetpack **plugin** to react-redux 9.3.0 / redux 5.0.1 / redux-thunk 3.1.0).

The Forms **package** declared `react-redux` (7.2.8), `redux` (4.2.1), and `redux-thunk` (2.3.0) in its dependencies, but does not import any of them anywhere in source or tests. The dashboard store is built entirely with `@wordpress/data` (`createReduxStore` / `register`), and the only reference to `redux` is a commented-out import in `src/dashboard/store/index.js`. These three dependencies have been dead since the Forms blocks were moved into the package in #28630.

Rather than shipping the react-redux 9 upgrade for code that never uses it, this PR **removes the three unused dependencies**. This is the cleaner fix — it drops dead deps instead of aligning versions for nothing.

Verification:
- `grep -rn "react-redux"` and `grep -rnE "from 'redux'|from 'redux-thunk'"` across `projects/packages/forms` (excluding node_modules/build/dist) return only the commented-out line.
- Lockfile change is limited to the Forms importer block, regenerated with CI's non-destructive `pnpm install --no-frozen-lockfile --resolution-only`; `--frozen-lockfile` confirms "Lockfile is up to date, resolution step is skipped".

**Follow-up (out of scope here):** `projects/packages/search` also pins `react-redux` 7.2.8 and `redux` 4.2.1, but unlike Forms it **genuinely uses** them (`Provider`/`connect` from react-redux; `createStore`/`applyMiddleware`/`combineReducers` from redux). Aligning Search would require the real migration mirroring #50246 (react-redux 9 connect() typings, etc.), so it belongs in a separate PR.

## Related product discussion/links

* Follow-up to #50246

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a build-tooling/dependency change with no runtime behavior change.

* Check out this branch and run `jp pnpm --filter "@automattic/jetpack-forms" run test` — all suites pass (56 suites / 678 tests).
* Run `jp pnpm --filter "@automattic/jetpack-forms" run typecheck` — passes (`tsgo --noEmit`, no errors).
* Confirm `git grep` finds no `react-redux` / `redux` / `redux-thunk` imports in `projects/packages/forms` (only the pre-existing commented-out line in `src/dashboard/store/index.js`).
* Confirm `jp pnpm install --frozen-lockfile` reports the lockfile is up to date.
