### PR TITLE
WP Build Polyfills: force-replace boot and theme on WP 7.0

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
+++ b/projects/packages/premium-analytics/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Analytics: Emit JetpackScriptData on the wp-admin integrated dashboard page.
+Emit JetpackScriptData on the wp-admin integrated dashboard page so connection route guards work outside full-page mode.

--- a/projects/packages/premium-analytics/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
+++ b/projects/packages/premium-analytics/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Analytics: Emit JetpackScriptData on the wp-admin integrated dashboard page.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -121,8 +121,11 @@ class Analytics {
 		// Remove the standalone Jetpack "Stats" menu so Premium Analytics takes its
 		// place. Runs after Stats registers itself (admin_menu priority 999).
 		add_action( 'admin_menu', array( static::class, 'remove_stats_menu' ), 1001 );
+		// Full-page mode (page.php interceptor, slug jetpack-premium-analytics).
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'ensure_script_data' ) );
+		// wp-admin integrated mode (page-wp-admin.php, slug jetpack-premium-analytics-wp-admin).
+		add_action( 'jetpack-premium-analytics-wp-admin_init', array( static::class, 'ensure_script_data' ) );
 	}
 
 	/**

--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -19,18 +19,18 @@ This package provides those missing or updated packages so that plugins using `@
 |-------------------|------------------------|-----------------|
 | `wp-notices`      | `@wordpress/notices`    | Yes on WP < 7.0 — missing component exports |
 | `wp-private-apis` | `@wordpress/private-apis` | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — incomplete allowlist |
-| `wp-theme`        | `@wordpress/theme`      | No — only registered if absent |
+| `wp-theme`        | `@wordpress/theme`      | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — Core 7.0 only exports `privateApis`; polyfill boot needs public `ThemeProvider` |
 | `wp-views`        | `@wordpress/views`      | No — only registered if absent |
 
 ### Script modules (ESM)
 
 | Module ID          | Source package       |
 |--------------------|----------------------|
-| `@wordpress/boot`  | `@wordpress/boot`    |
+| `@wordpress/boot`  | `@wordpress/boot`    | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — Core 7.0 `initSinglePage()` ignores `initModules` |
 | `@wordpress/route` | `@wordpress/route`   |
 | `@wordpress/a11y`  | `@wordpress/a11y`    |
 
-Script modules use "first-wins" semantics — if Core or Gutenberg already registered the module, the polyfill is silently ignored.
+Script modules other than `@wordpress/boot` use "first-wins" semantics — if Core or Gutenberg already registered the module, the polyfill is silently ignored. `@wordpress/boot` and `wp-theme` are force-replaced under the same WP/Gutenberg guard as `wp-private-apis` so page init modules run and boot can import public `ThemeProvider`.
 
 ## How it works
 

--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -19,18 +19,18 @@ This package provides those missing or updated packages so that plugins using `@
 |-------------------|------------------------|-----------------|
 | `wp-notices`      | `@wordpress/notices`    | Yes on WP < 7.0 — missing component exports |
 | `wp-private-apis` | `@wordpress/private-apis` | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — incomplete allowlist |
-| `wp-theme`        | `@wordpress/theme`      | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — Core 7.0 only exports `privateApis`; polyfill boot needs public `ThemeProvider` |
+| `wp-theme`        | `@wordpress/theme`      | No — only registered if absent |
 | `wp-views`        | `@wordpress/views`      | No — only registered if absent |
 
 ### Script modules (ESM)
 
 | Module ID          | Source package       |
 |--------------------|----------------------|
-| `@wordpress/boot`  | `@wordpress/boot`    | Yes on WP < 7.1 unless Gutenberg >= 23.5.0 is active — Core 7.0 `initSinglePage()` ignores `initModules` |
+| `@wordpress/boot`  | `@wordpress/boot`    |
 | `@wordpress/route` | `@wordpress/route`   |
 | `@wordpress/a11y`  | `@wordpress/a11y`    |
 
-Script modules other than `@wordpress/boot` use "first-wins" semantics — if Core or Gutenberg already registered the module, the polyfill is silently ignored. `@wordpress/boot` and `wp-theme` are force-replaced under the same WP/Gutenberg guard as `wp-private-apis` so page init modules run and boot can import public `ThemeProvider`.
+Script modules use "first-wins" semantics — if Core or Gutenberg already registered the module, the polyfill is silently ignored.
 
 ## How it works
 

--- a/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
+++ b/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Force-replace @wordpress/boot and wp-theme on WP 7.0 so wp-build init modules run and ThemeProvider is available.
+Force-replace @wordpress/boot and wp-theme on WordPress 7.0 so wp-build page init modules run and ThemeProvider is available without the Gutenberg plugin.

--- a/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
+++ b/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-boot-initmodules-wp-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Force-replace @wordpress/boot and wp-theme on WP 7.0 so wp-build init modules run and ThemeProvider is available.

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -234,6 +234,22 @@ class WP_Build_Polyfills {
 	}
 
 	/**
+	 * Check whether a script module is already registered.
+	 *
+	 * @param string $module_id Script module identifier (e.g. '@wordpress/boot').
+	 * @return bool True when the module is registered.
+	 */
+	private static function is_script_module_registered( $module_id ) {
+		$modules_registry = wp_script_modules();
+		if ( ! method_exists( $modules_registry, 'get_registered' ) ) {
+			return false;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredMethod -- Added in WP 6.9+; guarded by method_exists().
+		return null !== $modules_registry->get_registered( $module_id );
+	}
+
+	/**
 	 * Register polyfill script modules.
 	 *
 	 * Most modules use first-wins semantics. `@wordpress/boot` is force-replaced on
@@ -283,12 +299,8 @@ class WP_Build_Polyfills {
 				&& ! self::is_gutenberg_version_safe( $data['gutenberg_min_version'] ?? null, $gutenberg_version )
 				&& version_compare( $GLOBALS['wp_version'] ?? '0', $force_threshold, '<' );
 
-			if ( ! $force ) {
-				$modules_registry = wp_script_modules();
-				if ( method_exists( $modules_registry, 'get_registered' )
-					&& null !== $modules_registry->get_registered( $module_id ) ) {
-					continue;
-				}
+			if ( ! $force && self::is_script_module_registered( $module_id ) ) {
+				continue;
 			}
 
 			if ( $force ) {

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -107,7 +107,7 @@ class WP_Build_Polyfills {
 		// handles and module IDs being available regardless of init order.
 		if ( did_action( 'wp_default_scripts' ) ) {
 			self::register_scripts( wp_scripts(), $build_dir, $base_file, self::$wp_version_threshold );
-			self::register_modules( $build_dir, $base_file );
+			self::register_modules( $build_dir, $base_file, self::$wp_version_threshold );
 			return;
 		}
 
@@ -115,7 +115,7 @@ class WP_Build_Polyfills {
 			'wp_default_scripts',
 			function ( $scripts ) use ( $build_dir, $base_file ) {
 				self::register_scripts( $scripts, $build_dir, $base_file, self::$wp_version_threshold );
-				self::register_modules( $build_dir, $base_file );
+				self::register_modules( $build_dir, $base_file, self::$wp_version_threshold );
 			},
 			20
 		);
@@ -162,7 +162,12 @@ class WP_Build_Polyfills {
 				// dashboard packages too.
 			),
 			'wp-theme'        => array(
-				'path' => 'theme',
+				'path'                  => 'theme',
+				'force_threshold'       => '7.1',
+				'gutenberg_min_version' => self::GUTENBERG_PRIVATE_APIS_MIN_VERSION,
+				// WP 7.0 ships wp-theme with ThemeProvider locked in privateApis
+				// only. Polyfill @wordpress/boot imports ThemeProvider as a public
+				// wp.theme export, so boot must be paired with polyfill theme.
 			),
 			'wp-views'        => array(
 				'path' => 'views',
@@ -231,20 +236,32 @@ class WP_Build_Polyfills {
 	/**
 	 * Register polyfill script modules.
 	 *
-	 * Call to wp_register_script_module() silently ignores duplicate registrations (first wins),
-	 * so no explicit is_registered check is needed.
+	 * Most modules use first-wins semantics. `@wordpress/boot` is force-replaced on
+	 * WP versions below 7.1 when Gutenberg is inactive or too old, because Core 7.0
+	 * ships a boot module whose `initSinglePage()` ignores `initModules` — page init
+	 * hooks never run even though wp-build passes them through.
 	 *
-	 * @param string $build_dir Absolute path to the build directory.
-	 * @param string $base_file File path for plugins_url() computation.
+	 * @param string $build_dir             Absolute path to the build directory.
+	 * @param string $base_file             File path for plugins_url() computation.
+	 * @param string $wp_version_threshold  WP version below which force-replacements apply.
 	 */
-	private static function register_modules( $build_dir, $base_file ) {
+	private static function register_modules( $build_dir, $base_file, $wp_version_threshold ) {
 		if ( ! function_exists( 'wp_register_script_module' ) ) {
 			return;
 		}
 
-		$modules = array( 'boot', 'route', 'a11y' );
+		$gutenberg_version = defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : null;
 
-		foreach ( $modules as $name ) {
+		$modules = array(
+			'boot'  => array(
+				'force_threshold'       => '7.1',
+				'gutenberg_min_version' => self::GUTENBERG_PRIVATE_APIS_MIN_VERSION,
+			),
+			'route' => array(),
+			'a11y'  => array(),
+		);
+
+		foreach ( $modules as $name => $data ) {
 			$module_id = '@wordpress/' . $name;
 
 			if ( ! isset( self::$requested[ $module_id ] ) ) {
@@ -255,6 +272,27 @@ class WP_Build_Polyfills {
 
 			if ( ! file_exists( $asset_file ) ) {
 				continue;
+			}
+
+			$force_threshold = $data['force_threshold'] ?? null;
+			if ( null !== $force_threshold && version_compare( $wp_version_threshold, $force_threshold, '>' ) ) {
+				$force_threshold = $wp_version_threshold;
+			}
+
+			$force = null !== $force_threshold
+				&& ! self::is_gutenberg_version_safe( $data['gutenberg_min_version'] ?? null, $gutenberg_version )
+				&& version_compare( $GLOBALS['wp_version'] ?? '0', $force_threshold, '<' );
+
+			if ( ! $force ) {
+				$modules_registry = wp_script_modules();
+				if ( method_exists( $modules_registry, 'get_registered' )
+					&& null !== $modules_registry->get_registered( $module_id ) ) {
+					continue;
+				}
+			}
+
+			if ( $force ) {
+				wp_deregister_script_module( $module_id );
 			}
 
 			$asset = require $asset_file;

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
@@ -188,15 +188,17 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 
 	/**
 	 * Invoke the private register_modules method.
+	 *
+	 * @param string $wp_version_threshold WP version below which force-replacements apply.
 	 */
-	private function invoke_register_modules() {
+	private function invoke_register_modules( $wp_version_threshold = '7.0' ) {
 		$this->request_polyfills( WP_Build_Polyfills::MODULE_IDS );
 
 		$method = new \ReflectionMethod( WP_Build_Polyfills::class, 'register_modules' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
 		}
-		$method->invoke( null, $this->build_dir, __FILE__ );
+		$method->invoke( null, $this->build_dir, __FILE__, $wp_version_threshold );
 	}
 
 	/**
@@ -299,9 +301,10 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that wp-theme (non-force) keeps existing registration.
+	 * Test that wp-theme keeps existing registration on WP >= 7.1.
 	 */
 	public function test_register_scripts_skips_wp_theme_when_already_registered() {
+		$GLOBALS['wp_version'] = '7.1';
 		$this->create_asset_file( 'scripts/theme/index.asset.php', array(), '2.0.0' );
 
 		$scripts = $this->create_clean_scripts();
@@ -312,6 +315,23 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 		$registered = $scripts->query( 'wp-theme', 'registered' );
 		$this->assertNotFalse( $registered );
 		$this->assertSame( '1.0.0-original', $registered->ver );
+	}
+
+	/**
+	 * Test that wp-theme is force-replaced on WP 7.0 when Core registered it first.
+	 */
+	public function test_register_scripts_force_replaces_wp_theme_on_wp_7_0() {
+		$GLOBALS['wp_version'] = '7.0';
+		$this->create_asset_file( 'scripts/theme/index.asset.php', array(), '9.9.9' );
+
+		$scripts = $this->create_clean_scripts();
+		$scripts->add( 'wp-theme', 'https://example.com/core-theme.js', array(), '1.0.0-core' );
+
+		$this->invoke_register_scripts( $scripts );
+
+		$registered = $scripts->query( 'wp-theme', 'registered' );
+		$this->assertNotFalse( $registered );
+		$this->assertSame( '9.9.9', $registered->ver );
 	}
 
 	/**
@@ -560,11 +580,34 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that pre-registered modules are not replaced (first-wins semantics).
+	 * Test that pre-registered non-boot modules are not replaced (first-wins semantics).
 	 */
 	public function test_register_modules_does_not_replace_existing() {
+		$GLOBALS['wp_version']        = '7.1';
 		$GLOBALS['wp_script_modules'] = new \WP_Script_Modules();
-		// Pre-register @wordpress/boot.
+		// Pre-register @wordpress/route (boot is force-replaced on WP < 7.1).
+		wp_register_script_module( '@wordpress/route', 'https://example.com/core-route.js', array(), '1.0.0-core' );
+
+		$this->create_asset_file(
+			'modules/route/index.asset.php',
+			array(),
+			'9.9.9',
+			array( 'module_dependencies' => array() )
+		);
+
+		$this->invoke_register_modules( '7.1' );
+
+		$module = $this->get_module_data( '@wordpress/route' );
+		$this->assertNotNull( $module );
+		$this->assertSame( '1.0.0-core', $module['version'] );
+	}
+
+	/**
+	 * Test that @wordpress/boot is force-replaced on WP 7.0 when Core registered it first.
+	 */
+	public function test_register_modules_force_replaces_boot_on_wp_7_0() {
+		$GLOBALS['wp_version']        = '7.0';
+		$GLOBALS['wp_script_modules'] = new \WP_Script_Modules();
 		wp_register_script_module( '@wordpress/boot', 'https://example.com/core-boot.js', array(), '1.0.0-core' );
 
 		$this->create_asset_file(
@@ -574,11 +617,11 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 			array( 'module_dependencies' => array() )
 		);
 
-		$this->invoke_register_modules();
+		$this->invoke_register_modules( '7.0' );
 
 		$module = $this->get_module_data( '@wordpress/boot' );
 		$this->assertNotNull( $module );
-		$this->assertSame( '1.0.0-core', $module['version'] );
+		$this->assertSame( '9.9.9', $module['version'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* Force-replace `@wordpress/boot` on WP < 7.1 when Gutenberg is inactive or older than `23.5.0`.
Core `7.0` ships a `boot` module whose `initSinglePage()` ignores `initModules`, so `wp-build` page init hooks never run even though templates pass them through.
* Force-replace `wp-theme` under the same guard. 
Core `7.0` only exports `privateApis` from `wp.theme`; polyfill `boot` imports public `ThemeProvider`, which is _undefined_ without the polyfill theme.
* Premium Analytics: hook `ensure_script_data()` on `jetpack-premium-analytics-wp-admin_init` so `JetpackScriptData` is emitted on the wp-admin integrated dashboard page.

## Related product discussion/links

* Unblocks wp-build `init` modules on WP 7.0 without requiring the Gutenberg plugin (discovered while reviewing Premium Analytics #50048).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack test php packages/wp-build-polyfills` — 24 tests pass.
* On WP 7.0 with Gutenberg **deactivated**:
  * Open `wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`.
  * Confirm the dashboard loads without React errors.
  * Confirm `@jetpack-premium-analytics/init` runs (init modules register, widgets render).
  * In Network, confirm `@wordpress/boot` and `wp-theme` load from `jetpack-wp-build-polyfills/build/…`, not `/wp-includes/`.
* On WP 7.0 with Gutenberg **23.5.0+ active**, confirm polyfills are **not** force-replaced (Gutenberg boot/theme win).
* On WP >= 7.1, confirm force-replace does not apply and core handles remain in use.


Made with [Cursor](https://cursor.com)