### PR TITLE
Podcast: RSS feed emit a single enclosure per episode

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-dupe-enclosures
+++ b/projects/packages/podcast/changelog/fix-podcast-dupe-enclosures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast feed: emit a single <enclosure> per episode when a post has accumulated duplicate enclosure meta rows.

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -322,9 +322,14 @@ class Customize_Feed {
 			}
 		}
 
-		if ( self::is_duplicate_enclosure( $post_obj, $final_url ) ) {
+		// Drop repeats: rows keyed per post, by final URL, so distinct enclosures
+		// survive while the duplicate stats URLs collapse to one. Registry is
+		// cleared per render — see `reset_enclosure_dedup()`.
+		$post_id = null !== $post_obj ? (int) $post_obj->ID : 0;
+		if ( isset( self::$seen_enclosures[ $post_id ][ $final_url ] ) ) {
 			return '';
 		}
+		self::$seen_enclosures[ $post_id ][ $final_url ] = true;
 
 		if ( 0 === $attachment_id ) {
 			return $enclosure;
@@ -346,26 +351,6 @@ class Customize_Feed {
 	 */
 	public static function reset_enclosure_dedup() {
 		self::$seen_enclosures = array();
-	}
-
-	/**
-	 * Whether this enclosure URL was already emitted for the current item.
-	 * Keyed per post so each item starts fresh, and by the final (rewritten)
-	 * URL so genuinely-distinct enclosures survive while repeats are dropped.
-	 *
-	 * @param WP_Post|null $post_obj Post being rendered.
-	 * @param string       $url      Final (rewritten) enclosure URL.
-	 * @return bool
-	 */
-	private static function is_duplicate_enclosure( $post_obj, string $url ): bool {
-		$post_id = $post_obj instanceof WP_Post ? (int) $post_obj->ID : 0;
-
-		if ( isset( self::$seen_enclosures[ $post_id ][ $url ] ) ) {
-			return true;
-		}
-
-		self::$seen_enclosures[ $post_id ][ $url ] = true;
-		return false;
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -242,6 +242,13 @@ class Customize_Feed {
 	 * `<itunes:duration>` when resolvable. Duration is looked up against the
 	 * *original* attachment URL — the stats URL is synthetic.
 	 *
+	 * A podcast item is only valid with a single `<enclosure>`, but core
+	 * `rss_enclosure()` emits one per `enclosure` post-meta row and posts
+	 * routinely accumulate several (URL drift across re-uploads / CDN hosts
+	 * that `do_enclose()`'s dedup treats as distinct). Rewriting keys on
+	 * post ID, so those rows all collapse to the same stats URL — we track
+	 * emitted URLs per item and drop repeats so the feed carries exactly one.
+	 *
 	 * @param string $enclosure Generated enclosure markup.
 	 * @return string
 	 */
@@ -304,6 +311,10 @@ class Customize_Feed {
 			}
 		}
 
+		if ( self::is_duplicate_enclosure( $post_obj, $enclosure ) ) {
+			return '';
+		}
+
 		if ( 0 === $attachment_id ) {
 			return $enclosure;
 		}
@@ -314,6 +325,33 @@ class Customize_Feed {
 		return 0 === $duration
 			? $enclosure
 			: $enclosure . '<itunes:duration>' . $duration . "</itunes:duration>\n";
+	}
+
+	/**
+	 * Whether this enclosure URL was already emitted for the current item.
+	 * Keyed per post so each item starts fresh, and by the final (rewritten)
+	 * URL so genuinely-distinct enclosures survive while repeats are dropped.
+	 *
+	 * @param WP_Post|null $post_obj  Post being rendered.
+	 * @param string       $enclosure Final enclosure markup.
+	 * @return bool
+	 */
+	private static function is_duplicate_enclosure( $post_obj, string $enclosure ): bool {
+		static $seen = array();
+
+		if ( ! preg_match( '/url="([^"]*)"/i', $enclosure, $match ) ) {
+			return false;
+		}
+
+		$post_id = $post_obj instanceof WP_Post ? (int) $post_obj->ID : 0;
+		$url     = $match[1];
+
+		if ( isset( $seen[ $post_id ][ $url ] ) ) {
+			return true;
+		}
+
+		$seen[ $post_id ][ $url ] = true;
+		return false;
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -29,6 +29,15 @@ class Customize_Feed {
 	private static $registered = false;
 
 	/**
+	 * Enclosure URLs already emitted in the current feed render, keyed by post
+	 * ID then URL. Reset on `rss2_head` so each feed starts clean — see
+	 * {@see self::is_duplicate_enclosure()}.
+	 *
+	 * @var array<int, array<string, true>>
+	 */
+	private static $seen_enclosures = array();
+
+	/**
 	 * Wire the late-binding `wp` action that decides whether to register the
 	 * feed-modification hooks for this request. Idempotent.
 	 */
@@ -70,6 +79,7 @@ class Customize_Feed {
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );
+		add_action( 'rss2_head', array( __CLASS__, 'reset_enclosure_dedup' ), 0 );
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
@@ -260,6 +270,7 @@ class Customize_Feed {
 		}
 
 		$original_url = $match[1];
+		$final_url    = $original_url;
 		$post_obj     = $post instanceof WP_Post ? $post : null;
 
 		/**
@@ -290,7 +301,7 @@ class Customize_Feed {
 
 			// Bail when we can't resolve a real blog ID — emit the original URL rather than a guaranteed-404 stats URL.
 			if ( $blog_id > 0 ) {
-				$stats_url = self::build_stats_url( $blog_id, (int) $post_obj->ID, $original_url );
+				$final_url = esc_url( self::build_stats_url( $blog_id, (int) $post_obj->ID, $original_url ) );
 				$enclosure = preg_replace_callback(
 					'/url="[^"]*"/i',
 					/**
@@ -301,9 +312,9 @@ class Customize_Feed {
 					 * @param array $matches Regex matches.
 					 * @return string
 					 */
-					static function ( array $matches ) use ( $stats_url ) {
+					static function ( array $matches ) use ( $final_url ) {
 						unset( $matches );
-						return 'url="' . esc_url( $stats_url ) . '"';
+						return 'url="' . $final_url . '"';
 					},
 					$enclosure,
 					1
@@ -311,7 +322,7 @@ class Customize_Feed {
 			}
 		}
 
-		if ( self::is_duplicate_enclosure( $post_obj, $enclosure ) ) {
+		if ( self::is_duplicate_enclosure( $post_obj, $final_url ) ) {
 			return '';
 		}
 
@@ -328,29 +339,32 @@ class Customize_Feed {
 	}
 
 	/**
+	 * Clear the per-render enclosure dedup registry. Hooked on `rss2_head` (at
+	 * priority 0, before any item renders) so re-generating a feed within a
+	 * single long-lived process — WP-CLI, a warm worker — starts fresh instead
+	 * of dropping every enclosure as already-seen.
+	 */
+	public static function reset_enclosure_dedup() {
+		self::$seen_enclosures = array();
+	}
+
+	/**
 	 * Whether this enclosure URL was already emitted for the current item.
 	 * Keyed per post so each item starts fresh, and by the final (rewritten)
 	 * URL so genuinely-distinct enclosures survive while repeats are dropped.
 	 *
-	 * @param WP_Post|null $post_obj  Post being rendered.
-	 * @param string       $enclosure Final enclosure markup.
+	 * @param WP_Post|null $post_obj Post being rendered.
+	 * @param string       $url      Final (rewritten) enclosure URL.
 	 * @return bool
 	 */
-	private static function is_duplicate_enclosure( $post_obj, string $enclosure ): bool {
-		static $seen = array();
-
-		if ( ! preg_match( '/url="([^"]*)"/i', $enclosure, $match ) ) {
-			return false;
-		}
-
+	private static function is_duplicate_enclosure( $post_obj, string $url ): bool {
 		$post_id = $post_obj instanceof WP_Post ? (int) $post_obj->ID : 0;
-		$url     = $match[1];
 
-		if ( isset( $seen[ $post_id ][ $url ] ) ) {
+		if ( isset( self::$seen_enclosures[ $post_id ][ $url ] ) ) {
 			return true;
 		}
 
-		$seen[ $post_id ][ $url ] = true;
+		self::$seen_enclosures[ $post_id ][ $url ] = true;
 		return false;
 	}
 

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -342,6 +342,55 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
 	}
 
+	/**
+	 * Core `rss_enclosure()` emits one `<enclosure>` per `enclosure` post-meta
+	 * row, and posts accumulate several as the source URL drifts across saves.
+	 * All rows rewrite to the same post-ID-keyed stats URL, so the second and
+	 * subsequent rows must be dropped — a valid podcast item has exactly one.
+	 */
+	public function test_rewrite_enclosure_drops_repeated_rows_that_collapse_to_same_stats_url() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'        => 4242,
+				'post_type' => 'post',
+			)
+		);
+
+		add_filter(
+			'wpcom_podcasting_tracked_blog_id',
+			static function () {
+				return 555;
+			}
+		);
+
+		// Two distinct source URLs — a re-upload / CDN-host drift — both
+		// resolve to real attachments and both rewrite to `.../4242.mp3`.
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static function ( $pre, $url ) {
+				if ( 'https://i0.wp.com/example.com/episode.mp3' === $url ) {
+					return 8001;
+				}
+				if ( 'https://i1.wp.com/example.com/episode.mp3' === $url ) {
+					return 8002;
+				}
+				return $pre;
+			},
+			10,
+			2
+		);
+
+		$first  = Customize_Feed::rewrite_enclosure( '<enclosure url="https://i0.wp.com/example.com/episode.mp3" length="123" type="audio/mpeg" />' );
+		$second = Customize_Feed::rewrite_enclosure( '<enclosure url="https://i1.wp.com/example.com/episode.mp3" length="123" type="audio/mpeg" />' );
+
+		$this->assertStringContainsString(
+			'url="https://public-api.wordpress.com/wpcom/v2/sites/555/podcast-play/4242.mp3"',
+			$first
+		);
+		$this->assertSame( '', $second );
+	}
+
 	public function test_resolve_category_id_prefers_numeric_id_over_archive_slug() {
 		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -38,6 +38,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		Jetpack_Options::delete_option( 'id' );
+		Customize_Feed::reset_enclosure_dedup();
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
@@ -389,6 +390,32 @@ class Customize_Feed_Test extends BaseTestCase {
 			$first
 		);
 		$this->assertSame( '', $second );
+	}
+
+	/**
+	 * The dedup registry is per feed render: `reset_enclosure_dedup()` (hooked
+	 * on `rss2_head`) clears it so re-generating the same feed within one
+	 * long-lived process emits enclosures again instead of dropping them all.
+	 */
+	public function test_reset_enclosure_dedup_lets_the_same_url_emit_on_a_fresh_render() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'        => 4242,
+				'post_type' => 'post',
+			)
+		);
+
+		add_filter( 'wpcom_podcasting_enable_play_tracking', '__return_false' );
+
+		$markup = '<enclosure url="https://example.com/episode.mp3" length="123" type="audio/mpeg" />';
+
+		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
+		$this->assertSame( '', Customize_Feed::rewrite_enclosure( $markup ) );
+
+		Customize_Feed::reset_enclosure_dedup();
+
+		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 	}
 
 	public function test_resolve_category_id_prefers_numeric_id_over_archive_slug() {


### PR DESCRIPTION
Fixes PODS-191

## Proposed changes

Podcast feeds were repeating the same episode's `<enclosure>` and `<itunes:duration>` — [one item had 5 identical copies](https://suithink.me/2026/06/14/wwdc2618ylog/). That's invalid per Apple's spec and can break feed submission.

Why it happens: a post can end up with several `enclosure` meta rows (URL drift across re-uploads, CDN hosts, or query params). Core's `rss_enclosure()` emits one `<enclosure>` per row, and our filter rewrites each to the same tracked stats URL — so identical rows become identical duplicate tags.

The fix: `rewrite_enclosure()` now remembers which enclosure URLs it has already emitted for an item and skips repeats, so each episode has exactly one `<enclosure>`. Only true duplicates are dropped — genuinely different enclosures (e.g. rewrite-disabled private feeds) are kept.

The dedupe registry is per feed render (reset on `rss2_head`), so re-generating a feed within one long-lived process — WP-CLI, a warm worker — starts fresh rather than dropping every enclosure as already-seen.

This fixes feed output going forward. The stale meta rows stay in the DB but are now harmless; cleaning them up is optional and separate.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

* `cd projects/packages/podcast && composer phpunit -- --filter Customize_Feed_Test`
* `test_rewrite_enclosure_drops_repeated_rows_that_collapse_to_same_stats_url` fails without the fix and passes with it.
* `test_reset_enclosure_dedup_lets_the_same_url_emit_on_a_fresh_render` confirms the registry is per-render, not per-process.
* Manual: on a site with a podcast category, view the feed for an episode whose post has multiple `enclosure` meta rows and confirm only one `<enclosure>` + `<itunes:duration>` is emitted.
