### PR TITLE
VideoPress: bypass Stats module check in Overview video-plays proxy (VIDP-277)

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
+++ b/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: load Overview stats even when the Jetpack Stats module is inactive.
+Load VideoPress Overview stats even when the Jetpack Stats module is inactive.

--- a/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
+++ b/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: load Overview stats without requiring the Jetpack Stats module, matching the standalone VideoPress stats helper.
+VideoPress: load Overview stats even when the Jetpack Stats module is inactive.

--- a/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
+++ b/projects/packages/videopress/changelog/fix-videopress-overview-stats-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: load Overview stats without requiring the Jetpack Stats module, matching the standalone VideoPress stats helper.

--- a/projects/packages/videopress/src/class-rest-controller.php
+++ b/projects/packages/videopress/src/class-rest-controller.php
@@ -108,7 +108,10 @@ class Rest_Controller {
 	 *
 	 * Forwards the whitelisted query params to WPCOM (REST v1.1, blog-signed
 	 * — matching the existing `Stats::fetch_video_plays` path) and forces
-	 * `complete_stats=true`. In complete-stats mode, each day entry carries
+	 * `complete_stats=true`. `check_stats_module=false` is also forced so the
+	 * report loads for standalone VideoPress sites without the Jetpack Stats
+	 * module active, matching `Stats::fetch_video_plays`. In complete-stats
+	 * mode, each day entry carries
 	 * `total.views`, `total.impressions`, and `total.watch_time` (in hours)
 	 * plus a per-video `data[]` array whose entries have `post_id`, `title`,
 	 * `views`, `impressions`, `watch_time` (hours), and `retention_rate`.
@@ -127,7 +130,10 @@ class Rest_Controller {
 			);
 		}
 
-		$params = array( 'complete_stats' => 'true' );
+		$params = array(
+			'complete_stats'     => 'true',
+			'check_stats_module' => 'false',
+		);
 		foreach ( array_keys( self::stats_video_plays_args() ) as $key ) {
 			$value = $request->get_param( $key );
 			if ( $value !== null && $value !== '' ) {

--- a/projects/packages/videopress/src/class-rest-controller.php
+++ b/projects/packages/videopress/src/class-rest-controller.php
@@ -60,9 +60,9 @@ class Rest_Controller {
 
 	/**
 	 * Query params accepted by the video-plays proxy. Forwarded verbatim
-	 * to WPCOM after permission and shape validation; `complete_stats` is
-	 * always forced to `true` (the only mode the Overview cares about)
-	 * and is therefore not exposed as an incoming param.
+	 * to WPCOM after permission and shape validation. `complete_stats` and
+	 * `check_stats_module` are always forced by the callback and are
+	 * therefore not exposed as incoming params.
 	 *
 	 * @return array
 	 */
@@ -106,7 +106,7 @@ class Rest_Controller {
 	/**
 	 * Proxy the video-plays stats endpoint.
 	 *
-	 * Forwards the whitelisted query params to WPCOM (REST v1.1, blog-signed
+	 * Forwards the allowed query params to WPCOM (REST v1.1, blog-signed
 	 * — matching the existing `Stats::fetch_video_plays` path) and forces
 	 * `complete_stats=true`. `check_stats_module=false` is also forced so the
 	 * report loads for standalone VideoPress sites without the Jetpack Stats

--- a/projects/packages/videopress/tests/php/Rest_Controller_Test.php
+++ b/projects/packages/videopress/tests/php/Rest_Controller_Test.php
@@ -157,9 +157,9 @@ class Rest_Controller_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that whitelisted params are forwarded and empty ones are omitted.
+	 * Test that allowed params are forwarded and empty ones are omitted.
 	 */
-	public function test_forwards_whitelisted_params() {
+	public function test_forwards_allowed_params() {
 		$this->get_video_plays(
 			array(
 				'period' => 'week',

--- a/projects/packages/videopress/tests/php/Rest_Controller_Test.php
+++ b/projects/packages/videopress/tests/php/Rest_Controller_Test.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests for the VideoPress Rest_Controller video-plays proxy.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Tokens;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Tests for the `/jetpack/v4/videopress/stats/video-plays` proxy.
+ */
+class Rest_Controller_Test extends BaseTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * URL captured from the outbound WPCOM request.
+	 *
+	 * @var string|null
+	 */
+	private static $captured_url;
+
+	/**
+	 * The `jetpack_remote_request_url` closure, saved so it can be removed specifically.
+	 *
+	 * @var callable
+	 */
+	private $url_filter;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		$this->user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user_id );
+
+		// Mock a Jetpack connection so the blog-signed request can be built.
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+		\Jetpack_Options::update_option( 'master_user', $this->user_id );
+		( new Tokens() )->update_user_token( $this->user_id, sprintf( '%s.%s.%d', 'key', 'private', $this->user_id ), false );
+
+		/*
+		 * Capture the outbound WPCOM request URL. This filter fires before the
+		 * request is signed, so it records the URL regardless of whether the
+		 * (unconnected) test environment can complete the signed request.
+		 */
+		self::$captured_url = null;
+		$this->url_filter   = static function ( $url ) {
+			self::$captured_url = $url;
+			return $url;
+		};
+		add_filter( 'jetpack_remote_request_url', $this->url_filter );
+
+		Rest_Controller::init();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'jetpack_remote_request_url', $this->url_filter );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Dispatches a GET request to the video-plays proxy with the given params.
+	 *
+	 * @param array $params Request query params.
+	 * @return \WP_REST_Response The response object.
+	 */
+	private function get_video_plays( array $params = array() ) {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/videopress/stats/video-plays' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Test that the REST route is registered.
+	 */
+	public function test_rest_route_is_registered() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/jetpack/v4/videopress/stats/video-plays', $routes );
+	}
+
+	/**
+	 * Test that requests from users without manage_options are rejected.
+	 */
+	public function test_unauthorized_request_rejected() {
+		wp_set_current_user( 0 );
+
+		$response = $this->get_video_plays();
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Regression test for VIDP-277: the proxied WPCOM request must bypass the
+	 * Jetpack Stats module requirement so standalone VideoPress sites report.
+	 */
+	public function test_request_bypasses_stats_module_check() {
+		$this->get_video_plays();
+
+		$this->assertNotNull( self::$captured_url );
+		$this->assertStringContainsString( 'check_stats_module=false', self::$captured_url );
+	}
+
+	/**
+	 * Test that the proxy always forces complete-stats mode.
+	 */
+	public function test_request_forces_complete_stats() {
+		$this->get_video_plays();
+
+		$this->assertNotNull( self::$captured_url );
+		$this->assertStringContainsString( 'complete_stats=true', self::$captured_url );
+	}
+
+	/**
+	 * Test that whitelisted params are forwarded and empty ones are omitted.
+	 */
+	public function test_forwards_whitelisted_params() {
+		$this->get_video_plays(
+			array(
+				'period' => 'week',
+				'num'    => 7,
+			)
+		);
+
+		$this->assertNotNull( self::$captured_url );
+		$this->assertStringContainsString( 'period=week', self::$captured_url );
+		$this->assertStringContainsString( 'num=7', self::$captured_url );
+		$this->assertStringNotContainsString( 'start_date=', self::$captured_url );
+	}
+
+	/**
+	 * Test that a disconnected site returns an error before any request.
+	 */
+	public function test_disconnected_site_returns_error() {
+		\Jetpack_Options::delete_option( 'id' );
+
+		$response = $this->get_video_plays();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertNull( self::$captured_url );
+	}
+}


### PR DESCRIPTION
## Proposed changes

The new VideoPress Overview REST proxy (`Rest_Controller::get_stats_video_plays()`) built its WPCOM `sites/{id}/stats/video-plays` request with only `complete_stats=true`. WPCOM defaults `check_stats_module` to `true`, so the endpoint rejected standalone VideoPress sites with `404` / `invalid_blog` ("This blog does not have the Stats module enabled") whenever the Jetpack Stats module was inactive — even though VideoPress ships as a standalone plugin.

* Force `check_stats_module=false` in the proxied request, matching the existing `Stats::fetch_video_plays()` helper (`class-stats.php`), so the Overview report loads without the Stats module.
* Add `Rest_Controller_Test` covering the proxy: asserts the outbound request bypasses the Stats-module check, forces complete-stats mode, forwards whitelisted params (and omits empty ones), enforces the `manage_options` permission, and guards the disconnected-site path.

## Related product discussion/links

* [VIDP-277](https://linear.app/a8c/issue/VIDP-277/videopress-overview-stats-require-jetpack-stats-module)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with `jetpack` and `jetpack-videopress` active and connected to WordPress.com, **deactivate** the Jetpack Stats module.
* Open the VideoPress **Overview** tab (or hit `GET /jetpack/v4/videopress/stats/video-plays`).
* Before this change the request fails with `invalid_blog` / "This blog does not have the Stats module enabled". After it, the stats load normally.
* Re-activating the Stats module should continue to work as before.
* `cd projects/packages/videopress && composer phpunit -- --filter Rest_Controller_Test` should pass.
