### PR TITLE
Stats: show self-hosted site menu link in WP Admin

### DIFF
--- a/projects/plugins/jetpack/changelog/update-self-hosted-stats-admin-bar-link
+++ b/projects/plugins/jetpack/changelog/update-self-hosted-stats-admin-bar-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats: Show the site menu Stats link in WP Admin.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -65,7 +65,7 @@ function stats_load() {
 	Admin_Post_List_Column::register();
 
 	add_action( 'jetpack_admin_menu', 'stats_admin_menu' );
-	add_action( 'wp_before_admin_bar_render', 'stats_add_link_to_admin_bar_site_menu' );
+	add_action( 'admin_bar_menu', 'stats_add_link_to_admin_bar_site_menu', 40 );
 
 	add_filter( 'pre_option_db_version', 'stats_ignore_db_version' );
 
@@ -826,24 +826,29 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 }
 
 /**
- * Adds a Stats link to the site-name admin bar submenu, alongside Dashboard.
+ * Adds a Stats link to the site-name admin bar submenu.
  *
  * @access public
+ * @param WP_Admin_Bar|null $admin_bar WP_Admin_Bar instance.
  * @return void
  */
-function stats_add_link_to_admin_bar_site_menu() {
+function stats_add_link_to_admin_bar_site_menu( $admin_bar = null ) {
 	global $wp_admin_bar;
 
+	if ( null === $admin_bar ) {
+		$admin_bar = $wp_admin_bar;
+	}
+
 	if (
-		! is_object( $wp_admin_bar ) ||
-		! $wp_admin_bar->get_node( 'dashboard' ) ||
+		! is_object( $admin_bar ) ||
+		( ! $admin_bar->get_node( 'dashboard' ) && ! $admin_bar->get_node( 'view-site' ) ) ||
 		! current_user_can( 'view_stats' ) ||
 		( new Host() )->is_wpcom_platform()
 	) {
 		return;
 	}
 
-	$wp_admin_bar->add_node(
+	$admin_bar->add_node(
 		array(
 			'parent' => 'site-name',
 			'id'     => 'jetpack-stats',

--- a/projects/plugins/jetpack/tests/php/modules/stats/Stats_Admin_Bar_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/stats/Stats_Admin_Bar_Test.php
@@ -30,7 +30,7 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 		);
 		wp_set_current_user( $user_id );
 
-		add_action( 'wp_before_admin_bar_render', 'stats_add_link_to_admin_bar_site_menu' );
+		add_action( 'admin_bar_menu', 'stats_add_link_to_admin_bar_site_menu', 40 );
 	}
 
 	/**
@@ -38,9 +38,9 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		self::reset_admin_bar_global();
-		remove_action( 'wp_before_admin_bar_render', 'stats_add_link_to_admin_bar_site_menu' );
+		remove_action( 'admin_bar_menu', 'stats_add_link_to_admin_bar_site_menu', 40 );
 		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
-		remove_role( 'jetpack_no_stats' );
+		remove_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
 		Constants::clear_constants();
 		Status_Cache::clear();
 		wp_set_current_user( 0 );
@@ -60,13 +60,37 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the Stats link is added when the user can view Stats.
+	 * Forces current_user_can( 'view_stats' ) to false for the test.
+	 *
+	 * @param array $allcaps All capabilities of the user.
+	 * @return array
 	 */
-	public function test_stats_link_shown_when_user_can_view_stats() {
-		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
-		$admin_bar = self::make_test_admin_bar_with_dashboard();
+	public function deny_view_stats( $allcaps ) {
+		$allcaps['view_stats'] = false;
+		return $allcaps;
+	}
 
-		do_action( 'wp_before_admin_bar_render' );
+	/**
+	 * Tests that the Stats link is added when core's Dashboard node is present.
+	 */
+	public function test_stats_link_shown_when_dashboard_node_present() {
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard' );
+
+		$stats_node = $admin_bar->get_node( 'jetpack-stats' );
+
+		$this->assertNotNull( $stats_node );
+		$this->assertSame( 'site-name', $stats_node->parent );
+		$this->assertSame( 'Stats', $stats_node->title );
+		$this->assertSame( admin_url( 'admin.php?page=stats' ), $stats_node->href );
+	}
+
+	/**
+	 * Tests that the Stats link is added when core's View Site node is present.
+	 */
+	public function test_stats_link_shown_when_view_site_node_present() {
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'view-site' );
 
 		$stats_node = $admin_bar->get_node( 'jetpack-stats' );
 
@@ -80,32 +104,22 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 	 * Tests that the Stats link is hidden when the user cannot view Stats.
 	 */
 	public function test_stats_link_hidden_when_user_cannot_view_stats() {
-		add_role( 'jetpack_no_stats', 'No Stats', array( 'read' => true ) );
-		$user_id = self::factory()->user->create(
-			array(
-				'role' => 'jetpack_no_stats',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		$admin_bar = self::make_test_admin_bar_with_dashboard();
-
-		do_action( 'wp_before_admin_bar_render' );
+		add_filter( 'user_has_cap', array( $this, 'deny_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard' );
 
 		$stats_node = $admin_bar->get_node( 'jetpack-stats' );
 
-		$this->assertFalse( current_user_can( 'view_stats' ) );
 		$this->assertNull( $stats_node );
 	}
 
 	/**
-	 * Tests that the Stats link is hidden when core's Dashboard node is absent.
+	 * Tests that the Stats link is hidden when core's Dashboard and View Site nodes are absent.
 	 */
-	public function test_stats_link_hidden_when_dashboard_node_absent() {
+	public function test_stats_link_hidden_when_dashboard_and_view_site_nodes_absent() {
 		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
 		$admin_bar = self::make_test_admin_bar();
 
-		do_action( 'wp_before_admin_bar_render' );
+		do_action( 'admin_bar_menu', $admin_bar );
 
 		$stats_node = $admin_bar->get_node( 'jetpack-stats' );
 
@@ -118,9 +132,7 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 	public function test_stats_link_hidden_on_wpcom_platform() {
 		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
 		Constants::set_constant( 'IS_WPCOM', true );
-		$admin_bar = self::make_test_admin_bar_with_dashboard();
-
-		do_action( 'wp_before_admin_bar_render' );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard' );
 
 		$stats_node = $admin_bar->get_node( 'jetpack-stats' );
 
@@ -148,20 +160,23 @@ class Stats_Admin_Bar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Builds a test admin bar with core's site-name and dashboard nodes.
+	 * Builds a test admin bar with core's site-name node and a child node.
 	 *
+	 * @param string $site_name_child Child node ID.
 	 * @return WP_Admin_Bar
 	 */
-	private static function make_test_admin_bar_with_dashboard() {
+	private static function make_test_admin_bar_with_site_name( $site_name_child ) {
 		$admin_bar = self::make_test_admin_bar();
 		$admin_bar->add_node(
 			array(
 				'parent' => 'site-name',
-				'id'     => 'dashboard',
-				'title'  => 'Dashboard',
+				'id'     => $site_name_child,
+				'title'  => ucfirst( $site_name_child ),
 				'href'   => admin_url(),
 			)
 		);
+
+		do_action( 'admin_bar_menu', $admin_bar );
 
 		return $admin_bar;
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Move the self-hosted Jetpack Stats site-name admin bar link to the `admin_bar_menu` hook.
* Show the link when core adds either `dashboard` on the front end or `view-site` in WP Admin.
* Keep the existing `view_stats` capability and WordPress.com platform guards.
* Add PHPUnit coverage for the Dashboard and View Site admin bar node cases.

## Related product discussion/links
* Follow-up to https://github.com/Automattic/jetpack/pull/50345 for the self-hosted Jetpack path.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a self-hosted Jetpack site with Stats enabled, log in as a user who can view Stats.
* On the front end, open the admin bar site-name menu and confirm the Stats link appears alongside Dashboard.
* In WP Admin, open the admin bar site-name menu and confirm the Stats link appears alongside Visit Site.
* Confirm the Stats link points to `wp-admin/admin.php?page=stats`.
* Confirm the link is hidden for a user without the `view_stats` capability.

Automated checks run locally:
* `php -l projects/plugins/jetpack/modules/stats.php`
* `php -l projects/plugins/jetpack/tests/php/modules/stats/Stats_Admin_Bar_Test.php`
* `git diff --check`

Not run locally:
* `jp docker phpunit jetpack -- --filter=Stats_Admin_Bar_Test` because `jp` is not installed in this shell.
* `pnpm jetpack docker phpunit jetpack -- --filter=Stats_Admin_Bar_Test` because the Codex-provided `pnpm` uses Node 24.14.0 while the repo requires `^24.15.0`, and this fresh worktree does not have its own `node_modules`.
