### PR TITLE
Rename Premium Analytics sidebar label

### DIFF
--- a/projects/plugins/premium-analytics/changelog/rename-premium-analytics-sidebar
+++ b/projects/plugins/premium-analytics/changelog/rename-premium-analytics-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename the sidebar label to Analytics.

--- a/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
+++ b/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
@@ -25,7 +25,7 @@ class Jetpack_Premium_Analytics {
 	 * Constructor.
 	 */
 	public function __construct() {
-		Analytics::init( array( 'menu_title' => 'Stats' ) );
+		Analytics::init( array( 'menu_title' => 'Analytics' ) );
 		Cookie_Consent::init();
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Rename the Premium Analytics wp-admin sidebar menu label from "Stats" to "Analytics".
* Add a premium-analytics plugin changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Ensure Node 24.15.0 or newer is active.
* Run `pnpm jetpack test php plugins/premium-analytics`.
* Open wp-admin with Premium Analytics active and confirm the top-level sidebar menu item reads "Analytics".
