### PR TITLE
My Jetpack: register wp-build-polyfills so the app (and Boost) loads without Gutenberg on WP < 7.0

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the My Jetpack app failing to load on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle it depends on is otherwise unregistered.
+Fix the My Jetpack app failing to load on WordPress 6.9 installs without the Gutenberg plugin active, where the wp-theme script handle it depends on is otherwise unregistered.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Register the wp-build-polyfills shim so the My Jetpack app loads on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle is otherwise unregistered.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Register the wp-build-polyfills shim so the My Jetpack app loads on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle is otherwise unregistered.
+Fix the My Jetpack app failing to load on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle it depends on is otherwise unregistered.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -20,7 +20,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-protect-status": "@dev"
+		"automattic/jetpack-protect-status": "@dev",
+		"automattic/jetpack-wp-build-polyfills": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -277,6 +277,13 @@ class Initializer {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
+		// Register the wp-build-polyfills shim before the extension hook below or
+		// the app script can enqueue against wp-theme / wp-private-apis / wp-notices.
+		// WP_Build_Polyfills registers synchronously on its first caller, so calling
+		// it after a hook consumer would leave our handles recorded but unregistered
+		// for this request.
+		self::register_wp_build_polyfills();
+
 		/**
 		 * Fires after the My Jetpack page is initialized.
 		 * Allows for enqueuing additional scripts only on the My Jetpack page.
@@ -284,7 +291,6 @@ class Initializer {
 		 * @since 4.35.7
 		 */
 		do_action( 'myjetpack_enqueue_scripts' );
-		self::register_wp_build_polyfills();
 		Assets::register_script(
 			'my_jetpack_main_app',
 			'../build/index.js',

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -251,12 +251,7 @@ class Initializer {
 	/**
 	 * Register polyfills for the wp-notices / wp-private-apis / wp-theme handles the
 	 * My Jetpack app bundle depends on but WP < 7.0 does not ship (or ships with an
-	 * incomplete allowlist) when the Gutenberg plugin is not active.
-	 *
-	 * Without this, `my_jetpack_main_app` is enqueued with an unregistered `wp-theme`
-	 * dependency, so WP silently drops the script (no console error) and the My Jetpack
-	 * app — plus any consumer that hard-depends on it, such as Jetpack Boost — renders
-	 * a blank page. Only the handles the bundle actually uses are requested.
+	 * incomplete allowlist).
 	 *
 	 * @return void
 	 */

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,6 +29,7 @@ use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 use Jetpack;
 use WP_Error;
 
@@ -248,6 +249,29 @@ class Initializer {
 	}
 
 	/**
+	 * Register polyfills for the wp-notices / wp-private-apis / wp-theme handles the
+	 * My Jetpack app bundle depends on but WP < 7.0 does not ship (or ships with an
+	 * incomplete allowlist) when the Gutenberg plugin is not active.
+	 *
+	 * Without this, `my_jetpack_main_app` is enqueued with an unregistered `wp-theme`
+	 * dependency, so WP silently drops the script (no console error) and the My Jetpack
+	 * app — plus any consumer that hard-depends on it, such as Jetpack Boost — renders
+	 * a blank page. Only the handles the bundle actually uses are requested.
+	 *
+	 * @return void
+	 */
+	public static function register_wp_build_polyfills() {
+		if ( ! class_exists( WP_Build_Polyfills::class ) ) {
+			return;
+		}
+
+		WP_Build_Polyfills::register(
+			'my-jetpack',
+			array( 'wp-notices', 'wp-private-apis', 'wp-theme' )
+		);
+	}
+
+	/**
 	 * Enqueue admin page assets.
 	 *
 	 * @return void
@@ -260,6 +284,7 @@ class Initializer {
 		 * @since 4.35.7
 		 */
 		do_action( 'myjetpack_enqueue_scripts' );
+		self::register_wp_build_polyfills();
 		Assets::register_script(
 			'my_jetpack_main_app',
 			'../build/index.js',

--- a/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests for Initializer::register_wp_build_polyfills().
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies My Jetpack requests the wp-build-polyfills shim for the script handles
+ * its app bundle depends on but older WordPress (< 7.0, no Gutenberg) does not ship.
+ *
+ * @see \Automattic\Jetpack\My_Jetpack\Initializer::register_wp_build_polyfills
+ */
+class Register_Wp_Build_Polyfills_Test extends TestCase {
+
+	/**
+	 * The app bundle's polyfill-provided handles that must be requested.
+	 */
+	const EXPECTED_HANDLES = array( 'wp-notices', 'wp-private-apis', 'wp-theme' );
+
+	/**
+	 * Registering requests each required handle for the `my-jetpack` consumer.
+	 */
+	public function test_registers_required_polyfill_handles() {
+		Initializer::register_wp_build_polyfills();
+
+		$consumers = WP_Build_Polyfills::get_consumers();
+
+		foreach ( self::EXPECTED_HANDLES as $handle ) {
+			$this->assertArrayHasKey( $handle, $consumers, "$handle should be requested" );
+			$this->assertContains( 'my-jetpack', $consumers[ $handle ], "$handle should list the my-jetpack consumer" );
+		}
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * Verifies My Jetpack requests the wp-build-polyfills shim for the script handles
@@ -24,6 +25,24 @@ class Register_Wp_Build_Polyfills_Test extends TestCase {
 	const EXPECTED_HANDLES = array( 'wp-notices', 'wp-private-apis', 'wp-theme' );
 
 	/**
+	 * Reset the WP_Build_Polyfills static registrar so tests do not inherit state.
+	 */
+	public function tearDown(): void {
+		foreach ( array(
+			'requested'            => array(),
+			'hooked'               => false,
+			'wp_version_threshold' => '7.0',
+		) as $name => $value ) {
+			$prop = new ReflectionProperty( WP_Build_Polyfills::class, $name );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$prop->setAccessible( true );
+			}
+			$prop->setValue( null, $value );
+		}
+		parent::tearDown();
+	}
+
+	/**
 	 * Registering requests each required handle for the `my-jetpack` consumer.
 	 */
 	public function test_registers_required_polyfill_handles() {
@@ -35,5 +54,30 @@ class Register_Wp_Build_Polyfills_Test extends TestCase {
 			$this->assertArrayHasKey( $handle, $consumers, "$handle should be requested" );
 			$this->assertContains( 'my-jetpack', $consumers[ $handle ], "$handle should list the my-jetpack consumer" );
 		}
+	}
+
+	/**
+	 * Guards against bundle drift: if a future `@wordpress/*` bump makes the app
+	 * depend on another polyfill-covered handle (e.g. `wp-views`) that we do not
+	 * request, that page would blank out with no console error. Fail here instead.
+	 *
+	 * Skips when the package has not been built (no asset file to inspect).
+	 */
+	public function test_requested_handles_cover_polyfilled_bundle_dependencies() {
+		$asset_file = dirname( __DIR__, 2 ) . '/build/index.asset.php';
+		if ( ! is_readable( $asset_file ) ) {
+			$this->markTestSkipped( 'my_jetpack_main_app build asset not found; run the package build first.' );
+		}
+
+		$asset      = require $asset_file;
+		$deps       = $asset['dependencies'] ?? array();
+		$polyfilled = array_values( array_intersect( $deps, WP_Build_Polyfills::SCRIPT_HANDLES ) );
+		$missing    = array_values( array_diff( $polyfilled, self::EXPECTED_HANDLES ) );
+
+		$this->assertSame(
+			array(),
+			$missing,
+			'The app bundle depends on polyfill-covered handle(s) not requested by register_wp_build_polyfills(): ' . implode( ', ', $missing )
+		);
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Register_Wp_Build_Polyfills_Test.php
@@ -55,29 +55,4 @@ class Register_Wp_Build_Polyfills_Test extends TestCase {
 			$this->assertContains( 'my-jetpack', $consumers[ $handle ], "$handle should list the my-jetpack consumer" );
 		}
 	}
-
-	/**
-	 * Guards against bundle drift: if a future `@wordpress/*` bump makes the app
-	 * depend on another polyfill-covered handle (e.g. `wp-views`) that we do not
-	 * request, that page would blank out with no console error. Fail here instead.
-	 *
-	 * Skips when the package has not been built (no asset file to inspect).
-	 */
-	public function test_requested_handles_cover_polyfilled_bundle_dependencies() {
-		$asset_file = dirname( __DIR__, 2 ) . '/build/index.asset.php';
-		if ( ! is_readable( $asset_file ) ) {
-			$this->markTestSkipped( 'my_jetpack_main_app build asset not found; run the package build first.' );
-		}
-
-		$asset      = require $asset_file;
-		$deps       = $asset['dependencies'] ?? array();
-		$polyfilled = array_values( array_intersect( $deps, WP_Build_Polyfills::SCRIPT_HANDLES ) );
-		$missing    = array_values( array_diff( $polyfilled, self::EXPECTED_HANDLES ) );
-
-		$this->assertSame(
-			array(),
-			$missing,
-			'The app bundle depends on polyfill-covered handle(s) not requested by register_wp_build_polyfills(): ' . implode( ', ', $missing )
-		);
-	}
 }

--- a/projects/plugins/backup/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1325,7 +1325,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1344,6 +1344,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/boost/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a blank Boost admin page on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle the embedded My Jetpack app depends on was otherwise unregistered.

--- a/projects/plugins/boost/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a blank Boost admin page on WordPress installs without the Gutenberg plugin active, where the wp-theme script handle the embedded My Jetpack app depends on was otherwise unregistered.
+Fix a blank Boost admin page on WordPress 6.9 installs without the Gutenberg plugin active, where the wp-theme script handle the embedded My Jetpack app depends on was otherwise unregistered.

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1242,7 +1242,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1261,6 +1261,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -2081,6 +2082,72 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "116ceba3c357f49d40854f3083f60faa372f5c25"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run build",
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available or incomplete in older WP versions",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: other
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2303,7 +2303,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2322,6 +2322,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1304,7 +1304,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1323,6 +1323,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -2097,6 +2098,72 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Tools to assist with the Jetpack Web Application Firewall",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "116ceba3c357f49d40854f3083f60faa372f5c25"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run build",
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available or incomplete in older WP versions",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/search/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/search/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/search/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1182,7 +1182,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,6 +1201,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -2041,6 +2042,72 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "116ceba3c357f49d40854f3083f60faa372f5c25"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run build",
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available or incomplete in older WP versions",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/social/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/social/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/social/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1305,7 +1305,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1324,6 +1324,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1182,7 +1182,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,6 +1201,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -1831,6 +1832,72 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "116ceba3c357f49d40854f3083f60faa372f5c25"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run build",
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available or incomplete in older WP versions",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-wp-theme-polyfill
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-wp-theme-polyfill
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update composer.lock.
-
-

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1182,7 +1182,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d7e68e4abc1bfdb3cf59f52a5e181e21f886db65"
+                "reference": "c1600e21082d85771a93662fb7dd4f610785edf1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,6 +1201,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
## Proposed changes

* Register the shared `WP_Build_Polyfills` shim before enqueuing `my_jetpack_main_app`, providing the `wp-notices` / `wp-private-apis` / `wp-theme` script handles the My Jetpack bundle depends on when the runtime doesn't ship them (WP < 7.0 with the Gutenberg plugin inactive).
* On trunk, `my_jetpack_main_app` began depending on the `wp-theme` handle after the `@wordpress/*` monorepo bump (#49272, "Update Bundled @wordpress/* monorepo") — driven mainly by `@wordpress/dataviews` 14.3→17.x. DataViews 17.x renders its form controls with bundled `@wordpress/ui` popup/dialog components that wrap in `@wordpress/ui`'s `ThemeProvider`, which imports `@wordpress/theme`; the build externalizes that to the `wp-theme` script handle. (Verified via webpack's dependency reason graph on the frozen trunk build; Jetpack 16.0, on DataViews 14.3, does not pull this code path and has no `wp-theme` dep.) WP core registers `wp-theme` only from 7.0 (6.9 ships none); Jetpack supports the current + previous WP release (today 6.9 / 7.0). With Gutenberg inactive on 6.9, `wp-theme` is unregistered, so WordPress silently drops `my_jetpack_main_app` — and any script that hard-depends on it, notably **Jetpack Boost**'s admin bundle, is dropped too, rendering a **blank admin page with no console error**.
* This mirrors the existing approach in Jetpack Social / VideoPress / Newsletter / Forms, which already register `WP_Build_Polyfills`. The shim is conditional and no-ops once `wp-theme` is provided by Gutenberg or WP ≥ 7.0.
* Propagates the new `automattic/jetpack-wp-build-polyfills` dependency into the `composer.lock` of every plugin that bundles My Jetpack.

**Scope:** trunk regression, **not present in any released version**. The trigger (`@wordpress/dataviews` 17.x, via #49272) merged to trunk *after* `branch-16.0` was cut; every stable release through 16.0 bundles DataViews ≤ 14.3.0, which never pulls the `@wordpress/ui` ThemeProvider path — so `@wordpress/theme` is not imported and no `wp-theme` dep is emitted (verified by building the 16.0 tag frozen: `my_jetpack_main_app` has no `wp-theme`). It first reaches a release with 16.1.

## How the bug happens

```mermaid
flowchart TD
    A["my_jetpack_main_app build<br/>bundles @wordpress/dataviews 17.x"] --> B["DataViews renders form controls<br/>with @wordpress/ui components"]
    B --> C["@wordpress/ui ThemeProvider<br/>imports @wordpress/theme"]
    C --> D["build adds a script dependency:<br/>my_jetpack_main_app needs <b>wp-theme</b>"]
    D --> Q{"What registers wp-theme<br/>at runtime?"}
    Q -->|"WP 7.0+ core, or active Gutenberg"| G1["environment provides wp-theme"]
    Q -->|"this PR"| G2["WP_Build_Polyfills registers<br/>a fallback wp-theme"]
    Q -->|"WP 6.9 and Gutenberg off, no fix"| K["WordPress drops my_jetpack_main_app<br/>(no console error)"]
    G1 --> OK["script loads<br/>My Jetpack & Boost render"]
    G2 --> OK
    K --> M["My Jetpack page is blank"]
    K --> N["jetpack-boost-admin depends on it →<br/>dropped too → Boost page is blank"]
    classDef bad fill:#f8d7da,stroke:#c33,color:#611;
    classDef good fill:#d7f0d9,stroke:#3a3,color:#161;
    classDef fix fill:#d7e6fb,stroke:#36c,color:#124;
    class K,M,N bad
    class OK,G1 good
    class G2 fix
```

Cause and effect, step by step:

1. My Jetpack's admin app (`my_jetpack_main_app`) is built with `@wordpress/dataviews` 17.x.
2. DataViews 17.x renders its form controls with `@wordpress/ui` components (dropdowns, dialogs, tooltips). Those components use `@wordpress/ui`'s `ThemeProvider`, which imports `@wordpress/theme`.
3. The build turns that `@wordpress/theme` import into a WordPress script dependency named `wp-theme`. The code is **not** bundled into the file — the file now expects WordPress to provide a `wp-theme` script at runtime.
4. WordPress core first ships a `wp-theme` script in **WP 7.0**. WP 6.9 does not have it. The Gutenberg plugin also provides it — but only while Gutenberg is active.
5. So on **WordPress 6.9 with the Gutenberg plugin turned off**, no `wp-theme` script exists.
6. WordPress refuses to output any script whose dependency is missing, so it silently drops `my_jetpack_main_app`. No console error appears, because no script ever ran.
7. The My Jetpack page mounts its React app into that script. With the script gone, the page body renders **blank**.
8. **Jetpack Boost** is hit harder: its own admin script lists `my_jetpack_main_app` as a dependency, so when that is dropped, Boost's script is dropped too — the Boost settings page is also blank.

**How this PR mitigates it:** before enqueuing `my_jetpack_main_app`, My Jetpack registers a fallback `wp-theme` script (via the shared `WP_Build_Polyfills` shim) so the handle always exists. When WordPress 7.0+ or an active Gutenberg already provides `wp-theme`, the fallback does nothing.

## What pulls in the `wp-theme` dependency

The bug appears whenever `my_jetpack_main_app`'s bundle imports `@wordpress/theme` — directly, or transitively through `@wordpress/ui` — because the build externalizes that import to the `wp-theme` script handle.

In the current My Jetpack build the path is **`@wordpress/dataviews` 17.x → the `@wordpress/ui` components it renders → `ThemeProvider` → `@wordpress/theme`**, which is the change that introduced it here:

| Package | Its part in the chain | Evidence |
|---|---|---|
| `@wordpress/dataviews` | 17.x renders `@wordpress/ui` components that use `ThemeProvider` — the path that appeared in the trunk build | 14.3.0 → clean; bumping only DataViews to 17.1.0 → `wp-theme` appears |
| `@wordpress/ui` | its `ThemeProvider` does the actual `import from '@wordpress/theme'` | every `@wordpress/ui` ≥ 0.13 imports theme |
| `@wordpress/theme` | the imported package the build externalizes to the `wp-theme` handle | — |

DataViews is not special here — it is simply the path that pulled the import into *this* bundle. **Any direct use of `@wordpress/ui`, or a direct `@wordpress/theme` import, would introduce `wp-theme` on its own.** The fix therefore targets the missing handle, not any single package.

**Simplest check on any build:** the bug is present when `my_jetpack_main_app`'s built `index.asset.php` lists `wp-theme`. Combined with WordPress < 7.0 and Gutenberg inactive, that is the exact failing condition.

## Related product discussion/links

* Design Systems: `@wordpress/theme` stabilization for WP 7.1 (internal P2 — shortlink to add).
* Complementary shim-side change: #50309 (force-replace `wp-theme` / `@wordpress/boot` on WP 7.0, where core ships them incomplete). Both PRs touch `automattic/jetpack-wp-build-polyfills` (different parts — this one adds a *consumer*, #50309 changes the *shim*), so whichever merges second needs a lock refresh (`tools/check-intra-monorepo-deps.sh -au`).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Repro (before this PR, on trunk / a build with `@wordpress/dataviews` 17.x):**
1. WordPress < 7.0 (e.g. 6.9.x) with the **Gutenberg plugin deactivated**.
2. Jetpack and Jetpack Boost active.
3. Visit **Jetpack → Boost** (`admin.php?page=jetpack-boost`): the content area is blank, the admin menu/top bar render, and there is **no console error**. `my_jetpack_main_app` and `jetpack-boost-admin` are absent from the page source — dropped by WordPress because of the unregistered `wp-theme` dependency.

**Verify (with this PR):**
4. Same environment → the Boost admin page renders normally.
5. Activate the Gutenberg plugin → still renders (the polyfill no-ops when `wp-theme` is already registered).
6. The My Jetpack page (`admin.php?page=my-jetpack`) also renders in both states.
