### PR TITLE
Launchpad: fix "Launch your store" task opening an empty wc-admin page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-woo-launch-site-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-woo-launch-site-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launchpad: fix the WooCommerce "Launch your store" task opening an empty wc-admin page by pointing it at the canonical launch-your-store route.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -765,7 +765,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
-				return site_url( '/wp-admin/admin.php?page=wc-admin&task=launch_site' );
+				return site_url( '/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store' );
 			},
 		),
 		'migrating_site'                  => array(

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
@@ -531,6 +531,24 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the woo_launch_site task points at WooCommerce's canonical
+	 * "Launch your store" route (path=%2Flaunch-your-store), not the broken
+	 * task=launch_site link that matches no WooCommerce task.
+	 */
+	public function test_woo_launch_site_uses_path_route() {
+		$definitions = wpcom_launchpad_get_task_definitions();
+
+		$this->assertArrayHasKey( 'woo_launch_site', $definitions );
+		$this->assertArrayHasKey( 'get_calypso_path', $definitions['woo_launch_site'] );
+
+		$url = call_user_func( $definitions['woo_launch_site']['get_calypso_path'] );
+
+		$this->assertStringContainsString( 'page=wc-admin', $url );
+		$this->assertStringContainsString( 'path=%2Flaunch-your-store', $url );
+		$this->assertStringNotContainsString( 'task=launch_site', $url );
+	}
+
+	/**
 	 * Test dismiss temporally a task list when a date in future is used
 	 */
 	public function test_temporary_dismiss_task_when_date_is_in_the_future() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
@@ -539,9 +539,15 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		$definitions = wpcom_launchpad_get_task_definitions();
 
 		$this->assertArrayHasKey( 'woo_launch_site', $definitions );
-		$this->assertArrayHasKey( 'get_calypso_path', $definitions['woo_launch_site'] );
 
-		$url = call_user_func( $definitions['woo_launch_site']['get_calypso_path'] );
+		$get_calypso_path = $definitions['woo_launch_site']['get_calypso_path'] ?? null;
+		$this->assertIsCallable( $get_calypso_path );
+
+		if ( ! is_callable( $get_calypso_path ) ) {
+			return;
+		}
+
+		$url = call_user_func( $get_calypso_path );
 
 		$this->assertStringContainsString( 'page=wc-admin', $url );
 		$this->assertStringContainsString( 'path=%2Flaunch-your-store', $url );


### PR DESCRIPTION
Fixes: DOTCOM-17808

## Summary
- The `woo_launch_site` Launchpad task (the "Launch your store" item in the Sell flow) built a wc-admin deep link pointing at `page=wc-admin&task=launch_site`. No WooCommerce task has the ID `launch_site`, so the wc-admin router matched nothing and rendered an empty page.
- WooCommerce's own onboarding task (`LaunchYourStore`) uses ID `launch-your-store` and action URL `admin.php?page=wc-admin&path=%2Flaunch-your-store`. Verified the ID and route are stable across WooCommerce 9.6.1, 10.6.2, and 10.9.1; `launch_site` appears nowhere in WooCommerce.
- Fix points the task at the canonical `path=%2Flaunch-your-store` route, consistent with the sibling `woo_customize_store` task which already uses the `path` route.

<img width="1844" height="819" alt="Screenshot 2026-07-08 at 17 21 24" src="https://github.com/user-attachments/assets/42608388-2f79-4b9d-82df-6907b1b35b0f" />

| Before | After |
|--------|--------|
| <img width="1846" height="926" alt="Screenshot 2026-07-08 at 17 21 41" src="https://github.com/user-attachments/assets/82c072ff-ed63-4a54-b9d4-1c48ac777df2" /> | <img width="1844" height="929" alt="Screenshot 2026-07-08 at 17 21 54" src="https://github.com/user-attachments/assets/4c0455d8-9422-4a0a-bcc4-59dacad4fbac" /> |

## Does this pull request change what data or activity we track or use?
No changes related to this.

## Testing instructions
- Create a simple site.
- Add that site to the dev pool (`/atomic/wpcom-dev-blogs/`).
- Purchase an eCommerce plan.
- Install Jetpack Beta Tester and activate this PR's branch for the "WordPress.com Site Helper" plugin.
- Go to `wordpress.com/home/{SITE_SLUG}`.
- Click on the "Launch your store" task.
- Make sure that you don't see an empty page.

Automated coverage:
- [x] Added `test_woo_launch_site_uses_path_route` asserting the URL contains `path=%2Flaunch-your-store` and no longer contains `task=launch_site`.
- [x] `jetpack-mu-wpcom` PHP suite green (636 tests, 1852 assertions).

## Note
- The completion map in the same file (`'woo_launch_site' => 'launch_site'`, used against the `woocommerce_task_list_tracked_completed_tasks` option) may also be stale if WooCommerce records completion under `launch-your-store`. Left out of scope here; flagging for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
