### PR TITLE
WOOA7S-1524: Port Stats Site overview widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-site-overview-widget
+++ b/projects/packages/premium-analytics/changelog/add-site-overview-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a Site overview widget to the Analytics dashboard, showing the selected period's views, visitors, likes, and comments with period-over-period change.

--- a/projects/packages/premium-analytics/changelog/update-metric-tile-grid-comparison
+++ b/projects/packages/premium-analytics/changelog/update-metric-tile-grid-comparison
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add optional per-tile comparison, note, and value-title support to the shared MetricTileGrid, and render the Site overview widget through it.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-summary.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { statsSummaryQuery } from '../queries/stats-summary-query';
+import { useStatsReport } from './use-stats-report';
+import type { UseStatsOptions } from './use-stats-report';
+import type { StatsSummaryParams, StatsSummaryResponse } from '../queries/stats-summary-query';
+
+export type { StatsSummaryParams, StatsSummaryResponse } from '../queries/stats-summary-query';
+
+export function useStatsSummary( params: StatsSummaryParams, options?: UseStatsOptions ) {
+	return useStatsReport< StatsSummaryParams, StatsSummaryResponse >(
+		statsSummaryQuery,
+		params,
+		[ 'stats', 'summary', '__comparison__', 'disabled' ],
+		options
+	);
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-summary.ts
@@ -12,7 +12,7 @@ export function useStatsSummary( params: StatsSummaryParams, options?: UseStatsO
 	return useStatsReport< StatsSummaryParams, StatsSummaryResponse >(
 		statsSummaryQuery,
 		params,
-		[ 'stats', 'summary', '__comparison__', 'disabled' ],
+		'summary',
 		options
 	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -97,6 +97,11 @@ export {
 	type StatsVisitsStatField,
 	type StatsVisitsStatFields,
 } from './hooks/use-stats-visits';
+export {
+	useStatsSummary,
+	type StatsSummaryParams,
+	type StatsSummaryResponse,
+} from './hooks/use-stats-summary';
 export { useStatsInsights } from './hooks/use-stats-insights';
 export type {
 	StatsInsightsParams,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -45,7 +45,9 @@ export { mergeStatsDevicesComparisonRows, sanitizeStatsDevicesResponse } from '.
 export { sanitizeStatsPublicizeResponse } from './publicize';
 export { sanitizeStatsWordAdsStatsResponse, sanitizeStatsWordAdsEarningsResponse } from './wordads';
 export { sanitizeStatsSingleVideoResponse } from './single-video';
+export { sanitizeStatsSummaryResponse } from './summary';
 export type { StatsTopPostsComparisonItem, StatsTopPostsItem } from './top-posts';
+export type { StatsSummaryResponse } from './summary';
 export type {
 	StatsPostMeta,
 	StatsPostMonthValues,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/summary.ts
@@ -1,0 +1,38 @@
+import { safeParseFloat } from '../../utils/parsing';
+import { coerceStatsRecord } from './utils';
+
+/**
+ * The Stats `summary` endpoint returns a single flat object of period totals for
+ * the requested window (not a time series). `date`/`period` echo the request;
+ * the counts are the aggregated values over the period, except `followers`,
+ * which is the site's running follower total at that date.
+ */
+export type StatsSummaryResponse = {
+	date: string;
+	period: string;
+	views: number;
+	visitors: number;
+	likes: number;
+	reblogs: number;
+	comments: number;
+	followers: number;
+};
+
+function getString( value: unknown ) {
+	return typeof value === 'string' ? value : '';
+}
+
+export function sanitizeStatsSummaryResponse( response: unknown ): StatsSummaryResponse {
+	const payload = coerceStatsRecord( response );
+
+	return {
+		date: getString( payload.date ),
+		period: getString( payload.period ),
+		views: safeParseFloat( payload.views ),
+		visitors: safeParseFloat( payload.visitors ),
+		likes: safeParseFloat( payload.likes ),
+		reblogs: safeParseFloat( payload.reblogs ),
+		comments: safeParseFloat( payload.comments ),
+		followers: safeParseFloat( payload.followers ),
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/queries/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/index.ts
@@ -60,6 +60,8 @@ export {
 } from './stats-subscribers-query';
 export { statsStreakQuery } from './stats-streak-query';
 export { statsVisitsQuery } from './stats-visits-query';
+export { statsSummaryQuery } from './stats-summary-query';
+export type { StatsSummaryParams, StatsSummaryResponse } from './stats-summary-query';
 export { statsInsightsQuery } from './stats-insights-query';
 export { statsUtmQuery } from './stats-utm-query';
 export { statsHighlightsQuery } from './stats-highlights-query';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -31,6 +31,7 @@ import {
 	sanitizeStatsSiteResponse,
 	sanitizeStatsSubscribersCountsResponse,
 	sanitizeStatsSubscribersResponse,
+	sanitizeStatsSummaryResponse,
 	sanitizeStatsTopAuthorsResponse,
 	sanitizeStatsTopPostsResponse,
 	sanitizeStatsUtmResponse,
@@ -86,6 +87,7 @@ const statsSanitizers = {
 	emailBreakdown: sanitizeStatsEmailBreakdownResponse,
 	emailSummary: sanitizeStatsEmailSummaryResponse,
 	singleVideo: sanitizeStatsSingleVideoResponse,
+	summary: sanitizeStatsSummaryResponse,
 } satisfies Record< string, StatsSanitizer >;
 
 export type StatsSanitizerKey = keyof typeof statsSanitizers;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-summary-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-summary-query.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { reportParamsToStatsQueryParams, statsQueryParamsToApiParams } from '../utils/stats-params';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
+import type { StatsProxyParams } from '../api';
+
+export type { StatsSummaryResponse } from '../processing/stats';
+
+export type StatsSummaryParams = StatsReportParams;
+
+/**
+ * Builds the `stats/summary` proxy query for a dashboard date range.
+ *
+ * The summary endpoint aggregates the last `num` periods ending at `date`, so a
+ * date range is expressed as `period=day` with `num` equal to the number of days
+ * in the range (inclusive). The comparison period is fetched by `useReport`,
+ * which re-invokes this factory with the compare window swapped into `from`/`to`,
+ * so the date-range conversion stays here rather than in the widget.
+ *
+ * @param params - Report params carrying the dashboard date range.
+ * @return The query options for the summary report.
+ */
+export const statsSummaryQuery = (
+	params: StatsSummaryParams
+): StatsReportQueryOptions< 'summary' > => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const summaryParams: StatsProxyParams = {
+		period: 'day',
+		date: apiParams.date,
+		num: statsParams.days ?? 1,
+	};
+
+	return statsProxyQuery( {
+		name: 'summary',
+		version: '1.1',
+		endpoint: 'stats/summary',
+		params: summaryParams,
+		sanitizer: 'summary',
+		enabled: !! apiParams.date,
+	} );
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid.test.tsx
@@ -43,4 +43,38 @@ describe( 'MetricTileGrid', () => {
 
 		expect( screen.getAllByText( '—' ) ).toHaveLength( 2 );
 	} );
+
+	it( 'shows a period-over-period delta when a tile provides a previous value', () => {
+		render(
+			<MetricTileGrid
+				tiles={ [ { key: 'views', label: 'Views', value: 150, previousValue: 100 } ] }
+			/>
+		);
+
+		expect( screen.getByText( '150' ) ).toBeInTheDocument();
+		expect( screen.getByText( /%/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the value without a delta when the previous value is null', () => {
+		render(
+			<MetricTileGrid
+				tiles={ [ { key: 'views', label: 'Views', value: 150, previousValue: null } ] }
+			/>
+		);
+
+		expect( screen.getByText( '150' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /%/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'exposes a tile note as visually hidden assistive text', () => {
+		render(
+			<MetricTileGrid
+				tiles={ [
+					{ key: 'visitors', label: 'Visitors', value: 3, note: 'Sum of daily visitors.' },
+				] }
+			/>
+		);
+
+		expect( screen.getByText( 'Sum of daily visitors.' ) ).toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -72,6 +72,26 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	white-space: nowrap;
 }
 
+/* Comparison tiles render value + delta through MetricWithComparison, which
+ * manages its own value font size, so this cell only handles placement — it
+ * mirrors `.value`'s flex slot without the responsive font clamp. */
+.comparison {
+	display: flex;
+	flex: 0 0 auto;
+	justify-content: center;
+	min-inline-size: 0;
+	max-inline-size: 100%;
+}
+
+/* MetricValue emits the font-size token without a fallback, and the dashboard
+ * runtime does not always inject the WPDS typography tokens, so pin the metric
+ * total here with explicit fallbacks. Scoped to the comparison cell so the
+ * plain `.value` path keeps its responsive clamp. */
+.comparison span {
+	font-size: var(--wpds-typography-font-size-xl, 20px);
+	line-height: var(--wpds-typography-line-height-xl, 32px);
+}
+
 .placeholder {
 	font-weight: var(--wpds-typography-font-weight-medium, 500);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { Icon, Text } from '@wordpress/ui';
+import { Icon, Text, VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies
  */
 import { MetricValue } from '../metric-value';
+import { MetricWithComparison } from '../metric-with-comparison';
 import styles from './metric-tile-grid.module.scss';
 import type { DataFormat } from '../../types';
 import type { ComponentProps } from 'react';
@@ -33,6 +34,27 @@ type MetricTileGridItem = {
 	 * value (`undefined`, `NaN`) also falls back to the placeholder.
 	 */
 	value: number | null;
+
+	/**
+	 * The comparison-period value. Setting this — to a number or an explicit
+	 * `null` — opts the tile into the comparison layout, where the value renders
+	 * with a period-over-period delta. A number shows the delta; `null` renders
+	 * the value alone (comparison requested but no comparable data). Leaving it
+	 * `undefined` keeps the plain value layout used by non-comparison widgets.
+	 */
+	previousValue?: number | null;
+
+	/**
+	 * Caveat about how the value is aggregated. Shown as a hover tooltip on the
+	 * tile header and mirrored as visually hidden text for assistive technology.
+	 */
+	note?: string;
+
+	/**
+	 * `title` tooltip on the value, e.g. the exact count behind a shortened
+	 * display value (`18K` → `18,432`).
+	 */
+	valueTitle?: string;
 
 	/**
 	 * Format configuration for this tile's value. Falls back to the grid's
@@ -81,6 +103,53 @@ type MetricTileGridProps = {
 };
 
 /**
+ * The value cell for a single tile. A non-finite value renders the placeholder;
+ * a tile that opts into comparison (its `previousValue` is set) renders through
+ * `MetricWithComparison`; otherwise it renders a plain formatted value.
+ *
+ * @param props              - The component props.
+ * @param props.tile         - The tile to render the value for.
+ * @param props.dataFormat   - The grid's default value format.
+ * @param props.currencyCode - The grid's default currency code.
+ * @return The rendered value cell.
+ */
+function MetricTileValue( {
+	tile,
+	dataFormat,
+	currencyCode,
+}: {
+	tile: MetricTileGridItem;
+	dataFormat: DataFormat;
+	currencyCode?: string;
+} ) {
+	if ( ! Number.isFinite( tile.value ) ) {
+		return <Text className={ styles.placeholder }>{ tile.placeholder ?? '—' }</Text>;
+	}
+
+	if ( tile.previousValue !== undefined ) {
+		return (
+			<span className={ styles.comparison } title={ tile.valueTitle }>
+				<MetricWithComparison
+					value={ tile.value as number }
+					previousValue={ tile.previousValue }
+					dataFormat={ tile.dataFormat ?? dataFormat }
+				/>
+			</span>
+		);
+	}
+
+	return (
+		<MetricValue
+			value={ tile.value as number }
+			dataFormat={ tile.dataFormat ?? dataFormat }
+			currencyCode={ tile.currencyCode ?? currencyCode }
+			className={ styles.value }
+			title={ tile.valueTitle }
+		/>
+	);
+}
+
+/**
  * Responsive container for metric tiles. The layout tracks the widget cell size
  * and picks one of three shapes on its own, no column count needed:
  *
@@ -106,20 +175,18 @@ export function MetricTileGrid( {
 			<div className={ styles.grid } role="list">
 				{ tiles.map( tile => (
 					<div key={ tile.key } className={ clsx( styles.tile, tile.className ) } role="listitem">
-						<div className={ styles.header }>
+						<div className={ styles.header } title={ tile.note }>
 							{ tile.icon && <Icon icon={ tile.icon } size={ 24 } className={ styles.icon } /> }
 							<Text className={ styles.label }>{ tile.label }</Text>
+							{ /* The `title` tooltip is invisible to keyboard and screen-reader
+							     users, so the caveat is repeated as visually hidden text. */ }
+							{ tile.note && <VisuallyHidden>{ tile.note }</VisuallyHidden> }
 						</div>
-						{ Number.isFinite( tile.value ) ? (
-							<MetricValue
-								value={ tile.value as number }
-								dataFormat={ tile.dataFormat ?? dataFormat }
-								currencyCode={ tile.currencyCode ?? currencyCode }
-								className={ styles.value }
-							/>
-						) : (
-							<Text className={ styles.placeholder }>{ tile.placeholder ?? '—' }</Text>
-						) }
+						<MetricTileValue
+							tile={ tile }
+							dataFormat={ dataFormat }
+							currencyCode={ currencyCode }
+						/>
 					</div>
 				) ) }
 			</div>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -91,6 +91,34 @@ export const ThreeTiles: Story = {
 };
 
 /**
+ * Setting a tile's `previousValue` opts it into the comparison layout, where the
+ * value renders with a period-over-period delta. A number shows the delta; an
+ * explicit `null` (comparison requested but no comparable data) renders the
+ * value alone, so tiles stay consistently sized whether or not a comparison is
+ * available. `note` adds a hover caveat mirrored as visually hidden text.
+ */
+export const WithComparison: Story = {
+	args: {
+		dataFormat: COUNT_FORMAT,
+		tiles: [
+			{ key: 'views', icon: postList, label: 'Views', value: 18400, previousValue: 16100 },
+			{
+				key: 'visitors',
+				icon: starEmpty,
+				label: 'Visitors',
+				value: 12100,
+				previousValue: 10800,
+				note: 'Sum of daily visitors — a returning visitor is counted once per day.',
+			},
+			{ key: 'likes', icon: starEmpty, label: 'Likes', value: 842, previousValue: 905 },
+			// Comparison requested but no comparable data: the value renders alone.
+			{ key: 'comments', icon: comment, label: 'Comments', value: 296, previousValue: null },
+		],
+	},
+	decorators: [ makeCanvas( '100%', '320px' ) ],
+};
+
+/**
  * A `null` value renders the placeholder ("—" by default) instead of a
  * formatted zero — for metrics a site doesn't have yet, like a rate that
  * cannot be computed.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-value/metric-value.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-value/metric-value.tsx
@@ -34,6 +34,12 @@ export type MetricValueProps = {
 	className?: string;
 
 	/**
+	 * `title` tooltip on the value, e.g. the exact count behind a shortened
+	 * display value (`18K` → `18,432`).
+	 */
+	title?: string;
+
+	/**
 	 * Font size token from the WordPress Design System.
 	 * Maps directly to `--wpds-typography-font-size-{value}`.
 	 * @default 'lg'
@@ -52,6 +58,7 @@ export function MetricValue( {
 	dataFormat = { type: 'number' },
 	currencyCode,
 	className,
+	title,
 	fontSize = 'lg',
 	color = 'neutral',
 }: MetricValueProps ) {
@@ -74,6 +81,7 @@ export function MetricValue( {
 	return (
 		<span
 			style={ style }
+			title={ title }
 			className={ clsx( styles.metricValue, styles[ `color--${ color }` ], className ) }
 		>
 			{ displayValue }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -69,4 +69,6 @@ export { mockSiteSummary } from './site-summary';
 
 export { mockStatsInsightsData } from './insights';
 
+export { mockSiteOverviewData, mockSiteOverviewComparisonData } from './site-overview';
+
 export { mockStatsSubscribersCountsData } from './subscriber-counts';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -69,6 +69,6 @@ export { mockSiteSummary } from './site-summary';
 
 export { mockStatsInsightsData } from './insights';
 
-export { mockSiteOverviewData, mockSiteOverviewComparisonData } from './site-overview';
+export { mockStatsSummaryData, mockStatsSummaryComparisonData } from './summary';
 
 export { mockStatsSubscribersCountsData } from './subscriber-counts';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/site-overview.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/site-overview.ts
@@ -1,0 +1,27 @@
+/**
+ * Mock data for the Stats `summary` endpoint (`/proxy/v1.1/stats/summary`),
+ * consumed by the Site overview widget. The response is a single flat object of
+ * period totals; the comparison request returns the earlier period so tiles show
+ * a period-over-period delta.
+ */
+export const mockSiteOverviewData = {
+	date: '2026-06-22',
+	period: 'day',
+	views: 18240,
+	visitors: 11680,
+	likes: 842,
+	reblogs: 37,
+	comments: 296,
+	followers: 5124,
+};
+
+export const mockSiteOverviewComparisonData = {
+	date: '2026-05-22',
+	period: 'day',
+	views: 15980,
+	visitors: 10420,
+	likes: 910,
+	reblogs: 41,
+	comments: 268,
+	followers: 4980,
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/summary.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/summary.ts
@@ -4,7 +4,7 @@
  * period totals; the comparison request returns the earlier period so tiles show
  * a period-over-period delta.
  */
-export const mockSiteOverviewData = {
+export const mockStatsSummaryData = {
 	date: '2026-06-22',
 	period: 'day',
 	views: 18240,
@@ -15,7 +15,7 @@ export const mockSiteOverviewData = {
 	followers: 5124,
 };
 
-export const mockSiteOverviewComparisonData = {
+export const mockStatsSummaryComparisonData = {
 	date: '2026-05-22',
 	period: 'day',
 	views: 15980,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -51,8 +51,8 @@ import {
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
 	mockStatsInsightsData,
-	mockSiteOverviewData,
-	mockSiteOverviewComparisonData,
+	mockStatsSummaryData,
+	mockStatsSummaryComparisonData,
 	mockStatsSubscribersCountsData,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
@@ -883,8 +883,8 @@ function routeStatsReport( subPath: string ): unknown {
 			// Period summary — alternates primary/comparison so the Site overview
 			// widget shows a period-over-period delta on each tile.
 			return nextIsComparison( 'stats/summary' )
-				? mockSiteOverviewComparisonData
-				: mockSiteOverviewData;
+				? mockStatsSummaryComparisonData
+				: mockStatsSummaryData;
 		case '/search-terms':
 			return nextIsComparison( 'stats/search-terms' )
 				? mockSearchTermsComparisonData

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -51,6 +51,8 @@ import {
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
 	mockStatsInsightsData,
+	mockSiteOverviewData,
+	mockSiteOverviewComparisonData,
 	mockStatsSubscribersCountsData,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
@@ -877,6 +879,12 @@ function routeStatsReport( subPath: string ): unknown {
 		case '':
 			// Site summary — the bare `/stats` endpoint (all-time totals).
 			return mockSiteSummary;
+		case '/summary':
+			// Period summary — alternates primary/comparison so the Site overview
+			// widget shows a period-over-period delta on each tile.
+			return nextIsComparison( 'stats/summary' )
+				? mockSiteOverviewComparisonData
+				: mockSiteOverviewData;
 		case '/search-terms':
 			return nextIsComparison( 'stats/search-terms' )
 				? mockSearchTermsComparisonData

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -143,7 +143,7 @@ describe( 'SiteOverviewWidget', () => {
 			<SiteOverviewWidget
 				attributes={ {
 					reportParams: { from: '2026-03-01', to: '2026-03-10' },
-					showLikes: false,
+					metrics: [ 'views', 'visitors', 'comments' ],
 				} }
 			/>
 		);
@@ -161,10 +161,7 @@ describe( 'SiteOverviewWidget', () => {
 			<SiteOverviewWidget
 				attributes={ {
 					reportParams: { from: '2026-03-01', to: '2026-03-10' },
-					showViews: false,
-					showVisitors: false,
-					showLikes: false,
-					showComments: false,
+					metrics: [],
 				} }
 			/>
 		);

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -66,6 +66,43 @@ describe( 'SiteOverviewWidget', () => {
 		expect( screen.getByText( '17' ) ).toBeInTheDocument();
 	} );
 
+	it( 'hides a metric tile toggled off in the widget settings', async () => {
+		render(
+			<SiteOverviewWidget
+				attributes={ {
+					reportParams: { from: '2026-03-01', to: '2026-03-10' },
+					showLikes: false,
+				} }
+			/>
+		);
+
+		await expect( screen.findByText( 'Views' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Visitors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Comments' ) ).toBeInTheDocument();
+		// The Likes tile is toggled off, so neither its label nor its value renders.
+		expect( screen.queryByText( 'Likes' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '48' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'prompts to pick a metric when all tiles are toggled off', async () => {
+		render(
+			<SiteOverviewWidget
+				attributes={ {
+					reportParams: { from: '2026-03-01', to: '2026-03-10' },
+					showViews: false,
+					showVisitors: false,
+					showLikes: false,
+					showComments: false,
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByText( 'Select at least one metric to display.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Views' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'requests the dashboard date range from report params', async () => {
 		render(
 			<SiteOverviewWidget

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -77,8 +77,9 @@ describe( 'SiteOverviewWidget', () => {
 
 		// The tile abbreviates the count…
 		await expect( screen.findByText( '18K' ) ).resolves.toBeInTheDocument();
-		// …and its hover title carries the exact total.
-		expect( screen.getByTitle( ( 18400 ).toLocaleString() ) ).toBeInTheDocument();
+		// …and its hover title carries the exact total, formatted through the
+		// package formatter so tile and title agree on the app locale.
+		expect( screen.getByTitle( '18,400' ) ).toBeInTheDocument();
 	} );
 
 	it( 'explains the per-day visitor aggregation on the Visitors tile', async () => {
@@ -89,7 +90,11 @@ describe( 'SiteOverviewWidget', () => {
 		);
 
 		await expect( screen.findByText( 'Visitors' ) ).resolves.toBeInTheDocument();
+		// Sighted mouse users get the caveat as a hover title…
 		expect( screen.getByTitle( /Sum of daily visitors/ ) ).toBeInTheDocument();
+		// …and assistive technology gets it as visually hidden text, since a
+		// `title` on a non-focusable element is unreachable by keyboard.
+		expect( screen.getByText( /Sum of daily visitors/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the empty state when every visible metric is zero', async () => {

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import SiteOverviewWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const SUMMARY_RESPONSE = {
+	date: '2026-03-10',
+	period: 'day',
+	views: 420,
+	visitors: 260,
+	likes: 48,
+	reblogs: 3,
+	comments: 17,
+	followers: 512,
+};
+
+const COMPARISON_RESPONSE = {
+	date: '2026-02-10',
+	period: 'day',
+	views: 300,
+	visitors: 200,
+	likes: 60,
+	reblogs: 2,
+	comments: 12,
+	followers: 480,
+};
+
+describe( 'SiteOverviewWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( SUMMARY_RESPONSE );
+	} );
+
+	it( 'renders the period metrics from the summary response', async () => {
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Views' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Visitors' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Likes' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Comments' ) ).toBeInTheDocument();
+		expect( screen.getByText( '260' ) ).toBeInTheDocument();
+		expect( screen.getByText( '17' ) ).toBeInTheDocument();
+	} );
+
+	it( 'requests the dashboard date range from report params', async () => {
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/summary' );
+		expect( requestedPath ).toContain( 'date=2026-03-10' );
+	} );
+
+	it( 'fetches the comparison window when comparison params are present', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve( path.includes( 'date=2026-02-10' ) ? COMPARISON_RESPONSE : SUMMARY_RESPONSE )
+		);
+
+		render(
+			<SiteOverviewWidget
+				attributes={ {
+					reportParams: {
+						from: '2026-03-01',
+						to: '2026-03-10',
+						comp: '1',
+						compare_from: '2026-02-01',
+						compare_to: '2026-02-10',
+					},
+				} }
+			/>
+		);
+
+		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );
+		expect( requestedPaths.some( path => path.includes( 'date=2026-03-10' ) ) ).toBe( true );
+		expect( requestedPaths.some( path => path.includes( 'date=2026-02-10' ) ) ).toBe( true );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -104,5 +104,50 @@ describe( 'SiteOverviewWidget', () => {
 		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );
 		expect( requestedPaths.some( path => path.includes( 'date=2026-03-10' ) ) ).toBe( true );
 		expect( requestedPaths.some( path => path.includes( 'date=2026-02-10' ) ) ).toBe( true );
+	} );
+
+	it( 'keeps the stale tiles and overlays a spinner while a new date range loads', async () => {
+		// Hold the second period's fetch open so the refetch state is observable.
+		let resolveNextPeriod: ( () => void ) | undefined;
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+			if ( path.includes( 'date=2026-03-10' ) ) {
+				return Promise.resolve( SUMMARY_RESPONSE );
+			}
+			return new Promise( resolve => {
+				resolveNextPeriod = () => resolve( { ...SUMMARY_RESPONSE, views: 999 } );
+			} );
+		} );
+
+		const { container, rerender } = render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
+
+		// The overlay's spinner is decorative (`role="presentation"`), so there is
+		// no accessible role/text to query — assert on its stable class instead.
+		const hasOverlaySpinner = () =>
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- decorative spinner, no accessible query target
+			container.querySelector( '.components-spinner' ) !== null;
+
+		// Switch the date range: the new fetch is in flight but not yet resolved.
+		rerender(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-04-01', to: '2026-04-10' } } }
+			/>
+		);
+
+		// The previous period's tiles stay put rather than blanking to a spinner…
+		expect( screen.getByText( '420' ) ).toBeInTheDocument();
+		// …and the refetch overlay spinner is layered on top.
+		await waitFor( () => expect( hasOverlaySpinner() ).toBe( true ) );
+
+		// Once the new period resolves, its totals replace the stale ones and the
+		// overlay clears.
+		resolveNextPeriod?.();
+		await expect( screen.findByText( '999' ) ).resolves.toBeInTheDocument();
+		expect( hasOverlaySpinner() ).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -64,6 +64,73 @@ describe( 'SiteOverviewWidget', () => {
 		expect( screen.getByText( 'Comments' ) ).toBeInTheDocument();
 		expect( screen.getByText( '260' ) ).toBeInTheDocument();
 		expect( screen.getByText( '17' ) ).toBeInTheDocument();
+	} );
+
+	it( 'exposes the exact total on hover while the tile shows a shortened count', async () => {
+		mockApiFetch.mockResolvedValue( { ...SUMMARY_RESPONSE, views: 18400 } );
+
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		// The tile abbreviates the count…
+		await expect( screen.findByText( '18K' ) ).resolves.toBeInTheDocument();
+		// …and its hover title carries the exact total.
+		expect( screen.getByTitle( ( 18400 ).toLocaleString() ) ).toBeInTheDocument();
+	} );
+
+	it( 'explains the per-day visitor aggregation on the Visitors tile', async () => {
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect( screen.findByText( 'Visitors' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByTitle( /Sum of daily visitors/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when every visible metric is zero', async () => {
+		mockApiFetch.mockResolvedValue( {
+			...SUMMARY_RESPONSE,
+			views: 0,
+			visitors: 0,
+			likes: 0,
+			comments: 0,
+		} );
+
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect(
+			screen.findByText( 'No stats recorded for this period.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Views' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the error state with a Retry action that refetches', async () => {
+		// A 403 is not retried by the query client, so the error state is
+		// immediate; `no_connection` keeps it out of the plan-gated path.
+		mockApiFetch.mockRejectedValueOnce( { code: 'no_connection', data: { status: 403 } } );
+
+		render(
+			<SiteOverviewWidget
+				attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } }
+			/>
+		);
+
+		await expect(
+			screen.findByText( "We couldn't load the site overview. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+
+		// Retry re-runs the query; the next fetch succeeds and the tiles render.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'hides a metric tile toggled off in the widget settings', async () => {

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -129,7 +129,7 @@ describe( 'SiteOverviewWidget', () => {
 		).resolves.toBeInTheDocument();
 
 		// Retry re-runs the query; the next fetch succeeds and the tiles render.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
 		await expect( screen.findByText( '420' ) ).resolves.toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -104,6 +104,12 @@ describe( 'SiteOverviewWidget', () => {
 		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );
 		expect( requestedPaths.some( path => path.includes( 'date=2026-03-10' ) ) ).toBe( true );
 		expect( requestedPaths.some( path => path.includes( 'date=2026-02-10' ) ) ).toBe( true );
+
+		// Each tile derives its delta from the same metric in the comparison
+		// response, so distinct metrics show distinct period-over-period changes
+		// rather than one shared value: views 420 vs 300 rises, likes 48 vs 60 falls.
+		await expect( screen.findByText( '+40%' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( '-20%' ) ).toBeInTheDocument();
 	} );
 
 	it( 'keeps the stale tiles and overlays a spinner while a new date range loads', async () => {

--- a/projects/packages/premium-analytics/widgets/site-overview/package.json
+++ b/projects/packages/premium-analytics/widgets/site-overview/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/fields": "link:../../packages/fields",
 		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/widgets/site-overview/package.json
+++ b/projects/packages/premium-analytics/widgets/site-overview/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-site-overview",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@wordpress/api-fetch": "7.50.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/site-overview/package.json
+++ b/projects/packages/premium-analytics/widgets/site-overview/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -136,9 +136,10 @@ function SiteOverviewReport( {
 			label,
 			value,
 			// Only pair a comparison value when the comparison period actually
-			// returned a summary; a `null` keeps the tile in the comparison layout
-			// (no fabricated delta) so tile sizing stays consistent whether or not
-			// comparison data is available.
+			// returned a summary; a `null` (never `undefined`) keeps every tile in
+			// the fixed-size comparison layout — no fabricated delta, and one value
+			// size instead of MetricTileGrid's responsive `.value` clamp — so tiles
+			// stay consistently sized with or without comparison data.
 			previousValue: hasComparison && comparisonSummary ? metricValue( comparisonSummary ) : null,
 			note,
 			// The tile shows a shortened count (e.g. 18K); the hover title carries

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { useStatsSummary, type StatsSummaryResponse } from '@jetpack-premium-analytics/data';
+import {
+	MetricWithComparison,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	useWidgetRootContext,
+	type DataFormat,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { Icon, comment, people, seen, starEmpty } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import type { SiteOverviewAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+// Report params are dashboard-driven — WidgetRoot resolves them from the date
+// picker — but the host (and Storybook) may also inject them via `attributes`.
+type SiteOverviewRenderAttributes = SiteOverviewAttributes & Partial< ReportParamsFieldAttributes >;
+type SiteOverviewWidgetProps = WidgetRenderProps< SiteOverviewRenderAttributes >;
+
+const COUNT_FORMAT: DataFormat = {
+	type: 'number',
+	options: { useMultipliers: true, decimals: 0 },
+};
+
+/**
+ * The period metrics shown, in display order. Each key is a numeric field of the
+ * summary response, paired with its Stats icon. `summary` totals views/visitors/
+ * likes/comments over the period; `followers` is excluded because it is an
+ * all-time running total, not a period metric, so it has no meaningful
+ * period-over-period comparison.
+ */
+const METRICS = [
+	{ key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ), icon: seen },
+	{ key: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics' ), icon: people },
+	{ key: 'likes', label: __( 'Likes', 'jetpack-premium-analytics' ), icon: starEmpty },
+	{ key: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ), icon: comment },
+] as const;
+
+/**
+ * Fetches the period summary through the designated `useStatsSummary` Stats hook
+ * and renders views, visitors, likes, and comments as metric tiles. The date
+ * range and comparison period come from the dashboard picker via `reportParams`.
+ *
+ * When a comparison period is requested and returns data, each tile shows its
+ * period-over-period change; the comparison total is looked up per metric so a
+ * primary metric is never paired with a fabricated previous value.
+ *
+ * @return The widget content.
+ */
+function SiteOverviewReport() {
+	const { reportParams } = useWidgetRootContext();
+
+	const { primary, comparison, hasComparison, isLoading, isError } =
+		useStatsSummary( reportParams );
+
+	const summary = primary.data as StatsSummaryResponse | undefined;
+	const comparisonSummary = comparison.data as StatsSummaryResponse | undefined;
+
+	// Only wire comparison values when the comparison period actually returned a
+	// summary; otherwise the tiles render as bare current-period totals rather
+	// than showing a delta derived from missing data.
+	const previousByMetric = useMemo( () => {
+		const map = new Map< keyof StatsSummaryResponse, number >();
+		if ( hasComparison && comparisonSummary ) {
+			for ( const metric of METRICS ) {
+				map.set( metric.key, comparisonSummary[ metric.key ] );
+			}
+		}
+		return map;
+	}, [ hasComparison, comparisonSummary ] );
+
+	let content;
+	if ( isError ) {
+		content = (
+			<div className={ styles.state }>
+				<Text>{ __( 'Unable to load site overview.', 'jetpack-premium-analytics' ) }</Text>
+			</div>
+		);
+	} else if ( isLoading && ! summary ) {
+		content = <WidgetLoadingOverlay />;
+	} else if ( ! summary ) {
+		content = (
+			<div className={ styles.state }>
+				<Text>{ __( 'No stats recorded for this period.', 'jetpack-premium-analytics' ) }</Text>
+			</div>
+		);
+	} else {
+		content = (
+			<div className={ styles.grid }>
+				{ METRICS.map( metric => (
+					<div key={ metric.key } className={ styles.tile }>
+						<div className={ styles.tileHeader }>
+							<Icon className={ styles.tileIcon } icon={ metric.icon } size={ 24 } />
+							<Text className={ styles.tileLabel }>{ metric.label }</Text>
+						</div>
+						<MetricWithComparison
+							className={ styles.tileValue }
+							value={ summary[ metric.key ] }
+							previousValue={ previousByMetric.get( metric.key ) }
+							dataFormat={ COUNT_FORMAT }
+							fontSize="xl"
+						/>
+					</div>
+				) ) }
+			</div>
+		);
+	}
+
+	// The states share the `.root` body wrapper so sizing stays consistent
+	// whether data, a spinner, or a message shows.
+	return <div className={ styles.root }>{ content }</div>;
+}
+
+/**
+ * Widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client, chart theme, and the report
+ * params consumed by the inner report — resolved from the dashboard date range
+ * and comparison state via context, the same way the other Stats widgets read
+ * them.
+ *
+ * @param {SiteOverviewWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function SiteOverview( { attributes = {} }: SiteOverviewWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<SiteOverviewReport />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -59,11 +59,20 @@ const METRICS = [
 function SiteOverviewReport() {
 	const { reportParams } = useWidgetRootContext();
 
-	const { primary, comparison, hasComparison, isLoading, isError } =
+	const { primary, comparison, hasComparison, isLoading, isFetching, isError } =
 		useStatsSummary( reportParams );
 
 	const summary = primary.data as StatsSummaryResponse | undefined;
 	const comparisonSummary = comparison.data as StatsSummaryResponse | undefined;
+
+	// The summary response is a flat object, so `useReport`'s generic `hasData`
+	// (which looks for `.summary`/`.data`/`.steps`) never matches it — gate on the
+	// summary directly. Cover the widget only on the cold load; once a period's
+	// totals are on screen, a date-range change refetches in the background and we
+	// layer the overlay over the stale tiles instead of blanking them.
+	const hasSummary = !! summary;
+	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasSummary;
+	const isRefetching = isFetching && hasSummary;
 
 	// Only wire comparison values when the comparison period actually returned a
 	// summary; otherwise the tiles render as bare current-period totals rather
@@ -85,7 +94,7 @@ function SiteOverviewReport() {
 				<Text>{ __( 'Unable to load site overview.', 'jetpack-premium-analytics' ) }</Text>
 			</div>
 		);
-	} else if ( isLoading && ! summary ) {
+	} else if ( isInitialLoading ) {
 		content = <WidgetLoadingOverlay />;
 	} else if ( ! summary ) {
 		content = (
@@ -116,8 +125,14 @@ function SiteOverviewReport() {
 	}
 
 	// The states share the `.root` body wrapper so sizing stays consistent
-	// whether data, a spinner, or a message shows.
-	return <div className={ styles.root }>{ content }</div>;
+	// whether data, a spinner, or a message shows. `.root` is positioned, so the
+	// refetch overlay layers over the tiles while a new period loads.
+	return (
+		<div className={ styles.root }>
+			{ content }
+			{ isRefetching && <WidgetLoadingOverlay /> }
+		</div>
+	);
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -14,11 +14,13 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, comment, globe, people, seen, starEmpty } from '@wordpress/icons';
 import { Text, VisuallyHidden } from '@wordpress/ui';
+import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
 import {
+	DEFAULT_SITE_OVERVIEW_METRICS,
 	SITE_OVERVIEW_METRICS,
 	type SiteOverviewAttributes,
 	type SiteOverviewMetricId,
@@ -57,8 +59,8 @@ const TILE_CONFIG: Record<
 		note?: string;
 	}
 > = {
-	showViews: { icon: seen, value: summary => summary.views },
-	showVisitors: {
+	views: { icon: seen, value: summary => summary.views },
+	visitors: {
 		icon: people,
 		value: summary => summary.visitors,
 		// Mirrors the upstream Stats caveat: the endpoint sums each day's
@@ -68,8 +70,8 @@ const TILE_CONFIG: Record<
 			'jetpack-premium-analytics'
 		),
 	},
-	showLikes: { icon: starEmpty, value: summary => summary.likes },
-	showComments: { icon: comment, value: summary => summary.comments },
+	likes: { icon: starEmpty, value: summary => summary.likes },
+	comments: { icon: comment, value: summary => summary.comments },
 };
 
 /**
@@ -80,13 +82,17 @@ const TILE_CONFIG: Record<
  * When a comparison period is requested and returns data, each tile shows its
  * period-over-period change; the comparison total is looked up per metric so a
  * primary metric is never paired with a fabricated previous value. Which tiles
- * appear is controlled by the per-metric visibility attributes.
+ * appear is controlled by the `metrics` attribute.
  *
- * @param props            - The component props.
- * @param props.attributes - The per-metric visibility flags; a missing flag means enabled.
+ * @param props           - The component props.
+ * @param props.metricIds - The selected metric tile ids; missing means every metric.
  * @return The widget content.
  */
-function SiteOverviewReport( { attributes }: { attributes: SiteOverviewAttributes } ) {
+function SiteOverviewReport( {
+	metricIds = DEFAULT_SITE_OVERVIEW_METRICS,
+}: {
+	metricIds?: SiteOverviewMetricId[];
+} ) {
 	const { reportParams } = useWidgetRootContext();
 
 	const { primary, comparison, hasComparison, isLoading, isFetching, isError, refetch } =
@@ -95,10 +101,12 @@ function SiteOverviewReport( { attributes }: { attributes: SiteOverviewAttribute
 	const summary = primary.data as StatsSummaryResponse | undefined;
 	const comparisonSummary = comparison.data as StatsSummaryResponse | undefined;
 
-	// Drop tiles the user has toggled off in the widget settings, keeping the
-	// declared display order. A missing flag means enabled, matching the
-	// `getValue` defaults on the widget definition.
-	const visibleMetrics = SITE_OVERVIEW_METRICS.filter( ( { id } ) => attributes[ id ] ?? true );
+	// Resolve the selected ids against the canonical definitions so the tile
+	// order stays stable regardless of the order the ids were toggled in.
+	const visibleMetrics = useMemo( () => {
+		const selected = new Set( metricIds );
+		return SITE_OVERVIEW_METRICS.filter( metric => selected.has( metric.id ) );
+	}, [ metricIds ] );
 
 	// Not a data state: the user has toggled every tile off in the widget
 	// settings, so it stays outside `WidgetState` and shows in every fetch state.
@@ -199,7 +207,7 @@ function SiteOverviewReport( { attributes }: { attributes: SiteOverviewAttribute
 export default function SiteOverview( { attributes = {} }: SiteOverviewWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<SiteOverviewReport attributes={ attributes } />
+			<SiteOverviewReport metricIds={ attributes.metrics } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -4,14 +4,14 @@
 import { useStatsSummary, type StatsSummaryResponse } from '@jetpack-premium-analytics/data';
 import {
 	MetricWithComparison,
-	WidgetLoadingOverlay,
 	WidgetRoot,
+	WidgetState,
 	useWidgetRootContext,
 	type DataFormat,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Icon, comment, people, seen, starEmpty } from '@wordpress/icons';
+import { Icon, comment, globe, people, seen, starEmpty } from '@wordpress/icons';
 import { Text } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
@@ -36,6 +36,16 @@ const COUNT_FORMAT: DataFormat = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
+type MetricKey = 'views' | 'visitors' | 'likes' | 'comments';
+
+type Metric = {
+	key: MetricKey;
+	label: string;
+	icon: typeof seen;
+	/** Optional caveat about how the total is aggregated, surfaced on hover. */
+	note?: string;
+};
+
 /**
  * The period metrics shown, in display order. Each key is a numeric field of the
  * summary response, paired with its Stats icon. `summary` totals views/visitors/
@@ -43,12 +53,22 @@ const COUNT_FORMAT: DataFormat = {
  * all-time running total, not a period metric, so it has no meaningful
  * period-over-period comparison.
  */
-const METRICS = [
+const METRICS: Metric[] = [
 	{ key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ), icon: seen },
-	{ key: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics' ), icon: people },
+	{
+		key: 'visitors',
+		label: __( 'Visitors', 'jetpack-premium-analytics' ),
+		icon: people,
+		// Mirrors the upstream Stats caveat: the endpoint sums each day's
+		// visitors, so a returning visitor counts once per day, not once overall.
+		note: __(
+			'Sum of daily visitors — a returning visitor is counted once per day, not once for the whole period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	{ key: 'likes', label: __( 'Likes', 'jetpack-premium-analytics' ), icon: starEmpty },
 	{ key: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ), icon: comment },
-] as const;
+];
 
 /**
  * Fetches the period summary through the designated `useStatsSummary` Stats hook
@@ -71,20 +91,11 @@ function SiteOverviewReport( {
 }: SiteOverviewReportProps ) {
 	const { reportParams } = useWidgetRootContext();
 
-	const { primary, comparison, hasComparison, isLoading, isFetching, isError } =
+	const { primary, comparison, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsSummary( reportParams );
 
 	const summary = primary.data as StatsSummaryResponse | undefined;
 	const comparisonSummary = comparison.data as StatsSummaryResponse | undefined;
-
-	// The summary response is a flat object, so `useReport`'s generic `hasData`
-	// (which looks for `.summary`/`.data`/`.steps`) never matches it — gate on the
-	// summary directly. Cover the widget only on the cold load; once a period's
-	// totals are on screen, a date-range change refetches in the background and we
-	// layer the overlay over the stale tiles instead of blanking them.
-	const hasSummary = !! summary;
-	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasSummary;
-	const isRefetching = isFetching && hasSummary;
 
 	// Only wire comparison values when the comparison period actually returned a
 	// summary; otherwise the tiles render as bare current-period totals rather
@@ -101,7 +112,7 @@ function SiteOverviewReport( {
 
 	// Drop tiles the user has toggled off in the widget settings, keeping the
 	// declared display order.
-	const enabledByKey: Record< string, boolean > = {
+	const enabledByKey: Record< MetricKey, boolean > = {
 		views: showViews,
 		visitors: showVisitors,
 		likes: showLikes,
@@ -109,56 +120,70 @@ function SiteOverviewReport( {
 	};
 	const visibleMetrics = METRICS.filter( metric => enabledByKey[ metric.key ] );
 
-	let content;
-	if ( isError ) {
-		content = (
-			<div className={ styles.state }>
-				<Text>{ __( 'Unable to load site overview.', 'jetpack-premium-analytics' ) }</Text>
-			</div>
-		);
-	} else if ( isInitialLoading ) {
-		content = <WidgetLoadingOverlay />;
-	} else if ( ! summary ) {
-		content = (
-			<div className={ styles.state }>
-				<Text>{ __( 'No stats recorded for this period.', 'jetpack-premium-analytics' ) }</Text>
-			</div>
-		);
-	} else if ( visibleMetrics.length === 0 ) {
-		content = (
-			<div className={ styles.state }>
-				<Text>{ __( 'Select at least one metric to display.', 'jetpack-premium-analytics' ) }</Text>
-			</div>
-		);
-	} else {
-		content = (
-			<div className={ styles.grid }>
-				{ visibleMetrics.map( metric => (
-					<div key={ metric.key } className={ styles.tile }>
-						<div className={ styles.tileHeader }>
-							<Icon className={ styles.tileIcon } icon={ metric.icon } size={ 24 } />
-							<Text className={ styles.tileLabel }>{ metric.label }</Text>
-						</div>
-						<MetricWithComparison
-							className={ styles.tileValue }
-							value={ summary[ metric.key ] }
-							previousValue={ previousByMetric.get( metric.key ) }
-							dataFormat={ COUNT_FORMAT }
-							fontSize="xl"
-						/>
-					</div>
-				) ) }
+	// Not a data state: the user has toggled every tile off in the widget
+	// settings, so it stays outside `WidgetState` and shows in every fetch state.
+	if ( visibleMetrics.length === 0 ) {
+		return (
+			<div className={ styles.root }>
+				<div className={ styles.state }>
+					<Text>
+						{ __( 'Select at least one metric to display.', 'jetpack-premium-analytics' ) }
+					</Text>
+				</div>
 			</div>
 		);
 	}
 
-	// The states share the `.root` body wrapper so sizing stays consistent
-	// whether data, a spinner, or a message shows. `.root` is positioned, so the
-	// refetch overlay layers over the tiles while a new period loads.
+	// The summary endpoint resolves to a flat totals object even for an idle
+	// period, so "empty" is every visible metric at zero, not a missing payload.
+	const isEmpty = ! summary || visibleMetrics.every( metric => summary[ metric.key ] === 0 );
+
 	return (
 		<div className={ styles.root }>
-			{ content }
-			{ isRefetching && <WidgetLoadingOverlay /> }
+			<WidgetState
+				// `isPending` covers the query being disabled before a date resolves;
+				// once a period's totals are on screen a date-range change refetches in
+				// the background and the busy overlay layers over the stale tiles.
+				isLoading={ ( isLoading || primary.isPending ) && ! summary }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ isEmpty }
+				error={ {
+					description: __(
+						"We couldn't load the site overview. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+				} }
+				empty={ {
+					icon: globe,
+					description: __( 'No stats recorded for this period.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<div className={ styles.grid }>
+					{ visibleMetrics.map( metric => {
+						const value = summary?.[ metric.key ] ?? 0;
+						return (
+							<div key={ metric.key } className={ styles.tile }>
+								<div className={ styles.tileHeader } title={ metric.note }>
+									<Icon className={ styles.tileIcon } icon={ metric.icon } size={ 24 } />
+									<Text className={ styles.tileLabel }>{ metric.label }</Text>
+								</div>
+								{ /* The tile shows a shortened count (e.g. 18K); the hover title
+								     carries the exact total, as the upstream Stats tooltip does. */ }
+								<div className={ styles.tileValue } title={ value.toLocaleString() }>
+									<MetricWithComparison
+										value={ value }
+										previousValue={ previousByMetric.get( metric.key ) }
+										dataFormat={ COUNT_FORMAT }
+										fontSize="xl"
+									/>
+								</div>
+							</div>
+						);
+					} ) }
+				</div>
+			</WidgetState>
 		</div>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -26,6 +26,11 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type SiteOverviewRenderAttributes = SiteOverviewAttributes & Partial< ReportParamsFieldAttributes >;
 type SiteOverviewWidgetProps = WidgetRenderProps< SiteOverviewRenderAttributes >;
 
+/**
+ * The per-metric visibility flags from widget attributes, with defaults applied.
+ */
+type SiteOverviewReportProps = Required< SiteOverviewAttributes >;
+
 const COUNT_FORMAT: DataFormat = {
 	type: 'number',
 	options: { useMultipliers: true, decimals: 0 },
@@ -52,11 +57,18 @@ const METRICS = [
  *
  * When a comparison period is requested and returns data, each tile shows its
  * period-over-period change; the comparison total is looked up per metric so a
- * primary metric is never paired with a fabricated previous value.
+ * primary metric is never paired with a fabricated previous value. Which tiles
+ * appear is controlled by the per-metric visibility attributes.
  *
+ * @param {SiteOverviewReportProps} props - The component props.
  * @return The widget content.
  */
-function SiteOverviewReport() {
+function SiteOverviewReport( {
+	showViews,
+	showVisitors,
+	showLikes,
+	showComments,
+}: SiteOverviewReportProps ) {
 	const { reportParams } = useWidgetRootContext();
 
 	const { primary, comparison, hasComparison, isLoading, isFetching, isError } =
@@ -87,6 +99,16 @@ function SiteOverviewReport() {
 		return map;
 	}, [ hasComparison, comparisonSummary ] );
 
+	// Drop tiles the user has toggled off in the widget settings, keeping the
+	// declared display order.
+	const enabledByKey: Record< string, boolean > = {
+		views: showViews,
+		visitors: showVisitors,
+		likes: showLikes,
+		comments: showComments,
+	};
+	const visibleMetrics = METRICS.filter( metric => enabledByKey[ metric.key ] );
+
 	let content;
 	if ( isError ) {
 		content = (
@@ -102,10 +124,16 @@ function SiteOverviewReport() {
 				<Text>{ __( 'No stats recorded for this period.', 'jetpack-premium-analytics' ) }</Text>
 			</div>
 		);
+	} else if ( visibleMetrics.length === 0 ) {
+		content = (
+			<div className={ styles.state }>
+				<Text>{ __( 'Select at least one metric to display.', 'jetpack-premium-analytics' ) }</Text>
+			</div>
+		);
 	} else {
 		content = (
 			<div className={ styles.grid }>
-				{ METRICS.map( metric => (
+				{ visibleMetrics.map( metric => (
 					<div key={ metric.key } className={ styles.tile }>
 						<div className={ styles.tileHeader }>
 							<Icon className={ styles.tileIcon } icon={ metric.icon } size={ 24 } />
@@ -149,7 +177,12 @@ function SiteOverviewReport() {
 export default function SiteOverview( { attributes = {} }: SiteOverviewWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<SiteOverviewReport />
+			<SiteOverviewReport
+				showViews={ attributes.showViews ?? true }
+				showVisitors={ attributes.showVisitors ?? true }
+				showLikes={ attributes.showLikes ?? true }
+				showComments={ attributes.showComments ?? true }
+			/>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useStatsSummary, type StatsSummaryResponse } from '@jetpack-premium-analytics/data';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
 	MetricWithComparison,
 	WidgetRoot,
@@ -12,13 +13,16 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { Icon, comment, globe, people, seen, starEmpty } from '@wordpress/icons';
-import { Text } from '@wordpress/ui';
-import { useMemo } from 'react';
+import { Text, VisuallyHidden } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
-import type { SiteOverviewAttributes } from './widget';
+import {
+	SITE_OVERVIEW_METRICS,
+	type SiteOverviewAttributes,
+	type SiteOverviewMetricId,
+} from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 // Report params are dashboard-driven — WidgetRoot resolves them from the date
@@ -26,39 +30,37 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type SiteOverviewRenderAttributes = SiteOverviewAttributes & Partial< ReportParamsFieldAttributes >;
 type SiteOverviewWidgetProps = WidgetRenderProps< SiteOverviewRenderAttributes >;
 
-/**
- * The per-metric visibility flags from widget attributes, with defaults applied.
- */
-type SiteOverviewReportProps = Required< SiteOverviewAttributes >;
-
 const COUNT_FORMAT: DataFormat = {
 	type: 'number',
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-type MetricKey = 'views' | 'visitors' | 'likes' | 'comments';
-
-type Metric = {
-	key: MetricKey;
-	label: string;
-	icon: typeof seen;
-	/** Optional caveat about how the total is aggregated, surfaced on hover. */
-	note?: string;
-};
-
 /**
- * The period metrics shown, in display order. Each key is a numeric field of the
- * summary response, paired with its Stats icon. `summary` totals views/visitors/
- * likes/comments over the period; `followers` is excluded because it is an
- * all-time running total, not a period metric, so it has no meaningful
- * period-over-period comparison.
+ * Render-only config per metric: the tile icon, the summary-response field the
+ * tile displays, and an optional aggregation caveat. Ids and labels are shared
+ * with the settings checkboxes via `SITE_OVERVIEW_METRICS` in `widget.ts`.
+ *
+ * Each metric reads a numeric field of the `summary` response, which totals
+ * views/visitors/likes/comments over the period; `followers` is excluded
+ * because it is an all-time running total, not a period metric, so it has no
+ * meaningful period-over-period comparison.
  */
-const METRICS: Metric[] = [
-	{ key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ), icon: seen },
+const TILE_CONFIG: Record<
+	SiteOverviewMetricId,
 	{
-		key: 'visitors',
-		label: __( 'Visitors', 'jetpack-premium-analytics' ),
+		icon: typeof seen;
+		value: ( summary: StatsSummaryResponse ) => number;
+		/**
+		 * Optional caveat about how the total is aggregated, surfaced on hover
+		 * and as visually hidden text for assistive technology.
+		 */
+		note?: string;
+	}
+> = {
+	showViews: { icon: seen, value: summary => summary.views },
+	showVisitors: {
 		icon: people,
+		value: summary => summary.visitors,
 		// Mirrors the upstream Stats caveat: the endpoint sums each day's
 		// visitors, so a returning visitor counts once per day, not once overall.
 		note: __(
@@ -66,9 +68,9 @@ const METRICS: Metric[] = [
 			'jetpack-premium-analytics'
 		),
 	},
-	{ key: 'likes', label: __( 'Likes', 'jetpack-premium-analytics' ), icon: starEmpty },
-	{ key: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ), icon: comment },
-];
+	showLikes: { icon: starEmpty, value: summary => summary.likes },
+	showComments: { icon: comment, value: summary => summary.comments },
+};
 
 /**
  * Fetches the period summary through the designated `useStatsSummary` Stats hook
@@ -80,15 +82,11 @@ const METRICS: Metric[] = [
  * primary metric is never paired with a fabricated previous value. Which tiles
  * appear is controlled by the per-metric visibility attributes.
  *
- * @param {SiteOverviewReportProps} props - The component props.
+ * @param props            - The component props.
+ * @param props.attributes - The per-metric visibility flags; a missing flag means enabled.
  * @return The widget content.
  */
-function SiteOverviewReport( {
-	showViews,
-	showVisitors,
-	showLikes,
-	showComments,
-}: SiteOverviewReportProps ) {
+function SiteOverviewReport( { attributes }: { attributes: SiteOverviewAttributes } ) {
 	const { reportParams } = useWidgetRootContext();
 
 	const { primary, comparison, hasComparison, isLoading, isFetching, isError, refetch } =
@@ -97,28 +95,10 @@ function SiteOverviewReport( {
 	const summary = primary.data as StatsSummaryResponse | undefined;
 	const comparisonSummary = comparison.data as StatsSummaryResponse | undefined;
 
-	// Only wire comparison values when the comparison period actually returned a
-	// summary; otherwise the tiles render as bare current-period totals rather
-	// than showing a delta derived from missing data.
-	const previousByMetric = useMemo( () => {
-		const map = new Map< keyof StatsSummaryResponse, number >();
-		if ( hasComparison && comparisonSummary ) {
-			for ( const metric of METRICS ) {
-				map.set( metric.key, comparisonSummary[ metric.key ] );
-			}
-		}
-		return map;
-	}, [ hasComparison, comparisonSummary ] );
-
 	// Drop tiles the user has toggled off in the widget settings, keeping the
-	// declared display order.
-	const enabledByKey: Record< MetricKey, boolean > = {
-		views: showViews,
-		visitors: showVisitors,
-		likes: showLikes,
-		comments: showComments,
-	};
-	const visibleMetrics = METRICS.filter( metric => enabledByKey[ metric.key ] );
+	// declared display order. A missing flag means enabled, matching the
+	// `getValue` defaults on the widget definition.
+	const visibleMetrics = SITE_OVERVIEW_METRICS.filter( ( { id } ) => attributes[ id ] ?? true );
 
 	// Not a data state: the user has toggled every tile off in the widget
 	// settings, so it stays outside `WidgetState` and shows in every fetch state.
@@ -136,7 +116,8 @@ function SiteOverviewReport( {
 
 	// The summary endpoint resolves to a flat totals object even for an idle
 	// period, so "empty" is every visible metric at zero, not a missing payload.
-	const isEmpty = ! summary || visibleMetrics.every( metric => summary[ metric.key ] === 0 );
+	const isEmpty =
+		! summary || visibleMetrics.every( ( { id } ) => TILE_CONFIG[ id ].value( summary ) === 0 );
 
 	return (
 		<div className={ styles.root }>
@@ -161,20 +142,36 @@ function SiteOverviewReport( {
 				} }
 			>
 				<div className={ styles.grid }>
-					{ visibleMetrics.map( metric => {
-						const value = summary?.[ metric.key ] ?? 0;
+					{ visibleMetrics.map( ( { id, label } ) => {
+						const { icon, note, value: metricValue } = TILE_CONFIG[ id ];
+						const value = summary ? metricValue( summary ) : 0;
 						return (
-							<div key={ metric.key } className={ styles.tile }>
-								<div className={ styles.tileHeader } title={ metric.note }>
-									<Icon className={ styles.tileIcon } icon={ metric.icon } size={ 24 } />
-									<Text className={ styles.tileLabel }>{ metric.label }</Text>
+							<div key={ id } className={ styles.tile }>
+								<div className={ styles.tileHeader } title={ note }>
+									<Icon className={ styles.tileIcon } icon={ icon } size={ 24 } />
+									<Text className={ styles.tileLabel }>{ label }</Text>
+									{ /* The `title` tooltip is invisible to keyboard and screen-reader
+									     users, so the caveat is repeated as visually hidden text. */ }
+									{ note && <VisuallyHidden>{ note }</VisuallyHidden> }
 								</div>
 								{ /* The tile shows a shortened count (e.g. 18K); the hover title
-								     carries the exact total, as the upstream Stats tooltip does. */ }
-								<div className={ styles.tileValue } title={ value.toLocaleString() }>
+								     carries the exact total, as the upstream Stats tooltip does.
+								     Both go through the package formatter so they agree on locale. */ }
+								<div
+									className={ styles.tileValue }
+									title={ formatMetricValue( value, 'number', { decimals: 0 } ) }
+								>
 									<MetricWithComparison
 										value={ value }
-										previousValue={ previousByMetric.get( metric.key ) }
+										// Only wire a comparison value when the comparison period
+										// actually returned a summary; otherwise the tile renders as a
+										// bare current-period total rather than showing a delta
+										// derived from missing data.
+										previousValue={
+											hasComparison && comparisonSummary
+												? metricValue( comparisonSummary )
+												: undefined
+										}
 										dataFormat={ COUNT_FORMAT }
 										fontSize="xl"
 									/>
@@ -202,12 +199,7 @@ function SiteOverviewReport( {
 export default function SiteOverview( { attributes = {} }: SiteOverviewWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<SiteOverviewReport
-				showViews={ attributes.showViews ?? true }
-				showVisitors={ attributes.showVisitors ?? true }
-				showLikes={ attributes.showLikes ?? true }
-				showComments={ attributes.showComments ?? true }
-			/>
+			<SiteOverviewReport attributes={ attributes } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -4,7 +4,7 @@
 import { useStatsSummary, type StatsSummaryResponse } from '@jetpack-premium-analytics/data';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
-	MetricWithComparison,
+	MetricTileGrid,
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
@@ -12,8 +12,8 @@ import {
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Icon, comment, globe, people, seen, starEmpty } from '@wordpress/icons';
-import { Text, VisuallyHidden } from '@wordpress/ui';
+import { comment, globe, people, seen, starEmpty } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -127,6 +127,26 @@ function SiteOverviewReport( {
 	const isEmpty =
 		! summary || visibleMetrics.every( ( { id } ) => TILE_CONFIG[ id ].value( summary ) === 0 );
 
+	const tiles = visibleMetrics.map( ( { id, label } ) => {
+		const { icon, note, value: metricValue } = TILE_CONFIG[ id ];
+		const value = summary ? metricValue( summary ) : 0;
+		return {
+			key: id,
+			icon,
+			label,
+			value,
+			// Only pair a comparison value when the comparison period actually
+			// returned a summary; a `null` keeps the tile in the comparison layout
+			// (no fabricated delta) so tile sizing stays consistent whether or not
+			// comparison data is available.
+			previousValue: hasComparison && comparisonSummary ? metricValue( comparisonSummary ) : null,
+			note,
+			// The tile shows a shortened count (e.g. 18K); the hover title carries
+			// the exact total, as the upstream Stats tooltip does.
+			valueTitle: formatMetricValue( value, 'number', { decimals: 0 } ),
+		};
+	} );
+
 	return (
 		<div className={ styles.root }>
 			<WidgetState
@@ -149,45 +169,7 @@ function SiteOverviewReport( {
 					description: __( 'No stats recorded for this period.', 'jetpack-premium-analytics' ),
 				} }
 			>
-				<div className={ styles.grid }>
-					{ visibleMetrics.map( ( { id, label } ) => {
-						const { icon, note, value: metricValue } = TILE_CONFIG[ id ];
-						const value = summary ? metricValue( summary ) : 0;
-						return (
-							<div key={ id } className={ styles.tile }>
-								<div className={ styles.tileHeader } title={ note }>
-									<Icon className={ styles.tileIcon } icon={ icon } size={ 24 } />
-									<Text className={ styles.tileLabel }>{ label }</Text>
-									{ /* The `title` tooltip is invisible to keyboard and screen-reader
-									     users, so the caveat is repeated as visually hidden text. */ }
-									{ note && <VisuallyHidden>{ note }</VisuallyHidden> }
-								</div>
-								{ /* The tile shows a shortened count (e.g. 18K); the hover title
-								     carries the exact total, as the upstream Stats tooltip does.
-								     Both go through the package formatter so they agree on locale. */ }
-								<div
-									className={ styles.tileValue }
-									title={ formatMetricValue( value, 'number', { decimals: 0 } ) }
-								>
-									<MetricWithComparison
-										value={ value }
-										// Only wire a comparison value when the comparison period
-										// actually returned a summary; otherwise the tile renders as a
-										// bare current-period total rather than showing a delta
-										// derived from missing data.
-										previousValue={
-											hasComparison && comparisonSummary
-												? metricValue( comparisonSummary )
-												: undefined
-										}
-										dataFormat={ COUNT_FORMAT }
-										fontSize="xl"
-									/>
-								</div>
-							</div>
-						);
-					} ) }
-				</div>
+				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>
 		</div>
 	);

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -25,7 +25,10 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import SiteOverviewRender from '../render';
-import widgetDefinition from '../widget';
+import widgetDefinition, {
+	DEFAULT_SITE_OVERVIEW_METRICS,
+	type SiteOverviewMetricId,
+} from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -52,45 +55,24 @@ interface SiteOverviewStoryControls {
 	 */
 	withComparison: boolean;
 	/**
-	 * Whether the Views tile is shown.
+	 * Metric tiles to show in the widget body.
 	 */
-	showViews: boolean;
-	/**
-	 * Whether the Visitors tile is shown.
-	 */
-	showVisitors: boolean;
-	/**
-	 * Whether the Likes tile is shown.
-	 */
-	showLikes: boolean;
-	/**
-	 * Whether the Comments tile is shown.
-	 */
-	showComments: boolean;
+	metrics: SiteOverviewMetricId[];
 }
 
 /**
  * Renders the data-connected widget with report params derived from the
- * date-range picker preset and the per-metric visibility toggles.
+ * date-range picker preset and the selected metrics.
  *
  * @param {SiteOverviewStoryControls} props - The story controls.
  * @return The rendered widget.
  */
-function renderSiteOverview( {
-	withComparison,
-	showViews,
-	showVisitors,
-	showLikes,
-	showComments,
-}: SiteOverviewStoryControls ) {
+function renderSiteOverview( { withComparison, metrics }: SiteOverviewStoryControls ) {
 	return (
 		<SiteOverviewRender
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				showViews,
-				showVisitors,
-				showLikes,
-				showComments,
+				metrics,
 			} }
 		/>
 	);
@@ -114,17 +96,15 @@ function renderSiteOverviewOnPreset( preset: PresetType ) {
 }
 
 const METRIC_ARG_TYPES = {
-	showViews: { control: 'boolean' },
-	showVisitors: { control: 'boolean' },
-	showLikes: { control: 'boolean' },
-	showComments: { control: 'boolean' },
+	metrics: {
+		control: 'check',
+		options: DEFAULT_SITE_OVERVIEW_METRICS,
+		description: 'Metric tiles to show in the widget body.',
+	},
 } as const;
 
 const ALL_METRICS_ARGS = {
-	showViews: true,
-	showVisitors: true,
-	showLikes: true,
-	showComments: true,
+	metrics: DEFAULT_SITE_OVERVIEW_METRICS,
 } as const;
 
 // Close-up canvas so the metric grid fills the frame outside the dashboard grid.
@@ -146,7 +126,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Site overview" widget. Shows the selected period\'s headline traffic and engagement — views, visitors, likes, and comments — as metric tiles, sourced from the Jetpack Stats `summary` endpoint. Each metric tile can be toggled off via the widget\'s checkbox settings (the `show*` controls here). This module has genuine period-over-period comparison data, so the `WithComparison` story shows a change indicator on each tile.',
+					"The \"Site overview\" widget. Shows the selected period's headline traffic and engagement — views, visitors, likes, and comments — as metric tiles, sourced from the Jetpack Stats `summary` endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer. This module has genuine period-over-period comparison data, so the `WithComparison` story shows a change indicator on each tile.",
 			},
 		},
 	},
@@ -234,10 +214,7 @@ interface SiteOverviewDashboardStoryProps
  */
 function SiteOverviewDashboardStory( {
 	withComparison,
-	showViews,
-	showVisitors,
-	showLikes,
-	showComments,
+	metrics,
 	...dashboardArgs
 }: SiteOverviewDashboardStoryProps ) {
 	return (
@@ -248,10 +225,7 @@ function SiteOverviewDashboardStory( {
 			renderComponent={ SiteOverviewRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				showViews,
-				showVisitors,
-				showLikes,
-				showComments,
+				metrics,
 			} }
 		/>
 	);

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -1,0 +1,142 @@
+/**
+ * The stories drive the data-connected Site overview widget through the shared
+ * report-mock harness, which serves the Stats `summary` endpoint
+ * (`/proxy/v1.1/stats/summary`) via `routeStatsReport()`.
+ *
+ * This module has genuine period-over-period comparison data, so
+ * `WithComparison` renders a delta on every tile while `Default` shows bare
+ * period totals.
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import SiteOverviewRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SITE_OVERVIEW_RENDER_MODULE = 'storybook/site-overview';
+
+interface SiteOverviewStoryControls {
+	/**
+	 * Whether to include comparison report params.
+	 */
+	withComparison: boolean;
+}
+
+/**
+ * Renders the data-connected widget with report params derived from the
+ * date-range picker preset.
+ *
+ * @param {SiteOverviewStoryControls} props - The story controls.
+ * @return The rendered widget.
+ */
+function renderSiteOverview( { withComparison }: SiteOverviewStoryControls ) {
+	return (
+		<SiteOverviewRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
+	);
+}
+
+// Close-up canvas so the metric grid fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', maxWidth: '560px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/SiteOverview',
+	component: SiteOverviewRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Site overview" widget. Shows the selected period\'s headline traffic and engagement — views, visitors, likes, and comments — as metric tiles, sourced from the Jetpack Stats `summary` endpoint. This module has genuine period-over-period comparison data, so the `WithComparison` story shows a change indicator on each tile.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof SiteOverviewRender > & SiteOverviewStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< SiteOverviewStoryControls >;
+
+/**
+ * Default state — the period totals for the current preset, no comparison.
+ */
+export const Default: Story = {
+	render: renderSiteOverview,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison params flow through `reportParams`, and the summary module returns
+ * comparison-period data, so each tile shows its period-over-period change.
+ */
+export const WithComparison: Story = {
+	render: renderSiteOverview,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface SiteOverviewDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SiteOverviewStoryControls {}
+
+/**
+ * Renders the data-connected widget through the shared dashboard harness, so it
+ * appears exactly as it does in product (framed card, sizing, edit mode).
+ *
+ * @param {SiteOverviewDashboardStoryProps} props - The dashboard story controls.
+ * @return The widget mounted inside the real `WidgetDashboard`.
+ */
+function SiteOverviewDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: SiteOverviewDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ {
+				name: widgetDefinition.name,
+				title: widgetDefinition.title,
+				icon: widgetDefinition.icon,
+				presentation: 'framed',
+			} }
+			renderModule={ SITE_OVERVIEW_RENDER_MODULE }
+			renderComponent={ SiteOverviewRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< SiteOverviewDashboardStoryProps > = {
+	render: args => <SiteOverviewDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -10,11 +10,14 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -93,6 +96,23 @@ function renderSiteOverview( {
 	);
 }
 
+/**
+ * Renders the widget on a preset distinct from the other stories. The query key
+ * derives from the date range, so a unique preset gives the forced-state stories
+ * their own cache entry and they hit the mock fresh instead of reading another
+ * story's cached success from the shared query client.
+ *
+ * @param preset - The date-range preset for this story.
+ * @return The rendered widget.
+ */
+function renderSiteOverviewOnPreset( preset: PresetType ) {
+	return (
+		<SiteOverviewRender
+			attributes={ { reportParams: getDefaultQueryParams( false, preset ), ...ALL_METRICS_ARGS } }
+		/>
+	);
+}
+
 const METRIC_ARG_TYPES = {
 	showViews: { control: 'boolean' },
 	showVisitors: { control: 'boolean' },
@@ -153,6 +173,52 @@ export const WithComparison: Story = {
 	render: renderSiteOverview,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSiteOverviewOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/summary', 'loading' );
+		return () => setReportMockState( 'stats/summary', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSiteOverviewOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/summary', 'error' );
+		return () => setReportMockState( 'stats/summary', null );
+	},
+};
+
+/**
+ * Resolved with every metric at zero: the summary endpoint returns a flat totals
+ * object even for idle periods, so the widget derives its empty state ("No stats
+ * recorded for this period." under the neutral globe glyph) from all-zero
+ * visible metrics.
+ */
+export const Empty: Story = {
+	render: () => renderSiteOverviewOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/summary', 'empty' );
+		return () => setReportMockState( 'stats/summary', null );
+	},
 };
 
 interface SiteOverviewDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -24,32 +24,88 @@ import {
 import SiteOverviewRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const SITE_OVERVIEW_RENDER_MODULE = 'storybook/site-overview';
 
+// Carry the widget's metadata, including the metric-visibility attribute schema,
+// so the dashboard story's settings drawer renders the real checkboxes. The
+// attribute schema is typed loosely on the widget definition, so it is cast to
+// the WidgetType shape.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
+};
+
 interface SiteOverviewStoryControls {
 	/**
 	 * Whether to include comparison report params.
 	 */
 	withComparison: boolean;
+	/**
+	 * Whether the Views tile is shown.
+	 */
+	showViews: boolean;
+	/**
+	 * Whether the Visitors tile is shown.
+	 */
+	showVisitors: boolean;
+	/**
+	 * Whether the Likes tile is shown.
+	 */
+	showLikes: boolean;
+	/**
+	 * Whether the Comments tile is shown.
+	 */
+	showComments: boolean;
 }
 
 /**
  * Renders the data-connected widget with report params derived from the
- * date-range picker preset.
+ * date-range picker preset and the per-metric visibility toggles.
  *
  * @param {SiteOverviewStoryControls} props - The story controls.
  * @return The rendered widget.
  */
-function renderSiteOverview( { withComparison }: SiteOverviewStoryControls ) {
+function renderSiteOverview( {
+	withComparison,
+	showViews,
+	showVisitors,
+	showLikes,
+	showComments,
+}: SiteOverviewStoryControls ) {
 	return (
-		<SiteOverviewRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
+		<SiteOverviewRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				showViews,
+				showVisitors,
+				showLikes,
+				showComments,
+			} }
+		/>
 	);
 }
+
+const METRIC_ARG_TYPES = {
+	showViews: { control: 'boolean' },
+	showVisitors: { control: 'boolean' },
+	showLikes: { control: 'boolean' },
+	showComments: { control: 'boolean' },
+} as const;
+
+const ALL_METRICS_ARGS = {
+	showViews: true,
+	showVisitors: true,
+	showLikes: true,
+	showComments: true,
+} as const;
 
 // Close-up canvas so the metric grid fills the frame outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
@@ -64,12 +120,13 @@ const meta = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Site overview" widget. Shows the selected period\'s headline traffic and engagement — views, visitors, likes, and comments — as metric tiles, sourced from the Jetpack Stats `summary` endpoint. This module has genuine period-over-period comparison data, so the `WithComparison` story shows a change indicator on each tile.',
+					'The "Site overview" widget. Shows the selected period\'s headline traffic and engagement — views, visitors, likes, and comments — as metric tiles, sourced from the Jetpack Stats `summary` endpoint. Each metric tile can be toggled off via the widget\'s checkbox settings (the `show*` controls here). This module has genuine period-over-period comparison data, so the `WithComparison` story shows a change indicator on each tile.',
 			},
 		},
 	},
@@ -84,7 +141,7 @@ type Story = StoryObj< SiteOverviewStoryControls >;
  */
 export const Default: Story = {
 	render: renderSiteOverview,
-	args: { withComparison: false },
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -94,7 +151,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderSiteOverview,
-	args: { withComparison: true },
+	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -111,20 +168,25 @@ interface SiteOverviewDashboardStoryProps
  */
 function SiteOverviewDashboardStory( {
 	withComparison,
+	showViews,
+	showVisitors,
+	showLikes,
+	showComments,
 	...dashboardArgs
 }: SiteOverviewDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ {
-				name: widgetDefinition.name,
-				title: widgetDefinition.title,
-				icon: widgetDefinition.icon,
-				presentation: 'framed',
-			} }
+			widgetType={ storyWidgetType }
 			renderModule={ SITE_OVERVIEW_RENDER_MODULE }
 			renderComponent={ SiteOverviewRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				showViews,
+				showVisitors,
+				showLikes,
+				showComments,
+			} }
 		/>
 	);
 }
@@ -134,9 +196,11 @@ export const WidgetDashboardWithWidget: StoryObj< SiteOverviewDashboardStoryProp
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
+		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/site-overview/style.module.css
+++ b/projects/packages/premium-analytics/widgets/site-overview/style.module.css
@@ -8,14 +8,16 @@
 
 .grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: var(--wpds-dimension-gap-md, 12px);
+	grid-template-columns: 1fr;
+	gap: var(--wpds-dimension-gap-sm, 8px);
 }
 
 .tile {
 	display: flex;
-	flex-direction: column;
-	gap: var(--wpds-dimension-gap-sm, 8px);
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md, 12px);
 	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
 	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
 	border-radius: var(--wpds-border-radius-lg, 8px);
@@ -57,10 +59,23 @@
 	text-align: center;
 }
 
-/* Wide widths: lay the four tiles out in a single row. */
+/* Wide widths: lay the tiles out four across with the value stacked below the
+ * icon and label. */
 @container (min-width: 640px) {
 
 	.grid {
 		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	.tile {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		gap: var(--wpds-dimension-gap-lg, 16px);
+	}
+
+	.tileHeader {
+		flex-direction: column;
+		align-items: flex-start;
 	}
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/style.module.css
+++ b/projects/packages/premium-analytics/widgets/site-overview/style.module.css
@@ -1,0 +1,66 @@
+/* No outer padding: the host frames the widget and owns the padding. */
+.root {
+	position: relative;
+	container-type: inline-size;
+	height: 100%;
+	min-height: 120px;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--wpds-dimension-gap-md, 12px);
+}
+
+.tile {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
+	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-lg, 8px);
+}
+
+.tileHeader {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	min-width: 0;
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.tileIcon {
+	flex: 0 0 auto;
+	fill: var(--wpds-color-foreground-content-neutral);
+}
+
+.tileLabel {
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+/* MetricValue emits the font-size token without a fallback, and the dashboard
+ * runtime does not always inject the WPDS typography tokens, so pin the metric
+ * total here with explicit fallbacks. */
+.tileValue span {
+	font-size: var(--wpds-typography-font-size-xl, 20px);
+	line-height: var(--wpds-typography-line-height-xl, 32px);
+}
+
+.state {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 120px;
+	height: 100%;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-align: center;
+}
+
+/* Wide widths: lay the four tiles out in a single row. */
+@container (min-width: 640px) {
+
+	.grid {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+}

--- a/projects/packages/premium-analytics/widgets/site-overview/style.module.css
+++ b/projects/packages/premium-analytics/widgets/site-overview/style.module.css
@@ -1,52 +1,10 @@
-/* No outer padding: the host frames the widget and owns the padding. */
+/* No outer padding: the host frames the widget and owns the padding. The grid
+ * layout now lives in the shared MetricTileGrid; this only owns the height
+ * chain (the grid is a size container and collapses without a definite height)
+ * and the no-metrics message. */
 .root {
-	position: relative;
-	container-type: inline-size;
 	height: 100%;
 	min-height: 120px;
-}
-
-.grid {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: var(--wpds-dimension-gap-sm, 8px);
-}
-
-.tile {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--wpds-dimension-gap-md, 12px);
-	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
-	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
-	border-radius: var(--wpds-border-radius-lg, 8px);
-}
-
-.tileHeader {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: var(--wpds-dimension-gap-sm, 8px);
-	min-width: 0;
-	color: var(--wpds-color-foreground-content-neutral);
-}
-
-.tileIcon {
-	flex: 0 0 auto;
-	fill: var(--wpds-color-foreground-content-neutral);
-}
-
-.tileLabel {
-	color: var(--wpds-color-foreground-content-neutral);
-}
-
-/* MetricValue emits the font-size token without a fallback, and the dashboard
- * runtime does not always inject the WPDS typography tokens, so pin the metric
- * total here with explicit fallbacks. */
-.tileValue span {
-	font-size: var(--wpds-typography-font-size-xl, 20px);
-	line-height: var(--wpds-typography-line-height-xl, 32px);
 }
 
 .state {
@@ -57,25 +15,4 @@
 	height: 100%;
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
-}
-
-/* Wide widths: lay the tiles out four across with the value stacked below the
- * icon and label. */
-@container (min-width: 640px) {
-
-	.grid {
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-	}
-
-	.tile {
-		flex-direction: column;
-		align-items: flex-start;
-		justify-content: flex-start;
-		gap: var(--wpds-dimension-gap-lg, 16px);
-	}
-
-	.tileHeader {
-		flex-direction: column;
-		align-items: flex-start;
-	}
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.json
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/site-overview",
+	"title": "Site overview",
+	"description": "Views, visitors, likes, and comments for the selected period, with period-over-period change.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -32,6 +32,24 @@ export type SiteOverviewAttributes = {
 };
 
 /**
+ * The metric tiles the widget can show, in display order: the visibility
+ * attribute id of each metric and its label. Single source for the settings
+ * checkboxes and the rendered tiles so the two cannot drift apart; `render.tsx`
+ * maps the ids to icons and summary-response fields.
+ */
+export const SITE_OVERVIEW_METRICS = [
+	{ id: 'showViews', label: __( 'Views', 'jetpack-premium-analytics' ) },
+	{ id: 'showVisitors', label: __( 'Visitors', 'jetpack-premium-analytics' ) },
+	{ id: 'showLikes', label: __( 'Likes', 'jetpack-premium-analytics' ) },
+	{ id: 'showComments', label: __( 'Comments', 'jetpack-premium-analytics' ) },
+] as const satisfies readonly { id: keyof SiteOverviewAttributes; label: string }[];
+
+/**
+ * The visibility attribute id of one metric tile.
+ */
+export type SiteOverviewMetricId = ( typeof SITE_OVERVIEW_METRICS )[ number ][ 'id' ];
+
+/**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats "Site overview" card: the period's headline
@@ -42,41 +60,17 @@ export type SiteOverviewAttributes = {
 export default {
 	name: 'jpa/site-overview',
 	title: __( 'Site overview', 'jetpack-premium-analytics' ),
-	description: __(
-		'Views, visitors, likes, and comments for the selected period, with period-over-period change.',
-		'jetpack-premium-analytics'
-	),
 	icon: globe,
 	// Each metric defaults to enabled. The `getValue` defaults keep the settings
 	// checkbox in sync with the render, which also treats a missing flag as
 	// enabled: without them a metric absent from `attributes` would show as an
 	// unchecked box while its tile still rendered.
-	attributes: [
-		{
-			id: 'showViews',
-			label: __( 'Views', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showViews ?? true,
-		},
-		{
-			id: 'showVisitors',
-			label: __( 'Visitors', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showVisitors ?? true,
-		},
-		{
-			id: 'showLikes',
-			label: __( 'Likes', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showLikes ?? true,
-		},
-		{
-			id: 'showComments',
-			label: __( 'Comments', 'jetpack-premium-analytics' ),
-			type: 'boolean',
-			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showComments ?? true,
-		},
-	] as WidgetAttributeField< SiteOverviewAttributes >[],
+	attributes: SITE_OVERVIEW_METRICS.map( ( { id, label } ) => ( {
+		id,
+		label,
+		type: 'boolean',
+		getValue: ( { item }: { item: SiteOverviewAttributes } ) => item[ id ] ?? true,
+	} ) ) as WidgetAttributeField< SiteOverviewAttributes >[],
 	example: {
 		attributes: {
 			showViews: true,

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+
+/**
+ * The widget has no user-configurable attributes: it shows a fixed set of period
+ * metrics (views, visitors, likes, comments). It reads the dashboard date range
+ * and comparison state from report params via `useWidgetRootContext()`, not from
+ * attributes, so its shape is empty. `Record< never, never >` (not
+ * `Record< string, never >`) composes cleanly with the host's injected
+ * `reportParams` field in `render.tsx`.
+ */
+export type SiteOverviewAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats "Site overview" card: the period's headline
+ * traffic and engagement totals with period-over-period comparison.
+ */
+export default {
+	name: 'jpa/site-overview',
+	title: __( 'Site overview', 'jetpack-premium-analytics' ),
+	description: __(
+		'Views, visitors, likes, and comments for the selected period, with period-over-period change.',
+		'jetpack-premium-analytics'
+	),
+	icon: globe,
+};

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -3,22 +3,41 @@
  */
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
- * The widget has no user-configurable attributes: it shows a fixed set of period
- * metrics (views, visitors, likes, comments). It reads the dashboard date range
- * and comparison state from report params via `useWidgetRootContext()`, not from
- * attributes, so its shape is empty. `Record< never, never >` (not
- * `Record< string, never >`) composes cleanly with the host's injected
- * `reportParams` field in `render.tsx`.
+ * Configurable attributes for the Site overview widget: one visibility toggle
+ * per metric tile. Mirrors the `attributes` declared on the widget definition
+ * below; the host renders them as checkboxes and passes the selected values
+ * through to `render.tsx`. The date range and comparison state come from report
+ * params via `useWidgetRootContext()`, not from attributes.
  */
-export type SiteOverviewAttributes = Record< never, never >;
+export type SiteOverviewAttributes = {
+	/**
+	 * Whether the Views tile is shown.
+	 */
+	showViews?: boolean;
+	/**
+	 * Whether the Visitors tile is shown.
+	 */
+	showVisitors?: boolean;
+	/**
+	 * Whether the Likes tile is shown.
+	 */
+	showLikes?: boolean;
+	/**
+	 * Whether the Comments tile is shown.
+	 */
+	showComments?: boolean;
+};
 
 /**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats "Site overview" card: the period's headline
  * traffic and engagement totals with period-over-period comparison.
+ * `example.attributes` doubles as the defaults applied to new instances: every
+ * metric enabled.
  */
 export default {
 	name: 'jpa/site-overview',
@@ -28,4 +47,42 @@ export default {
 		'jetpack-premium-analytics'
 	),
 	icon: globe,
+	// Each metric defaults to enabled. The `getValue` defaults keep the settings
+	// checkbox in sync with the render, which also treats a missing flag as
+	// enabled: without them a metric absent from `attributes` would show as an
+	// unchecked box while its tile still rendered.
+	attributes: [
+		{
+			id: 'showViews',
+			label: __( 'Views', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showViews ?? true,
+		},
+		{
+			id: 'showVisitors',
+			label: __( 'Visitors', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showVisitors ?? true,
+		},
+		{
+			id: 'showLikes',
+			label: __( 'Likes', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showLikes ?? true,
+		},
+		{
+			id: 'showComments',
+			label: __( 'Comments', 'jetpack-premium-analytics' ),
+			type: 'boolean',
+			getValue: ( { item }: { item: SiteOverviewAttributes } ) => item.showComments ?? true,
+		},
+	] as WidgetAttributeField< SiteOverviewAttributes >[],
+	example: {
+		attributes: {
+			showViews: true,
+			showVisitors: true,
+			showLikes: true,
+			showComments: true,
+		},
+	},
 };

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -6,77 +6,76 @@ import { globe } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
- * Configurable attributes for the Site overview widget: one visibility toggle
- * per metric tile. Mirrors the `attributes` declared on the widget definition
- * below; the host renders them as checkboxes and passes the selected values
- * through to `render.tsx`. The date range and comparison state come from report
- * params via `useWidgetRootContext()`, not from attributes.
+ * Internal dependencies
+ */
+import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
+
+/**
+ * Identifier persisted in the widget's `metrics` attribute for each metric
+ * tile the widget can show.
+ */
+export type SiteOverviewMetricId = 'views' | 'visitors' | 'likes' | 'comments';
+
+/**
+ * Configurable attributes for the Site overview widget. The date range and
+ * comparison state come from report params via `useWidgetRootContext()`, not
+ * from attributes.
  */
 export type SiteOverviewAttributes = {
 	/**
-	 * Whether the Views tile is shown.
+	 * Metric tiles to show in the widget body.
 	 */
-	showViews?: boolean;
-	/**
-	 * Whether the Visitors tile is shown.
-	 */
-	showVisitors?: boolean;
-	/**
-	 * Whether the Likes tile is shown.
-	 */
-	showLikes?: boolean;
-	/**
-	 * Whether the Comments tile is shown.
-	 */
-	showComments?: boolean;
+	metrics?: SiteOverviewMetricId[];
 };
 
 /**
- * The metric tiles the widget can show, in display order: the visibility
- * attribute id of each metric and its label. Single source for the settings
- * checkboxes and the rendered tiles so the two cannot drift apart; `render.tsx`
- * maps the ids to icons and summary-response fields.
+ * The metric tiles the widget can show, in display order. Single source for
+ * the settings checkboxes and the rendered tiles so the two cannot drift
+ * apart; `render.tsx` maps the ids to icons and summary-response fields.
  */
-export const SITE_OVERVIEW_METRICS = [
-	{ id: 'showViews', label: __( 'Views', 'jetpack-premium-analytics' ) },
-	{ id: 'showVisitors', label: __( 'Visitors', 'jetpack-premium-analytics' ) },
-	{ id: 'showLikes', label: __( 'Likes', 'jetpack-premium-analytics' ) },
-	{ id: 'showComments', label: __( 'Comments', 'jetpack-premium-analytics' ) },
-] as const satisfies readonly { id: keyof SiteOverviewAttributes; label: string }[];
+export const SITE_OVERVIEW_METRICS: { id: SiteOverviewMetricId; label: string }[] = [
+	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics' ) },
+	{ id: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics' ) },
+	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics' ) },
+	{ id: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ) },
+];
 
 /**
- * The visibility attribute id of one metric tile.
+ * Default selection for new widget instances: every metric enabled.
  */
-export type SiteOverviewMetricId = ( typeof SITE_OVERVIEW_METRICS )[ number ][ 'id' ];
+export const DEFAULT_SITE_OVERVIEW_METRICS: SiteOverviewMetricId[] = SITE_OVERVIEW_METRICS.map(
+	metric => metric.id
+);
 
 /**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats "Site overview" card: the period's headline
  * traffic and engagement totals with period-over-period comparison.
- * `example.attributes` doubles as the defaults applied to new instances: every
- * metric enabled.
+ * The `metrics` attribute (`relevance: 'high'`) selects which metric tiles
+ * render; `example.attributes` doubles as the defaults applied to new
+ * instances: every metric enabled.
  */
 export default {
 	name: 'jpa/site-overview',
 	title: __( 'Site overview', 'jetpack-premium-analytics' ),
 	icon: globe,
-	// Each metric defaults to enabled. The `getValue` defaults keep the settings
-	// checkbox in sync with the render, which also treats a missing flag as
-	// enabled: without them a metric absent from `attributes` would show as an
-	// unchecked box while its tile still rendered.
-	attributes: SITE_OVERVIEW_METRICS.map( ( { id, label } ) => ( {
-		id,
-		label,
-		type: 'boolean',
-		getValue: ( { item }: { item: SiteOverviewAttributes } ) => item[ id ] ?? true,
-	} ) ) as WidgetAttributeField< SiteOverviewAttributes >[],
+	attributes: [
+		{
+			id: 'metrics',
+			label: __( 'Metrics', 'jetpack-premium-analytics' ),
+			type: 'array',
+			relevance: 'high',
+			Edit: ArrayCheckboxField,
+			elements: SITE_OVERVIEW_METRICS.map( metric => ( {
+				value: metric.id,
+				label: metric.label,
+			} ) ),
+		},
+	] as WidgetAttributeField< SiteOverviewAttributes >[],
 	example: {
 		attributes: {
-			showViews: true,
-			showVisitors: true,
-			showLikes: true,
-			showComments: true,
+			metrics: DEFAULT_SITE_OVERVIEW_METRICS,
 		},
 	},
 };


### PR DESCRIPTION
## Proposed changes

Ports the Stats "Site overview" card into Premium Analytics as the `jpa/site-overview` widget.

- New widget at `widgets/site-overview/` (`jpa/site-overview`, category `stats`, framed). The date range + comparison state come from `reportParams`; which tiles render (Views / Visitors / Likes / Comments) is selected by the widget's `metrics` array attribute (`relevance: 'high'`, edited via `ArrayCheckboxField` — same pattern as #50318 and #50371), defaulting to every metric enabled.
- Renders **Views / Visitors / Likes / Comments** as `MetricWithComparison` tiles. With a comparison period, each tile shows its own period-over-period delta, looked up per metric (no fabricated previous values). `followers` is excluded — it's an all-time total, not a period metric.
- Loading / error / empty states render through the shared `<WidgetState>` contract: the error state carries a **Retry** action wired to the report `refetch`, and "empty" means every visible metric is zero (the summary endpoint returns a flat totals object even for idle periods, so a missing payload is not a usable empty signal). On a date-range change the tiles keep the previous period's numbers under the busy overlay instead of blanking.
- Mirrors the upstream Stats tooltips: each tile's hover title carries the exact (un-abbreviated) total behind the shortened count, and the Visitors tile explains that the endpoint sums per-day visitors, so returning visitors count once per day.
- Data layer: added the `useStatsSummary` hook → `stats-summary-query` factory → `sanitizeStatsSummaryResponse` sanitizer for `stats/summary`. The `stats` prefix is already allow-listed — no new prefix.
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget`; added a `stats/summary` fixture + handler.

## Related product discussion/links

- WOOA7S-1524

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / SiteOverview**:
  - `Default` shows the four period totals; hovering a count shows the exact total in the native tooltip, and hovering the Visitors label shows the per-day aggregation note.
  - `WithComparison` shows a per-tile delta (e.g. Views 18K +14%, Likes 842 -7% — negative renders correctly).
  - On the dashboard story, change the date range — tiles keep the previous numbers and show a loading overlay until the new period arrives.
  - `Loading` / `Error` / `Empty` stories force each data state via the report-mock override; `Error` shows the Retry action and `Empty` shows the all-zero-period message.
  - In edit mode, toggle metrics off via the inline **Metrics** control in the widget header (or the settings drawer) — tiles drop in place, keeping the declared display order; with all four off the widget prompts to select at least one.
- Unit tests cover the states directly (`pnpm run test widgets/site-overview` in `projects/packages/premium-analytics`): all-zero periods render "No stats recorded for this period." and a failed fetch renders the error state whose Retry refetches.
- Or test the dashboard against a live connected site.



https://github.com/user-attachments/assets/bc181fe7-b095-4646-bc87-f974d53b01c1

