### PR TITLE
React 19 compat: mu-wpcom ref/useRef fixes (React 18-safe, mergeable)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/react-19-ref-useref-compat
+++ b/projects/packages/jetpack-mu-wpcom/changelog/react-19-ref-useref-compat
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: React 19 compatibility fixes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prewarm.ts
@@ -58,7 +58,7 @@ function startPrewarm( input: WizardInput ): void {
  * @param state - The partial wizard input collected so far.
  */
 export function usePrewarm( state: Partial< WizardInput > ): void {
-	const timer = useRef< ReturnType< typeof setTimeout > >();
+	const timer = useRef< ReturnType< typeof setTimeout > >( undefined );
 
 	// Depend on the stable cache key, not the `state` object, which is fresh every render and would re-arm the debounce on every re-render.
 	const input = isComplete( state ) ? state : null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
@@ -52,7 +52,11 @@ export default function DescriptionSupportLink( {
 					} );
 				} }
 				style={ { display: 'block', marginTop: 10, maxWidth: 'fit-content' } }
-				ref={ reference => ref !== reference && setRef( reference ) }
+				ref={ reference => {
+					if ( ref !== reference ) {
+						setRef( reference );
+					}
+				} }
 			>
 				{ __( 'Learn more', 'jetpack-mu-wpcom' ) }
 			</WpcomSupportLink>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
@@ -34,7 +34,7 @@ const { RichTextData } = window.wp.richText;
 function EditCodeMirror( props: EditBlockProps ) {
 	const { attributes, isSelected, setAttributes, insertBlocksAfter, onRemove } = props;
 
-	const ref: React.RefObject< HTMLDivElement > = React.useRef( null );
+	const ref = React.useRef< HTMLDivElement >( null );
 	const viewRef = React.useRef< import('@codemirror/view').EditorView >( undefined );
 	const currentLanguageRef = React.useRef< LanguageSupport >( undefined );
 	const trailingNewlineCounterRef = React.useRef( 0 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/block-edit-function/block-edit-function.tsx
@@ -35,10 +35,8 @@ function EditCodeMirror( props: EditBlockProps ) {
 	const { attributes, isSelected, setAttributes, insertBlocksAfter, onRemove } = props;
 
 	const ref: React.RefObject< HTMLDivElement > = React.useRef( null );
-	const viewRef: React.MutableRefObject< import('@codemirror/view').EditorView | undefined > =
-		React.useRef( undefined );
-	const currentLanguageRef: React.MutableRefObject< LanguageSupport | undefined > =
-		React.useRef( undefined );
+	const viewRef = React.useRef< import('@codemirror/view').EditorView >( undefined );
+	const currentLanguageRef = React.useRef< LanguageSupport >( undefined );
 	const trailingNewlineCounterRef = React.useRef( 0 );
 
 	const { getBlockOrder } = useSelect( blockEditorStore, [] );


### PR DESCRIPTION
Fixes DOTCOM-17513

## What

React 19 forward-compat fixes in `jetpack-mu-wpcom`, written so they remain **no-ops under React 18** (which is what trunk still ships):

- **`ai-launchpad/js/lib/prewarm.ts`** — pass explicit `undefined` to `useRef` (React 19 types drop the zero-arg `useRef<T>()` overload).
- **`wpcom-blocks/code/block-edit-function.tsx`** — drop the removed `React.MutableRefObject` annotations; use `useRef<T>( undefined )` directly.
- **`wpcom-block-description-links/description-support-link.tsx`** — give the `ref` callback a block body so it doesn't implicitly return a value (React 19 treats a ref-callback return as a cleanup function).

React is externalized to WordPress's global, so these mainly affect typecheck/Jest, not shipped bundles. Things like ensuring we're not using a React UMD build are not something the mu-wpcom plugin controls in this monorepo.

## Why this targets `trunk` (React 18)

This is the branch we intend to **merge**. It's the same change set validated on the React 19 test-drive branch, rebased onto `trunk` and confirmed to compile/behave under React 18 as well — so it's safe to land now, ahead of the broader React 19 migration.

Companion (React 19) PR, for reference / cross-check: **#50295** (stacked on `try/react-19-test-drive`; not for merge).

## Testing instructions:

`jetpack-mu-wpcom` typechecks and tests pass under both React 18 (this branch) and React 19 (#50295).

Smoke test

## Does this pull request change what data or activity we track or use?

No
