### PR TITLE
WOOA7S-1517: Port Stats Email breakdown widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-email-breakdown-widget
+++ b/projects/packages/premium-analytics/changelog/add-email-breakdown-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Email breakdown widget: break a sent email down by countries, devices, email clients, or clicked links.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -299,6 +299,7 @@ export type {
 	StatsVideoPlaysComparisonItem,
 	StatsVideoPlaysItem,
 } from './processing/stats';
+export { compareEmailBreakdownItems } from './processing/stats';
 export type { StatsCommentFollowersParams } from './queries/stats-comment-followers-query';
 export type { StatsReportParams } from './queries/stats-query';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
@@ -33,18 +33,33 @@ function normalizeEmailBreakdownScalarSummary( response: StatsRecord ) {
 	);
 }
 
+/**
+ * Comparator ordering breakdown items by value, descending, with the
+ * aggregated "Other" row pinned last. Exported for consumers that merge rows
+ * from several breakdown reports and need to restore this order — e.g. the
+ * email breakdown widget's links view.
+ *
+ * @param a - The first item.
+ * @param b - The second item.
+ * @return A standard comparator result.
+ */
+export function compareEmailBreakdownItems(
+	a: Pick< StatsEmailBreakdownItem, 'label' | 'value' >,
+	b: Pick< StatsEmailBreakdownItem, 'label' | 'value' >
+): number {
+	if ( a.label === 'Other' ) {
+		return 1;
+	}
+
+	if ( b.label === 'Other' ) {
+		return -1;
+	}
+
+	return b.value - a.value;
+}
+
 function sortEmailBreakdownItems( items: StatsEmailBreakdownItem[] ): StatsEmailBreakdownItem[] {
-	return [ ...items ].sort( ( a, b ) => {
-		if ( a.label === 'Other' ) {
-			return 1;
-		}
-
-		if ( b.label === 'Other' ) {
-			return -1;
-		}
-
-		return b.value - a.value;
-	} );
+	return [ ...items ].sort( compareEmailBreakdownItems );
 }
 
 function parseFieldlessEmailCountryRows( response: StatsRecord ): StatsEmailBreakdownItem[] {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -30,7 +30,7 @@ export { sanitizeStatsVisitsResponse } from './visits';
 export { sanitizeStatsInsightsResponse } from './insights';
 export { mergeStatsUtmComparisonRows, sanitizeStatsUtmResponse } from './utm';
 export { sanitizeStatsEmailSummaryResponse } from './email-summary';
-export { sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
+export { compareEmailBreakdownItems, sanitizeStatsEmailBreakdownResponse } from './email-breakdown';
 export { sanitizeStatsArchivesResponse } from './archives';
 export { sanitizeStatsCommentFollowersResponse } from './comment-followers';
 export { sanitizeStatsFollowersResponse } from './followers';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-breakdown.ts
@@ -4,9 +4,11 @@
  * These mirror the fieldless all-time shapes the
  * `sanitizeStatsEmailBreakdownResponse` parser reads for
  * `stats/opens/emails/{id}/{breakdown}` and `stats/clicks/emails/{id}/{breakdown}`:
- * `countries` + `countries-info`, `devices`, `clients`, and `links` +
- * `user-content-links`. One populated fixture per view so reviewers can validate
- * each. The endpoints have no comparison period.
+ * `countries` + `countries-info`, `devices`, `clients`, `links`, and
+ * `user-content-links`. Each per-breakdown endpoint returns only its own payload
+ * key (Calypso fetches `link` and `user-content-link` separately and merges), so
+ * the link fixtures are split per endpoint. One populated fixture per breakdown
+ * so reviewers can validate each. The endpoints have no comparison period.
  */
 
 export const mockEmailCountryBreakdown = {
@@ -58,7 +60,7 @@ export const mockEmailClientBreakdown = {
 	},
 };
 
-export const mockEmailLinkBreakdown = {
+export const mockEmailInternalLinkBreakdown = {
 	links: {
 		data: [
 			[ 'post-url', 640 ],
@@ -68,6 +70,9 @@ export const mockEmailLinkBreakdown = {
 			[ 'some-other-internal', 22 ],
 		],
 	},
+};
+
+export const mockEmailUserContentLinkBreakdown = {
 	'user-content-links': {
 		data: [
 			[ 'https://example.com/2026/spring-sale', 512 ],

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-breakdown.ts
@@ -1,0 +1,80 @@
+/**
+ * Raw WPCOM email breakdown responses for the "Email breakdown" widget stories.
+ *
+ * These mirror the fieldless all-time shapes the
+ * `sanitizeStatsEmailBreakdownResponse` parser reads for
+ * `stats/opens/emails/{id}/{breakdown}` and `stats/clicks/emails/{id}/{breakdown}`:
+ * `countries` + `countries-info`, `devices`, `clients`, and `links` +
+ * `user-content-links`. One populated fixture per view so reviewers can validate
+ * each. The endpoints have no comparison period.
+ */
+
+export const mockEmailCountryBreakdown = {
+	countries: {
+		data: [
+			[ 'US', 1840 ],
+			[ 'GB', 720 ],
+			[ 'CA', 510 ],
+			[ 'DE', 430 ],
+			[ 'FR', 380 ],
+			[ 'IN', 295 ],
+			[ 'BR', 210 ],
+			[ 'AU', 165 ],
+		],
+	},
+	'countries-info': {
+		US: { country_full: 'United States', map_region: '021' },
+		GB: { country_full: 'United Kingdom', map_region: '154' },
+		CA: { country_full: 'Canada', map_region: '021' },
+		DE: { country_full: 'Germany', map_region: '155' },
+		FR: { country_full: 'France', map_region: '155' },
+		IN: { country_full: 'India', map_region: '034' },
+		BR: { country_full: 'Brazil', map_region: '005' },
+		AU: { country_full: 'Australia', map_region: '053' },
+	},
+};
+
+export const mockEmailDeviceBreakdown = {
+	devices: {
+		data: [
+			[ 'Desktop', 3120 ],
+			[ 'Mobile', 2480 ],
+			[ 'Tablet', 610 ],
+			[ 'Other', 95 ],
+		],
+	},
+};
+
+export const mockEmailClientBreakdown = {
+	clients: {
+		data: [
+			[ 'Apple Mail', 2410 ],
+			[ 'Gmail', 1890 ],
+			[ 'Outlook', 940 ],
+			[ 'Yahoo Mail', 520 ],
+			[ 'Thunderbird', 180 ],
+			[ 'Other', 265 ],
+		],
+	},
+};
+
+export const mockEmailLinkBreakdown = {
+	links: {
+		data: [
+			[ 'post-url', 640 ],
+			[ 'like-post', 210 ],
+			[ 'comment-post', 130 ],
+			[ 'remove-subscription', 48 ],
+			[ 'some-other-internal', 22 ],
+		],
+	},
+	'user-content-links': {
+		data: [
+			[ 'https://example.com/2026/spring-sale', 512 ],
+			[ 'https://example.com/blog/whats-new', 388 ],
+			[ 'https://example.com/pricing', 205 ],
+			[ 'https://example.com/docs/getting-started', 154 ],
+			[ 'https://example.com/contact', 76 ],
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -80,5 +80,6 @@ export {
 	mockEmailCountryBreakdown,
 	mockEmailDeviceBreakdown,
 	mockEmailClientBreakdown,
-	mockEmailLinkBreakdown,
+	mockEmailInternalLinkBreakdown,
+	mockEmailUserContentLinkBreakdown,
 } from './email-breakdown';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -75,3 +75,10 @@ export { mockStatsSummaryData, mockStatsSummaryComparisonData } from './summary'
 export { mockStatsSubscribersCountsData } from './subscriber-counts';
 
 export { buildEmailRateResponse } from './email-rate';
+
+export {
+	mockEmailCountryBreakdown,
+	mockEmailDeviceBreakdown,
+	mockEmailClientBreakdown,
+	mockEmailLinkBreakdown,
+} from './email-breakdown';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -59,7 +59,8 @@ import {
 	mockEmailCountryBreakdown,
 	mockEmailDeviceBreakdown,
 	mockEmailClientBreakdown,
-	mockEmailLinkBreakdown,
+	mockEmailInternalLinkBreakdown,
+	mockEmailUserContentLinkBreakdown,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
@@ -895,8 +896,10 @@ function buildEmailBreakdownResponse( requestPath: string ): unknown {
 			return mockEmailDeviceBreakdown;
 		case 'client':
 			return mockEmailClientBreakdown;
+		case 'link':
+			return mockEmailInternalLinkBreakdown;
 		case 'user-content-link':
-			return mockEmailLinkBreakdown;
+			return mockEmailUserContentLinkBreakdown;
 		default:
 			return {};
 	}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -56,6 +56,10 @@ import {
 	mockStatsSummaryComparisonData,
 	mockStatsSubscribersCountsData,
 	buildEmailRateResponse,
+	mockEmailCountryBreakdown,
+	mockEmailDeviceBreakdown,
+	mockEmailClientBreakdown,
+	mockEmailLinkBreakdown,
 } from './data';
 import { getMockParamsFromPreset } from './presets';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
@@ -73,6 +77,8 @@ const STATS_SUBSCRIBERS_COUNTS_PATH = '/jetpack-premium-analytics/v1/proxy/v2/su
 const STATS_VISITS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/visits';
 const STATS_EMAIL_SUMMARY_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/emails/summary';
 const STATS_VIDEO_PLAYS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/video-plays';
+const STATS_EMAIL_OPENS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/opens/emails';
+const STATS_EMAIL_CLICKS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/clicks/emails';
 const WP_SETTINGS_PATH = '/wp/v2/settings';
 
 const coreSettingsMock = {
@@ -871,6 +877,32 @@ function buildEmailSummaryResponse() {
 }
 
 /**
+ * Builds a mock email breakdown response for the "Email breakdown" widget. The
+ * request path ends with the breakdown dimension
+ * (`.../stats/opens|clicks/emails/{id}/{breakdown}`), so the trailing segment
+ * selects the matching fieldless fixture. The endpoints have no comparison period.
+ *
+ * @param requestPath - The request path, used to read the breakdown dimension.
+ * @return Raw email breakdown response.
+ */
+function buildEmailBreakdownResponse( requestPath: string ): unknown {
+	const breakdown = requestPath.split( '?' )[ 0 ].split( '/' ).pop() ?? '';
+
+	switch ( breakdown ) {
+		case 'country':
+			return mockEmailCountryBreakdown;
+		case 'device':
+			return mockEmailDeviceBreakdown;
+		case 'client':
+			return mockEmailClientBreakdown;
+		case 'user-content-link':
+			return mockEmailLinkBreakdown;
+		default:
+			return {};
+	}
+}
+
+/**
  * Routes a Stats sub-path to the matching mock generator.
  *
  * @param subPath - Path relative to `STATS_API_BASE` (e.g. `/search-terms`).
@@ -1046,6 +1078,13 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 
 	if ( requestPath.startsWith( STATS_EMAIL_SUMMARY_PATH ) ) {
 		return buildEmailSummaryResponse();
+	}
+
+	if (
+		requestPath.startsWith( STATS_EMAIL_OPENS_PATH ) ||
+		requestPath.startsWith( STATS_EMAIL_CLICKS_PATH )
+	) {
+		return buildEmailBreakdownResponse( requestPath );
 	}
 
 	if ( requestPath.startsWith( STATS_VIDEO_PLAYS_PATH ) ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -78,8 +78,6 @@ const STATS_SUBSCRIBERS_COUNTS_PATH = '/jetpack-premium-analytics/v1/proxy/v2/su
 const STATS_VISITS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/visits';
 const STATS_EMAIL_SUMMARY_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/emails/summary';
 const STATS_VIDEO_PLAYS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/video-plays';
-const STATS_EMAIL_OPENS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/opens/emails';
-const STATS_EMAIL_CLICKS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/clicks/emails';
 const WP_SETTINGS_PATH = '/wp/v2/settings';
 
 const coreSettingsMock = {
@@ -923,6 +921,16 @@ function routeStatsReport( subPath: string ): unknown {
 		return buildEmailRateResponse( emailRate[ 1 ] as 'opens' | 'clicks' );
 	}
 
+	// Per-post email breakdowns: `/opens|clicks/emails/<postId>/<dimension>`. Matched here
+	// (after the `rate` case above) so the shared prefix can't swallow the rate endpoint.
+	if (
+		/^\/(?:opens|clicks)\/emails\/\d+\/(?:country|device|client|link|user-content-link)$/.test(
+			subPath
+		)
+	) {
+		return buildEmailBreakdownResponse( subPath );
+	}
+
 	switch ( subPath ) {
 		case '':
 			// Site summary — the bare `/stats` endpoint (all-time totals).
@@ -1081,13 +1089,6 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 
 	if ( requestPath.startsWith( STATS_EMAIL_SUMMARY_PATH ) ) {
 		return buildEmailSummaryResponse();
-	}
-
-	if (
-		requestPath.startsWith( STATS_EMAIL_OPENS_PATH ) ||
-		requestPath.startsWith( STATS_EMAIL_CLICKS_PATH )
-	) {
-		return buildEmailBreakdownResponse( requestPath );
 	}
 
 	if ( requestPath.startsWith( STATS_VIDEO_PLAYS_PATH ) ) {

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { queryClient } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { act, render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
@@ -77,7 +77,14 @@ describe( 'EmailBreakdownWidget', () => {
 	it( 'renders the opens-by-country breakdown for the selected email', async () => {
 		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
 
-		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries' } } /> );
+		render(
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'countries',
+				} }
+			/>
+		);
 
 		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'United Kingdom' ) ).toBeInTheDocument();
@@ -90,7 +97,13 @@ describe( 'EmailBreakdownWidget', () => {
 		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
 
 		render(
-			<EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries', metric: 'clicks' } } />
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'countries',
+					metric: 'clicks',
+				} }
+			/>
 		);
 
 		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
@@ -102,7 +115,14 @@ describe( 'EmailBreakdownWidget', () => {
 	it( 'merges internal link types with clicked links for the links view', async () => {
 		mockApiFetch.mockImplementation( linksViewFetchMock() );
 
-		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+		render(
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'links',
+				} }
+			/>
+		);
 
 		// User-content links render as external links opening in a new tab.
 		const link = await screen.findByRole( 'link', {
@@ -135,7 +155,14 @@ describe( 'EmailBreakdownWidget', () => {
 				: Promise.reject( { status: 403, message: 'Forbidden' } )
 		);
 
-		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+		render(
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'links',
+				} }
+			/>
+		);
 
 		await expect(
 			screen.findByText( /couldn't load this email's breakdown/ )
@@ -149,7 +176,14 @@ describe( 'EmailBreakdownWidget', () => {
 	it( 'keeps populated rows instead of the error state when a refetch fails', async () => {
 		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
 
-		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries' } } /> );
+		render(
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'countries',
+				} }
+			/>
+		);
 
 		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
 
@@ -180,7 +214,14 @@ describe( 'EmailBreakdownWidget', () => {
 			linksViewFetchMock( { 'user-content-links': { data: [ [ unsafeUrl, 99 ] ] } } )
 		);
 
-		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+		render(
+			<EmailBreakdownWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					view: 'links',
+				} }
+			/>
+		);
 
 		// The label still renders so the row is visible, but not as an anchor.
 		await expect( screen.findByText( unsafeUrl ) ).resolves.toBeInTheDocument();

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -122,6 +122,46 @@ describe( 'EmailBreakdownWidget', () => {
 		expect(
 			requestedPaths.some( path => path.includes( 'stats/clicks/emails/1234/user-content-link' ) )
 		).toBe( true );
+	} );
+
+	it( 'shows the error state when one of the two links-view queries fails on first load', async () => {
+		// The `link` breakdown fails (non-retryable 403 so React Query surfaces the
+		// error immediately) while `user-content-link` succeeds. Half a merged list
+		// with no error would silently hide the internal link types, so the widget
+		// must surface the error (with Retry) instead of the incomplete rows.
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			path.includes( '/user-content-link' )
+				? Promise.resolve( USER_CONTENT_LINKS_RESPONSE )
+				: Promise.reject( { status: 403, message: 'Forbidden' } )
+		);
+
+		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+
+		await expect(
+			screen.findByText( /couldn't load this email's breakdown/ )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: /https:\/\/example\.com\/spring-sale/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps populated rows instead of the error state when a refetch fails', async () => {
+		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
+
+		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries' } } /> );
+
+		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
+
+		// The next fetch fails, but the query already has data: the widget keeps
+		// showing the populated rows rather than swapping in the error state.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+		await act( async () => {
+			await queryClient.refetchQueries();
+		} );
+
+		expect( screen.getByText( 'United States' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /couldn't load this email's breakdown/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the empty state and makes no request without a selected email', async () => {

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import EmailBreakdownWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// Raw WPCOM fieldless all-time shapes the email breakdown sanitizer reads.
+const COUNTRY_RESPONSE = {
+	countries: {
+		data: [
+			[ 'US', 1840 ],
+			[ 'GB', 720 ],
+		],
+	},
+	'countries-info': {
+		US: { country_full: 'United States' },
+		GB: { country_full: 'United Kingdom' },
+	},
+};
+
+const LINK_RESPONSE = {
+	links: { data: [ [ 'post-url', 640 ] ] },
+	'user-content-links': { data: [ [ 'https://example.com/spring-sale', 512 ] ] },
+};
+
+describe( 'EmailBreakdownWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+	} );
+
+	it( 'renders the opens-by-country breakdown for the selected email', async () => {
+		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
+
+		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries' } } /> );
+
+		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'United Kingdom' ) ).toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/opens/emails/1234/country' );
+	} );
+
+	it( 'reads the clicks endpoint and renders clicked links for the links view', async () => {
+		mockApiFetch.mockResolvedValue( LINK_RESPONSE );
+
+		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+
+		// User-content links render as external links opening in a new tab.
+		const link = await screen.findByRole( 'link', {
+			name: /https:\/\/example\.com\/spring-sale/,
+		} );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/spring-sale' );
+		// Known internal link types are mapped to display labels.
+		expect( screen.getByText( 'Post URL' ) ).toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/clicks/emails/1234/user-content-link' );
+	} );
+
+	it( 'renders the empty state and makes no request without a selected email', async () => {
+		render( <EmailBreakdownWidget attributes={ { view: 'countries' } } /> );
+
+		await expect(
+			screen.findByText( 'No country data for this email yet.' )
+		).resolves.toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders an unsafe link protocol as plain text, never a clickable anchor', async () => {
+		// Built by concatenation so the literal does not trip the no-script-url lint rule.
+		const unsafeUrl = 'javascript' + ':alert(1)';
+		mockApiFetch.mockResolvedValue( {
+			links: { data: [] },
+			'user-content-links': { data: [ [ unsafeUrl, 99 ] ] },
+		} );
+
+		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
+
+		// The label still renders so the row is visible, but not as an anchor.
+		await expect( screen.findByText( unsafeUrl ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /alert/ } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -19,7 +19,9 @@ jest.mock( '@wordpress/route', () => ( {
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// Raw WPCOM fieldless all-time shapes the email breakdown sanitizer reads.
+// Raw WPCOM fieldless all-time shapes the email breakdown sanitizer reads. Each
+// per-breakdown endpoint returns only its own payload key, mirroring Calypso
+// fetching `link` and `user-content-link` separately and merging.
 const COUNTRY_RESPONSE = {
 	countries: {
 		data: [
@@ -33,10 +35,36 @@ const COUNTRY_RESPONSE = {
 	},
 };
 
-const LINK_RESPONSE = {
-	links: { data: [ [ 'post-url', 640 ] ] },
+const INTERNAL_LINKS_RESPONSE = {
+	links: {
+		data: [
+			[ 'post-url', 640 ],
+			[ 'some-other-internal', 22 ],
+		],
+	},
+};
+
+const USER_CONTENT_LINKS_RESPONSE = {
 	'user-content-links': { data: [ [ 'https://example.com/spring-sale', 512 ] ] },
 };
+
+/**
+ * Route a mocked links-view request to the fixture matching its breakdown path.
+ *
+ * @param userContentResponse - Response for the `user-content-link` breakdown.
+ * @param internalResponse    - Response for the `link` breakdown.
+ * @return The mock implementation for `apiFetch`.
+ */
+function linksViewFetchMock(
+	userContentResponse: unknown = USER_CONTENT_LINKS_RESPONSE,
+	internalResponse: unknown = INTERNAL_LINKS_RESPONSE
+) {
+	return ( { path }: { path: string } ) =>
+		// Match `user-content-link` first: a bare `/link` check would match it too.
+		Promise.resolve(
+			path.includes( '/user-content-link' ) ? userContentResponse : internalResponse
+		);
+}
 
 describe( 'EmailBreakdownWidget', () => {
 	beforeEach( () => {
@@ -58,8 +86,21 @@ describe( 'EmailBreakdownWidget', () => {
 		expect( requestedPath ).toContain( 'stats/opens/emails/1234/country' );
 	} );
 
-	it( 'reads the clicks endpoint and renders clicked links for the links view', async () => {
-		mockApiFetch.mockResolvedValue( LINK_RESPONSE );
+	it( 'reads the clicks endpoint for dimension views when metric is clicks', async () => {
+		mockApiFetch.mockResolvedValue( COUNTRY_RESPONSE );
+
+		render(
+			<EmailBreakdownWidget attributes={ { postId: 1234, view: 'countries', metric: 'clicks' } } />
+		);
+
+		await expect( screen.findByText( 'United States' ) ).resolves.toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/clicks/emails/1234/country' );
+	} );
+
+	it( 'merges internal link types with clicked links for the links view', async () => {
+		mockApiFetch.mockImplementation( linksViewFetchMock() );
 
 		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
 
@@ -68,18 +109,26 @@ describe( 'EmailBreakdownWidget', () => {
 			name: /https:\/\/example\.com\/spring-sale/,
 		} );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/spring-sale' );
-		// Known internal link types are mapped to display labels.
+		// Known internal link types are mapped to display labels; unknown ones are
+		// aggregated into "Other".
 		expect( screen.getByText( 'Post URL' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Other' ) ).toBeInTheDocument();
 
-		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
-		expect( requestedPath ).toContain( 'stats/clicks/emails/1234/user-content-link' );
+		// The links view fetches both clicks breakdowns, matching Calypso.
+		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );
+		expect(
+			requestedPaths.some( path => /stats\/clicks\/emails\/1234\/link(?:\?|$)/.test( path ) )
+		).toBe( true );
+		expect(
+			requestedPaths.some( path => path.includes( 'stats/clicks/emails/1234/user-content-link' ) )
+		).toBe( true );
 	} );
 
 	it( 'renders the empty state and makes no request without a selected email', async () => {
 		render( <EmailBreakdownWidget attributes={ { view: 'countries' } } /> );
 
 		await expect(
-			screen.findByText( 'No country data for this email yet.' )
+			screen.findByText( 'Select an email to see its breakdown.' )
 		).resolves.toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
@@ -87,10 +136,9 @@ describe( 'EmailBreakdownWidget', () => {
 	it( 'renders an unsafe link protocol as plain text, never a clickable anchor', async () => {
 		// Built by concatenation so the literal does not trip the no-script-url lint rule.
 		const unsafeUrl = 'javascript' + ':alert(1)';
-		mockApiFetch.mockResolvedValue( {
-			links: { data: [] },
-			'user-content-links': { data: [ [ unsafeUrl, 99 ] ] },
-		} );
+		mockApiFetch.mockImplementation(
+			linksViewFetchMock( { 'user-content-links': { data: [ [ unsafeUrl, 99 ] ] } } )
+		);
 
 		render( <EmailBreakdownWidget attributes={ { postId: 1234, view: 'links' } } /> );
 

--- a/projects/packages/premium-analytics/widgets/email-breakdown/package.json
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-email-breakdown",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
@@ -2,28 +2,28 @@
  * External dependencies
  */
 import {
-	useStatsEmailClicksBreakdown,
-	useStatsEmailOpensBreakdown,
-	type StatsEmailBreakdown,
-	type StatsEmailOpensBreakdown,
-} from '@jetpack-premium-analytics/data';
-import {
 	LeaderboardChart,
 	LeaderboardLabel,
-	WidgetLoadingOverlay,
 	WidgetRoot,
+	WidgetState,
 	flagUrl,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Link, Stack, Text } from '@wordpress/ui';
+import { envelope } from '@wordpress/icons';
+import { Link } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
-import { type EmailBreakdownAttributes, type EmailBreakdownView } from './widget';
+import useEmailBreakdownRows, { type EmailBreakdownRow } from './use-email-breakdown-rows';
+import {
+	type EmailBreakdownAttributes,
+	type EmailBreakdownMetric,
+	type EmailBreakdownView,
+} from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 type EmailBreakdownRenderAttributes = EmailBreakdownAttributes &
@@ -54,52 +54,6 @@ function safeHttpUrl( url: string | undefined ): string | null {
 }
 
 /**
- * Maps the `countries`/`devices`/`clients` views onto their email opens
- * breakdown dimension. The `links` view is intentionally excluded: it reads the
- * clicks breakdown instead (only clicked links exist) and is handled separately.
- */
-const VIEW_TO_OPENS_BREAKDOWN: Record<
-	Exclude< EmailBreakdownView, 'links' >,
-	StatsEmailOpensBreakdown
-> = {
-	countries: 'country',
-	devices: 'device',
-	clients: 'client',
-};
-
-/**
- * A single normalized breakdown row, flattened from the email breakdown report
- * into the shape the leaderboard renders. Exported so Storybook can build
- * fixtures for `EmailBreakdownLeaderboard`.
- */
-export type EmailBreakdownRow = {
-	/**
-	 * Stable identifier for the row (its index in the report).
-	 */
-	id: string | number;
-	/**
-	 * Display label (country/device/client name, or link URL).
-	 */
-	label: string;
-	/**
-	 * Metric value (opens or clicks) for the row.
-	 */
-	value: number;
-	/**
-	 * Two-letter country code, present only for the `countries` view.
-	 */
-	countryCode?: string;
-	/**
-	 * Full country name, present only for the `countries` view.
-	 */
-	countryFull?: string;
-	/**
-	 * External URL, present only for clicked user-content links (`links` view).
-	 */
-	link?: string;
-};
-
-/**
  * Maps normalized breakdown rows onto the shape `LeaderboardChart` expects.
  * Shares are relative to the highest value in the set so the top row always
  * fills. The breakdown endpoints return no comparison period, so the comparison
@@ -118,7 +72,7 @@ function buildLeaderboardData(
 ): LeaderboardChartData {
 	const maxValue = Math.max( ...rows.map( row => row.value ), 0 );
 
-	return rows.map( ( row, index ) => {
+	return rows.map( row => {
 		let label;
 
 		if ( view === 'countries' ) {
@@ -166,7 +120,7 @@ function buildLeaderboardData(
 		}
 
 		return {
-			id: `${ index }-${ row.id }`,
+			id: String( row.id ),
 			label,
 			currentValue: row.value,
 			currentShare: maxValue > 0 ? ( row.value / maxValue ) * 100 : 0,
@@ -209,28 +163,38 @@ type EmailBreakdownLeaderboardProps = {
 	 */
 	view?: EmailBreakdownView;
 	/**
-	 * When `true` and there are no rows yet, the full loading overlay is shown.
+	 * When `true` and there are no rows yet, the loading state is shown.
 	 */
 	isLoading?: boolean;
 	/**
-	 * When `true`, an in-place chart spinner is shown over existing rows during a
-	 * background refetch.
+	 * When `true`, a non-blocking busy overlay is shown over existing rows during
+	 * a background refetch.
 	 */
 	isFetching?: boolean;
 	/**
-	 * When `true`, an error message is rendered in place of the chart.
+	 * When `true`, the error state is rendered in place of the chart.
 	 */
 	isError?: boolean;
+	/**
+	 * Whether an email is selected; drives the empty-state copy when there are no
+	 * rows (`false` prompts to select an email instead of "no data yet").
+	 */
+	hasEmail?: boolean;
+	/**
+	 * Invoked by the error state's Retry action to re-run the queries.
+	 */
+	onRetry?: () => void;
 };
 
 /**
  * Presentational leaderboard for the "Email breakdown" widget. Lists a single
- * email's opens (or link clicks) broken down by the active view.
+ * email's opens (or clicks) broken down by the active view.
  *
- * Takes already-fetched rows and the active view via props and owns only the
- * loading, error, empty, and populated states. Exported so Storybook can
- * exercise those states with fixture rows (there is no analytics backend in
- * Storybook, so the data-connected entry point would only ever show chrome).
+ * Takes already-fetched rows and the active view via props and renders the
+ * loading, error, empty, and populated states through `WidgetState`. Exported so
+ * Storybook can exercise those states with fixture rows (there is no analytics
+ * backend in Storybook, so the data-connected entry point would only ever show
+ * chrome).
  *
  * @param {EmailBreakdownLeaderboardProps} props - The component props.
  * @return The rendered leaderboard.
@@ -241,102 +205,78 @@ export const EmailBreakdownLeaderboard = ( {
 	isLoading = false,
 	isFetching = false,
 	isError = false,
+	hasEmail = true,
+	onRetry,
 }: EmailBreakdownLeaderboardProps ) => {
 	const data = useMemo( () => buildLeaderboardData( rows, view ), [ rows, view ] );
 
-	let body;
-	if ( isError ) {
-		body = (
-			<Stack align="center" justify="center" className={ styles.placeholder }>
-				<Text>{ __( 'Unable to load email breakdown.', 'jetpack-premium-analytics' ) }</Text>
-			</Stack>
-		);
-	} else if ( isLoading && rows.length === 0 ) {
-		body = <WidgetLoadingOverlay />;
-	} else {
-		body = (
-			<LeaderboardChart
-				className={ styles.leaderboard }
-				data={ data }
-				loading={ isFetching }
-				withComparison={ false }
-				withOverlayLabel
-				showLegend={ false }
-				emptyStateText={ emptyStateText( view ) }
-				dataFormat={ DATA_FORMAT }
-			/>
-		);
-	}
-
-	return <div className={ styles.root }>{ body }</div>;
+	return (
+		<div className={ styles.root }>
+			<WidgetState
+				isLoading={ isLoading }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ rows.length === 0 }
+				error={ {
+					description: __(
+						"We couldn't load this email's breakdown. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: onRetry
+						? [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: onRetry } ]
+						: undefined,
+				} }
+				empty={ {
+					icon: envelope,
+					description: hasEmail
+						? emptyStateText( view )
+						: __( 'Select an email to see its breakdown.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<LeaderboardChart
+					className={ styles.leaderboard }
+					data={ data }
+					withComparison={ false }
+					withOverlayLabel
+					showLegend={ false }
+					dataFormat={ DATA_FORMAT }
+				/>
+			</WidgetState>
+		</div>
+	);
 };
-
-/**
- * Flatten the email breakdown report into the rows the leaderboard renders,
- * keeping the endpoint's (already value-sorted) order and trimming to `max`.
- *
- * @param report - The normalized breakdown report, or undefined while loading.
- * @param max    - Maximum rows to display; `0` keeps all rows.
- * @return The normalized breakdown rows.
- */
-function toRows( report: StatsEmailBreakdown | undefined, max: number ): EmailBreakdownRow[] {
-	const items = report?.data?.[ 0 ]?.items ?? [];
-
-	// `max = 0` means "all rows" (the Stats-widget convention), so only slice
-	// when a positive `max` is requested.
-	return items.slice( 0, max > 0 ? max : undefined ).map( ( item, index ) => ( {
-		id: index,
-		label: String( item.label ?? '' ),
-		value: item.value,
-		countryCode: item.countryCode,
-		countryFull: item.countryFull ? String( item.countryFull ) : undefined,
-		link: item.link,
-	} ) );
-}
 
 type EmailBreakdownReportProps = {
 	postId: number;
 	view: EmailBreakdownView;
+	metric: EmailBreakdownMetric;
 	max: number;
 };
 
 /**
- * Fetches the email breakdown report for the selected email and view, then hands
- * the normalized rows to the presentational `EmailBreakdownLeaderboard`.
- *
- * The `countries`/`devices`/`clients` views read the *opens* breakdown; the
- * `links` view reads the *clicks* breakdown. Both hooks are always called (rules
- * of hooks) but only the active one is enabled, so exactly one request is made.
+ * Fetches the email breakdown rows for the selected email, view, and metric,
+ * then hands them to the presentational `EmailBreakdownLeaderboard`.
  *
  * @param {EmailBreakdownReportProps} props - The component props.
  * @return The widget content.
  */
-function EmailBreakdownReport( { postId, view, max }: EmailBreakdownReportProps ) {
-	const isLinksView = view === 'links';
-	// The opens hook always runs (rules of hooks) but is disabled for the links
-	// view; `country` is an inert placeholder breakdown for that disabled case.
-	const opensBreakdown: StatsEmailOpensBreakdown =
-		view === 'links' ? 'country' : VIEW_TO_OPENS_BREAKDOWN[ view ];
-
-	const opens = useStatsEmailOpensBreakdown( postId, opensBreakdown, {
-		enabled: ! isLinksView,
+function EmailBreakdownReport( { postId, view, metric, max }: EmailBreakdownReportProps ) {
+	const { rows, isLoading, isFetching, isError, refetch } = useEmailBreakdownRows( {
+		postId,
+		view,
+		metric,
+		max,
 	} );
-	const clicks = useStatsEmailClicksBreakdown( postId, 'user-content-link', {
-		enabled: isLinksView,
-	} );
-
-	const active = isLinksView ? clicks : opens;
-	const report = active.data as StatsEmailBreakdown | undefined;
-
-	const rows = useMemo( () => toRows( report, max ), [ report, max ] );
 
 	return (
 		<EmailBreakdownLeaderboard
 			rows={ rows }
 			view={ view }
-			isLoading={ active.isLoading }
-			isFetching={ active.isFetching }
-			isError={ active.isError }
+			isLoading={ isLoading }
+			isFetching={ isFetching }
+			isError={ isError }
+			hasEmail={ postId > 0 }
+			onRetry={ refetch }
 		/>
 	);
 }
@@ -346,8 +286,9 @@ function EmailBreakdownReport( { postId, view, max }: EmailBreakdownReportProps 
  *
  * The breakdown is scoped to a single email via the `postId` attribute; the
  * `view` attribute (`relevance: 'high'`) is exposed as a control by the widget
- * host. The endpoints report across the whole lifetime of the email, so there is
- * no date range or comparison period — `reportParams` is still passed into
+ * host and the `metric` attribute picks opens or clicks for the dimension views.
+ * The endpoints report across the whole lifetime of the email, so there is no
+ * date range or comparison period — `reportParams` is still passed into
  * `WidgetRoot` so the host wiring stays consistent, but it is not used for data.
  *
  * @param {EmailBreakdownWidgetProps} props - The widget render props.
@@ -356,11 +297,12 @@ function EmailBreakdownReport( { postId, view, max }: EmailBreakdownReportProps 
 export default function EmailBreakdown( { attributes = {} }: EmailBreakdownWidgetProps ) {
 	const postId = attributes.postId ?? 0;
 	const view = attributes.view ?? 'countries';
+	const metric = attributes.metric ?? 'opens';
 	const max = attributes.max ?? 10;
 
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<EmailBreakdownReport postId={ postId } view={ view } max={ max } />
+			<EmailBreakdownReport postId={ postId } view={ view } metric={ metric } max={ max } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetRoot,
 	WidgetState,
 	flagUrl,
+	useWidgetRootContext,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
@@ -247,20 +248,39 @@ export const EmailBreakdownLeaderboard = ( {
 };
 
 type EmailBreakdownReportProps = {
-	postId: number;
 	view: EmailBreakdownView;
 	metric: EmailBreakdownMetric;
 	max: number;
 };
 
 /**
+ * Resolves the email's post ID from the host-composed report params. `post_id`
+ * is typed `string | number` (a string when it comes straight from the URL), so
+ * it is coerced to a positive integer; anything else yields `0`, which the
+ * widget treats as "no email selected".
+ *
+ * @param postId - The `post_id` report param.
+ * @return The email's post ID, or `0` when none is set.
+ */
+function toPostId( postId: string | number | undefined ): number {
+	const parsed = typeof postId === 'number' ? postId : Number.parseInt( postId ?? '', 10 );
+
+	return Number.isInteger( parsed ) && parsed > 0 ? parsed : 0;
+}
+
+/**
  * Fetches the email breakdown rows for the selected email, view, and metric,
- * then hands them to the presentational `EmailBreakdownLeaderboard`.
+ * then hands them to the presentational `EmailBreakdownLeaderboard`. The email
+ * is scoped by the host through `reportParams.post_id` — the shared
+ * single-resource "detail page" param — so the widget needs no id attribute.
  *
  * @param {EmailBreakdownReportProps} props - The component props.
  * @return The widget content.
  */
-function EmailBreakdownReport( { postId, view, metric, max }: EmailBreakdownReportProps ) {
+function EmailBreakdownReport( { view, metric, max }: EmailBreakdownReportProps ) {
+	const { reportParams } = useWidgetRootContext();
+	const postId = toPostId( reportParams.post_id );
+
 	const { rows, isLoading, isFetching, isError, refetch } = useEmailBreakdownRows( {
 		postId,
 		view,
@@ -284,25 +304,25 @@ function EmailBreakdownReport( { postId, view, metric, max }: EmailBreakdownRepo
 /**
  * Widget render entry point.
  *
- * The breakdown is scoped to a single email via the `postId` attribute; the
+ * The breakdown is scoped to a single email by the host through
+ * `reportParams.post_id` (the shared single-resource "detail page" param); the
  * `view` attribute (`relevance: 'high'`) is exposed as a control by the widget
  * host and the `metric` attribute picks opens or clicks for the dimension views.
- * The endpoints report across the whole lifetime of the email, so there is no
- * date range or comparison period — `reportParams` is still passed into
- * `WidgetRoot` so the host wiring stays consistent, but it is not used for data.
+ * The endpoints report across the whole lifetime of the email, so the date range
+ * and comparison period are ignored — `reportParams` is passed into `WidgetRoot`,
+ * which exposes it to the inner report, but only `post_id` is read from it.
  *
  * @param {EmailBreakdownWidgetProps} props - The widget render props.
  * @return The rendered widget.
  */
 export default function EmailBreakdown( { attributes = {} }: EmailBreakdownWidgetProps ) {
-	const postId = attributes.postId ?? 0;
 	const view = attributes.view ?? 'countries';
 	const metric = attributes.metric ?? 'opens';
 	const max = attributes.max ?? 10;
 
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<EmailBreakdownReport postId={ postId } view={ view } metric={ metric } max={ max } />
+			<EmailBreakdownReport view={ view } metric={ metric } max={ max } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
@@ -1,0 +1,366 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsEmailClicksBreakdown,
+	useStatsEmailOpensBreakdown,
+	type StatsEmailBreakdown,
+	type StatsEmailOpensBreakdown,
+} from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	LeaderboardLabel,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	flagUrl,
+	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Link, Stack, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import { type EmailBreakdownAttributes, type EmailBreakdownView } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type EmailBreakdownRenderAttributes = EmailBreakdownAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type EmailBreakdownWidgetProps = WidgetRenderProps< EmailBreakdownRenderAttributes >;
+
+const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
+
+/**
+ * Returns the URL only when it parses as an http(s) link, so remote link data
+ * cannot smuggle a clickable `javascript:`/`data:` protocol into an anchor.
+ *
+ * @param url - The candidate URL from remote breakdown data.
+ * @return The safe http(s) URL, or null when it is missing, unparseable, or a
+ *         non-http(s) protocol.
+ */
+function safeHttpUrl( url: string | undefined ): string | null {
+	if ( ! url ) {
+		return null;
+	}
+
+	try {
+		const { protocol } = new URL( url );
+		return protocol === 'http:' || protocol === 'https:' ? url : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Maps the `countries`/`devices`/`clients` views onto their email opens
+ * breakdown dimension. The `links` view is intentionally excluded: it reads the
+ * clicks breakdown instead (only clicked links exist) and is handled separately.
+ */
+const VIEW_TO_OPENS_BREAKDOWN: Record<
+	Exclude< EmailBreakdownView, 'links' >,
+	StatsEmailOpensBreakdown
+> = {
+	countries: 'country',
+	devices: 'device',
+	clients: 'client',
+};
+
+/**
+ * A single normalized breakdown row, flattened from the email breakdown report
+ * into the shape the leaderboard renders. Exported so Storybook can build
+ * fixtures for `EmailBreakdownLeaderboard`.
+ */
+export type EmailBreakdownRow = {
+	/**
+	 * Stable identifier for the row (its index in the report).
+	 */
+	id: string | number;
+	/**
+	 * Display label (country/device/client name, or link URL).
+	 */
+	label: string;
+	/**
+	 * Metric value (opens or clicks) for the row.
+	 */
+	value: number;
+	/**
+	 * Two-letter country code, present only for the `countries` view.
+	 */
+	countryCode?: string;
+	/**
+	 * Full country name, present only for the `countries` view.
+	 */
+	countryFull?: string;
+	/**
+	 * External URL, present only for clicked user-content links (`links` view).
+	 */
+	link?: string;
+};
+
+/**
+ * Maps normalized breakdown rows onto the shape `LeaderboardChart` expects.
+ * Shares are relative to the highest value in the set so the top row always
+ * fills. The breakdown endpoints return no comparison period, so the comparison
+ * fields are zeroed and the chart renders without deltas.
+ *
+ * The `countries` view renders a flag next to each label; the `links` view
+ * renders each row as an external link; other views render a plain label.
+ *
+ * @param rows - The normalized breakdown rows.
+ * @param view - The active breakdown view.
+ * @return The leaderboard chart data.
+ */
+function buildLeaderboardData(
+	rows: EmailBreakdownRow[],
+	view: EmailBreakdownView
+): LeaderboardChartData {
+	const maxValue = Math.max( ...rows.map( row => row.value ), 0 );
+
+	return rows.map( ( row, index ) => {
+		let label;
+
+		if ( view === 'countries' ) {
+			const imageUrl = row.countryCode ? flagUrl( row.countryCode ) : null;
+			label = (
+				<div className={ styles.label }>
+					<LeaderboardLabel
+						label={ row.label }
+						imageUrl={ imageUrl ?? undefined }
+						imageAlt={ sprintf(
+							/* translators: %s is the country name. */
+							__( 'Flag of %s', 'jetpack-premium-analytics' ),
+							row.countryFull ?? row.label
+						) }
+						imageClassName={ styles.flag }
+					/>
+				</div>
+			);
+		} else if ( view === 'links' ) {
+			// Link rows come from remote data, so only render an anchor for safe
+			// http(s) URLs; anything else (including internal link-type rows with no
+			// URL) falls back to a plain-text label.
+			const safeUrl = safeHttpUrl( row.link );
+			label = safeUrl ? (
+				<Link
+					className={ styles.labelLink }
+					href={ safeUrl }
+					variant="unstyled"
+					openInNewTab
+					title={ row.label }
+				>
+					{ row.label }
+				</Link>
+			) : (
+				<span className={ styles.labelText } title={ row.label }>
+					{ row.label }
+				</span>
+			);
+		} else {
+			label = (
+				<span className={ styles.labelText } title={ row.label }>
+					{ row.label }
+				</span>
+			);
+		}
+
+		return {
+			id: `${ index }-${ row.id }`,
+			label,
+			currentValue: row.value,
+			currentShare: maxValue > 0 ? ( row.value / maxValue ) * 100 : 0,
+			previousValue: 0,
+			previousShare: 0,
+			delta: 0,
+		};
+	} );
+}
+
+/**
+ * The per-view empty-state copy shown when the selected email has no data for
+ * the active breakdown.
+ *
+ * @param view - The active breakdown view.
+ * @return The empty-state text.
+ */
+function emptyStateText( view: EmailBreakdownView ): string {
+	switch ( view ) {
+		case 'devices':
+			return __( 'No device data for this email yet.', 'jetpack-premium-analytics' );
+		case 'clients':
+			return __( 'No email client data for this email yet.', 'jetpack-premium-analytics' );
+		case 'links':
+			return __( 'No link clicks for this email yet.', 'jetpack-premium-analytics' );
+		case 'countries':
+		default:
+			return __( 'No country data for this email yet.', 'jetpack-premium-analytics' );
+	}
+}
+
+type EmailBreakdownLeaderboardProps = {
+	/**
+	 * Normalized breakdown rows to render. When omitted, the empty state is shown
+	 * (unless `isLoading` is set).
+	 */
+	rows?: EmailBreakdownRow[];
+	/**
+	 * The active breakdown view; drives the label rendering and empty-state copy.
+	 */
+	view?: EmailBreakdownView;
+	/**
+	 * When `true` and there are no rows yet, the full loading overlay is shown.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, an in-place chart spinner is shown over existing rows during a
+	 * background refetch.
+	 */
+	isFetching?: boolean;
+	/**
+	 * When `true`, an error message is rendered in place of the chart.
+	 */
+	isError?: boolean;
+};
+
+/**
+ * Presentational leaderboard for the "Email breakdown" widget. Lists a single
+ * email's opens (or link clicks) broken down by the active view.
+ *
+ * Takes already-fetched rows and the active view via props and owns only the
+ * loading, error, empty, and populated states. Exported so Storybook can
+ * exercise those states with fixture rows (there is no analytics backend in
+ * Storybook, so the data-connected entry point would only ever show chrome).
+ *
+ * @param {EmailBreakdownLeaderboardProps} props - The component props.
+ * @return The rendered leaderboard.
+ */
+export const EmailBreakdownLeaderboard = ( {
+	rows = [],
+	view = 'countries',
+	isLoading = false,
+	isFetching = false,
+	isError = false,
+}: EmailBreakdownLeaderboardProps ) => {
+	const data = useMemo( () => buildLeaderboardData( rows, view ), [ rows, view ] );
+
+	let body;
+	if ( isError ) {
+		body = (
+			<Stack align="center" justify="center" className={ styles.placeholder }>
+				<Text>{ __( 'Unable to load email breakdown.', 'jetpack-premium-analytics' ) }</Text>
+			</Stack>
+		);
+	} else if ( isLoading && rows.length === 0 ) {
+		body = <WidgetLoadingOverlay />;
+	} else {
+		body = (
+			<LeaderboardChart
+				className={ styles.leaderboard }
+				data={ data }
+				loading={ isFetching }
+				withComparison={ false }
+				withOverlayLabel
+				showLegend={ false }
+				emptyStateText={ emptyStateText( view ) }
+				dataFormat={ DATA_FORMAT }
+			/>
+		);
+	}
+
+	return <div className={ styles.root }>{ body }</div>;
+};
+
+/**
+ * Flatten the email breakdown report into the rows the leaderboard renders,
+ * keeping the endpoint's (already value-sorted) order and trimming to `max`.
+ *
+ * @param report - The normalized breakdown report, or undefined while loading.
+ * @param max    - Maximum rows to display; `0` keeps all rows.
+ * @return The normalized breakdown rows.
+ */
+function toRows( report: StatsEmailBreakdown | undefined, max: number ): EmailBreakdownRow[] {
+	const items = report?.data?.[ 0 ]?.items ?? [];
+
+	// `max = 0` means "all rows" (the Stats-widget convention), so only slice
+	// when a positive `max` is requested.
+	return items.slice( 0, max > 0 ? max : undefined ).map( ( item, index ) => ( {
+		id: index,
+		label: String( item.label ?? '' ),
+		value: item.value,
+		countryCode: item.countryCode,
+		countryFull: item.countryFull ? String( item.countryFull ) : undefined,
+		link: item.link,
+	} ) );
+}
+
+type EmailBreakdownReportProps = {
+	postId: number;
+	view: EmailBreakdownView;
+	max: number;
+};
+
+/**
+ * Fetches the email breakdown report for the selected email and view, then hands
+ * the normalized rows to the presentational `EmailBreakdownLeaderboard`.
+ *
+ * The `countries`/`devices`/`clients` views read the *opens* breakdown; the
+ * `links` view reads the *clicks* breakdown. Both hooks are always called (rules
+ * of hooks) but only the active one is enabled, so exactly one request is made.
+ *
+ * @param {EmailBreakdownReportProps} props - The component props.
+ * @return The widget content.
+ */
+function EmailBreakdownReport( { postId, view, max }: EmailBreakdownReportProps ) {
+	const isLinksView = view === 'links';
+	// The opens hook always runs (rules of hooks) but is disabled for the links
+	// view; `country` is an inert placeholder breakdown for that disabled case.
+	const opensBreakdown: StatsEmailOpensBreakdown =
+		view === 'links' ? 'country' : VIEW_TO_OPENS_BREAKDOWN[ view ];
+
+	const opens = useStatsEmailOpensBreakdown( postId, opensBreakdown, {
+		enabled: ! isLinksView,
+	} );
+	const clicks = useStatsEmailClicksBreakdown( postId, 'user-content-link', {
+		enabled: isLinksView,
+	} );
+
+	const active = isLinksView ? clicks : opens;
+	const report = active.data as StatsEmailBreakdown | undefined;
+
+	const rows = useMemo( () => toRows( report, max ), [ report, max ] );
+
+	return (
+		<EmailBreakdownLeaderboard
+			rows={ rows }
+			view={ view }
+			isLoading={ active.isLoading }
+			isFetching={ active.isFetching }
+			isError={ active.isError }
+		/>
+	);
+}
+
+/**
+ * Widget render entry point.
+ *
+ * The breakdown is scoped to a single email via the `postId` attribute; the
+ * `view` attribute (`relevance: 'high'`) is exposed as a control by the widget
+ * host. The endpoints report across the whole lifetime of the email, so there is
+ * no date range or comparison period — `reportParams` is still passed into
+ * `WidgetRoot` so the host wiring stays consistent, but it is not used for data.
+ *
+ * @param {EmailBreakdownWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function EmailBreakdown( { attributes = {} }: EmailBreakdownWidgetProps ) {
+	const postId = attributes.postId ?? 0;
+	const view = attributes.view ?? 'countries';
+	const max = attributes.max ?? 10;
+
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<EmailBreakdownReport postId={ postId } view={ view } max={ max } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -6,8 +6,8 @@
  * `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
  * as it does in product.
  *
- * The breakdown is scoped to a single email via a mocked `postId`. These endpoints
- * report over the whole lifetime of the email and return no comparison period, so
+ * The breakdown is scoped to a single email via a mocked `reportParams.post_id`. These
+ * endpoints report over the whole lifetime of the email and return no comparison period, so
  * the `WithComparison` story still renders without deltas — it only verifies the
  * widget stays graceful when the date picker injects comparison `reportParams`.
  */
@@ -77,8 +77,7 @@ function renderEmailBreakdown( { withComparison, view, metric }: EmailBreakdownS
 	return (
 		<EmailBreakdownRender
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-				postId: MOCK_EMAIL_ID,
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
 				view,
 				metric,
 			} }
@@ -95,8 +94,7 @@ function renderEmailBreakdownForState( postId: number ) {
 	return (
 		<EmailBreakdownRender
 			attributes={ {
-				reportParams: getDefaultQueryParams( false ),
-				postId,
+				reportParams: { ...getDefaultQueryParams( false ), post_id: postId },
 				view: 'countries',
 				metric: 'opens',
 			} }
@@ -124,7 +122,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `postId`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
+					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `reportParams.post_id`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
 			},
 		},
 	},
@@ -199,8 +197,8 @@ export const Empty: Story = {
 };
 
 /**
- * No email selected: `postId` is unset, so no request is made and the empty
- * state prompts to select an email instead of "no data yet".
+ * No email selected: `reportParams.post_id` is unset, so no request is made and
+ * the empty state prompts to select an email instead of "no data yet".
  */
 export const NoEmailSelected: Story = {
 	render: () => (
@@ -228,8 +226,7 @@ function EmailBreakdownDashboardStory( {
 			renderModule={ EMAIL_BREAKDOWN_RENDER_MODULE }
 			renderComponent={ EmailBreakdownRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
-				postId: MOCK_EMAIL_ID,
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
 				view,
 				metric,
 			} }

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -43,8 +43,25 @@ const EMAIL_BREAKDOWN_RENDER_MODULE = 'storybook/email-breakdown';
 // A representative email whose breakdown the mocks return data for.
 const MOCK_EMAIL_ID = 1234;
 
-const VIEW_OPTIONS: EmailBreakdownView[] = [ 'countries', 'devices', 'clients', 'links' ];
-const METRIC_OPTIONS: EmailBreakdownMetric[] = [ 'opens', 'clicks' ];
+/**
+ * Read an attribute's declared element values off the widget definition, so the
+ * story controls always mirror the schema (a newly added view or metric shows
+ * up as a control option without touching this file).
+ *
+ * @param id - The attribute id on the widget definition.
+ * @return The attribute's element values.
+ */
+function attributeElementValues< Value extends string >( id: string ): Value[] {
+	return (
+		widgetDefinition.attributes
+			.find( attribute => attribute.id === id )
+			?.elements?.map( element => element.value as Value ) ?? []
+	);
+}
+
+const VIEW_OPTIONS: EmailBreakdownView[] = attributeElementValues< EmailBreakdownView >( 'view' );
+const METRIC_OPTIONS: EmailBreakdownMetric[] =
+	attributeElementValues< EmailBreakdownMetric >( 'metric' );
 
 /**
  * Widget-specific controls: the comparison toggle, the breakdown view, and the

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -1,8 +1,9 @@
 /**
- * The stories mount the data-connected "Email breakdown" widget; a mocked
- * `stats/opens/emails/{id}/{breakdown}` (and `stats/clicks/emails/{id}/{breakdown}`
- * for links) response from `registerReportMocks` supplies populated rows for each
- * view. `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
+ * The stories mount the data-connected "Email breakdown" widget; mocked
+ * `stats/opens|clicks/emails/{id}/{breakdown}` responses from
+ * `registerReportMocks` supply populated rows for each view and metric (the
+ * links view merges the `link` and `user-content-link` breakdowns).
+ * `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
  * as it does in product.
  *
  * The breakdown is scoped to a single email via a mocked `postId`. These endpoints
@@ -27,7 +28,7 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import EmailBreakdownRender from '../render';
 import widgetDefinition from '../widget';
-import type { EmailBreakdownView } from '../widget';
+import type { EmailBreakdownMetric, EmailBreakdownView } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -40,22 +41,26 @@ const EMAIL_BREAKDOWN_RENDER_MODULE = 'storybook/email-breakdown';
 const MOCK_EMAIL_ID = 1234;
 
 const VIEW_OPTIONS: EmailBreakdownView[] = [ 'countries', 'devices', 'clients', 'links' ];
+const METRIC_OPTIONS: EmailBreakdownMetric[] = [ 'opens', 'clicks' ];
 
 /**
- * Widget-specific controls: the comparison toggle and the breakdown view.
+ * Widget-specific controls: the comparison toggle, the breakdown view, and the
+ * opens/clicks metric for the dimension views.
  */
 interface EmailBreakdownStoryControls {
 	withComparison: boolean;
 	view: EmailBreakdownView;
+	metric: EmailBreakdownMetric;
 }
 
-function renderEmailBreakdown( { withComparison, view }: EmailBreakdownStoryControls ) {
+function renderEmailBreakdown( { withComparison, view, metric }: EmailBreakdownStoryControls ) {
 	return (
 		<EmailBreakdownRender
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
 				postId: MOCK_EMAIL_ID,
 				view,
+				metric,
 			} }
 		/>
 	);
@@ -75,12 +80,13 @@ const meta = {
 	argTypes: {
 		withComparison: { control: 'boolean' },
 		view: { control: 'select', options: VIEW_OPTIONS },
+		metric: { control: 'select', options: METRIC_OPTIONS },
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; `countries`/`devices`/`clients` read the email opens breakdown and `links` reads the clicks breakdown. Scoped to one email via a mocked `postId`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
+					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `postId`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
 			},
 		},
 	},
@@ -96,7 +102,7 @@ type Story = StoryObj< EmailBreakdownStoryControls >;
  */
 export const Default: Story = {
 	render: renderEmailBreakdown,
-	args: { withComparison: false, view: 'countries' },
+	args: { withComparison: false, view: 'countries', metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -106,7 +112,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderEmailBreakdown,
-	args: { withComparison: true, view: 'countries' },
+	args: { withComparison: true, view: 'countries', metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -117,6 +123,7 @@ interface EmailBreakdownDashboardStoryProps
 function EmailBreakdownDashboardStory( {
 	withComparison,
 	view,
+	metric,
 	...dashboardArgs
 }: EmailBreakdownDashboardStoryProps ) {
 	return (
@@ -129,6 +136,7 @@ function EmailBreakdownDashboardStory( {
 				reportParams: getDefaultQueryParams( withComparison ),
 				postId: MOCK_EMAIL_ID,
 				view,
+				metric,
 			} }
 		/>
 	);
@@ -140,10 +148,12 @@ export const WidgetDashboardWithWidget: StoryObj< EmailBreakdownDashboardStoryPr
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
 		view: 'countries',
+		metric: 'opens',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
 		view: { control: 'select', options: VIEW_OPTIONS },
+		metric: { control: 'select', options: METRIC_OPTIONS },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -18,7 +18,10 @@ import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -61,6 +64,24 @@ function renderEmailBreakdown( { withComparison, view, metric }: EmailBreakdownS
 				postId: MOCK_EMAIL_ID,
 				view,
 				metric,
+			} }
+		/>
+	);
+}
+
+// Renders the widget against a distinct email ID. The breakdown endpoints take
+// no date params, so (unlike the date-preset trick other widgets use) a unique
+// email ID is what gives the forced-state stories their own cache entry — they
+// hit the mock fresh instead of reading another story's cached success from the
+// shared query client.
+function renderEmailBreakdownForState( postId: number ) {
+	return (
+		<EmailBreakdownRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( false ),
+				postId,
+				view: 'countries',
+				metric: 'opens',
 			} }
 		/>
 	);
@@ -113,6 +134,63 @@ export const Default: Story = {
 export const WithComparison: Story = {
 	render: renderEmailBreakdown,
 	args: { withComparison: true, view: 'countries', metric: 'opens' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderEmailBreakdownForState( 5601 ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/opens/emails', 'loading' );
+		return () => setReportMockState( 'stats/opens/emails', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderEmailBreakdownForState( 5602 ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/opens/emails', 'error' );
+		return () => setReportMockState( 'stats/opens/emails', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the envelope glyph
+ * and the per-view "no data yet" copy).
+ */
+export const Empty: Story = {
+	render: () => renderEmailBreakdownForState( 5603 ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/opens/emails', 'empty' );
+		return () => setReportMockState( 'stats/opens/emails', null );
+	},
+};
+
+/**
+ * No email selected: `postId` is unset, so no request is made and the empty
+ * state prompts to select an email instead of "no data yet".
+ */
+export const NoEmailSelected: Story = {
+	render: () => (
+		<EmailBreakdownRender
+			attributes={ { reportParams: getDefaultQueryParams( false ), view: 'countries' } }
+		/>
+	),
 	decorators: [ withWidgetCanvas ],
 };
 

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -1,0 +1,149 @@
+/**
+ * The stories mount the data-connected "Email breakdown" widget; a mocked
+ * `stats/opens/emails/{id}/{breakdown}` (and `stats/clicks/emails/{id}/{breakdown}`
+ * for links) response from `registerReportMocks` supplies populated rows for each
+ * view. `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
+ * as it does in product.
+ *
+ * The breakdown is scoped to a single email via a mocked `postId`. These endpoints
+ * report over the whole lifetime of the email and return no comparison period, so
+ * the `WithComparison` story still renders without deltas — it only verifies the
+ * widget stays graceful when the date picker injects comparison `reportParams`.
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import EmailBreakdownRender from '../render';
+import widgetDefinition from '../widget';
+import type { EmailBreakdownView } from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const EMAIL_BREAKDOWN_RENDER_MODULE = 'storybook/email-breakdown';
+
+// A representative email whose breakdown the mocks return data for.
+const MOCK_EMAIL_ID = 1234;
+
+const VIEW_OPTIONS: EmailBreakdownView[] = [ 'countries', 'devices', 'clients', 'links' ];
+
+/**
+ * Widget-specific controls: the comparison toggle and the breakdown view.
+ */
+interface EmailBreakdownStoryControls {
+	withComparison: boolean;
+	view: EmailBreakdownView;
+}
+
+function renderEmailBreakdown( { withComparison, view }: EmailBreakdownStoryControls ) {
+	return (
+		<EmailBreakdownRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				postId: MOCK_EMAIL_ID,
+				view,
+			} }
+		/>
+	);
+}
+
+// Close-up canvas so the chart fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '320px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/EmailBreakdown',
+	component: EmailBreakdownRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+		view: { control: 'select', options: VIEW_OPTIONS },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; `countries`/`devices`/`clients` read the email opens breakdown and `links` reads the clicks breakdown. Scoped to one email via a mocked `postId`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
+			},
+		},
+	},
+	decorators: [ withChartTheme ],
+} satisfies Meta< ComponentProps< typeof EmailBreakdownRender > & EmailBreakdownStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< EmailBreakdownStoryControls >;
+
+/**
+ * Default populated state — the selected email broken down by country.
+ */
+export const Default: Story = {
+	render: renderEmailBreakdown,
+	args: { withComparison: false, view: 'countries' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison `reportParams` from the date picker. The breakdown endpoints return
+ * no comparison rows, so the widget renders normally without deltas.
+ */
+export const WithComparison: Story = {
+	render: renderEmailBreakdown,
+	args: { withComparison: true, view: 'countries' },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface EmailBreakdownDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		EmailBreakdownStoryControls {}
+
+function EmailBreakdownDashboardStory( {
+	withComparison,
+	view,
+	...dashboardArgs
+}: EmailBreakdownDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			renderModule={ EMAIL_BREAKDOWN_RENDER_MODULE }
+			renderComponent={ EmailBreakdownRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				postId: MOCK_EMAIL_ID,
+				view,
+			} }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< EmailBreakdownDashboardStoryProps > = {
+	render: args => <EmailBreakdownDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+		view: 'countries',
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+		view: { control: 'select', options: VIEW_OPTIONS },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/email-breakdown/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/style.module.css
@@ -64,11 +64,3 @@
 .labelLink:focus {
 	text-decoration: underline;
 }
-
-.placeholder {
-	flex: 1 1 0;
-	inline-size: 100%;
-	min-block-size: 200px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
-	text-align: center;
-}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/style.module.css
@@ -1,0 +1,74 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-block-size: 0;
+	overflow: hidden;
+}
+
+.leaderboard {
+	flex: 1 1 0;
+	min-inline-size: 0;
+	min-block-size: 0;
+	overflow: hidden;
+}
+
+/* Country rows: wrap the flag + name label so it fills the row and the overlay
+   bar gets a stable 36px height. */
+.label {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	min-height: 36px;
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+}
+
+.label > * {
+	min-width: 0;
+	max-width: 100%;
+}
+
+.flag {
+	height: 20px;
+	border-radius: var(--wpds-border-radius-sm, 2px);
+}
+
+/* Plain text rows (devices, clients). Vertical padding sets the overlay bar
+   height; the inline padding insets the text from the bar's left edge. */
+.labelText {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Link rows (clicked links) render as external links; mirror the chart's
+   overlay-label padding so the row height matches the other views. */
+.labelLink {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.labelLink:hover,
+.labelLink:focus {
+	text-decoration: underline;
+}
+
+.placeholder {
+	flex: 1 1 0;
+	inline-size: 100%;
+	min-block-size: 200px;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-align: center;
+}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
@@ -1,0 +1,204 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsEmailClicksBreakdown,
+	useStatsEmailOpensBreakdown,
+	type StatsEmailBreakdown,
+	type StatsEmailOpensBreakdown,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { type EmailBreakdownMetric, type EmailBreakdownView } from './widget';
+
+/**
+ * A single normalized breakdown row, flattened from the email breakdown report
+ * into the shape the leaderboard renders. Exported so Storybook can build
+ * fixtures for `EmailBreakdownLeaderboard`.
+ */
+export type EmailBreakdownRow = {
+	/**
+	 * Stable identifier for the row (its index in the displayed list).
+	 */
+	id: number;
+	/**
+	 * Display label (country/device/client name, link type, or link URL).
+	 */
+	label: string;
+	/**
+	 * Metric value (opens or clicks) for the row.
+	 */
+	value: number;
+	/**
+	 * Two-letter country code, present only for the `countries` view.
+	 */
+	countryCode?: string;
+	/**
+	 * Full country name, present only for the `countries` view.
+	 */
+	countryFull?: string;
+	/**
+	 * External URL, present only for clicked user-content links (`links` view).
+	 */
+	link?: string;
+};
+
+/**
+ * Maps the `countries`/`devices`/`clients` views onto their breakdown dimension.
+ * The `links` view is intentionally excluded: it merges the `link` and
+ * `user-content-link` clicks breakdowns instead and is handled separately.
+ */
+const VIEW_TO_BREAKDOWN: Record<
+	Exclude< EmailBreakdownView, 'links' >,
+	StatsEmailOpensBreakdown
+> = {
+	countries: 'country',
+	devices: 'device',
+	clients: 'client',
+};
+
+/**
+ * Flatten the email breakdown report into leaderboard rows, keeping the
+ * report's (already value-sorted) order.
+ *
+ * @param report - The normalized breakdown report, or undefined while loading.
+ * @return The breakdown rows, without display ids.
+ */
+function toRows( report: StatsEmailBreakdown | undefined ): Omit< EmailBreakdownRow, 'id' >[] {
+	const items = report?.data?.[ 0 ]?.items ?? [];
+
+	return items.map( item => ( {
+		label: String( item.label ?? '' ),
+		value: item.value,
+		countryCode: item.countryCode,
+		countryFull: item.countryFull ? String( item.countryFull ) : undefined,
+		link: item.link,
+	} ) );
+}
+
+/**
+ * Sort merged rows by value, keeping the aggregated "Other" row last — the same
+ * order the data layer's sanitizer applies within a single report.
+ *
+ * @param rows - The rows to sort.
+ * @return The sorted rows.
+ */
+function sortRows( rows: Omit< EmailBreakdownRow, 'id' >[] ): Omit< EmailBreakdownRow, 'id' >[] {
+	return [ ...rows ].sort( ( a, b ) => {
+		if ( a.label === 'Other' ) {
+			return 1;
+		}
+
+		if ( b.label === 'Other' ) {
+			return -1;
+		}
+
+		return b.value - a.value;
+	} );
+}
+
+type UseEmailBreakdownRowsArgs = {
+	/**
+	 * The email (post) ID whose breakdown to fetch; `0`/invalid disables fetching.
+	 */
+	postId: number;
+	/**
+	 * The active breakdown view.
+	 */
+	view: EmailBreakdownView;
+	/**
+	 * Whether the dimension views read the opens or the clicks breakdown. The
+	 * `links` view ignores this and always reads clicks (only clicked links exist).
+	 */
+	metric: EmailBreakdownMetric;
+	/**
+	 * Maximum rows to return; `0` keeps all rows.
+	 */
+	max: number;
+};
+
+type EmailBreakdownRowsState = {
+	rows: EmailBreakdownRow[];
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	refetch: () => void;
+};
+
+/**
+ * Fetch and normalize the email breakdown rows for the active view via the
+ * shared Stats data layer.
+ *
+ * The `countries`/`devices`/`clients` views read the opens or clicks breakdown
+ * per `metric`, matching the Calypso email detail page where the modules follow
+ * the active Opens/Clicks tab. The `links` view mirrors Calypso's links module:
+ * it fetches both the `link` breakdown (internal link types — Post URL, Like,
+ * Comment, Unsubscribe, aggregated Other) and the `user-content-link` breakdown
+ * (clicked user-content URLs) and merges them into one value-sorted list.
+ *
+ * All hooks always run (rules of hooks) but only the queries the active view and
+ * metric need are enabled; `country` is an inert placeholder dimension for the
+ * links view's disabled dimension queries.
+ *
+ * @param {UseEmailBreakdownRowsArgs} args - Hook arguments.
+ * @return The current rows/loading/error state.
+ */
+export default function useEmailBreakdownRows( {
+	postId,
+	view,
+	metric,
+	max,
+}: UseEmailBreakdownRowsArgs ): EmailBreakdownRowsState {
+	const isLinksView = view === 'links';
+	const dimension = isLinksView ? 'country' : VIEW_TO_BREAKDOWN[ view ];
+
+	const opens = useStatsEmailOpensBreakdown( postId, dimension, {
+		enabled: ! isLinksView && metric === 'opens',
+	} );
+	const clicks = useStatsEmailClicksBreakdown( postId, dimension, {
+		enabled: ! isLinksView && metric === 'clicks',
+	} );
+	const internalLinks = useStatsEmailClicksBreakdown( postId, 'link', {
+		enabled: isLinksView,
+	} );
+	const userContentLinks = useStatsEmailClicksBreakdown( postId, 'user-content-link', {
+		enabled: isLinksView,
+	} );
+
+	const dimensionQuery = metric === 'clicks' ? clicks : opens;
+	const activeQueries = isLinksView ? [ internalLinks, userContentLinks ] : [ dimensionQuery ];
+
+	const internalLinksReport = internalLinks.data as StatsEmailBreakdown | undefined;
+	const userContentLinksReport = userContentLinks.data as StatsEmailBreakdown | undefined;
+	const dimensionReport = dimensionQuery.data as StatsEmailBreakdown | undefined;
+
+	const rows = useMemo( () => {
+		const merged = isLinksView
+			? // Keep internal-type rows (no URL) from `link` and URL rows from
+			  // `user-content-link`, so a row can never be double-counted if an
+			  // endpoint ever answers with both payloads.
+			  sortRows( [
+					...toRows( internalLinksReport ).filter( row => ! row.link ),
+					...toRows( userContentLinksReport ).filter( row => Boolean( row.link ) ),
+			  ] )
+			: toRows( dimensionReport );
+
+		// `max = 0` means "all rows" (the Stats-widget convention), so only slice
+		// when a positive `max` is requested.
+		return merged
+			.slice( 0, max > 0 ? max : undefined )
+			.map( ( row, index ) => ( { ...row, id: index } ) );
+	}, [ isLinksView, internalLinksReport, userContentLinksReport, dimensionReport, max ] );
+
+	return {
+		rows,
+		isLoading: activeQueries.some( query => query.isLoading ),
+		isFetching: activeQueries.some( query => query.isFetching ),
+		// Surface the error only when there are no rows to show, so a transient
+		// refetch failure doesn't replace populated rows with the error state.
+		isError: rows.length === 0 && activeQueries.some( query => query.isError ),
+		refetch: () => activeQueries.forEach( query => query.refetch() ),
+	};
+}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	compareEmailBreakdownItems,
 	useStatsEmailClicksBreakdown,
 	useStatsEmailOpensBreakdown,
 	type StatsEmailBreakdown,
@@ -76,27 +77,6 @@ function toRows( report: StatsEmailBreakdown | undefined ): Omit< EmailBreakdown
 		countryFull: item.countryFull ? String( item.countryFull ) : undefined,
 		link: item.link,
 	} ) );
-}
-
-/**
- * Sort merged rows by value, keeping the aggregated "Other" row last — the same
- * order the data layer's sanitizer applies within a single report.
- *
- * @param rows - The rows to sort.
- * @return The sorted rows.
- */
-function sortRows( rows: Omit< EmailBreakdownRow, 'id' >[] ): Omit< EmailBreakdownRow, 'id' >[] {
-	return [ ...rows ].sort( ( a, b ) => {
-		if ( a.label === 'Other' ) {
-			return 1;
-		}
-
-		if ( b.label === 'Other' ) {
-			return -1;
-		}
-
-		return b.value - a.value;
-	} );
 }
 
 type UseEmailBreakdownRowsArgs = {
@@ -178,11 +158,12 @@ export default function useEmailBreakdownRows( {
 		const merged = isLinksView
 			? // Keep internal-type rows (no URL) from `link` and URL rows from
 			  // `user-content-link`, so a row can never be double-counted if an
-			  // endpoint ever answers with both payloads.
-			  sortRows( [
+			  // endpoint ever answers with both payloads. Re-sorting with the data
+			  // layer's comparator restores the single-report order across the merge.
+			  [
 					...toRows( internalLinksReport ).filter( row => ! row.link ),
 					...toRows( userContentLinksReport ).filter( row => Boolean( row.link ) ),
-			  ] )
+			  ].sort( compareEmailBreakdownItems )
 			: toRows( dimensionReport );
 
 		// `max = 0` means "all rows" (the Stats-widget convention), so only slice

--- a/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
@@ -177,9 +177,12 @@ export default function useEmailBreakdownRows( {
 		rows,
 		isLoading: activeQueries.some( query => query.isLoading ),
 		isFetching: activeQueries.some( query => query.isFetching ),
-		// Surface the error only when there are no rows to show, so a transient
-		// refetch failure doesn't replace populated rows with the error state.
-		isError: rows.length === 0 && activeQueries.some( query => query.isError ),
+		// A query that failed before ever returning data leaves its part of the
+		// view missing (for the links view, one of the two merged breakdowns), so
+		// surface the error even when another query produced rows. Once a query
+		// has data, a transient refetch failure keeps showing the populated rows
+		// instead of replacing them with the error state.
+		isError: activeQueries.some( query => query.isError && query.data === undefined ),
 		refetch: () => activeQueries.forEach( query => query.refetch() ),
 	};
 }

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/email-breakdown",
+	"title": "Email breakdown",
+	"description": "Breaks a sent email down by countries, devices, email clients, or clicked links.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -96,6 +96,9 @@ export default {
 					value: 'clicks',
 				},
 			],
+			// The `links` view always reads the clicks breakdown, so the opens/clicks
+			// metric has no effect there — hide the control to keep it from looking live.
+			isVisible: ( { view } ) => view !== 'links',
 		},
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -8,11 +8,17 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Which breakdown dimension the widget lists for the selected email.
  *
- * `countries`, `devices`, and `clients` read the email *opens* breakdown; `links`
- * reads the *clicks* breakdown (only clicked links exist), so the view selector
- * also picks the underlying opens/clicks endpoint. See `render.tsx`.
+ * `countries`, `devices`, and `clients` read the opens or clicks breakdown per
+ * the `metric` attribute; `links` always reads the *clicks* breakdown (only
+ * clicked links exist). See `use-email-breakdown-rows.ts`.
  */
 export type EmailBreakdownView = 'countries' | 'devices' | 'clients' | 'links';
+
+/**
+ * Which email metric the dimension views break down, matching the Opens/Clicks
+ * tabs of the Calypso email detail page. Ignored by the `links` view.
+ */
+export type EmailBreakdownMetric = 'opens' | 'clicks';
 
 /**
  * Configurable attributes for the Email breakdown widget. Mirrors the
@@ -29,6 +35,10 @@ export type EmailBreakdownAttributes = {
 	 * Which breakdown dimension to display. Defaults to `countries`.
 	 */
 	view?: EmailBreakdownView;
+	/**
+	 * Whether the dimension views show opens or clicks. Defaults to `opens`.
+	 */
+	metric?: EmailBreakdownMetric;
 	/**
 	 * Number of rows to show. `0` means as many as the endpoint returns.
 	 */
@@ -76,6 +86,21 @@ export default {
 			relevance: 'high',
 		},
 		{
+			id: 'metric',
+			label: __( 'Metric', 'jetpack-premium-analytics' ),
+			type: 'text',
+			elements: [
+				{
+					label: __( 'Opens', 'jetpack-premium-analytics' ),
+					value: 'opens',
+				},
+				{
+					label: __( 'Clicks', 'jetpack-premium-analytics' ),
+					value: 'clicks',
+				},
+			],
+		},
+		{
 			id: 'postId',
 			label: __( 'Email ID', 'jetpack-premium-analytics' ),
 			type: 'integer',
@@ -90,6 +115,7 @@ export default {
 		attributes: {
 			postId: 1234,
 			view: 'countries',
+			metric: 'opens',
 			max: 10,
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -27,11 +27,6 @@ export type EmailBreakdownMetric = 'opens' | 'clicks';
  */
 export type EmailBreakdownAttributes = {
 	/**
-	 * The email (post) ID to break down. The all-time breakdown endpoints are keyed
-	 * entirely by this ID, so the widget renders an empty state until one is set.
-	 */
-	postId?: number;
-	/**
 	 * Which breakdown dimension to display. Defaults to `countries`.
 	 */
 	view?: EmailBreakdownView;
@@ -53,8 +48,10 @@ export type EmailBreakdownAttributes = {
  * country, device, email client, and clicked link — so this ships as a single
  * widget with a `view` selector (`relevance: 'high'`, rendered as a control by
  * the widget host) instead of four near-identical widgets. The breakdown is
- * scoped to a single email via the `postId` attribute; the endpoints report over
- * the whole lifetime of the email, so there is no date range or comparison period.
+ * scoped to a single email by the host through `reportParams.post_id` (the
+ * shared single-resource "detail page" param), not by an attribute; the
+ * endpoints report over the whole lifetime of the email, so there is no date
+ * range or comparison period.
  */
 export default {
 	name: 'jpa/email-breakdown',
@@ -101,11 +98,6 @@ export default {
 			],
 		},
 		{
-			id: 'postId',
-			label: __( 'Email ID', 'jetpack-premium-analytics' ),
-			type: 'integer',
-		},
-		{
 			id: 'max',
 			label: __( 'Number of results', 'jetpack-premium-analytics' ),
 			type: 'integer',
@@ -113,7 +105,6 @@ export default {
 	] as WidgetAttributeField< EmailBreakdownAttributes >[],
 	example: {
 		attributes: {
-			postId: 1234,
 			view: 'countries',
 			metric: 'opens',
 			max: 10,

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { envelope } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Which breakdown dimension the widget lists for the selected email.
+ *
+ * `countries`, `devices`, and `clients` read the email *opens* breakdown; `links`
+ * reads the *clicks* breakdown (only clicked links exist), so the view selector
+ * also picks the underlying opens/clicks endpoint. See `render.tsx`.
+ */
+export type EmailBreakdownView = 'countries' | 'devices' | 'clients' | 'links';
+
+/**
+ * Configurable attributes for the Email breakdown widget. Mirrors the
+ * `attributes` declared on the widget definition below; the host passes the
+ * selected values through to `render.tsx`.
+ */
+export type EmailBreakdownAttributes = {
+	/**
+	 * The email (post) ID to break down. The all-time breakdown endpoints are keyed
+	 * entirely by this ID, so the widget renders an empty state until one is set.
+	 */
+	postId?: number;
+	/**
+	 * Which breakdown dimension to display. Defaults to `countries`.
+	 */
+	view?: EmailBreakdownView;
+	/**
+	 * Number of rows to show. `0` means as many as the endpoint returns.
+	 */
+	max?: number;
+};
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats email detail "breakdown" modules
+ * (`stats-email-module`). That family is one module rendered four times — by
+ * country, device, email client, and clicked link — so this ships as a single
+ * widget with a `view` selector (`relevance: 'high'`, rendered as a control by
+ * the widget host) instead of four near-identical widgets. The breakdown is
+ * scoped to a single email via the `postId` attribute; the endpoints report over
+ * the whole lifetime of the email, so there is no date range or comparison period.
+ */
+export default {
+	name: 'jpa/email-breakdown',
+	title: __( 'Email breakdown', 'jetpack-premium-analytics' ),
+	icon: envelope,
+	attributes: [
+		{
+			id: 'view',
+			label: __( 'Break down by', 'jetpack-premium-analytics' ),
+			type: 'text',
+			elements: [
+				{
+					label: __( 'Countries', 'jetpack-premium-analytics' ),
+					value: 'countries',
+				},
+				{
+					label: __( 'Devices', 'jetpack-premium-analytics' ),
+					value: 'devices',
+				},
+				{
+					label: __( 'Email clients', 'jetpack-premium-analytics' ),
+					value: 'clients',
+				},
+				{
+					label: __( 'Links', 'jetpack-premium-analytics' ),
+					value: 'links',
+				},
+			],
+			relevance: 'high',
+		},
+		{
+			id: 'postId',
+			label: __( 'Email ID', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	] as WidgetAttributeField< EmailBreakdownAttributes >[],
+	example: {
+		attributes: {
+			postId: 1234,
+			view: 'countries',
+			max: 10,
+		},
+	},
+};


### PR DESCRIPTION
## Proposed changes

Ports the Stats email detail "breakdown" modules (`stats-email-module`) into Premium Analytics as the `jpa/email-breakdown` widget.

- New widget at `widgets/email-breakdown/` — a single widget with a `view` selector (`countries | devices | clients | links`) exposed as a `relevance: 'high'` host control, instead of four near-identical widgets (mirrors `locations`).
- A `metric` attribute (`opens | clicks`) picks the breakdown the dimension views read, matching the Calypso email detail page where the modules follow the active Opens/Clicks tab. `links` always reads the **clicks** breakdown (only clicked links exist). Reuses the existing `useStatsEmailOpensBreakdown` / `useStatsEmailClicksBreakdown` hooks (`stats` prefix) — no new hook or proxy prefix; the fetch/merge orchestration lives in `use-email-breakdown-rows.ts`.
- The `links` view fetches **both** the `link` breakdown (internal link types — Post URL, Like, Comment, Unsubscribe, aggregated Other) and the `user-content-link` breakdown, merged into one value-sorted list — same as Calypso's `emailStatsAlltime()` + `parseEmailLinksData()`.
- Scoped to a single email by a `postId` attribute; the all-time endpoints take no date params, so the widget ignores the dashboard range and shows a "Select an email" empty state until a `postId` is set. No comparison rows, so it renders without deltas.
- Loading / error / empty states render through `WidgetState` (error state has a Retry action wired to refetch), per the current Stats-widget contract.
- Rows render via the toolkit `LeaderboardChart` (countries show flags, links render as external links; link anchors are restricted to http(s) URLs). Deliberately omits the upstream countries Geochart map hero — the per-email widget keeps the flags leaderboard only; a map could later reuse the `locations` widget's machinery if wanted.
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget` with the `view` and `metric` controls wired; fixtures + handlers cover each per-email breakdown path (the two link endpoints return their own payload keys separately, mirroring production).

## Related product discussion/links

- WOOA7S-1517

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / EmailBreakdown**: switch the `view` control through all four views and confirm each renders a populated leaderboard (countries with flags, links as external links plus internal link-type rows, devices/clients plain labels); flip the `metric` control between `opens`/`clicks` on a dimension view; the `WithComparison` story renders normally with no deltas.
- `pnpm run test widgets/email-breakdown` in `projects/packages/premium-analytics`.
- Smoke test against a live connected site with a sent email — in particular confirm the **Links** view: the real `user-content-link` endpoint response is expected to carry only `user-content-links` (the widget now also fetches `link` for the internal rows, like Calypso).

https://github.com/user-attachments/assets/cc024120-05ed-40b0-a01a-70c3790f3857



