### PR TITLE
Premium Analytics: Cover Top Platforms dimension in stories

### DIFF
--- a/projects/packages/premium-analytics/changelog/align-control-widget-stories
+++ b/projects/packages/premium-analytics/changelog/align-control-widget-stories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cover the Top Platforms browser/OS toolbar dimension in Storybook.

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -8,7 +8,7 @@ import {
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import TopPlatformsRender from '../render';
-import widgetDefinition from '../widget';
+import widgetDefinition, { type TopPlatformsAttributes } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -27,6 +27,7 @@ const storyWidgetType = {
 
 interface TopPlatformsStoryControls {
 	withComparison: boolean;
+	platformDimension: NonNullable< TopPlatformsAttributes[ 'platformDimension' ] >;
 }
 
 interface TopPlatformsDashboardStoryProps
@@ -39,12 +40,19 @@ const withWidgetCanvas: Decorator = Story => (
 	</div>
 );
 
-function renderTopPlatformsWidget( { withComparison }: TopPlatformsStoryControls ) {
-	return (
-		<TopPlatformsRender
-			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+function getTopPlatformsAttributes( {
+	withComparison,
+	platformDimension,
+}: TopPlatformsStoryControls ): ComponentProps< typeof TopPlatformsRender >[ 'attributes' ] {
+	return {
+		max: 10,
+		platformDimension,
+		reportParams: getDefaultQueryParams( withComparison ),
+	};
+}
+
+function renderTopPlatformsWidget( controls: TopPlatformsStoryControls ) {
+	return <TopPlatformsRender attributes={ getTopPlatformsAttributes( controls ) } />;
 }
 
 function TopPlatformsDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -53,6 +61,7 @@ function TopPlatformsDashboardRender( props: WidgetRenderProps< unknown > ) {
 
 function TopPlatformsDashboardStory( {
 	withComparison,
+	platformDimension,
 	...dashboardArgs
 }: TopPlatformsDashboardStoryProps ) {
 	return (
@@ -63,7 +72,7 @@ function TopPlatformsDashboardStory( {
 			renderComponent={
 				TopPlatformsDashboardRender as ComponentType< WidgetRenderProps< unknown > >
 			}
-			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ getTopPlatformsAttributes( { withComparison, platformDimension } ) }
 		/>
 	);
 }
@@ -77,12 +86,17 @@ const meta = {
 			control: 'boolean',
 			description: 'Include previous-period comparison report params.',
 		},
+		platformDimension: {
+			control: 'radio',
+			options: [ 'browser', 'platform' ],
+			description: 'The "View by" toolbar attribute rendered by the widget host.',
+		},
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Top Platforms" widget. Shows browser and OS breakdown as a ranked leaderboard. The active dimension (Browser / OS) is switched via a runtime dropdown in the widget body.',
+					'The "Top Platforms" widget. Shows browser and OS breakdown as a ranked leaderboard. The active dimension is the `platformDimension` attribute (`relevance: \'high\'`), exposed as a control by the widget host.',
 			},
 		},
 	},
@@ -94,13 +108,20 @@ type DashboardStory = StoryObj< TopPlatformsDashboardStoryProps >;
 
 export const Default: StoryObj< TopPlatformsStoryControls > = {
 	render: renderTopPlatformsWidget,
-	args: { withComparison: false },
+	args: { withComparison: false, platformDimension: 'browser' },
 	decorators: [ withWidgetCanvas ],
 };
 
 export const WithComparison: StoryObj< TopPlatformsStoryControls > = {
 	render: renderTopPlatformsWidget,
-	args: { withComparison: true },
+	args: { withComparison: true, platformDimension: 'browser' },
+	decorators: [ withWidgetCanvas ],
+};
+
+// OS view — the `platformDimension` attribute set to operating systems.
+export const ByOS: StoryObj< TopPlatformsStoryControls > = {
+	render: renderTopPlatformsWidget,
+	args: { withComparison: false, platformDimension: 'platform' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -109,12 +130,18 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
+		platformDimension: 'browser',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: {
 			control: 'boolean',
 			description: 'Include previous-period comparison report params.',
+		},
+		platformDimension: {
+			control: 'radio',
+			options: [ 'browser', 'platform' ],
+			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -10,7 +10,7 @@ import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/storie
 import TopPlatformsRender from '../render';
 import widgetDefinition, { type TopPlatformsAttributes } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -22,6 +22,10 @@ const storyWidgetType = {
 	name: widgetDefinition.name,
 	title: widgetDefinition.title,
 	icon: widgetDefinition.icon,
+	// attributes/example let the dashboard host render the real "View by"
+	// toolbar control for the `relevance: 'high'` attribute, as in Locations.
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
 	presentation: 'framed' as const,
 };
 


### PR DESCRIPTION
Follow-up to #50251.

## Proposed changes
* Expose the Top Platforms `platformDimension` toolbar attribute (`relevance: 'high'`) as a Storybook control on the close-up and dashboard stories, and add a dedicated `ByOS` story — the only default-layout widget with a host toolbar control whose dimension had no story coverage. This matches the Locations (`geoGranularity`) and UTM Insights (`ByCampaign`) story patterns.
* Update the story docs description, which still said the dimension is "switched via a runtime dropdown in the widget body" — it has been a widget-host toolbar control since the attribute promotion.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No. Storybook-only changes; no runtime code is touched.

## Testing instructions
* From `projects/packages/premium-analytics`: `pnpm run typecheck`.
* Run Storybook (`pnpm run storybook:dev` from `projects/js-packages/storybook`) and open `Packages/Premium Analytics/Widgets/TopPlatforms`.
* Confirm the `platformDimension` radio control (browser / platform) appears on the Default, WithComparison, and WidgetDashboardWithWidget stories and switches the leaderboard between Browser and OS rows.
* Confirm the new `ByOS` story renders the OS leaderboard.
