### PR TITLE
Premium Analytics: remove obsolete widget-picker preview aspect-ratio hack

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -510,13 +510,3 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
 - Empty state: pass `emptyStateText` to `LeaderboardChart` — do not add a separate
   `data.length === 0` render branch in the widget, unless the widget has a composite layout
   that needs to preserve body chrome or replace a non-leaderboard chart area.
-- Widget picker preview: add this to the CSS Module so the preview tile renders at a
-  sensible aspect ratio instead of collapsing:
-
-```css
-:global( [inert]:not( [inert='true'] ) ) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}
-```

--- a/projects/packages/premium-analytics/changelog/remove-widget-picker-preview-aspect-ratio-hack
+++ b/projects/packages/premium-analytics/changelog/remove-widget-picker-preview-aspect-ratio-hack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Remove the widget-picker preview aspect-ratio workaround now that the picker host sizes preview tiles itself.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -86,14 +86,6 @@
 	}
 }
 
-// Widget picker preview: the picker renders the tile inert. Constrain it to a
-// sensible aspect ratio so the preview doesn't collapse.
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}
-
 // The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
 // to all images inside the media cell, overriding our 20px flag height.
 // Restore correct sizing for flag images in any inert context.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/style.module.css
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/style.module.css
@@ -35,10 +35,3 @@
 	min-height: 120px;
 	text-align: center;
 }
-
-/* Widget picker preview: keep a sensible aspect ratio instead of collapsing. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/annual-highlights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/style.module.css
@@ -106,16 +106,3 @@
 		align-items: flex-start;
 	}
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the content. Targets only the picker
- * (inert="") — not the edit-mode wrapper (inert="true") where the grid tile
- * supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -42,19 +42,6 @@ a.postLabel:focus {
 	text-decoration: underline;
 }
 
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}
-
 /* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
  * to all images inside the media cell, overriding our 20px avatar size.
  * Restore correct sizing for avatar images in any inert context. */

--- a/projects/packages/premium-analytics/widgets/clicks/style.module.css
+++ b/projects/packages/premium-analytics/widgets/clicks/style.module.css
@@ -70,9 +70,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/emails/style.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/style.module.css
@@ -34,16 +34,3 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
+++ b/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
@@ -48,9 +48,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/latest-post/style.module.css
+++ b/projects/packages/premium-analytics/widgets/latest-post/style.module.css
@@ -135,16 +135,3 @@
 		margin-inline-end: calc(-1 * var(--latest-post-frame-pad));
 	}
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor. Setting
- * height: auto here lets aspect-ratio derive the height from the known inline
- * size, and overflow: hidden clips the content. Targets only the picker
- * (inert="") — not the edit-mode wrapper (inert="true") where the grid tile
- * supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -88,19 +88,6 @@
 	border-radius: var(--wpds-border-radius-sm, 2px);
 }
 
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}
-
 /* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
  * to all images inside the media cell, overriding our 20px flag height.
  * Restore correct sizing for flag images in any inert context. */

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -14,16 +14,3 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor. Setting
- * height: auto here lets aspect-ratio derive the height from the known inline
- * size and overflow: hidden clips the content. Targets only the picker
- * (inert="") — not the edit-mode wrapper (inert="true") where the grid tile
- * supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
@@ -20,16 +20,3 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor. Setting
- * height: auto here lets aspect-ratio derive the height from the known inline
- * size and overflow: hidden clips the content. Targets only the picker
- * (inert="") — not the edit-mode wrapper (inert="true") where the grid tile
- * supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
@@ -34,16 +34,3 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/search-terms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/search-terms/style.module.css
@@ -34,10 +34,3 @@
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/style.module.css
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/style.module.css
@@ -6,16 +6,3 @@
 	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/subscribers-list/style.module.css
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/style.module.css
@@ -1,11 +1,3 @@
-/* Constrain the widget-picker preview tile to a sensible aspect ratio instead
-   of letting the roster collapse. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}
-
 /* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
    to every image in its media cell, blowing the 32px avatars up to fill the
    tile. Restore their size in any inert (picker) context. */

--- a/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
@@ -6,16 +6,3 @@
 	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }
-
-/* Constrain the picker preview tile to a 4:3 aspect ratio. The picker's
- * .preview wrapper uses height: 125% of an auto-height parent, so height: 100%
- * on .root also resolves to auto, leaving aspect-ratio with no anchor.
- * Setting height: auto here lets aspect-ratio derive the height from the known
- * inline size and overflow: hidden clips the chart content. Targets only the
- * picker (inert="") — not the edit-mode wrapper (inert="true") where the grid
- * tile supplies a real height. */
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}


### PR DESCRIPTION
Fixes #

## Proposed changes

<!--- Explain what functional changes your PR includes -->

Premium Analytics widgets shipped a per-widget CSS workaround for the widget-picker preview:

```css
:global([inert]:not([inert="true"])) .root {
  height: auto;
  aspect-ratio: 4 / 3;
  overflow: hidden;
}
```

**Why:** The picker rendered each widget tile `inert`, and the preview wrapper's `height: 125%` of an auto-height parent left `height: 100%` on `.root` resolving to auto — so the tile collapsed. The 4:3 aspect-ratio rule gave it a sensible fallback shape.

**How:** #50271 updated the widget-picker host so it sizes preview tiles itself, so the workaround is now dead code. This PR:

- Removes the aspect-ratio rule from every widget that carried it (16 style modules).
- Removes the matching "Widget picker preview" guidance from the package `AGENTS.md` so new widgets don't reintroduce it.

**What is intentionally kept:** the separate `:global([inert]) … .leaderboardImage` / `.avatar` / `img` rules in `locations`, `authors`, `subscribers-list`, and `visitors-by-location`. Those counter the picker grid's `img { object-fit: cover }` blowing flags/avatars up to fill the tile — an unrelated concern that #50271 did not touch.

## Related product discussion/links

<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->

- Follow-up to #50271.

## Does this pull request change what data or activity we track or use?

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

- Build the package (`jetpack build --deps packages/premium-analytics`) or run Storybook.
- Open the Premium Analytics dashboard's widget picker.
- Confirm every widget preview tile still renders at a sensible size (no collapse, no full-bleed stretch).
- Confirm Locations/Visitors-by-Location flag images and Authors/Subscribers avatars still render at their intended small size in the picker preview (not stretched to fill the tile).
