### PR TITLE
Account Protection: "Update Verify your identity" page to reduce customer confusion

### DIFF
--- a/projects/packages/account-protection/changelog/update-account-protection-ui
+++ b/projects/packages/account-protection/changelog/update-account-protection-ui
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Account Protection: Added additional context to Verify your identity page to reduce user confusion.
+Account Protection: Add additional context to Verify your identity page to reduce user confusion.

--- a/projects/packages/account-protection/changelog/update-account-protection-ui
+++ b/projects/packages/account-protection/changelog/update-account-protection-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Account Protection: Added additional context to Verify your identity page to reduce user confusion.

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -324,15 +324,27 @@ class Password_Detection {
 							?>
 						</p>
 					<?php else : ?>
-						<p><?php esc_html_e( 'We\'ve noticed that your current password may have been compromised in a public leak. To keep your account safe, we\'ve added an extra layer of security.', 'jetpack-account-protection' ); ?></p>
+						<p>
+							<?php
+								printf(
+									/* translators: %s: Jetpack Account Protection link */
+									esc_html__( '%s has flagged that your password may appear in a known data breach.', 'jetpack-account-protection' ),
+									'<a class="how-it-works-link" href="' . esc_url( Config::SUPPORT_LINK . '#how-account-protection-works' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Jetpack Account Protection', 'jetpack-account-protection' ) . '</a>'
+								);
+							?>
+						</p>
+						<p><?php esc_html_e( 'This security feature was automatically activated with a recent Jetpack update to help keep your account safe. We\'ve added an extra layer of security to your login.', 'jetpack-account-protection' ); ?></p>
 						<p>
 							<?php
 								printf(
 									/* translators: %s: Masked email address */
-									esc_html__( 'We\'ve sent a code to %s. Please check your inbox and enter the code below to verify it\'s really you.', 'jetpack-account-protection' ),
+									esc_html__( 'We\'ve sent a verification code to your WordPress admin email (%s). ', 'jetpack-account-protection' ),
 									esc_html( $this->email_service->mask_email_address( $user->user_email ) )
 								);
 							?>
+						</p>
+						<p>
+							<?php esc_html_e( 'Please check your inbox and enter the code below to complete your login:', 'jetpack-account-protection' ); ?>
 						</p>
 						<div class="actions">
 							<form method="post">
@@ -364,12 +376,22 @@ class Password_Detection {
 							</p>
 						<?php else : ?>
 							<p class="email-status">
-								<span><?php esc_html_e( "Didn't get the code?", 'jetpack-account-protection' ); ?> </span>
+								<span><?php esc_html_e( "Didn't get the code? Check your spam folder or ", 'jetpack-account-protection' ); ?> </span>
 								<a class="resend-email-link" href="<?php echo esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ); ?>">
 									<?php esc_html_e( 'Resend email', 'jetpack-account-protection' ); ?>
 								</a>
 							</p>
+							<p class="email-status">
+								<?php
+									printf(
+										/* translators: %s: Contact Jetpack Support link */
+										esc_html__( 'No longer have access to your WordPress admin email address or need additional help? %s.', 'jetpack-account-protection' ),
+										'<a class="contact-support-link" href="' . esc_url( 'https://jetpack.com/contact-support/?rel=support' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Contact Jetpack Support', 'jetpack-account-protection' ) . '</a>'
+									);
+								?>
+							</p>
 						<?php endif; ?>
+				
 					<?php endif; ?>
 				</div>
 				<?php wp_footer(); ?>

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -338,7 +338,7 @@ class Password_Detection {
 							<?php
 								printf(
 									/* translators: %s: Masked email address */
-									esc_html__( 'We\'ve sent a verification code to your WordPress admin email (%s).', 'jetpack-account-protection' ),
+									esc_html__( 'We\'ve sent a verification code to your WordPress profile email address (%s).', 'jetpack-account-protection' ),
 									esc_html( $this->email_service->mask_email_address( $user->user_email ) )
 								);
 							?>
@@ -390,7 +390,7 @@ class Password_Detection {
 									/* translators: %s: Contact Jetpack Support link */
 									esc_html__( 'No longer have access to this email address or need additional help? %s.', 'jetpack-account-protection' ),
 									'<a class="contact-support-link" href="' . esc_url( 'https://jetpack.com/contact-support/?rel=support' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Contact Jetpack Support', 'jetpack-account-protection' ) . '</a>'
-									);
+								);
 								?>
 							</p>
 						<?php endif; ?>

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -386,10 +386,10 @@ class Password_Detection {
 							</p>
 							<p class="email-status">
 								<?php
-									printf(
-										/* translators: %s: Contact Jetpack Support link */
-										esc_html__( 'No longer have access to your WordPress admin email address or need additional help? %s.', 'jetpack-account-protection' ),
-										'<a class="contact-support-link" href="' . esc_url( 'https://jetpack.com/contact-support/?rel=support' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Contact Jetpack Support', 'jetpack-account-protection' ) . '</a>'
+								printf(
+									/* translators: %s: Contact Jetpack Support link */
+									esc_html__( 'No longer have access to this email address or need additional help? %s.', 'jetpack-account-protection' ),
+									'<a class="contact-support-link" href="' . esc_url( 'https://jetpack.com/contact-support/?rel=support' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Contact Jetpack Support', 'jetpack-account-protection' ) . '</a>'
 									);
 								?>
 							</p>

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -338,7 +338,7 @@ class Password_Detection {
 							<?php
 								printf(
 									/* translators: %s: Masked email address */
-									esc_html__( 'We\'ve sent a verification code to your WordPress admin email (%s). ', 'jetpack-account-protection' ),
+									esc_html__( 'We\'ve sent a verification code to your WordPress admin email (%s).', 'jetpack-account-protection' ),
 									esc_html( $this->email_service->mask_email_address( $user->user_email ) )
 								);
 							?>
@@ -376,10 +376,13 @@ class Password_Detection {
 							</p>
 						<?php else : ?>
 							<p class="email-status">
-								<span><?php esc_html_e( "Didn't get the code? Check your spam folder or ", 'jetpack-account-protection' ); ?> </span>
-								<a class="resend-email-link" href="<?php echo esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ); ?>">
-									<?php esc_html_e( 'Resend email', 'jetpack-account-protection' ); ?>
-								</a>
+								<?php
+									printf(
+										/* translators: %s: Resend email link */
+										esc_html__( "Didn't get the code? Check your spam folder or %s.", 'jetpack-account-protection' ),
+										'<a class="resend-email-link" href="' . esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ) . '">' . esc_html__( 'Resend email', 'jetpack-account-protection' ) . '</a>'
+									);
+								?>
 							</p>
 							<p class="email-status">
 								<?php
@@ -391,7 +394,7 @@ class Password_Detection {
 								?>
 							</p>
 						<?php endif; ?>
-				
+
 					<?php endif; ?>
 				</div>
 				<?php wp_footer(); ?>

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -333,12 +333,12 @@ class Password_Detection {
 								);
 							?>
 						</p>
-						<p><?php esc_html_e( 'This security feature was automatically activated with a recent Jetpack update to help keep your account safe. We\'ve added an extra layer of security to your login.', 'jetpack-account-protection' ); ?></p>
+						<p><?php esc_html_e( 'This security feature was automatically activated with a recent Jetpack update to help keep your account safe.', 'jetpack-account-protection' ); ?></p>
 						<p>
 							<?php
 								printf(
 									/* translators: %s: Masked email address */
-									esc_html__( 'We\'ve sent a verification code to your WordPress profile email address (%s).', 'jetpack-account-protection' ),
+									esc_html__( 'As an extra layer of security, we\'ve sent a verification code to your WordPress profile email address (%s).', 'jetpack-account-protection' ),
 									esc_html( $this->email_service->mask_email_address( $user->user_email ) )
 								);
 							?>
@@ -380,7 +380,7 @@ class Password_Detection {
 									printf(
 										/* translators: %s: Resend email link */
 										esc_html__( "Didn't get the code? Check your spam folder or %s.", 'jetpack-account-protection' ),
-										'<a class="resend-email-link" href="' . esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ) . '">' . esc_html__( 'Resend email', 'jetpack-account-protection' ) . '</a>'
+										'<a class="resend-email-link" href="' . esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ) . '">' . esc_html__( 'resend the email', 'jetpack-account-protection' ) . '</a>'
 									);
 								?>
 							</p>

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -473,13 +473,24 @@ class Password_Detection_Test extends BaseTestCase {
 		$sut->expects( $this->once() )
 			->method( 'exit' );
 
-		$sentence = htmlentities(
-			'This security feature was automatically activated with a recent Jetpack update to help keep your account safe. We\'ve added an extra layer of security to your login.',
-			ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
-		);
-
-		$this->expectOutputRegex( '@' . $sentence . '@' );
+		ob_start();
 		$sut->render_content( $user, 'my_cool_token' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			htmlentities(
+				'This security feature was automatically activated with a recent Jetpack update to help keep your account safe.',
+				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+			),
+			$output
+		);
+		$this->assertStringContainsString(
+			htmlentities(
+				'Please check your inbox and enter the code below to complete your login:',
+				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+			),
+			$output
+		);
 	}
 
 	public function test_render_content_shows_transient_error_if_set(): void {

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -477,18 +477,8 @@ class Password_Detection_Test extends BaseTestCase {
 		$sut->render_content( $user, 'my_cool_token' );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString(
-			htmlentities(
-				'Jetpack Account Protection',
-				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
-			),
-			$output
-		);
-		$this->assertStringContainsString(
-			htmlentities(
-				'has flagged that your password may appear in a known data breach.',
-				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
-			),
+		$this->assertMatchesRegularExpression(
+			'@Jetpack Account Protection</a>\s+has flagged that your password may appear in a known data breach\.@',
 			$output
 		);
 		$this->assertStringContainsString(

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -490,6 +490,13 @@ class Password_Detection_Test extends BaseTestCase {
 		);
 		$this->assertStringContainsString(
 			htmlentities(
+				'As an extra layer of security, we\'ve sent a verification code to your WordPress profile email address (j*******@e******.com).',
+				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+			),
+			$output
+		);
+		$this->assertStringContainsString(
+			htmlentities(
 				'Please check your inbox and enter the code below to complete your login:',
 				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
 			),

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -474,7 +474,7 @@ class Password_Detection_Test extends BaseTestCase {
 			->method( 'exit' );
 
 		$sentence = htmlentities(
-			'We\'ve noticed that your current password may have been compromised in a public leak. To keep your account safe, we\'ve added an extra layer of security.',
+			'This security feature was automatically activated with a recent Jetpack update to help keep your account safe. We\'ve added an extra layer of security to your login.',
 			ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
 		);
 

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -479,6 +479,20 @@ class Password_Detection_Test extends BaseTestCase {
 
 		$this->assertStringContainsString(
 			htmlentities(
+				'Jetpack Account Protection',
+				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+			),
+			$output
+		);
+		$this->assertStringContainsString(
+			htmlentities(
+				'has flagged that your password may appear in a known data breach.',
+				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+			),
+			$output
+		);
+		$this->assertStringContainsString(
+			htmlentities(
 				'This security feature was automatically activated with a recent Jetpack update to help keep your account safe.',
 				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
 			),

--- a/projects/plugins/jetpack/changelog/update-account-protection-ui
+++ b/projects/plugins/jetpack/changelog/update-account-protection-ui
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Account Protection: Added additional context to Verify your identity page to reduce user confusion.
+Account Protection: Add additional context to Verify your identity page to reduce user confusion.

--- a/projects/plugins/jetpack/changelog/update-account-protection-ui
+++ b/projects/plugins/jetpack/changelog/update-account-protection-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Account Protection: Added additional context to Verify your identity page to reduce user confusion.

--- a/projects/plugins/protect/changelog/update-account-protection-ui
+++ b/projects/plugins/protect/changelog/update-account-protection-ui
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Account Protection: Added additional context to Verify your identity page to reduce user confusion.
+Account Protection: Add additional context to Verify your identity page to reduce user confusion.

--- a/projects/plugins/protect/changelog/update-account-protection-ui
+++ b/projects/plugins/protect/changelog/update-account-protection-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Account Protection: Added additional context to Verify your identity page to reduce user confusion.


### PR DESCRIPTION
## Proposed changes

This changes the "Verify your identity" page to reduce customer confusion. The changes are only in the text, the underlying functionality remains.

**Before**

<img width="1169" height="763" alt="image" src="https://github.com/user-attachments/assets/927b68d0-f0d9-432f-981e-68d7d14db846" />

**After**

<img width="716" height="732" alt="image" src="https://github.com/user-attachments/assets/8b033201-9763-4c71-84f4-c22d6684f01c" />



## Related product discussion/links

* https://linear.app/a8c/issue/JETH-10031

Account Protection is a driver of support volume and we're hoping that these changes to the text can help clarify what is happening for the user.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a test site, add an admin with an insecure password (`password`) will work.
2. Log in as that admin and see that the wording on the "Verify your account" page has changed and is now more clear.
