### PR TITLE
Add archive filter to top pages widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-top-pages-archive-filter
+++ b/projects/packages/premium-analytics/changelog/add-top-pages-archive-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats widgets: Add archive filtering and comparison support to the top pages widget.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -64,6 +64,12 @@ export {
 
 export { mockSearchTermsData, mockSearchTermsComparisonData } from './search-terms';
 export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors';
+export {
+	mockArchivesComparisonData,
+	mockArchivesData,
+	mockTopPostsComparisonData,
+	mockTopPostsData,
+} from './top-posts';
 
 export { mockSiteSummary } from './site-summary';
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-posts.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/top-posts.ts
@@ -1,0 +1,225 @@
+export const mockTopPostsData = {
+	date: '2026-06-22',
+	period: 'month',
+	summary: {
+		postviews: [
+			{
+				id: 101,
+				href: 'https://example.com/hello-world/',
+				date: '2026-06-01 09:00:00',
+				title: 'Hello world!',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 173,
+			},
+			{
+				id: 210,
+				href: 'https://example.com/post-10/',
+				date: '2026-06-02 09:00:00',
+				title: 'Post 10',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 127,
+			},
+			{
+				id: 209,
+				href: 'https://example.com/post-9/',
+				date: '2026-06-03 09:00:00',
+				title: 'Post 9',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 99,
+			},
+			{
+				id: 208,
+				href: 'https://example.com/post-8/',
+				date: '2026-06-04 09:00:00',
+				title: 'Post 8',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 73,
+			},
+			{
+				id: 307,
+				href: 'https://example.com/pricing/',
+				date: '2026-05-15 09:00:00',
+				title: 'Pricing',
+				type: 'page',
+				status: 'publish',
+				public: true,
+				views: 54,
+			},
+			{
+				id: 0,
+				href: 'https://example.com/',
+				date: null,
+				title: 'Home page / Archives',
+				type: 'homepage',
+				status: null,
+				public: false,
+				views: 43,
+			},
+		],
+		total_views: 569,
+		dropped_ids: [],
+	},
+};
+
+export const mockTopPostsComparisonData = {
+	date: '2026-05-22',
+	period: 'month',
+	summary: {
+		postviews: [
+			{
+				id: 101,
+				href: 'https://example.com/hello-world/',
+				date: '2026-05-01 09:00:00',
+				title: 'Hello world!',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 159,
+			},
+			{
+				id: 210,
+				href: 'https://example.com/post-10/',
+				date: '2026-05-02 09:00:00',
+				title: 'Post 10',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 143,
+			},
+			{
+				id: 209,
+				href: 'https://example.com/post-9/',
+				date: '2026-05-03 09:00:00',
+				title: 'Post 9',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 93,
+			},
+			{
+				id: 208,
+				href: 'https://example.com/post-8/',
+				date: '2026-05-04 09:00:00',
+				title: 'Post 8',
+				type: 'post',
+				status: 'publish',
+				public: true,
+				views: 82,
+			},
+			{
+				id: 307,
+				href: 'https://example.com/pricing/',
+				date: '2026-04-15 09:00:00',
+				title: 'Pricing',
+				type: 'page',
+				status: 'publish',
+				public: true,
+				views: 61,
+			},
+		],
+		total_views: 538,
+		dropped_ids: [],
+	},
+};
+
+export const mockArchivesData = {
+	date: '2026-06-22',
+	period: 'month',
+	summary: {
+		cat: [
+			{
+				href: 'https://example.com/category/releases/',
+				value: 'Releases',
+				views: 83,
+			},
+			{
+				href: 'https://example.com/category/tutorials/',
+				value: 'Tutorials',
+				views: 71,
+			},
+		],
+		tax: {
+			topics: [
+				{
+					href: 'https://example.com/topics/performance/',
+					value: 'Performance',
+					views: 58,
+				},
+				{
+					href: 'https://example.com/topics/security/',
+					value: 'Security',
+					views: 44,
+				},
+			],
+		},
+		date: [
+			{
+				href: 'https://example.com/2026/06/',
+				value: '2026/06',
+				views: 36,
+			},
+		],
+		home: [
+			{
+				href: 'https://example.com/',
+				value: 'home',
+				views: 29,
+			},
+		],
+	},
+};
+
+export const mockArchivesComparisonData = {
+	date: '2026-05-22',
+	period: 'month',
+	summary: {
+		cat: [
+			{
+				href: 'https://example.com/category/releases/',
+				value: 'Releases',
+				views: 72,
+			},
+			{
+				href: 'https://example.com/category/tutorials/',
+				value: 'Tutorials',
+				views: 80,
+			},
+		],
+		tax: {
+			topics: [
+				{
+					href: 'https://example.com/topics/performance/',
+					value: 'Performance',
+					views: 51,
+				},
+				{
+					href: 'https://example.com/topics/security/',
+					value: 'Security',
+					views: 49,
+				},
+			],
+		},
+		date: [
+			{
+				href: 'https://example.com/2026/05/',
+				value: '2026/05',
+				views: 42,
+			},
+		],
+		home: [
+			{
+				href: 'https://example.com/',
+				value: 'home',
+				views: 32,
+			},
+		],
+	},
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -49,6 +49,10 @@ import {
 	mockSearchTermsComparisonData,
 	mockTopAuthorsData,
 	mockTopAuthorsComparisonData,
+	mockArchivesComparisonData,
+	mockArchivesData,
+	mockTopPostsComparisonData,
+	mockTopPostsData,
 	mockSiteSummary,
 	mockStatsInsightsData,
 } from './data';
@@ -853,6 +857,10 @@ function routeStatsReport( subPath: string ): unknown {
 			return nextIsComparison( 'stats/top-authors' )
 				? mockTopAuthorsComparisonData
 				: mockTopAuthorsData;
+		case '/top-posts':
+			return nextIsComparison( 'stats/top-posts' ) ? mockTopPostsComparisonData : mockTopPostsData;
+		case '/archives':
+			return nextIsComparison( 'stats/archives' ) ? mockArchivesComparisonData : mockArchivesData;
 		case '/insights':
 			return mockStatsInsightsData;
 		default:

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -43,8 +43,44 @@ const TOP_POSTS_RESPONSE = {
 				type: 'page',
 				views: 7,
 			},
+			{
+				id: 0,
+				href: 'https://example.com/',
+				date: null,
+				title: 'Home page / Archives',
+				type: 'homepage',
+				views: 5,
+			},
 		],
-		total_views: 49,
+		total_views: 54,
+	},
+};
+
+const ARCHIVES_RESPONSE = {
+	date: '2026-06-10',
+	days: {},
+	summary: {
+		cat: [
+			{
+				href: 'https://example.com/category/news/',
+				value: 'News',
+				views: 31,
+			},
+		],
+		date: [
+			{
+				href: 'https://example.com/2026/06/',
+				value: '2026/06',
+				views: 12,
+			},
+		],
+		home: [
+			{
+				href: 'https://example.com/',
+				value: 'home',
+				views: 5,
+			},
+		],
 	},
 };
 
@@ -65,6 +101,7 @@ describe( 'TopPostsWidget', () => {
 		const link = await screen.findByRole( 'link', { name: /Hello World Post/ } );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/hello-world/' );
 		expect( screen.getByText( 'About Page' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Home page / Archives' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'filters rows by post type when the postType attribute is set', async () => {
@@ -72,6 +109,25 @@ describe( 'TopPostsWidget', () => {
 
 		await expect( screen.findByText( 'About Page' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Hello World Post' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders archive rows when the contentType attribute is set to archive', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve( path.includes( 'stats/archives' ) ? ARCHIVES_RESPONSE : TOP_POSTS_RESPONSE )
+		);
+
+		render( <TopPostsWidget attributes={ { num: 10, contentType: 'archive' } } /> );
+
+		const archiveLink = await screen.findByRole( 'link', { name: /News/ } );
+		expect( archiveLink ).toHaveAttribute( 'href', 'https://example.com/category/news/' );
+		expect( screen.getByText( '2026/06' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Home page / Archives' ) ).toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls.map(
+			( [ { path } ]: [ { path: string } ] ) => path
+		);
+		expect( requestedPaths.some( p => p.includes( 'stats/archives' ) ) ).toBe( true );
+		expect( requestedPaths.some( p => p.includes( 'stats/top-posts' ) ) ).toBe( false );
 	} );
 
 	it( 'requests the dashboard date range from report params', async () => {
@@ -146,6 +202,71 @@ describe( 'TopPostsWidget', () => {
 		expect(
 			requestedPaths.some(
 				p => p.includes( 'start_date=2026-02-01' ) && p.includes( 'date=2026-02-10' )
+			)
+		).toBe( true );
+	} );
+
+	it( 'requests archive comparison data and aligns previous views by archive URL', async () => {
+		const comparisonArchivesResponse = {
+			date: '2026-02-10',
+			days: {},
+			summary: {
+				cat: [
+					{
+						href: 'https://example.com/category/news/',
+						value: 'News',
+						views: 18,
+					},
+				],
+			},
+		};
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) => {
+			if ( path.includes( 'stats/archives' ) && path.includes( 'date=2026-02-10' ) ) {
+				return Promise.resolve( comparisonArchivesResponse );
+			}
+
+			if ( path.includes( 'stats/archives' ) ) {
+				return Promise.resolve( ARCHIVES_RESPONSE );
+			}
+
+			return Promise.resolve( TOP_POSTS_RESPONSE );
+		} );
+
+		render(
+			<TopPostsWidget
+				attributes={ {
+					num: 10,
+					contentType: 'archive',
+					reportParams: {
+						from: '2026-03-01',
+						to: '2026-03-10',
+						comp: '1',
+						compare_from: '2026-02-01',
+						compare_to: '2026-02-10',
+					},
+				} }
+			/>
+		);
+
+		await expect( screen.findByRole( 'link', { name: /News/ } ) ).resolves.toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls.map(
+			( [ { path } ]: [ { path: string } ] ) => path
+		);
+		expect(
+			requestedPaths.some(
+				p =>
+					p.includes( 'stats/archives' ) &&
+					p.includes( 'start_date=2026-03-01' ) &&
+					p.includes( 'date=2026-03-10' )
+			)
+		).toBe( true );
+		expect(
+			requestedPaths.some(
+				p =>
+					p.includes( 'stats/archives' ) &&
+					p.includes( 'start_date=2026-02-01' ) &&
+					p.includes( 'date=2026-02-10' )
 			)
 		).toBe( true );
 	} );

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import {
+	useStatsArchives,
 	useStatsTopPosts,
+	type StatsArchivesItem,
 	type StatsNormalizedReport,
 	type StatsTopPostsItem,
 } from '@jetpack-premium-analytics/data';
@@ -17,7 +19,7 @@ import {
 	type LegendLabels,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
@@ -34,7 +36,7 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
  */
 export type TopPostRow = {
 	/**
-	 * Post or page title.
+	 * Row label.
 	 */
 	label: string;
 	/**
@@ -50,11 +52,15 @@ export type TopPostRow = {
 	/**
 	 * URL of the published post/page.
 	 */
-	href: string;
+	href?: string;
 	/**
 	 * Post type, e.g. `post` or `page`.
 	 */
-	type: string;
+	type?: string;
+	/**
+	 * Stable row key used to align the primary and comparison periods.
+	 */
+	key?: string;
 };
 
 // Report params are dashboard-driven — WidgetRoot resolves them from the date
@@ -62,7 +68,10 @@ export type TopPostRow = {
 type TopPostsRenderAttributes = TopPostsAttributes & Partial< ReportParamsFieldAttributes >;
 type TopPostsWidgetProps = WidgetRenderProps< TopPostsRenderAttributes >;
 
-type TopPostsReportProps = Pick< TopPostsAttributes, 'num' | 'postType' >;
+type TopPostsReportProps = Pick< TopPostsAttributes, 'contentType' | 'num' | 'postType' >;
+
+const DEFAULT_POST_TYPES = [ 'post', 'page' ];
+const DEFAULT_CONTENT_TYPE: NonNullable< TopPostsAttributes[ 'contentType' ] > = 'posts-pages';
 
 /**
  * Maps normalized top-posts rows onto the shape `LeaderboardChart` expects.
@@ -86,20 +95,26 @@ function buildLeaderboardData( rows: TopPostRow[], withComparison: boolean ): Le
 
 	return rows.map( ( row, index ) => {
 		const previousValue = row.previousValue ?? 0;
+		const rowKey = row.key ?? row.href ?? row.label;
+		const label = row.href ? (
+			<Link
+				className={ styles.labelLink }
+				href={ row.href }
+				variant="unstyled"
+				openInNewTab
+				title={ row.label }
+			>
+				{ row.label }
+			</Link>
+		) : (
+			<span className={ styles.labelText } title={ row.label }>
+				{ row.label }
+			</span>
+		);
 
 		return {
-			id: `${ index }-${ row.href }`,
-			label: (
-				<Link
-					className={ styles.labelLink }
-					href={ row.href }
-					variant="unstyled"
-					openInNewTab
-					title={ row.label }
-				>
-					{ row.label }
-				</Link>
-			),
+			id: `${ index }-${ rowKey }`,
+			label,
 			currentValue: row.value,
 			currentShare: ( row.value / maxCurrentViews ) * 100,
 			previousValue,
@@ -163,7 +178,7 @@ export const TopPostsLeaderboard = ( {
 	legendLabels,
 }: TopPostsLeaderboardProps ) => {
 	if ( isError ) {
-		return <Text>{ __( 'Unable to load top posts.', 'jetpack-premium-analytics' ) }</Text>;
+		return <Text>{ __( 'Unable to load top pages.', 'jetpack-premium-analytics' ) }</Text>;
 	}
 
 	if ( isLoading && ( ! rows || rows.length === 0 ) ) {
@@ -187,15 +202,15 @@ export const TopPostsLeaderboard = ( {
 /**
  * Flatten the designated `useStatsTopPosts` report into the `{ label, value,
  * href, type }` rows the leaderboard renders, dropping rows without a link and
- * (optionally) filtering by post type.
+ * filtering to posts and pages by default.
  *
  * @param report       - The normalized top-posts report, or undefined while loading.
- * @param allowedTypes - Post types to keep, or null to keep all.
+ * @param allowedTypes - Post types to keep.
  * @return The normalized top-posts rows.
  */
 function toTopPostRows(
 	report: StatsNormalizedReport< StatsTopPostsItem > | undefined,
-	allowedTypes: string[] | null
+	allowedTypes: string[]
 ): TopPostRow[] {
 	const items = report?.data.flatMap( point => point.items ) ?? [];
 
@@ -204,12 +219,95 @@ function toTopPostRows(
 			( item ): item is StatsTopPostsItem & { link: string } => typeof item.link === 'string'
 		)
 		.map( item => ( {
+			key: item.link ? `link:${ item.link }` : `post:${ String( item.id ) }`,
 			label: String( item.label ?? '' ),
 			value: item.views,
 			href: item.link,
 			type: String( item.type ?? '' ),
 		} ) )
-		.filter( row => ! allowedTypes || allowedTypes.includes( row.type ) );
+		.filter( row => row.type && allowedTypes.includes( row.type ) );
+}
+
+function getAllowedPostTypes( postType: TopPostsAttributes[ 'postType' ] ): string[] {
+	if ( postType === undefined || postType === '' ) {
+		return DEFAULT_POST_TYPES;
+	}
+
+	const types = Array.isArray( postType ) ? postType : [ postType ];
+	const filteredTypes = types.filter( type => type !== '' );
+
+	return filteredTypes.length ? filteredTypes : DEFAULT_POST_TYPES;
+}
+
+function getArchiveLabel( row: StatsArchivesItem, ancestors: string[] ) {
+	const label = String( row.label ?? '' );
+
+	if ( label === 'home' ) {
+		return __( 'Home page / Archives', 'jetpack-premium-analytics' );
+	}
+
+	if ( ancestors[ 0 ] === 'tax' && ancestors[ 1 ] ) {
+		return sprintf(
+			/* translators: 1: taxonomy name, 2: term name. */
+			__( '%1$s: %2$s', 'jetpack-premium-analytics' ),
+			ancestors[ 1 ],
+			label
+		);
+	}
+
+	return label;
+}
+
+function getArchiveChildAncestors( row: StatsArchivesItem, ancestors: string[] ) {
+	const label = String( row.label ?? '' );
+
+	if ( ancestors.length === 0 ) {
+		return [ label ];
+	}
+
+	if ( ancestors[ 0 ] === 'tax' && ancestors.length === 1 ) {
+		return [ ancestors[ 0 ], label ];
+	}
+
+	return ancestors;
+}
+
+function getTopPageRowKey( row: TopPostRow ) {
+	return row.key ?? row.href ?? row.label;
+}
+
+function flattenArchiveRows( rows: StatsArchivesItem[], ancestors: string[] = [] ): TopPostRow[] {
+	return rows.flatMap( row => {
+		const children = row.children ?? [];
+
+		if ( children.length ) {
+			return flattenArchiveRows( children, getArchiveChildAncestors( row, ancestors ) );
+		}
+
+		const href = typeof row.link === 'string' ? row.link : undefined;
+		const label = getArchiveLabel( row, ancestors );
+
+		return [
+			{
+				key: href ?? `${ ancestors.join( '/' ) }/${ label }`,
+				label,
+				value: row.value,
+				href,
+				type: 'archive',
+			},
+		];
+	} );
+}
+
+function toArchiveRows(
+	report: StatsNormalizedReport< StatsArchivesItem > | undefined,
+	max = 10
+): TopPostRow[] {
+	const items = report?.data.flatMap( point => point.items ) ?? [];
+
+	return flattenArchiveRows( items )
+		.sort( ( a, b ) => b.value - a.value )
+		.slice( 0, max > 0 ? max : undefined );
 }
 
 /**
@@ -221,66 +319,96 @@ function toTopPostRows(
  * @param {TopPostsReportProps} props - The component props.
  * @return The widget content.
  */
-function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
+function TopPostsReport( {
+	contentType = DEFAULT_CONTENT_TYPE,
+	num = 10,
+	postType,
+}: TopPostsReportProps ) {
 	const { reportParams } = useWidgetRootContext();
+	const isArchive = contentType === 'archive';
 
 	// The widget's "Number of results" maps to the WPCOM stats API's `max`; the
 	// date range is owned by the dashboard picker and carried in `reportParams`.
 	const statsParams = useMemo( () => ( { ...reportParams, max: num } ), [ reportParams, num ] );
 
-	const { primary, comparison, hasComparison, isLoading, isError } =
-		useStatsTopPosts( statsParams );
+	const topPostsReport = useStatsTopPosts( statsParams, { enabled: ! isArchive } );
+	const archivesReport = useStatsArchives( statsParams, { enabled: isArchive } );
+	const activeReport = isArchive ? archivesReport : topPostsReport;
 
 	const allowedTypes = useMemo( () => {
-		if ( postType === undefined || postType === '' ) {
-			return null;
-		}
-		return Array.isArray( postType ) ? postType : [ postType ];
+		return getAllowedPostTypes( postType );
 	}, [ postType ] );
 
 	const primaryRows = useMemo(
-		() => toTopPostRows( primary.data as StatsNormalizedReport< StatsTopPostsItem >, allowedTypes ),
-		[ primary.data, allowedTypes ]
+		() =>
+			isArchive
+				? toArchiveRows(
+						archivesReport.primary.data as StatsNormalizedReport< StatsArchivesItem > | undefined,
+						num
+				  )
+				: toTopPostRows(
+						topPostsReport.primary.data as StatsNormalizedReport< StatsTopPostsItem > | undefined,
+						allowedTypes
+				  ),
+		[ archivesReport.primary.data, allowedTypes, isArchive, num, topPostsReport.primary.data ]
 	);
 
-	// Comparison-period views keyed by the same post URL the primary rows use.
+	// Comparison-period views keyed by the same stable key the primary rows use.
 	// Empty when comparison is disabled or the comparison query returned no rows.
-	const previousViewsByHref = useMemo( () => {
-		if ( ! hasComparison ) {
+	const previousViewsByKey = useMemo( () => {
+		if ( ! activeReport.hasComparison ) {
 			return new Map< string, number >();
 		}
+
+		if ( isArchive ) {
+			return new Map(
+				toArchiveRows(
+					archivesReport.comparison.data as StatsNormalizedReport< StatsArchivesItem > | undefined,
+					0
+				).map( row => [ getTopPageRowKey( row ), row.value ] )
+			);
+		}
+
 		return new Map(
 			toTopPostRows(
-				comparison.data as StatsNormalizedReport< StatsTopPostsItem >,
+				topPostsReport.comparison.data as StatsNormalizedReport< StatsTopPostsItem > | undefined,
 				allowedTypes
-			).map( row => [ row.href, row.value ] )
+			).map( row => [ getTopPageRowKey( row ), row.value ] )
 		);
-	}, [ comparison.data, allowedTypes, hasComparison ] );
+	}, [
+		activeReport.hasComparison,
+		allowedTypes,
+		archivesReport.comparison.data,
+		isArchive,
+		topPostsReport.comparison.data,
+	] );
 
 	// Only render comparison UI when at least one primary row actually overlaps
 	// the comparison period; otherwise unmatched rows would fall to a placeholder
 	// `previousValue: 0` and the chart would show a fabricated delta (see AGENTS.md).
 	const withComparison =
-		hasComparison && primaryRows.some( row => previousViewsByHref.has( row.href ) );
+		activeReport.hasComparison &&
+		primaryRows.some( row => previousViewsByKey.has( getTopPageRowKey( row ) ) );
 
 	const rows = useMemo(
 		() =>
 			withComparison
 				? primaryRows.map( row => ( {
 						...row,
-						previousValue: previousViewsByHref.get( row.href ) ?? 0,
+						previousValue: previousViewsByKey.get( getTopPageRowKey( row ) ) ?? 0,
 				  } ) )
 				: primaryRows,
-		[ primaryRows, previousViewsByHref, withComparison ]
+		[ primaryRows, previousViewsByKey, withComparison ]
 	);
 
 	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+	const isLoading = activeReport.isLoading || ( activeReport.isFetching && activeReport.hasData );
 
 	return (
 		<TopPostsLeaderboard
 			rows={ rows }
 			isLoading={ isLoading }
-			isError={ isError }
+			isError={ activeReport.isError }
 			withComparison={ withComparison }
 			showLegend={ withComparison }
 			legendLabels={ legendLabels }
@@ -294,7 +422,7 @@ function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
  * WidgetRoot provides the analytics query client, chart theme, and the report
  * params consumed by the inner leaderboard — resolved from the dashboard date
  * range via context, the same way the other Stats widgets read them. The
- * widget's own `num`/`postType` settings are forwarded to the inner component.
+ * widget's own `num`/`contentType` settings are forwarded to the inner component.
  *
  * @param {TopPostsWidgetProps} props - The widget render props.
  * @return The rendered widget.
@@ -302,7 +430,11 @@ function TopPostsReport( { num = 10, postType }: TopPostsReportProps ) {
 export default function TopPosts( { attributes = {} }: TopPostsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<TopPostsReport num={ attributes.num } postType={ attributes.postType } />
+			<TopPostsReport
+				contentType={ attributes.contentType ?? DEFAULT_CONTENT_TYPE }
+				num={ attributes.num }
+				postType={ attributes.postType }
+			/>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -1,195 +1,165 @@
 /**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
  * Internal dependencies
  */
-import { withChartTheme } from '../../../packages/widgets-toolkit/src/stories/with-chart-theme';
-import { TopPostsLeaderboard, type TopPostRow } from '../render';
-import type { Meta, StoryObj, Decorator } from '@storybook/react';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import TopPostsRender from '../render';
+import widgetDefinition, { type TopPostsAttributes } from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
 
-const meta: Meta< typeof TopPostsLeaderboard > = {
+registerReportMocks();
+
+const TOP_POSTS_RENDER_MODULE = 'storybook/top-posts';
+const DEFAULT_NUM = 10;
+const DEFAULT_CONTENT_TYPE: NonNullable< TopPostsAttributes[ 'contentType' ] > = 'posts-pages';
+
+interface TopPostsStoryControls {
+	/**
+	 * Whether to request the previous-period comparison.
+	 */
+	withComparison: boolean;
+	/**
+	 * Top pages source displayed by the widget.
+	 */
+	contentType: NonNullable< TopPostsAttributes[ 'contentType' ] >;
+}
+
+function getTopPostsAttributes( {
+	contentType,
+	withComparison,
+}: TopPostsStoryControls ): ComponentProps< typeof TopPostsRender >[ 'attributes' ] {
+	return {
+		num: DEFAULT_NUM,
+		contentType,
+		reportParams: getDefaultQueryParams( withComparison ),
+	};
+}
+
+/**
+ * Render the data-connected Top pages widget with report params derived from
+ * the story controls, so the close-up stories exercise the real data flow.
+ *
+ * @param {TopPostsStoryControls} props - Story controls.
+ * @return The rendered widget.
+ */
+function renderTopPosts( props: TopPostsStoryControls ) {
+	return <TopPostsRender attributes={ getTopPostsAttributes( props ) } />;
+}
+
+function TopPostsDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <TopPostsRender { ...( props as ComponentProps< typeof TopPostsRender > ) } />;
+}
+
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '360px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TopPosts',
-	component: TopPostsLeaderboard,
+	component: TopPostsRender,
 	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+		contentType: {
+			control: 'select',
+			options: [ 'posts-pages', 'archive' ],
+			description: 'Select Posts & Pages or Archive rows.',
+		},
+	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Top posts & pages" widget. Renders the most-viewed posts and pages for the period as a leaderboard, with each row linking to the published content. This is the presentational layer — it takes already-fetched rows via props and handles the loading, error, empty, and populated states. The data-connected widget (render.tsx default export) wraps this in WidgetRoot and feeds it the designated useStatsTopPosts hook.',
+					'The "Top pages by views" widget. Renders the most-viewed posts/pages or archive pages for the selected period, with optional period-over-period comparison. The "View by" control is the `contentType` attribute (`relevance: \'high\'`), exposed by the widget host.',
 			},
 		},
 	},
-	decorators: [ withChartTheme ],
-};
+} satisfies Meta< ComponentProps< typeof TopPostsRender > & TopPostsStoryControls >;
 
 export default meta;
 
-type Story = StoryObj< typeof TopPostsLeaderboard >;
+type Story = StoryObj< TopPostsStoryControls >;
 
-const mockRows: TopPostRow[] = [
-	{
-		label: 'How we cut our build times in half',
-		value: 12840,
-		previousValue: 9870,
-		href: 'https://example.com/cut-build-times-in-half',
-		type: 'post',
-	},
-	{
-		label: 'Pricing',
-		value: 9320,
-		previousValue: 10110,
-		href: 'https://example.com/pricing',
-		type: 'page',
-	},
-	{
-		label: '10 lessons from scaling to a million users',
-		value: 7610,
-		previousValue: 5400,
-		href: 'https://example.com/lessons-scaling-million-users',
-		type: 'post',
-	},
-	{
-		label: 'About us',
-		value: 4180,
-		previousValue: 4360,
-		href: 'https://example.com/about',
-		type: 'page',
-	},
-	{
-		label: 'A practical guide to feature flags',
-		value: 2950,
-		previousValue: 0,
-		href: 'https://example.com/guide-to-feature-flags',
-		type: 'post',
-	},
-];
-
-const mockLongLabelRows: TopPostRow[] = [
-	{
-		label:
-			'An exhaustively long, keyword-stuffed headline that almost certainly needs to be truncated before it overflows the row',
-		value: 8400,
-		href: 'https://example.com/very-long-headline-that-needs-truncation',
-		type: 'post',
-	},
-	{
-		label: 'Frequently asked questions about billing, refunds, and account management',
-		value: 5120,
-		href: 'https://example.com/faq-billing-refunds-account-management',
-		type: 'page',
-	},
-	{
-		label: 'Changelog',
-		value: 2010,
-		href: 'https://example.com/changelog',
-		type: 'page',
-	},
-];
-
-/**
- * Default populated state — a mix of posts and pages ranked by views.
- */
 export const Default: Story = {
+	render: renderTopPosts,
 	args: {
-		rows: mockRows,
+		contentType: DEFAULT_CONTENT_TYPE,
+		withComparison: false,
 	},
+	decorators: [ withWidgetCanvas ],
 };
 
-/**
- * Comparison state — each value shows its change versus the previous period
- * (green for gains, red for losses), driven by each row's `previousValue`.
- * Mirrors the overlay comparison mode of the toolkit's `LeaderboardChart`.
- */
 export const WithComparison: Story = {
+	render: renderTopPosts,
 	args: {
-		rows: mockRows,
+		contentType: DEFAULT_CONTENT_TYPE,
 		withComparison: true,
-		showLegend: true,
-		legendLabels: {
-			primary: 'Jun 1 – 18, 2026',
-			comparison: 'May 14 – 31, 2026',
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+export const Archive: Story = {
+	render: renderTopPosts,
+	args: {
+		contentType: 'archive',
+		withComparison: true,
+	},
+	decorators: [ withWidgetCanvas ],
+};
+
+interface TopPostsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		TopPostsStoryControls {}
+
+function TopPostsDashboardStory( {
+	contentType,
+	withComparison,
+	...dashboardArgs
+}: TopPostsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ TOP_POSTS_RENDER_MODULE }
+			renderComponent={ TopPostsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getTopPostsAttributes( { contentType, withComparison } ) }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< TopPostsDashboardStoryProps > = {
+	render: args => <TopPostsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		contentType: DEFAULT_CONTENT_TYPE,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+		contentType: {
+			control: 'select',
+			options: [ 'posts-pages', 'archive' ],
+			description: 'Select Posts & Pages or Archive rows.',
 		},
 	},
-};
-
-/**
- * Loading state — the chart renders its loading overlay while data is fetched.
- */
-export const Loading: Story = {
-	args: {
-		rows: [],
-		isLoading: true,
-	},
-};
-
-/**
- * Empty state — no views were recorded for the selected period.
- */
-export const NoViews: Story = {
-	args: {
-		rows: [],
-	},
-};
-
-/**
- * Error state — the report could not be loaded.
- */
-export const ErrorState: Story = {
-	args: {
-		isError: true,
-	},
-};
-
-/**
- * Long titles are truncated with an ellipsis so rows stay single-line.
- */
-export const LongLabels: Story = {
-	args: {
-		rows: mockLongLabelRows,
-	},
-};
-
-/**
- * Creates a decorator that wraps the story in a fixed-size container so the
- * widget's responsiveness can be inspected at a given width.
- *
- * @param width    - The container width (any CSS length).
- * @param [height] - The container height; defaults to `auto`.
- * @return A Storybook decorator.
- */
-const createSizeDecorator = ( width: string, height = 'auto' ): Decorator => {
-	return Story => (
-		<div
-			style={ {
-				width,
-				height,
-				border: '1px dashed #ccc',
-				borderRadius: '8px',
-				padding: '16px',
-				background: '#fafafa',
-				containerType: 'inline-size',
-				containerName: 'widget',
-			} }
-		>
-			<Story />
-		</div>
-	);
-};
-
-/**
- * Medium container (448px / md breakpoint).
- */
-export const SizeMedium: Story = {
-	args: {
-		rows: mockRows,
-	},
-	decorators: [ createSizeDecorator( '448px' ) ],
-};
-
-/**
- * Large container (576px / xl breakpoint).
- */
-export const SizeLarge: Story = {
-	args: {
-		rows: mockRows,
-	},
-	decorators: [ createSizeDecorator( '576px' ) ],
 };

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -1,4 +1,5 @@
-.labelLink {
+.labelLink,
+.labelText {
 	display: block;
 
 	/* Vertical padding sets the overlay bar height — the bar fills the row,

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -13,11 +13,18 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
  */
 export type TopPostsAttributes = {
 	/**
-	 * Maximum number of posts to display.
+	 * Maximum number of rows to display.
 	 */
 	num?: number;
 	/**
-	 * Post type(s) to keep. When undefined or empty, all types are shown.
+	 * Which top-pages source to display.
+	 */
+	contentType?: 'posts-pages' | 'archive';
+	/**
+	 * Post type(s) to keep. When undefined or empty, posts and pages are shown.
+	 *
+	 * @deprecated Use `contentType`. Kept so existing widget instances that
+	 * filtered to posts or pages continue to render as saved.
 	 */
 	postType?: string | string[];
 };
@@ -26,7 +33,7 @@ export type TopPostsAttributes = {
  * Widget type definition.
  *
  * `example.attributes` doubles as the defaults applied to new instances: ten
- * posts, all post types. The date range comes from the dashboard picker.
+ * rows, posts and pages. The date range comes from the dashboard picker.
  */
 export default {
 	name: 'jpa/stats-top-posts',
@@ -39,19 +46,26 @@ export default {
 			type: 'integer',
 		},
 		{
-			id: 'postType',
-			label: __( 'Post type', 'jetpack-premium-analytics' ),
+			id: 'contentType',
+			label: __( 'View by', 'jetpack-premium-analytics' ),
 			type: 'text',
 			elements: [
-				{ label: __( 'All', 'jetpack-premium-analytics' ), value: '' },
-				{ label: __( 'Posts', 'jetpack-premium-analytics' ), value: 'post' },
-				{ label: __( 'Pages', 'jetpack-premium-analytics' ), value: 'page' },
+				{
+					label: __( 'Posts & Pages', 'jetpack-premium-analytics' ),
+					value: 'posts-pages',
+				},
+				{
+					label: __( 'Archive', 'jetpack-premium-analytics' ),
+					value: 'archive',
+				},
 			],
+			relevance: 'high',
 		},
 	] as WidgetAttributeField< TopPostsAttributes >[],
 	example: {
 		attributes: {
 			num: 10,
+			contentType: 'posts-pages',
 		},
 	},
 };


### PR DESCRIPTION
**Note:** Largest changes are in regards to the Storybook updates.

## Proposed changes
* Add a `Posts & Pages` / `Archive` attribute filter to the Top pages by views widget, keeping `Posts & Pages` as the default.
* Fetch archive stats when `Archive` is selected and map comparison rows by stable report keys.
* Update Storybook mocks/stories and focused tests for archive and comparison behavior.

<img width="641" height="335" alt="Screenshot 2026-07-08 at 17 26 54" src="https://github.com/user-attachments/assets/c28f15eb-1726-4bcc-9aff-85a4c5928319" />

## Testing instructions
* Run `env PATH=/Users/lourensschep/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --config.verify-deps-before-run=false --filter @automattic/jetpack-premium-analytics test -- widgets/top-posts/__tests__/top-posts.test.tsx`.
* Open the premium-analytics Storybook and inspect the Top pages by views stories.
* Confirm the widget shows `Posts & Pages` by default.
* Select `Archive` and confirm archive rows render correctly.
* Enable comparison and confirm positive/negative comparison values render for both `Posts & Pages` and `Archive` results.