### PR TITLE
AI Launchpad: second pass of design feedback (DSGCOM-757)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: second-pass design feedback — AI-picked theme-search keyword, wizard Skip (reverts to the regular launchpad), live site-title update, replace the born-completed post-sharing task, store-first sell theme picker, design polish
+AI Launchpad: apply the second pass of design feedback — let the AI pick the theme-search keyword, add a wizard Skip that reverts to the regular launchpad, update the site title without a reload, replace the born-completed post-sharing task, lead sell sites to store themes after store setup, and polish the preview card and wizard icons.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: second-pass design feedback — AI-picked theme-search keyword, wizard Skip (reverts to the regular launchpad), live site-title update, replace the born-completed post-sharing task, store-first sell theme picker, design polish

--- a/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-757-ai-launchpad-feedback-second-pass
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: apply the second pass of design feedback — let the AI pick the theme-search keyword, add a wizard Skip that reverts to the regular launchpad, update the site title without a reload, replace the born-completed post-sharing task, lead sell sites to store themes after store setup, and polish the preview card and wizard icons.
+AI Launchpad: apply the second pass of design feedback — let the AI pick the theme-search keyword, add a wizard Skip that reverts to the regular launchpad, update the site title without a reload, replace the born-completed post-sharing task, consolidate the legacy design tasks onto the actionable "Choose a theme" task and always offer it (store-filtered) on sell sites, and polish the preview card and wizard icons.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -68,8 +68,9 @@ class AI_Launchpad {
 	/**
 	 * Whether the current site is eligible for the AI Launchpad.
 	 *
-	 * Gate: not already AI-onboarded, and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled` option.
-	 * The paid-plan requirement is temporarily lifted (see below).
+	 * Gate: not already AI-onboarded, not dismissed (skipping the wizard dismisses it, reverting the site
+	 * to the regular launchpad), and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled`
+	 * option. The paid-plan requirement is temporarily lifted (see below).
 	 *
 	 * @return bool
 	 */
@@ -80,7 +81,8 @@ class AI_Launchpad {
 			// TEMPORARY: the paid-plan gate is lifted so the AI Launchpad is available on all plans, including free.
 			// Revert this commit to re-require a paid bundle (the removed has_paid_plan() check).
 			$eligible = self::is_enabled_for_site()
-				&& ! self::was_ai_onboarded();
+				&& ! self::was_ai_onboarded()
+				&& ! get_option( \AI_Launchpad_REST::OPTION_DISMISSED );
 		}
 
 		return $eligible;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -84,20 +84,6 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 */
 	const CTA_OVERRIDES = array(
 		'connect_social_media' => 'admin.php?page=jetpack-social',
-		'design_completed'     => 'themes.php',
-		'design_selected'      => 'themes.php',
-	);
-
-	/**
-	 * Theme-picker tasks. These point at the wordpress.com themes showcase pre-filtered for the site — the Store
-	 * category on sell sites, the AI's theme keyword elsewhere — so the theme list feels relevant to what the user
-	 * is building (instead of plain themes.php, which only filters already-installed themes). Falls back to the
-	 * paths above when there is nothing to filter by.
-	 */
-	const THEME_TASK_IDS = array(
-		'site_theme_selected',
-		'design_selected',
-		'design_completed',
 	);
 
 	/**
@@ -397,21 +383,23 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 		$theme_cta = $this->get_themes_showcase_path( $goal, $theme_search );
 
-		$tasks = array();
-		if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
-			$tasks = $this->build_tasks( $payload['tasks'], false, $theme_cta, $disable_hidden_woo );
+		$ai_tasks = isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ? $payload['tasks'] : array();
+
+		// A store needs a theme, so the sell list always offers "Choose a theme" — the AI is not required to pick
+		// one. Add it when absent so build_tasks enriches it like any catalog task (get_ai_task_ids mirrors this).
+		if ( 'sell' === $goal ) {
+			$ai_tasks = $this->ensure_theme_task( $ai_tasks );
 		}
+
+		$tasks = empty( $ai_tasks ) ? array() : $this->build_tasks( $ai_tasks, false, $theme_cta, $disable_hidden_woo );
 
 		// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
 		// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
 		if ( 'sell' === $goal ) {
 			// The store-setup tasks lead the sell list. Their synthetic ids never appear in the AI payload, so a
-			// plain prepend is safe. The theme task then follows them, wherever the AI ranked it: pick the
-			// store's look once the store exists. Reversed so multiple theme tasks keep their THEME_TASK_IDS order.
+			// plain prepend is safe. The theme task then follows them: pick the store's look once the store exists.
 			$tasks = array_merge( $this->build_store_tasks( $woo_active ), $tasks );
-			foreach ( array_reverse( self::THEME_TASK_IDS ) as $theme_task_id ) {
-				$tasks = $this->move_task_after( $tasks, $theme_task_id, 'setup_woocommerce_store' );
-			}
+			$tasks = $this->move_task_after( $tasks, 'site_theme_selected', 'setup_woocommerce_store' );
 		} else {
 			$gallery = $this->build_gallery_task( $inferred );
 			if ( null !== $gallery ) {
@@ -843,7 +831,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
 					: wpcom_launchpad_checklists()->is_task_complete( $definition );
 
-				$theme_showcase_path = in_array( $task['id'], self::THEME_TASK_IDS, true ) ? $theme_cta : null;
+				// The theme-picker task points at the showcase pre-filtered for the site (Store category on sell,
+				// the AI's theme keyword elsewhere) instead of plain themes.php. The legacy design_selected/
+				// design_completed ids consolidate onto site_theme_selected via wpcom_ai_launchpad_remap_task_id().
+				$theme_showcase_path = 'site_theme_selected' === $task['id'] ? $theme_cta : null;
 				$cta_override        = $this->get_cta_override( $task['id'] );
 				if ( null !== $theme_showcase_path ) {
 					$calypso_path = $theme_showcase_path;
@@ -957,6 +948,30 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		}
 
 		return '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $this->niche_to_search_term( $search ) );
+	}
+
+	/**
+	 * Ensures the persisted task list contains the theme-picker task, appending `site_theme_selected` when no
+	 * task already resolves to it. A design task that remaps onto it (via wpcom_ai_launchpad_remap_task_id)
+	 * counts as present, so a theme card is never duplicated.
+	 *
+	 * @param array $tasks The persisted `payload.tasks` array.
+	 * @return array
+	 */
+	private function ensure_theme_task( $tasks ) {
+		foreach ( $tasks as $task ) {
+			if ( is_array( $task ) && isset( $task['id'] ) && is_string( $task['id'] )
+				&& 'site_theme_selected' === wpcom_ai_launchpad_remap_task_id( $task['id'] ) ) {
+				return $tasks;
+			}
+		}
+
+		$tasks[] = array(
+			'id'       => 'site_theme_selected',
+			'subtitle' => __( 'Choose a theme that fits your store.', 'jetpack-mu-wpcom' ),
+		);
+
+		return $tasks;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -89,9 +89,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
-	 * Theme-picker tasks. When the AI infers a niche, these point at the wordpress.com themes showcase
-	 * pre-filtered by that niche, so the theme list feels relevant to what the user is building (instead of
-	 * plain themes.php, which only filters already-installed themes). Falls back to the paths above when no niche.
+	 * Theme-picker tasks. These point at the wordpress.com themes showcase pre-filtered for the site — the Store
+	 * category on sell sites, the AI's theme keyword elsewhere — so the theme list feels relevant to what the user
+	 * is building (instead of plain themes.php, which only filters already-installed themes). Falls back to the
+	 * paths above when there is nothing to filter by.
 	 */
 	const THEME_TASK_IDS = array(
 		'site_theme_selected',
@@ -394,17 +395,21 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		// roadmap instead of dropping them (which would collapse the list to almost nothing).
 		$disable_hidden_woo = 'sell' === $goal && ! $woo_active;
 
+		$theme_cta = $this->get_themes_showcase_path( $goal, $theme_search );
+
 		$tasks = array();
 		if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
-			$tasks = $this->build_tasks( $payload['tasks'], false, $theme_search, $disable_hidden_woo );
+			$tasks = $this->build_tasks( $payload['tasks'], false, $theme_cta, $disable_hidden_woo );
 		}
 
 		// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
 		// mutually exclusive so a sell site with a visual niche doesn't also get an off-target gallery task.
 		if ( 'sell' === $goal ) {
 			// The store-setup tasks lead the sell list. Their synthetic ids never appear in the AI payload, so a
-			// plain prepend is safe.
+			// plain prepend is safe. The theme task then follows them, wherever the AI ranked it: pick the
+			// store's look once the store exists.
 			$tasks = array_merge( $this->build_store_tasks( $woo_active ), $tasks );
+			$tasks = $this->move_task_after( $tasks, 'site_theme_selected', 'setup_woocommerce_store' );
 		} else {
 			$gallery = $this->build_gallery_task( $inferred );
 			if ( null !== $gallery ) {
@@ -753,15 +758,15 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	/**
 	 * Enriches the persisted tasks with title, completion state, and CTA path from the catalog.
 	 *
-	 * @param array  $tasks              The persisted `payload.tasks` array.
-	 * @param bool   $bypass_visibility  Skip the catalog visibility gate (for the all-tasks testing view).
-	 * @param string $theme_search       The AI's theme_keyword (or the inferred niche as fallback), used to
-	 *                                   pre-filter the theme-picker CTAs.
-	 * @param bool   $disable_hidden_woo Keep WOO_TASK_IDS that fail the visibility gate as disabled preview cards
-	 *                                   instead of dropping them (sell goal while WooCommerce is inactive).
+	 * @param array       $tasks              The persisted `payload.tasks` array.
+	 * @param bool        $bypass_visibility  Skip the catalog visibility gate (for the all-tasks testing view).
+	 * @param string|null $theme_cta          The resolved themes-showcase path for the theme-picker tasks, or
+	 *                                        null to keep their default CTAs.
+	 * @param bool        $disable_hidden_woo Keep WOO_TASK_IDS that fail the visibility gate as disabled preview
+	 *                                        cards instead of dropping them (sell goal while WooCommerce is inactive).
 	 * @return array
 	 */
-	private function build_tasks( $tasks, $bypass_visibility = false, $theme_search = '', $disable_hidden_woo = false ) {
+	private function build_tasks( $tasks, $bypass_visibility = false, $theme_cta = null, $disable_hidden_woo = false ) {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
 		$seen_ids    = array();
@@ -829,7 +834,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
 					: wpcom_launchpad_checklists()->is_task_complete( $definition );
 
-				$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $theme_search );
+				$theme_showcase_path = in_array( $task['id'], self::THEME_TASK_IDS, true ) ? $theme_cta : null;
 				$cta_override        = $this->get_cta_override( $task['id'] );
 				if ( null !== $theme_showcase_path ) {
 					$calypso_path = $theme_showcase_path;
@@ -922,22 +927,50 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * The wordpress.com themes-showcase path for a theme-picker task, pre-filtered by the AI's theme search term.
+	 * The wordpress.com themes-showcase path the theme-picker tasks should point at.
 	 *
-	 * Returns null for non-theme tasks or when nothing was inferred to search by, so the caller falls back to the
-	 * task's default CTA. The term is passed as the showcase's free-text search term (`?s=`), and the client's
-	 * `toNavigableUrl` resolves the relative path against wordpress.com.
+	 * Sell sites always land on the showcase's Store category so shop-ready templates lead; other goals get the
+	 * showcase pre-filtered by the AI's theme search term (as the free-text `?s=`), and null when nothing was
+	 * inferred to search by, so the caller falls back to the task's default CTA. The client's `toNavigableUrl`
+	 * resolves the relative path against wordpress.com.
 	 *
-	 * @param string $task_id The catalog task id.
-	 * @param string $search  The AI's theme_keyword, or the inferred niche as fallback.
+	 * @param string $goal   The inferred goal.
+	 * @param string $search The AI's theme_keyword, or the inferred niche as fallback.
 	 * @return string|null
 	 */
-	private function get_themes_showcase_path( $task_id, $search ) {
-		if ( '' === $search || ! in_array( $task_id, self::THEME_TASK_IDS, true ) ) {
+	private function get_themes_showcase_path( $goal, $search ) {
+		if ( 'sell' === $goal ) {
+			return '/themes/filter/store/' . rawurlencode( wpcom_get_site_slug() );
+		}
+
+		if ( '' === $search ) {
 			return null;
 		}
 
 		return '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $this->niche_to_search_term( $search ) );
+	}
+
+	/**
+	 * Moves the task with the given id to immediately after another task. The list is returned unchanged
+	 * unless both ids are present.
+	 *
+	 * @param array  $tasks    The built task list.
+	 * @param string $move_id  The id of the task to move.
+	 * @param string $after_id The id of the task to place it after.
+	 * @return array
+	 */
+	private function move_task_after( $tasks, $move_id, $after_id ) {
+		$ids = array_column( $tasks, 'id' );
+		if ( false === array_search( $move_id, $ids, true ) || false === array_search( $after_id, $ids, true ) ) {
+			return $tasks;
+		}
+
+		$moved = array_splice( $tasks, array_search( $move_id, $ids, true ), 1 );
+		// Recompute the anchor: extracting an earlier element shifts it left by one.
+		$to = array_search( $after_id, array_column( $tasks, 'id' ), true );
+		array_splice( $tasks, $to + 1, 0, $moved );
+
+		return $tasks;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -407,9 +407,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		if ( 'sell' === $goal ) {
 			// The store-setup tasks lead the sell list. Their synthetic ids never appear in the AI payload, so a
 			// plain prepend is safe. The theme task then follows them, wherever the AI ranked it: pick the
-			// store's look once the store exists.
+			// store's look once the store exists. Reversed so multiple theme tasks keep their THEME_TASK_IDS order.
 			$tasks = array_merge( $this->build_store_tasks( $woo_active ), $tasks );
-			$tasks = $this->move_task_after( $tasks, 'site_theme_selected', 'setup_woocommerce_store' );
+			foreach ( array_reverse( self::THEME_TASK_IDS ) as $theme_task_id ) {
+				$tasks = $this->move_task_after( $tasks, $theme_task_id, 'setup_woocommerce_store' );
+			}
 		} else {
 			$gallery = $this->build_gallery_task( $inferred );
 			if ( null !== $gallery ) {
@@ -652,14 +654,21 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * The persisted skipped task ids, always as a clean string array.
+	 * The persisted skipped task ids, always as a clean string array, remapped onto the
+	 * ids the launchpad renders — a skip recorded under a task's raw id before that id
+	 * was remapped must keep applying to the card it renders as now.
 	 *
 	 * @return string[]
 	 */
 	private function get_skipped_task_ids() {
 		$skipped = get_option( self::OPTION_SKIPPED, array() );
+		if ( ! is_array( $skipped ) ) {
+			return array();
+		}
 
-		return is_array( $skipped ) ? array_values( array_filter( $skipped, 'is_string' ) ) : array();
+		$skipped = array_map( 'wpcom_ai_launchpad_remap_task_id', array_filter( $skipped, 'is_string' ) );
+
+		return array_values( array_unique( $skipped ) );
 	}
 
 	/**
@@ -960,12 +969,13 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function move_task_after( $tasks, $move_id, $after_id ) {
-		$ids = array_column( $tasks, 'id' );
-		if ( false === array_search( $move_id, $ids, true ) || false === array_search( $after_id, $ids, true ) ) {
+		$ids  = array_column( $tasks, 'id' );
+		$from = array_search( $move_id, $ids, true );
+		if ( false === $from || false === array_search( $after_id, $ids, true ) ) {
 			return $tasks;
 		}
 
-		$moved = array_splice( $tasks, array_search( $move_id, $ids, true ), 1 );
+		$moved = array_splice( $tasks, $from, 1 );
 		// Recompute the anchor: extracting an earlier element shifts it left by one.
 		$to = array_search( $after_id, array_column( $tasks, 'id' ), true );
 		array_splice( $tasks, $to + 1, 0, $moved );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -377,6 +377,13 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			? trim( $inferred['niche'] )
 			: '';
 
+		// The AI's dedicated theme-search word beats the first-word-of-niche heuristic; outputs
+		// persisted before the field existed fall back to the niche.
+		$theme_keyword = isset( $inferred['theme_keyword'] ) && is_string( $inferred['theme_keyword'] )
+			? trim( $inferred['theme_keyword'] )
+			: '';
+		$theme_search  = '' !== $theme_keyword ? $theme_keyword : $niche;
+
 		$goal = isset( $inferred['goal'] ) && is_string( $inferred['goal'] ) ? $inferred['goal'] : '';
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -390,7 +397,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 		$tasks = array();
 		if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
-			$tasks = $this->build_tasks( $payload['tasks'], false, $niche, $disable_hidden_woo );
+			$tasks = $this->build_tasks( $payload['tasks'], false, $theme_search, $disable_hidden_woo );
 		}
 
 		// The sell goal leads with the store-setup task; every other goal may offer the gallery task. They are
@@ -749,12 +756,13 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 *
 	 * @param array  $tasks              The persisted `payload.tasks` array.
 	 * @param bool   $bypass_visibility  Skip the catalog visibility gate (for the all-tasks testing view).
-	 * @param string $niche              The AI-inferred niche, used to pre-filter the theme-picker CTAs.
+	 * @param string $theme_search       The AI's theme_keyword (or the inferred niche as fallback), used to
+	 *                                   pre-filter the theme-picker CTAs.
 	 * @param bool   $disable_hidden_woo Keep WOO_TASK_IDS that fail the visibility gate as disabled preview cards
 	 *                                   instead of dropping them (sell goal while WooCommerce is inactive).
 	 * @return array
 	 */
-	private function build_tasks( $tasks, $bypass_visibility = false, $niche = '', $disable_hidden_woo = false ) {
+	private function build_tasks( $tasks, $bypass_visibility = false, $theme_search = '', $disable_hidden_woo = false ) {
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$built       = array();
 		$seen_ids    = array();
@@ -827,7 +835,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					? AI_Launchpad_Memberships::is_task_complete( $task['id'] )
 					: wpcom_launchpad_checklists()->is_task_complete( $definition );
 
-				$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $niche );
+				$theme_showcase_path = $this->get_themes_showcase_path( $task['id'], $theme_search );
 				$cta_override        = $this->get_cta_override( $task['id'] );
 				if ( null !== $theme_showcase_path ) {
 					$calypso_path = $theme_showcase_path;
@@ -920,22 +928,22 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * The wordpress.com themes-showcase path for a theme-picker task, pre-filtered by the inferred niche.
+	 * The wordpress.com themes-showcase path for a theme-picker task, pre-filtered by the AI's theme search term.
 	 *
-	 * Returns null for non-theme tasks or when no niche was inferred, so the caller falls back to the task's
-	 * default CTA. The niche is passed as the showcase's free-text search term (`?s=`), and the client's
+	 * Returns null for non-theme tasks or when nothing was inferred to search by, so the caller falls back to the
+	 * task's default CTA. The term is passed as the showcase's free-text search term (`?s=`), and the client's
 	 * `toNavigableUrl` resolves the relative path against wordpress.com.
 	 *
 	 * @param string $task_id The catalog task id.
-	 * @param string $niche   The AI-inferred niche.
+	 * @param string $search  The AI's theme_keyword, or the inferred niche as fallback.
 	 * @return string|null
 	 */
-	private function get_themes_showcase_path( $task_id, $niche ) {
-		if ( '' === $niche || ! in_array( $task_id, self::THEME_TASK_IDS, true ) ) {
+	private function get_themes_showcase_path( $task_id, $search ) {
+		if ( '' === $search || ! in_array( $task_id, self::THEME_TASK_IDS, true ) ) {
 			return null;
 		}
 
-		return '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $this->niche_to_search_term( $niche ) );
+		return '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $this->niche_to_search_term( $search ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -105,7 +105,6 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	const SOCIAL_PAGE_TASK_IDS = array(
 		'connect_social_media',
 		'drive_traffic',
-		'post_sharing_enabled',
 	);
 
 	/**
@@ -779,21 +778,16 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				continue;
 			}
 
-			// The WooCommerce launch task deep-links into the WC onboarding task list, which renders blank when the
-			// guided setup was skipped, and only completes via a WC option the skipped-setup flow never writes. Normalize
-			// it to the canonical site-launch task, which reads the real launch signal and self-completes. The prompt no
-			// longer offers it, so this only catches a stray AI emission.
-			if ( 'woo_launch_site' === $task['id'] ) {
-				$task['id'] = 'site_launched';
-			}
+			// Broken/meaningless-in-context ids render as their working equivalent (see the helper for the why).
+			$task['id'] = wpcom_ai_launchpad_remap_task_id( $task['id'] );
 
 			if ( ! isset( $definitions[ $task['id'] ] ) ) {
 				continue;
 			}
 
-			// One card per id — the client keys cards by id. The woo_launch_site→site_launched remap above can collide
-			// with a real site_launched (notably the ?all_tasks=1 view, which enumerates every catalog id), so collapse
-			// any repeat to the first occurrence.
+			// One card per id — the client keys cards by id. The remap above can collide with the target id already
+			// being present (notably the ?all_tasks=1 view, which enumerates every catalog id), so collapse any
+			// repeat to the first occurrence.
 			if ( isset( $seen_ids[ $task['id'] ] ) ) {
 				continue;
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-social-listener.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-social-listener.php
@@ -4,16 +4,15 @@
  *
  * @package automattic/jetpack-mu-wpcom
  *
- * @phan-file-suppress PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- The Publicize classes (Connections, Publicize_Utils) ship in the Jetpack plugin, available at runtime on Atomic; calls are guarded by class_exists.
+ * @phan-file-suppress PhanUndeclaredClassReference, PhanUndeclaredClassMethod -- The Publicize Connections class ships in the Jetpack plugin, available at runtime on Atomic; calls are guarded by class_exists.
  */
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\AI_Launchpad;
 use Automattic\Jetpack\Publicize\Connections;
-use Automattic\Jetpack\Publicize\Publicize_Utils;
 
 /**
  * Completes the AI-selected Jetpack Social tasks from wp-admin: `connect_social_media` /
- * `drive_traffic` (a Publicize connection exists) and `post_sharing_enabled` (the Publicize module is active).
+ * `drive_traffic` complete once a Publicize connection exists.
  *
  * These catalog tasks have no `add_listener_callback` and there is no local "connection created" action on Atomic, so
  * this reconciles the local state when the AI Launchpad page loads. The page gate keeps the lookup off every other
@@ -48,16 +47,6 @@ class AI_Launchpad_Social_Listener {
 		}
 
 		$task_lists = wpcom_launchpad_checklists();
-
-		// post_sharing_enabled completes once the Publicize module is active.
-		if (
-			in_array( 'post_sharing_enabled', $ai_task_ids, true )
-			&& ! $task_lists->is_task_id_complete( 'post_sharing_enabled' )
-			&& class_exists( Publicize_Utils::class )
-			&& Publicize_Utils::is_publicize_active()
-		) {
-			wpcom_mark_launchpad_task_complete( 'post_sharing_enabled' );
-		}
 
 		// connect_social_media / drive_traffic complete once a Publicize connection exists. connect_social_media
 		// id-maps to drive_traffic, so we mark whichever the AI selected.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
@@ -51,6 +51,11 @@
 					"type": "string",
 					"maxLength": 120
 				},
+				"theme_keyword": {
+					"type": "string",
+					"maxLength": 40,
+					"description": "The single word that best captures the site's subject, used to pre-filter the theme showcase. The prompt steers it toward the core topic (\"hiking\") over incidental modifiers (\"weekend\")."
+				},
 				"vibe": {
 					"type": "string",
 					"maxLength": 120

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -5,9 +5,35 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+if ( ! function_exists( 'wpcom_ai_launchpad_remap_task_id' ) ) {
+	/**
+	 * Normalizes a persisted task id onto the task the AI Launchpad actually renders.
+	 *
+	 * Some catalog tasks are broken or meaningless in this context, so their ids are replaced on
+	 * read: `woo_launch_site` dead-ends in the WooCommerce onboarding list and never completes when
+	 * the guided setup was skipped; `post_sharing_enabled` is born completed (the sharing module is
+	 * active by default on wpcom), so the connection task is the meaningful version of that intent.
+	 * The prompt no longer offers either id, so this only catches stray AI emissions and outputs
+	 * persisted before the replacement.
+	 *
+	 * @param string $task_id A task id from the persisted AI output.
+	 * @return string The task id to render (and listen/skip) instead.
+	 */
+	function wpcom_ai_launchpad_remap_task_id( $task_id ) {
+		$remap = array(
+			'woo_launch_site'      => 'site_launched',
+			'post_sharing_enabled' => 'connect_social_media',
+		);
+
+		return $remap[ $task_id ] ?? $task_id;
+	}
+}
+
 if ( ! function_exists( 'wpcom_ai_launchpad_get_ai_task_ids' ) ) {
 	/**
-	 * The AI-selected task IDs from the `wpcom_ai_launchpad_ai_output` option.
+	 * The AI-selected task IDs from the `wpcom_ai_launchpad_ai_output` option, remapped
+	 * onto the ids the launchpad renders so listeners and skip validation see the same
+	 * ids as the task cards.
 	 *
 	 * @return string[] Task IDs, empty when the option is unset or malformed.
 	 */
@@ -20,10 +46,10 @@ if ( ! function_exists( 'wpcom_ai_launchpad_get_ai_task_ids' ) ) {
 		$task_ids = array();
 		foreach ( $ai_output['payload']['tasks'] as $task ) {
 			if ( is_array( $task ) && isset( $task['id'] ) && is_string( $task['id'] ) ) {
-				$task_ids[] = $task['id'];
+				$task_ids[] = wpcom_ai_launchpad_remap_task_id( $task['id'] );
 			}
 		}
 
-		return $task_ids;
+		return array_values( array_unique( $task_ids ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -12,8 +12,9 @@ if ( ! function_exists( 'wpcom_ai_launchpad_remap_task_id' ) ) {
 	 * Some catalog tasks are broken or meaningless in this context, so their ids are replaced on
 	 * read: `woo_launch_site` dead-ends in the WooCommerce onboarding list and never completes when
 	 * the guided setup was skipped; `post_sharing_enabled` is born completed (the sharing module is
-	 * active by default on wpcom), so the connection task is the meaningful version of that intent.
-	 * The prompt no longer offers either id, so this only catches stray AI emissions and outputs
+	 * active by default on wpcom); `design_selected` is born completed and `design_completed` has no
+	 * wp-admin completion path, so both consolidate onto the actionable `site_theme_selected` task.
+	 * The prompt no longer offers these ids, so this only catches stray AI emissions and outputs
 	 * persisted before the replacement.
 	 *
 	 * @param string $task_id A task id from the persisted AI output.
@@ -23,6 +24,8 @@ if ( ! function_exists( 'wpcom_ai_launchpad_remap_task_id' ) ) {
 		$remap = array(
 			'woo_launch_site'      => 'site_launched',
 			'post_sharing_enabled' => 'connect_social_media',
+			'design_selected'      => 'site_theme_selected',
+			'design_completed'     => 'site_theme_selected',
 		);
 
 		return $remap[ $task_id ] ?? $task_id;
@@ -39,17 +42,30 @@ if ( ! function_exists( 'wpcom_ai_launchpad_get_ai_task_ids' ) ) {
 	 */
 	function wpcom_ai_launchpad_get_ai_task_ids() {
 		$ai_output = get_option( 'wpcom_ai_launchpad_ai_output' );
-		if ( ! is_array( $ai_output ) || ! isset( $ai_output['payload']['tasks'] ) || ! is_array( $ai_output['payload']['tasks'] ) ) {
+		if ( ! is_array( $ai_output ) || ! isset( $ai_output['payload'] ) || ! is_array( $ai_output['payload'] ) ) {
 			return array();
 		}
+		$payload = $ai_output['payload'];
 
 		$task_ids = array();
-		foreach ( $ai_output['payload']['tasks'] as $task ) {
-			if ( is_array( $task ) && isset( $task['id'] ) && is_string( $task['id'] ) ) {
-				$task_ids[] = wpcom_ai_launchpad_remap_task_id( $task['id'] );
+		if ( isset( $payload['tasks'] ) && is_array( $payload['tasks'] ) ) {
+			foreach ( $payload['tasks'] as $task ) {
+				if ( is_array( $task ) && isset( $task['id'] ) && is_string( $task['id'] ) ) {
+					$task_ids[] = wpcom_ai_launchpad_remap_task_id( $task['id'] );
+				}
 			}
 		}
 
-		return array_values( array_unique( $task_ids ) );
+		$task_ids = array_values( array_unique( $task_ids ) );
+
+		// Sell sites always render a Choose-a-theme task (see AI_Launchpad_REST::get_current_tasks), so the
+		// switch_theme listener and skip validation must count it even when the AI did not pick one — and
+		// even when a partial write left the payload with an inferred goal but no task list.
+		$goal = isset( $payload['inferred']['goal'] ) && is_string( $payload['inferred']['goal'] ) ? $payload['inferred']['goal'] : '';
+		if ( 'sell' === $goal && ! in_array( 'site_theme_selected', $task_ids, true ) ) {
+			$task_ids[] = 'site_theme_selected';
+		}
+
+		return $task_ids;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -45,8 +45,13 @@ export function App() {
 			<Wizard
 				initialSiteName={ initialData?.site?.title }
 				initialIntent={ initialData?.site?.description }
-				onComplete={ ( _input, tailoring ) => {
+				onComplete={ ( input, tailoring ) => {
 					setPendingTailor( () => tailoring );
+					// The wizard wrote the entered Name to blogname; keep the preview
+					// card's title in sync without refetching.
+					setInitialData( data =>
+						data?.site ? { ...data, site: { ...data.site, title: input.site_name } } : data
+					);
 					setView( 'list' );
 				} }
 			/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -45,13 +45,18 @@ export function App() {
 			<Wizard
 				initialSiteName={ initialData?.site?.title }
 				initialIntent={ initialData?.site?.description }
+				siteUrl={ initialData?.site?.url }
 				onComplete={ ( input, tailoring ) => {
 					setPendingTailor( () => tailoring );
 					// The wizard wrote the entered Name to blogname; keep the preview
-					// card's title in sync without refetching.
-					setInitialData( data =>
-						data?.site ? { ...data, site: { ...data.site, title: input.site_name } } : data
-					);
+					// card's title in sync without refetching. Mirrors the server's
+					// guard: an empty/whitespace Name never overwrites the title.
+					const siteName = input.site_name.trim();
+					if ( siteName ) {
+						setInitialData( data =>
+							data?.site ? { ...data, site: { ...data.site, title: siteName } } : data
+						);
+					}
 					setView( 'list' );
 				} }
 			/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
@@ -33,4 +33,12 @@ describe( 'buildTailorPrompt', () => {
 		const prompt = buildTailorPrompt( fixtures[ 0 ].input );
 		assert.ok( /return only a json object/i.test( prompt ) );
 	} );
+
+	it( 'asks for a theme_keyword naming the core subject, not an incidental word', () => {
+		const prompt = buildTailorPrompt( fixtures[ 0 ].input );
+		assert.ok( prompt.includes( '"theme_keyword"' ), 'theme_keyword missing from prompt' );
+		// The instruction must steer the model toward the subject ("hiking") over
+		// incidental modifiers ("weekend"), which is the whole point of the field.
+		assert.ok( /weekend hiking/i.test( prompt ), 'guiding example missing from prompt' );
+	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
@@ -29,6 +29,14 @@ describe( 'buildTailorPrompt', () => {
 		}
 	} );
 
+	it( 'offers only the actionable theme task, not the legacy design tasks', () => {
+		// design_selected is always-complete and design_completed has no wp-admin
+		// completion path; both are consolidated onto site_theme_selected.
+		assert.ok( TASK_MENU.includes( 'site_theme_selected' ) );
+		assert.ok( ! TASK_MENU.includes( 'design_selected' ) );
+		assert.ok( ! TASK_MENU.includes( 'design_completed' ) );
+	} );
+
 	it( 'instructs the model to return only JSON', () => {
 		const prompt = buildTailorPrompt( fixtures[ 0 ].input );
 		assert.ok( /return only a json object/i.test( prompt ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -51,7 +51,6 @@ export const TASK_MENU: readonly string[] = [
 	'setup_ssh',
 	'site_monitoring_page',
 	'mobile_app_installed',
-	'post_sharing_enabled',
 	'share_site',
 	'front_page_updated',
 	'drive_traffic',
@@ -105,7 +104,7 @@ HARD RULES (do not break - the server rejects output that violates these):
 - Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
 - For the sell goal, order the commerce tasks store-first: "woo_customize_store", then "woo_products", then "set_up_payments", keeping the launch task last. Installing WooCommerce is added automatically as the first step, so do not include a task for it.
 - Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
-- For the social tasks "connect_social_media", "drive_traffic", and "post_sharing_enabled", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
+- For the social tasks "connect_social_media" and "drive_traffic", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
 - Subtitles must be plain text: no URLs, no HTML, and no template syntax such as {{ }} or [[ ]].
 
 ============ STEP 3 - first_post_draft ============

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -82,6 +82,7 @@ First, read the description closely and infer the site's context. You will use t
 - "goal": echo the goal value above verbatim. One of: write, build, sell, newsletter, educate, portfolio. Required.
 - "brand_name": the site name. Per the name-resolution rule below.
 - "niche": the specific subject area in a few words (e.g. "long-distance hiking", "handmade ceramics", "indie game reviews").
+- "theme_keyword": ONE lowercase word used to search for matching site designs. Pick the single most significant word for what the site is about, preferring the subject or site type over incidental modifiers: for "my weekend hiking trips" it is "hiking" (never "weekend"); for a handmade-ceramics shop it is "ceramics".
 - "vibe": aesthetic hint if implied (e.g. "minimal and editorial", "warm and personal"). Omit if neutral.
 - "audience": who the site is for, if implied (e.g. "home cooks", "small-business owners").
 - "tagline": a polished site tagline drafted from the description. Max 200 characters. Noun phrase or third person, not first-person.
@@ -123,7 +124,7 @@ ${ TASK_MENU.map( id => '- ' + id ).join( '\n' ) }
 Return only a JSON object matching this schema. Do not include prose, code fences, or commentary. The first character MUST be "{".
 
 {
-  "inferred": { "goal": "...", "brand_name": "...", "niche": "...", "vibe": "...", "audience": "...", "tagline": "..." },
+  "inferred": { "goal": "...", "brand_name": "...", "niche": "...", "theme_keyword": "...", "vibe": "...", "audience": "...", "tagline": "..." },
   "tasks": [ { "id": "...", "subtitle": "..." }, ... 6 total ],
   "first_post_draft": { "title": "...", "subtitle": "...", "paragraphs": [ "...", "..." ] }
 }`;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -13,8 +13,6 @@ export const TASK_MENU: readonly string[] = [
 	'update_about_page',
 	'edit_page',
 	'design_edited',
-	'design_completed',
-	'design_selected',
 	'domain_claim',
 	'domain_upsell',
 	'domain_customize',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.test.mts
@@ -92,6 +92,12 @@ describe( 'validateAgainstSchema', () => {
 		assert.ok( validateAgainstSchema( out, fileSchema ).length > 0 );
 	} );
 
+	it( 'accepts an inferred theme_keyword', () => {
+		const out = validOutput();
+		( out.inferred as Record< string, unknown > ).theme_keyword = 'hiking';
+		assert.deepEqual( validateAgainstSchema( out, fileSchema ), [] );
+	} );
+
 	it( 'rejects an unknown goal enum value', () => {
 		const out = validOutput();
 		( out.inferred as { goal: string } ).goal = 'cook';

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
@@ -47,6 +47,7 @@ export const AGENT_OUTPUT_SCHEMA: JsonSchema = {
 				},
 				brand_name: { type: 'string', maxLength: 80 },
 				niche: { type: 'string', maxLength: 120 },
+				theme_keyword: { type: 'string', maxLength: 40 },
 				vibe: { type: 'string', maxLength: 120 },
 				audience: { type: 'string', maxLength: 200 },
 				tagline: { type: 'string', maxLength: 200 },

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
@@ -28,6 +28,11 @@ export function trackWizardCompleted(): void {
 	record( 'jetpack_ai_launchpad_wizard_completed' );
 }
 
+/** Records the wizard-skipped event. */
+export function trackWizardSkipped(): void {
+	record( 'jetpack_ai_launchpad_wizard_skipped' );
+}
+
 /**
  * Records the AI-response-received event.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
@@ -16,6 +16,7 @@ export interface TailoredInferred {
 	goal: GoalSlug;
 	brand_name?: string;
 	niche?: string;
+	theme_keyword?: string;
 	vibe?: string;
 	audience?: string;
 	tagline?: string;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/style.scss
@@ -156,7 +156,6 @@
 
 			&:hover,
 			&:focus-within {
-				border-color: var(--wp-admin-theme-color, #3858e9);
 
 				.ai-launchpad-tailored-list__preview-edit {
 					opacity: 1;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
@@ -122,7 +122,7 @@
 .ai-launchpad-wizard__footer {
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
 	gap: 12px;
 	margin-top: 24px;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/style.scss
@@ -88,7 +88,6 @@
 
 	svg {
 		flex-shrink: 0;
-		margin-top: 2px;
 		fill: currentColor;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -3,7 +3,7 @@ import { Modal, Button } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getPrewarmedTailor, usePrewarm } from '../lib/prewarm.ts';
-import { trackViewed, trackWizardCompleted } from '../lib/tracks.ts';
+import { trackViewed, trackWizardCompleted, trackWizardSkipped } from '../lib/tracks.ts';
 import DetailsStep from './details-step.tsx';
 import GoalsStep from './goals-step.tsx';
 import {
@@ -52,6 +52,7 @@ export function Wizard( {
 	const [ goal, setGoal ] = useState< GoalSlug | null >( null );
 	const [ siteName, setSiteName ] = useState< string >( initialSiteName );
 	const [ intent, setIntent ] = useState< string >( initialIntent );
+	const [ skipping, setSkipping ] = useState( false );
 
 	const state: WizardState = { goal, siteName, intent, locale };
 
@@ -89,6 +90,19 @@ export function Wizard( {
 		}
 	};
 
+	// Skipping opts out of the AI Launchpad entirely: dismiss it server-side (which reverts
+	// the site to the regular launchpad surfaces) and leave for Calypso My Home.
+	const handleSkip = async () => {
+		setSkipping( true );
+		trackWizardSkipped();
+		try {
+			await apiFetch( { path: '/wpcom/v2/ai-launchpad', method: 'DELETE' } );
+		} catch {
+			// Still navigate away: a failed dismiss write must not trap the user in the wizard.
+		}
+		window.location.href = 'https://wordpress.com/home/' + window.location.hostname;
+	};
+
 	return (
 		<Modal
 			title=""
@@ -117,16 +131,19 @@ export function Wizard( {
 			) }
 
 			<footer className="ai-launchpad-wizard__footer">
+				<Button variant="link" onClick={ handleSkip } disabled={ skipping }>
+					{ __( 'Skip', 'jetpack-mu-wpcom' ) }
+				</Button>
 				<div className="ai-launchpad-wizard__footer-right">
 					{ step > 0 && (
-						<Button variant="secondary" onClick={ handleBack }>
+						<Button variant="secondary" onClick={ handleBack } disabled={ skipping }>
 							{ __( 'Back', 'jetpack-mu-wpcom' ) }
 						</Button>
 					) }
 					<Button
 						variant="primary"
 						onClick={ handleNext }
-						disabled={ ! canContinue( step, state ) }
+						disabled={ skipping || ! canContinue( step, state ) }
 					>
 						{ isLastStep( step )
 							? __( 'Finish', 'jetpack-mu-wpcom' )

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -79,6 +79,15 @@ export function Wizard( {
 			method: 'PUT',
 			data: payload,
 		} ).catch( () => {} );
+
+		// The PUT above writes the entered Name to blogname, but the admin bar is
+		// server-rendered, so reflect the new title in place. A reload instead would
+		// re-show the wizard: the tailored output is not persisted yet at this point.
+		const adminBarSiteName = document.querySelector( '#wp-admin-bar-site-name > a' );
+		if ( adminBarSiteName && payload.site_name ) {
+			adminBarSiteName.textContent = payload.site_name;
+		}
+
 		const tailoring = getPrewarmedTailor( payload );
 		trackWizardCompleted();
 		onComplete?.( payload, tailoring );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -24,6 +24,8 @@ interface Props {
 	initialSiteName?: string;
 	// Existing site tagline (blogdescription). Pre-fills the Brief description.
 	initialIntent?: string;
+	// The site's front-end URL, used to key the Calypso My Home URL on Skip.
+	siteUrl?: string;
 	// User locale, forwarded to the wizard payload and the AI call.
 	locale?: string;
 	// Fired once Finish completes, with the persisted input and the in-flight
@@ -38,6 +40,7 @@ interface Props {
  * @param props                 - Component props.
  * @param props.initialSiteName - Existing site title used to pre-fill Name.
  * @param props.initialIntent   - Existing site tagline used to pre-fill the description.
+ * @param props.siteUrl         - The site's front-end URL (for the Skip redirect).
  * @param props.locale          - User locale forwarded to the payload.
  * @param props.onComplete      - Called with the input and tailor promise on Finish.
  * @return The wizard element.
@@ -45,6 +48,7 @@ interface Props {
 export function Wizard( {
 	initialSiteName = '',
 	initialIntent = '',
+	siteUrl,
 	locale = 'en',
 	onComplete,
 }: Props ) {
@@ -74,19 +78,22 @@ export function Wizard( {
 		}
 		const payload = buildWizardPayload( goal, state );
 		// Persist in the background, best-effort so a failed save isn't an unhandled rejection.
+		// Once it lands, reflect the new title in the server-rendered admin bar in place —
+		// a reload instead would re-show the wizard (the tailored output isn't persisted yet).
+		// Mirrors the server's guard: an empty/whitespace Name never writes blogname.
 		apiFetch( {
 			path: '/wpcom/v2/ai-launchpad/wizard',
 			method: 'PUT',
 			data: payload,
-		} ).catch( () => {} );
-
-		// The PUT above writes the entered Name to blogname, but the admin bar is
-		// server-rendered, so reflect the new title in place. A reload instead would
-		// re-show the wizard: the tailored output is not persisted yet at this point.
-		const adminBarSiteName = document.querySelector( '#wp-admin-bar-site-name > a' );
-		if ( adminBarSiteName && payload.site_name ) {
-			adminBarSiteName.textContent = payload.site_name;
-		}
+		} )
+			.then( () => {
+				const adminBarSiteName = document.querySelector( '#wp-admin-bar-site-name > a' );
+				const savedName = payload.site_name.trim();
+				if ( adminBarSiteName && savedName ) {
+					adminBarSiteName.textContent = savedName;
+				}
+			} )
+			.catch( () => {} );
 
 		const tailoring = getPrewarmedTailor( payload );
 		trackWizardCompleted();
@@ -100,7 +107,8 @@ export function Wizard( {
 	};
 
 	// Skipping opts out of the AI Launchpad entirely: dismiss it server-side (which reverts
-	// the site to the regular launchpad surfaces) and leave for Calypso My Home.
+	// the site to the regular launchpad surfaces) and leave for Calypso My Home. Calypso keys
+	// sites by their front-end host, so prefer the site URL over the wp-admin request host.
 	const handleSkip = async () => {
 		setSkipping( true );
 		trackWizardSkipped();
@@ -109,7 +117,13 @@ export function Wizard( {
 		} catch {
 			// Still navigate away: a failed dismiss write must not trap the user in the wizard.
 		}
-		window.location.href = 'https://wordpress.com/home/' + window.location.hostname;
+		let siteHost = window.location.hostname;
+		try {
+			siteHost = siteUrl ? new URL( siteUrl ).host : siteHost;
+		} catch {
+			// Malformed site URL: keep the request host.
+		}
+		window.location.href = 'https://wordpress.com/home/' + siteHost;
 	};
 
 	return (

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -119,7 +119,7 @@ export function Wizard( {
 		}
 		let siteHost = window.location.hostname;
 		try {
-			siteHost = siteUrl ? new URL( siteUrl ).host : siteHost;
+			siteHost = siteUrl ? new URL( siteUrl ).hostname : siteHost;
 		} catch {
 			// Malformed site URL: keep the request host.
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -62,11 +62,10 @@ function load_wpcom_dashboard_widgets() {
 	$checklist_slug    = get_option( 'site_intent' );
 
 	// The AI Launchpad's Site Setup screen supersedes this widget: showing both surfaces two
-	// different checklists under the same name. A user who dismissed the AI Launchpad gets
-	// this widget back — eligibility alone doesn't track the dismissal.
+	// different checklists under the same name. Eligibility covers dismissal, so a user who
+	// dismissed the AI Launchpad gets this widget back.
 	$has_ai_launchpad = function_exists( 'wpcom_ai_launchpad_is_eligible' )
-		&& wpcom_ai_launchpad_is_eligible()
-		&& ! get_option( 'wpcom_ai_launchpad_dismissed' );
+		&& wpcom_ai_launchpad_is_eligible();
 
 	if (
 		defined( 'IS_WPCOM' ) && IS_WPCOM &&

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -45,17 +45,21 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * @param bool $was_ai_onboarded Whether the site already went through AI onboarding.
 	 * @param bool $enabled          Whether the site has the wpcom_ai_launchpad_enabled option set.
+	 * @param bool $dismissed        Whether the user dismissed the AI Launchpad.
 	 * @param bool $expected         Expected eligibility result.
 	 */
 	#[DataProvider( 'provide_eligibility_inputs' )]
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_is_eligible( $was_ai_onboarded, $enabled, $expected ) {
+	public function test_is_eligible( $was_ai_onboarded, $enabled, $dismissed, $expected ) {
 		if ( $was_ai_onboarded ) {
 			update_option( 'site_intent', 'ai-assembler' );
 		}
 		if ( $enabled ) {
 			update_option( 'wpcom_ai_launchpad_enabled', true );
+		}
+		if ( $dismissed ) {
+			update_option( 'wpcom_ai_launchpad_dismissed', true );
 		}
 
 		$this->assertSame( $expected, AI_Launchpad::is_eligible() );
@@ -64,16 +68,18 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Data provider for test_is_eligible.
 	 *
-	 * The paid-plan requirement is temporarily lifted, so eligibility depends only on
-	 * the per-site enabled option and the site not already being AI-onboarded.
+	 * The paid-plan requirement is temporarily lifted, so eligibility depends on the
+	 * per-site enabled option, the site not already being AI-onboarded, and the user
+	 * not having dismissed the AI Launchpad (skipping the wizard dismisses it).
 	 *
 	 * @return array
 	 */
 	public static function provide_eligibility_inputs() {
 		return array(
-			'enabled'          => array( false, true, true ),
-			'not enabled'      => array( false, false, false ),
-			'onboarded blocks' => array( true, true, false ),
+			'enabled'          => array( false, true, false, true ),
+			'not enabled'      => array( false, false, false, false ),
+			'onboarded blocks' => array( true, true, false, false ),
+			'dismissed blocks' => array( false, true, true, false ),
 		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1568,6 +1568,66 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the sell reorder covers every theme-picker task id, not just
+	 * site_theme_selected — an output whose theme task is design_selected must
+	 * also land right after the store-setup lead tasks.
+	 */
+	public function test_get_sell_moves_design_selected_after_store_setup() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'woo_products',
+							'subtitle' => 'Add products.',
+						),
+						array(
+							'id'       => 'design_selected',
+							'subtitle' => 'Pick a look.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array( 'goal' => 'sell' ),
+				),
+			),
+			false
+		);
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertSame(
+			array( 'install_woocommerce', 'setup_woocommerce_store', 'design_selected' ),
+			array_slice( $ids, 0, 3 )
+		);
+	}
+
+	/**
+	 * Test that a skip recorded under a task's raw id before the id was remapped
+	 * still applies to the card the id now renders as — a skip must never pop
+	 * back open after a deploy.
+	 */
+	public function test_get_applies_pre_remap_skips_to_remapped_task() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'post_sharing_enabled', 'site_launched' ) );
+		// As written by skip_task() before the remap existed.
+		update_option( 'wpcom_ai_launchpad_skipped_tasks', array( 'post_sharing_enabled' ), false );
+
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertTrue( $tasks['connect_social_media']['skipped'] );
+		$this->assertTrue( $tasks['connect_social_media']['completed'] );
+	}
+
+	/**
 	 * Test that POST /complete-task marks an allowlisted acknowledgment task complete.
 	 */
 	public function test_complete_task_marks_acknowledgment_task() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1534,6 +1534,40 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the sell list places the theme task right after the store-setup lead
+	 * tasks, wherever the AI ranked it: pick the store's look once the store exists.
+	 */
+	public function test_get_sell_moves_theme_task_after_store_setup() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		$this->seed_sell_output_with_commerce_tasks();
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertSame(
+			array( 'install_woocommerce', 'setup_woocommerce_store', 'site_theme_selected' ),
+			array_slice( $ids, 0, 3 )
+		);
+	}
+
+	/**
+	 * Test that on a sell site the theme CTAs point at the showcase's Store category
+	 * instead of the niche search, so users land on shop-ready templates.
+	 */
+	public function test_get_sell_theme_cta_uses_store_filter() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		$this->seed_sell_output_with_commerce_tasks();
+
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertSame(
+			'/themes/filter/store/' . rawurlencode( wpcom_get_site_slug() ),
+			$tasks['site_theme_selected']['calypso_path']
+		);
+	}
+
+	/**
 	 * Test that POST /complete-task marks an allowlisted acknowledgment task complete.
 	 */
 	public function test_complete_task_marks_acknowledgment_task() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -505,11 +505,54 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 			$paths[ $task['id'] ] = $task['calypso_path'];
 		}
 
-		$expected = '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=ceramics';
+		$expected = '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=ceramics';
 		$this->assertSame( $expected, $paths['site_theme_selected'] );
 		$this->assertSame( $expected, $paths['design_selected'] );
 		// A non-theme task is untouched by the niche filter.
 		$this->assertNull( $paths['site_launched'] );
+	}
+
+	/**
+	 * Test that when the AI supplied a dedicated theme_keyword, the theme CTAs search
+	 * by it instead of the first-word niche heuristic — "weekend hiking trips" should
+	 * surface hiking themes, not "weekend" ones.
+	 */
+	public function test_get_prefers_inferred_theme_keyword_for_theme_ctas() {
+		wp_set_current_user( $this->admin_id );
+
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'site_theme_selected',
+							'subtitle' => 'Pick a theme.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array(
+						'goal'          => 'write',
+						'niche'         => 'weekend hiking trips',
+						'theme_keyword' => 'hiking',
+					),
+				),
+			),
+			false
+		);
+
+		$paths = array();
+		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
+			$paths[ $task['id'] ] = $task['calypso_path'];
+		}
+
+		$this->assertSame( '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=hiking', $paths['site_theme_selected'] );
 	}
 
 	/**
@@ -559,7 +602,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 			}
 		}
 
-		$this->assertSame( '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $expected ), $path );
+		$this->assertSame( '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=' . rawurlencode( $expected ), $path );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1037,7 +1037,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	public function test_get_hides_social_tasks_on_private_site() {
 		wp_set_current_user( $this->admin_id );
 		$this->seed_ai_output_with_tasks(
-			array( 'connect_social_media', 'drive_traffic', 'post_sharing_enabled', 'first_post_published', 'site_launched' )
+			array( 'connect_social_media', 'drive_traffic', 'first_post_published', 'site_launched' )
 		);
 
 		$ids = function () {
@@ -1049,17 +1049,48 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$public_ids = $ids();
 		$this->assertContains( 'connect_social_media', $public_ids );
 		$this->assertContains( 'drive_traffic', $public_ids );
-		$this->assertContains( 'post_sharing_enabled', $public_ids );
 
 		// Private site: the Social tasks are gone, the rest remain.
 		update_option( 'blog_public', '-1' );
 		$private_ids = $ids();
 		$this->assertNotContains( 'connect_social_media', $private_ids );
 		$this->assertNotContains( 'drive_traffic', $private_ids );
-		$this->assertNotContains( 'post_sharing_enabled', $private_ids );
 		$this->assertContains( 'first_post_published', $private_ids );
 
 		update_option( 'blog_public', '1' );
+	}
+
+	/**
+	 * Test that a persisted post_sharing_enabled task renders as connect_social_media.
+	 * The sharing module is active by default on wpcom, so the original task was born
+	 * completed; the connection task is the meaningful version of the same intent. A
+	 * payload holding both collapses to one card.
+	 */
+	public function test_get_remaps_post_sharing_enabled_to_connect_social_media() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks(
+			array( 'post_sharing_enabled', 'connect_social_media', 'first_post_published', 'site_launched' )
+		);
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertNotContains( 'post_sharing_enabled', $ids );
+		$this->assertSame( 1, array_count_values( $ids )['connect_social_media'] );
+	}
+
+	/**
+	 * Test that the rendered id of a remapped task is skippable: an output persisted
+	 * before the post_sharing_enabled remap renders a connect_social_media card, and
+	 * skipping that card must validate against the remapped ids, not the raw payload.
+	 */
+	public function test_skip_task_accepts_remapped_task_id() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'post_sharing_enabled', 'site_launched' ) );
+
+		$result = $this->call_api( 'POST', '/skip-task', array( 'task_id' => 'connect_social_media' ) );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertTrue( $result->get_data()['skipped'] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -436,14 +436,14 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that GET repoints the social/design CTAs to wp-admin targets, since the
-	 * catalog sends them to Calypso flows that are a poor fit for the wp-admin AI
+	 * Test that GET repoints the connect-social CTA to its wp-admin target, since the
+	 * catalog sends it to a Calypso flow that is a poor fit for the wp-admin AI
 	 * Launchpad (and connect_social_media completes on the wp-admin Jetpack Social
 	 * page, where its CTA should land).
 	 */
 	public function test_get_overrides_calypso_ctas_with_wp_admin_targets() {
 		wp_set_current_user( $this->admin_id );
-		$this->seed_ai_output_with_tasks( array( 'connect_social_media', 'design_selected', 'site_launched' ) );
+		$this->seed_ai_output_with_tasks( array( 'connect_social_media', 'first_post_published', 'site_launched' ) );
 
 		$paths = array();
 		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
@@ -451,7 +451,6 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		}
 
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-social' ), $paths['connect_social_media'] );
-		$this->assertSame( admin_url( 'themes.php' ), $paths['design_selected'] );
 		// A task without an override keeps its catalog path unchanged (null for the
 		// launch task, which routes to the wordpress.com launch flow client-side).
 		$this->assertArrayHasKey( 'site_launched', $paths );
@@ -459,7 +458,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that GET points the theme tasks at the Calypso themes showcase pre-filtered
+	 * Test that GET points the theme task at the Calypso themes showcase pre-filtered
 	 * by the AI-inferred niche, so the theme list feels relevant to what the user is
 	 * building. This overrides the plain wp-admin themes.php target, which can only
 	 * filter already-installed themes.
@@ -483,10 +482,6 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 							'subtitle' => 'Pick a gallery-style theme.',
 						),
 						array(
-							'id'       => 'design_selected',
-							'subtitle' => 'Make it yours.',
-						),
-						array(
 							'id'       => 'site_launched',
 							'subtitle' => 'Go live.',
 						),
@@ -507,7 +502,6 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$expected = '/themes/all/' . rawurlencode( wpcom_get_site_slug() ) . '?s=ceramics';
 		$this->assertSame( $expected, $paths['site_theme_selected'] );
-		$this->assertSame( $expected, $paths['design_selected'] );
 		// A non-theme task is untouched by the niche filter.
 		$this->assertNull( $paths['site_launched'] );
 	}
@@ -622,21 +616,19 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that without an inferred niche the theme CTAs keep their existing targets
-	 * (the wp-admin override for design_selected), so the filter is purely additive.
+	 * Test that without an inferred niche the theme task keeps its catalog target, so
+	 * the showcase filter is purely additive.
 	 */
 	public function test_get_leaves_theme_ctas_unfiltered_without_niche() {
 		wp_set_current_user( $this->admin_id );
 		// seed_ai_output_with_tasks writes no `inferred` block, so there is no niche.
-		$this->seed_ai_output_with_tasks( array( 'site_theme_selected', 'design_selected', 'site_launched' ) );
+		$this->seed_ai_output_with_tasks( array( 'site_theme_selected', 'site_launched' ) );
 
 		$paths = array();
 		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
 			$paths[ $task['id'] ] = $task['calypso_path'];
 		}
 
-		// The CTA_OVERRIDES branch keeps its wp-admin target.
-		$this->assertSame( admin_url( 'themes.php' ), $paths['design_selected'] );
 		// The load_calypso_path branch keeps the catalog's default theme path.
 		$this->assertSame( '/themes/' . rawurlencode( wpcom_get_site_slug() ) . '#theme-selected', $paths['site_theme_selected'] );
 	}
@@ -1434,8 +1426,9 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	 * wpcom_ai_launchpad_get_ai_task_ids() reports them as on the site's list.
 	 *
 	 * @param string[] $task_ids The task IDs to seed.
+	 * @param string   $goal     Optional inferred goal to record (drives sell-specific behavior).
 	 */
-	private function seed_ai_output_with_tasks( array $task_ids ) {
+	private function seed_ai_output_with_tasks( array $task_ids, $goal = '' ) {
 		$tasks = array();
 		foreach ( $task_ids as $id ) {
 			$tasks[] = array(
@@ -1443,13 +1436,17 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 				'subtitle' => 'Subtitle for ' . $id . '.',
 			);
 		}
+		$payload = array( 'tasks' => $tasks );
+		if ( '' !== $goal ) {
+			$payload['inferred'] = array( 'goal' => $goal );
+		}
 		update_option(
 			'wpcom_ai_launchpad_ai_output',
 			array(
 				'version'      => 1,
 				'source'       => 'ai',
 				'generated_at' => 1717000000,
-				'payload'      => array( 'tasks' => $tasks ),
+				'payload'      => $payload,
 			),
 			false
 		);
@@ -1568,11 +1565,12 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that the sell reorder covers every theme-picker task id, not just
-	 * site_theme_selected — an output whose theme task is design_selected must
-	 * also land right after the store-setup lead tasks.
+	 * Test that a persisted design_selected task renders as the actionable
+	 * site_theme_selected and is repositioned after the store-setup lead tasks:
+	 * the legacy "Select a design" task is always-complete and has no wp-admin
+	 * completion path, so it is consolidated onto the theme task.
 	 */
-	public function test_get_sell_moves_design_selected_after_store_setup() {
+	public function test_get_sell_remaps_and_repositions_design_selected() {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'active_plugins', array() );
 		update_option(
@@ -1604,10 +1602,100 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 
+		$this->assertNotContains( 'design_selected', $ids );
 		$this->assertSame(
-			array( 'install_woocommerce', 'setup_woocommerce_store', 'design_selected' ),
+			array( 'install_woocommerce', 'setup_woocommerce_store', 'site_theme_selected' ),
 			array_slice( $ids, 0, 3 )
 		);
+	}
+
+	/**
+	 * Test that the legacy design tasks are consolidated onto site_theme_selected on
+	 * read: both remap to the one actionable theme task (deduped), and it is not the
+	 * always-complete "Select a design" card.
+	 */
+	public function test_get_remaps_design_tasks_to_site_theme_selected() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'design_selected', 'design_completed', 'site_launched' ), 'build' );
+
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertArrayNotHasKey( 'design_selected', $tasks );
+		$this->assertArrayNotHasKey( 'design_completed', $tasks );
+		$this->assertArrayHasKey( 'site_theme_selected', $tasks );
+		// site_theme_selected reads a real signal, so it is not born-complete like design_selected was.
+		$this->assertFalse( $tasks['site_theme_selected']['completed'] );
+	}
+
+	/**
+	 * Test that a sell list always includes a Choose-a-theme task even when the AI
+	 * did not pick one, positioned right after the store-setup lead tasks and
+	 * pointed at the showcase Store category.
+	 */
+	public function test_get_guarantees_theme_task_on_sell() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'active_plugins', array() );
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version'      => 1,
+				'source'       => 'ai',
+				'generated_at' => 1717000000,
+				'payload'      => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'woo_products',
+							'subtitle' => 'Add products.',
+						),
+						array(
+							'id'       => 'woo_marketing',
+							'subtitle' => 'Promote it.',
+						),
+						array(
+							'id'       => 'site_launched',
+							'subtitle' => 'Go live.',
+						),
+					),
+					'inferred' => array( 'goal' => 'sell' ),
+				),
+			),
+			false
+		);
+
+		$tasks = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], null, 'id' );
+
+		$this->assertArrayHasKey( 'site_theme_selected', $tasks );
+		$ids = array_keys( $tasks );
+		$this->assertSame(
+			array( 'install_woocommerce', 'setup_woocommerce_store', 'site_theme_selected' ),
+			array_slice( $ids, 0, 3 )
+		);
+		$this->assertSame(
+			'/themes/filter/store/' . rawurlencode( wpcom_get_site_slug() ),
+			$tasks['site_theme_selected']['calypso_path']
+		);
+	}
+
+	/**
+	 * Test that a non-sell list is not given a theme task it did not ask for.
+	 */
+	public function test_get_does_not_inject_theme_task_for_non_sell() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ), 'write' );
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertNotContains( 'site_theme_selected', $ids );
+	}
+
+	/**
+	 * Test that the AI-selected id list counts the sell theme guarantee, so the
+	 * switch_theme listener and skip validation see the card the site renders.
+	 */
+	public function test_ai_task_ids_include_guaranteed_sell_theme() {
+		$this->seed_ai_output_with_tasks( array( 'woo_products', 'site_launched' ), 'sell' );
+
+		$this->assertContains( 'site_theme_selected', wpcom_ai_launchpad_get_ai_task_ids() );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Social_Listener_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Social_Listener_Test.php
@@ -73,34 +73,51 @@ class AI_Launchpad_Social_Listener_Test extends \WorDBless\BaseTestCase {
 	public function test_completes_only_when_selected_signalled_and_on_page() {
 		$task_lists = wpcom_launchpad_checklists();
 
-		// Selected + on-page, but signals off: nothing completes.
-		$this->seed_tasks( array( 'post_sharing_enabled', 'connect_social_media', 'drive_traffic' ) );
+		// Selected + on-page, but no connection yet: nothing completes.
+		$this->seed_tasks( array( 'connect_social_media', 'drive_traffic' ) );
 		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
-		$this->assertFalse( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
 		$this->assertFalse( $task_lists->is_task_id_complete( 'connect_social_media' ) );
 
-		// Turn the signals on for the remaining cases.
-		Publicize_Utils::$active = true;
-		Connections::$all        = array( array( 'connection_id' => '1' ) );
+		// Turn the signal on for the remaining cases.
+		Connections::$all = array( array( 'connection_id' => '1' ) );
 
 		// Signalled + selected, but off the launchpad page: still nothing.
 		$_GET['page'] = 'some-other-page';
 		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
-		$this->assertFalse( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
 		$this->assertFalse( $task_lists->is_task_id_complete( 'connect_social_media' ) );
 
 		// Signalled + on-page, but the tasks are not AI-selected: still nothing.
 		$_GET['page'] = 'site-setup-wp-admin';
 		$this->seed_tasks( array( 'site_launched' ) );
 		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
-		$this->assertFalse( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
 		$this->assertFalse( $task_lists->is_task_id_complete( 'connect_social_media' ) );
 
 		// All three conditions met: the selected social tasks complete.
-		$this->seed_tasks( array( 'post_sharing_enabled', 'connect_social_media', 'drive_traffic' ) );
+		$this->seed_tasks( array( 'connect_social_media', 'drive_traffic' ) );
 		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
-		$this->assertTrue( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
 		$this->assertTrue( $task_lists->is_task_id_complete( 'connect_social_media' ) );
 		$this->assertTrue( $task_lists->is_task_id_complete( 'drive_traffic' ) );
+	}
+
+	/**
+	 * Test that an output persisted before the post_sharing_enabled remap counts as
+	 * selecting connect_social_media: the always-true module-active signal completes
+	 * nothing anymore, and the connection signal completes the remapped task.
+	 */
+	public function test_pre_remap_post_sharing_output_completes_connection_task() {
+		$task_lists = wpcom_launchpad_checklists();
+
+		// The sharing module is active (the wpcom default) but no connection exists:
+		// nothing may complete — post_sharing_enabled used to be born-completed here.
+		$this->seed_tasks( array( 'post_sharing_enabled' ) );
+		Publicize_Utils::$active = true;
+		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
+		$this->assertFalse( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
+		$this->assertFalse( $task_lists->is_task_id_complete( 'connect_social_media' ) );
+
+		// A connection appears: the task the card actually renders as completes.
+		Connections::$all = array( array( 'connection_id' => '1' ) );
+		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
+		$this->assertTrue( $task_lists->is_task_id_complete( 'connect_social_media' ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Social_Listener_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Social_Listener_Test.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Publicize\Connections;
-use Automattic\Jetpack\Publicize\Publicize_Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 require_once __DIR__ . '/fixtures/social-stubs.php';
@@ -31,9 +30,8 @@ class AI_Launchpad_Social_Listener_Test extends \WorDBless\BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 		wpcom_register_default_launchpad_checklists();
-		Publicize_Utils::$active = false;
-		Connections::$all        = array();
-		$_GET['page']            = 'site-setup-wp-admin';
+		Connections::$all = array();
+		$_GET['page']     = 'site-setup-wp-admin';
 	}
 
 	/**
@@ -107,10 +105,10 @@ class AI_Launchpad_Social_Listener_Test extends \WorDBless\BaseTestCase {
 	public function test_pre_remap_post_sharing_output_completes_connection_task() {
 		$task_lists = wpcom_launchpad_checklists();
 
-		// The sharing module is active (the wpcom default) but no connection exists:
-		// nothing may complete — post_sharing_enabled used to be born-completed here.
+		// A pre-remap output that selected post_sharing_enabled, but no connection exists:
+		// nothing may complete — post_sharing_enabled used to be born-completed here off the
+		// always-on module-active signal, which the listener no longer consults.
 		$this->seed_tasks( array( 'post_sharing_enabled' ) );
-		Publicize_Utils::$active = true;
 		AI_Launchpad_Social_Listener::maybe_complete_social_tasks();
 		$this->assertFalse( $task_lists->is_task_id_complete( 'post_sharing_enabled' ) );
 		$this->assertFalse( $task_lists->is_task_id_complete( 'connect_social_media' ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Theme_Listener_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Theme_Listener_Test.php
@@ -87,6 +87,59 @@ class AI_Launchpad_Theme_Listener_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * A sell list always shows a Choose-a-theme task, so switch_theme completes it
+	 * even when the AI did not explicitly pick site_theme_selected.
+	 */
+	public function test_switch_theme_completes_guaranteed_sell_theme() {
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version' => 1,
+				'payload' => array(
+					'tasks'    => array(
+						array(
+							'id'       => 'woo_products',
+							'subtitle' => 'Add products.',
+						),
+					),
+					'inferred' => array( 'goal' => 'sell' ),
+				),
+			),
+			false
+		);
+
+		AI_Launchpad_Theme_Listener::mark_theme_selected_complete();
+
+		$statuses = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertIsArray( $statuses );
+		$this->assertTrue( $statuses['site_theme_selected'] );
+	}
+
+	/**
+	 * A sell output can carry an inferred goal but no task list (a partial write). The
+	 * render side still shows the guaranteed Choose-a-theme task, so switch_theme must
+	 * complete it here too.
+	 */
+	public function test_switch_theme_completes_guaranteed_sell_theme_without_task_list() {
+		update_option(
+			'wpcom_ai_launchpad_ai_output',
+			array(
+				'version' => 1,
+				'payload' => array(
+					'inferred' => array( 'goal' => 'sell' ),
+				),
+			),
+			false
+		);
+
+		AI_Launchpad_Theme_Listener::mark_theme_selected_complete();
+
+		$statuses = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertIsArray( $statuses );
+		$this->assertTrue( $statuses['site_theme_selected'] );
+	}
+
+	/**
 	 * The listener self-registers on the switch_theme action at file load.
 	 */
 	public function test_listener_is_registered_on_switch_theme() {


### PR DESCRIPTION
## Proposed changes

Second pass of Núria's design feedback on the AI Launchpad (Linear DSGCOM-757):

* **Theme-search keyword** — the tailoring AI now picks a dedicated single-word `inferred.theme_keyword` (the core subject, e.g. "hiking" not "weekend"), and the theme CTA points at the All-themes showcase (`/themes/all/{site}?s={keyword}`), which searches every theme while preferring internal/modern ones.
* **Wizard Skip** — the wizard modal was unclosable. A Skip link (footer-left, both steps) now disables the AI Launchpad via the existing DELETE endpoint and returns to the regular launchpad / Calypso My Home. Dismissal folds into the eligibility gate, so the Site Setup menu drops and My Home + the dashboard widget come back on their own.
* **Live site title** — finishing the wizard writes the entered name to `blogname`; the admin-bar label and the preview card now update in place instead of waiting for a reload.
* **Post-sharing task** — `post_sharing_enabled` was born-completed (the sharing module is on by default), so it appeared pre-done. Dropped from the AI menu and remapped to `connect_social_media`, whose connection signal is the meaningful version of the same intent.
* **Design tasks** — consolidated the legacy `design_selected`/`design_completed` tasks onto the actionable "Choose a theme" (`site_theme_selected`), and always offer it (store-filtered) on sell sites, placed right after store setup.
* **Design polish** — dropped the blue hover border on the preview card and the 2px icon offset in the wizard goal cards.

Stacked on #50268 — the PR base is `dotobrd-507-ai-launchpad-launch-store-task`; GitHub retargets to `trunk` once #50268 merges. **Merge #50268 first**, deploy together. The AI Launchpad feature is OFF in production.

## Related product discussion/links

* Linear: DSGCOM-757

## Does this pull request change what data or activity we track or use?

Yes — adds one new Tracks event, `jetpack_ai_launchpad_wizard_skipped`, recorded when the user skips the onboarding wizard (a click event, no PII), consistent with the AI Launchpad's existing wizard/tailoring events. No other data-collection changes. May warrant the `[Status] Needs Privacy Updates` label.

## Testing instructions

* On a test site with the AI Launchpad enabled (`?enable-ai-launchpad=1`), open the Site Setup menu and run the wizard.
* Confirm the **Skip** link (footer-left, both steps) disables the launchpad and lands on Calypso My Home, with the Site Setup menu gone and My Home restored.
* Complete the wizard and confirm the **site title** updates in the admin bar and preview card without a reload.
* Confirm the theme task opens the **All-themes showcase** filtered by the inferred keyword (and the **Store** category on a sell site).
* Confirm there is no born-completed "Enable post sharing" task, and that sell lists show "Choose a theme" right after store setup.
