### PR TITLE
Write: clearer uploading indicator for dragged-in images

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-uploading-image-placeholder
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-uploading-image-placeholder
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Write editor: dragged-in images now show a pulsing placeholder sized to the image's aspect ratio while uploading, so the in-flight state is obvious and the placeholder stays visible even when the local preview can't render.
+Write editor: dragged-in images now show a pulsing placeholder sized to the image's aspect ratio while uploading, so the in-flight state is obvious and the placeholder stays visible even when the local preview can't render. The upload is also announced to assistive tech via aria-busy and a live region.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-uploading-image-placeholder
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-uploading-image-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write editor: dragged-in images now show a pulsing placeholder sized to the image's aspect ratio while uploading, so the in-flight state is obvious and the placeholder stays visible even when the local preview can't render.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1221,10 +1221,44 @@
 	bottom: -2px;
 }
 
-/* Pre-upload placeholder figure: dim the locally-previewed image while
-   the upload is in flight, then snap back once the real URL is in place. */
+/* Pre-upload placeholder figure. While the upload is in flight the figure is
+   sized to the image's aspect ratio (set inline in view.js) and painted as a
+   pulsing gray skeleton box. The locally-previewed image sits on top at reduced
+   opacity so the pulse reads through it as a "still uploading" signal; when the
+   preview can't decode (e.g. HEIC) the pulsing box stands in on its own so the
+   user always sees a correctly-sized placeholder instead of nothing. The class
+   and inline aspect-ratio are removed once the real URL is in place. */
+.bw-content .bw-image-figure.bw-image-uploading {
+	background-color: #f3f4f6;
+	border-radius: 6px;
+	overflow: hidden;
+	animation: bw-image-uploading-pulse 1.4s ease-in-out infinite;
+}
+
 .bw-content .bw-image-figure.bw-image-uploading img {
-	opacity: 0.5;
+	opacity: 0.6;
+}
+
+@keyframes bw-image-uploading-pulse {
+
+	0%,
+	100% {
+		background-color: #f3f4f6;
+	}
+
+	50% {
+		background-color: #e2e4e8;
+	}
+}
+
+/* Respect reduced-motion preferences: hold a static dimmed skeleton box
+   instead of pulsing. The gray fill + dimmed preview still signal the
+   in-flight upload. */
+@media (prefers-reduced-motion: reduce) {
+
+	.bw-content .bw-image-figure.bw-image-uploading {
+		animation: none;
+	}
 }
 
 .bw-content p {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -518,6 +518,13 @@ function stripRuntimeFigureControls( root ) {
 	root
 		.querySelectorAll( '.bw-img-delete, .bw-img-caption-btn, .bw-img-edit' )
 		.forEach( el => el.remove() );
+	// Drop the in-flight upload treatment (pulsing skeleton class + the inline
+	// aspect-ratio that reserves the placeholder box) so a save or undo capture
+	// taken mid-upload never bakes the runtime-only styling into stored HTML.
+	root.querySelectorAll( '.bw-image-uploading' ).forEach( fig => {
+		fig.classList.remove( 'bw-image-uploading' );
+		fig.style.removeProperty( 'aspect-ratio' );
+	} );
 }
 
 /**
@@ -3354,6 +3361,23 @@ function uploadAndInsertImage( file ) {
 	figure.className = 'bw-image-figure bw-image-uploading size-large';
 	const img = document.createElement( 'img' );
 	const localUrl = URL.createObjectURL( file );
+	// Reserve the image's box up-front so the pulsing placeholder is the right
+	// size before (or even without) the local preview decoding, and so the
+	// figure doesn't reflow when the uploaded URL swaps in. Start from a 3:2
+	// fallback, then refine to the real proportions once the preview reports
+	// its natural dimensions. Some formats (e.g. HEIC) never decode in-browser,
+	// in which case the fallback box stands in and the user still sees a
+	// correctly-sized, pulsing placeholder instead of nothing.
+	figure.style.aspectRatio = '3 / 2';
+	img.addEventListener(
+		'load',
+		() => {
+			if ( img.naturalWidth && img.naturalHeight ) {
+				figure.style.aspectRatio = img.naturalWidth + ' / ' + img.naturalHeight;
+			}
+		},
+		{ once: true }
+	);
 	img.src = localUrl;
 	img.alt = '';
 	figure.appendChild( img );
@@ -3384,6 +3408,10 @@ function uploadAndInsertImage( file ) {
 			img.alt = media.alt_text || '';
 			img.className = 'wp-image-' + media.id;
 			figure.className = 'bw-image-figure size-large';
+			// Release the reserved placeholder box — the swapped-in image now
+			// dictates the figure height. It shares the preview's aspect ratio,
+			// so clearing this produces no visible reflow.
+			figure.style.aspectRatio = '';
 			mediaSizesCache.set( media.id, media.media_details?.sizes || null );
 			// The figure was decorated by addDeleteButtons() before upload,
 			// so it's missing the Size button (that branch is gated on

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -516,14 +516,18 @@ function stripRuntimeFigureControls( root ) {
 		wrapper.remove();
 	} );
 	root
-		.querySelectorAll( '.bw-img-delete, .bw-img-caption-btn, .bw-img-edit' )
+		.querySelectorAll(
+			'.bw-img-delete, .bw-img-caption-btn, .bw-img-edit, .bw-image-uploading-status'
+		)
 		.forEach( el => el.remove() );
-	// Drop the in-flight upload treatment (pulsing skeleton class + the inline
-	// aspect-ratio that reserves the placeholder box) so a save or undo capture
-	// taken mid-upload never bakes the runtime-only styling into stored HTML.
+	// Drop the in-flight upload treatment (pulsing skeleton class, the inline
+	// aspect-ratio that reserves the placeholder box, and the aria-busy flag)
+	// so a save or undo capture taken mid-upload never bakes the runtime-only
+	// styling or state into stored HTML.
 	root.querySelectorAll( '.bw-image-uploading' ).forEach( fig => {
 		fig.classList.remove( 'bw-image-uploading' );
 		fig.style.removeProperty( 'aspect-ratio' );
+		fig.removeAttribute( 'aria-busy' );
 	} );
 }
 
@@ -3372,7 +3376,17 @@ function uploadAndInsertImage( file ) {
 	img.addEventListener(
 		'load',
 		() => {
-			if ( img.naturalWidth && img.naturalHeight ) {
+			// Guard on the uploading class: if the upload finished before the
+			// local preview decoded, the swap below already reassigned img.src
+			// and cleared the reserved box. Without this check the load event
+			// for the swapped-in URL would re-add an inline aspect-ratio to a
+			// completed figure, which stripRuntimeFigureControls (scoped to
+			// .bw-image-uploading) would then miss and leak into saved HTML.
+			if (
+				figure.classList.contains( 'bw-image-uploading' ) &&
+				img.naturalWidth &&
+				img.naturalHeight
+			) {
 				figure.style.aspectRatio = img.naturalWidth + ' / ' + img.naturalHeight;
 			}
 		},
@@ -3382,10 +3396,23 @@ function uploadAndInsertImage( file ) {
 	img.alt = '';
 	figure.appendChild( img );
 
+	// Announce the in-flight upload to assistive tech: the pulsing box is a
+	// purely visual cue, so pair it with aria-busy and a visually-hidden live
+	// region. Both are removed on swap (and stripped from any save/undo capture
+	// taken mid-upload) so they never reach stored HTML.
+	figure.setAttribute( 'aria-busy', 'true' );
+	const srStatus = document.createElement( 'span' );
+	srStatus.className = 'bw-visually-hidden bw-image-uploading-status';
+	srStatus.setAttribute( 'role', 'status' );
+	figure.appendChild( srStatus );
+
 	const p = insertMediaBlock( figure );
 	if ( p ) {
 		placeCursorAt( p );
 	}
+	// Set the text after the live region is in the DOM so assistive tech
+	// reliably picks up the change as an announcement.
+	srStatus.textContent = i18n.uploadingImage || 'Uploading image…';
 	// Deliberately do NOT push undo history here: the placeholder figure's
 	// img.src is a blob: URL that gets revoked when the upload completes.
 	// Capturing the placeholder in an undo snapshot would let Cmd+Z restore
@@ -3412,6 +3439,9 @@ function uploadAndInsertImage( file ) {
 			// dictates the figure height. It shares the preview's aspect ratio,
 			// so clearing this produces no visible reflow.
 			figure.style.aspectRatio = '';
+			// Tear down the in-flight a11y affordances now the upload is done.
+			figure.removeAttribute( 'aria-busy' );
+			srStatus.remove();
 			mediaSizesCache.set( media.id, media.media_details?.sizes || null );
 			// The figure was decorated by addDeleteButtons() before upload,
 			// so it's missing the Size button (that branch is gated on

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -96,6 +96,7 @@ function wpcom_write_get_editor_strings() {
 		'writeCaption'         => __( 'Write a caption...', 'jetpack-mu-wpcom' ),
 		// translators: %s is the error message from the upload failure.
 		'uploadFailed'         => __( 'Upload failed: %s', 'jetpack-mu-wpcom' ),
+		'uploadingImage'       => __( 'Uploading image…', 'jetpack-mu-wpcom' ),
 		'libraryLoading'       => __( 'Loading your library…', 'jetpack-mu-wpcom' ),
 		'libraryEmpty'         => __( 'No images in your library yet.', 'jetpack-mu-wpcom' ),
 		'libraryNoResults'     => __( 'No matching images.', 'jetpack-mu-wpcom' ),


### PR DESCRIPTION
## Proposed changes

While a dragged-in image is uploading, the Write editor previously only dimmed the local preview to `opacity: 0.5`. That signal is easy to miss, and if the local preview can't render (e.g. HEIC, or a slow decode) the figure collapses and the user sees *nothing* while the upload is in flight.

This PR replaces the dim-only treatment with a size-matched, pulsing placeholder:

* The placeholder figure reserves the image's box via an inline `aspect-ratio`, defaulting to `3 / 2` and refining to the preview's real natural dimensions once it decodes. This eliminates the layout snap when the uploaded URL swaps in.
* `.bw-image-uploading` renders as a pulsing gray skeleton box (`bw-image-uploading-pulse` keyframe) with the dimmed preview on top, so the "still uploading" state is obvious — and a correctly-sized box stays visible even when the preview can't decode.
* `prefers-reduced-motion` holds the box static instead of pulsing.
* `stripRuntimeFigureControls` now strips the runtime uploading class and inline `aspect-ratio`, so a save or undo captured mid-upload can't bake placeholder styling into stored post HTML.

No new dependencies — this surface is vanilla DOM on `@wordpress/interactivity`, so there's no Gutenberg `<Spinner>`/`<Placeholder>` to reuse; the skeleton mirrors the existing media-modal preview styling.

## Related product discussion/links

* RSM-3942

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Write editor (`wp-admin/admin.php?page=write`).
* Drag an image file from your desktop and drop it into the post body.
* While the upload is in flight, confirm you see a **pulsing gray placeholder box sized to the image's aspect ratio** with the dimmed preview on top — not just a faintly dimmed image.
* Confirm that when the upload completes, the real image swaps in with **no layout jump** and the pulsing/box styling is gone.
* Optional (the original bug): drop a format the browser can't preview (e.g. a HEIC). Confirm you still see a correctly-sized pulsing placeholder while it uploads, instead of nothing.
* Optional: enable "Reduce motion" in your OS accessibility settings and confirm the placeholder is a static gray box rather than pulsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)