### PR TITLE
Premium Analytics: stage build zip via jetpack rsync from the working tree

### DIFF
--- a/projects/plugins/premium-analytics/README.md
+++ b/projects/plugins/premium-analytics/README.md
@@ -11,25 +11,33 @@ jetpack watch plugins/premium-analytics
 
 ## Installable zip
 
-Use the local build script to create a WordPress-installable plugin zip that
-combines this plugin bootstrap with the mirrored Premium Analytics package:
+Use the local build script to create a WordPress-installable plugin zip from the
+**current monorepo working tree**:
 
 ```bash
 composer build-zip
 ```
 
-By default, the script clones `trunk` from
-`https://github.com/Automattic/jetpack-premium-analytics.git` and writes the zip
-to `jetpack-premium-analytics.zip` in this plugin directory.
+The script:
 
-Useful options:
+1. Builds the plugin for production in place (`jetpack build plugins/premium-analytics --production`),
+   which installs the production autoloader and compiles the bundled
+   Premium Analytics package.
+2. Stages the production file set with the same file-collection `jetpack rsync`
+   uses — filtered by `.gitattributes`, following the `jetpack_vendor/*` package
+   symlinks — so dev-only source, configs, and dev dependencies are left out.
+3. Writes `jetpack-premium-analytics.zip` to this plugin directory.
 
-```bash
-composer build-zip -- --package-ref <branch|tag|sha>
-composer build-zip -- --package-path /path/to/jetpack-premium-analytics
-```
+Because it builds from the working tree, any in-progress local edits to the
+plugin or the bundled package are reflected in the zip.
 
-The package source must already contain the `build/build.php` output generated
-by `wp-build`. The package mirror is expected to contain this output. A local
-monorepo package checkout usually needs to be built before it can be used with
-`--package-path`.
+### Requirements
+
+- A set-up monorepo dev environment (run `pnpm install` at the repo root first).
+- Standard `rsync`. macOS ships openrsync, which cannot sync the package
+  symlinks and would silently produce an empty archive; install real rsync with
+  `brew install rsync`. The script fails fast if it detects openrsync.
+
+> **Note:** The build performs a production install (`composer install --no-dev`)
+> in your working tree. Re-run `jetpack build plugins/premium-analytics`
+> afterwards to restore your dev dependencies.

--- a/projects/plugins/premium-analytics/bin/build-zip.sh
+++ b/projects/plugins/premium-analytics/bin/build-zip.sh
@@ -113,6 +113,12 @@ log "Staging production files via jetpack rsync..."
 mkdir -p "$PLUGIN_STAGE"
 jetpack rsync premium-analytics "$PLUGIN_STAGE/" --non-interactive
 
+# rsync can exit 0 while copying nothing (e.g. an unsupported rsync fork or a
+# filter mishap), and `zip` happily archives an empty directory. Verify the
+# stage contains the plugin bootstrap and the bundled packages before zipping.
+[[ -f "$PLUGIN_STAGE/jetpack-premium-analytics.php" ]] || error "Staged tree at $PLUGIN_STAGE is missing jetpack-premium-analytics.php; refusing to zip an incomplete stage."
+[[ -d "$PLUGIN_STAGE/jetpack_vendor" ]] || error "Staged tree at $PLUGIN_STAGE is missing jetpack_vendor/; refusing to zip an incomplete stage."
+
 log "Creating zip..."
 mkdir -p "$(dirname "$OUTPUT_PATH")"
 rm -f "$OUTPUT_PATH"

--- a/projects/plugins/premium-analytics/bin/build-zip.sh
+++ b/projects/plugins/premium-analytics/bin/build-zip.sh
@@ -3,9 +3,7 @@
 set -euo pipefail
 
 PLUGIN_SLUG="jetpack-premium-analytics"
-PACKAGE_REPO_URL="${PACKAGE_REPO_URL:-https://github.com/Automattic/jetpack-premium-analytics.git}"
-PACKAGE_REF="trunk"
-PACKAGE_PATH=""
+PROJECT="plugins/premium-analytics"
 
 SCRIPT_DIR="$(
 	cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -15,23 +13,38 @@ PLUGIN_DIR="$(
 	cd "$SCRIPT_DIR/.."
 	pwd -P
 )"
+# projects/plugins/premium-analytics -> monorepo root is three levels up.
+MONOREPO_ROOT="$(
+	cd "$PLUGIN_DIR/../../.."
+	pwd -P
+)"
+JETPACK_CLI="$MONOREPO_ROOT/tools/cli/bin/jetpack.js"
 OUTPUT_PATH="$PLUGIN_DIR/${PLUGIN_SLUG}.zip"
 
 usage() {
 	cat <<EOF
 Build an installable Jetpack Premium Analytics plugin zip.
 
+The zip is built from the current monorepo working tree: the plugin is compiled
+for production in place and staged with the same file-collection that
+\`jetpack rsync\` uses, so the archive contains exactly the production file set
+(plugin PHP, the bundled package build output, and the production autoloader).
+
 Usage:
-  composer build-zip -- [options]
+  composer build-zip
   bin/build-zip.sh [options]
 
 Options:
-  --package-ref <ref>      Branch, tag, or SHA to fetch from the package mirror. Default: trunk
-  --package-path <path>    Use a local Premium Analytics package checkout instead of cloning.
   -h, --help               Show this help text.
 
-Environment:
-  PACKAGE_REPO_URL         Override the package mirror URL. Default: ${PACKAGE_REPO_URL}
+Requirements:
+  - A monorepo dev environment (run \`pnpm install\` at the repo root first).
+  - Standard rsync. macOS ships openrsync, which cannot sync the package
+    symlinks; install real rsync with \`brew install rsync\`.
+
+Note: this performs a production build (\`composer install --no-dev\`) in your
+working tree. Re-run \`jetpack build $PROJECT\` afterwards to restore dev
+dependencies.
 EOF
 }
 
@@ -50,125 +63,23 @@ require_command() {
 	fi
 }
 
-absolute_dir() {
-	local path="$1"
+require_rsync() {
+	require_command rsync
 
-	if [[ ! -d "$path" ]]; then
-		error "Directory does not exist: $path"
+	# Apple ships a fork of openrsync that cannot properly sync the package
+	# symlinks; it silently copies nothing. Match the guidance from
+	# tools/cli/commands/rsync.js and fail fast.
+	if [[ "$(uname)" == "Darwin" ]] && rsync --version 2>/dev/null | grep -q openrsync; then
+		error "macOS's built-in rsync (openrsync) cannot sync the package symlinks. Please install standard rsync (e.g. \`brew install rsync\`)."
 	fi
-
-	(
-		cd "$path"
-		pwd -P
-	)
 }
 
-fetch_package_source() {
-	local source_dir="$1"
-
-	log "Cloning ${PACKAGE_REPO_URL} at ${PACKAGE_REF}..."
-
-	if git clone --no-tags --depth=1 --branch "$PACKAGE_REF" "$PACKAGE_REPO_URL" "$source_dir"; then
-		return
-	fi
-
-	rm -rf "$source_dir"
-
-	log "Fetching ${PACKAGE_REF} directly..."
-	git clone --no-tags --depth=1 "$PACKAGE_REPO_URL" "$source_dir"
-	git -C "$source_dir" fetch --depth=1 origin "$PACKAGE_REF"
-	git -C "$source_dir" checkout --detach FETCH_HEAD
-}
-
-validate_package_source() {
-	local package_source="$1"
-
-	[[ -f "$package_source/composer.json" ]] || error "No composer.json found in package source: $package_source"
-	[[ -f "$package_source/build/build.php" ]] || error "No build/build.php found in package source: $package_source. Use the package mirror, or build the package before using --package-path."
-}
-
-write_staged_composer_json() {
-	local composer_json="$1"
-	local package_source="$2"
-
-	php -r '
-		$composer_file = $argv[1];
-		$package_source = $argv[2];
-		$data = json_decode( file_get_contents( $composer_file ), true );
-
-		if ( ! is_array( $data ) ) {
-			fwrite( STDERR, "Unable to decode staged composer.json.\n" );
-			exit( 1 );
-		}
-
-		unset( $data["require-dev"] );
-
-		if ( isset( $data["scripts"] ) && is_array( $data["scripts"] ) ) {
-			unset( $data["scripts"]["phpunit"], $data["scripts"]["test-php"], $data["scripts"]["test-php-coverage"] );
-			if ( array() === $data["scripts"] ) {
-				unset( $data["scripts"] );
-			}
-		}
-
-		if ( ! isset( $data["extra"] ) || ! is_array( $data["extra"] ) ) {
-			$data["extra"] = array();
-		}
-		$data["extra"]["wp-plugin-slug"] = "jetpack-premium-analytics";
-
-		$plugin_file = dirname( $composer_file ) . "/jetpack-premium-analytics.php";
-		if ( is_readable( $plugin_file ) && preg_match( "/^\\s*\\*\\s*Version:\\s*([^\\r\\n]+)/m", file_get_contents( $plugin_file ), $matches ) ) {
-			$data["version"] = trim( $matches[1] );
-		}
-
-		$data["repositories"] = array(
-			array(
-				"type" => "path",
-				"url" => $package_source,
-				"options" => array(
-					"symlink" => false,
-				),
-			),
-		);
-
-		file_put_contents(
-			$composer_file,
-			json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n"
-		);
-	' "$composer_json" "$package_source"
-}
-
-prune_development_artifacts() {
-	local plugin_stage="$1"
-
-	find "$plugin_stage" \
-		\( -type d \( -name .git -o -name node_modules -o -name .cache -o -name .idea -o -name tests -o -name test -o -name changelog \) -prune \) \
-		-exec rm -rf {} +
-
-	find "$plugin_stage" \
-		\( -name '.DS_Store' -o -name 'phpunit*.xml.dist' -o -name 'phpunit.xml' \) \
-		-delete
+jetpack() {
+	node "$JETPACK_CLI" "$@"
 }
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--package-ref)
-			[[ $# -ge 2 ]] || error "--package-ref requires a value"
-			PACKAGE_REF="$2"
-			shift 2
-			;;
-		--package-ref=*)
-			PACKAGE_REF="${1#*=}"
-			shift
-			;;
-		--package-path)
-			[[ $# -ge 2 ]] || error "--package-path requires a value"
-			PACKAGE_PATH="$2"
-			shift 2
-			;;
-		--package-path=*)
-			PACKAGE_PATH="${1#*=}"
-			shift
-			;;
 		-h|--help)
 			usage
 			exit 0
@@ -179,16 +90,13 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-require_command composer
-require_command php
+require_command node
 require_command zip
+require_rsync
 
-if [[ -z "$PACKAGE_PATH" ]]; then
-	require_command git
-fi
+[[ -f "$JETPACK_CLI" ]] || error "Jetpack CLI not found at $JETPACK_CLI. Run this from a monorepo checkout."
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PLUGIN_SLUG}-zip.XXXXXX")"
-PACKAGE_SOURCE="$WORK_DIR/package-source"
 PLUGIN_STAGE="$WORK_DIR/$PLUGIN_SLUG"
 
 cleanup() {
@@ -196,32 +104,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [[ -n "$PACKAGE_PATH" ]]; then
-	PACKAGE_SOURCE="$(absolute_dir "$PACKAGE_PATH")"
-else
-	fetch_package_source "$PACKAGE_SOURCE"
-fi
+log "Building production assets for $PROJECT..."
+# --deps also builds the bundled packages (premium-analytics, cookie-consent) so
+# their production `build/` output exists for the symlinks that rsync follows.
+jetpack build "$PROJECT" --production --deps
 
-validate_package_source "$PACKAGE_SOURCE"
-
-log "Staging plugin files..."
-mkdir -p "$PLUGIN_STAGE/src"
-cp "$PLUGIN_DIR/jetpack-premium-analytics.php" "$PLUGIN_STAGE/"
-cp "$PLUGIN_DIR/composer.json" "$PLUGIN_STAGE/"
-cp "$PLUGIN_DIR/readme.txt" "$PLUGIN_STAGE/"
-cp "$PLUGIN_DIR/README.md" "$PLUGIN_STAGE/"
-cp "$PLUGIN_DIR/src/class-jetpack-premium-analytics.php" "$PLUGIN_STAGE/src/"
-
-write_staged_composer_json "$PLUGIN_STAGE/composer.json" "$PACKAGE_SOURCE"
-
-log "Installing production dependencies..."
-(
-	cd "$PLUGIN_STAGE"
-	composer install --no-dev --no-interaction --optimize-autoloader
-)
-
-log "Pruning development artifacts..."
-prune_development_artifacts "$PLUGIN_STAGE"
+log "Staging production files via jetpack rsync..."
+mkdir -p "$PLUGIN_STAGE"
+jetpack rsync premium-analytics "$PLUGIN_STAGE/" --non-interactive
 
 log "Creating zip..."
 mkdir -p "$(dirname "$OUTPUT_PATH")"

--- a/projects/plugins/premium-analytics/changelog/update-build-zip-rsync-staging
+++ b/projects/plugins/premium-analytics/changelog/update-build-zip-rsync-staging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stage the plugin zip from the working tree via jetpack rsync file-collection instead of a composer path-repo rewrite, dropping bundled dev files and the package mirror-clone modes.


### PR DESCRIPTION
## Follow-up to #50316

Addresses @Nikschavan's two non-blocking review comments on `projects/plugins/premium-analytics/bin/build-zip.sh`.

### What changed

Replaces the composer path-repo rewrite + prune machinery — and drops the package mirror-clone (`--package-ref`) and `--package-path` modes — with a build straight from the **monorepo working tree**:

1. `jetpack build plugins/premium-analytics --production --deps` builds the plugin and its bundled packages for production in place → production `--no-dev` classmap-authoritative autoloader + compiled `build/` output.
2. `jetpack rsync premium-analytics <stage>/ --non-interactive` stages the exact production file set, filtered by `.gitattributes` and following the `jetpack_vendor/*` package symlinks. Dev source (`.ts`, `tsconfig.json`, `eslint.config.mjs`), dev deps, and `.phpunit.cache/` never get copied.
3. Zip the stage.

### Nikhil's comments

- **rsync-based collection** (comment 1): adopted directly — this is the whole change.
- **`.phpunit.cache/` prune** (comment 2): handled for free. With mirror mode gone, `prune_development_artifacts()` is deleted entirely and rsync's `.gitattributes` filter already excludes `.phpunit.cache/` (it isn't `production-include`), so there's no standalone prune to add.

### Trade-off

The rsync path needs standard `rsync`. macOS ships openrsync (can't sync the symlinks); the script detects it and fails fast with `brew install rsync` guidance, matching `tools/cli/commands/rsync.js`. Also documented: the production build happens in-tree, so re-run `jetpack build plugins/premium-analytics` afterwards to restore dev deps.

### Verification

- ✅ `composer build-zip` exits 0 → **868 files / 4.0M** zip (was 6,180 files / 9.6M).
- ✅ No dev source/configs, no `.phpunit.cache/`, no dev vendor deps (`phpunit`, `yoast`, …).
- ✅ Production autoloader: `--no-dev` classmap-authoritative, 200 classes incl. the plugin bootstrap + bundled package + cookie-consent, no test classes.
- ✅ In-progress working-tree edits propagate into the zip.
- ✅ macOS openrsync guard fails fast before doing any work.

---

## Testing instructions

Prerequisites: a set-up monorepo (`pnpm install` at the repo root) and standard `rsync` on your `PATH`. On macOS, install it with `brew install rsync` — the built-in openrsync can't sync the package symlinks.

**1. Build the zip**

```bash
cd projects/plugins/premium-analytics
composer build-zip
```

Expect exit 0 and a final `Zip created: …/jetpack-premium-analytics.zip` line. (The first `jetpack build … --deps` step takes a minute or two.)

**2. Sanity-check the contents**

```bash
unzip -l jetpack-premium-analytics.zip | tail -1          # ~868 files, ~4M (was 6,180 / 9.6M)
# Should be EMPTY (no dev source, configs, or test cache):
unzip -l jetpack-premium-analytics.zip | grep -iE '\.tsx?$|tsconfig|eslint|\.phpunit\.cache|/tests/'
# Should be EMPTY (no dev vendor deps):
unzip -l jetpack-premium-analytics.zip | grep -E 'vendor/(phpunit|yoast|sebastian|nikic|myclabs)/'
# Should be PRESENT (production autoloader + compiled package assets):
unzip -l jetpack-premium-analytics.zip | grep -E 'vendor/composer/jetpack_autoload_classmap.php|jetpack-premium-analytics/build/scripts.php'
```

**3. Install and smoke-test on WordPress**

Upload `jetpack-premium-analytics.zip` via *Plugins → Add New → Upload Plugin* (or drop it into `wp-content/plugins/`), activate it, and open the Premium Analytics dashboard. Confirm it loads with no PHP fatals / missing-class errors — this verifies the production `--no-dev` autoloader shipped correctly.

**4. In-progress edits propagate (optional)**

Make a visible local edit in `projects/packages/premium-analytics` (e.g. a widget title), re-run `composer build-zip`, and confirm the change is present in the rebuilt zip — the build reads the working tree, so uncommitted work is included.

**5. macOS openrsync guard (optional)**

On a Mac without real rsync (or with openrsync first on `PATH`), `composer build-zip` should fail fast with `install standard rsync (e.g. brew install rsync)` before doing any work, rather than silently producing an empty archive.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
