### PR TITLE
Docker: harden seed-worktree-env.sh backfill + match jp's envfile parser

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -163,13 +163,13 @@ To avoid that, seed the worktree's `.env` once:
 tools/docker/bin/seed-worktree-env.sh
 ```
 
-This writes a unique `COMPOSE_PROJECT_NAME` (derived from the worktree's name, e.g. `jetpack_<name>`) plus a free set of host ports that avoid the primary instance and every other worktree. Ports are allocated as the first free value at or above a per-service base — `8080` (WordPress), `8282` (phpMyAdmin), `1180` (inbox), `2525` (SMTP), `2222` (SFTP) — so the values that land in `.env` are predictable. After that, a bare `jetpack docker up -d` brings up an isolated instance for this worktree, and subsequent `up`s are stable. The script is:
+This writes a unique `COMPOSE_PROJECT_NAME` (derived from git's worktree id — fixed when the worktree was created, not the current folder name — e.g. `jetpack_<id>`) plus a free set of host ports that avoid the primary instance and every other worktree. Ports are allocated as the first free value at or above a per-service base — `8080` (WordPress), `8282` (phpMyAdmin), `1180` (inbox), `2525` (SMTP), `2222` (SFTP) — so the values that land in `.env` are predictable. After that, a bare `jetpack docker up -d` brings up an isolated instance for this worktree, and subsequent `up`s are stable. The script is:
 
 - **host-only** — run it on your machine, not inside the container;
 - **idempotent** — it only fills in the keys that are missing (so it also backfills ports for a name-only `.env` left by `up --name`) and is a no-op once fully configured, so it's safe to run before every `up`;
 - **a no-op in the primary checkout** — that always stays `jetpack_dev` on the default ports.
 
-It reserves ports already recorded in other worktrees' `.env` files and the primary defaults, but does not probe for live-bound host ports — if a non-Jetpack process already holds a chosen port, `jetpack docker up` will report `address already in use`; edit the port in `.env` and retry.
+It reserves ports already recorded in other worktrees' `.env` files and the primary defaults, but does not probe for live-bound host ports, and does not lock against another worktree seeding at the same instant — so two worktrees seeded in parallel can, in principle, pick the same port. Either way a genuine clash surfaces when `jetpack docker up` reports `address already in use`; edit the port in `.env` and retry.
 
 To undo it, delete the seeded lines from `tools/docker/.env` (the file is git-ignored and removed with the worktree). To set the name/ports yourself instead, edit `.env` by hand or use the manual flags below.
 

--- a/tools/docker/bin/seed-worktree-env.sh
+++ b/tools/docker/bin/seed-worktree-env.sh
@@ -70,22 +70,22 @@ alloc_port() {
 	ALLOCATED="$port"
 }
 
-# jp parses tools/docker/.env with the `envfile` npm package (tools/cli/commands/docker.js
-# readEnvFile → envfile.parse). Its parser is one regex per line: /^([^=:#]+?)[=:](.*)/ with
-# key = match[1].trim() and value = match[2].trim() then ALL quote characters removed. So it:
-#   - splits on the first `=` OR `:`,
-#   - drops a line whose key part contains `#` (a `#`-led comment never matches),
-#   - strips surrounding (and any) single/double quotes from the value,
-#   - does NOT understand a leading `export` (the key becomes `export KEY`, i.e. unreadable),
-#   - does NOT strip an inline ` # comment` from the value.
-# envfile_parse() below is the single source of truth mirroring exactly that, so every guard here
-# agrees with what `jp docker up` will actually load: a key envfile can't read counts as absent,
-# and we append a clean line rather than no-op behind a value the CLI would drop and then fall
-# back to the primary jetpack_dev instance's name and ports for.
+# tools/docker/.env is read by two code paths that must agree: the global `jp docker up/down/stop/
+# clean` host wrapper parses it with `dotenv`, while the in-repo `jetpack docker …` (and `jp docker
+# config`) parses it with `envfile`. The two diverge on a leading `export` (dotenv reads it, envfile
+# doesn't), a `:` delimiter (envfile always; dotenv only for `KEY: value` with a space), and an
+# inline ` # comment` (dotenv strips it, envfile keeps it). To behave the same whichever command you
+# run, this script always WRITES plain `KEY=value`, which every parser reads identically. Two reads
+# of an existing file follow, with opposite biases:
+#   - OUR file (parse_env_line): trust only the plain `KEY=value` form. Anything else is treated as
+#     absent and a clean `=` line is appended — last assignment wins for both parsers, so the clean
+#     line becomes authoritative rather than the script no-opping behind a value one CLI would drop.
+#   - A SIBLING file (parse_sibling_line): reserve the UNION of what either parser might bind, so we
+#     never allocate a port/name a neighbouring worktree already occupies under its chosen command.
 
 # Trim leading and trailing whitespace (bash 3.2 parameter expansion, no external process). Also
-# strips a leading UTF-8 BOM, which JS `String.prototype.trim()` (what envfile uses) removes but
-# `[[:space:]]` does not — otherwise a BOM-prefixed first line would read as a different key.
+# strips a leading UTF-8 BOM, which JS `String.prototype.trim()` removes but `[[:space:]]` does not
+# — otherwise a BOM-prefixed first line would read as a different key.
 trim() {
 	local s="$1"
 	s="${s#$'\xEF\xBB\xBF'}"
@@ -94,35 +94,63 @@ trim() {
 	printf '%s' "$s"
 }
 
-# Parse one .env line the way envfile.parse does. On a readable assignment, set EF_KEY / EF_VAL
-# and return 0; otherwise return 1. Keep this the ONLY place the parser shape lives.
-EF_KEY=""
-EF_VAL=""
-ENVFILE_RE='^([^=:#]+)[=:](.*)$'
-envfile_parse() {
-	[[ $1 =~ $ENVFILE_RE ]] || return 1
-	EF_KEY="$( trim "${BASH_REMATCH[1]}" )"
-	EF_VAL="$( trim "${BASH_REMATCH[2]}" )"
-	EF_VAL="${EF_VAL//\"/}"   # envfile removes all quote chars
-	EF_VAL="${EF_VAL//\'/}"
+# Parse one .env line as the plain `KEY=value` shape when deciding what is already settled in OUR
+# file (used by env_has_key / env_value). This deliberately recognizes only the common form both
+# parsers read the same; a shape only one reads — a `:` delimiter, a leading `export`, an inline
+# ` # comment` — is left for the rewrite path, which appends a clean `=` line both parsers then
+# agree on. On a match set PARSED_KEY / PARSED_VAL and return 0, else return 1. (Note: a comment or
+# `:` line has no `=` and fails the regex; an `export KEY=` line DOES match but yields key
+# `export KEY`, which no lookup ever asks for — so it too is effectively absent.)
+PARSED_KEY=""
+PARSED_VAL=""
+ENV_LINE_RE='^([^=#]+)=(.*)$'
+parse_env_line() {
+	[[ $1 =~ $ENV_LINE_RE ]] || return 1
+	PARSED_KEY="$( trim "${BASH_REMATCH[1]}" )"
+	PARSED_VAL="$( trim "${BASH_REMATCH[2]}" )"
+	# Strip only a single matched surrounding quote pair — the one thing dotenv and envfile both do.
+	# Removing every quote (envfile's own behavior) would over-normalize an unbalanced value like
+	# `jetpack_"x` that dotenv keeps verbatim, hiding a Compose-invalid name from the guard below.
+	case "$PARSED_VAL" in
+		\"*\" ) PARSED_VAL="${PARSED_VAL#\"}"; PARSED_VAL="${PARSED_VAL%\"}" ;;
+		\'*\' ) PARSED_VAL="${PARSED_VAL#\'}"; PARSED_VAL="${PARSED_VAL%\'}" ;;
+	esac
 	return 0
 }
 
-# Is key $1 assigned anywhere envfile can read it in $ENV_FILE? (Present-but-empty counts.)
+# Parse one SIBLING .env line as leniently as either parser might — strip a leading `export`, split
+# on `=` OR `:`, drop an inline comment, strip quotes. This is the UNION (not the intersection):
+# for collision avoidance we must reserve any port/name a sibling's `up` could actually occupy,
+# whichever CLI ran it, and over-reserving merely skips a value (harmless). On a match set SIB_KEY /
+# SIB_VAL and return 0, else return 1.
+SIB_KEY=""
+SIB_VAL=""
+SIB_LINE_RE='^[[:space:]]*(export[[:space:]]+)?([^=:#[:space:]][^=:#]*)[[:space:]]*[=:](.*)$'
+parse_sibling_line() {
+	[[ $1 =~ $SIB_LINE_RE ]] || return 1
+	SIB_KEY="$( trim "${BASH_REMATCH[2]}" )"
+	SIB_VAL="${BASH_REMATCH[3]%%#*}"   # dotenv stops an unquoted value at the first `#`
+	SIB_VAL="$( trim "$SIB_VAL" )"
+	SIB_VAL="${SIB_VAL//\"/}"
+	SIB_VAL="${SIB_VAL//\'/}"
+	return 0
+}
+
+# Is key $1 assigned in a plain form both parsers read in $ENV_FILE? (Present-but-empty counts.)
 env_has_key() {
 	local line
 	while IFS= read -r line || [ -n "$line" ]; do
-		if envfile_parse "$line" && [ "$EF_KEY" = "$1" ]; then return 0; fi
+		if parse_env_line "$line" && [ "$PARSED_KEY" = "$1" ]; then return 0; fi
 	done < "$ENV_FILE"
 	return 1
 }
 
-# Echo the envfile value of key $1 in $ENV_FILE (last assignment wins, matching envfile), or
-# nothing when the key is absent or written in a shape envfile can't read.
+# Echo the value of key $1 in $ENV_FILE (last assignment wins), or nothing when the key is absent
+# or not written in the plain form both parsers read.
 env_value() {
 	local line val=""
 	while IFS= read -r line || [ -n "$line" ]; do
-		if envfile_parse "$line" && [ "$EF_KEY" = "$1" ]; then val="$EF_VAL"; fi
+		if parse_env_line "$line" && [ "$PARSED_KEY" = "$1" ]; then val="$PARSED_VAL"; fi
 	done < "$ENV_FILE"
 	printf '%s' "$val"
 }
@@ -185,22 +213,22 @@ while IFS= read -r line; do
 			# `|| [ -n "$kv" ]` so a final line with no trailing newline is still processed —
 			# otherwise that sibling's last PORT_ would be missed and could be re-allocated.
 			while IFS= read -r kv || [ -n "$kv" ]; do
-				# Read the line exactly as jp will (quotes/`:`/`export`/`#` handled by
-				# envfile_parse). A key envfile can't read — e.g. `export PORT_…` — is skipped;
-				# that sibling then falls back to a primary default port already reserved above.
-				envfile_parse "$kv" || continue
-				case "$EF_KEY" in
+				# Reserve anything a sibling could bind under EITHER parser (parse_sibling_line is
+				# the lenient union), so we never hand ourselves a port/name a sibling's `up`
+				# already occupies — whether that worktree runs `jp` or `jetpack`.
+				parse_sibling_line "$kv" || continue
+				case "$SIB_KEY" in
 					PORT_* )
-						case "$EF_VAL" in
-							'' | *[!0-9]* ) ;;  # not a plain number — envfile passes it to compose, which falls back to a reserved default
+						case "$SIB_VAL" in
+							'' | *[!0-9]* ) ;;  # not a plain number — no port to reserve
 							* )
-								val="$(( 10#$EF_VAL ))"  # normalize so `08080` matches `8080`
+								val="$(( 10#$SIB_VAL ))"  # normalize so `08080` matches `8080`
 								is_claimed "$val" || CLAIMED="${CLAIMED}${val} "
 								;;
 						esac
 						;;
 					COMPOSE_PROJECT_NAME )
-						[ -n "$EF_VAL" ] && CLAIMED_NAMES="${CLAIMED_NAMES}${EF_VAL} "
+						[ -n "$SIB_VAL" ] && CLAIMED_NAMES="${CLAIMED_NAMES}${SIB_VAL} "
 						;;
 				esac
 			done < "$sibling"
@@ -226,6 +254,16 @@ if env_has_key COMPOSE_PROJECT_NAME; then
 	if [ "$suffix" = "$INSTANCE" ] || [ -z "$suffix" ] || [ "$suffix" = dev ] || [ "$suffix" = e2e ]; then
 		echo "tools/docker/.env sets COMPOSE_PROJECT_NAME='${INSTANCE}', which jp docker up does not honor —" >&2
 		echo "it would fall back to the primary jetpack_dev instance. Use jetpack_<unique>, or delete the line to re-derive one." >&2
+		exit 1
+	fi
+	# Even a `jetpack_`-prefixed name is useless if Compose won't accept it (e.g. a space or an
+	# uppercase letter pasted in): the CLI honors it, then `up` dies at the Compose layer. Reject it
+	# here against Compose's own charset — the same rule normalizeProjectShortName (docker.js) checks.
+	# Unlike the `--name` flag, which lowercases first, a .env value is used verbatim, so we reject
+	# rather than repair.
+	if ! [[ "$INSTANCE" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+		echo "tools/docker/.env sets COMPOSE_PROJECT_NAME='${INSTANCE}', which Docker Compose rejects —" >&2
+		echo "a project name must be lowercase letters, digits, '-' and '_', starting with a letter or digit. Fix or delete the line." >&2
 		exit 1
 	fi
 	case "$CLAIMED_NAMES" in
@@ -294,7 +332,7 @@ if [ "$NAME_PRESENT" = 0 ]; then add_kv COMPOSE_PROJECT_NAME "jetpack_${SLUG}"; 
 if [ -z "$BLOCK" ]; then
 	echo "tools/docker/.env already fully configured for '${INSTANCE}' — nothing to add."
 	# Display only; `|| true` so a zero-match grep can't abort under pipefail before `exit 0`.
-	{ grep -E '^[[:space:]]*(COMPOSE_PROJECT_NAME|PORT_[A-Z]+)[[:space:]]*[=:]' "$ENV_FILE" | sed 's/^/  /'; } || true
+	{ grep -E '^[[:space:]]*(COMPOSE_PROJECT_NAME|PORT_[A-Z]+)[[:space:]]*=' "$ENV_FILE" | sed 's/^/  /'; } || true
 	exit 0
 fi
 

--- a/tools/docker/bin/seed-worktree-env.sh
+++ b/tools/docker/bin/seed-worktree-env.sh
@@ -7,10 +7,10 @@
 # linked git worktree, several checkouts therefore collide: they share one set of containers
 # and the bind-mounts get re-pointed at whichever worktree ran `up` last.
 #
-# This script seeds the worktree's tools/docker/.env with a unique project name (derived from
-# the worktree's name) plus a free set of host ports that avoid the primary instance and every
-# other worktree. After running it once, a bare `jp docker up -d` brings up an isolated instance
-# for this worktree. It is:
+# This script seeds the worktree's tools/docker/.env with a unique project name (derived from git's
+# worktree id — fixed when the worktree was created, not the current folder name) plus a free set of
+# host ports that avoid the primary instance and every other worktree. After running it once, a bare
+# `jp docker up -d` brings up an isolated instance for this worktree. It is:
 #   - host-only (run it on your machine, not inside the container),
 #   - idempotent (it only fills the keys that are missing; a no-op once fully configured), and
 #   - a no-op in the primary checkout, which keeps using `jetpack_dev`.
@@ -70,20 +70,61 @@ alloc_port() {
 	ALLOCATED="$port"
 }
 
-# Normalize a raw .env value the way a dotenv parser would: drop an inline ` # comment`, trim
-# surrounding whitespace, and strip one layer of surrounding single or double quotes.
-clean_scalar() {
-	printf '%s' "$1" | sed -E "s/[[:space:]]+#.*\$//; s/^[[:space:]]+//; s/[[:space:]]+\$//; s/^\"(.*)\"\$/\\1/; s/^'(.*)'\$/\\1/"
+# jp parses tools/docker/.env with the `envfile` npm package (tools/cli/commands/docker.js
+# readEnvFile → envfile.parse). Its parser is one regex per line: /^([^=:#]+?)[=:](.*)/ with
+# key = match[1].trim() and value = match[2].trim() then ALL quote characters removed. So it:
+#   - splits on the first `=` OR `:`,
+#   - drops a line whose key part contains `#` (a `#`-led comment never matches),
+#   - strips surrounding (and any) single/double quotes from the value,
+#   - does NOT understand a leading `export` (the key becomes `export KEY`, i.e. unreadable),
+#   - does NOT strip an inline ` # comment` from the value.
+# envfile_parse() below is the single source of truth mirroring exactly that, so every guard here
+# agrees with what `jp docker up` will actually load: a key envfile can't read counts as absent,
+# and we append a clean line rather than no-op behind a value the CLI would drop and then fall
+# back to the primary jetpack_dev instance's name and ports for.
+
+# Trim leading and trailing whitespace (bash 3.2 parameter expansion, no external process). Also
+# strips a leading UTF-8 BOM, which JS `String.prototype.trim()` (what envfile uses) removes but
+# `[[:space:]]` does not — otherwise a BOM-prefixed first line would read as a different key.
+trim() {
+	local s="$1"
+	s="${s#$'\xEF\xBB\xBF'}"
+	s="${s#"${s%%[![:space:]]*}"}"
+	s="${s%"${s##*[![:space:]]}"}"
+	printf '%s' "$s"
 }
 
-# Echo the current value of key $1 in $ENV_FILE (last assignment wins, matching dotenv), or
-# nothing when the key is absent. Tolerates a leading `export ` / indentation. `|| true` keeps a
-# no-match grep (non-zero under pipefail) from aborting the script when captured in an assignment.
+# Parse one .env line the way envfile.parse does. On a readable assignment, set EF_KEY / EF_VAL
+# and return 0; otherwise return 1. Keep this the ONLY place the parser shape lives.
+EF_KEY=""
+EF_VAL=""
+ENVFILE_RE='^([^=:#]+)[=:](.*)$'
+envfile_parse() {
+	[[ $1 =~ $ENVFILE_RE ]] || return 1
+	EF_KEY="$( trim "${BASH_REMATCH[1]}" )"
+	EF_VAL="$( trim "${BASH_REMATCH[2]}" )"
+	EF_VAL="${EF_VAL//\"/}"   # envfile removes all quote chars
+	EF_VAL="${EF_VAL//\'/}"
+	return 0
+}
+
+# Is key $1 assigned anywhere envfile can read it in $ENV_FILE? (Present-but-empty counts.)
+env_has_key() {
+	local line
+	while IFS= read -r line || [ -n "$line" ]; do
+		if envfile_parse "$line" && [ "$EF_KEY" = "$1" ]; then return 0; fi
+	done < "$ENV_FILE"
+	return 1
+}
+
+# Echo the envfile value of key $1 in $ENV_FILE (last assignment wins, matching envfile), or
+# nothing when the key is absent or written in a shape envfile can't read.
 env_value() {
-	local raw
-	raw="$( { grep -E "^[[:space:]]*(export[[:space:]]+)?$1[[:space:]]*=" "$ENV_FILE" | tail -n1 \
-		| sed -E "s/^[[:space:]]*(export[[:space:]]+)?$1[[:space:]]*=//"; } || true )"
-	clean_scalar "$raw"
+	local line val=""
+	while IFS= read -r line || [ -n "$line" ]; do
+		if envfile_parse "$line" && [ "$EF_KEY" = "$1" ]; then val="$EF_VAL"; fi
+	done < "$ENV_FILE"
+	printf '%s' "$val"
 }
 
 # Sanitize a raw name to the Compose project-name charset. Result is empty or starts with [a-z0-9].
@@ -136,26 +177,30 @@ while IFS= read -r line; do
 			# `-r` (not `-f`): an existing-but-unreadable sibling should be skipped, not abort.
 			sibling="${line#worktree }/tools/docker/.env"
 			[ -r "$sibling" ] || continue
+			# Skip our own .env (git worktree list includes this worktree): assign_port reserves
+			# our ports below, and counting our own name into CLAIMED_NAMES would make the
+			# collision guard reject us on every re-run. `-ef` compares device+inode, so it holds
+			# across symlinked or relative worktree paths.
+			if [ "$sibling" -ef "$ENV_FILE" ]; then continue; fi
 			# `|| [ -n "$kv" ]` so a final line with no trailing newline is still processed —
 			# otherwise that sibling's last PORT_ would be missed and could be re-allocated.
 			while IFS= read -r kv || [ -n "$kv" ]; do
-				# Tolerate indentation and an optional `export ` so the keys still match.
-				kv="${kv#"${kv%%[![:space:]]*}"}"
-				kv="${kv#export }"
-				case "$kv" in
-					PORT_*=* )
-						val="$( clean_scalar "${kv#*=}" )"
-						case "$val" in
-							'' | *[!0-9]* ) ;;  # not a plain number — skip
+				# Read the line exactly as jp will (quotes/`:`/`export`/`#` handled by
+				# envfile_parse). A key envfile can't read — e.g. `export PORT_…` — is skipped;
+				# that sibling then falls back to a primary default port already reserved above.
+				envfile_parse "$kv" || continue
+				case "$EF_KEY" in
+					PORT_* )
+						case "$EF_VAL" in
+							'' | *[!0-9]* ) ;;  # not a plain number — envfile passes it to compose, which falls back to a reserved default
 							* )
-								val="$(( 10#$val ))"  # normalize so `08080` matches `8080`
+								val="$(( 10#$EF_VAL ))"  # normalize so `08080` matches `8080`
 								is_claimed "$val" || CLAIMED="${CLAIMED}${val} "
 								;;
 						esac
 						;;
-					COMPOSE_PROJECT_NAME=* )
-						nm="$( clean_scalar "${kv#*=}" )"
-						[ -n "$nm" ] && CLAIMED_NAMES="${CLAIMED_NAMES}${nm} "
+					COMPOSE_PROJECT_NAME )
+						[ -n "$EF_VAL" ] && CLAIMED_NAMES="${CLAIMED_NAMES}${EF_VAL} "
 						;;
 				esac
 			done < "$sibling"
@@ -167,11 +212,33 @@ done <<< "$WORKTREES"
 
 # Keep an existing COMPOSE_PROJECT_NAME untouched (respect `up --name`, hand edits, or a prior
 # run); only derive and write a slug when none is set yet.
-if grep -qE '^[[:space:]]*(export[[:space:]]+)?COMPOSE_PROJECT_NAME[[:space:]]*=' "$ENV_FILE"; then
+if env_has_key COMPOSE_PROJECT_NAME; then
 	NAME_PRESENT=1
 	INSTANCE="$( env_value COMPOSE_PROJECT_NAME )"
+
+	# Trusting the existing name blindly is the one way this backfill lands two worktrees on one
+	# instance behind a success message. jp docker up (augmentArgvFromEnvFile) only honors a name
+	# shaped `jetpack_<x>` with <x> neither 'dev' nor 'e2e'; anything else — empty, a bare slug,
+	# jetpack_dev/e2e — is ignored and silently drives the primary jetpack_dev containers and DB.
+	# And a name another worktree already claimed would share that worktree's containers and DB.
+	# Refuse both rather than seed ports around a name that was never going to isolate anything.
+	suffix="${INSTANCE#jetpack_}"
+	if [ "$suffix" = "$INSTANCE" ] || [ -z "$suffix" ] || [ "$suffix" = dev ] || [ "$suffix" = e2e ]; then
+		echo "tools/docker/.env sets COMPOSE_PROJECT_NAME='${INSTANCE}', which jp docker up does not honor —" >&2
+		echo "it would fall back to the primary jetpack_dev instance. Use jetpack_<unique>, or delete the line to re-derive one." >&2
+		exit 1
+	fi
+	case "$CLAIMED_NAMES" in
+		*" $INSTANCE "* )
+			echo "tools/docker/.env sets COMPOSE_PROJECT_NAME='${INSTANCE}', but another worktree already uses that name." >&2
+			echo "Two worktrees sharing a project name drive the same containers and DB. Pick a unique name, or delete the line to re-derive one." >&2
+			exit 1
+			;;
+	esac
 else
 	NAME_PRESENT=0
+	# GIT_ABS_DIR is …/worktrees/<id>, so this is git's worktree id (frozen at creation, and
+	# already unique among worktrees), not the current folder name.
 	RAW_NAME="$( basename "$GIT_ABS_DIR" )"
 	SLUG="$( slugify "$RAW_NAME" )"
 	case "$SLUG" in
@@ -226,7 +293,8 @@ if [ "$NAME_PRESENT" = 0 ]; then add_kv COMPOSE_PROJECT_NAME "jetpack_${SLUG}"; 
 
 if [ -z "$BLOCK" ]; then
 	echo "tools/docker/.env already fully configured for '${INSTANCE}' — nothing to add."
-	grep -E '^[[:space:]]*(export[[:space:]]+)?(COMPOSE_PROJECT_NAME|PORT_)' "$ENV_FILE" | sed 's/^/  /'
+	# Display only; `|| true` so a zero-match grep can't abort under pipefail before `exit 0`.
+	{ grep -E '^[[:space:]]*(COMPOSE_PROJECT_NAME|PORT_[A-Z]+)[[:space:]]*[=:]' "$ENV_FILE" | sed 's/^/  /'; } || true
 	exit 0
 fi
 

--- a/tools/docker/bin/seed-worktree-env.test.sh
+++ b/tools/docker/bin/seed-worktree-env.test.sh
@@ -13,6 +13,11 @@
 
 set -euo pipefail
 
+# Isolate every git call from the developer's / CI's config, so an inherited commit.gpgsign (which
+# dies non-interactively — CI, or gpg behind pinentry with no TTY), core.hooksPath, or template dir
+# can't make the fixture's setup commit fail before a single assertion runs.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
 SUT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/seed-worktree-env.sh"
 
 TMP="$( mktemp -d 2>/dev/null || mktemp -d -t seed-wt )"
@@ -102,19 +107,26 @@ printf 'COMPOSE_PROJECT_NAME=\n' > "$( env_of wt-empty )"
 run "$TMP/wt-empty"
 assert_rc nonzero "empty project name is rejected"
 
-# --- envfile can't read `export NAME=…`, so treat it as absent (concern 2) -
+# --- a name Compose would reject (space/uppercase) is refused (concern 1) ---
+add_wt wt-badname
+printf 'COMPOSE_PROJECT_NAME=jetpack_bad name\n' > "$( env_of wt-badname )"
+run "$TMP/wt-badname"
+assert_rc nonzero "a Compose-invalid project name (space) is rejected"
+case "$RUN_OUT" in *"Docker Compose rejects"* ) pass "Compose-invalid message is shown" ;; * ) bad "Compose-invalid message is shown ($RUN_OUT)" ;; esac
+
+# --- `export NAME=…` is not the plain form both parsers read → treat absent --
 add_wt wt-e
 printf 'export COMPOSE_PROJECT_NAME=jetpack_exported\n' > "$( env_of wt-e )"
 run "$TMP/wt-e"
 assert_rc zero "export-only name is treated as absent (exit 0)"
-assert_grep "$( env_of wt-e )" '^COMPOSE_PROJECT_NAME=jetpack_wt-e$' "a clean, envfile-readable name line is written"
+assert_grep "$( env_of wt-e )" '^COMPOSE_PROJECT_NAME=jetpack_wt-e$' "a clean, plain name line both parsers read is written"
 
-# --- envfile can't read an inline comment, so the port is reallocated ------
+# --- an inline comment is not the plain form → the port is reallocated ------
 add_wt wt-f
 printf 'COMPOSE_PROJECT_NAME=jetpack_feat\nPORT_WORDPRESS=9090 # note\n' > "$( env_of wt-f )"
 run "$TMP/wt-f"
 assert_rc zero "inline-comment port is reallocated (exit 0)"
-# The junk `9090 # note` value must be superseded: envfile takes the LAST assignment, so the
+# The junk `9090 # note` value must be superseded: both parsers take the LAST assignment, so the
 # final PORT_WORDPRESS line must be a clean number and must not be the junk 9090.
 last_wp="$( grep '^PORT_WORDPRESS' "$( env_of wt-f )" | tail -n1 )"
 case "$last_wp" in
@@ -123,7 +135,7 @@ case "$last_wp" in
 	* )                          bad "inline-comment port superseded by a clean value ($last_wp)" ;;
 esac
 
-# --- envfile STRIPS quotes, so a quoted name jp honors must be accepted -----
+# --- both parsers strip quotes, so a quoted name they honor must be accepted -
 # (Regression guard: treating a quoted value as unreadable would falsely reject a valid name.)
 add_wt wt-q
 printf 'COMPOSE_PROJECT_NAME="jetpack_quoted"\n' > "$( env_of wt-q )"
@@ -131,24 +143,26 @@ run "$TMP/wt-q"
 assert_rc zero "quoted name jp honors is accepted, not rejected (exit 0)"
 assert_grep "$( env_of wt-q )" '^PORT_WORDPRESS=[0-9]+$' "quoted-name worktree gets its ports backfilled"
 
-# --- envfile strips quotes on ports too: a quoted numeric port is reused ----
+# --- both parsers strip quotes on ports too: a quoted numeric port is reused -
 add_wt wt-qp
 printf 'COMPOSE_PROJECT_NAME=jetpack_qp\nPORT_WORDPRESS="8080"\n' > "$( env_of wt-qp )"
 run "$TMP/wt-qp"
 assert_rc zero "quoted numeric port is honored (exit 0)"
-# 8080 is a clean value to envfile (quotes stripped), so it is reused, not reallocated.
+# 8080 is a clean value once quotes are stripped, so it is reused, not reallocated.
 if [ "$( grep '^PORT_WORDPRESS' "$( env_of wt-qp )" | tail -n1 )" = 'PORT_WORDPRESS="8080"' ]; then
 	pass "quoted numeric port is reused as-is (no reallocation)"
 else
 	bad "quoted numeric port is reused as-is (no reallocation)"
 fi
 
-# --- envfile also splits on `:`, so a colon-set name jp honors is kept ------
+# --- a `:` delimiter is envfile-only (dotenv drops it), so it is NOT trusted --
+# `jp docker up` (dotenv) would drop this line and land on the primary, so the seeder treats it as
+# absent and writes a clean `=` line that BOTH parsers read — keeping jp and jetpack in agreement.
 add_wt wt-colon
 printf 'COMPOSE_PROJECT_NAME:jetpack_colon\n' > "$( env_of wt-colon )"
 run "$TMP/wt-colon"
-assert_rc zero "colon-delimited name is recognized (exit 0)"
-assert_absent "$( env_of wt-colon )" '^COMPOSE_PROJECT_NAME=jetpack_wt-colon$' "colon-set name is not overridden by a derived one"
+assert_rc zero "colon-delimited name is treated as absent (exit 0)"
+assert_grep "$( env_of wt-colon )" '^COMPOSE_PROJECT_NAME=jetpack_wt-colon$' "a clean = name line both parsers read is written"
 
 # --- a bare non-jetpack_ name jp ignores is rejected (concern 1) ------------
 add_wt wt-bare
@@ -178,6 +192,41 @@ printf '\xEF\xBB\xBFCOMPOSE_PROJECT_NAME=jetpack_bom\n' > "$( env_of wt-bom )"
 run "$TMP/wt-bom"
 assert_rc zero "BOM-prefixed name is read, not treated as absent (exit 0)"
 assert_absent "$( env_of wt-bom )" '^COMPOSE_PROJECT_NAME=jetpack_wt-bom$' "BOM-prefixed name is not overridden by a derived one"
+
+# --- an unbalanced quote is NOT stripped, so the Compose-invalid name is caught ---
+# (Only a matched surrounding pair is stripped; `jetpack_"x` stays, and dotenv would feed that
+# verbatim to Compose. The guard must see the un-stripped value and reject it.)
+add_wt wt-uq
+printf 'COMPOSE_PROJECT_NAME=jetpack_%sx\n' '"' > "$( env_of wt-uq )"
+run "$TMP/wt-uq"
+assert_rc nonzero "an unbalanced-quote name is rejected (Compose-invalid)"
+
+# --- sibling reservation covers the union both CLIs might bind --------------
+# A fresh repo so the reservation is isolated from ports the cases above already claimed. The
+# sibling pins base ports via a colon-space and an export form; without the lenient sibling reader
+# the fresh worktree would reuse them, colliding at `up`.
+PRIMARY2="$TMP/primary2"
+mkdir -p "$PRIMARY2/tools/docker/bin"
+git -C "$PRIMARY2" init -q
+git -C "$PRIMARY2" config user.email test@example.test
+git -C "$PRIMARY2" config user.name  seed-test
+cp "$SUT" "$PRIMARY2/tools/docker/bin/seed-worktree-env.sh"
+chmod +x "$PRIMARY2/tools/docker/bin/seed-worktree-env.sh"
+git -C "$PRIMARY2" add -A
+git -C "$PRIMARY2" commit -qm init
+git -C "$PRIMARY2" worktree add -q "$TMP/p2-sib"   -b br-p2-sib
+git -C "$PRIMARY2" worktree add -q "$TMP/p2-fresh" -b br-p2-fresh
+printf 'COMPOSE_PROJECT_NAME: jetpack_p2sib\nPORT_WORDPRESS: 8080\nexport PORT_PHPMY=8282\n' > "$TMP/p2-sib/tools/docker/.env"
+run "$TMP/p2-fresh"
+assert_rc zero "fresh worktree seeds beside a colon/export sibling (exit 0)"
+assert_absent "$TMP/p2-fresh/tools/docker/.env" '^PORT_WORDPRESS=8080$' "colon-space sibling port 8080 is reserved (not reused)"
+assert_absent "$TMP/p2-fresh/tools/docker/.env" '^PORT_PHPMY=8282$'    "export sibling port 8282 is reserved (not reused)"
+
+# A colon-space sibling NAME must also feed the duplicate-name guard.
+git -C "$PRIMARY2" worktree add -q "$TMP/p2-dupe" -b br-p2-dupe
+printf 'COMPOSE_PROJECT_NAME=jetpack_p2sib\n' > "$TMP/p2-dupe/tools/docker/.env"
+run "$TMP/p2-dupe"
+assert_rc nonzero "a name duplicating a colon-space sibling is rejected"
 
 # --- reaching the primary through a symlinked path is still a no-op ---------
 # (Guards the pwd -P handling that resolves --absolute-git-dir's symlink resolution.)

--- a/tools/docker/bin/seed-worktree-env.test.sh
+++ b/tools/docker/bin/seed-worktree-env.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+# Fixture test for seed-worktree-env.sh. Builds a throwaway git repo with real linked worktrees
+# and drives the actual script through its no-op / seed / backfill / rejection paths. No Docker,
+# no network — just git and plain asserts, so it runs anywhere in a second or two.
+#
+# It is deliberately standalone (the CLI's jest suite lives in a different project and wouldn't be
+# triggered by a change to this script): run it by hand after touching the script —
+#
+#   tools/docker/bin/seed-worktree-env.test.sh
+#
+# Exits non-zero if any assertion fails.
+
+set -euo pipefail
+
+SUT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/seed-worktree-env.sh"
+
+TMP="$( mktemp -d 2>/dev/null || mktemp -d -t seed-wt )"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { printf '  ok   - %s\n' "$1"; }
+bad()  { printf '  FAIL - %s\n' "$1"; fail=1; }
+
+# assert_grep FILE ERE MSG — the ERE must match a line in FILE.
+assert_grep() {
+	if [ -f "$1" ] && grep -qE "$2" "$1"; then pass "$3"; else bad "$3 (expected /$2/ in $1)"; fi
+}
+# assert_absent FILE ERE MSG — the ERE must NOT match any line in FILE.
+assert_absent() {
+	if [ -f "$1" ] && grep -qE "$2" "$1"; then bad "$3 (unexpected /$2/ in $1)"; else pass "$3"; fi
+}
+# assert_rc zero|nonzero MSG — check the last run()'s exit status.
+assert_rc() {
+	if { [ "$1" = zero ] && [ "$RUN_RC" = 0 ]; } || { [ "$1" = nonzero ] && [ "$RUN_RC" != 0 ]; }; then
+		pass "$2"
+	else
+		bad "$2 (exit $RUN_RC)"
+	fi
+}
+
+# run WORKTREE_DIR — runs the seeded script from that worktree, capturing output + exit status
+# into RUN_OUT / RUN_RC without tripping `set -e`.
+run() {
+	RUN_OUT="$( cd "$1" && ./tools/docker/bin/seed-worktree-env.sh 2>&1 )" && RUN_RC=0 || RUN_RC=$?
+}
+
+# --- a primary repo with the script committed at tools/docker/bin ----------
+PRIMARY="$TMP/primary"
+mkdir -p "$PRIMARY/tools/docker/bin"
+git -C "$PRIMARY" init -q
+git -C "$PRIMARY" config user.email test@example.test
+git -C "$PRIMARY" config user.name  seed-test
+cp "$SUT" "$PRIMARY/tools/docker/bin/seed-worktree-env.sh"
+chmod +x "$PRIMARY/tools/docker/bin/seed-worktree-env.sh"
+git -C "$PRIMARY" add -A
+git -C "$PRIMARY" commit -qm init
+
+add_wt() { git -C "$PRIMARY" worktree add -q "$TMP/$1" -b "br-$1"; }
+env_of() { printf '%s/tools/docker/.env' "$TMP/$1"; }
+
+# --- primary checkout is a no-op -------------------------------------------
+run "$PRIMARY"
+case "$RUN_OUT" in *"Not a linked git worktree"* ) pass "primary checkout is a no-op" ;; * ) bad "primary checkout is a no-op ($RUN_OUT)" ;; esac
+assert_absent "$PRIMARY/tools/docker/.env" 'COMPOSE_PROJECT_NAME' "primary .env left unseeded"
+
+# --- a linked worktree seeds a unique name + base ports --------------------
+add_wt wt-a
+run "$TMP/wt-a"
+assert_rc zero "linked worktree seeds (exit 0)"
+assert_grep "$( env_of wt-a )" '^COMPOSE_PROJECT_NAME=jetpack_wt-a$' "name derives from the git worktree id"
+assert_grep "$( env_of wt-a )" '^PORT_WORDPRESS=8080$'               "base WordPress port lands at 8080"
+
+# --- re-running is idempotent ----------------------------------------------
+run "$TMP/wt-a"
+case "$RUN_OUT" in *"already fully configured"* ) pass "re-run is a no-op" ;; * ) bad "re-run is a no-op ($RUN_OUT)" ;; esac
+if [ "$( grep -c '^COMPOSE_PROJECT_NAME=' "$( env_of wt-a )" )" = 1 ]; then pass "re-run leaves a single name line"; else bad "re-run duplicated the name line"; fi
+
+# --- name-only .env gets its ports backfilled around the sibling -----------
+add_wt wt-b
+printf 'COMPOSE_PROJECT_NAME=jetpack_beta\n' > "$( env_of wt-b )"
+run "$TMP/wt-b"
+assert_rc zero "name-only .env backfills (exit 0)"
+assert_grep "$( env_of wt-b )" '^COMPOSE_PROJECT_NAME=jetpack_beta$' "hand-set name is kept"
+assert_grep "$( env_of wt-b )" '^PORT_WORDPRESS=8081$'              "backfilled port avoids the sibling's 8080"
+
+# --- a name a sibling already uses is refused (concern 1) ------------------
+add_wt wt-c
+printf 'COMPOSE_PROJECT_NAME=jetpack_beta\n' > "$( env_of wt-c )"
+run "$TMP/wt-c"
+assert_rc nonzero "duplicate project name is rejected"
+case "$RUN_OUT" in *"already uses that name"* ) pass "duplicate-name message is shown" ;; * ) bad "duplicate-name message is shown ($RUN_OUT)" ;; esac
+
+# --- jetpack_dev / empty names are refused (concern 1) ---------------------
+add_wt wt-d
+printf 'COMPOSE_PROJECT_NAME=jetpack_dev\n' > "$( env_of wt-d )"
+run "$TMP/wt-d"
+assert_rc nonzero "jetpack_dev is rejected (would drive the primary)"
+
+add_wt wt-empty
+printf 'COMPOSE_PROJECT_NAME=\n' > "$( env_of wt-empty )"
+run "$TMP/wt-empty"
+assert_rc nonzero "empty project name is rejected"
+
+# --- envfile can't read `export NAME=…`, so treat it as absent (concern 2) -
+add_wt wt-e
+printf 'export COMPOSE_PROJECT_NAME=jetpack_exported\n' > "$( env_of wt-e )"
+run "$TMP/wt-e"
+assert_rc zero "export-only name is treated as absent (exit 0)"
+assert_grep "$( env_of wt-e )" '^COMPOSE_PROJECT_NAME=jetpack_wt-e$' "a clean, envfile-readable name line is written"
+
+# --- envfile can't read an inline comment, so the port is reallocated ------
+add_wt wt-f
+printf 'COMPOSE_PROJECT_NAME=jetpack_feat\nPORT_WORDPRESS=9090 # note\n' > "$( env_of wt-f )"
+run "$TMP/wt-f"
+assert_rc zero "inline-comment port is reallocated (exit 0)"
+# The junk `9090 # note` value must be superseded: envfile takes the LAST assignment, so the
+# final PORT_WORDPRESS line must be a clean number and must not be the junk 9090.
+last_wp="$( grep '^PORT_WORDPRESS' "$( env_of wt-f )" | tail -n1 )"
+case "$last_wp" in
+	PORT_WORDPRESS=9090*|*'#'* ) bad "inline-comment port superseded by a clean value ($last_wp)" ;;
+	PORT_WORDPRESS=[0-9]* )      pass "inline-comment port superseded by a clean value" ;;
+	* )                          bad "inline-comment port superseded by a clean value ($last_wp)" ;;
+esac
+
+# --- envfile STRIPS quotes, so a quoted name jp honors must be accepted -----
+# (Regression guard: treating a quoted value as unreadable would falsely reject a valid name.)
+add_wt wt-q
+printf 'COMPOSE_PROJECT_NAME="jetpack_quoted"\n' > "$( env_of wt-q )"
+run "$TMP/wt-q"
+assert_rc zero "quoted name jp honors is accepted, not rejected (exit 0)"
+assert_grep "$( env_of wt-q )" '^PORT_WORDPRESS=[0-9]+$' "quoted-name worktree gets its ports backfilled"
+
+# --- envfile strips quotes on ports too: a quoted numeric port is reused ----
+add_wt wt-qp
+printf 'COMPOSE_PROJECT_NAME=jetpack_qp\nPORT_WORDPRESS="8080"\n' > "$( env_of wt-qp )"
+run "$TMP/wt-qp"
+assert_rc zero "quoted numeric port is honored (exit 0)"
+# 8080 is a clean value to envfile (quotes stripped), so it is reused, not reallocated.
+if [ "$( grep '^PORT_WORDPRESS' "$( env_of wt-qp )" | tail -n1 )" = 'PORT_WORDPRESS="8080"' ]; then
+	pass "quoted numeric port is reused as-is (no reallocation)"
+else
+	bad "quoted numeric port is reused as-is (no reallocation)"
+fi
+
+# --- envfile also splits on `:`, so a colon-set name jp honors is kept ------
+add_wt wt-colon
+printf 'COMPOSE_PROJECT_NAME:jetpack_colon\n' > "$( env_of wt-colon )"
+run "$TMP/wt-colon"
+assert_rc zero "colon-delimited name is recognized (exit 0)"
+assert_absent "$( env_of wt-colon )" '^COMPOSE_PROJECT_NAME=jetpack_wt-colon$' "colon-set name is not overridden by a derived one"
+
+# --- a bare non-jetpack_ name jp ignores is rejected (concern 1) ------------
+add_wt wt-bare
+printf 'COMPOSE_PROJECT_NAME=beta\n' > "$( env_of wt-bare )"
+run "$TMP/wt-bare"
+assert_rc nonzero "bare non-jetpack_ name is rejected (would drive the primary)"
+
+# --- a valid existing port is reused + base-10 normalized, not reallocated --
+add_wt wt-reuse
+printf 'COMPOSE_PROJECT_NAME=jetpack_reuse\nPORT_WORDPRESS=08080\n' > "$( env_of wt-reuse )"
+run "$TMP/wt-reuse"
+assert_rc zero "valid existing port is reused (exit 0)"
+assert_grep "$( env_of wt-reuse )" '^COMPOSE_PROJECT_NAME=jetpack_reuse$' "reuse worktree keeps its name"
+# All four missing PORT_ keys are backfilled and none collide with the reused 8080.
+for k in PORT_PHPMY PORT_INBOX PORT_SMTP PORT_SFTP; do
+	assert_grep "$( env_of wt-reuse )" "^${k}=[0-9]+$" "backfill wrote ${k}"
+done
+if grep -qE '^(PORT_PHPMY|PORT_INBOX|PORT_SMTP|PORT_SFTP)=8080$' "$( env_of wt-reuse )"; then
+	bad "no backfilled port collides with the reused 08080/8080"
+else
+	pass "no backfilled port collides with the reused 08080/8080"
+fi
+
+# --- a leading UTF-8 BOM is trimmed like JS .trim(), so the name is kept ----
+add_wt wt-bom
+printf '\xEF\xBB\xBFCOMPOSE_PROJECT_NAME=jetpack_bom\n' > "$( env_of wt-bom )"
+run "$TMP/wt-bom"
+assert_rc zero "BOM-prefixed name is read, not treated as absent (exit 0)"
+assert_absent "$( env_of wt-bom )" '^COMPOSE_PROJECT_NAME=jetpack_wt-bom$' "BOM-prefixed name is not overridden by a derived one"
+
+# --- reaching the primary through a symlinked path is still a no-op ---------
+# (Guards the pwd -P handling that resolves --absolute-git-dir's symlink resolution.)
+ln -s "$PRIMARY" "$TMP/primary-link"
+run "$TMP/primary-link"
+case "$RUN_OUT" in *"Not a linked git worktree"* ) pass "symlinked primary path is a no-op" ;; * ) bad "symlinked primary path is a no-op ($RUN_OUT)" ;; esac
+assert_absent "$PRIMARY/tools/docker/.env" 'COMPOSE_PROJECT_NAME' "symlinked primary .env left unseeded"
+
+echo
+if [ "$fail" = 0 ]; then echo "All seed-worktree-env.sh fixture checks passed."; else echo "seed-worktree-env.sh fixture checks FAILED."; fi
+exit "$fail"


### PR DESCRIPTION
Fixes #

Hey @LiamSarsfield — apologies for the quick trigger merging #49949 before this round landed. You were right on both counts; this PR addresses your two should-fix items plus the non-blockers.

## Proposed changes

Follow-up to #49949, all under `tools/docker/`.

* **Validate a kept `COMPOSE_PROJECT_NAME` in the backfill path.** It no longer trusts an existing name blindly. It now exits non-zero when the name is one `jp docker up` would silently ignore — not `jetpack_<x>` with `x` other than `dev`/`e2e` (empty, a bare slug, `jetpack_dev`/`jetpack_e2e`), mirroring `augmentArgvFromEnvFile`'s rule — or one another worktree already claims (via `CLAIMED_NAMES`). Both otherwise put two worktrees on the same containers and DB behind a success message.
* **Parse `.env` exactly the way `jp` does.** I went to the shipped `envfile@7.1.0` source rather than trusting the model: its parser splits on the first `=` **or** `:`, strips **all** quotes from the value, drops a line whose key contains `#`, and does not understand `export` or an inline ` # comment`. A single `envfile_parse()` helper now mirrors that precisely and is the one place the parser shape lives (value lookup, key-presence check, and the sibling scan all use it). Anything `envfile` can't read counts as absent, so the script appends a clean line the CLI can load instead of no-opping behind a value it would drop and fall back to the primary instance for. Notably this corrects my first attempt at this guard, which was *more lenient* than the real parser — it would have falsely rejected a valid quoted name and missed quoted/colon sibling names and ports.
* **Add a Docker-free fixture test** (`tools/docker/bin/seed-worktree-env.test.sh`): builds a throwaway repo with real linked worktrees and asserts the no-op / seed / idempotent re-run / backfill / name-rejection paths plus quote/colon/BOM/`export`/inline-comment parsing. 36 checks, runs in ~a second by hand.
* **Doc nits:** the name comes from git's frozen worktree id, not the folder name; README now notes the no-locking caveat.

No changelog entry — everything is under `tools/docker/`, which is outside `/projects` (`AGENTS.md` § changelog), consistent with #49949.

## Related product discussion/links

* Follow-up to #49949

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* This only affects the manual per-worktree Docker helper; the primary checkout is untouched (still a no-op there).
* Run the fixture test — no Docker needed: `tools/docker/bin/seed-worktree-env.test.sh` (expect 36 `ok` lines and exit 0).
* Optional real-world check: from a linked git worktree, `tools/docker/bin/seed-worktree-env.sh` then `jp docker up -d` brings up an isolated instance. Try a hand-set `COMPOSE_PROJECT_NAME=jetpack_dev` or a name a sibling already uses in that worktree's `tools/docker/.env` and confirm the script now refuses with a clear message instead of quietly sharing the primary instance.
