### PR TITLE
Premium Analytics: Storybook stats mocks fall through on unknown endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-storybook-stats-mock-fallthrough
+++ b/projects/packages/premium-analytics/changelog/fix-storybook-stats-mock-fallthrough
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Storybook: let the two stats mock middlewares fall through on unknown endpoints instead of swallowing them.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1034,7 +1034,15 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 	if ( requestPath.startsWith( STATS_API_BASE ) ) {
 		const subPath = requestPath.slice( STATS_API_BASE.length ).split( '?' )[ 0 ];
 		const response = routeStatsReport( subPath );
-		return response !== null ? response : { data: [], summary: {} };
+
+		if ( response !== null ) {
+			return response;
+		}
+
+		// Stats endpoints this middleware doesn't route may be owned by the
+		// legacy stats mocks (register-stats-mocks.ts). Fall through so
+		// middleware registration order doesn't decide whether they load.
+		return next( options );
 	}
 
 	if ( ! requestPath.startsWith( API_BASE ) ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1035,7 +1035,13 @@ const statsMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOption
 		return prepareStatsMockResponse( mock, options.parse );
 	}
 
-	return prepareStatsMockResponse( { data: [], summary: {} }, options.parse );
+	// Stats endpoints this middleware doesn't know may be owned by the shared
+	// report mocks (register-report-mocks.ts), including its forced-state
+	// overrides. Fall through instead of answering with an empty catch-all:
+	// story-module load order decides which mock middleware runs first, so
+	// swallowing unknown endpoints here starves the other middleware whenever
+	// this one registers later.
+	return next( options );
 };
 
 let registered = false;


### PR DESCRIPTION
Fixes WOOA7S-1674

## Proposed changes

Storybook's Stats widgets are mocked by two independent `apiFetch` middlewares in `packages/widgets-toolkit/src/stories/mocks/`, with disjoint endpoint coverage:

- `register-report-mocks.ts` (the one `AGENTS.md` prescribes, with `setReportMockState` forced-state overrides) — video-plays, search-terms, top-authors, visits, subscribers, …
- `register-stats-mocks.ts` (used by the referrers / clicks / devices / locations / utm-insights / file-downloads / top-platforms stories) — clicks, referrers, file-downloads, location-views, utm, devices.

Both answered stats endpoints they **didn't** know with an empty `{ data: [], summary: {} }` catch-all instead of calling `next()`. Since `apiFetch.use()` runs the most recently registered middleware first, and Storybook's vite builder streams every story module (each registering its mock at module scope) in the background after first render, **story-module load order decided which middleware answered** — and the loser's endpoints silently resolved to "success with no rows":

- Switching between stories of a report-mocks widget (e.g. Search Terms or the VideoPress port in #50311) after the legacy middleware registered made every request resolve empty: `Loading` / `Error` stories rendered the empty state (the never-resolve / reject overrides were never consulted), and non-default date presets showed no rows.
- A full page reload looked correct only because the current story's request won the race before the background registrations landed.

This PR makes both middlewares **fall through (`next( options )`) on stats endpoints they don't route**, so whichever registered later hands unknown endpoints to the one that owns them, and registration order no longer matters. Endpoints known to neither now surface a visible error state instead of a silent empty — consistent with the `AGENTS.md` guidance that every new Stats endpoint must be added to the mocks.

Story-only infrastructure; no shipped code changes.

## Related product discussion/links

* WOOA7S-1674
* Found while adding forced-state stories in #50311 (WOOA7S-1519)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `cd projects/js-packages/storybook && pnpm run storybook:dev`
2. Open **Packages / Premium Analytics / Widgets / SearchTerms → Default** and wait a few seconds (so the other story modules finish loading in the background).
3. Without reloading, switch between `Default`, `Empty`, `Loading`, `Error`, and `WithComparison` in the sidebar:
   - Before this fix, `Loading`/`Error` rendered the empty state and preset stories showed no rows.
   - With the fix, every story renders its own state (spinner, error + Retry, empty, populated rows).
4. Cross-check the legacy-mock widgets in the same session (e.g. **Referrers → Default**, **Clicks → Default**) — they still render their mock rows.



https://github.com/user-attachments/assets/c4842524-da84-4b44-ac09-96f6670c4235

