### PR TITLE
Newsletter: render the styled Subscribers announcement app instead of the bare fallback

### DIFF
--- a/projects/packages/newsletter/changelog/fix-subscribers-announcement-page
+++ b/projects/packages/newsletter/changelog/fix-subscribers-announcement-page
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Subscribers announcement page: render the styled wp-build app instead of the bare fallback by matching the modernization filter default (true) used by the menu-registration call sites.
+Subscribers: show the styled "Subscribers moved" announcement page instead of the bare fallback.

--- a/projects/packages/newsletter/changelog/fix-subscribers-announcement-page
+++ b/projects/packages/newsletter/changelog/fix-subscribers-announcement-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers announcement page: render the styled wp-build app instead of the bare fallback by matching the modernization filter default (true) used by the menu-registration call sites.

--- a/projects/packages/newsletter/src/class-subscribers-announcement.php
+++ b/projects/packages/newsletter/src/class-subscribers-announcement.php
@@ -95,8 +95,17 @@ class Subscribers_Announcement {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		/** This filter is documented in projects/packages/newsletter/src/class-settings.php */
-		return (bool) apply_filters( Settings::MODERNIZATION_FILTER, false );
+		/**
+		 * This filter is documented in projects/packages/newsletter/src/class-settings.php
+		 *
+		 * The default must match the menu-registration call sites
+		 * (subscriptions.php, wpcom-admin-menu.php) and Settings::is_modernized(),
+		 * which all default to `true`. If this defaults to `false` while the menu
+		 * is registered, maybe_load_wp_build() bails, the wp-build render function
+		 * is never defined, and add_menu() serves the bare render_fallback() page
+		 * instead of the styled announcement app.
+		 */
+		return (bool) apply_filters( Settings::MODERNIZATION_FILTER, true );
 	}
 
 	/**

--- a/projects/packages/newsletter/src/class-subscribers-announcement.php
+++ b/projects/packages/newsletter/src/class-subscribers-announcement.php
@@ -95,16 +95,13 @@ class Subscribers_Announcement {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		/**
-		 * This filter is documented in projects/packages/newsletter/src/class-settings.php
-		 *
-		 * The default must match the menu-registration call sites
-		 * (subscriptions.php, wpcom-admin-menu.php) and Settings::is_modernized(),
-		 * which all default to `true`. If this defaults to `false` while the menu
-		 * is registered, maybe_load_wp_build() bails, the wp-build render function
-		 * is never defined, and add_menu() serves the bare render_fallback() page
-		 * instead of the styled announcement app.
-		 */
+		// The default must match the menu-registration call sites
+		// (subscriptions.php, wpcom-admin-menu.php) and Settings::is_modernized(),
+		// which all default to `true`. If this defaulted to `false` while the menu
+		// is registered, maybe_load_wp_build() would bail, the wp-build render
+		// function would never be defined, and add_menu() would serve the bare
+		// render_fallback() page instead of the styled announcement app.
+		/** This filter is documented in projects/packages/newsletter/src/class-settings.php */
 		return (bool) apply_filters( Settings::MODERNIZATION_FILTER, true );
 	}
 

--- a/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
+++ b/projects/packages/newsletter/tests/php/Subscribers_Announcement_Test.php
@@ -68,13 +68,13 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Confirms is_enabled() defaults to false and follows the modernization filter.
+	 * Confirms is_enabled() defaults to true and follows the modernization filter.
 	 */
 	public function test_is_enabled_follows_modernization_filter() {
-		$this->assertFalse( Subscribers_Announcement::is_enabled() );
-
-		add_filter( Settings::MODERNIZATION_FILTER, '__return_true' );
 		$this->assertTrue( Subscribers_Announcement::is_enabled() );
+
+		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
+		$this->assertFalse( Subscribers_Announcement::is_enabled() );
 	}
 
 	/**
@@ -204,6 +204,7 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	 * Confirms maybe_load_wp_build() does nothing when the feature is disabled.
 	 */
 	public function test_maybe_load_wp_build_noop_when_disabled() {
+		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
 		$_GET['page'] = Subscribers_Announcement::PAGE_SLUG;
 
 		Subscribers_Announcement::maybe_load_wp_build();
@@ -329,7 +330,8 @@ class Subscribers_Announcement_Test extends BaseTestCase {
 	 * Confirms handle_toggle_menu() rejects the request when the feature is disabled.
 	 */
 	public function test_handle_toggle_menu_rejects_when_disabled() {
-		// Feature off (default) — even an admin with a valid nonce is rejected.
+		// Feature explicitly off — even an admin with a valid nonce is rejected.
+		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
 		$this->login_as_admin();
 
 		$_POST['removed']        = '1';


### PR DESCRIPTION
## Proposed changes

The transitional **Jetpack → Subscribers** "Subscribers moved" page rendered as an unstyled bare-bones page (`Subscribers_Announcement::render_fallback()`) instead of the intended wp-build React app, on any site where the Newsletter modernization filter was left at its default.

Root cause: a default-value mismatch on the `rsm_jetpack_ui_modernization_newsletter` filter.

* `Subscribers_Announcement::is_enabled()` defaulted the filter to `false`.
* The menu-registration call sites (`subscriptions.php`, `wpcom-admin-menu.php`) and `Settings::is_modernized()` all default it to `true`.

`is_enabled()` gates `maybe_load_wp_build()`, which defines the generated `..._wp_admin_render_page()` function. So on a default site the Subscribers menu item *was* registered (default `true`) but the wp-build bundle was *never loaded* (default `false`). `function_exists()` then failed and `add_menu()` fell back to the plain `render_fallback()` page.

This flips `is_enabled()`'s default to `true` so it matches the three other sites, and adds a comment documenting why the default must stay aligned.

Note that `is_enabled()` also gates `handle_toggle_menu()` and the click tracking in `handle_go_to_newsletter()`, not just the render path. So this default flip also turns those on for any site that never set the filter. That is intended: the announcement page is meant to be live by default as part of the rollout (the menu-registration sites already default the filter to `true`) — this change just makes the page it points at actually functional.

## Related product discussion/links

* Newsletter modernization / transitional Subscribers announcement page.

## Does this pull request change what data or activity we track or use?

No new data or events. The page already recorded existing Tracks events (`subscribers_announcement_page_view`, `subscribers_announcement_remove_menu_click`, `subscribers_announcement_newsletter_click`); because of the default flip these now fire by default on sites that never set the modernization filter, rather than only when it was explicitly enabled.

## Testing instructions

1. On a site with the Newsletter modernization enabled (default) and Jetpack connected with the Subscriptions module active, go to **Jetpack → Subscribers** (`/wp-admin/admin.php?page=jetpack-subscribers`).
2. Confirm the page renders the styled announcement app: the Jetpack header, the "Subscribers moved" card, a **View my subscribers** button, and a working **Remove Subscribers from the sidebar** toggle — not the bare "Take me to Newsletter" fallback.
3. Toggle **Remove Subscribers from the sidebar** and confirm the sidebar item disappears/reappears and the choice persists across reloads.

Verified live on a Jurassic Ninja site (Jetpack connected, Subscriptions module active).

### Before / After

Captured on a live Jurassic Ninja site at `/wp-admin/admin.php?page=jetpack-subscribers`, 1400×900.

| Before (bare fallback) | After (styled app) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/subscribers-announcement-page/before-subscribers.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/subscribers-announcement-page/after-subscribers.png) |
