### PR TITLE
WOOA7S-1513: Port Stats Subscriber highlights widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-subscriber-highlights-widget
+++ b/projects/packages/premium-analytics/changelog/add-subscriber-highlights-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Subscriber highlights widget to the Premium Analytics dashboard.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -68,3 +68,5 @@ export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors'
 export { mockSiteSummary } from './site-summary';
 
 export { mockStatsInsightsData } from './insights';
+
+export { mockStatsSubscribersCountsData } from './subscriber-counts';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/subscriber-counts.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/subscriber-counts.ts
@@ -1,0 +1,14 @@
+/**
+ * Raw `subscribers/counts` response (pre-sanitizer shape), populated so the
+ * Subscriber highlights widget renders every metric tile in Storybook. The
+ * endpoint reports current totals for the whole site and has no comparison
+ * period, so the values are a single snapshot.
+ */
+export const mockStatsSubscribersCountsData = {
+	counts: {
+		total_subscribers: 12840,
+		email_subscribers: 9320,
+		paid_subscribers: 1180,
+		social_followers: 2340,
+	},
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -51,6 +51,7 @@ import {
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
 	mockStatsInsightsData,
+	mockStatsSubscribersCountsData,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
@@ -62,6 +63,9 @@ import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 const API_BASE = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports';
 const STATS_FOLLOWERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/followers';
 const STATS_SUBSCRIBERS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/subscribers';
+// The subscribers/counts endpoint is a v2 proxy path (not under /stats), so it
+// is matched on its own rather than through routeStatsReport().
+const STATS_SUBSCRIBERS_COUNTS_PATH = '/jetpack-premium-analytics/v1/proxy/v2/subscribers/counts';
 const STATS_VISITS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/visits';
 const STATS_EMAIL_SUMMARY_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/emails/summary';
 const STATS_VIDEO_PLAYS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/video-plays';
@@ -949,6 +953,10 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 
 	if ( requestPath.startsWith( STATS_FOLLOWERS_PATH ) ) {
 		return buildFollowersResponse();
+	}
+
+	if ( requestPath.startsWith( STATS_SUBSCRIBERS_COUNTS_PATH ) ) {
+		return mockStatsSubscribersCountsData;
 	}
 
 	if ( requestPath.startsWith( STATS_SUBSCRIBERS_PATH ) ) {

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import SubscriberHighlightsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const COUNTS_RESPONSE = {
+	counts: {
+		total_subscribers: 12840,
+		email_subscribers: 9320,
+		paid_subscribers: 1180,
+		social_followers: 2340,
+	},
+};
+
+describe( 'SubscriberHighlightsWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( COUNTS_RESPONSE );
+	} );
+
+	it( 'requests the subscribers/counts endpoint and renders every metric tile', async () => {
+		render( <SubscriberHighlightsWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Total subscribers' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Paid subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Free subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Social followers' ) ).toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'proxy/v2/subscribers/counts' );
+	} );
+
+	it( 'hides a metric tile when its visibility attribute is off', async () => {
+		render( <SubscriberHighlightsWidget attributes={ { showPaid: false, showSocial: false } } /> );
+
+		await expect( screen.findByText( 'Total subscribers' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Free subscribers' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Paid subscribers' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Social followers' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'prompts to select a metric when every tile is disabled', async () => {
+		render(
+			<SubscriberHighlightsWidget
+				attributes={ {
+					showTotal: false,
+					showPaid: false,
+					showFree: false,
+					showSocial: false,
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByText( 'Select at least one metric to display.' )
+		).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
@@ -49,6 +49,56 @@ describe( 'SubscriberHighlightsWidget', () => {
 		expect( requestedPath ).toContain( 'proxy/v2/subscribers/counts' );
 	} );
 
+	it( 'maps each subscriber count to its matching tile', async () => {
+		// Distinct sub-1000 values so the `useMultipliers` formatter leaves them
+		// unabbreviated, and `social_followers` is omitted so the `?? 0` fallback
+		// renders. The `Free` tile reads `email_subscribers`, so a mis-wired field
+		// (or a dropped fallback) changes this sequence and fails the test.
+		mockApiFetch.mockResolvedValue( {
+			counts: {
+				total_subscribers: 428,
+				email_subscribers: 186,
+				paid_subscribers: 317,
+			},
+		} );
+
+		render( <SubscriberHighlightsWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Total subscribers' ) ).resolves.toBeInTheDocument();
+
+		// Tiles render in a fixed order: Total, Paid, Free, Social. Reading the
+		// metric values in document order pins the field-to-tile wiring.
+		const values = screen.getAllByText( /^\d+$/ ).map( el => el.textContent );
+		expect( values ).toEqual( [ '428', '317', '186', '0' ] );
+	} );
+
+	it( 'shows the error placeholder when the counts request fails', async () => {
+		// Reject with a non-retryable (403) error so React Query surfaces the
+		// error state immediately instead of retrying with backoff.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		render( <SubscriberHighlightsWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( 'Unable to load subscriber highlights.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Total subscribers' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the loading overlay while the counts request is pending', () => {
+		// A promise that never settles keeps the query in its loading state.
+		mockApiFetch.mockReturnValue( new Promise( () => {} ) );
+
+		const { container } = render( <SubscriberHighlightsWidget attributes={ {} } /> );
+
+		// WidgetLoadingOverlay renders a WP Spinner (role="presentation", no
+		// accessible name), so the class is the only stable handle for it.
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- No accessible role/text on the spinner to query.
+		expect( container.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Total subscribers' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Unable to load subscriber highlights.' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'hides a metric tile when its visibility attribute is off', async () => {
 		render( <SubscriberHighlightsWidget attributes={ { showPaid: false, showSocial: false } } /> );
 

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-subscriber-highlights",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import { useStatsSubscribersCounts } from '@jetpack-premium-analytics/data';
+import {
+	MetricWithComparison,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	type DataFormat,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { envelope, payment, people, share } from '@wordpress/icons';
+import { Icon, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import type { SubscriberHighlightsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+// The subscribers/counts endpoint reports current totals and is not
+// period-scoped, so the widget ignores the dashboard date range. Report params
+// are still accepted at the WidgetRoot boundary (and Storybook may inject them)
+// so the host contract holds.
+type SubscriberHighlightsRenderAttributes = SubscriberHighlightsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type SubscriberHighlightsWidgetProps = WidgetRenderProps< SubscriberHighlightsRenderAttributes >;
+
+/**
+ * The enabled-metric flags from widget attributes, with defaults applied.
+ */
+type SubscriberHighlightsReportProps = Required< SubscriberHighlightsAttributes >;
+
+const COUNT_FORMAT: DataFormat = {
+	type: 'number',
+	options: { useMultipliers: true, decimals: 0 },
+};
+
+/**
+ * Fetches the subscriber counts through the designated `useStatsSubscribersCounts`
+ * Stats hook and renders the totals as a grid of metric tiles. The counts module
+ * has no comparison period, so each tile shows a bare formatted count. Which
+ * tiles appear is controlled by the per-metric visibility attributes.
+ *
+ * @param {SubscriberHighlightsReportProps} props - The component props.
+ * @return The widget content.
+ */
+function SubscriberHighlightsReport( {
+	showTotal,
+	showPaid,
+	showFree,
+	showSocial,
+}: SubscriberHighlightsReportProps ) {
+	const { data, isLoading, isError } = useStatsSubscribersCounts();
+
+	if ( isError ) {
+		return (
+			<div className={ styles.root }>
+				<Text className={ styles.placeholder }>
+					{ __( 'Unable to load subscriber highlights.', 'jetpack-premium-analytics' ) }
+				</Text>
+			</div>
+		);
+	}
+
+	if ( isLoading && ! data ) {
+		return (
+			<div className={ styles.root }>
+				<WidgetLoadingOverlay />
+			</div>
+		);
+	}
+
+	const tiles = [
+		{
+			key: 'total',
+			icon: people,
+			label: __( 'Total subscribers', 'jetpack-premium-analytics' ),
+			value: data?.total_subscribers ?? 0,
+			enabled: showTotal,
+		},
+		{
+			key: 'paid',
+			icon: payment,
+			label: __( 'Paid subscribers', 'jetpack-premium-analytics' ),
+			value: data?.paid_subscribers ?? 0,
+			enabled: showPaid,
+		},
+		{
+			key: 'free',
+			icon: envelope,
+			label: __( 'Free subscribers', 'jetpack-premium-analytics' ),
+			value: data?.email_subscribers ?? 0,
+			enabled: showFree,
+		},
+		{
+			key: 'social',
+			icon: share,
+			label: __( 'Social followers', 'jetpack-premium-analytics' ),
+			value: data?.social_followers ?? 0,
+			enabled: showSocial,
+		},
+	].filter( tile => tile.enabled );
+
+	return (
+		<div className={ styles.root }>
+			{ tiles.length === 0 ? (
+				<Text className={ styles.placeholder }>
+					{ __( 'Select at least one metric to display.', 'jetpack-premium-analytics' ) }
+				</Text>
+			) : (
+				<div className={ styles.grid }>
+					{ tiles.map( tile => (
+						<div key={ tile.key } className={ styles.tile }>
+							<div className={ styles.tileHeader }>
+								<Icon icon={ tile.icon } size={ 24 } className={ styles.tileIcon } />
+								<Text className={ styles.tileLabel }>{ tile.label }</Text>
+							</div>
+							<MetricWithComparison
+								value={ tile.value }
+								dataFormat={ COUNT_FORMAT }
+								fontSize="xl"
+								className={ styles.tileValue }
+							/>
+						</div>
+					) ) }
+				</div>
+			) }
+		</div>
+	);
+}
+
+/**
+ * Widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client and chart theme consumed by the
+ * inner report. Host attributes are forwarded so any injected report params are
+ * preserved even though the counts endpoint is not period-scoped.
+ *
+ * @param {SubscriberHighlightsWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function SubscriberHighlights( {
+	attributes = {},
+}: SubscriberHighlightsWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<SubscriberHighlightsReport
+				showTotal={ attributes.showTotal ?? true }
+				showPaid={ attributes.showPaid ?? true }
+				showFree={ attributes.showFree ?? true }
+				showSocial={ attributes.showSocial ?? true }
+			/>
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { useStatsSubscribersCounts } from '@jetpack-premium-analytics/data';
+import {
+	useStatsSubscribersCounts,
+	type StatsSubscribersCounts,
+} from '@jetpack-premium-analytics/data';
 import {
 	MetricWithComparison,
 	WidgetLoadingOverlay,
@@ -16,7 +19,11 @@ import { Icon, Text } from '@wordpress/ui';
  * Internal dependencies
  */
 import styles from './style.module.css';
-import type { SubscriberHighlightsAttributes } from './widget';
+import {
+	SUBSCRIBER_METRICS,
+	type SubscriberHighlightsAttributes,
+	type SubscriberMetricId,
+} from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 // The subscribers/counts endpoint reports current totals and is not
@@ -38,6 +45,21 @@ const COUNT_FORMAT: DataFormat = {
 };
 
 /**
+ * Render-only config per metric: the tile icon and the counts-payload field the
+ * tile displays. Ids and labels are shared with the settings checkboxes via
+ * `SUBSCRIBER_METRICS` in `widget.ts`.
+ */
+const TILE_CONFIG: Record<
+	SubscriberMetricId,
+	{ icon: typeof people; count: ( data?: StatsSubscribersCounts ) => number }
+> = {
+	showTotal: { icon: people, count: data => data?.total_subscribers ?? 0 },
+	showPaid: { icon: payment, count: data => data?.paid_subscribers ?? 0 },
+	showFree: { icon: envelope, count: data => data?.email_subscribers ?? 0 },
+	showSocial: { icon: share, count: data => data?.social_followers ?? 0 },
+};
+
+/**
  * Fetches the subscriber counts through the designated `useStatsSubscribersCounts`
  * Stats hook and renders the totals as a grid of metric tiles. The counts module
  * has no comparison period, so each tile shows a bare formatted count. Which
@@ -46,12 +68,7 @@ const COUNT_FORMAT: DataFormat = {
  * @param {SubscriberHighlightsReportProps} props - The component props.
  * @return The widget content.
  */
-function SubscriberHighlightsReport( {
-	showTotal,
-	showPaid,
-	showFree,
-	showSocial,
-}: SubscriberHighlightsReportProps ) {
+function SubscriberHighlightsReport( props: SubscriberHighlightsReportProps ) {
 	const { data, isLoading, isError } = useStatsSubscribersCounts();
 
 	if ( isError ) {
@@ -72,36 +89,12 @@ function SubscriberHighlightsReport( {
 		);
 	}
 
-	const tiles = [
-		{
-			key: 'total',
-			icon: people,
-			label: __( 'Total subscribers', 'jetpack-premium-analytics' ),
-			value: data?.total_subscribers ?? 0,
-			enabled: showTotal,
-		},
-		{
-			key: 'paid',
-			icon: payment,
-			label: __( 'Paid subscribers', 'jetpack-premium-analytics' ),
-			value: data?.paid_subscribers ?? 0,
-			enabled: showPaid,
-		},
-		{
-			key: 'free',
-			icon: envelope,
-			label: __( 'Free subscribers', 'jetpack-premium-analytics' ),
-			value: data?.email_subscribers ?? 0,
-			enabled: showFree,
-		},
-		{
-			key: 'social',
-			icon: share,
-			label: __( 'Social followers', 'jetpack-premium-analytics' ),
-			value: data?.social_followers ?? 0,
-			enabled: showSocial,
-		},
-	].filter( tile => tile.enabled );
+	const tiles = SUBSCRIBER_METRICS.filter( ( { id } ) => props[ id ] ).map( ( { id, label } ) => ( {
+		key: id,
+		label,
+		icon: TILE_CONFIG[ id ].icon,
+		value: TILE_CONFIG[ id ].count( data ),
+	} ) );
 
 	return (
 		<div className={ styles.root }>

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -1,0 +1,208 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SubscriberHighlightsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SUBSCRIBER_HIGHLIGHTS_RENDER_MODULE = 'storybook/subscriber-highlights';
+
+// Carry the widget's metadata, including the metric-visibility attribute schema
+// so the dashboard story's settings drawer renders the real checkboxes.
+// Presentation is left unset so the host frames the widget and renders its
+// identity (title + icon), matching widget.json. The attribute schema is typed
+// loosely on the widget definition, so it is cast to the WidgetType shape.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
+};
+
+interface SubscriberHighlightsStoryControls {
+	/**
+	 * Whether to inject comparison report params.
+	 */
+	withComparison: boolean;
+	/**
+	 * Whether the Total subscribers tile is shown.
+	 */
+	showTotal: boolean;
+	/**
+	 * Whether the Paid subscribers tile is shown.
+	 */
+	showPaid: boolean;
+	/**
+	 * Whether the Free subscribers tile is shown.
+	 */
+	showFree: boolean;
+	/**
+	 * Whether the Social followers tile is shown.
+	 */
+	showSocial: boolean;
+}
+
+/**
+ * Renders the data-connected widget with report params derived from the
+ * comparison toggle and the per-metric visibility toggles. The counts endpoint
+ * is not period-scoped, so toggling comparison does not change what the widget
+ * shows — it is wired through only to prove the widget renders unchanged when the
+ * host injects comparison params. The metric toggles mirror the widget's
+ * checkbox settings and hide/show the matching tile.
+ *
+ * @param {SubscriberHighlightsStoryControls} props - Story controls.
+ * @return The rendered widget.
+ */
+function renderSubscriberHighlights( {
+	withComparison,
+	showTotal,
+	showPaid,
+	showFree,
+	showSocial,
+}: SubscriberHighlightsStoryControls ) {
+	return (
+		<SubscriberHighlightsRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				showTotal,
+				showPaid,
+				showFree,
+				showSocial,
+			} }
+		/>
+	);
+}
+
+const METRIC_ARG_TYPES = {
+	showTotal: { control: 'boolean' },
+	showPaid: { control: 'boolean' },
+	showFree: { control: 'boolean' },
+	showSocial: { control: 'boolean' },
+} as const;
+
+const ALL_METRICS_ARGS = {
+	showTotal: true,
+	showPaid: true,
+	showFree: true,
+	showSocial: true,
+} as const;
+
+// Close-up canvas so the grid fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SubscriberHighlights',
+	component: SubscriberHighlightsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Subscriber highlights" widget. Shows current subscriber totals — total, paid, free, and social followers — as a grid of metric tiles. Each metric tile can be toggled off via the widget\'s checkbox settings (the `show*` controls here). Data comes from the designated `useStatsSubscribersCounts` hook; in Storybook it is served by `registerReportMocks()` (the `subscribers/counts` handler). The counts module has no comparison period, so the tiles show bare counts and the `WithComparison` story renders identically to `Default`.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof SubscriberHighlightsRender > & SubscriberHighlightsStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< SubscriberHighlightsStoryControls >;
+
+/**
+ * The widget on its own, populated from the mocked subscribers/counts payload.
+ */
+export const Default: Story = {
+	render: renderSubscriberHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Same close-up with comparison report params injected. The counts module has no
+ * comparison data, so this renders identically to `Default` — it only verifies
+ * the widget stays stable when the host provides comparison params.
+ */
+export const WithComparison: Story = {
+	render: renderSubscriberHighlights,
+	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface SubscriberHighlightsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SubscriberHighlightsStoryControls {}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness.
+ *
+ * @param {SubscriberHighlightsDashboardStoryProps} props - Dashboard and widget controls.
+ * @return The rendered dashboard with the widget.
+ */
+function SubscriberHighlightsDashboardStory( {
+	withComparison,
+	showTotal,
+	showPaid,
+	showFree,
+	showSocial,
+	...dashboardArgs
+}: SubscriberHighlightsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ SUBSCRIBER_HIGHLIGHTS_RENDER_MODULE }
+			renderComponent={
+				SubscriberHighlightsRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				showTotal,
+				showPaid,
+				showFree,
+				showSocial,
+			} }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< SubscriberHighlightsDashboardStoryProps > = {
+	render: args => <SubscriberHighlightsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 1,
+		widgetHeight: 1,
+		withComparison: true,
+		...ALL_METRICS_ARGS,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
+	},
+};

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/style.module.css
@@ -1,0 +1,82 @@
+/* No outer padding: the host frames the widget and owns the padding. */
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-lg, 16px);
+	height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+}
+
+.tile {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md, 12px);
+	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
+	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-lg, 8px);
+}
+
+.tileHeader {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	min-width: 0;
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.tileIcon {
+	flex: 0 0 auto;
+}
+
+.tileLabel {
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+/* MetricValue emits the font-size token without a fallback, and the dashboard
+ * runtime does not always inject the WPDS typography tokens, so pin the metric
+ * total here with explicit fallbacks. */
+.tileValue span {
+	font-size: var(--wpds-typography-font-size-xl, 20px);
+	line-height: var(--wpds-typography-line-height-xl, 32px);
+}
+
+.placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-align: center;
+}
+
+/* Wide widths: lay the tiles out four across with the value stacked below the
+ * icon and label. */
+@container (min-width: 640px) {
+
+	.grid {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	.tile {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		gap: var(--wpds-dimension-gap-lg, 16px);
+	}
+
+	.tileHeader {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/subscriber-highlights",
+	"title": "Subscriber highlights",
+	"description": "Your subscriber totals at a glance — total, paid, free, and social followers.",
+	"category": "subscribers",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
@@ -33,6 +33,24 @@ export type SubscriberHighlightsAttributes = {
 };
 
 /**
+ * The metric tiles the widget can show, in display order: the visibility
+ * attribute id of each metric and its label. Single source for the settings
+ * checkboxes and the rendered tiles so the two cannot drift apart; `render.tsx`
+ * maps the ids to icons and counts fields.
+ */
+export const SUBSCRIBER_METRICS = [
+	{ id: 'showTotal', label: __( 'Total subscribers', 'jetpack-premium-analytics' ) },
+	{ id: 'showPaid', label: __( 'Paid subscribers', 'jetpack-premium-analytics' ) },
+	{ id: 'showFree', label: __( 'Free subscribers', 'jetpack-premium-analytics' ) },
+	{ id: 'showSocial', label: __( 'Social followers', 'jetpack-premium-analytics' ) },
+] as const satisfies readonly { id: keyof SubscriberHighlightsAttributes; label: string }[];
+
+/**
+ * The visibility attribute id of one metric tile.
+ */
+export type SubscriberMetricId = ( typeof SUBSCRIBER_METRICS )[ number ][ 'id' ];
+
+/**
  * Widget type definition.
  *
  * `example.attributes` doubles as the defaults applied to new instances: every
@@ -46,32 +64,12 @@ export default {
 	// checkbox in sync with the render, which also treats a missing flag as
 	// enabled: without them a metric absent from `attributes` would show as an
 	// unchecked box while its tile still rendered.
-	attributes: [
-		{
-			id: 'showTotal',
-			label: __( 'Total subscribers', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showTotal ?? true,
-		},
-		{
-			id: 'showPaid',
-			label: __( 'Paid subscribers', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showPaid ?? true,
-		},
-		{
-			id: 'showFree',
-			label: __( 'Free subscribers', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showFree ?? true,
-		},
-		{
-			id: 'showSocial',
-			label: __( 'Social followers', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showSocial ?? true,
-		},
-	] as WidgetAttributeField< SubscriberHighlightsAttributes >[],
+	attributes: SUBSCRIBER_METRICS.map( ( { id, label } ) => ( {
+		id,
+		label,
+		type: 'boolean',
+		getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item[ id ] ?? true,
+	} ) ) as WidgetAttributeField< SubscriberHighlightsAttributes >[],
 	example: {
 		attributes: {
 			showTotal: true,

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Configurable attributes for the Subscriber highlights widget: one visibility
+ * toggle per metric tile. Mirrors the `attributes` declared on the widget
+ * definition below; the host renders them as checkboxes and passes the selected
+ * values through to `render.tsx`. The widget has no date range — the
+ * `subscribers/counts` endpoint reports current totals and is not
+ * period-scoped.
+ */
+export type SubscriberHighlightsAttributes = {
+	/**
+	 * Whether the Total subscribers tile is shown.
+	 */
+	showTotal?: boolean;
+	/**
+	 * Whether the Paid subscribers tile is shown.
+	 */
+	showPaid?: boolean;
+	/**
+	 * Whether the Free subscribers tile is shown.
+	 */
+	showFree?: boolean;
+	/**
+	 * Whether the Social followers tile is shown.
+	 */
+	showSocial?: boolean;
+};
+
+/**
+ * Widget type definition.
+ *
+ * `example.attributes` doubles as the defaults applied to new instances: every
+ * metric enabled.
+ */
+export default {
+	name: 'jpa/subscriber-highlights',
+	title: __( 'Subscriber highlights', 'jetpack-premium-analytics' ),
+	icon: people,
+	// Each metric defaults to enabled. The `getValue` defaults keep the settings
+	// checkbox in sync with the render, which also treats a missing flag as
+	// enabled: without them a metric absent from `attributes` would show as an
+	// unchecked box while its tile still rendered.
+	attributes: [
+		{
+			id: 'showTotal',
+			label: __( 'Total subscribers', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showTotal ?? true,
+		},
+		{
+			id: 'showPaid',
+			label: __( 'Paid subscribers', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showPaid ?? true,
+		},
+		{
+			id: 'showFree',
+			label: __( 'Free subscribers', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showFree ?? true,
+		},
+		{
+			id: 'showSocial',
+			label: __( 'Social followers', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SubscriberHighlightsAttributes } ) => item.showSocial ?? true,
+		},
+	] as WidgetAttributeField< SubscriberHighlightsAttributes >[],
+	example: {
+		attributes: {
+			showTotal: true,
+			showPaid: true,
+			showFree: true,
+			showSocial: true,
+		},
+	},
+};


### PR DESCRIPTION
## Proposed changes

Ports the Stats "Subscriber highlights" section into Premium Analytics as the `jpa/subscriber-highlights` widget, mirroring the shipped Annual highlights widget.

- New widget at `widgets/subscriber-highlights/` — four metric tiles (Total / Paid / Free / Social followers), each with a per-metric visibility toggle (default on).
- Reads the existing `useStatsSubscribersCounts` hook (`subscribers/counts`, already-allow-listed `subscribers` prefix). No new hook or proxy prefix.
- The endpoint reports current totals only, so the widget shows bare counts with no comparison — same as Annual highlights.
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget`; added a `subscribers/counts` fixture + handler.

## Related product discussion/links

- WOOA7S-1513

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / SubscriberHighlights**: the four tiles (Total / Paid / Free / Social) render populated; the metric toggles hide/show tiles; `WithComparison` renders the same as `Default`.
- Smoke test against a live connected site



https://github.com/user-attachments/assets/2564dca8-b6e5-46ec-98c3-741ca44e25ac

