### PR TITLE
WOOA7S-1516: Port Stats Email top row widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-email-top-row-widget
+++ b/projects/packages/premium-analytics/changelog/add-email-top-row-widget
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add the Email top row Stats widget showing a single email's send, open, and click totals.
+Add the Email top row Stats widget: per-email Opens and Clicks headline totals, read from the per-post rate breakdown, with a help note and loading/error/empty states.

--- a/projects/packages/premium-analytics/changelog/add-email-top-row-widget
+++ b/projects/packages/premium-analytics/changelog/add-email-top-row-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the Email top row Stats widget showing a single email's send, open, and click totals.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-rate.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-rate.ts
@@ -1,0 +1,17 @@
+/**
+ * Builds a mock all-time `stats/<opens|clicks>/emails/<postId>/rate` response so
+ * the Email top row widget renders populated in Storybook. The `rate` breakdown
+ * is a flat object of scalar totals; each endpoint only carries the fields for
+ * its view (see the upstream Calypso `emailStatsAlltimeTransform`), which the
+ * data layer's summary sanitizer keeps as numbers.
+ *
+ * @param metric - Which view's totals to return.
+ * @return Raw email rate-breakdown response.
+ */
+export function buildEmailRateResponse( metric: 'opens' | 'clicks' ) {
+	if ( metric === 'clicks' ) {
+		return { total_sends: 1000, total_opens: 400, total_clicks: 40, clicks_rate: 3.81 };
+	}
+
+	return { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 };
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -73,3 +73,5 @@ export { mockStatsInsightsData } from './insights';
 export { mockStatsSummaryData, mockStatsSummaryComparisonData } from './summary';
 
 export { mockStatsSubscribersCountsData } from './subscriber-counts';
+
+export { buildEmailRateResponse } from './email-rate';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -55,6 +55,7 @@ import {
 	mockStatsSummaryData,
 	mockStatsSummaryComparisonData,
 	mockStatsSubscribersCountsData,
+	buildEmailRateResponse,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
@@ -867,24 +868,6 @@ function buildEmailSummaryResponse() {
 		total_sends: 1000,
 	} ) );
 	return { posts };
-}
-
-/**
- * Builds a mock all-time `stats/<statType>/emails/<postId>/rate` response so the
- * Email top row widget renders populated in Storybook. The `rate` breakdown is a
- * flat object of scalar totals; each endpoint only carries the fields for its
- * stat type (see the upstream Calypso `emailStatsAlltimeTransform`), which the
- * data layer's summary sanitizer keeps as numbers.
- *
- * @param statType - Which view's totals to return.
- * @return Raw email rate-breakdown response.
- */
-function buildEmailRateResponse( statType: 'opens' | 'clicks' ) {
-	if ( statType === 'clicks' ) {
-		return { total_sends: 1000, total_opens: 400, total_clicks: 40, clicks_rate: 3.81 };
-	}
-
-	return { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 };
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -870,6 +870,24 @@ function buildEmailSummaryResponse() {
 }
 
 /**
+ * Builds a mock all-time `stats/<statType>/emails/<postId>/rate` response so the
+ * Email top row widget renders populated in Storybook. The `rate` breakdown is a
+ * flat object of scalar totals; each endpoint only carries the fields for its
+ * stat type (see the upstream Calypso `emailStatsAlltimeTransform`), which the
+ * data layer's summary sanitizer keeps as numbers.
+ *
+ * @param statType - Which view's totals to return.
+ * @return Raw email rate-breakdown response.
+ */
+function buildEmailRateResponse( statType: 'opens' | 'clicks' ) {
+	if ( statType === 'clicks' ) {
+		return { total_sends: 1000, total_opens: 400, total_clicks: 40, clicks_rate: 3.81 };
+	}
+
+	return { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 };
+}
+
+/**
  * Routes a Stats sub-path to the matching mock generator.
  *
  * @param subPath - Path relative to `STATS_API_BASE` (e.g. `/search-terms`).
@@ -879,6 +897,12 @@ function routeStatsReport( subPath: string ): unknown {
 	// Single-video detail: `/video/{postId}` (drives the "Video embeds" widget).
 	if ( /^\/video\/\d+$/.test( subPath ) ) {
 		return mockSingleVideoData;
+	}
+
+	// Per-post email rate breakdowns: `/opens/emails/<postId>/rate`, `/clicks/emails/<postId>/rate`.
+	const emailRate = subPath.match( /^\/(opens|clicks)\/emails\/\d+\/rate$/ );
+	if ( emailRate ) {
+		return buildEmailRateResponse( emailRate[ 1 ] as 'opens' | 'clicks' );
 	}
 
 	switch ( subPath ) {

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import EmailTopRowWidget, { selectEmailRow, toEmailTopRowMetrics } from '../render';
+import type { StatsEmailSummary } from '@jetpack-premium-analytics/data';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const EMAIL_SUMMARY_RESPONSE = {
+	posts: [
+		{
+			id: 2000,
+			title: 'Latest newsletter',
+			href: 'https://example.com/latest',
+			type: 'post',
+			opens_rate: 38.1,
+			clicks_rate: 3.81,
+			opens: 400,
+			clicks: 40,
+			unique_opens: 380,
+			unique_clicks: 38,
+			total_sends: 1000,
+		},
+		{
+			id: 2001,
+			title: 'Older newsletter',
+			href: 'https://example.com/older',
+			type: 'post',
+			opens_rate: 22.5,
+			clicks_rate: 2.1,
+			opens: 200,
+			clicks: 18,
+			unique_opens: 190,
+			unique_clicks: 17,
+			total_sends: 900,
+		},
+	],
+};
+
+describe( 'EmailTopRowWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( EMAIL_SUMMARY_RESPONSE );
+	} );
+
+	it( 'renders the selected email totals as metric tiles', async () => {
+		render(
+			<EmailTopRowWidget
+				attributes={ { postId: 2000, reportParams: getDefaultQueryParams( false ) } }
+			/>
+		);
+
+		// The tile captions for the selected email.
+		await expect( screen.findByText( 'Total sends' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Unique opens' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Open rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Click rate' ) ).toBeInTheDocument();
+
+		// The open rate is formatted as a percentage from the 0–100 rate.
+		expect( screen.getByText( '38.1%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when the selected email is not in the summary', async () => {
+		render(
+			<EmailTopRowWidget
+				attributes={ { postId: 9999, reportParams: getDefaultQueryParams( false ) } }
+			/>
+		);
+
+		await expect(
+			screen.findByText( 'Select an email to see its opens and clicks.' )
+		).resolves.toBeInTheDocument();
+	} );
+} );
+
+describe( 'selectEmailRow', () => {
+	const report = {
+		summary: {},
+		data: [
+			{
+				time_interval: 'alltime',
+				date_start: '',
+				date_end: '',
+				items: [
+					{
+						id: 2000,
+						label: 'Latest newsletter',
+						value: 400,
+						opens: 400,
+						clicks: 40,
+						opens_rate: 38.1,
+						clicks_rate: 3.81,
+						unique_opens: 380,
+						unique_clicks: 38,
+						total_sends: 1000,
+						children: null,
+					},
+				],
+			},
+		],
+	} as unknown as StatsEmailSummary;
+
+	it( 'returns undefined when no email is selected', () => {
+		expect( selectEmailRow( report, undefined ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when the email is not present', () => {
+		expect( selectEmailRow( report, 1234 ) ).toBeUndefined();
+	} );
+
+	it( 'matches the row by post ID', () => {
+		expect( selectEmailRow( report, 2000 )?.total_sends ).toBe( 1000 );
+	} );
+} );
+
+describe( 'toEmailTopRowMetrics', () => {
+	it( 'maps counts and converts 0–100 rates to fractions in order', () => {
+		const metrics = toEmailTopRowMetrics( {
+			id: 2000,
+			label: 'Latest newsletter',
+			value: 400,
+			opens: 400,
+			clicks: 40,
+			opens_rate: 38.1,
+			clicks_rate: 3.81,
+			unique_opens: 380,
+			unique_clicks: 38,
+			total_sends: 1000,
+			children: null,
+		} );
+
+		expect( metrics.map( metric => metric.key ) ).toEqual( [
+			'total_sends',
+			'opens',
+			'unique_opens',
+			'opens_rate',
+			'clicks',
+			'clicks_rate',
+		] );
+		expect( metrics.find( metric => metric.key === 'opens_rate' )?.value ).toBeCloseTo( 0.381 );
+		expect( metrics.find( metric => metric.key === 'total_sends' )?.value ).toBe( 1000 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ describe( 'EmailTopRowWidget', () => {
 			<EmailTopRowWidget
 				attributes={ {
 					postId: 2000,
-					statType: 'opens',
+					metric: 'opens',
 					reportParams: getDefaultQueryParams( false ),
 				} }
 			/>
@@ -77,12 +77,12 @@ describe( 'EmailTopRowWidget', () => {
 		expect( screen.getByText( '38.1%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the Clicks view tiles when statType is clicks', async () => {
+	it( 'renders the Clicks view tiles when metric is clicks', async () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ {
 					postId: 2000,
-					statType: 'clicks',
+					metric: 'clicks',
 					reportParams: getDefaultQueryParams( false ),
 				} }
 			/>
@@ -102,7 +102,7 @@ describe( 'EmailTopRowWidget', () => {
 			<EmailTopRowWidget
 				attributes={ {
 					postId: 9999,
-					statType: 'opens',
+					metric: 'opens',
 					reportParams: getDefaultQueryParams( false ),
 				} }
 			/>
@@ -116,7 +116,7 @@ describe( 'EmailTopRowWidget', () => {
 	it( 'prompts to select an email when no post is selected', async () => {
 		render(
 			<EmailTopRowWidget
-				attributes={ { statType: 'opens', reportParams: getDefaultQueryParams( false ) } }
+				attributes={ { metric: 'opens', reportParams: getDefaultQueryParams( false ) } }
 			/>
 		);
 
@@ -125,6 +125,33 @@ describe( 'EmailTopRowWidget', () => {
 		).resolves.toBeInTheDocument();
 		// A disabled query must not fetch.
 		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the error state and refetches from the Retry action', async () => {
+		// Reject with a non-retryable (403) error so React Query surfaces the
+		// error state immediately instead of retrying with backoff.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		render(
+			<EmailTopRowWidget
+				attributes={ {
+					postId: 2000,
+					metric: 'opens',
+					reportParams: getDefaultQueryParams( false ),
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByText( "We couldn't load this email's stats. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+
+		// Retry re-runs the query; the tiles can only render from a successful
+		// refetch, since the initial request rejected.
+		mockApiFetch.mockImplementation( routeRateResponse );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'Total emails sent' ) ).resolves.toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -60,9 +60,8 @@ describe( 'EmailTopRowWidget', () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ {
-					postId: 2000,
 					metric: 'opens',
-					reportParams: getDefaultQueryParams( false ),
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 2000 },
 				} }
 			/>
 		);
@@ -81,9 +80,8 @@ describe( 'EmailTopRowWidget', () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ {
-					postId: 2000,
 					metric: 'clicks',
-					reportParams: getDefaultQueryParams( false ),
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 2000 },
 				} }
 			/>
 		);
@@ -101,9 +99,8 @@ describe( 'EmailTopRowWidget', () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ {
-					postId: 9999,
 					metric: 'opens',
-					reportParams: getDefaultQueryParams( false ),
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 9999 },
 				} }
 			/>
 		);
@@ -135,9 +132,8 @@ describe( 'EmailTopRowWidget', () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ {
-					postId: 2000,
 					metric: 'opens',
-					reportParams: getDefaultQueryParams( false ),
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 2000 },
 				} }
 			/>
 		);

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -73,12 +73,20 @@ describe( 'EmailTopRowWidget', () => {
 		expect( screen.getByText( '38.1%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows the empty state when the selected email is not in the summary', async () => {
+	it( 'shows the unavailable message when the selected email is not in the summary', async () => {
 		render(
 			<EmailTopRowWidget
 				attributes={ { postId: 9999, reportParams: getDefaultQueryParams( false ) } }
 			/>
 		);
+
+		await expect(
+			screen.findByText( /this email's stats aren't available yet/i )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'prompts to select an email when no post is selected', async () => {
+		render( <EmailTopRowWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } /> );
 
 		await expect(
 			screen.findByText( 'Select an email to see its opens and clicks.' )

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -7,8 +7,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import EmailTopRowWidget, { selectEmailRow, toEmailTopRowMetrics } from '../render';
-import type { StatsEmailSummary } from '@jetpack-premium-analytics/data';
+import EmailTopRowWidget, { hasEmailMetrics, toEmailTopRowMetrics } from '../render';
+import type { StatsEmailBreakdown } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -18,147 +18,174 @@ jest.mock( '@wordpress/route', () => ( {
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-const EMAIL_SUMMARY_RESPONSE = {
-	posts: [
-		{
-			id: 2000,
-			title: 'Latest newsletter',
-			href: 'https://example.com/latest',
-			type: 'post',
-			opens_rate: 38.1,
-			clicks_rate: 3.81,
-			opens: 400,
-			clicks: 40,
-			unique_opens: 380,
-			unique_clicks: 38,
-			total_sends: 1000,
-		},
-		{
-			id: 2001,
-			title: 'Older newsletter',
-			href: 'https://example.com/older',
-			type: 'post',
-			opens_rate: 22.5,
-			clicks_rate: 2.1,
-			opens: 200,
-			clicks: 18,
-			unique_opens: 190,
-			unique_clicks: 17,
-			total_sends: 900,
-		},
-	],
+// Raw per-post `rate` breakdown responses: flat scalars, one endpoint per view.
+const OPENS_RATE_RESPONSE = {
+	total_sends: 1000,
+	total_opens: 400,
+	unique_opens: 380,
+	opens_rate: 38.1,
 };
+
+const CLICKS_RATE_RESPONSE = {
+	total_sends: 1000,
+	total_opens: 400,
+	total_clicks: 40,
+	clicks_rate: 3.81,
+};
+
+function routeRateResponse( options: unknown ) {
+	const path = typeof options === 'string' ? options : ( options as { path?: string } )?.path ?? '';
+
+	if ( path.includes( '/clicks/emails/' ) ) {
+		return Promise.resolve( CLICKS_RATE_RESPONSE );
+	}
+	if ( path.includes( '/opens/emails/' ) ) {
+		return Promise.resolve( OPENS_RATE_RESPONSE );
+	}
+	return Promise.resolve( {} );
+}
+
+// The summary type is index-signature only; tests build fixtures as plain objects.
+const asSummary = ( fields: Record< string, number > ) =>
+	fields as unknown as StatsEmailBreakdown[ 'summary' ];
 
 describe( 'EmailTopRowWidget', () => {
 	beforeEach( () => {
 		queryClient.clear();
 		mockApiFetch.mockReset();
-		mockApiFetch.mockResolvedValue( EMAIL_SUMMARY_RESPONSE );
+		mockApiFetch.mockImplementation( routeRateResponse );
 	} );
 
-	it( 'renders the selected email totals as metric tiles', async () => {
+	it( 'renders the Opens view tiles from the per-post rate breakdown', async () => {
 		render(
 			<EmailTopRowWidget
-				attributes={ { postId: 2000, reportParams: getDefaultQueryParams( false ) } }
+				attributes={ {
+					postId: 2000,
+					statType: 'opens',
+					reportParams: getDefaultQueryParams( false ),
+				} }
 			/>
 		);
 
-		// The tile captions for the selected email.
-		await expect( screen.findByText( 'Total sends' ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Total emails sent' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Unique opens' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total opens' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Open rate' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Click rate' ) ).toBeInTheDocument();
-
+		// Clicks-only tiles are not in the Opens view.
+		expect( screen.queryByText( 'Click rate' ) ).not.toBeInTheDocument();
 		// The open rate is formatted as a percentage from the 0–100 rate.
 		expect( screen.getByText( '38.1%' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows the unavailable message when the selected email is not in the summary', async () => {
+	it( 'renders the Clicks view tiles when statType is clicks', async () => {
 		render(
 			<EmailTopRowWidget
-				attributes={ { postId: 9999, reportParams: getDefaultQueryParams( false ) } }
+				attributes={ {
+					postId: 2000,
+					statType: 'clicks',
+					reportParams: getDefaultQueryParams( false ),
+				} }
+			/>
+		);
+
+		await expect( screen.findByText( 'Total clicks' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Click rate' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Total opens' ) ).toBeInTheDocument();
+		// Opens-only tiles are not in the Clicks view.
+		expect( screen.queryByText( 'Unique opens' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when the email has no stats', async () => {
+		mockApiFetch.mockImplementation( () => Promise.resolve( {} ) );
+
+		render(
+			<EmailTopRowWidget
+				attributes={ {
+					postId: 9999,
+					statType: 'opens',
+					reportParams: getDefaultQueryParams( false ),
+				} }
 			/>
 		);
 
 		await expect(
-			screen.findByText( /this email's stats aren't available yet/i )
+			screen.findByText( 'No stats are available for this email yet.' )
 		).resolves.toBeInTheDocument();
 	} );
 
 	it( 'prompts to select an email when no post is selected', async () => {
-		render( <EmailTopRowWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } /> );
+		render(
+			<EmailTopRowWidget
+				attributes={ { statType: 'opens', reportParams: getDefaultQueryParams( false ) } }
+			/>
+		);
 
 		await expect(
-			screen.findByText( 'Select an email to see its opens and clicks.' )
+			screen.findByText( 'Select an email to see its stats.' )
 		).resolves.toBeInTheDocument();
-	} );
-} );
-
-describe( 'selectEmailRow', () => {
-	const report = {
-		summary: {},
-		data: [
-			{
-				time_interval: 'alltime',
-				date_start: '',
-				date_end: '',
-				items: [
-					{
-						id: 2000,
-						label: 'Latest newsletter',
-						value: 400,
-						opens: 400,
-						clicks: 40,
-						opens_rate: 38.1,
-						clicks_rate: 3.81,
-						unique_opens: 380,
-						unique_clicks: 38,
-						total_sends: 1000,
-						children: null,
-					},
-				],
-			},
-		],
-	} as unknown as StatsEmailSummary;
-
-	it( 'returns undefined when no email is selected', () => {
-		expect( selectEmailRow( report, undefined ) ).toBeUndefined();
-	} );
-
-	it( 'returns undefined when the email is not present', () => {
-		expect( selectEmailRow( report, 1234 ) ).toBeUndefined();
-	} );
-
-	it( 'matches the row by post ID', () => {
-		expect( selectEmailRow( report, 2000 )?.total_sends ).toBe( 1000 );
+		// A disabled query must not fetch.
+		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
 } );
 
 describe( 'toEmailTopRowMetrics', () => {
-	it( 'maps counts and converts 0–100 rates to fractions in order', () => {
-		const metrics = toEmailTopRowMetrics( {
-			id: 2000,
-			label: 'Latest newsletter',
-			value: 400,
-			opens: 400,
-			clicks: 40,
-			opens_rate: 38.1,
-			clicks_rate: 3.81,
-			unique_opens: 380,
-			unique_clicks: 38,
-			total_sends: 1000,
-			children: null,
-		} );
+	it( 'builds the Opens view tiles in order and converts the 0–100 rate', () => {
+		const metrics = toEmailTopRowMetrics(
+			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 } ),
+			'opens'
+		);
 
 		expect( metrics.map( metric => metric.key ) ).toEqual( [
 			'total_sends',
-			'opens',
 			'unique_opens',
+			'total_opens',
 			'opens_rate',
-			'clicks',
-			'clicks_rate',
 		] );
 		expect( metrics.find( metric => metric.key === 'opens_rate' )?.value ).toBeCloseTo( 0.381 );
 		expect( metrics.find( metric => metric.key === 'total_sends' )?.value ).toBe( 1000 );
+	} );
+
+	it( 'builds the Clicks view tiles in order', () => {
+		const metrics = toEmailTopRowMetrics(
+			asSummary( { total_opens: 400, total_clicks: 40, clicks_rate: 3.81 } ),
+			'clicks'
+		);
+
+		expect( metrics.map( metric => metric.key ) ).toEqual( [
+			'total_opens',
+			'total_clicks',
+			'clicks_rate',
+		] );
+		expect( metrics.find( metric => metric.key === 'clicks_rate' )?.value ).toBeCloseTo( 0.0381 );
+	} );
+
+	it( 'hides the Unique opens tile when there are no unique opens', () => {
+		const metrics = toEmailTopRowMetrics(
+			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 0, opens_rate: 38.1 } ),
+			'opens'
+		);
+
+		expect( metrics.map( metric => metric.key ) ).not.toContain( 'unique_opens' );
+	} );
+
+	it( 'renders a missing or zero rate as null so the tile shows a placeholder', () => {
+		const metrics = toEmailTopRowMetrics(
+			asSummary( { total_sends: 1000, total_opens: 0, unique_opens: 0 } ),
+			'opens'
+		);
+
+		expect( metrics.find( metric => metric.key === 'opens_rate' )?.value ).toBeNull();
+	} );
+} );
+
+describe( 'hasEmailMetrics', () => {
+	it( 'is false for an empty or missing summary', () => {
+		expect( hasEmailMetrics( undefined ) ).toBe( false );
+		expect( hasEmailMetrics( asSummary( {} ) ) ).toBe( false );
+	} );
+
+	it( 'is true when a metric field is present, including zero', () => {
+		expect( hasEmailMetrics( asSummary( { total_sends: 0 } ) ) ).toBe( true );
+		expect( hasEmailMetrics( asSummary( { total_opens: 400 } ) ) ).toBe( true );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/email-top-row/package.json
+++ b/projects/packages/premium-analytics/widgets/email-top-row/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-email-top-row",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -1,0 +1,258 @@
+/**
+ * External dependencies
+ */
+import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
+import {
+	MetricValue,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	type DataFormat,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import { type EmailTopRowAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+// Report params are dashboard-driven, but this widget reads the all-time
+// `stats/emails/summary` endpoint and ignores the date range. The host (and
+// Storybook) may still inject them via `attributes`, so accept them here.
+type EmailTopRowRenderAttributes = EmailTopRowAttributes & Partial< ReportParamsFieldAttributes >;
+type EmailTopRowWidgetProps = WidgetRenderProps< EmailTopRowRenderAttributes >;
+
+// A single row from the emails summary report, holding one email's all-time totals.
+type EmailSummaryRow = StatsEmailSummary[ 'data' ][ number ][ 'items' ][ number ];
+
+const COUNT_FORMAT: DataFormat = {
+	type: 'number',
+	options: { useMultipliers: true, decimals: 0 },
+};
+
+const RATE_FORMAT: DataFormat = {
+	type: 'percentage',
+	options: { decimals: 1, signDisplay: 'never' },
+};
+
+/**
+ * A single top-row tile: the metric value with a caption beneath it.
+ */
+export type EmailTopRowMetric = {
+	/**
+	 * Stable key for the tile.
+	 */
+	key: string;
+	/**
+	 * Caption shown beneath the value (e.g. "Total opens").
+	 */
+	label: string;
+	/**
+	 * The numeric value to render. Rates are fractions (0–1); counts are integers.
+	 */
+	value: number;
+	/**
+	 * How to format the value.
+	 */
+	dataFormat: DataFormat;
+};
+
+/**
+ * Maps one email's summary row onto the ordered top-row tiles. Mirrors the union
+ * of the Jetpack Stats "Email top row" opens and clicks views: send/open counts,
+ * unique opens, clicks, and the open/click rates. Rates arrive as 0–100
+ * percentages and are converted to fractions for the percentage formatter.
+ *
+ * @param row - The selected email's summary row.
+ * @return The ordered metric tiles.
+ */
+export function toEmailTopRowMetrics( row: EmailSummaryRow ): EmailTopRowMetric[] {
+	return [
+		{
+			key: 'total_sends',
+			label: __( 'Total sends', 'jetpack-premium-analytics' ),
+			value: row.total_sends,
+			dataFormat: COUNT_FORMAT,
+		},
+		{
+			key: 'opens',
+			label: __( 'Total opens', 'jetpack-premium-analytics' ),
+			value: row.opens,
+			dataFormat: COUNT_FORMAT,
+		},
+		{
+			key: 'unique_opens',
+			label: __( 'Unique opens', 'jetpack-premium-analytics' ),
+			value: row.unique_opens,
+			dataFormat: COUNT_FORMAT,
+		},
+		{
+			key: 'opens_rate',
+			label: __( 'Open rate', 'jetpack-premium-analytics' ),
+			value: row.opens_rate / 100,
+			dataFormat: RATE_FORMAT,
+		},
+		{
+			key: 'clicks',
+			label: __( 'Total clicks', 'jetpack-premium-analytics' ),
+			value: row.clicks,
+			dataFormat: COUNT_FORMAT,
+		},
+		{
+			key: 'clicks_rate',
+			label: __( 'Click rate', 'jetpack-premium-analytics' ),
+			value: row.clicks_rate / 100,
+			dataFormat: RATE_FORMAT,
+		},
+	];
+}
+
+/**
+ * Finds the summary row for a specific email. The summary endpoint returns the
+ * latest emails newest-first with no per-post filter, so the widget selects the
+ * matching row by ID. Returns `undefined` when no email is selected or the
+ * selected email is not in the returned page.
+ *
+ * @param report - The normalized email-summary report, or undefined while loading.
+ * @param postId - The selected email's post ID.
+ * @return The matching row, or undefined when unavailable.
+ */
+export function selectEmailRow(
+	report: StatsEmailSummary | undefined,
+	postId?: number
+): EmailSummaryRow | undefined {
+	if ( ! postId ) {
+		return undefined;
+	}
+
+	const items = report?.data?.[ 0 ]?.items ?? [];
+
+	return items.find( item => Number( item.id ) === postId );
+}
+
+type EmailTopRowTilesProps = {
+	/**
+	 * The ordered metric tiles to render. When omitted, the empty state is shown
+	 * (unless `isLoading` is set).
+	 */
+	metrics?: EmailTopRowMetric[];
+	/**
+	 * When `true` and there is no data yet, the full loading overlay is shown.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, a background refetch is in progress. Existing tiles stay
+	 * visible; the container is marked busy for assistive tech.
+	 */
+	isFetching?: boolean;
+	/**
+	 * When `true`, an error message is rendered in place of the tiles.
+	 */
+	isError?: boolean;
+};
+
+/**
+ * Presentational top row for the "Email top row" widget. Renders the selected
+ * email's headline totals as metric tiles and owns the loading, error, empty,
+ * and populated states. Exported so Storybook and tests can exercise those
+ * states with fixture metrics.
+ *
+ * @param {EmailTopRowTilesProps} props - The component props.
+ * @return The rendered top row.
+ */
+export const EmailTopRowTiles = ( {
+	metrics,
+	isLoading = false,
+	isFetching = false,
+	isError = false,
+}: EmailTopRowTilesProps ) => {
+	let body;
+	if ( isError ) {
+		body = (
+			<Stack align="center" justify="center" className={ styles.placeholder }>
+				<Text>{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }</Text>
+			</Stack>
+		);
+	} else if ( isLoading && ! metrics ) {
+		body = <WidgetLoadingOverlay />;
+	} else if ( ! metrics ) {
+		body = (
+			<Stack align="center" justify="center" className={ styles.placeholder }>
+				<Text>
+					{ __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' ) }
+				</Text>
+			</Stack>
+		);
+	} else {
+		body = (
+			<div className={ styles.tiles } aria-busy={ isFetching }>
+				{ metrics.map( metric => (
+					<Stack key={ metric.key } direction="column" gap="xs" className={ styles.tile }>
+						<MetricValue value={ metric.value } dataFormat={ metric.dataFormat } fontSize="2xl" />
+						<Text variant="body-sm" className={ styles.caption }>
+							{ metric.label }
+						</Text>
+					</Stack>
+				) ) }
+			</div>
+		);
+	}
+
+	return <div className={ styles.root }>{ body }</div>;
+};
+
+type EmailTopRowReportProps = {
+	/**
+	 * The selected email's post ID.
+	 */
+	postId?: number;
+};
+
+/**
+ * Fetches the emails summary through `useStatsEmailSummary`, selects the row for
+ * the given `postId`, and hands its top-row metrics to `EmailTopRowTiles`. The
+ * summary is all-time and site-wide, so it does not read the dashboard date
+ * range; it is requested at its maximum row count to widen the chance the
+ * selected email is present.
+ *
+ * @param {EmailTopRowReportProps} props - The component props.
+ * @return The widget content.
+ */
+function EmailTopRowReport( { postId }: EmailTopRowReportProps ) {
+	// The summary endpoint accepts 1–30 rows; request its maximum so a recently
+	// selected email is likely to be in the returned page.
+	const { data, isLoading, isFetching, isError } = useStatsEmailSummary( { quantity: 30 } );
+
+	const row = useMemo( () => selectEmailRow( data, postId ), [ data, postId ] );
+	const metrics = useMemo( () => ( row ? toEmailTopRowMetrics( row ) : undefined ), [ row ] );
+
+	return (
+		<EmailTopRowTiles
+			metrics={ metrics }
+			isLoading={ isLoading }
+			isFetching={ isFetching }
+			isError={ isError }
+		/>
+	);
+}
+
+/**
+ * Widget render entry point.
+ *
+ * The email is selected by the `postId` attribute supplied by the host. Host
+ * attributes (including `reportParams`) are passed through to `<WidgetRoot>` for
+ * the widget contract even though this all-time summary ignores the date range.
+ *
+ * @param {EmailTopRowWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function EmailTopRow( { attributes = {} }: EmailTopRowWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<EmailTopRowReport postId={ attributes.postId } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -10,6 +10,7 @@ import {
 	MetricTileGrid,
 	WidgetRoot,
 	WidgetState,
+	useWidgetRootContext,
 	type DataFormat,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
@@ -328,11 +329,22 @@ const EmailTopRowTiles = ( {
 	);
 };
 
+/**
+ * Resolves the email's post ID from the host-composed report params. `post_id`
+ * is typed `string | number` (a string when it comes straight from the URL), so
+ * it is coerced to a positive integer; anything else yields `0`, which the
+ * widget treats as "no email selected".
+ *
+ * @param postId - The `post_id` report param.
+ * @return The email's post ID, or `0` when none is set.
+ */
+function toPostId( postId: string | number | undefined ): number {
+	const parsed = typeof postId === 'number' ? postId : Number.parseInt( postId ?? '', 10 );
+
+	return Number.isInteger( parsed ) && parsed > 0 ? parsed : 0;
+}
+
 type EmailTopRowReportProps = {
-	/**
-	 * The selected email's post ID.
-	 */
-	postId?: number;
 	/**
 	 * Which view's metrics to fetch and show.
 	 */
@@ -341,25 +353,29 @@ type EmailTopRowReportProps = {
 
 /**
  * Fetches the selected email's all-time rate breakdown for the active view and
- * hands its metrics to `EmailTopRowTiles`. The Opens and Clicks views each read
- * their own per-post `stats/<opens|clicks>/emails/<postId>/rate` endpoint — the
- * same source the Jetpack Stats top row uses — so the widget resolves a specific
- * email by ID rather than scanning a summary list, and it works for any email
- * regardless of how recently it was sent. Only the active view's request runs.
+ * hands its metrics to `EmailTopRowTiles`. The email is scoped by the host
+ * through `reportParams.post_id` — the shared single-resource "detail page"
+ * param — so the widget needs no id attribute of its own. The Opens and Clicks
+ * views each read their own per-post `stats/<opens|clicks>/emails/<postId>/rate`
+ * endpoint — the same source the Jetpack Stats top row uses — so the widget
+ * resolves a specific email by ID rather than scanning a summary list, and it
+ * works for any email regardless of how recently it was sent. Only the active
+ * view's request runs.
  *
  * @param {EmailTopRowReportProps} props - The component props.
  * @return The widget content.
  */
-function EmailTopRowReport( { postId, metric }: EmailTopRowReportProps ) {
-	const hasSelection = Number.isInteger( postId ) && ( postId ?? 0 ) > 0;
-	const safePostId = hasSelection ? ( postId as number ) : 0;
+function EmailTopRowReport( { metric }: EmailTopRowReportProps ) {
+	const { reportParams } = useWidgetRootContext();
+	const postId = toPostId( reportParams.post_id );
+	const hasSelection = postId > 0;
 
 	// Both hooks are called every render (hooks rule); only the active view's
 	// query is enabled, so a single request runs.
-	const opens = useStatsEmailOpensBreakdown( safePostId, 'rate', {
+	const opens = useStatsEmailOpensBreakdown( postId, 'rate', {
 		enabled: hasSelection && metric === 'opens',
 	} );
-	const clicks = useStatsEmailClicksBreakdown( safePostId, 'rate', {
+	const clicks = useStatsEmailClicksBreakdown( postId, 'rate', {
 		enabled: hasSelection && metric === 'clicks',
 	} );
 	const active = metric === 'clicks' ? clicks : opens;
@@ -385,10 +401,12 @@ function EmailTopRowReport( { postId, metric }: EmailTopRowReportProps ) {
 /**
  * Widget render entry point.
  *
- * The email is selected by the `postId` attribute and the view by `metric`
- * (defaulting to Opens), both supplied by the host. Host attributes (including
- * `reportParams`) are passed through to `<WidgetRoot>` for the widget contract
- * even though the all-time rate breakdown ignores the date range.
+ * The email is selected by the host through `reportParams.post_id` (the shared
+ * single-resource "detail page" scope) and the view by the `metric` attribute
+ * (defaulting to Opens). Host attributes (including `reportParams`) are passed
+ * through to `<WidgetRoot>`, which exposes `reportParams` to the inner report;
+ * the all-time rate breakdown ignores the date range but reads the single-email
+ * scope from `post_id`.
  *
  * @param {EmailTopRowWidgetProps} props - The widget render props.
  * @return The rendered widget.
@@ -398,7 +416,7 @@ export default function EmailTopRow( { attributes = {} }: EmailTopRowWidgetProps
 
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<EmailTopRowReport postId={ attributes.postId } metric={ metric } />
+			<EmailTopRowReport metric={ metric } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -21,7 +21,7 @@ import { Icon, Stack, Text } from '@wordpress/ui';
  * Internal dependencies
  */
 import styles from './style.module.css';
-import { type EmailStatType, type EmailTopRowAttributes } from './widget';
+import { type EmailMetric, type EmailTopRowAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
@@ -31,7 +31,7 @@ import type { ComponentProps } from 'react';
 type EmailTopRowRenderAttributes = EmailTopRowAttributes & Partial< ReportParamsFieldAttributes >;
 type EmailTopRowWidgetProps = WidgetRenderProps< EmailTopRowRenderAttributes >;
 
-// The scalar summary of a per-post `stats/<statType>/emails/<postId>/rate` breakdown.
+// The scalar summary of a per-post `stats/<opens|clicks>/emails/<postId>/rate` breakdown.
 type EmailRateSummary = StatsEmailBreakdown[ 'summary' ];
 
 type TileIcon = ComponentProps< typeof Icon >[ 'icon' ];
@@ -46,20 +46,100 @@ const RATE_FORMAT: DataFormat = {
 	options: { decimals: 1, signDisplay: 'never' },
 };
 
-// Shown in place of a rate tile when the email has no rate yet (mirrors the
-// Jetpack Stats top row, which renders "-" for a missing or zero rate).
+// Shown in place of a rate tile's value when the email has no rate yet. Mirrors
+// the Jetpack Stats top row, which renders "-" for a missing or zero rate: in
+// wp-calypso, `client/my-sites/stats/stats-email-top-row/index.jsx` passes
+// `counts?.opens_rate ? … : null` (a truthy check, so 0 becomes null) and
+// `top-card.jsx` renders a null value as "-".
 const NO_RATE_PLACEHOLDER = '—';
 
-// The scalar keys a `rate` breakdown may carry. The endpoint drops the keys that
-// don't apply to its stat type, so presence of any of these signals real data.
-const EMAIL_METRIC_KEYS = [
-	'total_sends',
-	'total_opens',
-	'unique_opens',
-	'opens_rate',
-	'total_clicks',
-	'clicks_rate',
-] as const;
+/**
+ * One row of the metric table below: everything that describes a top-row tile —
+ * its summary key, icon, label, whether it is a count or a rate, and which
+ * view(s) it belongs to. The tiles and the "does this summary carry email
+ * metrics" check both derive from the same table, so they cannot drift.
+ */
+type EmailMetricSpec = {
+	/**
+	 * The scalar key on the rate summary, also used as the tile's stable key.
+	 */
+	key: string;
+	/**
+	 * Icon shown alongside the label.
+	 */
+	icon: TileIcon;
+	/**
+	 * Builds the translated label (deferred so it runs at render time).
+	 */
+	label: () => string;
+	/**
+	 * Counts are read with a zero default; rates convert 0–100 to a fraction and
+	 * collapse missing/zero to `null` for the placeholder.
+	 */
+	kind: 'count' | 'rate';
+	/**
+	 * Which view(s) show this tile, in table order.
+	 */
+	views: readonly EmailMetric[];
+	/**
+	 * Skip the tile when its count is zero (upstream hides Unique opens then).
+	 */
+	hideWhenZero?: boolean;
+};
+
+/**
+ * The single source of truth for the top-row tiles, in display order. Mirrors
+ * the Jetpack Stats "Email top row": the Opens view shows total sends, unique
+ * opens (hidden when zero, as upstream does), total opens, and open rate; the
+ * Clicks view shows total opens, total clicks, and click rate. The endpoint
+ * drops the keys that don't apply to its view, so presence of any of these keys
+ * signals real data (see `hasEmailMetrics`).
+ */
+const EMAIL_METRICS: readonly EmailMetricSpec[] = [
+	{
+		key: 'total_sends',
+		icon: send,
+		label: () => __( 'Total emails sent', 'jetpack-premium-analytics' ),
+		kind: 'count',
+		views: [ 'opens' ],
+	},
+	{
+		key: 'unique_opens',
+		icon: people,
+		label: () => __( 'Unique opens', 'jetpack-premium-analytics' ),
+		kind: 'count',
+		views: [ 'opens' ],
+		hideWhenZero: true,
+	},
+	{
+		key: 'total_opens',
+		icon: seen,
+		label: () => __( 'Total opens', 'jetpack-premium-analytics' ),
+		kind: 'count',
+		views: [ 'opens', 'clicks' ],
+	},
+	{
+		key: 'opens_rate',
+		icon: percent,
+		label: () => __( 'Open rate', 'jetpack-premium-analytics' ),
+		kind: 'rate',
+		views: [ 'opens' ],
+	},
+	{
+		key: 'total_clicks',
+		icon: link,
+		label: () => __( 'Total clicks', 'jetpack-premium-analytics' ),
+		kind: 'count',
+		views: [ 'clicks' ],
+	},
+	{
+		key: 'clicks_rate',
+		icon: chartBar,
+		label: () => __( 'Click rate', 'jetpack-premium-analytics' ),
+		kind: 'rate',
+		views: [ 'clicks' ],
+	},
+];
 
 /**
  * A single top-row tile: an icon, a label, and the formatted metric value.
@@ -105,7 +185,9 @@ function readCount( summary: EmailRateSummary, key: string ): number {
 /**
  * Reads a rate field (0–100 percentage) off a rate summary and converts it to a
  * fraction for the percentage formatter. Returns `null` for a missing or zero
- * rate so the tile can render the placeholder, matching the Jetpack Stats top row.
+ * rate so the tile can render the placeholder — verified against the Jetpack
+ * Stats top row, which treats a zero rate the same way (see the
+ * `NO_RATE_PLACEHOLDER` comment above for the upstream files).
  *
  * @param summary - The email rate summary.
  * @param key     - The rate field to read.
@@ -128,8 +210,8 @@ function readRate( summary: EmailRateSummary, key: string ): number | null {
 export function hasEmailMetrics( summary: EmailRateSummary | undefined ): boolean {
 	return (
 		!! summary &&
-		EMAIL_METRIC_KEYS.some( key => {
-			const value = summary[ key ];
+		EMAIL_METRICS.some( spec => {
+			const value = summary[ spec.key ];
 
 			return value !== undefined && value !== null && Number.isFinite( Number( value ) );
 		} )
@@ -138,79 +220,40 @@ export function hasEmailMetrics( summary: EmailRateSummary | undefined ): boolea
 
 /**
  * Maps a per-post rate summary onto the ordered top-row tiles for the active
- * view. Mirrors the Jetpack Stats "Email top row": the Opens view shows total
- * sends, unique opens (hidden when zero, as upstream does), total opens, and
- * open rate; the Clicks view shows total opens, total clicks, and click rate.
+ * view, straight from the `EMAIL_METRICS` table.
  *
- * @param summary  - The selected email's rate summary.
- * @param statType - Which view's tiles to build.
+ * @param summary - The selected email's rate summary.
+ * @param metric  - Which view's tiles to build.
  * @return The ordered metric tiles.
  */
 export function toEmailTopRowMetrics(
 	summary: EmailRateSummary,
-	statType: EmailStatType
+	metric: EmailMetric
 ): EmailTopRowMetric[] {
-	if ( statType === 'clicks' ) {
-		return [
-			{
-				key: 'total_opens',
-				icon: seen,
-				label: __( 'Total opens', 'jetpack-premium-analytics' ),
-				value: readCount( summary, 'total_opens' ),
-				dataFormat: COUNT_FORMAT,
-			},
-			{
-				key: 'total_clicks',
-				icon: link,
-				label: __( 'Total clicks', 'jetpack-premium-analytics' ),
-				value: readCount( summary, 'total_clicks' ),
-				dataFormat: COUNT_FORMAT,
-			},
-			{
-				key: 'clicks_rate',
-				icon: chartBar,
-				label: __( 'Click rate', 'jetpack-premium-analytics' ),
-				value: readRate( summary, 'clicks_rate' ),
-				dataFormat: RATE_FORMAT,
-			},
-		];
+	const tiles: EmailTopRowMetric[] = [];
+
+	for ( const spec of EMAIL_METRICS ) {
+		if ( ! spec.views.includes( metric ) ) {
+			continue;
+		}
+
+		const value =
+			spec.kind === 'rate' ? readRate( summary, spec.key ) : readCount( summary, spec.key );
+
+		if ( spec.hideWhenZero && ! value ) {
+			continue;
+		}
+
+		tiles.push( {
+			key: spec.key,
+			icon: spec.icon,
+			label: spec.label(),
+			value,
+			dataFormat: spec.kind === 'rate' ? RATE_FORMAT : COUNT_FORMAT,
+		} );
 	}
 
-	const tiles: EmailTopRowMetric[] = [
-		{
-			key: 'total_sends',
-			icon: send,
-			label: __( 'Total emails sent', 'jetpack-premium-analytics' ),
-			value: readCount( summary, 'total_sends' ),
-			dataFormat: COUNT_FORMAT,
-		},
-		{
-			key: 'unique_opens',
-			icon: people,
-			label: __( 'Unique opens', 'jetpack-premium-analytics' ),
-			value: readCount( summary, 'unique_opens' ),
-			dataFormat: COUNT_FORMAT,
-		},
-		{
-			key: 'total_opens',
-			icon: seen,
-			label: __( 'Total opens', 'jetpack-premium-analytics' ),
-			value: readCount( summary, 'total_opens' ),
-			dataFormat: COUNT_FORMAT,
-		},
-		{
-			key: 'opens_rate',
-			icon: percent,
-			label: __( 'Open rate', 'jetpack-premium-analytics' ),
-			value: readRate( summary, 'opens_rate' ),
-			dataFormat: RATE_FORMAT,
-		},
-	];
-
-	// Upstream hides the Unique opens tile when there are no unique opens.
-	return tiles.filter(
-		tile => tile.key !== 'unique_opens' || readCount( summary, 'unique_opens' ) > 0
-	);
+	return tiles;
 }
 
 type EmailTopRowTilesProps = {
@@ -245,14 +288,13 @@ type EmailTopRowTilesProps = {
 /**
  * Presentational top row for the "Email top row" widget. Renders the selected
  * email's headline totals as bordered metric tiles and delegates the loading,
- * error, and empty states to `<WidgetState>`. Exported so Storybook and tests can
- * exercise it with fixture metrics. The rate breakdowns have no comparison period,
- * so each tile shows a bare formatted value with no delta.
+ * error, and empty states to `<WidgetState>`. The rate breakdowns have no
+ * comparison period, so each tile shows a bare formatted value with no delta.
  *
  * @param {EmailTopRowTilesProps} props - The component props.
  * @return The rendered top row.
  */
-export const EmailTopRowTiles = ( {
+const EmailTopRowTiles = ( {
 	metrics,
 	hasSelection = false,
 	isLoading = false,
@@ -318,38 +360,38 @@ type EmailTopRowReportProps = {
 	/**
 	 * Which view's metrics to fetch and show.
 	 */
-	statType: EmailStatType;
+	metric: EmailMetric;
 };
 
 /**
  * Fetches the selected email's all-time rate breakdown for the active view and
  * hands its metrics to `EmailTopRowTiles`. The Opens and Clicks views each read
- * their own per-post `stats/<statType>/emails/<postId>/rate` endpoint — the same
- * source the Jetpack Stats top row uses — so the widget resolves a specific email
- * by ID rather than scanning a summary list, and it works for any email
+ * their own per-post `stats/<opens|clicks>/emails/<postId>/rate` endpoint — the
+ * same source the Jetpack Stats top row uses — so the widget resolves a specific
+ * email by ID rather than scanning a summary list, and it works for any email
  * regardless of how recently it was sent. Only the active view's request runs.
  *
  * @param {EmailTopRowReportProps} props - The component props.
  * @return The widget content.
  */
-function EmailTopRowReport( { postId, statType }: EmailTopRowReportProps ) {
+function EmailTopRowReport( { postId, metric }: EmailTopRowReportProps ) {
 	const hasSelection = Number.isInteger( postId ) && ( postId ?? 0 ) > 0;
 	const safePostId = hasSelection ? ( postId as number ) : 0;
 
 	// Both hooks are called every render (hooks rule); only the active view's
 	// query is enabled, so a single request runs.
 	const opens = useStatsEmailOpensBreakdown( safePostId, 'rate', {
-		enabled: hasSelection && statType === 'opens',
+		enabled: hasSelection && metric === 'opens',
 	} );
 	const clicks = useStatsEmailClicksBreakdown( safePostId, 'rate', {
-		enabled: hasSelection && statType === 'clicks',
+		enabled: hasSelection && metric === 'clicks',
 	} );
-	const active = statType === 'clicks' ? clicks : opens;
+	const active = metric === 'clicks' ? clicks : opens;
 
 	const summary = ( active.data as StatsEmailBreakdown | undefined )?.summary;
 	const metrics = useMemo(
-		() => ( hasEmailMetrics( summary ) ? toEmailTopRowMetrics( summary!, statType ) : undefined ),
-		[ summary, statType ]
+		() => ( hasEmailMetrics( summary ) ? toEmailTopRowMetrics( summary!, metric ) : undefined ),
+		[ summary, metric ]
 	);
 
 	return (
@@ -367,7 +409,7 @@ function EmailTopRowReport( { postId, statType }: EmailTopRowReportProps ) {
 /**
  * Widget render entry point.
  *
- * The email is selected by the `postId` attribute and the view by `statType`
+ * The email is selected by the `postId` attribute and the view by `metric`
  * (defaulting to Opens), both supplied by the host. Host attributes (including
  * `reportParams`) are passed through to `<WidgetRoot>` for the widget contract
  * even though the all-time rate breakdown ignores the date range.
@@ -376,11 +418,11 @@ function EmailTopRowReport( { postId, statType }: EmailTopRowReportProps ) {
  * @return The rendered widget.
  */
 export default function EmailTopRow( { attributes = {} }: EmailTopRowWidgetProps ) {
-	const statType: EmailStatType = attributes.statType === 'clicks' ? 'clicks' : 'opens';
+	const metric: EmailMetric = attributes.metric === 'clicks' ? 'clicks' : 'opens';
 
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<EmailTopRowReport postId={ attributes.postId } statType={ statType } />
+			<EmailTopRowReport postId={ attributes.postId } metric={ metric } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -154,6 +154,12 @@ type EmailTopRowTilesProps = {
 	 */
 	metrics?: EmailTopRowMetric[];
 	/**
+	 * Whether an email is selected. Drives which empty-state message is shown when
+	 * there are no metrics: prompt to select an email when `false`, or an
+	 * "unavailable" message when `true` (the selected email is not in the summary).
+	 */
+	hasSelection?: boolean;
+	/**
 	 * When `true` and there is no data yet, the full loading overlay is shown.
 	 */
 	isLoading?: boolean;
@@ -180,6 +186,7 @@ type EmailTopRowTilesProps = {
  */
 export const EmailTopRowTiles = ( {
 	metrics,
+	hasSelection = false,
 	isLoading = false,
 	isFetching = false,
 	isError = false,
@@ -203,11 +210,16 @@ export const EmailTopRowTiles = ( {
 	}
 
 	if ( ! metrics ) {
+		const message = hasSelection
+			? __(
+					"This email's stats aren't available yet — it may be older than your most recent sent emails.",
+					'jetpack-premium-analytics'
+			  )
+			: __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' );
+
 		return (
 			<div className={ styles.root }>
-				<Text className={ styles.placeholder }>
-					{ __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' ) }
-				</Text>
+				<Text className={ styles.placeholder }>{ message }</Text>
 			</div>
 		);
 	}
@@ -262,6 +274,7 @@ function EmailTopRowReport( { postId }: EmailTopRowReportProps ) {
 	return (
 		<EmailTopRowTiles
 			metrics={ metrics }
+			hasSelection={ Boolean( postId ) }
 			isLoading={ isLoading }
 			isFetching={ isFetching }
 			isError={ isError }

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -7,7 +7,7 @@ import {
 	type StatsEmailBreakdown,
 } from '@jetpack-premium-analytics/data';
 import {
-	MetricWithComparison,
+	MetricTileGrid,
 	WidgetRoot,
 	WidgetState,
 	type DataFormat,
@@ -16,7 +16,7 @@ import {
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chartBar, envelope, link, people, percent, seen, send } from '@wordpress/icons';
-import { Icon, Stack, Text } from '@wordpress/ui';
+import { Icon, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -45,13 +45,6 @@ const RATE_FORMAT: DataFormat = {
 	type: 'percentage',
 	options: { decimals: 1, signDisplay: 'never' },
 };
-
-// Shown in place of a rate tile's value when the email has no rate yet. Mirrors
-// the Jetpack Stats top row, which renders "-" for a missing or zero rate: in
-// wp-calypso, `client/my-sites/stats/stats-email-top-row/index.jsx` passes
-// `counts?.opens_rate ? … : null` (a truthy check, so 0 becomes null) and
-// `top-card.jsx` renders a null value as "-".
-const NO_RATE_PLACEHOLDER = '—';
 
 /**
  * One row of the metric table below: everything that describes a top-row tile —
@@ -185,9 +178,11 @@ function readCount( summary: EmailRateSummary, key: string ): number {
 /**
  * Reads a rate field (0–100 percentage) off a rate summary and converts it to a
  * fraction for the percentage formatter. Returns `null` for a missing or zero
- * rate so the tile can render the placeholder — verified against the Jetpack
- * Stats top row, which treats a zero rate the same way (see the
- * `NO_RATE_PLACEHOLDER` comment above for the upstream files).
+ * rate so the tile renders the grid's placeholder ("—") instead of "0%". Mirrors
+ * the Jetpack Stats top row, which renders "-" for a missing or zero rate: in
+ * wp-calypso, `client/my-sites/stats/stats-email-top-row/index.jsx` passes
+ * `counts?.opens_rate ? … : null` (a truthy check, so 0 becomes null) and
+ * `top-card.jsx` renders a null value as "-".
  *
  * @param summary - The email rate summary.
  * @param key     - The rate field to read.
@@ -326,26 +321,7 @@ const EmailTopRowTiles = ( {
 							: __( 'Select an email to see its stats.', 'jetpack-premium-analytics' ),
 					} }
 				>
-					<div className={ styles.grid }>
-						{ metrics?.map( metric => (
-							<div key={ metric.key } className={ styles.tile }>
-								<div className={ styles.tileHeader }>
-									<Icon icon={ metric.icon } size={ 24 } className={ styles.tileIcon } />
-									<Text className={ styles.tileLabel }>{ metric.label }</Text>
-								</div>
-								{ metric.value === null ? (
-									<Text className={ styles.tilePlaceholder }>{ NO_RATE_PLACEHOLDER }</Text>
-								) : (
-									<MetricWithComparison
-										value={ metric.value }
-										dataFormat={ metric.dataFormat }
-										fontSize="xl"
-										className={ styles.tileValue }
-									/>
-								) }
-							</div>
-						) ) }
-					</div>
+					<MetricTileGrid tiles={ metrics ?? [] } />
 				</WidgetState>
 			</div>
 		</Stack>

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -1,34 +1,38 @@
 /**
  * External dependencies
  */
-import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
+import {
+	useStatsEmailOpensBreakdown,
+	useStatsEmailClicksBreakdown,
+	type StatsEmailBreakdown,
+} from '@jetpack-premium-analytics/data';
 import {
 	MetricWithComparison,
-	WidgetLoadingOverlay,
 	WidgetRoot,
+	WidgetState,
 	type DataFormat,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { chartBar, link, people, percent, seen, send } from '@wordpress/icons';
-import { Icon, Text } from '@wordpress/ui';
+import { chartBar, envelope, link, people, percent, seen, send } from '@wordpress/icons';
+import { Icon, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
-import { type EmailTopRowAttributes } from './widget';
+import { type EmailStatType, type EmailTopRowAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-// Report params are dashboard-driven, but this widget reads the all-time
-// `stats/emails/summary` endpoint and ignores the date range. The host (and
-// Storybook) may still inject them via `attributes`, so accept them here.
+// Report params are dashboard-driven, but this widget reads the all-time per-post
+// rate breakdown and ignores the date range. The host (and Storybook) may still
+// inject them via `attributes`, so accept them here.
 type EmailTopRowRenderAttributes = EmailTopRowAttributes & Partial< ReportParamsFieldAttributes >;
 type EmailTopRowWidgetProps = WidgetRenderProps< EmailTopRowRenderAttributes >;
 
-// A single row from the emails summary report, holding one email's all-time totals.
-type EmailSummaryRow = StatsEmailSummary[ 'data' ][ number ][ 'items' ][ number ];
+// The scalar summary of a per-post `stats/<statType>/emails/<postId>/rate` breakdown.
+type EmailRateSummary = StatsEmailBreakdown[ 'summary' ];
 
 type TileIcon = ComponentProps< typeof Icon >[ 'icon' ];
 
@@ -41,6 +45,21 @@ const RATE_FORMAT: DataFormat = {
 	type: 'percentage',
 	options: { decimals: 1, signDisplay: 'never' },
 };
+
+// Shown in place of a rate tile when the email has no rate yet (mirrors the
+// Jetpack Stats top row, which renders "-" for a missing or zero rate).
+const NO_RATE_PLACEHOLDER = '—';
+
+// The scalar keys a `rate` breakdown may carry. The endpoint drops the keys that
+// don't apply to its stat type, so presence of any of these signals real data.
+const EMAIL_METRIC_KEYS = [
+	'total_sends',
+	'total_opens',
+	'unique_opens',
+	'opens_rate',
+	'total_clicks',
+	'clicks_rate',
+] as const;
 
 /**
  * A single top-row tile: an icon, a label, and the formatted metric value.
@@ -59,9 +78,10 @@ export type EmailTopRowMetric = {
 	 */
 	label: string;
 	/**
-	 * The numeric value to render. Rates are fractions (0–1); counts are integers.
+	 * The value to render. Counts are integers; rates are fractions (0–1). `null`
+	 * marks a rate the email doesn't have yet, rendered as a placeholder.
 	 */
-	value: number;
+	value: number | null;
 	/**
 	 * How to format the value.
 	 */
@@ -69,116 +89,164 @@ export type EmailTopRowMetric = {
 };
 
 /**
- * Maps one email's summary row onto the ordered top-row tiles. Mirrors the union
- * of the Jetpack Stats "Email top row" opens and clicks views: send/open counts,
- * unique opens, clicks, and the open/click rates. Rates arrive as 0–100
- * percentages and are converted to fractions for the percentage formatter.
+ * Reads a count field off a rate summary, defaulting a missing or non-numeric
+ * value to 0.
  *
- * @param row - The selected email's summary row.
+ * @param summary - The email rate summary.
+ * @param key     - The count field to read.
+ * @return The count.
+ */
+function readCount( summary: EmailRateSummary, key: string ): number {
+	const value = Number( summary[ key ] );
+
+	return Number.isFinite( value ) ? value : 0;
+}
+
+/**
+ * Reads a rate field (0–100 percentage) off a rate summary and converts it to a
+ * fraction for the percentage formatter. Returns `null` for a missing or zero
+ * rate so the tile can render the placeholder, matching the Jetpack Stats top row.
+ *
+ * @param summary - The email rate summary.
+ * @param key     - The rate field to read.
+ * @return The rate as a fraction (0–1), or `null` when unavailable.
+ */
+function readRate( summary: EmailRateSummary, key: string ): number | null {
+	const value = Number( summary[ key ] );
+
+	return Number.isFinite( value ) && value !== 0 ? value / 100 : null;
+}
+
+/**
+ * Whether a rate summary carries any of the email metric fields. Distinguishes a
+ * real (possibly all-zero) email from an empty response for a post that has no
+ * stats, so the widget can show its empty state rather than a row of zeros.
+ *
+ * @param summary - The email rate summary, or undefined while loading.
+ * @return Whether the summary holds email metrics.
+ */
+export function hasEmailMetrics( summary: EmailRateSummary | undefined ): boolean {
+	return (
+		!! summary &&
+		EMAIL_METRIC_KEYS.some( key => {
+			const value = summary[ key ];
+
+			return value !== undefined && value !== null && Number.isFinite( Number( value ) );
+		} )
+	);
+}
+
+/**
+ * Maps a per-post rate summary onto the ordered top-row tiles for the active
+ * view. Mirrors the Jetpack Stats "Email top row": the Opens view shows total
+ * sends, unique opens (hidden when zero, as upstream does), total opens, and
+ * open rate; the Clicks view shows total opens, total clicks, and click rate.
+ *
+ * @param summary  - The selected email's rate summary.
+ * @param statType - Which view's tiles to build.
  * @return The ordered metric tiles.
  */
-export function toEmailTopRowMetrics( row: EmailSummaryRow ): EmailTopRowMetric[] {
-	return [
+export function toEmailTopRowMetrics(
+	summary: EmailRateSummary,
+	statType: EmailStatType
+): EmailTopRowMetric[] {
+	if ( statType === 'clicks' ) {
+		return [
+			{
+				key: 'total_opens',
+				icon: seen,
+				label: __( 'Total opens', 'jetpack-premium-analytics' ),
+				value: readCount( summary, 'total_opens' ),
+				dataFormat: COUNT_FORMAT,
+			},
+			{
+				key: 'total_clicks',
+				icon: link,
+				label: __( 'Total clicks', 'jetpack-premium-analytics' ),
+				value: readCount( summary, 'total_clicks' ),
+				dataFormat: COUNT_FORMAT,
+			},
+			{
+				key: 'clicks_rate',
+				icon: chartBar,
+				label: __( 'Click rate', 'jetpack-premium-analytics' ),
+				value: readRate( summary, 'clicks_rate' ),
+				dataFormat: RATE_FORMAT,
+			},
+		];
+	}
+
+	const tiles: EmailTopRowMetric[] = [
 		{
 			key: 'total_sends',
 			icon: send,
-			label: __( 'Total sends', 'jetpack-premium-analytics' ),
-			value: row.total_sends,
-			dataFormat: COUNT_FORMAT,
-		},
-		{
-			key: 'opens',
-			icon: seen,
-			label: __( 'Total opens', 'jetpack-premium-analytics' ),
-			value: row.opens,
+			label: __( 'Total emails sent', 'jetpack-premium-analytics' ),
+			value: readCount( summary, 'total_sends' ),
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'unique_opens',
 			icon: people,
 			label: __( 'Unique opens', 'jetpack-premium-analytics' ),
-			value: row.unique_opens,
+			value: readCount( summary, 'unique_opens' ),
+			dataFormat: COUNT_FORMAT,
+		},
+		{
+			key: 'total_opens',
+			icon: seen,
+			label: __( 'Total opens', 'jetpack-premium-analytics' ),
+			value: readCount( summary, 'total_opens' ),
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'opens_rate',
 			icon: percent,
 			label: __( 'Open rate', 'jetpack-premium-analytics' ),
-			value: row.opens_rate / 100,
-			dataFormat: RATE_FORMAT,
-		},
-		{
-			key: 'clicks',
-			icon: link,
-			label: __( 'Total clicks', 'jetpack-premium-analytics' ),
-			value: row.clicks,
-			dataFormat: COUNT_FORMAT,
-		},
-		{
-			key: 'clicks_rate',
-			icon: chartBar,
-			label: __( 'Click rate', 'jetpack-premium-analytics' ),
-			value: row.clicks_rate / 100,
+			value: readRate( summary, 'opens_rate' ),
 			dataFormat: RATE_FORMAT,
 		},
 	];
-}
 
-/**
- * Finds the summary row for a specific email. The summary endpoint returns the
- * latest emails newest-first with no per-post filter, so the widget selects the
- * matching row by ID. Returns `undefined` when no email is selected or the
- * selected email is not in the returned page.
- *
- * @param report - The normalized email-summary report, or undefined while loading.
- * @param postId - The selected email's post ID.
- * @return The matching row, or undefined when unavailable.
- */
-export function selectEmailRow(
-	report: StatsEmailSummary | undefined,
-	postId?: number
-): EmailSummaryRow | undefined {
-	if ( ! postId ) {
-		return undefined;
-	}
-
-	const items = report?.data?.[ 0 ]?.items ?? [];
-
-	return items.find( item => Number( item.id ) === postId );
+	// Upstream hides the Unique opens tile when there are no unique opens.
+	return tiles.filter(
+		tile => tile.key !== 'unique_opens' || readCount( summary, 'unique_opens' ) > 0
+	);
 }
 
 type EmailTopRowTilesProps = {
 	/**
 	 * The ordered metric tiles to render. When omitted, the empty state is shown
-	 * (unless `isLoading` is set).
+	 * (unless the widget is loading or in error).
 	 */
 	metrics?: EmailTopRowMetric[];
 	/**
-	 * Whether an email is selected. Drives which empty-state message is shown when
-	 * there are no metrics: prompt to select an email when `false`, or an
-	 * "unavailable" message when `true` (the selected email is not in the summary).
+	 * Whether an email is selected. Drives the empty-state message: a prompt to
+	 * select an email when `false`, or a "no stats yet" message when `true`.
 	 */
 	hasSelection?: boolean;
 	/**
-	 * When `true` and there is no data yet, the full loading overlay is shown.
+	 * First load with no data yet — shows the loading overlay.
 	 */
 	isLoading?: boolean;
 	/**
-	 * When `true`, a background refetch is in progress. Existing tiles stay
-	 * visible; the grid is marked busy for assistive tech.
+	 * Background refetch with data shown — a non-blocking busy overlay.
 	 */
 	isFetching?: boolean;
 	/**
-	 * When `true`, an error message is rendered in place of the tiles.
+	 * Whether the request failed — shows the error state.
 	 */
 	isError?: boolean;
+	/**
+	 * Re-runs the request from the error state's Retry action.
+	 */
+	onRetry?: () => void;
 };
 
 /**
  * Presentational top row for the "Email top row" widget. Renders the selected
- * email's headline totals as bordered metric tiles and owns the loading, error,
- * empty, and populated states. Exported so Storybook and tests can exercise
- * those states with fixture metrics. The emails summary has no comparison period,
+ * email's headline totals as bordered metric tiles and delegates the loading,
+ * error, and empty states to `<WidgetState>`. Exported so Storybook and tests can
+ * exercise it with fixture metrics. The rate breakdowns have no comparison period,
  * so each tile shows a bare formatted value with no delta.
  *
  * @param {EmailTopRowTilesProps} props - The component props.
@@ -190,59 +258,55 @@ export const EmailTopRowTiles = ( {
 	isLoading = false,
 	isFetching = false,
 	isError = false,
+	onRetry,
 }: EmailTopRowTilesProps ) => {
-	if ( isError ) {
-		return (
-			<div className={ styles.root }>
-				<Text className={ styles.placeholder }>
-					{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }
-				</Text>
-			</div>
-		);
-	}
-
-	if ( isLoading && ! metrics ) {
-		return (
-			<div className={ styles.root }>
-				<WidgetLoadingOverlay />
-			</div>
-		);
-	}
-
-	if ( ! metrics ) {
-		const message = hasSelection
-			? __(
-					"This email's stats aren't available yet — it may be older than your most recent sent emails.",
-					'jetpack-premium-analytics'
-			  )
-			: __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' );
-
-		return (
-			<div className={ styles.root }>
-				<Text className={ styles.placeholder }>{ message }</Text>
-			</div>
-		);
-	}
-
 	return (
-		<div className={ styles.root }>
-			<div className={ styles.grid } aria-busy={ isFetching }>
-				{ metrics.map( metric => (
-					<div key={ metric.key } className={ styles.tile }>
-						<div className={ styles.tileHeader }>
-							<Icon icon={ metric.icon } size={ 24 } className={ styles.tileIcon } />
-							<Text className={ styles.tileLabel }>{ metric.label }</Text>
-						</div>
-						<MetricWithComparison
-							value={ metric.value }
-							dataFormat={ metric.dataFormat }
-							fontSize="xl"
-							className={ styles.tileValue }
-						/>
+		<Stack className={ styles.root }>
+			<div className={ styles.content }>
+				<WidgetState
+					isLoading={ isLoading }
+					isFetching={ isFetching }
+					isError={ isError }
+					isEmpty={ ! metrics || metrics.length === 0 }
+					error={ {
+						description: __(
+							"We couldn't load this email's stats. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: onRetry
+							? [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: onRetry } ]
+							: undefined,
+					} }
+					empty={ {
+						icon: envelope,
+						description: hasSelection
+							? __( 'No stats are available for this email yet.', 'jetpack-premium-analytics' )
+							: __( 'Select an email to see its stats.', 'jetpack-premium-analytics' ),
+					} }
+				>
+					<div className={ styles.grid }>
+						{ metrics?.map( metric => (
+							<div key={ metric.key } className={ styles.tile }>
+								<div className={ styles.tileHeader }>
+									<Icon icon={ metric.icon } size={ 24 } className={ styles.tileIcon } />
+									<Text className={ styles.tileLabel }>{ metric.label }</Text>
+								</div>
+								{ metric.value === null ? (
+									<Text className={ styles.tilePlaceholder }>{ NO_RATE_PLACEHOLDER }</Text>
+								) : (
+									<MetricWithComparison
+										value={ metric.value }
+										dataFormat={ metric.dataFormat }
+										fontSize="xl"
+										className={ styles.tileValue }
+									/>
+								) }
+							</div>
+						) ) }
 					</div>
-				) ) }
+				</WidgetState>
 			</div>
-		</div>
+		</Stack>
 	);
 };
 
@@ -251,33 +315,51 @@ type EmailTopRowReportProps = {
 	 * The selected email's post ID.
 	 */
 	postId?: number;
+	/**
+	 * Which view's metrics to fetch and show.
+	 */
+	statType: EmailStatType;
 };
 
 /**
- * Fetches the emails summary through `useStatsEmailSummary`, selects the row for
- * the given `postId`, and hands its top-row metrics to `EmailTopRowTiles`. The
- * summary is all-time and site-wide, so it does not read the dashboard date
- * range; it is requested at its maximum row count to widen the chance the
- * selected email is present.
+ * Fetches the selected email's all-time rate breakdown for the active view and
+ * hands its metrics to `EmailTopRowTiles`. The Opens and Clicks views each read
+ * their own per-post `stats/<statType>/emails/<postId>/rate` endpoint — the same
+ * source the Jetpack Stats top row uses — so the widget resolves a specific email
+ * by ID rather than scanning a summary list, and it works for any email
+ * regardless of how recently it was sent. Only the active view's request runs.
  *
  * @param {EmailTopRowReportProps} props - The component props.
  * @return The widget content.
  */
-function EmailTopRowReport( { postId }: EmailTopRowReportProps ) {
-	// The summary endpoint accepts 1–30 rows; request its maximum so a recently
-	// selected email is likely to be in the returned page.
-	const { data, isLoading, isFetching, isError } = useStatsEmailSummary( { quantity: 30 } );
+function EmailTopRowReport( { postId, statType }: EmailTopRowReportProps ) {
+	const hasSelection = Number.isInteger( postId ) && ( postId ?? 0 ) > 0;
+	const safePostId = hasSelection ? ( postId as number ) : 0;
 
-	const row = useMemo( () => selectEmailRow( data, postId ), [ data, postId ] );
-	const metrics = useMemo( () => ( row ? toEmailTopRowMetrics( row ) : undefined ), [ row ] );
+	// Both hooks are called every render (hooks rule); only the active view's
+	// query is enabled, so a single request runs.
+	const opens = useStatsEmailOpensBreakdown( safePostId, 'rate', {
+		enabled: hasSelection && statType === 'opens',
+	} );
+	const clicks = useStatsEmailClicksBreakdown( safePostId, 'rate', {
+		enabled: hasSelection && statType === 'clicks',
+	} );
+	const active = statType === 'clicks' ? clicks : opens;
+
+	const summary = ( active.data as StatsEmailBreakdown | undefined )?.summary;
+	const metrics = useMemo(
+		() => ( hasEmailMetrics( summary ) ? toEmailTopRowMetrics( summary!, statType ) : undefined ),
+		[ summary, statType ]
+	);
 
 	return (
 		<EmailTopRowTiles
 			metrics={ metrics }
-			hasSelection={ Boolean( postId ) }
-			isLoading={ isLoading }
-			isFetching={ isFetching }
-			isError={ isError }
+			hasSelection={ hasSelection }
+			isLoading={ active.isLoading }
+			isFetching={ active.isFetching }
+			isError={ active.isError }
+			onRetry={ active.refetch }
 		/>
 	);
 }
@@ -285,17 +367,20 @@ function EmailTopRowReport( { postId }: EmailTopRowReportProps ) {
 /**
  * Widget render entry point.
  *
- * The email is selected by the `postId` attribute supplied by the host. Host
- * attributes (including `reportParams`) are passed through to `<WidgetRoot>` for
- * the widget contract even though this all-time summary ignores the date range.
+ * The email is selected by the `postId` attribute and the view by `statType`
+ * (defaulting to Opens), both supplied by the host. Host attributes (including
+ * `reportParams`) are passed through to `<WidgetRoot>` for the widget contract
+ * even though the all-time rate breakdown ignores the date range.
  *
  * @param {EmailTopRowWidgetProps} props - The widget render props.
  * @return The rendered widget.
  */
 export default function EmailTopRow( { attributes = {} }: EmailTopRowWidgetProps ) {
+	const statType: EmailStatType = attributes.statType === 'clicks' ? 'clicks' : 'opens';
+
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<EmailTopRowReport postId={ attributes.postId } />
+			<EmailTopRowReport postId={ attributes.postId } statType={ statType } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -3,7 +3,7 @@
  */
 import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
 import {
-	MetricValue,
+	MetricWithComparison,
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	type DataFormat,
@@ -11,13 +11,15 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Stack, Text } from '@wordpress/ui';
+import { chartBar, link, people, percent, seen, send } from '@wordpress/icons';
+import { Icon, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
 import { type EmailTopRowAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
 
 // Report params are dashboard-driven, but this widget reads the all-time
 // `stats/emails/summary` endpoint and ignores the date range. The host (and
@@ -27,6 +29,8 @@ type EmailTopRowWidgetProps = WidgetRenderProps< EmailTopRowRenderAttributes >;
 
 // A single row from the emails summary report, holding one email's all-time totals.
 type EmailSummaryRow = StatsEmailSummary[ 'data' ][ number ][ 'items' ][ number ];
+
+type TileIcon = ComponentProps< typeof Icon >[ 'icon' ];
 
 const COUNT_FORMAT: DataFormat = {
 	type: 'number',
@@ -39,7 +43,7 @@ const RATE_FORMAT: DataFormat = {
 };
 
 /**
- * A single top-row tile: the metric value with a caption beneath it.
+ * A single top-row tile: an icon, a label, and the formatted metric value.
  */
 export type EmailTopRowMetric = {
 	/**
@@ -47,7 +51,11 @@ export type EmailTopRowMetric = {
 	 */
 	key: string;
 	/**
-	 * Caption shown beneath the value (e.g. "Total opens").
+	 * Icon shown alongside the label.
+	 */
+	icon: TileIcon;
+	/**
+	 * Label shown next to the icon (e.g. "Total opens").
 	 */
 	label: string;
 	/**
@@ -73,36 +81,42 @@ export function toEmailTopRowMetrics( row: EmailSummaryRow ): EmailTopRowMetric[
 	return [
 		{
 			key: 'total_sends',
+			icon: send,
 			label: __( 'Total sends', 'jetpack-premium-analytics' ),
 			value: row.total_sends,
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'opens',
+			icon: seen,
 			label: __( 'Total opens', 'jetpack-premium-analytics' ),
 			value: row.opens,
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'unique_opens',
+			icon: people,
 			label: __( 'Unique opens', 'jetpack-premium-analytics' ),
 			value: row.unique_opens,
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'opens_rate',
+			icon: percent,
 			label: __( 'Open rate', 'jetpack-premium-analytics' ),
 			value: row.opens_rate / 100,
 			dataFormat: RATE_FORMAT,
 		},
 		{
 			key: 'clicks',
+			icon: link,
 			label: __( 'Total clicks', 'jetpack-premium-analytics' ),
 			value: row.clicks,
 			dataFormat: COUNT_FORMAT,
 		},
 		{
 			key: 'clicks_rate',
+			icon: chartBar,
 			label: __( 'Click rate', 'jetpack-premium-analytics' ),
 			value: row.clicks_rate / 100,
 			dataFormat: RATE_FORMAT,
@@ -145,7 +159,7 @@ type EmailTopRowTilesProps = {
 	isLoading?: boolean;
 	/**
 	 * When `true`, a background refetch is in progress. Existing tiles stay
-	 * visible; the container is marked busy for assistive tech.
+	 * visible; the grid is marked busy for assistive tech.
 	 */
 	isFetching?: boolean;
 	/**
@@ -156,9 +170,10 @@ type EmailTopRowTilesProps = {
 
 /**
  * Presentational top row for the "Email top row" widget. Renders the selected
- * email's headline totals as metric tiles and owns the loading, error, empty,
- * and populated states. Exported so Storybook and tests can exercise those
- * states with fixture metrics.
+ * email's headline totals as bordered metric tiles and owns the loading, error,
+ * empty, and populated states. Exported so Storybook and tests can exercise
+ * those states with fixture metrics. The emails summary has no comparison period,
+ * so each tile shows a bare formatted value with no delta.
  *
  * @param {EmailTopRowTilesProps} props - The component props.
  * @return The rendered top row.
@@ -169,39 +184,54 @@ export const EmailTopRowTiles = ( {
 	isFetching = false,
 	isError = false,
 }: EmailTopRowTilesProps ) => {
-	let body;
 	if ( isError ) {
-		body = (
-			<Stack align="center" justify="center" className={ styles.placeholder }>
-				<Text>{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }</Text>
-			</Stack>
-		);
-	} else if ( isLoading && ! metrics ) {
-		body = <WidgetLoadingOverlay />;
-	} else if ( ! metrics ) {
-		body = (
-			<Stack align="center" justify="center" className={ styles.placeholder }>
-				<Text>
-					{ __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' ) }
+		return (
+			<div className={ styles.root }>
+				<Text className={ styles.placeholder }>
+					{ __( 'Unable to load email stats.', 'jetpack-premium-analytics' ) }
 				</Text>
-			</Stack>
-		);
-	} else {
-		body = (
-			<div className={ styles.tiles } aria-busy={ isFetching }>
-				{ metrics.map( metric => (
-					<Stack key={ metric.key } direction="column" gap="xs" className={ styles.tile }>
-						<MetricValue value={ metric.value } dataFormat={ metric.dataFormat } fontSize="2xl" />
-						<Text variant="body-sm" className={ styles.caption }>
-							{ metric.label }
-						</Text>
-					</Stack>
-				) ) }
 			</div>
 		);
 	}
 
-	return <div className={ styles.root }>{ body }</div>;
+	if ( isLoading && ! metrics ) {
+		return (
+			<div className={ styles.root }>
+				<WidgetLoadingOverlay />
+			</div>
+		);
+	}
+
+	if ( ! metrics ) {
+		return (
+			<div className={ styles.root }>
+				<Text className={ styles.placeholder }>
+					{ __( 'Select an email to see its opens and clicks.', 'jetpack-premium-analytics' ) }
+				</Text>
+			</div>
+		);
+	}
+
+	return (
+		<div className={ styles.root }>
+			<div className={ styles.grid } aria-busy={ isFetching }>
+				{ metrics.map( metric => (
+					<div key={ metric.key } className={ styles.tile }>
+						<div className={ styles.tileHeader }>
+							<Icon icon={ metric.icon } size={ 24 } className={ styles.tileIcon } />
+							<Text className={ styles.tileLabel }>{ metric.label }</Text>
+						</div>
+						<MetricWithComparison
+							value={ metric.value }
+							dataFormat={ metric.dataFormat }
+							fontSize="xl"
+							className={ styles.tileValue }
+						/>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
 };
 
 type EmailTopRowReportProps = {

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -1,13 +1,17 @@
 /**
- * The close-up stories render the data-connected widget against a mocked
- * `stats/emails/summary` response so the tiles populate without a backend.
- * `WidgetDashboardWithWidget` mounts the real dashboard with the same widget.
+ * The close-up stories render the data-connected widget against a mocked per-post
+ * `stats/<statType>/emails/<postId>/rate` response so the tiles populate without a
+ * backend. `WidgetDashboardWithWidget` mounts the real dashboard with the same
+ * widget.
  *
- * The widget is scoped to a single email by the `postId` attribute; the stories
- * mock `postId` 2000, one of the emails returned by `registerReportMocks`. The
- * summary endpoint is all-time and returns no comparison rows, so the
- * `WithComparison` story renders identically to `Default` — there is no
- * period-over-period data to display and no deltas are shown.
+ * The widget is scoped to a single email by the `postId` attribute and to one
+ * view by `statType` (Opens or Clicks). The rate breakdown is all-time and returns
+ * no comparison rows, so the `WithComparison` story renders identically to
+ * `Default` — there is no period-over-period data and no deltas are shown.
+ *
+ * The Loading / Error / Empty stories force the mock into that state with
+ * `setReportMockState`; each uses a distinct `postId` so its request has its own
+ * query key and hits the override fresh rather than reading a sibling's cache.
  */
 /**
  * Internal dependencies
@@ -19,9 +23,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import EmailTopRowRender from '../render';
 import widgetDefinition from '../widget';
+import type { EmailStatType } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -30,18 +38,26 @@ registerReportMocks();
 
 const EMAIL_TOP_ROW_RENDER_MODULE = 'storybook/email-top-row';
 
-// A representative email present in the mocked `stats/emails/summary` response.
+// A representative email; the mock returns populated totals for any post ID.
 const MOCK_POST_ID = 2000;
 
+// Overrides are keyed by this fragment of the opens rate-breakdown path.
+const OPENS_MOCK_FRAGMENT = 'stats/opens/emails';
+
 interface EmailTopRowStoryControls {
+	statType: EmailStatType;
 	withComparison: boolean;
 }
 
-function renderEmailTopRow( { withComparison }: EmailTopRowStoryControls ) {
+function renderEmailTopRow(
+	{ statType, withComparison }: EmailTopRowStoryControls,
+	postId: number = MOCK_POST_ID
+) {
 	return (
 		<EmailTopRowRender
 			attributes={ {
-				postId: MOCK_POST_ID,
+				postId,
+				statType,
 				reportParams: getDefaultQueryParams( withComparison ),
 			} }
 		/>
@@ -60,13 +76,17 @@ const meta = {
 	component: EmailTopRowRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
+		statType: {
+			control: 'inline-radio',
+			options: [ 'opens', 'clicks' ],
+		},
 		withComparison: { control: 'boolean' },
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Email top row" widget. Shows a single email\'s all-time headline totals — total sends, total opens, unique opens, total clicks — plus the open and click rates, as a row of metric tiles. The email is selected by the `postId` attribute. Data comes from the all-time `stats/emails/summary` endpoint, which has no per-post filter and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
+					'The "Email top row" widget. Shows a single email\'s all-time headline totals as a row of metric tiles, switching between the Opens view (total sends, unique opens, total opens, open rate) and the Clicks view (total opens, total clicks, click rate) via the `statType` attribute. The email is selected by `postId`. Data comes from the per-post `stats/<statType>/emails/<postId>/rate` breakdown, which is all-time and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
 			},
 		},
 	},
@@ -77,22 +97,91 @@ export default meta;
 type Story = StoryObj< EmailTopRowStoryControls >;
 
 /**
- * Default populated state — the selected email's totals, current period only.
+ * Default populated state — the selected email's Opens totals.
  */
 export const Default: Story = {
-	render: renderEmailTopRow,
-	args: { withComparison: false },
+	render: args => renderEmailTopRow( args ),
+	args: { statType: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
 /**
- * With comparison `reportParams` from the date range picker. The summary
- * endpoint has no comparison data, so the widget renders the same tiles with no
- * deltas rather than inventing period-over-period values.
+ * The Clicks view — total opens, total clicks, and click rate for the same email.
+ */
+export const ClicksView: Story = {
+	render: args => renderEmailTopRow( args ),
+	args: { statType: 'clicks', withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * With comparison `reportParams` from the date range picker. The rate breakdown
+ * has no comparison data, so the widget renders the same tiles with no deltas
+ * rather than inventing period-over-period values.
  */
 export const WithComparison: Story = {
-	render: renderEmailTopRow,
-	args: { withComparison: true },
+	render: args => renderEmailTopRow( args ),
+	args: { statType: 'opens', withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load with no data yet: the widget shows its loading overlay.
+ */
+export const Loading: Story = {
+	render: args => renderEmailTopRow( args, 2001 ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	args: { statType: 'opens', withComparison: false },
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( OPENS_MOCK_FRAGMENT, 'loading' );
+		return () => setReportMockState( OPENS_MOCK_FRAGMENT, null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: args => renderEmailTopRow( args, 2002 ),
+	tags: [ '!autodocs' ],
+	args: { statType: 'opens', withComparison: false },
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( OPENS_MOCK_FRAGMENT, 'error' );
+		return () => setReportMockState( OPENS_MOCK_FRAGMENT, null );
+	},
+};
+
+/**
+ * Resolved with no stats for the email: the widget shows its empty state (the
+ * envelope glyph and "No stats are available for this email yet.").
+ */
+export const Empty: Story = {
+	render: args => renderEmailTopRow( args, 2003 ),
+	tags: [ '!autodocs' ],
+	args: { statType: 'opens', withComparison: false },
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( OPENS_MOCK_FRAGMENT, 'empty' );
+		return () => setReportMockState( OPENS_MOCK_FRAGMENT, null );
+	},
+};
+
+/**
+ * No email selected (no `postId`): the widget prompts to pick an email instead of
+ * fetching. This is how the widget renders on a report page before a row is chosen.
+ */
+export const NoEmailSelected: Story = {
+	render: ( { statType, withComparison }: EmailTopRowStoryControls ) => (
+		<EmailTopRowRender
+			attributes={ { statType, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	),
+	args: { statType: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -101,6 +190,7 @@ interface EmailTopRowDashboardStoryProps
 		EmailTopRowStoryControls {}
 
 function EmailTopRowDashboardStory( {
+	statType,
 	withComparison,
 	...dashboardArgs
 }: EmailTopRowDashboardStoryProps ) {
@@ -112,6 +202,7 @@ function EmailTopRowDashboardStory( {
 			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				postId: MOCK_POST_ID,
+				statType,
 				reportParams: getDefaultQueryParams( withComparison ),
 			} }
 		/>
@@ -122,10 +213,15 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTopRowDashboardStoryProps
 	render: args => <EmailTopRowDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		statType: 'opens',
 		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
+		statType: {
+			control: 'inline-radio',
+			options: [ 'opens', 'clicks' ],
+		},
 		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -56,7 +56,7 @@ const withWidgetCanvas: Decorator = Story => (
 );
 
 const meta = {
-	title: 'Packages/Premium Analytics/Widgets/Email top row',
+	title: 'Packages/Premium Analytics/Widgets/EmailTopRow',
 	component: EmailTopRowRender,
 	tags: [ 'autodocs' ],
 	argTypes: {

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -1,11 +1,11 @@
 /**
  * The close-up stories render the data-connected widget against a mocked per-post
- * `stats/<statType>/emails/<postId>/rate` response so the tiles populate without a
+ * `stats/<opens|clicks>/emails/<postId>/rate` response so the tiles populate without a
  * backend. `WidgetDashboardWithWidget` mounts the real dashboard with the same
  * widget.
  *
  * The widget is scoped to a single email by the `postId` attribute and to one
- * view by `statType` (Opens or Clicks). The rate breakdown is all-time and returns
+ * view by `metric` (Opens or Clicks). The rate breakdown is all-time and returns
  * no comparison rows, so the `WithComparison` story renders identically to
  * `Default` — there is no period-over-period data and no deltas are shown.
  *
@@ -29,7 +29,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import EmailTopRowRender from '../render';
 import widgetDefinition from '../widget';
-import type { EmailStatType } from '../widget';
+import type { EmailMetric } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -45,19 +45,19 @@ const MOCK_POST_ID = 2000;
 const OPENS_MOCK_FRAGMENT = 'stats/opens/emails';
 
 interface EmailTopRowStoryControls {
-	statType: EmailStatType;
+	metric: EmailMetric;
 	withComparison: boolean;
 }
 
 function renderEmailTopRow(
-	{ statType, withComparison }: EmailTopRowStoryControls,
+	{ metric, withComparison }: EmailTopRowStoryControls,
 	postId: number = MOCK_POST_ID
 ) {
 	return (
 		<EmailTopRowRender
 			attributes={ {
 				postId,
-				statType,
+				metric,
 				reportParams: getDefaultQueryParams( withComparison ),
 			} }
 		/>
@@ -76,7 +76,7 @@ const meta = {
 	component: EmailTopRowRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		statType: {
+		metric: {
 			control: 'inline-radio',
 			options: [ 'opens', 'clicks' ],
 		},
@@ -86,7 +86,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email top row" widget. Shows a single email\'s all-time headline totals as a row of metric tiles, switching between the Opens view (total sends, unique opens, total opens, open rate) and the Clicks view (total opens, total clicks, click rate) via the `statType` attribute. The email is selected by `postId`. Data comes from the per-post `stats/<statType>/emails/<postId>/rate` breakdown, which is all-time and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
+					'The "Email top row" widget. Shows a single email\'s all-time headline totals as a row of metric tiles, switching between the Opens view (total sends, unique opens, total opens, open rate) and the Clicks view (total opens, total clicks, click rate) via the `metric` attribute. The email is selected by `postId`. Data comes from the per-post `stats/<opens|clicks>/emails/<postId>/rate` breakdown, which is all-time and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
 			},
 		},
 	},
@@ -101,7 +101,7 @@ type Story = StoryObj< EmailTopRowStoryControls >;
  */
 export const Default: Story = {
 	render: args => renderEmailTopRow( args ),
-	args: { statType: 'opens', withComparison: false },
+	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -110,7 +110,7 @@ export const Default: Story = {
  */
 export const ClicksView: Story = {
 	render: args => renderEmailTopRow( args ),
-	args: { statType: 'clicks', withComparison: false },
+	args: { metric: 'clicks', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -121,7 +121,7 @@ export const ClicksView: Story = {
  */
 export const WithComparison: Story = {
 	render: args => renderEmailTopRow( args ),
-	args: { statType: 'opens', withComparison: true },
+	args: { metric: 'opens', withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -133,7 +133,7 @@ export const Loading: Story = {
 	// Kept off the shared autodocs page: the mock override is keyed by path, so it
 	// would otherwise force the sibling stories on that page into the same state.
 	tags: [ '!autodocs' ],
-	args: { statType: 'opens', withComparison: false },
+	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'loading' );
@@ -148,7 +148,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: args => renderEmailTopRow( args, 2002 ),
 	tags: [ '!autodocs' ],
-	args: { statType: 'opens', withComparison: false },
+	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'error' );
@@ -163,7 +163,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: args => renderEmailTopRow( args, 2003 ),
 	tags: [ '!autodocs' ],
-	args: { statType: 'opens', withComparison: false },
+	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'empty' );
@@ -176,12 +176,12 @@ export const Empty: Story = {
  * fetching. This is how the widget renders on a report page before a row is chosen.
  */
 export const NoEmailSelected: Story = {
-	render: ( { statType, withComparison }: EmailTopRowStoryControls ) => (
+	render: ( { metric, withComparison }: EmailTopRowStoryControls ) => (
 		<EmailTopRowRender
-			attributes={ { statType, reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { metric, reportParams: getDefaultQueryParams( withComparison ) } }
 		/>
 	),
-	args: { statType: 'opens', withComparison: false },
+	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -190,7 +190,7 @@ interface EmailTopRowDashboardStoryProps
 		EmailTopRowStoryControls {}
 
 function EmailTopRowDashboardStory( {
-	statType,
+	metric,
 	withComparison,
 	...dashboardArgs
 }: EmailTopRowDashboardStoryProps ) {
@@ -202,7 +202,7 @@ function EmailTopRowDashboardStory( {
 			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				postId: MOCK_POST_ID,
-				statType,
+				metric,
 				reportParams: getDefaultQueryParams( withComparison ),
 			} }
 		/>
@@ -213,12 +213,12 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTopRowDashboardStoryProps
 	render: args => <EmailTopRowDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		statType: 'opens',
+		metric: 'opens',
 		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		statType: {
+		metric: {
 			control: 'inline-radio',
 			options: [ 'opens', 'clicks' ],
 		},

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -1,0 +1,131 @@
+/**
+ * The close-up stories render the data-connected widget against a mocked
+ * `stats/emails/summary` response so the tiles populate without a backend.
+ * `WidgetDashboardWithWidget` mounts the real dashboard with the same widget.
+ *
+ * The widget is scoped to a single email by the `postId` attribute; the stories
+ * mock `postId` 2000, one of the emails returned by `registerReportMocks`. The
+ * summary endpoint is all-time and returns no comparison rows, so the
+ * `WithComparison` story renders identically to `Default` — there is no
+ * period-over-period data to display and no deltas are shown.
+ */
+/**
+ * Internal dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import EmailTopRowRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const EMAIL_TOP_ROW_RENDER_MODULE = 'storybook/email-top-row';
+
+// A representative email present in the mocked `stats/emails/summary` response.
+const MOCK_POST_ID = 2000;
+
+interface EmailTopRowStoryControls {
+	withComparison: boolean;
+}
+
+function renderEmailTopRow( { withComparison }: EmailTopRowStoryControls ) {
+	return (
+		<EmailTopRowRender
+			attributes={ {
+				postId: MOCK_POST_ID,
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+// Close-up canvas so the tiles fill the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Email top row',
+	component: EmailTopRowRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Email top row" widget. Shows a single email\'s all-time headline totals — total sends, total opens, unique opens, total clicks — plus the open and click rates, as a row of metric tiles. The email is selected by the `postId` attribute. Data comes from the all-time `stats/emails/summary` endpoint, which has no per-post filter and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof EmailTopRowRender > & EmailTopRowStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< EmailTopRowStoryControls >;
+
+/**
+ * Default populated state — the selected email's totals, current period only.
+ */
+export const Default: Story = {
+	render: renderEmailTopRow,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * With comparison `reportParams` from the date range picker. The summary
+ * endpoint has no comparison data, so the widget renders the same tiles with no
+ * deltas rather than inventing period-over-period values.
+ */
+export const WithComparison: Story = {
+	render: renderEmailTopRow,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface EmailTopRowDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		EmailTopRowStoryControls {}
+
+function EmailTopRowDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: EmailTopRowDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ EMAIL_TOP_ROW_RENDER_MODULE }
+			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				postId: MOCK_POST_ID,
+				reportParams: getDefaultQueryParams( withComparison ),
+			} }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< EmailTopRowDashboardStoryProps > = {
+	render: args => <EmailTopRowDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -4,13 +4,14 @@
  * backend. `WidgetDashboardWithWidget` mounts the real dashboard with the same
  * widget.
  *
- * The widget is scoped to a single email by the `postId` attribute and to one
- * view by `metric` (Opens or Clicks). The rate breakdown is all-time and returns
- * no comparison rows, so the `WithComparison` story renders identically to
- * `Default` — there is no period-over-period data and no deltas are shown.
+ * The widget is scoped to a single email by the host through
+ * `reportParams.post_id` and to one view by the `metric` attribute (Opens or
+ * Clicks). The rate breakdown is all-time and returns no comparison rows, so the
+ * `WithComparison` story renders identically to `Default` — there is no
+ * period-over-period data and no deltas are shown.
  *
  * The Loading / Error / Empty stories force the mock into that state with
- * `setReportMockState`; each uses a distinct `postId` so its request has its own
+ * `setReportMockState`; each uses a distinct `post_id` so its request has its own
  * query key and hits the override fresh rather than reading a sibling's cache.
  */
 /**
@@ -56,9 +57,8 @@ function renderEmailTopRow(
 	return (
 		<EmailTopRowRender
 			attributes={ {
-				postId,
 				metric,
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: postId },
 			} }
 		/>
 	);
@@ -86,7 +86,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email top row" widget. Shows a single email\'s all-time headline totals as a row of metric tiles, switching between the Opens view (total sends, unique opens, total opens, open rate) and the Clicks view (total opens, total clicks, click rate) via the `metric` attribute. The email is selected by `postId`. Data comes from the per-post `stats/<opens|clicks>/emails/<postId>/rate` breakdown, which is all-time and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
+					'The "Email top row" widget. Shows a single email\'s all-time headline totals as a row of metric tiles, switching between the Opens view (total sends, unique opens, total opens, open rate) and the Clicks view (total opens, total clicks, click rate) via the `metric` attribute. The email is selected by the host through `reportParams.post_id`. Data comes from the per-post `stats/<opens|clicks>/emails/<postId>/rate` breakdown, which is all-time and returns no comparison rows, so the widget ignores the dashboard date range and never shows period-over-period deltas.',
 			},
 		},
 	},
@@ -172,7 +172,7 @@ export const Empty: Story = {
 };
 
 /**
- * No email selected (no `postId`): the widget prompts to pick an email instead of
+ * No email selected (no `post_id`): the widget prompts to pick an email instead of
  * fetching. This is how the widget renders on a report page before a row is chosen.
  */
 export const NoEmailSelected: Story = {
@@ -201,9 +201,8 @@ function EmailTopRowDashboardStory( {
 			renderModule={ EMAIL_TOP_ROW_RENDER_MODULE }
 			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				postId: MOCK_POST_ID,
 				metric,
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_POST_ID },
 			} }
 		/>
 	);

--- a/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
@@ -9,6 +9,14 @@
 	overflow-y: auto;
 }
 
+/* Fills the widget body so WidgetState's loading/empty/error states center. */
+.content {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+}
+
 .grid {
 	display: grid;
 	grid-template-columns: 1fr;
@@ -51,13 +59,12 @@
 	line-height: var(--wpds-typography-line-height-xl, 32px);
 }
 
-.placeholder {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
+/* The "no rate yet" placeholder sits where a MetricValue would, so match its
+ * size and mute the color. */
+.tilePlaceholder {
+	font-size: var(--wpds-typography-font-size-xl, 20px);
+	line-height: var(--wpds-typography-line-height-xl, 32px);
 	color: var(--wpds-color-foreground-content-neutral-weak);
-	text-align: center;
 }
 
 /* Wide widths: lay the tiles out three across with the value stacked below the

--- a/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
@@ -67,12 +67,15 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-/* Wide widths: lay the tiles out three across with the value stacked below the
- * icon and label. */
+/* Wide widths: lay every tile out in a single equal-width row (matching
+ * upstream's single-row highlight cards) with the value stacked below the icon
+ * and label. Auto-flow columns adapt to the tile count so the Opens view's four
+ * tiles and the Clicks view's three both stay on one row. */
 @container (min-width: 640px) {
 
 	.grid {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-auto-flow: column;
+		grid-auto-columns: minmax(0, 1fr);
 	}
 
 	.tile {

--- a/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
@@ -1,34 +1,82 @@
+/* No outer padding: the host frames the widget and owns the padding. */
 .root {
 	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
+	gap: var(--wpds-dimension-gap-lg, 16px);
 	height: 100%;
-	min-block-size: 0;
-	overflow: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
-/* A responsive row of metric tiles: as many columns as fit, wrapping to new
-   rows on narrow widget widths. */
-.tiles {
+.grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-	gap: var(--wpds-dimension-gap-lg);
-	align-content: start;
-	padding-block: var(--wpds-dimension-padding-sm);
+	grid-template-columns: 1fr;
+	gap: var(--wpds-dimension-gap-sm, 8px);
 }
 
 .tile {
-	min-inline-size: 0;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md, 12px);
+	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
+	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-lg, 8px);
 }
 
-.caption {
-	color: var(--wpds-color-foreground-content-neutral-weak);
+.tileHeader {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	min-width: 0;
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+.tileIcon {
+	flex: 0 0 auto;
+}
+
+.tileLabel {
+	color: var(--wpds-color-foreground-content-neutral);
+}
+
+/* MetricValue emits the font-size token without a fallback, and the dashboard
+ * runtime does not always inject the WPDS typography tokens, so pin the metric
+ * total here with explicit fallbacks. */
+.tileValue span {
+	font-size: var(--wpds-typography-font-size-xl, 20px);
+	line-height: var(--wpds-typography-line-height-xl, 32px);
 }
 
 .placeholder {
-	flex: 1 1 0;
-	inline-size: 100%;
-	min-block-size: 200px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-align: center;
+}
+
+/* Wide widths: lay the tiles out three across with the value stacked below the
+ * icon and label. */
+@container (min-width: 640px) {
+
+	.grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.tile {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		gap: var(--wpds-dimension-gap-lg, 16px);
+	}
+
+	.tileHeader {
+		flex-direction: column;
+		align-items: flex-start;
+	}
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
@@ -1,0 +1,34 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-block-size: 0;
+	overflow: hidden;
+}
+
+/* A responsive row of metric tiles: as many columns as fit, wrapping to new
+   rows on narrow widget widths. */
+.tiles {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+	gap: var(--wpds-dimension-gap-lg);
+	align-content: start;
+	padding-block: var(--wpds-dimension-padding-sm);
+}
+
+.tile {
+	min-inline-size: 0;
+}
+
+.caption {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.placeholder {
+	flex: 1 1 0;
+	inline-size: 100%;
+	min-block-size: 200px;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-align: center;
+}

--- a/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-top-row/style.module.css
@@ -1,6 +1,5 @@
 /* No outer padding: the host frames the widget and owns the padding. */
 .root {
-	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-gap-lg, 16px);
@@ -9,84 +8,12 @@
 	overflow-y: auto;
 }
 
-/* Fills the widget body so WidgetState's loading/empty/error states center. */
+/* Fills the widget body so WidgetState centers its loading/empty/error states
+ * and so MetricTileGrid — a size container that takes no height of its own —
+ * has a definite-height parent to stretch into. */
 .content {
 	display: flex;
 	flex-direction: column;
 	flex: 1;
 	min-height: 0;
-}
-
-.grid {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: var(--wpds-dimension-gap-sm, 8px);
-}
-
-.tile {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
-	gap: var(--wpds-dimension-gap-md, 12px);
-	padding: var(--wpds-dimension-padding-md, 12px) var(--wpds-dimension-padding-lg, 16px);
-	border: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak);
-	border-radius: var(--wpds-border-radius-lg, 8px);
-}
-
-.tileHeader {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: var(--wpds-dimension-gap-sm, 8px);
-	min-width: 0;
-	color: var(--wpds-color-foreground-content-neutral);
-}
-
-.tileIcon {
-	flex: 0 0 auto;
-}
-
-.tileLabel {
-	color: var(--wpds-color-foreground-content-neutral);
-}
-
-/* MetricValue emits the font-size token without a fallback, and the dashboard
- * runtime does not always inject the WPDS typography tokens, so pin the metric
- * total here with explicit fallbacks. */
-.tileValue span {
-	font-size: var(--wpds-typography-font-size-xl, 20px);
-	line-height: var(--wpds-typography-line-height-xl, 32px);
-}
-
-/* The "no rate yet" placeholder sits where a MetricValue would, so match its
- * size and mute the color. */
-.tilePlaceholder {
-	font-size: var(--wpds-typography-font-size-xl, 20px);
-	line-height: var(--wpds-typography-line-height-xl, 32px);
-	color: var(--wpds-color-foreground-content-neutral-weak);
-}
-
-/* Wide widths: lay every tile out in a single equal-width row (matching
- * upstream's single-row highlight cards) with the value stacked below the icon
- * and label. Auto-flow columns adapt to the tile count so the Opens view's four
- * tiles and the Clicks view's three both stay on one row. */
-@container (min-width: 640px) {
-
-	.grid {
-		grid-auto-flow: column;
-		grid-auto-columns: minmax(0, 1fr);
-	}
-
-	.tile {
-		flex-direction: column;
-		align-items: flex-start;
-		justify-content: flex-start;
-		gap: var(--wpds-dimension-gap-lg, 16px);
-	}
-
-	.tileHeader {
-		flex-direction: column;
-		align-items: flex-start;
-	}
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.json
@@ -1,7 +1,7 @@
 {
 	"name": "jpa/email-top-row",
 	"title": "Email top row",
-	"description": "Headline send, open, and click totals for a single email.",
+	"description": "Headline open and click totals for a single email, split into Opens and Clicks views.",
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/email-top-row",
+	"title": "Email top row",
+	"description": "Headline send, open, and click totals for a single email.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -41,7 +41,7 @@ export default {
 	attributes: [
 		{
 			id: 'postId',
-			label: __( 'Email', 'jetpack-premium-analytics' ),
+			label: __( 'Email ID', 'jetpack-premium-analytics' ),
 			type: 'integer',
 		},
 	] as WidgetAttributeField< EmailTopRowAttributes >[],

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -8,16 +8,21 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Which set of headline metrics the top row shows for the selected email —
  * mirrors the Opens and Clicks internal tabs on the Jetpack Stats email detail
- * page. Each view is backed by its own all-time `stats/<statType>/emails/<postId>/rate`
+ * page. Each view is backed by its own all-time `stats/<opens|clicks>/emails/<postId>/rate`
  * breakdown, so the tiles and the data source switch together.
+ *
+ * Same name and value set as `EmailMetric` in the sibling `emails` widget
+ * (`widgets/emails/widget.ts`) — the email detail page host drives both widgets
+ * from one tab state, so the attribute must stay aligned. Mirrored locally
+ * because widgets are separate workspace packages and cannot import each other.
  */
-export type EmailStatType = 'opens' | 'clicks';
+export type EmailMetric = 'opens' | 'clicks';
 
 /**
  * Configurable attributes for the "Email top row" widget.
  *
  * The widget is scoped to a single email by `postId` and to one metric view by
- * `statType`. Both are supplied by the host (the email detail page passes the
+ * `metric`. Both are supplied by the host (the email detail page passes the
  * selected email and the active Opens/Clicks tab); there is no report-param
  * scoping because the underlying rate endpoints are per-post and always all-time.
  */
@@ -31,7 +36,7 @@ export type EmailTopRowAttributes = {
 	 * Which headline metrics to show: the Opens view (sends, unique opens, opens,
 	 * open rate) or the Clicks view (opens, clicks, click rate). Defaults to `opens`.
 	 */
-	statType?: EmailStatType;
+	metric?: EmailMetric;
 };
 
 /**
@@ -40,8 +45,8 @@ export type EmailTopRowAttributes = {
  * Ported from the Jetpack Stats "Email top row" module (the header row on an
  * individual email's stats detail page). Shows one email's all-time headline
  * counts as a row of metric tiles, switching between the Opens and Clicks views
- * with the `statType` attribute (`relevance: 'high'`, so the host renders the
- * control). Data comes from the per-post `stats/<statType>/emails/<postId>/rate`
+ * with the `metric` attribute (`relevance: 'high'`, so the host renders the
+ * control). Data comes from the per-post `stats/<opens|clicks>/emails/<postId>/rate`
  * breakdown, which is all-time and returns no comparison rows, so the widget
  * ignores the dashboard date range and never shows period-over-period deltas.
  */
@@ -62,7 +67,7 @@ export default {
 			type: 'integer',
 		},
 		{
-			id: 'statType',
+			id: 'metric',
 			label: __( 'View by', 'jetpack-premium-analytics' ),
 			type: 'text',
 			elements: [
@@ -81,7 +86,7 @@ export default {
 	example: {
 		attributes: {
 			postId: 2000,
-			statType: 'opens',
+			metric: 'opens',
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -21,17 +21,15 @@ export type EmailMetric = 'opens' | 'clicks';
 /**
  * Configurable attributes for the "Email top row" widget.
  *
- * The widget is scoped to a single email by `postId` and to one metric view by
- * `metric`. Both are supplied by the host (the email detail page passes the
- * selected email and the active Opens/Clicks tab); there is no report-param
- * scoping because the underlying rate endpoints are per-post and always all-time.
+ * The widget shows one metric view (`metric`) of a single email. The email is
+ * scoped by the host through `reportParams.post_id` (the shared single-resource
+ * "detail page" param), not by an attribute — the email detail page seeds
+ * `post_id` from its route so every widget on the page shares one scope. Only
+ * the Opens/Clicks view is a per-widget setting, supplied via the active tab.
+ * The underlying rate endpoints are per-post and always all-time, so the
+ * dashboard date range is ignored.
  */
 export type EmailTopRowAttributes = {
-	/**
-	 * Post ID of the email whose totals to display. When absent, the widget
-	 * prompts to select an email.
-	 */
-	postId?: number;
 	/**
 	 * Which headline metrics to show: the Opens view (sends, unique opens, opens,
 	 * open rate) or the Clicks view (opens, clicks, click rate). Defaults to `opens`.
@@ -62,11 +60,6 @@ export default {
 	},
 	attributes: [
 		{
-			id: 'postId',
-			label: __( 'Email ID', 'jetpack-premium-analytics' ),
-			type: 'integer',
-		},
-		{
 			id: 'metric',
 			label: __( 'View by', 'jetpack-premium-analytics' ),
 			type: 'text',
@@ -85,7 +78,6 @@ export default {
 	] as WidgetAttributeField< EmailTopRowAttributes >[],
 	example: {
 		attributes: {
-			postId: 2000,
 			metric: 'opens',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { envelope } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Configurable attributes for the "Email top row" widget.
+ *
+ * The widget is scoped to a single email by `postId`. The dashboard supplies
+ * the selected email's post ID through this attribute; there is no report-param
+ * (`post_id`) scoping because the underlying `stats/emails/summary` endpoint has
+ * no per-post filter and is always all-time, so the widget selects the matching
+ * row client-side from the latest emails.
+ */
+export type EmailTopRowAttributes = {
+	/**
+	 * Post ID of the email whose totals to display. When absent or not present in
+	 * the latest emails summary, the widget shows its empty state.
+	 */
+	postId?: number;
+};
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats "Email top row" module (the header row on an
+ * individual email's stats detail page). Shows the email's all-time headline
+ * counts — total sends, total opens, unique opens, and total clicks — plus the
+ * open and click rates, as a row of metric tiles.
+ *
+ * The `stats/emails/summary` endpoint is all-time and site-wide, so the widget
+ * ignores the dashboard date range and comparison period; the endpoint returns
+ * no comparison rows, so no period-over-period deltas are shown.
+ */
+export default {
+	name: 'jpa/email-top-row',
+	title: __( 'Email top row', 'jetpack-premium-analytics' ),
+	icon: envelope,
+	attributes: [
+		{
+			id: 'postId',
+			label: __( 'Email', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	] as WidgetAttributeField< EmailTopRowAttributes >[],
+	example: {
+		attributes: {
+			postId: 2000,
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -6,48 +6,82 @@ import { envelope } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
+ * Which set of headline metrics the top row shows for the selected email —
+ * mirrors the Opens and Clicks internal tabs on the Jetpack Stats email detail
+ * page. Each view is backed by its own all-time `stats/<statType>/emails/<postId>/rate`
+ * breakdown, so the tiles and the data source switch together.
+ */
+export type EmailStatType = 'opens' | 'clicks';
+
+/**
  * Configurable attributes for the "Email top row" widget.
  *
- * The widget is scoped to a single email by `postId`. The dashboard supplies
- * the selected email's post ID through this attribute; there is no report-param
- * (`post_id`) scoping because the underlying `stats/emails/summary` endpoint has
- * no per-post filter and is always all-time, so the widget selects the matching
- * row client-side from the latest emails.
+ * The widget is scoped to a single email by `postId` and to one metric view by
+ * `statType`. Both are supplied by the host (the email detail page passes the
+ * selected email and the active Opens/Clicks tab); there is no report-param
+ * scoping because the underlying rate endpoints are per-post and always all-time.
  */
 export type EmailTopRowAttributes = {
 	/**
-	 * Post ID of the email whose totals to display. When absent or not present in
-	 * the latest emails summary, the widget shows its empty state.
+	 * Post ID of the email whose totals to display. When absent, the widget
+	 * prompts to select an email.
 	 */
 	postId?: number;
+	/**
+	 * Which headline metrics to show: the Opens view (sends, unique opens, opens,
+	 * open rate) or the Clicks view (opens, clicks, click rate). Defaults to `opens`.
+	 */
+	statType?: EmailStatType;
 };
 
 /**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats "Email top row" module (the header row on an
- * individual email's stats detail page). Shows the email's all-time headline
- * counts — total sends, total opens, unique opens, and total clicks — plus the
- * open and click rates, as a row of metric tiles.
- *
- * The `stats/emails/summary` endpoint is all-time and site-wide, so the widget
- * ignores the dashboard date range and comparison period; the endpoint returns
- * no comparison rows, so no period-over-period deltas are shown.
+ * individual email's stats detail page). Shows one email's all-time headline
+ * counts as a row of metric tiles, switching between the Opens and Clicks views
+ * with the `statType` attribute (`relevance: 'high'`, so the host renders the
+ * control). Data comes from the per-post `stats/<statType>/emails/<postId>/rate`
+ * breakdown, which is all-time and returns no comparison rows, so the widget
+ * ignores the dashboard date range and never shows period-over-period deltas.
  */
 export default {
 	name: 'jpa/email-top-row',
 	title: __( 'Email top row', 'jetpack-premium-analytics' ),
 	icon: envelope,
+	help: {
+		content: __(
+			'Headline stats for a single email. The Opens view shows total sends, unique opens, total opens, and open rate; the Clicks view shows total opens, total clicks, and click rate. Rates are measured against total sends. Figures are all-time and are not affected by the dashboard date range.',
+			'jetpack-premium-analytics'
+		),
+	},
 	attributes: [
 		{
 			id: 'postId',
 			label: __( 'Email ID', 'jetpack-premium-analytics' ),
 			type: 'integer',
 		},
+		{
+			id: 'statType',
+			label: __( 'View by', 'jetpack-premium-analytics' ),
+			type: 'text',
+			elements: [
+				{
+					label: __( 'Opens', 'jetpack-premium-analytics' ),
+					value: 'opens',
+				},
+				{
+					label: __( 'Clicks', 'jetpack-premium-analytics' ),
+					value: 'clicks',
+				},
+			],
+			relevance: 'high',
+		},
 	] as WidgetAttributeField< EmailTopRowAttributes >[],
 	example: {
 		attributes: {
 			postId: 2000,
+			statType: 'opens',
 		},
 	},
 };


### PR DESCRIPTION
## Proposed changes

Ports the Stats "Email top row" module into Premium Analytics as the `jpa/email-top-row` widget — the headline counts shown on an individual email's Stats detail header, mirroring the Annual highlights tile layout.

- New widget at `widgets/email-top-row/` — six metric tiles for one email (Total sends, Total opens, Unique opens, Open rate, Total clicks, Click rate), built with the toolkit `MetricWithComparison` tiles.
- Scoped to a single email by a `postId` widget attribute. Reads the existing `useStatsEmailSummary` hook (`stats/emails/summary`, already-allow-listed `stats` prefix) and selects the matching email row — no new hook or proxy prefix.
- The summary endpoint is all-time with no comparison rows, so tiles show bare counts with no deltas — same as Annual highlights.
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget` (reuses the existing `stats/emails/summary` fixture).

## Related product discussion/links

- WOOA7S-1516

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / EmailTopRow**: the six tiles render populated for the mocked email (e.g. `1K`, `38.1%`); the `WithComparison` story renders the same as `Default`.
- Smoke test against a live connected site with a sent email.



https://github.com/user-attachments/assets/3bb16267-d9dc-4eea-b1fb-c3c170cf11a1


