### PR TITLE
SEO: Label the Content tab row action column "Edit SEO"

### DIFF
--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -216,7 +216,7 @@ const ContentScreen: FC = () => {
 			},
 			{
 				id: 'editAction',
-				label: __( 'Actions', 'jetpack-seo' ),
+				label: editSeoLabel,
 				enableSorting: false,
 				enableHiding: false,
 				getValue: () => '',

--- a/projects/packages/seo/changelog/fix-content-row-action-label
+++ b/projects/packages/seo/changelog/fix-content-row-action-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Content tab: Rename the row action column from "Actions" to "Edit SEO".


### PR DESCRIPTION
Fixes JETPACK-1853

## Proposed changes
* Rename the SEO Content tab's row action column header from "Actions" to "Edit SEO".  That plural header was the bug: it implied a menu of several actions when there is only one.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Reveal the SEO screen

The SEO surface sits behind the `rsm_jetpack_seo` feature filter.

Use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin to enable it:

* Install and activate **Code Snippets**.
* Add a new snippet, set it to **Run everywhere**, paste the following, then **Save and activate**:

```php
add_filter( 'rsm_jetpack_seo', '__return_true' );
```
### Test the change

* Install this PR's build via the Jetpack Beta plugin (branch `fix/seo-content-row-action-label`).
* Go to **SEO** in the wp-admin menu (`admin.php?page=jetpack-seo`), then open the **Content** tab.
* Look at the table's column headers. The action column should read **"Edit SEO"**.

|Before|After|
|---|---|
|<img width="3841" height="953" alt="Screenshot from 2026-07-08 18-19-31" src="https://github.com/user-attachments/assets/df9830c5-7bb3-45bb-a452-eaddb911d797" />|<img width="3850" height="1128" alt="image" src="https://github.com/user-attachments/assets/9d9b9dc7-fc54-4872-899f-23793d5dd79f" />|