### PR TITLE
Add Premium Analytics build zip script

### DIFF
--- a/projects/plugins/premium-analytics/.gitignore
+++ b/projects/plugins/premium-analytics/.gitignore
@@ -1,0 +1,5 @@
+vendor/
+jetpack_vendor/
+node_modules/
+build/
+.cache/

--- a/projects/plugins/premium-analytics/.gitignore
+++ b/projects/plugins/premium-analytics/.gitignore
@@ -1,5 +1,5 @@
 vendor/
 jetpack_vendor/
 node_modules/
-build/
+jetpack-premium-analytics.zip
 .cache/

--- a/projects/plugins/premium-analytics/README.md
+++ b/projects/plugins/premium-analytics/README.md
@@ -8,3 +8,29 @@ Internal WordPress plugin that activates the `automattic/jetpack-premium-analyti
 jetpack build plugins/premium-analytics
 jetpack watch plugins/premium-analytics
 ```
+
+## Installable zip
+
+Use the local build script to create a WordPress-installable plugin zip that
+combines this plugin bootstrap with the mirrored Premium Analytics package:
+
+```bash
+composer build-zip
+```
+
+By default, the script clones `trunk` from
+`https://github.com/Automattic/jetpack-premium-analytics.git` and writes the zip
+to `build/jetpack-premium-analytics.zip`.
+
+Useful options:
+
+```bash
+composer build-zip -- --package-ref <branch|tag|sha>
+composer build-zip -- --package-path /path/to/jetpack-premium-analytics
+composer build-zip -- --output /path/to/jetpack-premium-analytics.zip
+```
+
+The package source must already contain the `build/build.php` output generated
+by `wp-build`. The package mirror is expected to contain this output. A local
+monorepo package checkout usually needs to be built before it can be used with
+`--package-path`.

--- a/projects/plugins/premium-analytics/README.md
+++ b/projects/plugins/premium-analytics/README.md
@@ -20,14 +20,13 @@ composer build-zip
 
 By default, the script clones `trunk` from
 `https://github.com/Automattic/jetpack-premium-analytics.git` and writes the zip
-to `build/jetpack-premium-analytics.zip`.
+to `jetpack-premium-analytics.zip` in this plugin directory.
 
 Useful options:
 
 ```bash
 composer build-zip -- --package-ref <branch|tag|sha>
 composer build-zip -- --package-path /path/to/jetpack-premium-analytics
-composer build-zip -- --output /path/to/jetpack-premium-analytics.zip
 ```
 
 The package source must already contain the `build/build.php` output generated

--- a/projects/plugins/premium-analytics/bin/build-zip.sh
+++ b/projects/plugins/premium-analytics/bin/build-zip.sh
@@ -6,8 +6,6 @@ PLUGIN_SLUG="jetpack-premium-analytics"
 PACKAGE_REPO_URL="${PACKAGE_REPO_URL:-https://github.com/Automattic/jetpack-premium-analytics.git}"
 PACKAGE_REF="trunk"
 PACKAGE_PATH=""
-OUTPUT_PATH=""
-KEEP_WORKDIR=0
 
 SCRIPT_DIR="$(
 	cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -17,7 +15,7 @@ PLUGIN_DIR="$(
 	cd "$SCRIPT_DIR/.."
 	pwd -P
 )"
-INITIAL_CWD="$(pwd -P)"
+OUTPUT_PATH="$PLUGIN_DIR/${PLUGIN_SLUG}.zip"
 
 usage() {
 	cat <<EOF
@@ -30,8 +28,6 @@ Usage:
 Options:
   --package-ref <ref>      Branch, tag, or SHA to fetch from the package mirror. Default: trunk
   --package-path <path>    Use a local Premium Analytics package checkout instead of cloning.
-  --output <path>          Zip file to create. Default: build/${PLUGIN_SLUG}.zip
-  --keep-workdir           Keep the temporary staging directory for debugging.
   -h, --help               Show this help text.
 
 Environment:
@@ -65,16 +61,6 @@ absolute_dir() {
 		cd "$path"
 		pwd -P
 	)
-}
-
-resolve_output_path() {
-	local path="$1"
-
-	if [[ "$path" == /* ]]; then
-		printf '%s\n' "$path"
-	else
-		printf '%s/%s\n' "$INITIAL_CWD" "$path"
-	fi
 }
 
 fetch_package_source() {
@@ -183,19 +169,6 @@ while [[ $# -gt 0 ]]; do
 			PACKAGE_PATH="${1#*=}"
 			shift
 			;;
-		--output)
-			[[ $# -ge 2 ]] || error "--output requires a value"
-			OUTPUT_PATH="$2"
-			shift 2
-			;;
-		--output=*)
-			OUTPUT_PATH="${1#*=}"
-			shift
-			;;
-		--keep-workdir)
-			KEEP_WORKDIR=1
-			shift
-			;;
 		-h|--help)
 			usage
 			exit 0
@@ -214,22 +187,11 @@ if [[ -z "$PACKAGE_PATH" ]]; then
 	require_command git
 fi
 
-if [[ -z "$OUTPUT_PATH" ]]; then
-	OUTPUT_PATH="$PLUGIN_DIR/build/${PLUGIN_SLUG}.zip"
-else
-	OUTPUT_PATH="$(resolve_output_path "$OUTPUT_PATH")"
-fi
-
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PLUGIN_SLUG}-zip.XXXXXX")"
 PACKAGE_SOURCE="$WORK_DIR/package-source"
 PLUGIN_STAGE="$WORK_DIR/$PLUGIN_SLUG"
 
 cleanup() {
-	if [[ "$KEEP_WORKDIR" -eq 1 ]]; then
-		log "Keeping work directory: $WORK_DIR"
-		return
-	fi
-
 	rm -rf "$WORK_DIR"
 }
 trap cleanup EXIT

--- a/projects/plugins/premium-analytics/bin/build-zip.sh
+++ b/projects/plugins/premium-analytics/bin/build-zip.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLUGIN_SLUG="jetpack-premium-analytics"
+PACKAGE_REPO_URL="${PACKAGE_REPO_URL:-https://github.com/Automattic/jetpack-premium-analytics.git}"
+PACKAGE_REF="trunk"
+PACKAGE_PATH=""
+OUTPUT_PATH=""
+KEEP_WORKDIR=0
+
+SCRIPT_DIR="$(
+	cd "$(dirname "${BASH_SOURCE[0]}")"
+	pwd -P
+)"
+PLUGIN_DIR="$(
+	cd "$SCRIPT_DIR/.."
+	pwd -P
+)"
+INITIAL_CWD="$(pwd -P)"
+
+usage() {
+	cat <<EOF
+Build an installable Jetpack Premium Analytics plugin zip.
+
+Usage:
+  composer build-zip -- [options]
+  bin/build-zip.sh [options]
+
+Options:
+  --package-ref <ref>      Branch, tag, or SHA to fetch from the package mirror. Default: trunk
+  --package-path <path>    Use a local Premium Analytics package checkout instead of cloning.
+  --output <path>          Zip file to create. Default: build/${PLUGIN_SLUG}.zip
+  --keep-workdir           Keep the temporary staging directory for debugging.
+  -h, --help               Show this help text.
+
+Environment:
+  PACKAGE_REPO_URL         Override the package mirror URL. Default: ${PACKAGE_REPO_URL}
+EOF
+}
+
+log() {
+	printf '%s\n' "$*"
+}
+
+error() {
+	printf 'Error: %s\n' "$*" >&2
+	exit 1
+}
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		error "Missing required command: $1"
+	fi
+}
+
+absolute_dir() {
+	local path="$1"
+
+	if [[ ! -d "$path" ]]; then
+		error "Directory does not exist: $path"
+	fi
+
+	(
+		cd "$path"
+		pwd -P
+	)
+}
+
+resolve_output_path() {
+	local path="$1"
+
+	if [[ "$path" == /* ]]; then
+		printf '%s\n' "$path"
+	else
+		printf '%s/%s\n' "$INITIAL_CWD" "$path"
+	fi
+}
+
+fetch_package_source() {
+	local source_dir="$1"
+
+	log "Cloning ${PACKAGE_REPO_URL} at ${PACKAGE_REF}..."
+
+	if git clone --no-tags --depth=1 --branch "$PACKAGE_REF" "$PACKAGE_REPO_URL" "$source_dir"; then
+		return
+	fi
+
+	rm -rf "$source_dir"
+
+	log "Fetching ${PACKAGE_REF} directly..."
+	git clone --no-tags --depth=1 "$PACKAGE_REPO_URL" "$source_dir"
+	git -C "$source_dir" fetch --depth=1 origin "$PACKAGE_REF"
+	git -C "$source_dir" checkout --detach FETCH_HEAD
+}
+
+validate_package_source() {
+	local package_source="$1"
+
+	[[ -f "$package_source/composer.json" ]] || error "No composer.json found in package source: $package_source"
+	[[ -f "$package_source/build/build.php" ]] || error "No build/build.php found in package source: $package_source. Use the package mirror, or build the package before using --package-path."
+}
+
+write_staged_composer_json() {
+	local composer_json="$1"
+	local package_source="$2"
+
+	php -r '
+		$composer_file = $argv[1];
+		$package_source = $argv[2];
+		$data = json_decode( file_get_contents( $composer_file ), true );
+
+		if ( ! is_array( $data ) ) {
+			fwrite( STDERR, "Unable to decode staged composer.json.\n" );
+			exit( 1 );
+		}
+
+		unset( $data["require-dev"] );
+
+		if ( isset( $data["scripts"] ) && is_array( $data["scripts"] ) ) {
+			unset( $data["scripts"]["phpunit"], $data["scripts"]["test-php"], $data["scripts"]["test-php-coverage"] );
+			if ( array() === $data["scripts"] ) {
+				unset( $data["scripts"] );
+			}
+		}
+
+		if ( ! isset( $data["extra"] ) || ! is_array( $data["extra"] ) ) {
+			$data["extra"] = array();
+		}
+		$data["extra"]["wp-plugin-slug"] = "jetpack-premium-analytics";
+
+		$plugin_file = dirname( $composer_file ) . "/jetpack-premium-analytics.php";
+		if ( is_readable( $plugin_file ) && preg_match( "/^\\s*\\*\\s*Version:\\s*([^\\r\\n]+)/m", file_get_contents( $plugin_file ), $matches ) ) {
+			$data["version"] = trim( $matches[1] );
+		}
+
+		$data["repositories"] = array(
+			array(
+				"type" => "path",
+				"url" => $package_source,
+				"options" => array(
+					"symlink" => false,
+				),
+			),
+		);
+
+		file_put_contents(
+			$composer_file,
+			json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n"
+		);
+	' "$composer_json" "$package_source"
+}
+
+prune_development_artifacts() {
+	local plugin_stage="$1"
+
+	find "$plugin_stage" \
+		\( -type d \( -name .git -o -name node_modules -o -name .cache -o -name .idea -o -name tests -o -name test -o -name changelog \) -prune \) \
+		-exec rm -rf {} +
+
+	find "$plugin_stage" \
+		\( -name '.DS_Store' -o -name 'phpunit*.xml.dist' -o -name 'phpunit.xml' \) \
+		-delete
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--package-ref)
+			[[ $# -ge 2 ]] || error "--package-ref requires a value"
+			PACKAGE_REF="$2"
+			shift 2
+			;;
+		--package-ref=*)
+			PACKAGE_REF="${1#*=}"
+			shift
+			;;
+		--package-path)
+			[[ $# -ge 2 ]] || error "--package-path requires a value"
+			PACKAGE_PATH="$2"
+			shift 2
+			;;
+		--package-path=*)
+			PACKAGE_PATH="${1#*=}"
+			shift
+			;;
+		--output)
+			[[ $# -ge 2 ]] || error "--output requires a value"
+			OUTPUT_PATH="$2"
+			shift 2
+			;;
+		--output=*)
+			OUTPUT_PATH="${1#*=}"
+			shift
+			;;
+		--keep-workdir)
+			KEEP_WORKDIR=1
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			error "Unknown option: $1"
+			;;
+	esac
+done
+
+require_command composer
+require_command php
+require_command zip
+
+if [[ -z "$PACKAGE_PATH" ]]; then
+	require_command git
+fi
+
+if [[ -z "$OUTPUT_PATH" ]]; then
+	OUTPUT_PATH="$PLUGIN_DIR/build/${PLUGIN_SLUG}.zip"
+else
+	OUTPUT_PATH="$(resolve_output_path "$OUTPUT_PATH")"
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PLUGIN_SLUG}-zip.XXXXXX")"
+PACKAGE_SOURCE="$WORK_DIR/package-source"
+PLUGIN_STAGE="$WORK_DIR/$PLUGIN_SLUG"
+
+cleanup() {
+	if [[ "$KEEP_WORKDIR" -eq 1 ]]; then
+		log "Keeping work directory: $WORK_DIR"
+		return
+	fi
+
+	rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+if [[ -n "$PACKAGE_PATH" ]]; then
+	PACKAGE_SOURCE="$(absolute_dir "$PACKAGE_PATH")"
+else
+	fetch_package_source "$PACKAGE_SOURCE"
+fi
+
+validate_package_source "$PACKAGE_SOURCE"
+
+log "Staging plugin files..."
+mkdir -p "$PLUGIN_STAGE/src"
+cp "$PLUGIN_DIR/jetpack-premium-analytics.php" "$PLUGIN_STAGE/"
+cp "$PLUGIN_DIR/composer.json" "$PLUGIN_STAGE/"
+cp "$PLUGIN_DIR/readme.txt" "$PLUGIN_STAGE/"
+cp "$PLUGIN_DIR/README.md" "$PLUGIN_STAGE/"
+cp "$PLUGIN_DIR/src/class-jetpack-premium-analytics.php" "$PLUGIN_STAGE/src/"
+
+write_staged_composer_json "$PLUGIN_STAGE/composer.json" "$PACKAGE_SOURCE"
+
+log "Installing production dependencies..."
+(
+	cd "$PLUGIN_STAGE"
+	composer install --no-dev --no-interaction --optimize-autoloader
+)
+
+log "Pruning development artifacts..."
+prune_development_artifacts "$PLUGIN_STAGE"
+
+log "Creating zip..."
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+rm -f "$OUTPUT_PATH"
+(
+	cd "$WORK_DIR"
+	zip -qr "$OUTPUT_PATH" "$PLUGIN_SLUG"
+)
+
+log "Zip created: $OUTPUT_PATH"

--- a/projects/plugins/premium-analytics/changelog/add-build-zip-script
+++ b/projects/plugins/premium-analytics/changelog/add-build-zip-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: Add a script to create an installable Premium Analytics plugin zip from the package mirror.

--- a/projects/plugins/premium-analytics/composer.json
+++ b/projects/plugins/premium-analytics/composer.json
@@ -19,6 +19,9 @@
 		]
 	},
 	"scripts": {
+		"build-zip": [
+			"bash bin/build-zip.sh"
+		],
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a local `composer build-zip` flow for `projects/plugins/premium-analytics`.
* Stage the lightweight plugin bootstrap with the mirrored `automattic/jetpack-premium-analytics` package source and install production Composer dependencies into an installable plugin zip.
* Document the build options, ignore generated local build output, and add a changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* From `projects/plugins/premium-analytics`, run `composer build-zip -- --package-ref trunk`.
* Confirm the command completes and creates `projects/plugins/premium-analytics/jetpack-premium-analytics.zip`.
* Run `unzip -l projects/plugins/premium-analytics/jetpack-premium-analytics.zip | rg 'jetpack-premium-analytics/(jetpack-premium-analytics.php|vendor/autoload_packages.php|jetpack_vendor/automattic/jetpack-premium-analytics/build/build.php|jetpack_vendor/i18n-map.php)'` and confirm all four expected files are listed.
* Run `unzip -l projects/plugins/premium-analytics/jetpack-premium-analytics.zip | rg '(^|/)\\.git/|node_modules|/\\.cache/|/tests/|/test/|/changelog/'` and confirm no development-only paths are listed.

Validation performed:
* `bash -n projects/plugins/premium-analytics/bin/build-zip.sh`
* `composer validate` from `projects/plugins/premium-analytics` (passes with existing `@dev` dependency warnings)
* `composer build-zip -- --package-ref trunk`
* Zip content checks listed above
