### PR TITLE
cli: Improve handling of built package versions in mirror build

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-improve-build-package-version-handling
+++ b/projects/packages/premium-analytics/changelog/fix-improve-build-package-version-handling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Revert dummy dev-deps now that `jetpack build` is fixed.
+
+

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -15,8 +15,6 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/block-delimiter": "@dev",
-		"automattic/jetpack-device-detection": "@dev",
 		"automattic/phpunit-select-config": "@dev",
 		"automattic/jetpack-test-environment": "@dev"
 	},

--- a/projects/plugins/premium-analytics/changelog/fix-improve-build-package-version-handling
+++ b/projects/plugins/premium-analytics/changelog/fix-improve-build-package-version-handling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update lock file
+
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "5f4200e2a8be37fb82bd948a19c6d40c719d52b9"
+                "reference": "2520bcc0d3875df8436b0fbef27888e00700b989"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -854,8 +854,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/block-delimiter": "@dev",
-                "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -793,7 +793,11 @@ async function buildProject( t ) {
 		// Mirroring needs to munge the project's composer.json to point to the built files..
 		const idx = composerJson.repositories?.findIndex( r => r.options?.monorepo );
 		if ( typeof idx === 'number' && idx >= 0 ) {
-			// Extract only the versions this project actually depends on, in a consistent order,
+			t.output(
+				`\n=== Munging composer.json to fetch built packages and remove test-only deps ===\n\n`
+			);
+
+			// Point to the built copies of all (known) dependencies, in a consistent order,
 			// to avoid vendor/composer/installed.json changing randomly every build.
 			const deps = new Set( t.ctx.dependencies.get( t.project ) );
 			for ( const dep of deps ) {
@@ -801,51 +805,60 @@ async function buildProject( t ) {
 					deps.add( d );
 				}
 			}
-			const versions = {};
+			const versionedPkgs = [];
+			const allPkgs = [];
 			for ( const dep of [ ...deps ].sort() ) {
 				if ( t.ctx.versions[ dep ] ) {
-					versions[ t.ctx.versions[ dep ].name ] = t.ctx.versions[ dep ].runversion;
+					allPkgs.push( t.ctx.versions[ dep ].name );
+					if ( t.ctx.versions[ dep ].runversion === null ) {
+						delete composerJson[ 'require-dev' ]?.[ t.ctx.versions[ dep ].name ];
+					} else {
+						versionedPkgs.push( {
+							type: 'path',
+							url: t.ctx.versions[ dep ].path,
+							options: {
+								monorepo: true,
+								versions: {
+									[ t.ctx.versions[ dep ].name ]: t.ctx.versions[ dep ].runversion,
+								},
+							},
+						} );
+					}
+				}
+			}
+			if ( versionedPkgs.length > 0 ) {
+				composerJson.repositories.splice( idx, 0, ...versionedPkgs );
+			}
+
+			// Remove test-only deps. No need to install or publish them.
+			if ( composerJson.extra?.dependencies?.[ 'test-only' ]?.length > 0 ) {
+				for ( const dep of composerJson.extra.dependencies[ 'test-only' ] ) {
+					const depName = JSON.parse(
+						await fs.readFile( `projects/${ dep }/composer.json`, { encoding: 'utf8' } )
+					).name;
+					delete composerJson[ 'require-dev' ]?.[ depName ];
 				}
 			}
 
-			if (
-				Object.keys( versions ).length > 0 ||
-				composerJson.extra?.dependencies?.[ 'test-only' ]?.length > 0
-			) {
-				t.output(
-					`\n=== Munging composer.json to fetch built packages and/or remove test-only deps ===\n\n`
-				);
-				if ( Object.keys( versions ).length > 0 ) {
-					composerJson.repositories.splice( idx, 0, {
-						type: 'path',
-						url: t.argv.forMirrors + '/*/*',
-						options: {
-							monorepo: true,
-							versions,
-						},
-					} );
-				}
-				if ( composerJson.extra?.dependencies?.[ 'test-only' ]?.length > 0 ) {
-					for ( const dep of composerJson.extra.dependencies[ 'test-only' ] ) {
-						const depName = JSON.parse(
-							await fs.readFile( `projects/${ dep }/composer.json`, { encoding: 'utf8' } )
-						).name;
-						delete composerJson[ 'require-dev' ]?.[ depName ];
-					}
-				}
-				await writeFileAtomic(
-					`${ t.cwd }/composer.json`,
-					JSON.stringify( composerJson, null, '\t' ) + '\n',
-					{ encoding: 'utf8' }
-				);
-				// Update composer.lock too, if any and if we're installing.
-				if ( ! skipInstall && ( await fsExists( `${ t.cwd }/composer.lock` ) ) ) {
-					await t.execa( 'composer', [ 'update', '--no-install', ...Object.keys( versions ) ], {
-						cwd: t.cwd,
-						stdio: [ 'ignore', 'inherit', 'inherit' ],
-						buffer: false,
-					} );
-				}
+			// Remove the fallback to the unbuilt monorepo packages. Everything *should* already be handled above.
+			// Unknown indirect deps via a third-party package (e.g. automattic/woocommerce-analytics) will get
+			// resolved from Packagist.
+			composerJson.repositories = composerJson.repositories.filter(
+				r => ! r.options?.monorepo || r.options?.versions
+			);
+
+			await writeFileAtomic(
+				`${ t.cwd }/composer.json`,
+				JSON.stringify( composerJson, null, '\t' ) + '\n',
+				{ encoding: 'utf8' }
+			);
+			// Update composer.lock too, if any and if we're installing.
+			if ( ! skipInstall && allPkgs.length && ( await fsExists( `${ t.cwd }/composer.lock` ) ) ) {
+				await t.execa( 'composer', [ 'update', '--no-install', ...allPkgs ], {
+					cwd: t.cwd,
+					stdio: [ 'ignore', 'inherit', 'inherit' ],
+					buffer: false,
+				} );
 			}
 		}
 	}
@@ -887,6 +900,13 @@ async function buildProject( t ) {
 	const gitSlug = composerJson.extra?.[ 'mirror-repo' ];
 	if ( typeof gitSlug !== 'string' || gitSlug === '' ) {
 		t.output( `No mirror repo is configured for ${ t.project }\n` );
+		t.ctx.versions[ t.project ] = {
+			name: composerJson.name,
+			jsName: undefined,
+			path: null,
+			version: null,
+			runversion: null,
+		};
 		return;
 	}
 	t.output( `Repo name: ${ gitSlug }\n` );
@@ -987,29 +1007,35 @@ async function buildProject( t ) {
 	}
 
 	// Remove monorepo repos from composer.json.
-	if ( composerJson.repositories && composerJson.repositories.some( r => r.options?.monorepo ) ) {
-		composerJson.repositories = composerJson.repositories.filter( r => ! r.options?.monorepo );
-		if ( composerJson.repositories.length === 0 ) {
-			delete composerJson.repositories;
-		}
+	if ( composerJson.repositories ) {
+		if ( composerJson.repositories.some( r => r.options?.monorepo ) ) {
+			composerJson.repositories = composerJson.repositories.filter( r => ! r.options?.monorepo );
 
-		// Update '@dev' dependency version numbers in composer.json.
-		const composerDepTyes = [ 'require', 'require-dev' ];
-		for ( const key of composerDepTyes ) {
-			if ( composerJson[ key ] ) {
-				for ( const [ pkg, ver ] of Object.entries( composerJson[ key ] ) ) {
-					if ( ver === '@dev' ) {
-						for ( const ctxPkg of Object.values( t.ctx.versions ) ) {
-							if ( ctxPkg.name === pkg ) {
-								let massagedVer = ctxPkg.version;
-								massagedVer = `^${ massagedVer }`;
-								composerJson[ key ][ pkg ] = massagedVer;
-								break;
+			// Update '@dev' dependency version numbers in composer.json.
+			const composerDepTyes = [ 'require', 'require-dev' ];
+			for ( const key of composerDepTyes ) {
+				if ( composerJson[ key ] ) {
+					for ( const [ pkg, ver ] of Object.entries( composerJson[ key ] ) ) {
+						if ( ver === '@dev' ) {
+							for ( const ctxPkg of Object.values( t.ctx.versions ) ) {
+								if ( ctxPkg.name === pkg ) {
+									if ( key === 'require-dev' && ctxPkg.version === null ) {
+										delete composerJson[ key ][ pkg ];
+									} else {
+										let massagedVer = ctxPkg.version;
+										massagedVer = `^${ massagedVer }`;
+										composerJson[ key ][ pkg ] = massagedVer;
+									}
+									break;
+								}
 							}
 						}
 					}
 				}
 			}
+		}
+		if ( composerJson.repositories.length === 0 ) {
+			delete composerJson.repositories;
 		}
 
 		await writeFileAtomic(
@@ -1173,6 +1199,7 @@ async function buildProject( t ) {
 	t.ctx.versions[ t.project ] = {
 		name: composerJson.name,
 		jsName: packageJson?.name,
+		path: buildDir,
 		version: projectVersionNumber,
 		runversion: projectRunVersionNumber,
 	};


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We recently had an incident where trunk builds were broken because the premium-analytics package was indirectly depending on a few monorepo packages via a new dep on `automattic/woocommerce-analytics`, with no fully intra-monorepo dependency path. This meant that our dependency analysis didn't know about these dependencies.

When built alone, this worked ok-ish: the indirect monorepo deps weren't built and so the package wound up pulling in the monorepo trunk version rather than a built copy.

When built for trunk, however, things broke: the indirect deps still get built because trunk builds everything, while the Composer config for loading the built copies of packages didn't set a version for these since #23867. Composer therefore decides that the version is "dev-main" (it ignores `COMPOSER_ROOT_VERSION=dev-trunk` for this since the built copies are outside of the git tree), and then blows up because the dep from `automattic/woocommerce-analytics` can't be satisfied by a "dev-main" version.

The fix here is to be even more strict about the loading of the built copies, by configuring Composer to only see the built copies we have versions for in the first place.

To make things even more reliable in such a situation, we then also configure Composer to _not_ fall back to the in-monorepo unbuilt copy of the package. Instead it will have to fall back to whatever version is publicly released since we don't know about the dependency in order to have built it.

This, however, causes problems with `packages/test-environment` that isn't and shouldn't be mirrored, even though we do still "build" it. To resolve that, we extend the `composer.json` munging to delete the `require-dev` entry if the package is built but not mirrored, matching the logic we already use for "test-only" dependencies.

The end result, as far as current built artifacts go, is that anything that was previously published with a `require-dev` on the unpublished package "automattic/jetpack-test-environment" will no longer have that.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1783434192128649/1783398194.703009-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* A CI build of everything (which should happen in this PR) should work correctly. Built artifacts should have only the changes described, plus the usual noise.