### PR TITLE
Pricing table: align highlighted column gradient background to the right

### DIFF
--- a/projects/js-packages/components/changelog/fix-backup-card-gradient-position
+++ b/projects/js-packages/components/changelog/fix-backup-card-gradient-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pricing table: align the highlighted column's gradient background to the right edge of the card.

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -98,11 +98,7 @@
 			background-image: url(./gradient.svg);
 			background-repeat: no-repeat;
 			background-size: 450px;
-			background-position-x: center;
-
-			@media (max-width: gb.$break-large) {
-				background-position-x: right;
-			}
+			background-position-x: right;
 		}
 
 		> :last-child {

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -1,5 +1,3 @@
-@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
-
 .container {
 	--padding: calc(var(--spacing-base) * 4);
 	--padding-horizontal: calc(var(--spacing-base) * 3);


### PR DESCRIPTION
## Proposed changes

* The highlighted (primary) column in the shared `PricingTable` component (`js-packages/components`) anchored its decorative gradient background to the **center** of the card. On wide, single-column layouts — e.g. the My Jetpack Backup interstitial when the pricing table renders as one full-width column (viewport below the `large` breakpoint) — this left the gradient's green blob stranded in the middle of the card.
* This sets `background-position-x: right` as the base value so the gradient consistently hugs the right edge of the card at every width. The old `@media (max-width: $break-large)` override that already applied `right` is now redundant and has been removed.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build & activate Jetpack (or sync this branch to a Jurassic Ninja site).
* Go to **Jetpack → My Jetpack** and open the **Backup** interstitial (`wp-admin/admin.php?page=my-jetpack#/add-backup`).
* Make the browser window narrower than `960px` so the pricing cards stack into a single full-width column.
* Observe the Backup card's gradient background: it should now sit against the **right** edge of the card instead of the center.

### Before / After

Captured on a live Jurassic Ninja site at the My Jetpack Backup interstitial (single-column / sub-`960px` layout).

| Before (centered) | After (right-aligned) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/backup-card-gradient-position/before-backup.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/backup-card-gradient-position/after-backup.png) |
