### PR TITLE
WOOA7S-1519: Port Stats VideoPress widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-videopress-widget
+++ b/projects/packages/premium-analytics/changelog/add-videopress-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add VideoPress video plays leaderboard widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -46,3 +46,5 @@ export {
 export { flagUrl } from './flag-url';
 export { isEmptyChartData, isEmptyPieChartData, getEmptyChartDomain } from './chart-empty-state';
 export { formatDisplayLabel } from './format-display-label';
+export { getVideoKey, getVideoLabel, toVideoItems } from './video-plays';
+export { toMaxRows } from './to-max-rows';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/to-max-rows.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/to-max-rows.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve a widget's `max` attribute to the row count requested from Stats.
+ * Per the Stats widget contract `max = 0` means "all rows", so it passes
+ * through; only negative or non-numeric values fall back to the default.
+ * Integer form controls can serialize the attribute to a string, so both
+ * forms are accepted.
+ *
+ * @param value    - The raw `max` attribute value.
+ * @param fallback - The widget's default row count.
+ * @return The row count to request.
+ */
+export function toMaxRows( value: string | number | undefined, fallback: number ) {
+	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
+
+	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/video-plays.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/video-plays.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+/**
+ * Shared helpers for widgets built on the Stats `video-plays` report
+ * (`jpa/videos`, `jpa/videopress`). Each widget keeps its own row builder;
+ * these cover the report-shape concerns they have in common.
+ */
+
+/**
+ * Resolve a display label for a video, falling back to a translated
+ * "Untitled video" label when the API provides none.
+ *
+ * @param video - The video-plays item.
+ * @return The video's display label.
+ */
+export function getVideoLabel( video: StatsVideoPlaysItem ) {
+	return typeof video.label === 'string' && video.label
+		? video.label
+		: __( 'Untitled video', 'jetpack-premium-analytics' );
+}
+
+/**
+ * Resolve the key used to align a video across the primary and comparison
+ * periods, and to identify its leaderboard row. Prefers the stable post ID,
+ * then the video URL, and only falls back to the display label when the API
+ * omits both — so multiple untitled videos don't collapse onto one key.
+ *
+ * @param video - The video-plays item.
+ * @return The alignment key.
+ */
+export function getVideoKey( video: StatsVideoPlaysItem ) {
+	if ( video.id != null ) {
+		return String( video.id );
+	}
+
+	return video.link || getVideoLabel( video );
+}
+
+/**
+ * Flatten a normalized video-plays report into its per-video items. The Stats
+ * query layer summarizes multi-day ranges server-side and the endpoint returns
+ * videos already ranked and limited by `max`, so the report carries a single
+ * data point of per-video totals.
+ *
+ * @param report - The normalized video-plays report, or undefined while loading.
+ * @return The per-video items for the period.
+ */
+export function toVideoItems(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): StatsVideoPlaysItem[] {
+	return report?.data.flatMap( point => point.items ) ?? [];
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -84,6 +84,10 @@ export {
 	buildSalesByUtmData,
 	formatLegendLabels,
 	formatDisplayLabel,
+	getVideoKey,
+	getVideoLabel,
+	toVideoItems,
+	toMaxRows,
 } from './helpers';
 
 /**

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/build-video-plays-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/build-video-plays-data.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import { toVideoPlaysRows } from '../build-video-plays-data';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+const report = (
+	items: Array< Partial< StatsVideoPlaysItem > >
+): StatsNormalizedReport< StatsVideoPlaysItem > =>
+	( {
+		summary: {},
+		data: [ { date: '2026-06-16', items } ],
+	} ) as unknown as StatsNormalizedReport< StatsVideoPlaysItem >;
+
+describe( 'toVideoPlaysRows', () => {
+	it( 'matches comparison plays by stable video id, not by row order', () => {
+		const rows = toVideoPlaysRows(
+			report( [
+				{ id: 101, label: 'Walkthrough', link: 'https://example.com/a/', plays: 100 },
+				{ id: 102, label: 'Launch', link: 'https://example.com/b/', plays: 50 },
+			] ),
+			// Reversed order, and only one overlapping video.
+			report( [ { id: 102, label: 'Launch', link: 'https://example.com/b/', plays: 80 } ] )
+		);
+
+		expect( rows ).toEqual( [
+			expect.objectContaining( { key: '101', plays: 100, previousPlays: null } ),
+			expect.objectContaining( { key: '102', plays: 50, previousPlays: 80 } ),
+		] );
+	} );
+
+	it( 'keeps previousPlays null (not zero) for videos missing from the comparison period', () => {
+		const rows = toVideoPlaysRows(
+			report( [ { id: 101, label: 'Walkthrough', link: null, plays: 100 } ] ),
+			report( [] )
+		);
+
+		expect( rows[ 0 ].previousPlays ).toBeNull();
+	} );
+
+	it( 'carries the video link and falls back to an untitled label', () => {
+		const rows = toVideoPlaysRows(
+			report( [ { id: 107, label: '', link: 'https://example.com/video/107/', plays: 10 } ] ),
+			undefined
+		);
+
+		expect( rows[ 0 ] ).toEqual( {
+			key: '107',
+			label: 'Untitled video',
+			link: 'https://example.com/video/107/',
+			plays: 10,
+			previousPlays: null,
+		} );
+	} );
+
+	it( 'keys untitled videos without an id by their link so they do not collapse', () => {
+		const rows = toVideoPlaysRows(
+			report( [
+				{ label: '', link: 'https://example.com/video/1/', plays: 10 },
+				{ label: '', link: 'https://example.com/video/2/', plays: 5 },
+			] ),
+			undefined
+		);
+
+		expect( rows.map( row => row.key ) ).toEqual( [
+			'https://example.com/video/1/',
+			'https://example.com/video/2/',
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -85,6 +85,11 @@ describe( 'VideoPressWidget', () => {
 
 		const requestedPath = mockApiFetch.mock.calls[ 0 ]?.[ 0 ]?.path ?? '';
 		expect( requestedPath ).toContain( 'stats/video-plays' );
+		// The query factory derives the Stats date params from `reportParams`:
+		// `to` becomes the end `date` and the inclusive range length becomes `days`.
+		expect( requestedPath ).toContain( 'start_date=2026-03-01' );
+		expect( requestedPath ).toContain( 'date=2026-03-10' );
+		expect( requestedPath ).toContain( 'days=10' );
 	} );
 
 	it( 'shows the empty state when the period has no video plays', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { GlobalErrorProvider, queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import VideoPressWidget from '../render';
+import type { ReactElement } from 'react';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// Build a raw Stats "video-plays" response that satisfies both the summarized
+// (multi-day) and single-day read paths of `sanitizeStatsVideoPlaysResponse`.
+const buildResponse = ( videos: Array< { post_id: number; title: string; plays: number } > ) => {
+	const date = '2026-06-16';
+	const rows = videos.map( video => ( {
+		post_id: video.post_id,
+		title: video.title,
+		url: `https://example.com/video/${ video.post_id }/`,
+		plays: video.plays,
+		impressions: video.plays * 2,
+		watch_time: video.plays * 10,
+		retention_rate: 60,
+	} ) );
+
+	return { date, period: 'day', summary: { plays: rows }, days: { [ date ]: { plays: rows } } };
+};
+
+const VIDEO_PLAYS_RESPONSE = buildResponse( [
+	{ post_id: 101, title: 'Getting Started Walkthrough', plays: 3820 },
+	{ post_id: 102, title: 'Product Launch Highlights', plays: 2640 },
+] );
+
+// The dashboard wraps widgets in a GlobalErrorProvider; `useWidgetError` reads
+// that context, so mirror it here to render the widget as it runs in product.
+const renderInDashboard = ( ui: ReactElement ) =>
+	render( <GlobalErrorProvider>{ ui }</GlobalErrorProvider> );
+
+describe( 'VideoPressWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( VIDEO_PLAYS_RESPONSE );
+	} );
+
+	it( 'renders the fetched videos as leaderboard rows', async () => {
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		await expect( screen.findByText( 'Getting Started Walkthrough' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Product Launch Highlights' ) ).toBeInTheDocument();
+	} );
+
+	it( 'requests the dashboard date range from report params', async () => {
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } } />
+		);
+
+		await expect( screen.findByText( 'Getting Started Walkthrough' ) ).resolves.toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ]?.[ 0 ]?.path ?? '';
+		expect( requestedPath ).toContain( 'stats/video-plays' );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -42,8 +42,8 @@ const VIDEO_PLAYS_RESPONSE = buildResponse( [
 	{ post_id: 102, title: 'Product Launch Highlights', plays: 2640 },
 ] );
 
-// The dashboard wraps widgets in a GlobalErrorProvider; `useWidgetError` reads
-// that context, so mirror it here to render the widget as it runs in product.
+// The dashboard wraps widgets in a GlobalErrorProvider, so mirror it here to
+// render the widget as it runs in product.
 const renderInDashboard = ( ui: ReactElement ) =>
 	render( <GlobalErrorProvider>{ ui }</GlobalErrorProvider> );
 
@@ -65,6 +65,17 @@ describe( 'VideoPressWidget', () => {
 		expect( screen.getByText( 'Product Launch Highlights' ) ).toBeInTheDocument();
 	} );
 
+	it( 'links each row to the video page', async () => {
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		// The Link's new-tab icon appends "(opens in a new tab)" to the accessible name.
+		const link = await screen.findByRole( 'link', { name: /Getting Started Walkthrough/ } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/101/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'requests the dashboard date range from report params', async () => {
 		renderInDashboard(
 			<VideoPressWidget attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } } />
@@ -74,5 +85,32 @@ describe( 'VideoPressWidget', () => {
 
 		const requestedPath = mockApiFetch.mock.calls[ 0 ]?.[ 0 ]?.path ?? '';
 		expect( requestedPath ).toContain( 'stats/video-plays' );
+	} );
+
+	it( 'shows the empty state when the period has no video plays', async () => {
+		mockApiFetch.mockResolvedValue( buildResponse( [] ) );
+
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		await expect(
+			screen.findByText( /which VideoPress videos your visitors watch most/ )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'shows the error state with a retry action when the request fails', async () => {
+		// Reject with a non-retryable (403) error so React Query surfaces the
+		// error state immediately instead of retrying with backoff.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		await expect(
+			screen.findByText( "We couldn't load video plays. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import {
+	calculateDelta,
+	type LeaderboardChartData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+/**
+ * Resolve a display label for a video, falling back to a translated
+ * "Untitled video" label when the API provides none.
+ *
+ * @param video - The video-plays item.
+ * @return The video's display label.
+ */
+function getVideoLabel( video: StatsVideoPlaysItem ) {
+	return typeof video.label === 'string' && video.label
+		? video.label
+		: __( 'Untitled video', 'jetpack-premium-analytics' );
+}
+
+/**
+ * Resolve the key used to align a video across the primary and comparison
+ * periods, and to identify its leaderboard row. Prefers the stable post ID,
+ * then the video URL, and only falls back to the display label when the API
+ * omits both — so multiple untitled videos don't collapse onto one key.
+ *
+ * @param video - The video-plays item.
+ * @return The alignment key.
+ */
+function getVideoKey( video: StatsVideoPlaysItem ) {
+	if ( video.id != null ) {
+		return String( video.id );
+	}
+
+	return video.link || getVideoLabel( video );
+}
+
+/**
+ * Flatten a normalized video-plays report into its per-video items. The Stats
+ * query layer summarizes multi-day ranges server-side and the endpoint returns
+ * videos already ranked and limited by `max`, so the report carries a single
+ * data point of per-video totals.
+ *
+ * @param report - The normalized video-plays report, or undefined while loading.
+ * @return The per-video items for the period.
+ */
+function toVideoItems(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): StatsVideoPlaysItem[] {
+	return report?.data.flatMap( point => point.items ) ?? [];
+}
+
+/**
+ * Builds leaderboard chart data for the VideoPress widget.
+ *
+ * Transforms Jetpack Stats video-plays data into the format required by
+ * LeaderboardChart, with comparison values aligned by video (videos missing
+ * from the comparison period count as zero).
+ *
+ * @param primary    - Primary period video-plays report
+ * @param comparison - Comparison period video-plays report
+ * @return Processed data ready for the LeaderboardChart component
+ */
+export function buildVideoPlaysData(
+	primary: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
+	comparison: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): LeaderboardChartData {
+	const videos = toVideoItems( primary );
+
+	if ( videos.length === 0 ) {
+		return [];
+	}
+
+	const comparisonPlays = new Map(
+		toVideoItems( comparison ).map( video => [ getVideoKey( video ), video.plays ] )
+	);
+
+	// Share each value against the largest of either period so the overlay bars
+	// stay proportional; `1` guards against division by zero.
+	const maxValue = Math.max(
+		...videos.map( video =>
+			Math.max( video.plays, comparisonPlays.get( getVideoKey( video ) ) ?? 0 )
+		),
+		1
+	);
+
+	return videos.map( video => {
+		const key = getVideoKey( video );
+		const currentValue = video.plays;
+		const previousValue = comparisonPlays.get( key ) ?? 0;
+
+		return {
+			id: key,
+			label: getVideoLabel( video ),
+			currentValue,
+			previousValue,
+			currentShare: ( currentValue / maxValue ) * 100,
+			previousShare: ( previousValue / maxValue ) * 100,
+			delta: calculateDelta( currentValue, previousValue ),
+		};
+	} );
+}

--- a/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
@@ -1,12 +1,38 @@
 /**
  * External dependencies
  */
-import {
-	calculateDelta,
-	type LeaderboardChartData,
-} from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+/**
+ * A single normalized video row, flattened from the video-plays report with
+ * its comparison-period plays already matched by stable video key.
+ */
+export type VideoPlaysRow = {
+	/**
+	 * Stable row key: the video's post ID, else its URL, else its label.
+	 */
+	key: string;
+	/**
+	 * Video title, falling back to a translated "Untitled video" label.
+	 */
+	label: string;
+	/**
+	 * URL of the page embedding the video, used to render the row label as an
+	 * outbound link. `null` when the API provides none.
+	 */
+	link: string | null;
+	/**
+	 * Play count for the selected period.
+	 */
+	plays: number;
+	/**
+	 * Play count for the comparison period. `null` when the video has no
+	 * matching comparison row — distinct from a real zero, so the widget can
+	 * fall back to a non-comparison view instead of fabricating deltas.
+	 */
+	previousPlays: number | null;
+};
 
 /**
  * Resolve a display label for a video, falling back to a translated
@@ -54,52 +80,32 @@ function toVideoItems(
 }
 
 /**
- * Builds leaderboard chart data for the VideoPress widget.
- *
- * Transforms Jetpack Stats video-plays data into the format required by
- * LeaderboardChart, with comparison values aligned by video (videos missing
- * from the comparison period count as zero).
+ * Flattens the primary video-plays report into normalized rows, attaching each
+ * video's comparison-period plays matched by stable video key. Videos missing
+ * from the comparison period keep `previousPlays: null` so the caller can tell
+ * "no comparison row" apart from a real zero.
  *
  * @param primary    - Primary period video-plays report
  * @param comparison - Comparison period video-plays report
- * @return Processed data ready for the LeaderboardChart component
+ * @return Normalized rows ready for the leaderboard
  */
-export function buildVideoPlaysData(
+export function toVideoPlaysRows(
 	primary: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
 	comparison: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
-): LeaderboardChartData {
-	const videos = toVideoItems( primary );
-
-	if ( videos.length === 0 ) {
-		return [];
-	}
-
+): VideoPlaysRow[] {
 	const comparisonPlays = new Map(
 		toVideoItems( comparison ).map( video => [ getVideoKey( video ), video.plays ] )
 	);
 
-	// Share each value against the largest of either period so the overlay bars
-	// stay proportional; `1` guards against division by zero.
-	const maxValue = Math.max(
-		...videos.map( video =>
-			Math.max( video.plays, comparisonPlays.get( getVideoKey( video ) ) ?? 0 )
-		),
-		1
-	);
-
-	return videos.map( video => {
+	return toVideoItems( primary ).map( video => {
 		const key = getVideoKey( video );
-		const currentValue = video.plays;
-		const previousValue = comparisonPlays.get( key ) ?? 0;
 
 		return {
-			id: key,
+			key,
 			label: getVideoLabel( video ),
-			currentValue,
-			previousValue,
-			currentShare: ( currentValue / maxValue ) * 100,
-			previousShare: ( previousValue / maxValue ) * 100,
-			delta: calculateDelta( currentValue, previousValue ),
+			link: video.link,
+			plays: video.plays,
+			previousPlays: comparisonPlays.get( key ) ?? null,
 		};
 	} );
 }

--- a/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import {
+	getVideoKey,
+	getVideoLabel,
+	toVideoItems,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 
 /**
@@ -33,51 +37,6 @@ export type VideoPlaysRow = {
 	 */
 	previousPlays: number | null;
 };
-
-/**
- * Resolve a display label for a video, falling back to a translated
- * "Untitled video" label when the API provides none.
- *
- * @param video - The video-plays item.
- * @return The video's display label.
- */
-function getVideoLabel( video: StatsVideoPlaysItem ) {
-	return typeof video.label === 'string' && video.label
-		? video.label
-		: __( 'Untitled video', 'jetpack-premium-analytics' );
-}
-
-/**
- * Resolve the key used to align a video across the primary and comparison
- * periods, and to identify its leaderboard row. Prefers the stable post ID,
- * then the video URL, and only falls back to the display label when the API
- * omits both — so multiple untitled videos don't collapse onto one key.
- *
- * @param video - The video-plays item.
- * @return The alignment key.
- */
-function getVideoKey( video: StatsVideoPlaysItem ) {
-	if ( video.id != null ) {
-		return String( video.id );
-	}
-
-	return video.link || getVideoLabel( video );
-}
-
-/**
- * Flatten a normalized video-plays report into its per-video items. The Stats
- * query layer summarizes multi-day ranges server-side and the endpoint returns
- * videos already ranked and limited by `max`, so the report carries a single
- * data point of per-video totals.
- *
- * @param report - The normalized video-plays report, or undefined while loading.
- * @return The per-video items for the period.
- */
-function toVideoItems(
-	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
-): StatsVideoPlaysItem[] {
-	return report?.data.flatMap( point => point.items ) ?? [];
-}
 
 /**
  * Flattens the primary video-plays report into normalized rows, attaching each

--- a/projects/packages/premium-analytics/widgets/videopress/package.json
+++ b/projects/packages/premium-analytics/widgets/videopress/package.json
@@ -8,6 +8,7 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
 		"@wordpress/widget-primitives": "0.2.0",
 		"react": "18.3.1"
 	}

--- a/projects/packages/premium-analytics/widgets/videopress/package.json
+++ b/projects/packages/premium-analytics/widgets/videopress/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-videopress",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -8,6 +8,7 @@ import {
 	WidgetState,
 	calculateDelta,
 	formatLegendLabels,
+	toMaxRows,
 	useWidgetRootContext,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
@@ -21,11 +22,9 @@ import { useMemo } from 'react';
  */
 import { toVideoPlaysRows, type VideoPlaysRow } from './build-video-plays-data';
 import styles from './style.module.css';
-import type { VideoPressAttributes } from './widget';
+import { DEFAULT_MAX, type VideoPressAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
-
-const DEFAULT_MAX = 7;
 
 // The dashboard injects its date range and comparison state through
 // `reportParams`; the widget's own settings come from `VideoPressAttributes`.
@@ -36,15 +35,6 @@ type VideoPressWidgetProps = WidgetRenderProps< VideoPressRenderAttributes > & {
 	 * Dashboard error handler.
 	 */
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
-};
-
-// Resolve the `max` attribute to the row count requested from Stats. Per the
-// Stats widget contract `max = 0` means "all rows", so it passes through; only
-// negative or non-numeric values fall back to the default.
-const toMaxRows = ( value: string | number | undefined, fallback: number ) => {
-	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
-
-	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -4,22 +4,23 @@
 import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
-	WidgetLoadingOverlay,
 	WidgetRoot,
+	WidgetState,
+	calculateDelta,
 	formatLegendLabels,
-	useWidgetError,
 	useWidgetRootContext,
 	type LeaderboardChartData,
-	type LegendLabels,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
+import { Link } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { buildVideoPlaysData } from './build-video-plays-data';
+import { toVideoPlaysRows, type VideoPlaysRow } from './build-video-plays-data';
+import styles from './style.module.css';
 import type { VideoPressAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
@@ -46,69 +47,50 @@ const toMaxRows = ( value: string | number | undefined, fallback: number ) => {
 	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
 };
 
-type VideoPressLeaderboardProps = {
-	/**
-	 * Leaderboard rows to render, already built from the video-plays report.
-	 * When omitted, the empty state is shown (unless `isLoading` is set).
-	 */
-	data?: LeaderboardChartData;
-	/**
-	 * When `true`, the initial loading overlay is rendered instead of the chart.
-	 */
-	isLoading?: boolean;
-	/**
-	 * When `true`, a loading overlay is layered over the chart while data
-	 * refetches in the background.
-	 */
-	isRefetching?: boolean;
-	/**
-	 * When `true`, render each row's previous-period delta next to its value.
-	 */
-	withComparison?: boolean;
-	/**
-	 * Custom legend labels for the current/comparison periods.
-	 */
-	legendLabels?: LegendLabels;
-};
-
 /**
- * Presentational leaderboard for the VideoPress widget. Renders the site's most
- * played VideoPress videos and is responsible only for the loading, empty, and
- * populated states.
+ * Maps normalized video rows onto the shape `LeaderboardChart` expects. Each
+ * row's label opens the video's page in a new tab when the report carries a
+ * URL. Shares are computed against the largest value of either period so the
+ * overlay bars stay proportional.
  *
- * @param {VideoPressLeaderboardProps} props - The component props.
- * @return The rendered leaderboard.
+ * @param rows           - The normalized video-plays rows.
+ * @param withComparison - Whether to derive previous-period shares and deltas.
+ * @return The leaderboard chart data.
  */
-function VideoPressLeaderboard( {
-	data = [],
-	isLoading = false,
-	isRefetching = false,
-	withComparison = false,
-	legendLabels,
-}: VideoPressLeaderboardProps ) {
-	if ( isLoading ) {
-		return <WidgetLoadingOverlay />;
-	}
+function buildLeaderboardData(
+	rows: VideoPlaysRow[],
+	withComparison: boolean
+): LeaderboardChartData {
+	// `1` guards against division by zero when every value is 0.
+	const maxPlays = Math.max( ...rows.flatMap( row => [ row.plays, row.previousPlays ?? 0 ] ), 1 );
 
-	return (
-		<>
-			<LeaderboardChart
-				data={ data }
-				withComparison={ withComparison }
-				legendLabels={ legendLabels }
-				dataFormat={ {
-					type: 'number',
-					options: { useMultipliers: true, decimals: 0 },
-				} }
-				emptyStateIcon={ video }
-				emptyStateText={ __(
-					'Learn which VideoPress videos your visitors watch most to understand what keeps them engaged.',
-					'jetpack-premium-analytics'
-				) }
-			/>
-			{ isRefetching && <WidgetLoadingOverlay /> }
-		</>
-	);
+	return rows.map( row => {
+		const previousValue = row.previousPlays ?? 0;
+
+		return {
+			id: row.key,
+			label: row.link ? (
+				<Link
+					className={ styles.labelLink }
+					href={ row.link }
+					variant="unstyled"
+					openInNewTab
+					title={ row.label }
+				>
+					{ row.label }
+				</Link>
+			) : (
+				<span className={ styles.labelText } title={ row.label }>
+					{ row.label }
+				</span>
+			),
+			currentValue: row.plays,
+			currentShare: ( row.plays / maxPlays ) * 100,
+			previousValue,
+			previousShare: withComparison ? ( previousValue / maxPlays ) * 100 : 0,
+			delta: withComparison ? calculateDelta( row.plays, previousValue ) : 0,
+		};
+	} );
 }
 
 type VideoPressReportProps = {
@@ -120,7 +102,7 @@ type VideoPressReportProps = {
 
 /**
  * Fetches the video-plays report through the Jetpack Stats hook, builds the
- * leaderboard rows, and hands them to the presentational `VideoPressLeaderboard`.
+ * leaderboard rows, and renders them through the shared widget content states.
  *
  * @param {VideoPressReportProps} props - The component props.
  * @return The widget content.
@@ -129,45 +111,64 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 	const { reportParams } = useWidgetRootContext();
 	const statsParams = useMemo( () => ( { ...reportParams, max } ), [ reportParams, max ] );
 
-	const {
-		primary,
-		comparison,
-		hasComparison,
-		isLoading,
-		isFetching,
-		hasData,
-		isError,
-		error,
-		refetch,
-	} = useStatsVideoPlays( statsParams );
+	const { primary, comparison, hasComparison, isLoading, isFetching, hasData, isError, refetch } =
+		useStatsVideoPlays( statsParams );
 
 	// `primary.isPending` also covers the brief window where the query is disabled
 	// while the report params resolve (isLoading is false there).
 	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
-	const isRefetching = isFetching && hasData;
 	const primaryData = primary.data;
 	const comparisonData = comparison.data;
 
-	const chartData = useMemo(
-		() => buildVideoPlaysData( primaryData, comparisonData ),
+	const rows = useMemo(
+		() => toVideoPlaysRows( primaryData, comparisonData ),
 		[ primaryData, comparisonData ]
+	);
+
+	// Only render comparison UI when at least one primary row matched a
+	// comparison row; otherwise every row would show a fabricated vs-zero delta.
+	const withComparison = hasComparison && rows.some( row => row.previousPlays !== null );
+
+	const chartData = useMemo(
+		() => buildLeaderboardData( rows, withComparison ),
+		[ rows, withComparison ]
 	);
 
 	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
 
-	const hasError = useWidgetError( isError, error, refetch );
-	if ( hasError ) {
-		return null;
-	}
-
 	return (
-		<VideoPressLeaderboard
-			data={ chartData }
+		<WidgetState
 			isLoading={ isInitialLoading }
-			isRefetching={ isRefetching }
-			withComparison={ hasComparison }
-			legendLabels={ legendLabels }
-		/>
+			isFetching={ isFetching }
+			isError={ isError }
+			isEmpty={ rows.length === 0 }
+			error={ {
+				description: __(
+					"We couldn't load video plays. Please try again in a moment.",
+					'jetpack-premium-analytics'
+				),
+				actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+			} }
+			empty={ {
+				icon: video,
+				description: __(
+					'Learn which VideoPress videos your visitors watch most to understand what keeps them engaged.',
+					'jetpack-premium-analytics'
+				),
+			} }
+		>
+			<LeaderboardChart
+				data={ chartData }
+				withComparison={ withComparison }
+				withOverlayLabel
+				showLegend={ withComparison }
+				legendLabels={ legendLabels }
+				dataFormat={ {
+					type: 'number',
+					options: { useMultipliers: true, decimals: 0 },
+				} }
+			/>
+		</WidgetState>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
+import {
+	LeaderboardChart,
+	WidgetLoadingOverlay,
+	WidgetRoot,
+	formatLegendLabels,
+	useWidgetError,
+	useWidgetRootContext,
+	type LeaderboardChartData,
+	type LegendLabels,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { buildVideoPlaysData } from './build-video-plays-data';
+import type { VideoPressAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
+
+const DEFAULT_MAX = 7;
+
+// The dashboard injects its date range and comparison state through
+// `reportParams`; the widget's own settings come from `VideoPressAttributes`.
+type VideoPressRenderAttributes = VideoPressAttributes & Partial< ReportParamsFieldAttributes >;
+
+type VideoPressWidgetProps = WidgetRenderProps< VideoPressRenderAttributes > & {
+	/**
+	 * Dashboard error handler.
+	 */
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+// Resolve the `max` attribute to the row count requested from Stats. Per the
+// Stats widget contract `max = 0` means "all rows", so it passes through; only
+// negative or non-numeric values fall back to the default.
+const toMaxRows = ( value: string | number | undefined, fallback: number ) => {
+	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
+
+	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
+};
+
+type VideoPressLeaderboardProps = {
+	/**
+	 * Leaderboard rows to render, already built from the video-plays report.
+	 * When omitted, the empty state is shown (unless `isLoading` is set).
+	 */
+	data?: LeaderboardChartData;
+	/**
+	 * When `true`, the initial loading overlay is rendered instead of the chart.
+	 */
+	isLoading?: boolean;
+	/**
+	 * When `true`, a loading overlay is layered over the chart while data
+	 * refetches in the background.
+	 */
+	isRefetching?: boolean;
+	/**
+	 * When `true`, render each row's previous-period delta next to its value.
+	 */
+	withComparison?: boolean;
+	/**
+	 * Custom legend labels for the current/comparison periods.
+	 */
+	legendLabels?: LegendLabels;
+};
+
+/**
+ * Presentational leaderboard for the VideoPress widget. Renders the site's most
+ * played VideoPress videos and is responsible only for the loading, empty, and
+ * populated states.
+ *
+ * @param {VideoPressLeaderboardProps} props - The component props.
+ * @return The rendered leaderboard.
+ */
+function VideoPressLeaderboard( {
+	data = [],
+	isLoading = false,
+	isRefetching = false,
+	withComparison = false,
+	legendLabels,
+}: VideoPressLeaderboardProps ) {
+	if ( isLoading ) {
+		return <WidgetLoadingOverlay />;
+	}
+
+	return (
+		<>
+			<LeaderboardChart
+				data={ data }
+				withComparison={ withComparison }
+				legendLabels={ legendLabels }
+				dataFormat={ {
+					type: 'number',
+					options: { useMultipliers: true, decimals: 0 },
+				} }
+				emptyStateIcon={ video }
+				emptyStateText={ __(
+					'Learn which VideoPress videos your visitors watch most to understand what keeps them engaged.',
+					'jetpack-premium-analytics'
+				) }
+			/>
+			{ isRefetching && <WidgetLoadingOverlay /> }
+		</>
+	);
+}
+
+type VideoPressReportProps = {
+	/**
+	 * Maximum number of videos to display.
+	 */
+	max: number;
+};
+
+/**
+ * Fetches the video-plays report through the Jetpack Stats hook, builds the
+ * leaderboard rows, and hands them to the presentational `VideoPressLeaderboard`.
+ *
+ * @param {VideoPressReportProps} props - The component props.
+ * @return The widget content.
+ */
+function VideoPressReport( { max }: VideoPressReportProps ) {
+	const { reportParams } = useWidgetRootContext();
+	const statsParams = useMemo( () => ( { ...reportParams, max } ), [ reportParams, max ] );
+
+	const {
+		primary,
+		comparison,
+		hasComparison,
+		isLoading,
+		isFetching,
+		hasData,
+		isError,
+		error,
+		refetch,
+	} = useStatsVideoPlays( statsParams );
+
+	// `primary.isPending` also covers the brief window where the query is disabled
+	// while the report params resolve (isLoading is false there).
+	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
+	const isRefetching = isFetching && hasData;
+	const primaryData = primary.data;
+	const comparisonData = comparison.data;
+
+	const chartData = useMemo(
+		() => buildVideoPlaysData( primaryData, comparisonData ),
+		[ primaryData, comparisonData ]
+	);
+
+	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const hasError = useWidgetError( isError, error, refetch );
+	if ( hasError ) {
+		return null;
+	}
+
+	return (
+		<VideoPressLeaderboard
+			data={ chartData }
+			isLoading={ isInitialLoading }
+			isRefetching={ isRefetching }
+			withComparison={ hasComparison }
+			legendLabels={ legendLabels }
+		/>
+	);
+}
+
+/**
+ * VideoPress widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client, chart theme, and the report
+ * params consumed by the inner leaderboard — resolved from the dashboard date
+ * range via context, the same way the other Stats widgets read them.
+ *
+ * @param {VideoPressWidgetProps} props - The widget render props.
+ * @return The rendered VideoPress widget.
+ */
+export default function VideoPress( { attributes = {}, setError }: VideoPressWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError }>
+			<VideoPressReport max={ toMaxRows( attributes.max, DEFAULT_MAX ) } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -1,11 +1,14 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -44,6 +47,18 @@ function renderVideoPress( { withComparison }: VideoPressStoryControls ) {
 	return (
 		<VideoPressRender
 			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderVideoPressOnPreset( preset: PresetType ) {
+	return (
+		<VideoPressRender
+			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -93,6 +108,50 @@ export const WithComparison: Story = {
 	render: renderVideoPress,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderVideoPressOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/video-plays', 'loading' );
+		return () => setReportMockState( 'stats/video-plays', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderVideoPressOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/video-plays', 'error' );
+		return () => setReportMockState( 'stats/video-plays', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the video glyph and
+ * the "learn which videos your visitors watch most" hint).
+ */
+export const Empty: Story = {
+	render: () => renderVideoPressOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/video-plays', 'empty' );
+		return () => setReportMockState( 'stats/video-plays', null );
+	},
 };
 
 interface VideoPressDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -16,7 +16,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import VideoPressRender from '../render';
-import widgetDefinition from '../widget';
+import widgetDefinition, { DEFAULT_MAX } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -24,8 +24,6 @@ import type { ComponentProps, ComponentType } from 'react';
 registerReportMocks();
 
 const VIDEOPRESS_RENDER_MODULE = 'storybook/videopress';
-
-const DEFAULT_MAX = 7;
 
 // Widget-specific story control: toggles the previous-period comparison.
 interface VideoPressStoryControls {

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import VideoPressRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const VIDEOPRESS_RENDER_MODULE = 'storybook/videopress';
+
+const DEFAULT_MAX = 7;
+
+// Widget-specific story control: toggles the previous-period comparison.
+interface VideoPressStoryControls {
+	/**
+	 * Whether to request the previous-period comparison.
+	 */
+	withComparison: boolean;
+}
+
+/**
+ * Render the data-connected VideoPress widget with report params derived from
+ * the `withComparison` control, so the close-up stories exercise the real data
+ * flow (served by `registerReportMocks`).
+ *
+ * @param {VideoPressStoryControls} props - Story controls.
+ * @return The rendered widget.
+ */
+function renderVideoPress( { withComparison }: VideoPressStoryControls ) {
+	return (
+		<VideoPressRender
+			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Close-up canvas so the leaderboard fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '360px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/VideoPress',
+	component: VideoPressRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Dashboard widget showing the site's most played VideoPress videos as a leaderboard, sourced from the Jetpack Stats `video-plays` module via `useStatsVideoPlays`, with optional period-over-period comparison. In Storybook the data is served by `registerReportMocks`.",
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof VideoPressRender > & VideoPressStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< VideoPressStoryControls >;
+
+/**
+ * The widget on its own, current period only.
+ */
+export const Default: Story = {
+	render: renderVideoPress,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Same close-up with each video's period-over-period delta (green for gains,
+ * red for losses) driven by the mocked comparison window.
+ */
+export const WithComparison: Story = {
+	render: renderVideoPress,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface VideoPressDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		VideoPressStoryControls {}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness, so
+ * it appears exactly as it does in product, inheriting the size / edit-mode /
+ * host-environment controls.
+ *
+ * @param {VideoPressDashboardStoryProps} props - Story controls.
+ * @return The widget mounted in the dashboard harness.
+ */
+function VideoPressDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: VideoPressDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ VIDEOPRESS_RENDER_MODULE }
+			renderComponent={ VideoPressRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< VideoPressDashboardStoryProps > = {
+	render: args => <VideoPressDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -1,0 +1,23 @@
+.labelLink,
+.labelText {
+	display: block;
+
+	/* Vertical padding sets the overlay bar height — the bar fills the row,
+	   whose height is driven by this label (there is no image to size it). */
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+
+	/* Inset the text from the bar's rounded left edge. The chart applies this to
+	   its default `.label` in overlay mode (`.is-overlay .label`), but a custom
+	   label element bypasses that rule, so we mirror it here. */
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: inherit;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.labelLink:hover,
+.labelLink:focus {
+	text-decoration: underline;
+}

--- a/projects/packages/premium-analytics/widgets/videopress/widget.json
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/videopress",
+	"title": "VideoPress",
+	"description": "Your most played VideoPress videos, sourced from Jetpack Stats.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/videopress/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.ts
@@ -6,6 +6,11 @@ import { video } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
+ * Default number of videos shown when the `max` attribute is unset or invalid.
+ */
+export const DEFAULT_MAX = 7;
+
+/**
  * Configurable attributes for the VideoPress widget. Mirrors the `attributes`
  * declared on the widget definition below; the host passes the selected values
  * through to `render.tsx`.
@@ -35,7 +40,7 @@ export default {
 	] as WidgetAttributeField< VideoPressAttributes >[],
 	example: {
 		attributes: {
-			max: 7,
+			max: DEFAULT_MAX,
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/videopress/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Configurable attributes for the VideoPress widget. Mirrors the `attributes`
+ * declared on the widget definition below; the host passes the selected values
+ * through to `render.tsx`.
+ */
+export type VideoPressAttributes = {
+	/**
+	 * Maximum number of videos to show; `0` means all. Maps to the WPCOM stats
+	 * `max` param. Integer form controls can serialize the value to a string, so
+	 * the render entry accepts either.
+	 */
+	max?: string | number;
+};
+
+/**
+ * Widget type definition.
+ */
+export default {
+	name: 'jpa/videopress',
+	title: __( 'VideoPress', 'jetpack-premium-analytics' ),
+	icon: video,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Maximum videos', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	] as WidgetAttributeField< VideoPressAttributes >[],
+	example: {
+		attributes: {
+			max: 7,
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videos/build-video-plays-data.ts
@@ -3,56 +3,12 @@
  */
 import {
 	calculateDelta,
+	getVideoKey,
+	getVideoLabel,
+	toVideoItems,
 	type LeaderboardChartData,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __ } from '@wordpress/i18n';
 import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
-
-/**
- * Resolve a display label for a video, falling back to a translated
- * "Untitled video" label when the API provides none.
- *
- * @param video - The video-plays item.
- * @return The video's display label.
- */
-function getVideoLabel( video: StatsVideoPlaysItem ) {
-	return typeof video.label === 'string' && video.label
-		? video.label
-		: __( 'Untitled video', 'jetpack-premium-analytics' );
-}
-
-/**
- * Resolve the key used to align a video across the primary and comparison
- * periods, and to identify its leaderboard row. Prefers the stable post ID,
- * then the video URL, and only falls back to the display label when the API
- * omits both — so multiple untitled videos don't collapse onto one key.
- *
- * @param video - The video-plays item.
- * @return The alignment key.
- */
-function getVideoKey( video: StatsVideoPlaysItem ) {
-	if ( video.id != null ) {
-		return String( video.id );
-	}
-
-	return video.link || getVideoLabel( video );
-}
-
-/**
- * Flatten a normalized video-plays report into its per-video items. The Stats
- * query layer summarizes multi-day ranges server-side and the endpoint returns
- * videos already ranked and limited by `max`, so the report carries a single
- * data point of per-video totals — mirroring how the Authors widget reads its
- * report.
- *
- * @param report - The normalized video-plays report, or undefined while loading.
- * @return The per-video items for the period.
- */
-function toVideoItems(
-	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
-): StatsVideoPlaysItem[] {
-	return report?.data.flatMap( point => point.items ) ?? [];
-}
 
 /**
  * Builds leaderboard chart data for the Videos widget.

--- a/projects/packages/premium-analytics/widgets/videos/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videos/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetLoadingOverlay,
 	WidgetRoot,
 	formatLegendLabels,
+	toMaxRows,
 	useWidgetError,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -20,11 +21,9 @@ import { useMemo } from 'react';
  * Internal dependencies
  */
 import { buildVideoPlaysData } from './build-video-plays-data';
-import type { VideosAttributes } from './widget';
+import { DEFAULT_MAX, type VideosAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
-
-const DEFAULT_MAX = 7;
 
 // The dashboard injects its date range and comparison state through
 // `reportParams`; the widget's own settings come from `VideosAttributes`.
@@ -35,15 +34,6 @@ type VideosWidgetProps = WidgetRenderProps< VideosRenderAttributes > & {
 	 * Dashboard error handler.
 	 */
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
-};
-
-// Resolve the `max` attribute to the row count requested from Stats. Per the
-// Stats widget contract `max = 0` means "all rows", so it passes through; only
-// negative or non-numeric values fall back to the default.
-const toMaxRows = ( value: string | number | undefined, fallback: number ) => {
-	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
-
-	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
 };
 
 type VideosLeaderboardProps = {

--- a/projects/packages/premium-analytics/widgets/videos/stories/videos-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videos/stories/videos-widget.stories.tsx
@@ -13,7 +13,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import VideosRender from '../render';
-import widgetDefinition from '../widget';
+import widgetDefinition, { DEFAULT_MAX } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -21,8 +21,6 @@ import type { ComponentProps, ComponentType } from 'react';
 registerReportMocks();
 
 const VIDEOS_RENDER_MODULE = 'storybook/videos';
-
-const DEFAULT_MAX = 7;
 
 // Widget-specific story control: toggles the previous-period comparison.
 interface VideosStoryControls {

--- a/projects/packages/premium-analytics/widgets/videos/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videos/widget.ts
@@ -6,6 +6,11 @@ import { video } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
+ * Default number of videos shown when the `max` attribute is unset or invalid.
+ */
+export const DEFAULT_MAX = 7;
+
+/**
  * Configurable attributes for the Videos widget. Mirrors the `attributes`
  * declared on the widget definition below; the host passes the selected values
  * through to `render.tsx`.
@@ -35,7 +40,7 @@ export default {
 	] as WidgetAttributeField< VideosAttributes >[],
 	example: {
 		attributes: {
-			max: 7,
+			max: DEFAULT_MAX,
 		},
 	},
 };


### PR DESCRIPTION
## Proposed changes

Ports the Stats "VideoPress" (video plays) module into Premium Analytics as the `jpa/videopress` widget.

- New widget at `widgets/videopress/` (`jpa/videopress`, category `stats`, framed). A single `max` attribute caps the number of rows (`max = 0` means all); the date range + comparison state come from `reportParams`.
- Renders a **leaderboard of videos by plays** via `LeaderboardChart` with overlay labels, matching the other linked leaderboard ports (`top-posts`, `referrers`, `clicks`). Play counts use the multiplier number format (`useMultipliers`).
- **Each row's label links out to the video's page** in a new tab (parity with the legacy module's link action); rows without a URL render as plain text.
- With a comparison period, each row shows its own period-over-period delta, matched per video by a **stable video id** (no fabricated previous values). The builder keeps `previousPlays: null` (not zero) for unmatched videos, and the comparison UI only renders when at least one primary row matched a comparison row — otherwise the widget falls back to the plain leaderboard instead of showing vs-zero deltas.
- Loading / error / empty states render through the shared **`<WidgetState>`** contract: initial load shows the overlay, background refetches keep rows visible under a busy overlay, the error state offers a Retry action wired to the hook's `refetch`, and the empty state uses the widget's video glyph.
- Data layer: reuses the existing `useStatsVideoPlays` hook for `stats/video-plays` — no new hook, and the `stats` prefix is already allow-listed (no new prefix).
- Storybook: `Default`, `WithComparison`, `WidgetDashboardWithWidget`; reuses the existing `stats/video-plays` fixture + handler (no shared-mock changes).

Not in scope: the per-video drill-down and the `complete_stats` metrics (impressions, watch time, retention) belong to the Video detail page (WOOA7S-1625), which composes this widget.

**Relationship to `jpa/videos` (#49573):** the two widgets port two _different_ upstream Calypso modules — `jpa/videos` is the Traffic-page Videos card (`stats-videos.tsx`, a plain plays list), while `jpa/videopress` is the VideoPress stats module (`videopress-stats-module/index.jsx`, whose full form adds the `complete_stats` metrics grid — Impressions / Hours Watched / Retention Rate / Views — and per-video drill-down). Because those metrics and the drill-down are deferred to WOOA7S-1625, the two widgets currently render a near-identical plays leaderboard; they diverge once WOOA7S-1625 lands. The video-plays helpers they had in common (`getVideoLabel` / `getVideoKey` / `toVideoItems`, plus the `max`-attribute resolver) are deduplicated into `widgets-toolkit` here, while each widget keeps its own row builder.

## Related product discussion/links

- WOOA7S-1519

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / VideoPress**:
  - `Default` shows the video plays leaderboard; each row opens its video page in a new tab, and the untitled fixture row falls back to "Untitled video".
  - `WithComparison` shows a per-row delta matched by video id.
  - On the dashboard story, change the date range — rows keep the previous numbers and show a busy overlay until the new period arrives.
  - `Loading` / `Error` / `Empty` (off the autodocs page) force each widget state via `setReportMockState`; `Error` shows the Retry action.
- Jest covers the row links, empty state, and the error state's Retry action (`pnpm jest --config=tests/jest.config.cjs widgets/videopress`).
- Or test the dashboard against a live connected site with VideoPress data (JN/Atomic smoke test is the acceptance step).

https://github.com/user-attachments/assets/0aafeabb-9b53-4c8a-8fd1-f5410a436913
