### PR TITLE
React 19: mu-wpcom ref/useRef compat fixes (stacked on try/react-19-test-drive)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
@@ -58,7 +58,7 @@ function startPrewarm( input: WizardInput ): void {
  * @param state - The partial wizard input collected so far.
  */
 export function usePrewarm( state: Partial< WizardInput > ): void {
-	const timer = useRef< ReturnType< typeof setTimeout > >();
+	const timer = useRef< ReturnType< typeof setTimeout > >( undefined );
 
 	// Depend on the stable cache key, not the `state` object, which is fresh every render and would re-arm the debounce on every re-render.
 	const input = isComplete( state ) ? state : null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
@@ -52,7 +52,11 @@ export default function DescriptionSupportLink( {
 					} );
 				} }
 				style={ { display: 'block', marginTop: 10, maxWidth: 'fit-content' } }
-				ref={ reference => ref !== reference && setRef( reference ) }
+				ref={ reference => {
+					if ( ref !== reference ) {
+						setRef( reference );
+					}
+				} }
 			>
 				{ __( 'Learn more', 'jetpack-mu-wpcom' ) }
 			</WpcomSupportLink>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
@@ -35,10 +35,8 @@ function EditCodeMirror( props: EditBlockProps ) {
 	const { attributes, isSelected, setAttributes, insertBlocksAfter, onRemove } = props;
 
 	const ref = React.useRef< HTMLDivElement >( null );
-	const viewRef: React.MutableRefObject< import('@codemirror/view').EditorView | undefined > =
-		React.useRef( undefined );
-	const currentLanguageRef: React.MutableRefObject< LanguageSupport | undefined > =
-		React.useRef( undefined );
+	const viewRef = React.useRef< import('@codemirror/view').EditorView >( undefined );
+	const currentLanguageRef = React.useRef< LanguageSupport >( undefined );
 	const trailingNewlineCounterRef = React.useRef( 0 );
 
 	const { getBlockOrder } = useSelect( blockEditorStore, [] );


### PR DESCRIPTION
## ⚠️ Stacked PR — base is `try/react-19-test-drive`, not `trunk`

This PR is **intentionally stacked on top of [`try/react-19-test-drive`](https://github.com/Automattic/jetpack/tree/try/react-19-test-drive)** (the whole-monorepo React 19.2.7 bump). Review/merge that base first. The diff shown here should contain **only** the three source changes below; if it shows the full React bump, GitHub hasn't picked up the base yet.

Planned follow-up: copy this branch, rebase it onto `trunk`, and confirm these same changes still compile/behave under React 18 (peer deps stay `^18 || ^19`).

## What

React 19 type/API compat fixes in `jetpack-mu-wpcom`, teased out of the audit:

- **`ai-launchpad/js/lib/prewarm.ts`** — pass explicit `undefined` to `useRef` (`useRef<T>()` no longer has a zero-arg overload in React 19 types).
- **`wpcom-blocks/code/block-edit-function.tsx`** — drop the removed `React.MutableRefObject` type annotation; use `useRef<T>( undefined )` directly.
- **`wpcom-block-description-links/description-support-link.tsx`** — give the `ref` callback a block body so it doesn't implicitly return a value (React 19 rejects ref-callback return values, treating them as cleanup functions).

Runtime-neutral: React is externalized to WordPress's global, so these mainly affect typecheck/Jest.

## Changelog

No changelog entries, matching the base `try/` branch (its React bump commit also adds none). This is experimental compat work; changelog will be sorted when the R19 effort lands for real.

## Testing

- `jetpack-mu-wpcom` typechecks and tests pass against React 19 (per base-branch validation).
EOF
