### PR TITLE
WOOA7S-1520: Port Stats Video detail embeds widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-video-detail-embeds-widget
+++ b/projects/packages/premium-analytics/changelog/add-video-detail-embeds-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Video embeds Stats widget, listing where a single video is embedded.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -151,6 +151,7 @@ export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
 	type StatsSingleVideoPage,
+	type StatsSingleVideoParams,
 	type StatsSingleVideoResponse,
 } from './use-stats-single-video';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -5,15 +5,16 @@ import { statsSingleVideoQuery } from '../queries/stats-single-video-query';
 import { useStatsQuery } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 import type { StatsSingleVideoReport } from '../processing/stats';
-import type { StatsQueryParams } from '../utils/stats-params';
+import type { StatsSingleVideoParams } from '../queries/stats-single-video-query';
 
 export type { StatsSingleVideoDataPoint, StatsSingleVideoPage } from '../processing/stats';
+export type { StatsSingleVideoParams } from '../queries/stats-single-video-query';
 
 export type StatsSingleVideoResponse = StatsSingleVideoReport;
 
 export function useStatsSingleVideo(
 	videoId: number,
-	params?: StatsQueryParams,
+	params?: StatsSingleVideoParams,
 	options?: UseStatsOptions
 ) {
 	return useStatsQuery( statsSingleVideoQuery( videoId, params ), options );

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -159,6 +159,7 @@ export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
 	type StatsSingleVideoPage,
+	type StatsSingleVideoParams,
 	type StatsSingleVideoResponse,
 } from './hooks/use-stats-single-video';
 export {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -486,23 +486,24 @@ describe( 'Stats query factories', () => {
 			'1.1',
 			'stats/video/31533',
 			'GET',
-			{},
+			{ period: 'day' },
 			undefined,
 			'singleVideo',
 		] );
 	} );
 
-	it( 'passes single video params through to the request', () => {
+	it( 'converts the report date range for the single video request', () => {
 		const query = statsSingleVideoQuery( 31533, {
-			period: 'day',
-			end_date: '2026-06-14',
-			statType: 'watch_time',
+			from: '2026-06-08',
+			to: '2026-06-14',
+			interval: 'day',
 		} );
 
 		expect( query.queryKey[ 5 ] ).toEqual( {
 			period: 'day',
 			date: '2026-06-14',
-			statType: 'watch_time',
+			start_date: '2026-06-08',
+			days: 7,
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-single-video-query.ts
@@ -1,15 +1,24 @@
 /**
  * Internal dependencies
  */
-import { statsProxyQuery } from './stats-query';
-import type { StatsQueryParams } from '../utils/stats-params';
+import { reportParamsToStatsQueryParams } from '../utils/stats-params';
+import {
+	statsProxyQuery,
+	type StatsReportParams,
+	type StatsReportQueryOptions,
+} from './stats-query';
 
-export const statsSingleVideoQuery = ( videoId: number, params: StatsQueryParams = {} ) =>
+export type StatsSingleVideoParams = Partial< StatsReportParams >;
+
+export const statsSingleVideoQuery = (
+	videoId: number,
+	params: StatsSingleVideoParams = {}
+): StatsReportQueryOptions< 'singleVideo' > =>
 	statsProxyQuery( {
 		name: 'single-video',
 		version: '1.1',
 		endpoint: `stats/video/${ videoId }`,
-		params,
+		params: reportParamsToStatsQueryParams( params ),
 		sanitizer: 'singleVideo',
 		enabled: Number.isInteger( videoId ) && videoId > 0,
 	} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -31,6 +31,8 @@ export {
 	type BarChartData,
 	type BarChartStyle,
 	WidgetLoadingOverlay,
+	ChartEmptyState,
+	type ChartEmptyStateProps,
 	WidgetState,
 	type WidgetStateProps,
 	type WidgetStateError,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -63,6 +63,7 @@ export {
 } from './customers';
 
 export { mockSearchTermsData, mockSearchTermsComparisonData } from './search-terms';
+export { mockSingleVideoData } from './single-video';
 export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors';
 
 export { mockSiteSummary } from './site-summary';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/single-video.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/single-video.ts
@@ -1,0 +1,24 @@
+/**
+ * Mock response for the Jetpack Stats single-video module (`stats/video/%d`),
+ * so the "Video embeds" widget renders populated in Storybook. The shape matches
+ * what `sanitizeStatsSingleVideoResponse` reads: `data` is a `[ date, plays ]`
+ * time series and `pages` is the list of URLs where the video is embedded.
+ */
+export const mockSingleVideoData = {
+	data: [
+		[ '2026-06-16', 42 ],
+		[ '2026-06-17', 58 ],
+		[ '2026-06-18', 37 ],
+		[ '2026-06-19', 61 ],
+		[ '2026-06-20', 49 ],
+		[ '2026-06-21', 73 ],
+		[ '2026-06-22', 88 ],
+	],
+	pages: [
+		'https://example.com/getting-started-walkthrough/',
+		'https://example.com/2026/06/product-launch-highlights/',
+		'https://example.com/tutorials/advanced-settings/',
+		'https://example.com/about/behind-the-scenes/',
+		'https://example.com/blog/weekly-recap/',
+	],
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -47,6 +47,7 @@ import {
 	mockCustomersByDateComparisonData,
 	mockSearchTermsData,
 	mockSearchTermsComparisonData,
+	mockSingleVideoData,
 	mockTopAuthorsData,
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
@@ -873,6 +874,11 @@ function buildEmailSummaryResponse() {
  * @return The mock response body, or `null` if no specific handler matched.
  */
 function routeStatsReport( subPath: string ): unknown {
+	// Single-video detail: `/video/{postId}` (drives the "Video embeds" widget).
+	if ( /^\/video\/\d+$/.test( subPath ) ) {
+		return mockSingleVideoData;
+	}
+
 	switch ( subPath ) {
 		case '':
 			// Site summary — the bare `/stats` endpoint (all-time totals).

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/__tests__/video-detail-embeds.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/__tests__/video-detail-embeds.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import VideoDetailEmbedsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const SINGLE_VIDEO_RESPONSE = {
+	data: [
+		[ '2026-06-21', 12 ],
+		[ '2026-06-22', 34 ],
+	],
+	pages: [ 'https://example.com/getting-started/', 'https://example.com/blog/weekly-recap/' ],
+};
+
+// A 403 is not retried by the data layer's `shouldRetryApiError`, so the error
+// state shows at once instead of after the query's retry backoff.
+const MOCK_API_ERROR = {
+	code: 'stats_mock_error',
+	message: 'Mocked error response.',
+	data: { status: 403 },
+};
+
+function renderWidget( postId?: number ) {
+	return render(
+		<VideoDetailEmbedsWidget
+			attributes={ {
+				reportParams: {
+					...getDefaultQueryParams( false, 'last-7-days' ),
+					...( postId === undefined ? {} : { post_id: postId } ),
+				},
+			} }
+		/>
+	);
+}
+
+describe( 'VideoDetailEmbedsWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( SINGLE_VIDEO_RESPONSE );
+	} );
+
+	it( 'lists the pages where the selected video is embedded as external links', async () => {
+		renderWidget( 105 );
+
+		const link = await screen.findByRole( 'link', { name: /getting-started/i } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/getting-started/' );
+		expect( screen.getByRole( 'link', { name: /weekly-recap/i } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/blog/weekly-recap/'
+		);
+	} );
+
+	it( 'prompts to select a video and skips fetching when no video is scoped', () => {
+		renderWidget();
+
+		expect( screen.getByText( /select a video/i ) ).toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the empty state when the video is not embedded anywhere', async () => {
+		mockApiFetch.mockResolvedValue( { ...SINGLE_VIDEO_RESPONSE, pages: [] } );
+
+		renderWidget( 105 );
+
+		await expect( screen.findByText( /has not been embedded/i ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'shows the error state with a Retry action that re-runs the query', async () => {
+		mockApiFetch.mockRejectedValue( MOCK_API_ERROR );
+
+		renderWidget( 105 );
+
+		await expect( screen.findByRole( 'alert' ) ).resolves.toHaveTextContent(
+			/couldn't load video embeds/i
+		);
+
+		const requestsBeforeRetry = mockApiFetch.mock.calls.length;
+		mockApiFetch.mockResolvedValue( SINGLE_VIDEO_RESPONSE );
+		fireEvent.click( screen.getByRole( 'button', { name: /retry/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect(
+			screen.findByRole( 'link', { name: /getting-started/i } )
+		).resolves.toBeInTheDocument();
+		expect( mockApiFetch.mock.calls.length ).toBeGreaterThan( requestsBeforeRetry );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/package.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-video-detail-embeds",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsSingleVideo,
+	reportParamsToStatsQueryParams,
+	type StatsSingleVideoPage,
+} from '@jetpack-premium-analytics/data';
+import {
+	ChartEmptyState,
+	WidgetRoot,
+	WidgetState,
+	useWidgetRootContext,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+import { Link, Stack } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import { type VideoDetailEmbedsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+// The widget has no own settings; the host injects the date range and the
+// single-video scope (`post_id`) through `reportParams`.
+type VideoDetailEmbedsRenderAttributes = VideoDetailEmbedsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type VideoDetailEmbedsWidgetProps = WidgetRenderProps< VideoDetailEmbedsRenderAttributes >;
+
+/**
+ * Resolves the VideoPress post ID from the host-composed report params. The
+ * value arrives as a string from the URL, so it is coerced to a positive
+ * integer; anything else yields `NaN`, which signals "no video selected".
+ *
+ * @param postId - The `post_id` report param.
+ * @return The video's post ID, or `NaN` when none is set.
+ */
+function toVideoId( postId: string | number | undefined ): number {
+	const parsed = typeof postId === 'number' ? postId : Number.parseInt( postId ?? '', 10 );
+
+	return Number.isInteger( parsed ) && parsed > 0 ? parsed : NaN;
+}
+
+type VideoEmbedsListProps = {
+	/**
+	 * Pages where the video is embedded, each rendered as an external link.
+	 */
+	pages: StatsSingleVideoPage[];
+};
+
+/**
+ * Presentational list for the "Video embeds" widget: the pages where the
+ * selected video is embedded, each as an external link. Loading / error /
+ * empty are owned by the surrounding `WidgetState`. Exported so Storybook
+ * and tests can exercise the populated state with fixtures.
+ *
+ * @param {VideoEmbedsListProps} props - The component props.
+ * @return The rendered list.
+ */
+export function VideoEmbedsList( { pages }: VideoEmbedsListProps ) {
+	return (
+		<ul className={ styles.list }>
+			{ pages.map( ( page, index ) => (
+				<li key={ `${ index }-${ page.link }` } className={ styles.item }>
+					<Link
+						className={ styles.link }
+						href={ page.link }
+						variant="unstyled"
+						openInNewTab
+						title={ page.label }
+					>
+						{ page.label }
+					</Link>
+				</li>
+			) ) }
+		</ul>
+	);
+}
+
+/**
+ * Fetches the single-video report through `useStatsSingleVideo` and renders the
+ * embed pages through `WidgetState`. The video is scoped by the host through
+ * `reportParams.post_id`; the query stays disabled until a video is selected,
+ * with a prompt shown instead of the data states.
+ *
+ * @return The widget content.
+ */
+function VideoDetailEmbedsReport() {
+	const { reportParams } = useWidgetRootContext();
+	const videoId = toVideoId( reportParams.post_id );
+
+	const statsParams = useMemo(
+		() => reportParamsToStatsQueryParams( reportParams ),
+		[ reportParams ]
+	);
+
+	const { data, isLoading, isFetching, isError, refetch } = useStatsSingleVideo(
+		videoId,
+		statsParams
+	);
+
+	let body;
+
+	if ( ! Number.isInteger( videoId ) ) {
+		body = (
+			<ChartEmptyState
+				icon={ video }
+				text={ __(
+					'Select a video to see where it is embedded across your site.',
+					'jetpack-premium-analytics'
+				) }
+			/>
+		);
+	} else {
+		const pages = data?.pages ?? [];
+
+		body = (
+			<WidgetState
+				isLoading={ isLoading }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ pages.length === 0 }
+				error={ {
+					description: __(
+						"We couldn't load video embeds. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [
+						{ label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: () => void refetch() },
+					],
+				} }
+				empty={ {
+					icon: video,
+					description: __(
+						'This video has not been embedded on any pages yet.',
+						'jetpack-premium-analytics'
+					),
+				} }
+			>
+				<VideoEmbedsList pages={ pages } />
+			</WidgetState>
+		);
+	}
+
+	return (
+		<Stack className={ styles.root }>
+			<div className={ styles.content }>{ body }</div>
+		</Stack>
+	);
+}
+
+/**
+ * Video embeds widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client, chart theme, and the report
+ * params consumed by the inner component — including the single-video scope
+ * (`post_id`) the host composes for detail views.
+ *
+ * @param {VideoDetailEmbedsWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function VideoDetailEmbeds( { attributes = {} }: VideoDetailEmbedsWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<VideoDetailEmbedsReport />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	useStatsSingleVideo,
-	reportParamsToStatsQueryParams,
-	type StatsSingleVideoPage,
-} from '@jetpack-premium-analytics/data';
+import { useStatsSingleVideo, type StatsSingleVideoPage } from '@jetpack-premium-analytics/data';
 import {
 	ChartEmptyState,
 	WidgetRoot,
@@ -13,7 +9,6 @@ import {
 	useWidgetRootContext,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
 import { Link, Stack } from '@wordpress/ui';
@@ -92,14 +87,9 @@ function VideoDetailEmbedsReport() {
 	const { reportParams } = useWidgetRootContext();
 	const videoId = toVideoId( reportParams.post_id );
 
-	const statsParams = useMemo(
-		() => reportParamsToStatsQueryParams( reportParams ),
-		[ reportParams ]
-	);
-
 	const { data, isLoading, isFetching, isError, refetch } = useStatsSingleVideo(
 		videoId,
-		statsParams
+		reportParams
 	);
 
 	let body;

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/render.tsx
@@ -27,8 +27,9 @@ type VideoDetailEmbedsWidgetProps = WidgetRenderProps< VideoDetailEmbedsRenderAt
 
 /**
  * Resolves the VideoPress post ID from the host-composed report params. The
- * value arrives as a string from the URL, so it is coerced to a positive
- * integer; anything else yields `NaN`, which signals "no video selected".
+ * `post_id` report param is typed `string | number`, so it is defensively
+ * coerced to a positive integer; anything else yields `NaN`, which signals
+ * "no video selected".
  *
  * @param postId - The `post_id` report param.
  * @return The video's post ID, or `NaN` when none is set.
@@ -49,13 +50,12 @@ type VideoEmbedsListProps = {
 /**
  * Presentational list for the "Video embeds" widget: the pages where the
  * selected video is embedded, each as an external link. Loading / error /
- * empty are owned by the surrounding `WidgetState`. Exported so Storybook
- * and tests can exercise the populated state with fixtures.
+ * empty are owned by the surrounding `WidgetState`.
  *
  * @param {VideoEmbedsListProps} props - The component props.
  * @return The rendered list.
  */
-export function VideoEmbedsList( { pages }: VideoEmbedsListProps ) {
+function VideoEmbedsList( { pages }: VideoEmbedsListProps ) {
 	return (
 		<ul className={ styles.list }>
 			{ pages.map( ( page, index ) => (

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -1,0 +1,239 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import VideoDetailEmbedsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const VIDEO_DETAIL_EMBEDS_RENDER_MODULE = 'storybook/video-detail-embeds';
+
+// The single-video endpoint path fragment the forced-state stories override.
+// The trailing slash keeps it from matching `stats/video-plays`.
+const SINGLE_VIDEO_PATH_FRAGMENT = 'stats/video/';
+
+// A stand-in VideoPress post ID. The widget has no meaning without a selected
+// video, so the host scopes it through `reportParams.post_id`; the mocked
+// `stats/video/{id}` endpoint returns the same fixture for any ID.
+const MOCK_VIDEO_ID = 105;
+
+// Widget-specific story control: toggles the previous-period comparison params.
+interface VideoDetailEmbedsStoryControls {
+	/**
+	 * Whether to request the previous-period comparison.
+	 */
+	withComparison: boolean;
+}
+
+/**
+ * Builds the host-composed report params for the selected video, deriving the
+ * date range / comparison from the `withComparison` control.
+ *
+ * @param {boolean}    withComparison - Whether to include comparison params.
+ * @param {PresetType} preset         - Optional date preset override.
+ * @return The report params with the single-video `post_id` scope.
+ */
+function reportParamsForVideo( withComparison: boolean, preset?: PresetType ) {
+	return { ...getDefaultQueryParams( withComparison, preset ), post_id: MOCK_VIDEO_ID };
+}
+
+/**
+ * Render the data-connected widget with report params derived from the
+ * `withComparison` control, so the close-up stories exercise the real data flow
+ * (served by `registerReportMocks`).
+ *
+ * @param {VideoDetailEmbedsStoryControls} props - Story controls.
+ * @return The rendered widget.
+ */
+function renderVideoDetailEmbeds( { withComparison }: VideoDetailEmbedsStoryControls ) {
+	return (
+		<VideoDetailEmbedsRender
+			attributes={ { reportParams: reportParamsForVideo( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderVideoDetailEmbedsOnPreset( preset: PresetType ) {
+	return (
+		<VideoDetailEmbedsRender
+			attributes={ { reportParams: reportParamsForVideo( false, preset ) } }
+		/>
+	);
+}
+
+// Close-up frame: a white, widget-sized card so each state reads the way it does
+// as a real dashboard widget (in product the host supplies this frame).
+const withWidgetCanvas: Decorator = Story => (
+	<div
+		style={ {
+			width: '380px',
+			height: '520px',
+			margin: '0 auto',
+			padding: '16px',
+			boxSizing: 'border-box',
+			background: '#fff',
+			border: '1px solid #e0e0e0',
+			borderRadius: '8px',
+			overflow: 'hidden',
+		} }
+	>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/VideoDetailEmbeds',
+	component: VideoDetailEmbedsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Dashboard widget listing the pages where a single video is embedded, sourced from the Jetpack Stats `stats/video/%d` module via `useStatsSingleVideo`. The widget is scoped to one video through the host-composed `reportParams.post_id`; without one it prompts to select a video. The single-video module has no comparison data, so the `WithComparison` control only exercises that the widget still renders normally when comparison params are present. In Storybook the data is served by `registerReportMocks`.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof VideoDetailEmbedsRender > & VideoDetailEmbedsStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< VideoDetailEmbedsStoryControls >;
+
+/**
+ * The widget on its own, current period only.
+ */
+export const Default: Story = {
+	render: renderVideoDetailEmbeds,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Same close-up with comparison report params. The single-video module returns
+ * no comparison rows, so the list renders normally without fabricated deltas.
+ */
+export const WithComparison: Story = {
+	render: renderVideoDetailEmbeds,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * No video scoped through `reportParams.post_id`: the query stays disabled and
+ * the widget prompts to select a video instead of fetching.
+ */
+export const NoVideoSelected: Story = {
+	render: () => (
+		<VideoDetailEmbedsRender attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+	),
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderVideoDetailEmbedsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, 'loading' );
+		return () => setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderVideoDetailEmbedsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, 'error' );
+		return () => setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("This video has not
+ * been embedded on any pages yet.").
+ */
+export const Empty: Story = {
+	render: () => renderVideoDetailEmbedsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, 'empty' );
+		return () => setReportMockState( SINGLE_VIDEO_PATH_FRAGMENT, null );
+	},
+};
+
+interface VideoDetailEmbedsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		VideoDetailEmbedsStoryControls {}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness, so
+ * it appears exactly as it does in product, inheriting the size / edit-mode /
+ * host-environment controls.
+ *
+ * @param {VideoDetailEmbedsDashboardStoryProps} props - Story controls.
+ * @return The widget mounted in the dashboard harness.
+ */
+function VideoDetailEmbedsDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: VideoDetailEmbedsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ VIDEO_DETAIL_EMBEDS_RENDER_MODULE }
+			renderComponent={ VideoDetailEmbedsRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { reportParams: reportParamsForVideo( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< VideoDetailEmbedsDashboardStoryProps > = {
+	render: args => <VideoDetailEmbedsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
@@ -1,0 +1,50 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+/* Hosts the WidgetState (or the no-video prompt); its `.ready` wrapper fills
+   this box so the list can scroll within the widget frame. */
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-block-size: 0;
+}
+
+.content > * {
+	flex: 1 1 0;
+	min-block-size: 0;
+}
+
+.list {
+	block-size: 100%;
+	margin: 0;
+	padding: 0;
+	overflow-y: auto;
+	list-style: none;
+}
+
+.item {
+	border-block-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+}
+
+.item:last-child {
+	border-block-end: none;
+}
+
+/* A stable 36px row height for the common single-line label case. */
+.link {
+	display: block;
+	min-block-size: 36px;
+	padding-block: var(--wpds-dimension-padding-sm, 8px);
+	padding-inline: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	color: var(--wpds-color-foreground-interactive-brand);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
@@ -1,7 +1,7 @@
 {
 	"name": "jpa/video-detail-embeds",
 	"title": "Video embeds",
-	"description": "Pages where a single video is embedded, sourced from Jetpack Stats.",
+	"description": "Pages where the selected video is embedded, sourced from Jetpack Stats.",
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/video-detail-embeds",
+	"title": "Video embeds",
+	"description": "Pages where a single video is embedded, sourced from Jetpack Stats.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+
+/**
+ * Configurable attributes for the Video embeds widget.
+ *
+ * The widget is scoped to a single video and has no own settings: the video is
+ * chosen by the host, which composes the report params with a `post_id` (the
+ * VideoPress post ID), the same single-resource scope other detail widgets use.
+ * A zero-attribute widget must be typed as `Record< never, never >` so the
+ * render-only type can still compose host fields like `reportParams`.
+ */
+export type VideoDetailEmbedsAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * Ported from the Jetpack Stats "Video Details" module (`stats/video/%d`). Lists
+ * the pages where the selected video is embedded. It has no meaning without a
+ * selected video, so the host scopes it through `reportParams.post_id` rather
+ * than a widget attribute.
+ */
+export default {
+	name: 'jpa/video-detail-embeds',
+	title: __( 'Video embeds', 'jetpack-premium-analytics' ),
+	description: __(
+		'Pages where the selected video is embedded, sourced from Jetpack Stats.',
+		'jetpack-premium-analytics'
+	),
+	help: {
+		content: __(
+			'Lists every page on your site where the selected video is embedded, so you can see where it is being watched.',
+			'jetpack-premium-analytics'
+		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
+	},
+	icon: video,
+};


### PR DESCRIPTION
## Proposed changes

Ports the Stats single-video detail module into Premium Analytics as the `jpa/video-detail-embeds` widget.

- New widget at `widgets/video-detail-embeds/` (`jpa/video-detail-embeds`, category `stats`, framed). Zero attributes — the selected video is supplied by the host via `reportParams.post_id`, mirroring the established single-resource "detail page" scoping (`ReportParams` already carries `post_id`).
- Renders the **pages where the selected video is embedded** (the Calypso `stats-video-details` "Video Embeds" list), each as an external link, via the existing `useStatsSingleVideo` hook.
- With no `post_id` set the query stays disabled and the widget shows a "select a video" placeholder instead of blanking or erroring.
- Loading / refetch / error / empty render through the shared `<WidgetState>` (per the current Stats-widget contract): first-load overlay, non-blocking busy overlay during background refetch, an error state with a **Retry** action wired to the query's `refetch`, and an explicit empty state ("This video has not been embedded on any pages yet.") with the widget's video glyph.
- Widget metadata: `widget.ts` now carries a translatable `description` and a `help` note (`WidgetTypeMetadata.help`), which the dashboard header surfaces as the ⓘ infotip, with a "Learn more" link to the Jetpack Stats support page.
- The single-video endpoint returns no comparison rows, so `WithComparison` just verifies graceful rendering — no fabricated deltas.
- Data layer: reuses the existing `useStatsSingleVideo` hook for `stats/video/%d` — no new hook, and the `stats` prefix is already allow-listed (no new prefix).
- Storybook: `Default`, `WithComparison`, `NoVideoSelected`, and `WidgetDashboardWithWidget`, plus forced-state `Loading` / `Error` / `Empty` stories via `setReportMockState` (kept off autodocs, each on its own date preset). Added a `single-video` fixture + a small additive `/video/{id}` handler in `routeStatsReport()`.
- Tests cover the populated list, the no-video prompt (no fetch), the empty state, and the error state's Retry re-running the query.

## Related product discussion/links

- WOOA7S-1520

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open Storybook → **Packages / Premium Analytics / Widgets / VideoDetailEmbeds**:
  - `Default` shows the embed-location list for a mocked video id.
  - `NoVideoSelected` shows the "select a video" prompt with the query disabled.
  - `Loading` / `Error` / `Empty` force each `WidgetState` branch (Retry stays failing while the Error story is active).
  - `WithComparison` renders gracefully (single-video endpoint has no comparison rows — no fabricated deltas).
  - On the dashboard story, the widget scopes to the composed `post_id`, and the header shows the ⓘ help note.
- `cd projects/packages/premium-analytics && pnpm run test -- widgets/video-detail-embeds`
- Or test the dashboard against a live connected site with VideoPress data



https://github.com/user-attachments/assets/06d04be1-a4ee-41ee-861c-e1abbce845ab


