### PR TITLE
VideoPress: Fix media library edit link to open the modernized dashboard

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-edit-video-details-link
+++ b/projects/packages/videopress/changelog/fix-videopress-edit-video-details-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix the media library "Edit video details" link to open the modernized dashboard, and reconcile legacy hash links to the new route

--- a/projects/packages/videopress/changelog/fix-videopress-edit-video-details-link
+++ b/projects/packages/videopress/changelog/fix-videopress-edit-video-details-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: Fix the media library "Edit video details" link to open the modernized dashboard, and reconcile legacy hash links to the new route
+VideoPress: Fix the media library "Edit video details" link so it opens the modernized dashboard. Old links now redirect to the new location.

--- a/projects/packages/videopress/routes/overview/route.tsx
+++ b/projects/packages/videopress/routes/overview/route.tsx
@@ -1,1 +1,21 @@
-export const route = {};
+/**
+ * WordPress dependencies
+ */
+import { redirect } from '@wordpress/route';
+
+export const route = {
+	/**
+	 * Reconcile legacy hash-router links from the pre-wp-build dashboard.
+	 *
+	 * Old links pointed at `#/video/<id>/edit`. The hash is never sent to the
+	 * server, so those links land on the index route with no `p` arg; convert
+	 * them client-side to the modernized `/video/<id>` route.
+	 */
+	beforeLoad: () => {
+		const legacyMatch = window.location.hash.match( /^#\/video\/(\d+)(?:\/edit)?\/?$/ );
+
+		if ( legacyMatch ) {
+			throw redirect( { href: `/video/${ legacyMatch[ 1 ] }` } );
+		}
+	},
+};

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -277,8 +277,7 @@ class Admin_UI {
 			return $link;
 		}
 
-		$route = sprintf( '#/video/%d/edit', $post_id );
-		$url   = self::get_admin_page_url() . $route;
+		$url = add_query_arg( 'p', sprintf( '/video/%d', $post_id ), self::get_admin_page_url() );
 
 		if ( 'display' === $context ) {
 			return esc_url( $url );


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* The media library **Edit video details** button linked to the legacy hash route (`admin.php?page=jetpack-videopress#/video/<id>/edit`), which the modernized wp-build dashboard no longer serves. `edit_video_link()` (the `get_edit_post_link` filter behind the attachment template's `data.editLink`) now builds the modernized query-param route: `admin.php?page=jetpack-videopress&p=/video/<id>`.
* Added a `beforeLoad` reconciler to the overview (index) route that maps old hash links to the new route. The hash is never sent to the server, so stale `#/video/<id>/edit` links land on the index route with no `p` arg; this converts them client-side to `/video/<id>` via `redirect()`, mirroring the existing pattern in Jetpack Forms' `responses` route, so old bookmarks and links keep working.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

* Ensure VideoPress is active and you have at least one VideoPress video in the media library.
* Go to **Media** → open (or hover) a VideoPress video and open the attachment details.
* Click **Edit video details**.
  * **Before:** the button opens `…admin.php?page=jetpack-videopress#/video/<id>/edit`, which no longer resolves.
  * **After:** the button opens `…admin.php?page=jetpack-videopress&p=/video/<id>` and lands on the Video details screen.
* Visit an old-style URL directly, e.g. `…admin.php?page=jetpack-videopress#/video/<id>/edit`, and confirm it redirects to the new `&p=/video/<id>` route.

https://claude.ai/code/session_011y87JHZX9f9qq4eoiv3wYw
