### PR TITLE
VideoPress: flag moved videos as read-only in the dashboard library

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-moved-video-library-guard
+++ b/projects/packages/videopress/changelog/fix-videopress-moved-video-library-guard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+VideoPress: Flag videos that have been moved to another site as read-only in the library, and show a clear message instead of a generic error when trying to edit one.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -17,12 +17,74 @@ use WP_REST_Request;
 class Data {
 
 	/**
+	 * Transient-key prefix for the per-GUID video-ownership cache.
+	 */
+	const OWNERSHIP_CACHE_PREFIX = 'jetpack_vp_owner_';
+
+	/**
+	 * How long a resolved video owner is cached. Moves are rare, so a long TTL keeps
+	 * the per-GUID WPCOM lookups off the hot path; a moved-away video may keep showing
+	 * on the source for up to this long before it is flagged.
+	 */
+	const OWNERSHIP_CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+	/**
 	 * Gets the Jetpack blog ID
 	 *
 	 * @return int The blog ID
 	 */
 	public static function get_blog_id() {
 		return VideoPressToken::blog_id();
+	}
+
+	/**
+	 * Whether this site still owns a VideoPress video, per WPCOM's canonical record.
+	 *
+	 * The dashboard library is built entirely from LOCAL media-library attachments, so
+	 * a video that has been moved to another blog ( its canonical `videos` row re-pointed )
+	 * still lists here with stale local metadata, and can no longer be edited from this
+	 * site. This confirms current ownership against WPCOM so the UI can flag / hide such
+	 * videos.
+	 *
+	 * Fails OPEN: on any transient or unknown lookup failure it returns true, so a WPCOM
+	 * hiccup never makes a site's own videos disappear. Results are cached per GUID
+	 * ( including the "not owned" outcome ) to keep this off the hot path.
+	 *
+	 * @param string $guid The VideoPress GUID.
+	 * @return bool True when owned ( or ownership can't be determined ); false only when
+	 *              WPCOM confirms the video belongs to a different blog.
+	 */
+	public static function is_video_owned_by_site( $guid ) {
+		if ( empty( $guid ) ) {
+			return true;
+		}
+
+		$site_blog_id = (int) self::get_blog_id();
+		if ( $site_blog_id <= 0 ) {
+			// Can't determine our own blog id; don't hide anything.
+			return true;
+		}
+
+		$cache_key  = self::OWNERSHIP_CACHE_PREFIX . md5( $guid );
+		$owner_blog = get_transient( $cache_key );
+
+		if ( false === $owner_blog ) {
+			$owner_blog = Site::get_video_owner_blog_id( $guid );
+			if ( is_wp_error( $owner_blog ) ) {
+				// Transient/unknown failure -> fail open and do not cache, so we retry.
+				return true;
+			}
+			set_transient( $cache_key, (int) $owner_blog, self::OWNERSHIP_CACHE_TTL );
+		}
+
+		$owner_blog = (int) $owner_blog;
+
+		// 0 means WPCOM denied this blog access to the video -> not the owner.
+		if ( 0 === $owner_blog ) {
+			return false;
+		}
+
+		return $owner_blog === $site_blog_id;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-site.php
+++ b/projects/packages/videopress/src/class-site.php
@@ -44,6 +44,61 @@ class Site {
 	}
 
 	/**
+	 * Fetches the current owner blog_id of a VideoPress video from WPCOM.
+	 *
+	 * A VideoPress GUID is globally single-owner: WPCOM's canonical `videos` record
+	 * binds it to exactly one blog, and that binding can change over the video's
+	 * lifetime ( most notably a move to another blog ). This asks WPCOM who owns the
+	 * GUID right now so the caller can tell whether this site still does.
+	 *
+	 * @param string $guid The VideoPress GUID.
+	 * @return int|WP_Error Owner blog_id ( > 0 ) on success; 0 when WPCOM denies this
+	 *                      blog access to the video ( i.e. it is not the owner, e.g. a
+	 *                      private video that was moved away ); WP_Error on a transient
+	 *                      or unknown failure ( callers should fail open ).
+	 */
+	public static function get_video_owner_blog_id( $guid ) {
+		if ( empty( $guid ) ) {
+			return new WP_Error(
+				'videopress_missing_guid',
+				__( 'A VideoPress GUID is required.', 'jetpack-videopress-pkg' )
+			);
+		}
+
+		$request_path = sprintf( 'videos/%s', rawurlencode( $guid ) );
+		$response     = Client::wpcom_json_api_request_as_blog( $request_path, '1.1', array(), null, 'rest' );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		// A 401/403 for a GUID this site holds locally means the site is not the owner
+		// ( most commonly a private video that has been moved to another blog ).
+		if ( 401 === $response_code || 403 === $response_code ) {
+			return 0;
+		}
+
+		if ( 200 !== $response_code ) {
+			return new WP_Error(
+				'videopress_owner_lookup_failed',
+				__( 'Could not determine the video owner.', 'jetpack-videopress-pkg' )
+			);
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) || ! isset( $body['blog_id'] ) ) {
+			return new WP_Error(
+				'videopress_owner_lookup_failed',
+				__( 'Could not determine the video owner.', 'jetpack-videopress-pkg' )
+			);
+		}
+
+		return (int) $body['blog_id'];
+	}
+
+	/**
 	 * Returns all the purchases provided by WPCOM for the site.
 	 *
 	 * @return array the list of purchases, or an empty list on failure.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -250,6 +250,17 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 		// The video needs a playback token if it's private for any reason (video privacy setting or site default privacy setting)
 		$video_needs_playback_token = $is_private;
 
+		// On a Jetpack site the library is built from LOCAL attachment metadata, which
+		// stays behind if the video's canonical owner changed ( e.g. it was moved to
+		// another blog ). Confirm ownership against WPCOM so the dashboard can flag a
+		// video this site no longer owns and can no longer edit. On WPCOM the videos
+		// table is authoritative already ( a moved-away video resolves to no info here ),
+		// and the blog-signed lookup is not meaningful, so this stays true there.
+		$is_owned = true;
+		if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ! empty( $info->guid ) ) {
+			$is_owned = Data::is_video_owned_by_site( $info->guid );
+		}
+
 		return array(
 			'title'                    => $title,
 			'description'              => $description,
@@ -264,6 +275,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			'needs_playback_token'     => $video_needs_playback_token,
 			'is_private'               => $is_private,
 			'private_enabled_for_site' => $private_enabled_for_site,
+			'is_owned'                 => $is_owned,
 		);
 	}
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -589,6 +589,29 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				)
 			);
 		} else {
+			// WPCOM rejects an edit from a blog that does not own the video with a 401/403
+			// ( see the ownership check on wpcom/v2/videos ). The local attachment still
+			// carries the GUID after a move, so the dashboard can reach this point; surface
+			// a clear, actionable message instead of the raw "Not allowed."
+			$status = 0;
+			if ( isset( $response_body->data ) ) {
+				if ( is_object( $response_body->data ) && isset( $response_body->data->status ) ) {
+					$status = (int) $response_body->data->status;
+				} elseif ( is_int( $response_body->data ) ) {
+					$status = $response_body->data;
+				}
+			}
+
+			if ( 401 === $status || 403 === $status ) {
+				return rest_ensure_response(
+					new WP_Error(
+						'videopress_not_owner',
+						__( 'This video has been moved to another site and can no longer be edited here.', 'jetpack-videopress-pkg' ),
+						array( 'status' => $status )
+					)
+				);
+			}
+
 			return rest_ensure_response(
 				new WP_Error(
 					$response_body->code,

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/jetpack-components';
 import {
 	Button,
+	Notice,
 	SelectControl,
 	RadioControl,
 	CheckboxControl,
@@ -142,6 +143,7 @@ const EditVideoDetails = () => {
 		deleted,
 		isFetching,
 		isDeleting,
+		isOwned,
 		handleSaveChanges,
 		handleDelete,
 		// Metadata
@@ -267,6 +269,14 @@ const EditVideoDetails = () => {
 				<Container horizontalSpacing={ 0 }>
 					<Col>
 						<div id="jp-admin-notices" className={ styles[ 'jetpack-videopress-jitm-card' ] } />
+						{ isOwned === false && (
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'This video has been moved to another site and can no longer be edited here.',
+									'jetpack-videopress-pkg'
+								) }
+							</Notice>
+						) }
 					</Col>
 				</Container>
 				<AdminSection>
@@ -282,7 +292,7 @@ const EditVideoDetails = () => {
 								actions={
 									<Button
 										variant="primary"
-										disabled={ ! hasChanges || isBusy || isFetchingData }
+										disabled={ ! hasChanges || isBusy || isFetchingData || isOwned === false }
 										onClick={ handleSaveChanges }
 										isBusy={ isBusy || isFetchingData }
 									>

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -27,12 +27,18 @@ const QuickActions = ( {
 	id,
 	onVideoDetailsClick,
 	className,
+	isOwned = true,
 }: {
 	id: VideoCardProps[ 'id' ];
 	onVideoDetailsClick: VideoCardProps[ 'onVideoDetailsClick' ];
 	className?: VideoCardProps[ 'className' ];
+	isOwned?: VideoCardProps[ 'isOwned' ];
 } ) => {
 	const { canPerformAction } = usePermission();
+
+	// A video that was moved to another blog stays in this local library but can no
+	// longer be edited here, so disable the edit action for it.
+	const editDisabled = ! canPerformAction || isOwned === false;
 
 	return (
 		<div className={ clsx( styles[ 'video-card__quick-actions-section' ], className ) }>
@@ -41,12 +47,12 @@ const QuickActions = ( {
 				size="small"
 				onClick={ onVideoDetailsClick }
 				className={ styles[ 'video-card__quick-actions__edit-button' ] }
-				disabled={ ! canPerformAction }
+				disabled={ editDisabled }
 			>
 				{ __( 'Edit video details', 'jetpack-videopress-pkg' ) }
 			</Button>
 
-			{ id && <ConnectVideoQuickActions videoId={ id } /> }
+			{ id && isOwned !== false && <ConnectVideoQuickActions videoId={ id } /> }
 		</div>
 	);
 };
@@ -71,6 +77,7 @@ export const VideoCard = ( {
 	processing = false,
 	uploadProgress,
 	onVideoDetailsClick,
+	isOwned = true,
 }: VideoCardProps ) => {
 	const isBlank = ! title && ! duration && ! plays && ! thumbnail && ! loading;
 
@@ -136,6 +143,11 @@ export const VideoCard = ( {
 									{ playsCount }
 								</Text>
 							) }
+							{ isOwned === false && (
+								<Text component="div">
+									{ __( 'Moved to another site', 'jetpack-videopress-pkg' ) }
+								</Text>
+							) }
 						</>
 					) }
 				</div>
@@ -146,6 +158,7 @@ export const VideoCard = ( {
 					<QuickActions
 						id={ id }
 						onVideoDetailsClick={ onVideoDetailsClick }
+						isOwned={ isOwned }
 						className={ clsx( {
 							[ styles[ 'is-blank' ] ]: loading,
 						} ) }
@@ -157,6 +170,7 @@ export const VideoCard = ( {
 				<QuickActions
 					id={ id }
 					onVideoDetailsClick={ onVideoDetailsClick }
+					isOwned={ isOwned }
 					className={ styles.small }
 				/>
 			) }

--- a/projects/packages/videopress/src/client/admin/components/video-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-card/types.ts
@@ -2,7 +2,7 @@ import { VideoPressVideo } from '../../types';
 import { VideoQuickActionsProps } from '../video-quick-actions/types';
 import { VideoThumbnailProps } from '../video-thumbnail/types';
 
-export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' > &
+export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' | 'isOwned' > &
 	VideoThumbnailProps &
 	VideoQuickActionsProps & {
 		/**

--- a/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
@@ -39,6 +39,7 @@ const VideoGrid = ( { videos, count = 6, onVideoDetailsClick, loading }: VideoGr
 									thumbnail={ video?.posterImage } // TODO: we should use thumbnail when the API is ready https://github.com/Automattic/jetpack/issues/26319
 									duration={ video.duration }
 									plays={ video.plays }
+									isOwned={ video?.isOwned }
 									onVideoDetailsClick={ handleClickWithIndex( index, onVideoDetailsClick ) }
 									loading={ loading }
 								/>

--- a/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
@@ -62,6 +62,10 @@ const VideoList = ( {
 				const isPrivate =
 					VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE;
 
+				// A video moved to another blog stays in this local library but can no
+				// longer be edited here: flag it and disable its edit action.
+				const isMoved = video?.isOwned === false;
+
 				return video.error ? (
 					<VideoRowError key={ video?.guid ?? video?.id } id={ video?.id } title={ video?.title } />
 				) : (
@@ -74,8 +78,16 @@ const VideoList = ( {
 						plays={ hidePlays ? null : video.plays }
 						isPrivate={ hidePrivacy ? null : isPrivate }
 						uploadDate={ video.uploadDate }
-						showQuickActions={ ! video?.uploading && showQuickActions }
+						showQuickActions={ ! video?.uploading && showQuickActions && ! isMoved }
 						showActionButton={ ! video?.uploading && showActionButton }
+						disableActionButton={ isMoved }
+						titleAdornment={
+							isMoved ? (
+								<Text variant="body-small" component="span">
+									{ __( 'Moved to another site', 'jetpack-videopress-pkg' ) }
+								</Text>
+							) : null
+						}
 						className={ styles.row }
 						onActionClick={ handleClickWithIndex( index, onVideoDetailsClick ) }
 						loading={ loading }

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -128,6 +128,13 @@ export type OriginalVideoPressVideo = {
 		 * If the site video default privacy setting is private.
 		 */
 		private_enabled_for_site?: boolean;
+		/**
+		 * Whether this site still owns the video on WordPress.com. False when the
+		 * video's canonical owner is a different blog (e.g. it was moved away), in
+		 * which case it remains in this local library but can no longer be edited
+		 * here. Absent means the ownership could not be determined (treated as owned).
+		 */
+		is_owned?: boolean;
 	};
 	/**
 	 * Video source URL
@@ -170,6 +177,12 @@ export type VideoPressVideo = {
 	uploading?: boolean;
 	plays?: number; // Not provided yet
 	error?: string;
+	/**
+	 * Whether this site still owns the video on WordPress.com. Defaults to true
+	 * (owned / unknown); false marks a video that was moved to another blog and is
+	 * therefore read-only here.
+	 */
+	isOwned?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'is_owned' ];
 };
 
 export type LocalVideo = {

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -25,6 +25,11 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		privacy_setting: privacySetting,
 		needs_playback_token: needsPlaybackToken,
 		is_private: isPrivate,
+		// Whether this site still owns the video on WordPress.com. A video that was
+		// moved to another blog stays in this (local) library with stale metadata;
+		// the server marks it not-owned so the UI can flag it as read-only. Absent
+		// means unknown -> treat as owned so nothing is spuriously flagged.
+		is_owned: isOwned = true,
 	} = jetpackVideoPress;
 
 	const {
@@ -75,6 +80,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		thumbnail,
 		finished,
 		filename,
+		isOwned,
 	};
 };
 

--- a/projects/packages/videopress/src/client/state/utils/test/map-videos.test.ts
+++ b/projects/packages/videopress/src/client/state/utils/test/map-videos.test.ts
@@ -1,0 +1,46 @@
+import { mapVideoFromWPV2MediaEndpoint } from '../map-videos';
+import type { OriginalVideoPressVideo } from '../../../admin/types';
+
+/**
+ * Builds a minimal media-endpoint video whose jetpack_videopress field can carry
+ * ( or omit ) the is_owned flag the server sets after confirming ownership.
+ *
+ * @param {object} jetpackVideoPressOverrides - Overrides merged into jetpack_videopress.
+ * @return {OriginalVideoPressVideo} A media-endpoint video shape.
+ */
+const buildVideo = ( jetpackVideoPressOverrides = {} ): OriginalVideoPressVideo =>
+	( {
+		id: 1,
+		jetpack_videopress_guid: 'abcd1234',
+		media_details: { width: 1920, height: 1080, videopress: { original: 'https://x/o.mp4' } },
+		jetpack_videopress: {
+			title: 'T',
+			description: '',
+			caption: '',
+			rating: 'G',
+			allow_download: 0,
+			display_embed: 0,
+			privacy_setting: 2,
+			needs_playback_token: false,
+			is_private: false,
+			...jetpackVideoPressOverrides,
+		},
+	} ) as unknown as OriginalVideoPressVideo;
+
+describe( 'mapVideoFromWPV2MediaEndpoint isOwned mapping', () => {
+	it( 'defaults to owned when the server omits is_owned', () => {
+		expect( mapVideoFromWPV2MediaEndpoint( buildVideo() ).isOwned ).toBe( true );
+	} );
+
+	it( 'is owned when is_owned is true', () => {
+		expect( mapVideoFromWPV2MediaEndpoint( buildVideo( { is_owned: true } ) ).isOwned ).toBe(
+			true
+		);
+	} );
+
+	it( 'is not owned when the server marks the video moved ( is_owned false )', () => {
+		expect( mapVideoFromWPV2MediaEndpoint( buildVideo( { is_owned: false } ) ).isOwned ).toBe(
+			false
+		);
+	} );
+} );

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -313,4 +313,66 @@ class Data_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'videopress_auto_subtitles_disabled', $settings );
 		$this->assertTrue( $settings['videopress_auto_subtitles_disabled'] );
 	}
+
+	/**
+	 * Seeds the per-GUID ownership cache so is_video_owned_by_site() resolves without
+	 * an HTTP round-trip ( the WPCOM lookup only runs on a cache miss ).
+	 *
+	 * @param string $guid       The VideoPress GUID.
+	 * @param int    $owner_blog The cached owner blog id ( 0 = WPCOM denied access ).
+	 */
+	private function seed_owner_cache( $guid, $owner_blog ) {
+		set_transient( Data::OWNERSHIP_CACHE_PREFIX . md5( $guid ), (int) $owner_blog, Data::OWNERSHIP_CACHE_TTL );
+	}
+
+	/**
+	 * An empty GUID is never gated ( there is nothing to own ).
+	 */
+	public function test_is_video_owned_by_site_true_for_empty_guid() {
+		\Jetpack_Options::update_option( 'id', 123 );
+
+		$this->assertTrue( Data::is_video_owned_by_site( '' ) );
+		$this->assertTrue( Data::is_video_owned_by_site( null ) );
+	}
+
+	/**
+	 * When the cached owner is this site's blog id, the video is owned.
+	 */
+	public function test_is_video_owned_by_site_true_when_owner_matches_site() {
+		\Jetpack_Options::update_option( 'id', 123 );
+		$this->seed_owner_cache( 'ownedGUID', 123 );
+
+		$this->assertTrue( Data::is_video_owned_by_site( 'ownedGUID' ) );
+	}
+
+	/**
+	 * When the cached owner is a different blog ( e.g. after a move ), it is not owned.
+	 */
+	public function test_is_video_owned_by_site_false_when_owner_is_another_blog() {
+		\Jetpack_Options::update_option( 'id', 123 );
+		$this->seed_owner_cache( 'movedGUID', 456 );
+
+		$this->assertFalse( Data::is_video_owned_by_site( 'movedGUID' ) );
+	}
+
+	/**
+	 * A cached 0 ( WPCOM denied this blog access — a private video moved away ) is not owned.
+	 */
+	public function test_is_video_owned_by_site_false_when_access_denied() {
+		\Jetpack_Options::update_option( 'id', 123 );
+		$this->seed_owner_cache( 'privateMovedGUID', 0 );
+
+		$this->assertFalse( Data::is_video_owned_by_site( 'privateMovedGUID' ) );
+	}
+
+	/**
+	 * Fails open: with no resolvable site blog id, nothing is hidden even if a
+	 * ( stale ) owner is cached.
+	 */
+	public function test_is_video_owned_by_site_fails_open_without_site_blog_id() {
+		\Jetpack_Options::update_option( 'id', 0 );
+		$this->seed_owner_cache( 'someGUID', 456 );
+
+		$this->assertTrue( Data::is_video_owned_by_site( 'someGUID' ) );
+	}
 }


### PR DESCRIPTION
### What / why

The VideoPress dashboard "video library" is built **entirely from the local media library** — `GET wp/v2/media?mime_type=video/videopress` — so a row exists purely because a local attachment carries the `video/videopress` mime type and a `videopress_guid`.

When a video is **moved to another blog** on WordPress.com (its canonical `videos` record re-pointed to the destination), the source site keeps that local attachment with stale metadata. Result: the moved video **keeps showing in the source library and looks editable**, even though the site no longer owns it. Edits are also rejected server-side once the wpcom ownership check lands (paired wpcom PR — see below), but the dashboard still presented the video as a normal, editable item and surfaced only a generic "Not allowed."

This adds an ownership guard so the dashboard reflects reality.

### Changes

- **`Data::is_video_owned_by_site( $guid )`** confirms the current owner against WPCOM. `Site::get_video_owner_blog_id()` reads the owner `blog_id` from a blog-signed `GET videos/{guid}` and it's compared to this site's blog id.
  - **Fails open**: any transient/unknown WPCOM error returns "owned", so a hiccup never hides a site's own videos.
  - **Cached per GUID** (`OWNERSHIP_CACHE_TTL` = 12h; moves are rare) to keep the lookup off the hot path. A `401/403` for a GUID the site holds locally is treated as "not owned" (e.g. a private video moved away).
- The **`jetpack_videopress` REST field** exposes **`is_owned`** (Jetpack sites only — on WPCOM the `videos` table is already authoritative and a moved-away video resolves to no info).
- **Library grid & list**: a not-owned video is labeled **"Moved to another site"** and its **edit action is disabled** (reuses existing `disabled` / `disableActionButton` — no new visual chrome).
- **Edit-details screen**: shows a clear **Notice** and disables **Save** when the video isn't owned.
- **Edit endpoint** (`videopress_block_update_meta`): translates the WPCOM ownership `401/403` into a clear *"This video has been moved to another site and can no longer be edited here."* instead of the raw "Not allowed."

### Tests

- `tests/php/Data_Test.php`: cached ownership comparison — owner match, another blog, access-denied (`0`), empty guid, and fail-open when the site blog id is unknown.
- `src/client/state/utils/test/map-videos.test.ts`: the `is_owned` → `isOwned` mapping (absent → owned, true, false).
- Full `videopress` PHP suite green (151 tests); `typecheck` + `eslint` clean.

### Not in this PR / notes

- **Paired wpcom change** closes the actual security hole (any Jetpack blog token could edit any Jetpack-owned video by its public GUID via `wpcom/v2/videos`): Automattic/wpcom#227341. This Jetpack PR is the client-side UX guard for the same move scenario.
- The guard **flags** moved videos rather than hard-hiding them: hiding would desync the server's paginated `X-WP-Total` count and silently drop media. Flagging + disabling edit was chosen deliberately.
- Manual QA of the grid/list/edit UI is still recommended (the automated coverage here is the data layer + mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)