### PR TITLE
Premium Analytics: Keep settings drawer above widget chrome in stories

### DIFF
--- a/projects/packages/premium-analytics/changelog/storybook-drawer-stacking
+++ b/projects/packages/premium-analytics/changelog/storybook-drawer-stacking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the widget settings drawer above widget chrome in dashboard Storybook stories.

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -188,6 +188,14 @@ export function WidgetDashboardWithWidget( {
 				 * wp-admin viewport. Without a definite height the page collapses to its
 				 * content height and the fixed-row-height grid resizes it back on every
 				 * vertical widget resize, so the two oscillate and the grid flickers.
+				 *
+				 * `isolation: isolate` keeps dashboard-internal z-indexes (widget
+				 * headers, resize handles) inside this box's stacking context. The
+				 * settings drawer has no z-index of its own (`--wp-ui-drawer-z-index`
+				 * defaults to `initial`), so without the isolation those `z-index: 1`
+				 * elements escalate to the document level and paint over the
+				 * body-portaled drawer — in the real dashboard the wp-admin shell
+				 * provides this containing stacking context.
 				 */ }
 				<div
 					style={ {
@@ -195,6 +203,7 @@ export function WidgetDashboardWithWidget( {
 						display: 'flex',
 						flexDirection: 'column',
 						inlineSize: '100%',
+						isolation: 'isolate',
 						overflowX: 'auto',
 					} }
 				>


### PR DESCRIPTION
Fixes a Storybook-only stacking bug noticed while testing #50328.

## Proposed changes
* Add `isolation: isolate` to the outer box of the shared `WidgetDashboardWithWidget` story helper. The widget settings drawer carries no z-index of its own (`--wp-ui-drawer-z-index` defaults to `initial`, per the `@wordpress/ui` Drawer contract), so dashboard-internal `z-index: 1` elements (widget headers, resize handles) escalated to the document level and painted over the body-portaled drawer. Isolating the helper's stacking context keeps them contained — the same containment the wp-admin shell provides on the real dashboard, which is why the product surface was unaffected.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No. Storybook story helper only; no runtime code is touched.

## Testing instructions
* Run Storybook (`pnpm run storybook:dev` from `projects/js-packages/storybook`).
* Open any `WidgetDashboardWithWidget` story (e.g. `Packages/Premium Analytics/Widgets/Locations` or `TopPlatforms`).
* Click the widget's settings (⋯) trigger: the settings drawer should slide in above the widget, not behind its header.
* Confirm the wide-dashboard behavior still works: set a `dashboardWidth` wider than the preview and check the canvas scrolls horizontally while the drawer stays anchored to the viewport edge.
