### PR TITLE
jetpack-mu-wpcom: show Stats admin bar link in wp-admin too

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/kangzj-stats-287-admin-bar-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/kangzj-stats-287-admin-bar-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Show the Stats admin bar link in wp-admin too, not just the front end, so the wpcom/v2/sites/%d/admin-bar REST endpoint can report it.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -497,16 +497,16 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
 
 /**
- * Adds a "Stats" link to the site-name submenu, alongside "Dashboard" (STATS-287).
+ * Adds a "Stats" link to the site-name submenu, alongside "Dashboard"/"Visit Site" (STATS-287).
  *
- * Hooks `wp_before_admin_bar_render`, the last point before WP_Admin_Bar builds
- * its render tree, so core's `dashboard` node (added during `admin_bar_menu`) is
- * guaranteed to exist.
+ * Hooks `admin_bar_menu` at priority 40, after core's `wp_admin_bar_site_menu`
+ * (priority 30) has added the `site-name` node and either `dashboard` (front end)
+ * or `view-site` (wp-admin), so this shows in both contexts.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
  */
-function wpcom_add_stats_to_site_menu() {
-	global $wp_admin_bar;
-
-	if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'dashboard' ) || ! current_user_can( 'view_stats' ) ) {
+function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
+	if ( ( ! $wp_admin_bar->get_node( 'dashboard' ) && ! $wp_admin_bar->get_node( 'view-site' ) ) || ! current_user_can( 'view_stats' ) ) {
 		return;
 	}
 
@@ -519,4 +519,4 @@ function wpcom_add_stats_to_site_menu() {
 		)
 	);
 }
-add_action( 'wp_before_admin_bar_render', 'wpcom_add_stats_to_site_menu' );
+add_action( 'admin_bar_menu', 'wpcom_add_stats_to_site_menu', 40 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -223,6 +223,9 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
 
 		$this->assertNotNull( $stats_node );
+		$this->assertSame( 'site-name', $stats_node->parent );
+		$this->assertSame( 'Stats', $stats_node->title );
+		$this->assertSame( admin_url( 'admin.php?page=stats' ), $stats_node->href );
 	}
 
 	public function test_stats_link_hidden_when_user_cannot_view_stats() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -144,41 +144,36 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Builds an admin bar with a 'dashboard' child of 'site-name' (as core adds
-	 * on the front end) and fires `wp_before_admin_bar_render`, the hook our
-	 * Stats node listens on.
+	 * Builds an admin bar with a 'site-name' node and, optionally, a child of it
+	 * (e.g. 'dashboard' as core adds on the front end, or 'view-site' as core
+	 * adds in wp-admin), then fires `admin_bar_menu`, the hook our Stats node
+	 * listens on.
+	 *
+	 * @param string|null $site_name_child Child node id to add under 'site-name', or null for none.
 	 */
-	private static function make_test_admin_bar_with_dashboard() {
-		global $wp_admin_bar;
-
-		$admin_bar = self::make_test_admin_bar();
+	private static function make_test_admin_bar_with_site_name( $site_name_child = null ) {
+		$admin_bar = new \WP_Admin_Bar();
 		$admin_bar->add_node(
 			array(
 				'id'    => 'site-name',
 				'title' => 'Test Site',
 			)
 		);
-		$admin_bar->add_node(
-			array(
-				'id'     => 'dashboard',
-				'parent' => 'site-name',
-				'title'  => 'Dashboard',
-				'href'   => 'https://example.com/wp-admin/',
-			)
-		);
 
-		$wp_admin_bar = $admin_bar;
-		do_action( 'wp_before_admin_bar_render' );
+		if ( $site_name_child !== null ) {
+			$admin_bar->add_node(
+				array(
+					'id'     => $site_name_child,
+					'parent' => 'site-name',
+					'title'  => ucfirst( $site_name_child ),
+					'href'   => 'https://example.com/wp-admin/',
+				)
+			);
+		}
+
+		do_action( 'admin_bar_menu', $admin_bar );
 
 		return $admin_bar;
-	}
-
-	/**
-	 * Clears the `$wp_admin_bar` global so it doesn't leak between tests.
-	 */
-	private static function reset_admin_bar_global(): void {
-		global $wp_admin_bar;
-		$wp_admin_bar = null;
 	}
 
 	/**
@@ -203,13 +198,12 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		return $allcaps;
 	}
 
-	public function test_stats_link_shown_when_user_can_view_stats() {
+	public function test_stats_link_shown_when_dashboard_node_present() {
 		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
-		$admin_bar = self::make_test_admin_bar_with_dashboard();
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard' );
 		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
 
 		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
-		self::reset_admin_bar_global();
 
 		$this->assertNotNull( $stats_node );
 		$this->assertSame( 'site-name', $stats_node->parent );
@@ -217,28 +211,36 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( admin_url( 'admin.php?page=stats' ), $stats_node->href );
 	}
 
+	/**
+	 * Core adds 'view-site' instead of 'dashboard' under 'site-name' in wp-admin
+	 * (is_admin() === true). The Stats link must show there too.
+	 */
+	public function test_stats_link_shown_when_view_site_node_present() {
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'view-site' );
+		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+
+		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
+
+		$this->assertNotNull( $stats_node );
+	}
+
 	public function test_stats_link_hidden_when_user_cannot_view_stats() {
 		add_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
-		$admin_bar = self::make_test_admin_bar_with_dashboard();
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard' );
 		remove_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
 
 		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
-		self::reset_admin_bar_global();
 
 		$this->assertNull( $stats_node );
 	}
 
-	public function test_stats_link_hidden_when_dashboard_node_absent() {
-		global $wp_admin_bar;
-
+	public function test_stats_link_hidden_when_dashboard_and_view_site_nodes_absent() {
 		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
-		$admin_bar    = self::make_test_admin_bar();
-		$wp_admin_bar = $admin_bar;
-		do_action( 'wp_before_admin_bar_render' );
+		$admin_bar = self::make_test_admin_bar_with_site_name();
 		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
 
 		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
-		self::reset_admin_bar_global();
 
 		$this->assertNull( $stats_node );
 	}


### PR DESCRIPTION
## Why this matters
While reviewing wp-calypso#112405 (client-side Stats-node injection into the Calypso omnibar), fushar asked whether that duplicates something the backend already provides. It didn't — `wpcom/v2/sites/%d/admin-bar` never returned a Stats node, because the endpoint only fires `admin_bar_menu`, while the Stats link was added on `wp_before_admin_bar_render` and only when core's `dashboard` node existed (front-end only, `is_admin() === false`).

This PR moves the Stats link's hook onto `admin_bar_menu` and widens its gate to also match wp-admin's `view-site` node (added when `is_admin() === true`). Net effect: the link now shows in wp-admin too, not just the front end, and the REST endpoint reports it for free — wp-calypso's existing dedup guard already recognizes the `wpcom-stats` id, so no further wp-calypso changes are needed.

Fixes #

## Proposed changes
* Move `wpcom_add_stats_to_site_menu()` from the `wp_before_admin_bar_render` hook to `admin_bar_menu` (priority 40, after core's site menu at priority 30).
* Widen its gate to accept core's `view-site` node (wp-admin) in addition to `dashboard` (front end).
* Update/add PHPUnit coverage for both the `dashboard` and `view-site` cases.

## Related product discussion/links
* Related to Automattic/jetpack#50222 (original Stats admin-bar link, front-end only)
* Related to Automattic/wp-calypso#112405 (client-side Stats-node injection in the Calypso omnibar)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* In wp-admin on a Simple or Atomic site, as a user who can `view_stats`, open the site-name dropdown in the top-left toolbar — it should now include a "Stats" link alongside "Visit Site", linking to `admin.php?page=stats`.
* On the front end, confirm the "Stats" link still appears alongside "Dashboard" as before (no regression).
* As a user without `view_stats`, confirm the link is absent in both contexts.
* `GET /wpcom/v2/sites/%d/admin-bar` — the `site-name` node's children should now include a `wpcom-stats` node.
* `WPCOM_Admin_Bar_Test::test_stats_link_shown_when_dashboard_node_present` and `::test_stats_link_shown_when_view_site_node_present` cover both contexts and pass locally.
