### PR TITLE
WOOA7S-1525: Port Stats Reach widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-reach-widget
+++ b/projects/packages/premium-analytics/changelog/add-reach-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a Reach widget to the Analytics dashboard, ranking your subscriber channels — WordPress.com, email, and connected social services — by follower count.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -68,3 +68,5 @@ export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors'
 export { mockSiteSummary } from './site-summary';
 
 export { mockStatsInsightsData } from './insights';
+
+export { mockStatsPublicizeData } from './publicize';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/publicize.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/publicize.ts
@@ -1,0 +1,14 @@
+/**
+ * Mock Stats "publicize" response for the Reach widget. The shape matches what
+ * `sanitizeStatsPublicizeResponse` reads (`{ services: [ { service, followers } ] }`);
+ * follower counts are chosen so the ranked list interleaves the social services
+ * with the WordPress.com / Email totals from the followers mock.
+ */
+export const mockStatsPublicizeData = {
+	services: [
+		{ service: 'facebook', followers: 24 },
+		{ service: 'twitter', followers: 15 },
+		{ service: 'linkedin', followers: 9 },
+		{ service: 'tumblr', followers: 4 },
+	],
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -51,6 +51,7 @@ import {
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
 	mockStatsInsightsData,
+	mockStatsPublicizeData,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
@@ -855,6 +856,8 @@ function routeStatsReport( subPath: string ): unknown {
 				: mockTopAuthorsData;
 		case '/insights':
 			return mockStatsInsightsData;
+		case '/publicize':
+			return mockStatsPublicizeData;
 		default:
 			return null;
 	}

--- a/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import ReachWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const FOLLOWERS_RESPONSE = {
+	page: 1,
+	pages: 1,
+	total: 30,
+	total_email: 18,
+	total_wpcom: 12,
+	subscribers: [],
+};
+
+const PUBLICIZE_RESPONSE = {
+	services: [
+		{ service: 'facebook', followers: 24 },
+		{ service: 'twitter', followers: 15 },
+	],
+};
+
+// Resolves each proxied Stats endpoint the widget requests: `stats/followers`
+// for the WordPress.com / email totals and `stats/publicize` for the connected
+// social services.
+function routeRequest( { path }: { path: string } ) {
+	if ( path.includes( 'stats/publicize' ) ) {
+		return Promise.resolve( PUBLICIZE_RESPONSE );
+	}
+	return Promise.resolve( FOLLOWERS_RESPONSE );
+}
+
+describe( 'ReachWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockImplementation( routeRequest );
+	} );
+
+	it( 'ranks every subscriber channel by follower count', async () => {
+		render( <ReachWidget attributes={ {} } /> );
+
+		// Highest count first: Facebook (24), Email (18), Twitter (15),
+		// WordPress.com (12).
+		await expect( screen.findByText( 'Facebook' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Twitter' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits channels with no followers', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+			if ( path.includes( 'stats/publicize' ) ) {
+				return Promise.resolve( { services: [] } );
+			}
+			return Promise.resolve( { total_email: 18, total_wpcom: 0, subscribers: [] } );
+		} );
+
+		render( <ReachWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Email' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'WordPress.com' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the empty state when there are no subscribers', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+			if ( path.includes( 'stats/publicize' ) ) {
+				return Promise.resolve( { services: [] } );
+			}
+			return Promise.resolve( { total_email: 0, total_wpcom: 0, subscribers: [] } );
+		} );
+
+		render( <ReachWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'No subscribers yet.' ) ).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
@@ -91,4 +91,22 @@ describe( 'ReachWidget', () => {
 
 		await expect( screen.findByText( 'No subscribers yet.' ) ).resolves.toBeInTheDocument();
 	} );
+
+	it( 'still renders followers reach when the Publicize request fails', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+			if ( path.includes( 'stats/publicize' ) ) {
+				// A 401/403 rejection resolves deterministically (no retry), matching a
+				// plan- or permission-gated Publicize endpoint.
+				return Promise.reject( { status: 403 } );
+			}
+			return Promise.resolve( FOLLOWERS_RESPONSE );
+		} );
+
+		render( <ReachWidget attributes={ {} } /> );
+
+		// The supplementary Publicize failure must not hide the WordPress.com / email reach.
+		await expect( screen.findByText( 'Email' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Unable to load your reach.' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/__tests__/reach.test.tsx
@@ -57,12 +57,19 @@ describe( 'ReachWidget', () => {
 	it( 'ranks every subscriber channel by follower count', async () => {
 		render( <ReachWidget attributes={ {} } /> );
 
-		// Highest count first: Facebook (24), Email (18), Twitter (15),
-		// WordPress.com (12).
 		await expect( screen.findByText( 'Facebook' ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Twitter' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'WordPress.com' ) ).toBeInTheDocument();
+
+		// Assert the rendered order, not just presence: highest count first —
+		// Facebook (24), Email (18), Twitter (15), WordPress.com (12). Comparing the
+		// DOM-ordered labels against the expected sequence catches a sort regression
+		// that a presence-only check would miss.
+		const rankedLabels = screen.getAllByText( /^(Facebook|Email|Twitter|WordPress\.com)$/ );
+		expect( rankedLabels ).toEqual( [
+			screen.getByText( 'Facebook' ),
+			screen.getByText( 'Email' ),
+			screen.getByText( 'Twitter' ),
+			screen.getByText( 'WordPress.com' ),
+		] );
 	} );
 
 	it( 'omits channels with no followers', async () => {

--- a/projects/packages/premium-analytics/widgets/reach/package.json
+++ b/projects/packages/premium-analytics/widgets/reach/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-reach",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@wordpress/api-fetch": "7.50.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/reach/render.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/render.tsx
@@ -188,7 +188,9 @@ function toReachRows(
  * @return The widget content.
  */
 function ReachReport() {
-	const followers = useStatsFollowers();
+	// Only the wpcom/email summary totals are used, so skip fetching the
+	// subscriber list the endpoint would otherwise return.
+	const followers = useStatsFollowers( { max: 1 } );
 	const publicize = useStatsPublicize();
 
 	const rows = useMemo(
@@ -200,7 +202,9 @@ function ReachReport() {
 		<ReachLeaderboard
 			rows={ rows }
 			isLoading={ followers.isLoading || publicize.isLoading }
-			isError={ followers.isError || publicize.isError }
+			// Publicize is a supplementary channel: when only it fails, still show
+			// the WordPress.com and email reach instead of erroring the whole widget.
+			isError={ followers.isError }
 		/>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/reach/render.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/render.tsx
@@ -1,0 +1,225 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsFollowers,
+	useStatsPublicize,
+	type StatsFollowersResponse,
+	type StatsPublicizeResponse,
+} from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	type DataFormat,
+	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import type { ReachAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+const VALUE_FORMAT: DataFormat = {
+	type: 'number',
+	options: { useMultipliers: true, decimals: 0 },
+};
+
+/**
+ * A single subscriber-source row: one channel (WordPress.com, Email, or a
+ * connected social service) and its follower count. Exported so Storybook and
+ * tests can build fixtures for `ReachLeaderboard`.
+ */
+export type ReachRow = {
+	/**
+	 * Stable identifier for the channel (`wpcom`, `email`, `publicize-<service>`).
+	 */
+	key: string;
+	/**
+	 * Human-readable channel name.
+	 */
+	label: string;
+	/**
+	 * Follower count for the channel.
+	 */
+	value: number;
+};
+
+// The follower and Publicize modules report lifetime totals and are not
+// period-scoped, so this widget ignores the dashboard date range. Report params
+// are still accepted at the WidgetRoot boundary (and Storybook may inject them)
+// so the host contract holds.
+type ReachRenderAttributes = ReachAttributes & Partial< ReportParamsFieldAttributes >;
+type ReachWidgetProps = WidgetRenderProps< ReachRenderAttributes >;
+
+/**
+ * Maps the normalized reach rows onto the shape `LeaderboardChart` expects.
+ * Shares are computed relative to the highest-count channel so the overlay bars
+ * are proportional. There is no comparison period, so the comparison fields are
+ * zeroed and the comparison UI stays off.
+ *
+ * @param rows - The ranked reach rows.
+ * @return The leaderboard chart data.
+ */
+function buildLeaderboardData( rows: ReachRow[] ): LeaderboardChartData {
+	// `1` guards against division by zero when every value is 0.
+	const maxValue = Math.max( ...rows.map( row => row.value ), 1 );
+
+	return rows.map( ( row, index ) => ( {
+		id: `${ index }-${ row.key }`,
+		label: (
+			<Text className={ styles.label } title={ row.label }>
+				{ row.label }
+			</Text>
+		),
+		currentValue: row.value,
+		currentShare: ( row.value / maxValue ) * 100,
+		previousValue: 0,
+		previousShare: 0,
+		delta: 0,
+	} ) );
+}
+
+type ReachLeaderboardProps = {
+	/**
+	 * Ranked reach rows to render. When omitted, the empty state is shown
+	 * (unless `isLoading` is set).
+	 */
+	rows?: ReachRow[];
+	/**
+	 * When `true`, a loading overlay is rendered instead of data.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, an error message is rendered in place of the chart.
+	 */
+	isError?: boolean;
+};
+
+/**
+ * Presentational leaderboard for the "Reach" widget. Renders each subscriber
+ * channel — WordPress.com, Email, and every connected social service — ranked
+ * by follower count.
+ *
+ * Takes already-ranked rows via props and owns only the loading, error, empty,
+ * and populated states. Exported so Storybook and tests can exercise those
+ * states with fixture rows.
+ *
+ * @param {ReachLeaderboardProps} props - The component props.
+ * @return The rendered leaderboard.
+ */
+export const ReachLeaderboard = ( {
+	rows = [],
+	isLoading = false,
+	isError = false,
+}: ReachLeaderboardProps ) => {
+	if ( isError ) {
+		return <Text>{ __( 'Unable to load your reach.', 'jetpack-premium-analytics' ) }</Text>;
+	}
+
+	if ( isLoading && rows.length === 0 ) {
+		return <WidgetLoadingOverlay />;
+	}
+
+	return (
+		<LeaderboardChart
+			data={ buildLeaderboardData( rows ) }
+			loading={ isLoading }
+			withOverlayLabel
+			showLegend={ false }
+			emptyStateText={ __( 'No subscribers yet.', 'jetpack-premium-analytics' ) }
+			dataFormat={ VALUE_FORMAT }
+		/>
+	);
+};
+
+/**
+ * Flattens the followers summary and Publicize report into ranked reach rows:
+ * WordPress.com and email follower totals plus one row per connected social
+ * service. Channels with no followers are dropped, and the remaining rows are
+ * sorted by follower count, descending.
+ *
+ * @param followers - The normalized followers report, or undefined while loading.
+ * @param publicize - The normalized Publicize report, or undefined while loading.
+ * @return The ranked reach rows.
+ */
+function toReachRows(
+	followers: StatsFollowersResponse | undefined,
+	publicize: StatsPublicizeResponse | undefined
+): ReachRow[] {
+	const summary = followers?.summary ?? {};
+
+	const rows: ReachRow[] = [
+		{
+			key: 'wpcom',
+			label: __( 'WordPress.com', 'jetpack-premium-analytics' ),
+			value: Number( summary.total_wpcom ?? 0 ),
+		},
+		{
+			key: 'email',
+			label: __( 'Email', 'jetpack-premium-analytics' ),
+			value: Number( summary.total_email ?? 0 ),
+		},
+	];
+
+	const services = publicize?.data?.[ 0 ]?.items ?? [];
+	services.forEach( service => {
+		rows.push( {
+			key: `publicize-${ service.service }`,
+			label: String( service.label ?? '' ),
+			value: service.value,
+		} );
+	} );
+
+	return rows.filter( row => row.value > 0 ).sort( ( a, b ) => b.value - a.value );
+}
+
+/**
+ * Fetches the followers summary and the Publicize report through their
+ * designated Stats hooks and hands the ranked rows to the presentational
+ * `ReachLeaderboard`. Neither module is period-scoped, so the dashboard date
+ * range is intentionally ignored.
+ *
+ * @return The widget content.
+ */
+function ReachReport() {
+	const followers = useStatsFollowers();
+	const publicize = useStatsPublicize();
+
+	const rows = useMemo(
+		() => toReachRows( followers.data, publicize.data ),
+		[ followers.data, publicize.data ]
+	);
+
+	return (
+		<ReachLeaderboard
+			rows={ rows }
+			isLoading={ followers.isLoading || publicize.isLoading }
+			isError={ followers.isError || publicize.isError }
+		/>
+	);
+}
+
+/**
+ * Widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client and chart theme the inner
+ * leaderboard relies on. This widget has no own attributes and ignores the
+ * dashboard date range, but host attributes are still passed through for the
+ * widget contract.
+ *
+ * @param {ReachWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function Reach( { attributes = {} }: ReachWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<ReachReport />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/reach/stories/reach-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/reach/stories/reach-widget.stories.tsx
@@ -1,0 +1,136 @@
+/**
+ * The Reach widget combines the WordPress.com and email follower totals (from
+ * the proxied `stats/followers` endpoint) with each connected social service
+ * (from `stats/publicize`) into a single ranked list. Both modules report
+ * lifetime totals, so there is no comparison period: the `WithComparison` story
+ * passes comparison `reportParams` but renders identically to `Default`. Data is
+ * served in Storybook by `registerReportMocks()` (the `stats/followers` and
+ * `stats/publicize` handlers).
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import ReachRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const REACH_RENDER_MODULE = 'storybook/reach';
+
+interface ReachStoryControls {
+	/**
+	 * Whether to inject comparison report params.
+	 */
+	withComparison: boolean;
+}
+
+/**
+ * Renders the data-connected widget with report params from the date range
+ * picker. The follower and Publicize modules report lifetime totals, so toggling
+ * comparison does not change what the widget shows — it is wired through only to
+ * prove the widget renders unchanged when the host injects comparison params.
+ *
+ * @param {ReachStoryControls} controls - The story controls.
+ * @return The rendered widget.
+ */
+function renderReach( { withComparison }: ReachStoryControls ) {
+	return <ReachRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />;
+}
+
+// Close-up canvas so the leaderboard fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Reach',
+	component: ReachRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Reach" widget ranks every subscriber channel — WordPress.com, Email, and each connected social (Publicize) service — by follower count. Data comes from the `useStatsFollowers` and `useStatsPublicize` hooks; in Storybook it is served by `registerReportMocks()`. These modules report lifetime totals, so there is no comparison period and the `WithComparison` story renders identically to `Default`.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof ReachRender > & ReachStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< ReachStoryControls >;
+
+/**
+ * Default — the ranked subscriber channels, populated from the mocked followers
+ * and Publicize payloads.
+ */
+export const Default: Story = {
+	render: renderReach,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * WithComparison — comparison `reportParams` are supplied by the date range
+ * picker, but these modules have no comparison data, so the widget renders
+ * identically to `Default` (no deltas).
+ */
+export const WithComparison: Story = {
+	render: renderReach,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface ReachDashboardStoryProps extends WidgetDashboardWithWidgetControls, ReachStoryControls {}
+
+/**
+ * Mounts the real `WidgetDashboard` with this single widget so it renders
+ * exactly as it does in product (framed card, sizing, edit mode).
+ *
+ * @param {ReachDashboardStoryProps} props - The dashboard story controls.
+ * @return The widget mounted inside the real dashboard.
+ */
+function ReachDashboardStory( { withComparison, ...dashboardArgs }: ReachDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			renderModule={ REACH_RENDER_MODULE }
+			renderComponent={ ReachRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< ReachDashboardStoryProps > = {
+	render: args => <ReachDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 1,
+		widgetHeight: 2,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/reach/style.module.css
+++ b/projects/packages/premium-analytics/widgets/reach/style.module.css
@@ -1,0 +1,16 @@
+.label {
+	display: block;
+
+	/* Vertical padding sets the overlay bar height — the bar fills the row,
+	   whose height is driven by this label (there is no image to size it). */
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+
+	/* Inset the text from the bar's rounded left edge. The chart applies this to
+	   its default `.label` in overlay mode (`.is-overlay .label`), but a custom
+	   label element bypasses that rule, so we mirror it here. */
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/projects/packages/premium-analytics/widgets/reach/widget.json
+++ b/projects/packages/premium-analytics/widgets/reach/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/reach",
+	"title": "Reach",
+	"description": "How many people you reach across WordPress.com, email, and social media.",
+	"category": "subscribers",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/reach/widget.ts
+++ b/projects/packages/premium-analytics/widgets/reach/widget.ts
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * The Reach widget has no configurable attributes: it always shows the
+ * subscriber totals across every channel. `Record< never, never >` (not
+ * `Record< string, never >`) so the render-only type can compose host fields
+ * such as `reportParams` without collapsing them to `never`.
+ */
+export type ReachAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats "Reach" module. Combines the WordPress.com and
+ * email follower totals with each connected social (Publicize) service into a
+ * single ranked list. The follower and Publicize modules report lifetime
+ * totals, so there is no date range or comparison period.
+ */
+export default {
+	name: 'jpa/reach',
+	title: __( 'Reach', 'jetpack-premium-analytics' ),
+	icon: people,
+	attributes: [] as WidgetAttributeField< ReachAttributes >[],
+	example: {
+		attributes: {},
+	},
+};


### PR DESCRIPTION
## Proposed changes

Ports the Stats "Reach" module into Premium Analytics as the `jpa/reach` widget.

- New widget at `widgets/reach/` (`jpa/reach`, category `subscribers`, framed).
- Merges WordPress.com + email totals (`useStatsFollowers`) with each connected Publicize service (`useStatsPublicize`) into one list ranked by follower count; zero-follower channels are dropped.
- Renders via the toolkit `LeaderboardChart` (no direct `@automattic/charts` import). Zero attributes (`Record<never, never>`).
- Both modules report lifetime totals only — no period scope, so no comparison and no fabricated deltas.
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget`; added a `stats/publicize` fixture + handler. Existing `subscribers` prefix and hooks — no data-layer changes.

## Related product discussion/links

- WOOA7S-1525

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / Reach**: channels render as a single list ranked by follower count (Facebook 24, Email 18, Twitter 15, WordPress.com 12, LinkedIn 9, Tumblr 4); channels with zero followers are omitted.
- Or test the dashboard against a live connected site.

https://github.com/user-attachments/assets/2b1bde5f-3e26-465c-8f70-6d9965dc17b1
