### PR TITLE
Podcast Episode: render the player in all contexts

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-render-all-contexts
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-render-all-contexts
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast Episode: render the full player in all contexts (including the RSS feed) so it shows in the WPCOM Reader on Atomic and Jetpack sites.
+Podcast Episode: render the full player in all contexts (including the RSS feed) so it shows in the WPCOM Reader on Atomic and Jetpack sites, with a linked title and a native media fallback link for clients that strip the player.

--- a/projects/packages/podcast/changelog/fix-podcast-episode-render-all-contexts
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-render-all-contexts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast Episode: render the full player in all contexts (including the RSS feed) so it shows in the WPCOM Reader on Atomic and Jetpack sites.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Podcast;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Request;
 
 /**
  * Registers and renders the Podcast Episode block.
@@ -187,29 +186,19 @@ class Podcast_Episode_Block {
 	/**
 	 * Render callback.
 	 *
+	 * Renders the full player in every context so the RSS feed carries it — how the WPCOM Reader shows
+	 * it on Atomic/Jetpack sites. Email is handled separately by render_email().
+	 *
 	 * Pulls title, author, and date from the surrounding post — the post is
 	 * the episode. Cover art falls back to the show-level `podcasting_image`
 	 * option when the block has no episode-specific override.
 	 *
 	 * @param array     $attributes Block attributes.
-	 * @param string    $content    Inner content (fallback direct-link markup from save.js).
+	 * @param string    $content    Saved inner content from save.js; unused, the block renders its own markup.
 	 * @param \WP_Block $block      The parsed block instance, used to read post context.
 	 * @return string
 	 */
 	public static function render_block( $attributes, $content, $block = null ) {
-		// Outside the frontend, fall back to the saved direct link so RSS / email / REST export stays
-		// simple and predictable. The WPCOM Reader is the exception: it serves posts through the REST
-		// API but wants the full interactive player, so detect its render context and render normally.
-		$is_wpcom_reader = false;
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_once WP_CONTENT_DIR . '/lib/display-context.php';
-			$is_wpcom_reader = \A8C\Display_Context\READER === \A8C\Display_Context\get_current_context();
-		}
-
-		if ( ! Request::is_frontend() && ! $is_wpcom_reader ) {
-			return $content;
-		}
-
 		if ( empty( $attributes['mediaUrl'] ) ) {
 			return '';
 		}

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -331,7 +331,13 @@ class Podcast_Episode_Block {
 					<?php endif; ?>
 
 					<?php if ( $title ) : ?>
-						<h3 class="jetpack-podcast-episode__title" itemprop="name"><?php echo esc_html( $title ); ?></h3>
+						<h3 class="jetpack-podcast-episode__title" itemprop="name">
+							<?php if ( $episode_url ) : ?>
+								<a href="<?php echo esc_url( $episode_url ); ?>"><?php echo esc_html( $title ); ?></a>
+							<?php else : ?>
+								<?php echo esc_html( $title ); ?>
+							<?php endif; ?>
+						</h3>
 					<?php endif; ?>
 
 					<?php if ( $author_name || $publish_date || $duration ) : ?>
@@ -389,7 +395,7 @@ class Podcast_Episode_Block {
 								if ( $mime_type ) :
 									?>
 									data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
-							></video>
+							><a href="<?php echo esc_url( $media_url ); ?>"><?php esc_html_e( 'Watch the episode', 'jetpack-podcast' ); ?></a></video>
 						<?php else : ?>
 							<audio
 								class="jetpack-podcast-episode__audio"
@@ -400,7 +406,7 @@ class Podcast_Episode_Block {
 								if ( $mime_type ) :
 									?>
 									data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
-							></audio>
+							><a href="<?php echo esc_url( $media_url ); ?>"><?php esc_html_e( 'Listen to the episode', 'jetpack-podcast' ); ?></a></audio>
 						<?php endif; ?>
 					</div>
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/style.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/style.scss
@@ -96,6 +96,16 @@ $jetpack-podcast-episode-gap: 16px;
 		margin: 0;
 		font-size: 1.4em;
 		line-height: 1.3;
+
+		a {
+			color: inherit;
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	.jetpack-podcast-episode__byline {

--- a/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
+++ b/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
@@ -93,16 +93,24 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 		return $result;
 	}
 
-	public function test_non_frontend_returns_content_unchanged() {
+	public function test_renders_player_in_non_frontend_context() {
 		remove_filter( 'jetpack_is_frontend', '__return_true' );
 		add_filter( 'jetpack_is_frontend', '__return_false' );
 
-		$result = Podcast_Episode_Block::render_block( array(), '<a href="x">Listen</a>' );
+		$post_id = $this->create_episode_post();
+		$result  = Podcast_Episode_Block::render_block(
+			$this->default_attrs,
+			'<a class="jetpack-podcast-episode__direct-link" href="x">x</a>',
+			$this->block_ctx( $post_id )
+		);
+		wp_delete_post( $post_id, true );
 
 		remove_filter( 'jetpack_is_frontend', '__return_false' );
 		add_filter( 'jetpack_is_frontend', '__return_true' );
 
-		$this->assertSame( '<a href="x">Listen</a>', $result );
+		$this->assertStringContainsString( 'jetpack-podcast-episode__player', $result );
+		$this->assertStringContainsString( '<audio', $result );
+		$this->assertStringNotContainsString( '__direct-link', $result );
 	}
 
 	public function test_empty_media_url_returns_empty_string() {

--- a/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
+++ b/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
@@ -168,12 +168,13 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 			)
 		);
 
-		$result = Podcast_Episode_Block::render_block( $this->default_attrs, '', $this->block_ctx( $post_id ) );
+		$result    = Podcast_Episode_Block::render_block( $this->default_attrs, '', $this->block_ctx( $post_id ) );
+		$permalink = get_permalink( $post_id );
 
 		wp_delete_post( $post_id, true );
 		wp_delete_user( $user_id );
 
-		$this->assertStringContainsString( 'Episode 7: The Renderer', $result );
+		$this->assertStringContainsString( '<a href="' . esc_url( $permalink ) . '">Episode 7: The Renderer</a>', $result );
 		$this->assertStringContainsString( 'Jane Host', $result );
 		$this->assertStringContainsString( 'itemprop="author" itemscope itemtype="https://schema.org/Person"', $result );
 		$this->assertStringContainsString( 'datetime="2026-04-15', $result );
@@ -189,12 +190,14 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( '<video', $result );
 		$this->assertStringContainsString( 'https://example.com/episode.mp4', $result );
+		$this->assertStringContainsString( 'Watch the episode</a></video>', $result );
 		$this->assertStringNotContainsString( '<audio', $result );
 	}
 
 	public function test_audio_media_type_renders_audio_element() {
 		$result = $this->render( array() );
 		$this->assertStringContainsString( '<audio', $result );
+		$this->assertStringContainsString( 'Listen to the episode</a></audio>', $result );
 		$this->assertStringNotContainsString( '<video', $result );
 	}
 

--- a/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
+++ b/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
@@ -29,12 +29,11 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 	private $default_attrs = array( 'mediaUrl' => 'https://example.com/episode.mp3' );
 
 	/**
-	 * Force is_frontend true and prime WP_Block_Supports so direct render_block
-	 * calls don't warn from get_block_wrapper_attributes().
+	 * Prime WP_Block_Supports so direct render_block calls don't warn from
+	 * get_block_wrapper_attributes().
 	 */
 	public function set_up() {
 		parent::set_up();
-		add_filter( 'jetpack_is_frontend', '__return_true' );
 		update_option( 'date_format', 'F j, Y' );
 		WP_Block_Supports::$block_to_render = array(
 			'blockName' => 'jetpack/podcast-episode',
@@ -46,7 +45,6 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 	 * Tear down filters/options/block-supports state set in set_up.
 	 */
 	public function tear_down() {
-		remove_filter( 'jetpack_is_frontend', '__return_true' );
 		delete_option( 'podcasting_image' );
 		delete_option( 'date_format' );
 		WP_Block_Supports::$block_to_render = null;
@@ -93,10 +91,7 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 		return $result;
 	}
 
-	public function test_renders_player_in_non_frontend_context() {
-		remove_filter( 'jetpack_is_frontend', '__return_true' );
-		add_filter( 'jetpack_is_frontend', '__return_false' );
-
+	public function test_renders_player_ignoring_saved_fallback_content() {
 		$post_id = $this->create_episode_post();
 		$result  = Podcast_Episode_Block::render_block(
 			$this->default_attrs,
@@ -105,11 +100,7 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 		);
 		wp_delete_post( $post_id, true );
 
-		remove_filter( 'jetpack_is_frontend', '__return_false' );
-		add_filter( 'jetpack_is_frontend', '__return_true' );
-
 		$this->assertStringContainsString( 'jetpack-podcast-episode__player', $result );
-		$this->assertStringContainsString( '<audio', $result );
 		$this->assertStringNotContainsString( '__direct-link', $result );
 	}
 


### PR DESCRIPTION
## What this does

The Podcast Episode block used to only show its full player on the front end of a site. Everywhere else — RSS feed, Reader on Atomic/Jetpack sites — you just got a plain "listen" link.

This makes the block render the full player in **every** context. Because the player now lives in the RSS feed, the WPCOM Reader picks it up on Atomic/Jetpack sites too, with no wpcom-side change.

Also:
* The episode title is now a link back to the post.
* The `<audio>`/`<video>` tags carry a plain link inside them, so clients that strip the player still show something clickable.
* Email is untouched — it's handled separately by `render_email()`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the Podcast module on, publish a post with a Podcast Episode block that has a media URL.
2. Open the post's RSS feed (`/feed/`) — the item should contain the full player markup (`jetpack-podcast-episode__player`, `<audio>`/`<video>`), not just a bare link.
3. On an Atomic/Jetpack site, open the post in the Reader (`wordpress.com/read`) — the player should render.
4. View the post on the front end — the player should look the same as before.
