### PR TITLE
wpcomsh: table-driven PHP 8.3 duplicate-static patchers for plugins and themes

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-17392-php83-plugin-patches
+++ b/projects/plugins/wpcomsh/changelog/dotcom-17392-php83-plugin-patches
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-CLI: generalize `wpcomsh php83-plugin-patch` into a table-driven patcher for PHP 8.3+ duplicate-static-variable fatals; support the dash-slug mega-main-menu folder and add ninja-forms and wiziapp patches.
+CLI: generalize `wpcomsh php83-plugin-patch` into a table-driven patcher for PHP 8.3+ duplicate-static-variable fatals and add a `php83-theme-patch` counterpart. Covers the dash-slug mega-main-menu folder, ninja-forms, wiziapp, thegem-blocks, deepcore, malina-elements, sfwd-lms, cp-addons-for-vc and ingeniofy plugins, plus the SecondLine (tusant/gumbo/dixie/satchmo/bolden) and Select-Themes (hazel/hazel1/alma/maple/rhythm/architek) theme families.

--- a/projects/plugins/wpcomsh/changelog/dotcom-17392-php83-plugin-patches
+++ b/projects/plugins/wpcomsh/changelog/dotcom-17392-php83-plugin-patches
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+CLI: generalize `wpcomsh php83-plugin-patch` into a table-driven patcher for PHP 8.3+ duplicate-static-variable fatals; support the dash-slug mega-main-menu folder and add ninja-forms and wiziapp patches.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1194,7 +1194,8 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 			// Resolve which of the plugin's known folder slugs is installed.
 			$plugin_file = null;
-			foreach ( get_plugins() as $file => $data ) {
+			foreach ( array_keys( get_plugins() ) as $file ) {
+				$file = (string) $file;
 				if ( in_array( dirname( $file ), $patch['folders'], true ) ) {
 					$plugin_file = $file;
 					break;
@@ -1216,7 +1217,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				WP_CLI::error( "An update to $slug $new_version is available; update the plugin instead of patching." );
 			}
 
-			$file = WP_PLUGIN_DIR . '/' . dirname( $plugin_file ) . '/' . $patch['file'];
+			$file = WP_PLUGIN_DIR . '/' . dirname( (string) $plugin_file ) . '/' . $patch['file'];
 
 			$this->apply_php83_patch( $file, $patch );
 		}

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -922,15 +922,114 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		}
 
 		/**
-		 * Patch mega_main_menu plugin to work with PHP 8.3+.
+		 * Patch definitions for the php83-plugin-patch subcommand.
 		 *
-		 * The `mm_options_generator()` function declares `static $theme_option_file`
-		 * in both the `file` and `background_image` cases of the same switch. PHP 8.3
-		 * turned a repeated `static` declaration of the same variable in one function
-		 * scope into a "Duplicate declaration of static variable" fatal error. This
-		 * renames the copy in the `background_image` case so only a single declaration
-		 * of `$theme_option_file` remains. Both cases merely enqueue the media uploader
-		 * scripts, and `wp_enqueue_*` is idempotent, so behavior is unchanged.
+		 * PHP 8.3 turned a repeated `static` declaration of the same variable in one
+		 * function scope into a "Duplicate declaration of static variable" fatal
+		 * error, which old plugin versions trip over. Each entry describes a minimal,
+		 * behavior-preserving rename of the duplicate declaration (DOTCOM-17392).
+		 *
+		 * Shared keys:
+		 * - folders:        plugin directory names to look for (vendors ship the same
+		 *                   product under different folder slugs).
+		 * - file:           the file to patch, relative to the plugin directory.
+		 * - patched_marker: string that only exists after patching; makes re-runs a
+		 *                   safe no-op.
+		 * - strategy:       'split_rename' renames every occurrence of `search` after
+		 *                   `split_marker`; 'replace_once' applies exact search/replace
+		 *                   pairs that must each match exactly once.
+		 *
+		 * @return array<string,array> Patch definitions keyed by plugin slug.
+		 */
+		private static function php83_plugin_patches() {
+			return array(
+
+				/*
+				 * The `mm_options_generator()` function declares `static $theme_option_file`
+				 * in both the `file` and `background_image` cases of the same switch. This
+				 * renames the copy in the `background_image` case so only a single
+				 * declaration of `$theme_option_file` remains. Both cases merely enqueue
+				 * the media uploader scripts, and `wp_enqueue_*` is idempotent, so behavior
+				 * is unchanged. The same product ships as both `mega_main_menu` and
+				 * `mega-main-menu`.
+				 */
+				'mega_main_menu' => array(
+					'folders'        => array( 'mega_main_menu', 'mega-main-menu' ),
+					'file'           => 'framework/options_generator.php',
+					'patched_marker' => '$theme_option_file_background',
+					'strategy'       => 'split_rename',
+					'split_marker'   => "case 'background_image':",
+					'search'         => '$theme_option_file',
+					'replace'        => '$theme_option_file_background',
+				),
+
+				/*
+				 * `custom_columns()` in includes/Admin/CPT/Submission.php declares
+				 * `static $fields` in both the fieldset-repeater branch and the
+				 * numeric-column branch of the same function (unchanged 3.6.14–3.6.28).
+				 * Both are per-column memo caches keyed by `$column`; renaming the
+				 * numeric-branch copy just splits the cache in two, so behavior is
+				 * unchanged.
+				 */
+				'ninja-forms'    => array(
+					'folders'        => array( 'ninja-forms' ),
+					'file'           => 'includes/Admin/CPT/Submission.php',
+					'patched_marker' => '$fields_by_column',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"            static \$fields;\n"
+							. "            if( ! isset( \$fields[ \$column ] ) ) {\n"
+							. "                \$fields[\$column] = Ninja_Forms()->form( \$form_id )->get_field( \$column );\n"
+							. "            }\n"
+							. '            $field = $fields[$column];',
+							"            // Renamed by wpcomsh to avoid a PHP 8.3+ \"Duplicate declaration of\n"
+							. "            // static variable\" fatal: the repeater branch above also declares\n"
+							. "            // `static \$fields`.\n"
+							. "            static \$fields_by_column;\n"
+							. "            if( ! isset( \$fields_by_column[ \$column ] ) ) {\n"
+							. "                \$fields_by_column[\$column] = Ninja_Forms()->form( \$form_id )->get_field( \$column );\n"
+							. "            }\n"
+							. '            $field = $fields_by_column[$column];',
+						),
+					),
+				),
+
+				/*
+				 * `theme_list()` in modules/theme_purchase.php declares
+				 * `static $header_tags` twice — two identical, constant `wp_kses()`
+				 * allowlists in different loops of the same function (unchanged
+				 * 4.2.7–4.3.5). The second declaration is nested one level deeper, so
+				 * its 5-tab indentation uniquely identifies it. Renaming a constant
+				 * allowlist is behavior-neutral.
+				 */
+				'wiziapp-create-your-own-native-iphone-app' => array(
+					'folders'        => array( 'wiziapp-create-your-own-native-iphone-app' ),
+					'file'           => 'modules/theme_purchase.php',
+					'patched_marker' => '$header_tags_title',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"\t\t\t\t\tstatic \$header_tags = array(",
+							"\t\t\t\t\t// Renamed by wpcomsh to avoid a PHP 8.3+ \"Duplicate declaration\n"
+							. "\t\t\t\t\t// of static variable\" fatal: theme_list() declares this allowlist twice.\n"
+							. "\t\t\t\t\tstatic \$header_tags_title = array(",
+						),
+						array(
+							"\t\t\t\t\t\$theme['title'] = wp_kses(\$theme['title'], \$header_tags);",
+							"\t\t\t\t\t\$theme['title'] = wp_kses(\$theme['title'], \$header_tags_title);",
+						),
+					),
+				),
+			);
+		}
+
+		/**
+		 * Patch a plugin to work with PHP 8.3+.
+		 *
+		 * Applies a minimal, behavior-preserving rename of a duplicate `static`
+		 * variable declaration that fatals on PHP 8.3+ ("Duplicate declaration of
+		 * static variable"). See php83_plugin_patches() for the per-plugin rationale.
 		 *
 		 * ## OPTIONS
 		 *
@@ -940,15 +1039,26 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		 * @subcommand php83-plugin-patch
 		 */
 		public function php_83_plugin_patch( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			if ( 'mega_main_menu' !== $args[0] ) {
-				WP_CLI::error( 'Wrong plugin to patch.' );
+			$patches = self::php83_plugin_patches();
+			$slug    = $args[0];
+
+			if ( ! isset( $patches[ $slug ] ) ) {
+				WP_CLI::error( sprintf( 'No PHP 8.3 patch for %s. Available: %s.', $slug, implode( ', ', array_keys( $patches ) ) ) );
 			}
 
-			$plugins = get_plugins();
-			$folder  = 'mega_main_menu/mega_main_menu.php';
+			$patch = $patches[ $slug ];
 
-			if ( ! isset( $plugins[ $folder ] ) ) {
-				WP_CLI::error( 'mega_main_menu plugin is not installed.' );
+			// Resolve which of the plugin's known folder slugs is installed.
+			$plugin_file = null;
+			foreach ( get_plugins() as $file => $data ) {
+				if ( in_array( dirname( $file ), $patch['folders'], true ) ) {
+					$plugin_file = $file;
+					break;
+				}
+			}
+
+			if ( null === $plugin_file ) {
+				WP_CLI::error( "$slug plugin is not installed." );
 			}
 
 			// Don't patch if an update is pending: the new version may already fix this,
@@ -957,13 +1067,27 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			wp_update_plugins();
 			$update_plugins = get_site_transient( 'update_plugins' );
 
-			if ( isset( $update_plugins->response[ $folder ] ) ) {
-				$new_version = $update_plugins->response[ $folder ]->new_version ?? 'unknown';
-				WP_CLI::error( "An update to mega_main_menu $new_version is available; update the plugin instead of patching." );
+			if ( isset( $update_plugins->response[ $plugin_file ] ) ) {
+				$new_version = $update_plugins->response[ $plugin_file ]->new_version ?? 'unknown';
+				WP_CLI::error( "An update to $slug $new_version is available; update the plugin instead of patching." );
 			}
 
-			$file = WP_PLUGIN_DIR . '/mega_main_menu/framework/options_generator.php';
+			$file = WP_PLUGIN_DIR . '/' . dirname( $plugin_file ) . '/' . $patch['file'];
 
+			$this->apply_php83_patch( $file, $patch );
+		}
+
+		/**
+		 * Apply one php83 patch definition to a file on disk.
+		 *
+		 * Exits via WP_CLI::error() when the file or any patch target does not look
+		 * exactly as expected — an unknown vendor version is a reason to stop, not
+		 * to guess.
+		 *
+		 * @param string $file  Absolute path of the file to patch.
+		 * @param array  $patch Patch definition (see php83_plugin_patches()).
+		 */
+		private function apply_php83_patch( $file, array $patch ) {
 			if ( ! file_exists( $file ) ) {
 				WP_CLI::error( 'File not found: ' . $file );
 			}
@@ -972,40 +1096,52 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			$file_content = file_get_contents( $file );
 
 			if ( false === $file_content ) {
-				WP_CLI::error( 'File not found: ' . $file );
+				WP_CLI::error( 'File not readable: ' . $file );
 			}
 
 			// Already patched: re-running is a safe no-op.
-			if ( false !== strpos( $file_content, '$theme_option_file_background' ) ) {
+			if ( false !== strpos( $file_content, $patch['patched_marker'] ) ) {
 				WP_CLI::success( 'Already patched.' );
 				return;
 			}
 
-			// The duplicate `static $theme_option_file` lives in the `background_image`
-			// case. Split the file there so we only rename that copy and leave the
-			// original declaration in the `file` case untouched.
-			$marker     = "case 'background_image':";
-			$marker_pos = strpos( $file_content, $marker );
+			if ( 'split_rename' === $patch['strategy'] ) {
+				// Rename every occurrence of `search` after `split_marker`, leaving the
+				// original declaration before the marker untouched.
+				$marker_pos = strpos( $file_content, $patch['split_marker'] );
 
-			if ( false === $marker_pos ) {
-				WP_CLI::error( 'Patch target not found in ' . $file );
-			}
+				if ( false === $marker_pos ) {
+					WP_CLI::error( 'Patch target not found in ' . $file );
+				}
 
-			$before = substr( $file_content, 0, $marker_pos );
-			$after  = substr( $file_content, $marker_pos );
+				$before = substr( $file_content, 0, $marker_pos );
+				$after  = substr( $file_content, $marker_pos );
 
-			// Within $after only the `background_image` case references
-			// `$theme_option_file` (the `file` case sits in $before, `gradient` uses a
-			// different variable), so renaming every occurrence here is surgical.
-			$count = 0;
-			$after = str_replace( '$theme_option_file', '$theme_option_file_background', $after, $count );
+				$count = 0;
+				$after = str_replace( $patch['search'], $patch['replace'], $after, $count );
 
-			if ( ! $count ) {
-				WP_CLI::error( 'String not found on ' . $file );
+				if ( ! $count ) {
+					WP_CLI::error( 'String not found on ' . $file );
+				}
+
+				$file_content = $before . $after;
+			} else {
+				// replace_once: every pair must match exactly once, or the installed
+				// version differs from the one the patch was written against.
+				foreach ( $patch['replacements'] as $replacement ) {
+					list( $search, $replace ) = $replacement;
+					$occurrences              = substr_count( $file_content, $search );
+
+					if ( 1 !== $occurrences ) {
+						WP_CLI::error( sprintf( 'Expected exactly 1 match in %s, found %d — unknown plugin version?', $file, $occurrences ) );
+					}
+
+					$file_content = str_replace( $search, $replace, $file_content );
+				}
 			}
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			if ( ! file_put_contents( $file, $before . $after ) ) {
+			if ( ! file_put_contents( $file, $file_content ) ) {
 				WP_CLI::error( 'Failed to write to ' . $file );
 			}
 

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -953,7 +953,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				 * is unchanged. The same product ships as both `mega_main_menu` and
 				 * `mega-main-menu`.
 				 */
-				'mega_main_menu' => array(
+				'mega_main_menu'          => array(
 					'folders'        => array( 'mega_main_menu', 'mega-main-menu' ),
 					'file'           => 'framework/options_generator.php',
 					'patched_marker' => '$theme_option_file_background',
@@ -971,7 +971,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				 * numeric-branch copy just splits the cache in two, so behavior is
 				 * unchanged.
 				 */
-				'ninja-forms'    => array(
+				'ninja-forms'             => array(
 					'folders'        => array( 'ninja-forms' ),
 					'file'           => 'includes/Admin/CPT/Submission.php',
 					'patched_marker' => '$fields_by_column',
@@ -1018,6 +1018,150 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 						array(
 							"\t\t\t\t\t\$theme['title'] = wp_kses(\$theme['title'], \$header_tags);",
 							"\t\t\t\t\t\$theme['title'] = wp_kses(\$theme['title'], \$header_tags_title);",
+						),
+					),
+				),
+
+				/*
+				 * `initData()` in inc/classes/thegem-blocks.php declares
+				 * `static $globalColors;` twice in the same declaration list, two lines
+				 * apart — a plain copy/paste bug (verified on 1.0.2 and 1.1.x installs).
+				 * Deleting the second declaration is behavior-neutral. The plugin ships
+				 * as both `thegem-blocks-elementor` and `-thegem-blocks-elementor`.
+				 */
+				'thegem-blocks-elementor' => array(
+					'folders'        => array( 'thegem-blocks-elementor', '-thegem-blocks-elementor' ),
+					'file'           => 'inc/classes/thegem-blocks.php',
+					'patched_marker' => 'removed a duplicate `static $globalColors;`',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"        static \$dummyListByUrl;\n        static \$globalColors;",
+							'        static $dummyListByUrl; // wpcomsh: removed a duplicate `static $globalColors;` here (PHP 8.3+ fatal); it is declared two lines above.',
+						),
+					),
+				),
+
+				/*
+				 * `deep_magazine_ele_ajax()` declares `static $magazin_uniqid = 0;` in
+				 * three magazine-type branches. The counter feeds unique data-id
+				 * attributes shared across the types, so the declaration is hoisted to
+				 * the top of the function (one shared slot, initial 0 — identical to the
+				 * pre-8.3 compile-time semantics) and the branch declarations become
+				 * plain increments. The file uses CRLF line endings.
+				 */
+				'deepcore'                => array(
+					'folders'        => array( 'deepcore' ),
+					'file'           => 'src/components/functions/functions-general.php',
+					'patched_marker' => 'wpcomsh: hoisted',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"function deep_magazine_ele_ajax() {\r\n",
+							"function deep_magazine_ele_ajax() {\r\n\t// wpcomsh: hoisted out of the type branches below (PHP 8.3+ duplicate-static fatal).\r\n\tstatic \$magazin_uniqid = 0;\r\n",
+						),
+						array(
+							"\t\tstatic \$magazin_uniqid = 0;\r\n\t\t\$magazin_uniqid++;",
+							"\t\t\$magazin_uniqid++;",
+							3,
+						),
+					),
+				),
+
+				/*
+				 * `MalinaGridPosts()` in inc/shortcodes.php declares `static $i = 0;` in
+				 * both the style_3 and style_7 branches (shared layout counter). Hoisted
+				 * to the top of the function, branch declarations deleted. The file uses
+				 * CRLF line endings; the searches are newline-anchored so the 5-tab
+				 * declaration cannot match inside the 6-tab one.
+				 */
+				'malina-elements'         => array(
+					'folders'        => array( 'malina-elements' ),
+					'file'           => 'inc/shortcodes.php',
+					'patched_marker' => 'wpcomsh: hoisted',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"\tfunction MalinaGridPosts(\$atts, \$content = null){\r\n",
+							"\tfunction MalinaGridPosts(\$atts, \$content = null){\r\n\t\t// wpcomsh: hoisted out of the style branches below (PHP 8.3+ duplicate-static fatal).\r\n\t\tstatic \$i = 0;\r\n",
+						),
+						array(
+							"\n\t\t\t\t\t\tstatic \$i = 0;\r",
+							'',
+						),
+						array(
+							"\n\t\t\t\t\tstatic \$i = 0;\r",
+							'',
+						),
+					),
+				),
+
+				/*
+				 * `admin_notice()` in includes/ld-autoupdate.php (LearnDash 3.2.x) was
+				 * hand-edited on the site: a `static $notice_shown = true; # code by Tj`
+				 * line sits directly below the stock `static $notice_shown = false;`
+				 * declaration to suppress the license notice. Pre-8.3 the last
+				 * initializer won (true); keeping the site's customized line and
+				 * removing the stock one preserves that behavior exactly.
+				 */
+				'sfwd-lms'                => array(
+					'folders'        => array( 'sfwd-lms' ),
+					'file'           => 'includes/ld-autoupdate.php',
+					'patched_marker' => 'wpcomsh: removed the duplicate',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"\t\t\tstatic \$notice_shown = false;\n\t\t\tstatic \$notice_shown = true; # code by Tj",
+							"\t\t\t// wpcomsh: removed the duplicate stock declaration (PHP 8.3+ fatal); the site-customized line below is the effective initializer.\n\t\t\tstatic \$notice_shown = true; # code by Tj",
+						),
+					),
+				),
+
+				/*
+				 * `ecoist_gallery_layouts_shortcode()` declares
+				 * `static $image_counter_classic = 1;` in two gallery-layout branches
+				 * (shared element counter). Hoisted to the top of the function, branch
+				 * declarations deleted.
+				 */
+				'cp-addons-for-vc'        => array(
+					'folders'        => array( 'cp-addons-for-vc' ),
+					'file'           => 'modules/ecoist_gallery_layouts.php',
+					'patched_marker' => 'wpcomsh: hoisted',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"\t\tfunction ecoist_gallery_layouts_shortcode( \$atts, \$content = null ) {",
+							"\t\tfunction ecoist_gallery_layouts_shortcode( \$atts, \$content = null ) {\n\t\t\t// wpcomsh: hoisted out of the layout branches below (PHP 8.3+ duplicate-static fatal).\n\t\t\tstatic \$image_counter_classic = 1;",
+						),
+						array(
+							"\n\t\t\t\t\t\t\t\t\t\t\t\t\tstatic \$image_counter_classic = 1;",
+							'',
+							2,
+						),
+					),
+				),
+
+				/*
+				 * The Elementor widget's `render()` in
+				 * elementor-widgets/widgets_classes/gallery_layouts.php declares
+				 * `static $counter = 1;` in three gallery-layout branches (shared
+				 * element counter; same vendored code family as cp-addons-for-vc).
+				 * Hoisted to the top of render(), branch declarations deleted.
+				 */
+				'ingeniofy'               => array(
+					'folders'        => array( 'ingeniofy' ),
+					'file'           => 'elementor-widgets/widgets_classes/gallery_layouts.php',
+					'patched_marker' => 'wpcomsh: hoisted',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							'  protected function render(){',
+							"  protected function render(){\n    // wpcomsh: hoisted out of the layout branches below (PHP 8.3+ duplicate-static fatal).\n    static \$counter = 1;",
+						),
+						array(
+							"\n\t\t\t\t\t\t\t\tstatic \$counter = 1;",
+							'',
+							3,
 						),
 					),
 				),
@@ -1078,6 +1222,125 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		}
 
 		/**
+		 * Patch definitions for the php83-theme-patch subcommand.
+		 *
+		 * Same duplicate-static-variable fatal as php83_plugin_patches(), for themes.
+		 * Two vendor families cover every affected theme:
+		 *
+		 * - SecondLine podcast themes share inc/audio-functions.php, where
+		 *   `secondline_powerpress_options()` declares `static $secondline_player_called;`
+		 *   at the top and then `static $secondline_player_called = true;` inside a
+		 *   branch. Pre-8.3, the branch initializer set the slot's compile-time initial
+		 *   value (true); dropping the duplicate `static` keyword and keeping a plain
+		 *   `= true` assignment in that branch reproduces the same values on every path.
+		 *   These theme files use CRLF line endings.
+		 *
+		 * - Select-Themes themes share lib/functions/meta.php, where the theme-prefixed
+		 *   `*_print_meta_box()` declares `static $muindex = 1;` in both the
+		 *   `mediaupload` and `mediaupload_standard` switch cases. The counter feeds
+		 *   unique uploader DOM ids shared across both cases, so it is hoisted to the
+		 *   top of the function (one shared slot, initial 1 — identical to the pre-8.3
+		 *   compile-time semantics) and the case declarations are deleted. `hazel1` is
+		 *   a site-local copy of hazel and shares its function prefix.
+		 *
+		 * @return array<string,array> Patch definitions keyed by theme slug.
+		 */
+		private static function php83_theme_patches() {
+			$patches = array();
+
+			$secondline_replacement = array(
+				array(
+					"\t\t\tstatic \$secondline_player_called = true;\r\n",
+					"\t\t\t\$secondline_player_called = true; // wpcomsh: dropped a duplicate `static` keyword (PHP 8.3+ fatal); the variable is declared static at the top of this function.\r\n",
+				),
+			);
+
+			foreach ( array( 'tusant-secondline', 'gumbo-secondline', 'dixie-secondline', 'satchmo-secondline', 'bolden-secondline' ) as $slug ) {
+				$patches[ $slug ] = array(
+					'file'           => 'inc/audio-functions.php',
+					'patched_marker' => 'wpcomsh: dropped a duplicate',
+					'strategy'       => 'replace_once',
+					'replacements'   => $secondline_replacement,
+				);
+			}
+
+			$select_themes = array(
+				'hazel'    => 'hazel',
+				'hazel1'   => 'hazel',
+				'alma'     => 'alma',
+				'maple'    => 'maple',
+				'rhythm'   => 'rhythm',
+				'architek' => 'architek',
+			);
+
+			foreach ( $select_themes as $slug => $function_prefix ) {
+				$patches[ $slug ] = array(
+					'file'           => 'lib/functions/meta.php',
+					'patched_marker' => 'wpcomsh: hoisted',
+					'strategy'       => 'replace_once',
+					'replacements'   => array(
+						array(
+							"function {$function_prefix}_print_meta_box(\$meta_box, \$post){",
+							"function {$function_prefix}_print_meta_box(\$meta_box, \$post){\n\t// wpcomsh: hoisted out of the mediaupload cases below (PHP 8.3+ duplicate-static fatal).\n\tstatic \$muindex = 1;",
+						),
+						array(
+							"\n\t\t\tstatic \$muindex = 1;",
+							'',
+							2,
+						),
+					),
+				);
+			}
+
+			return $patches;
+		}
+
+		/**
+		 * Patch a theme to work with PHP 8.3+.
+		 *
+		 * Applies a minimal, behavior-preserving fix for a duplicate `static`
+		 * variable declaration that fatals on PHP 8.3+ ("Duplicate declaration of
+		 * static variable"). See php83_theme_patches() for the per-theme rationale.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <theme>
+		 * : The theme to patch.
+		 *
+		 * @subcommand php83-theme-patch
+		 */
+		public function php_83_theme_patch( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$patches = self::php83_theme_patches();
+			$slug    = $args[0];
+
+			if ( ! isset( $patches[ $slug ] ) ) {
+				WP_CLI::error( sprintf( 'No PHP 8.3 patch for %s. Available: %s.', $slug, implode( ', ', array_keys( $patches ) ) ) );
+			}
+
+			$patch = $patches[ $slug ];
+			$theme = wp_get_theme( $slug );
+
+			if ( ! $theme->exists() ) {
+				WP_CLI::error( "$slug theme is not installed." );
+			}
+
+			// Don't patch if an update is pending: the new version may already fix this,
+			// and an update would overwrite the patched file anyway. Refresh the
+			// transient first so the decision is based on current data.
+			wp_update_themes();
+			$update_themes = get_site_transient( 'update_themes' );
+
+			if ( isset( $update_themes->response[ $slug ] ) ) {
+				$new_version = $update_themes->response[ $slug ]['new_version'] ?? 'unknown';
+				WP_CLI::error( "An update to $slug $new_version is available; update the theme instead of patching." );
+			}
+
+			$file = $theme->get_stylesheet_directory() . '/' . $patch['file'];
+
+			$this->apply_php83_patch( $file, $patch );
+		}
+
+		/**
 		 * Apply one php83 patch definition to a file on disk.
 		 *
 		 * Exits via WP_CLI::error() when the file or any patch target does not look
@@ -1126,14 +1389,17 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 				$file_content = $before . $after;
 			} else {
-				// replace_once: every pair must match exactly once, or the installed
-				// version differs from the one the patch was written against.
+				// replace_once: every pair must match exactly as many times as expected
+				// (default 1), or the installed version differs from the one the patch
+				// was written against.
 				foreach ( $patch['replacements'] as $replacement ) {
-					list( $search, $replace ) = $replacement;
-					$occurrences              = substr_count( $file_content, $search );
+					$search      = $replacement[0];
+					$replace     = $replacement[1];
+					$expected    = $replacement[2] ?? 1;
+					$occurrences = substr_count( $file_content, $search );
 
-					if ( 1 !== $occurrences ) {
-						WP_CLI::error( sprintf( 'Expected exactly 1 match in %s, found %d — unknown plugin version?', $file, $occurrences ) );
+					if ( $expected !== $occurrences ) {
+						WP_CLI::error( sprintf( 'Expected exactly %d match(es) in %s, found %d — unknown vendor version?', $expected, $file, $occurrences ) );
 					}
 
 					$file_content = str_replace( $search, $replace, $file_content );


### PR DESCRIPTION
## Proposed changes

* Generalize the `wp wpcomsh php83-plugin-patch` CLI command from a single hard-coded plugin (`mega_main_menu`) into a table-driven patcher for "Duplicate declaration of static variable" fatals (a PHP 8.3 breaking change), and add a `wp wpcomsh php83-theme-patch` counterpart for themes.
* Engine guarantees: refuses to patch when an update for the extension is pending (updating beats patching), idempotent re-runs via per-patch markers, and every `replace_once` search string must match the installed file exactly N times or the command errors out instead of guessing — unknown vendor versions are a reason to stop, not to improvise.
* Plugin patches: `mega_main_menu` (now also matched under its dash-slug folder), `ninja-forms` 3.6.x, `wiziapp`, `thegem-blocks-elementor` (both folder slugs), `deepcore`, `malina-elements`, `sfwd-lms`, `cp-addons-for-vc`, `ingeniofy`.
* Theme patches: the SecondLine podcast themes (tusant/gumbo/dixie/satchmo/bolden) and the Select-Themes family (hazel/hazel1/alma/maple/rhythm/architek).
* The patch strategies preserve pre-8.3 semantics exactly: duplicated declarations in independent branches are renamed or dropped, while shared static counters declared in multiple switch/if branches are hoisted to the top of the enclosing function so they keep a single slot with the same initial value.

## Why are these changes being made?

WordPress.com on Atomic is migrating sites off deprecated PHP versions (internal refs: DOTCOM-17392, part of the WoA PHP-version migration effort under DOTCOM-17319). The final cohort of sites fails the automated migration with post-upgrade fatals, and nearly all of them share one root cause: PHP 8.3 turned a duplicate `static` variable declaration in one function scope into a compile-time fatal, and a set of unmaintained premium plugins/themes ships exactly that pattern.

For most of these products there is no update path — their update feeds are license-gated and the installs are unlicensed — so the sites cannot self-update even where a fixed version exists upstream. The remediation is a minimal, verified, on-site patch applied via WP-CLI (this command), driven per affected site from the WordPress.com jobs system. Each patch was authored against the vendor code actually installed on the affected sites and verified byte-for-byte, including CRLF line endings in several of the files.

## Related product discussion/links

* Internal: DOTCOM-17392 / DOTCOM-17319 (WoA PHP-version migration)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `php -l` and phpcs pass on `class-wpcomsh-cli-commands.php`.
* On a test site with one of the listed plugins/themes installed:
  * `wp wpcomsh php83-plugin-patch ninja-forms` (or another slug) → `Success`; the target file keeps a single declaration of the previously duplicated static variable and passes `php -l` on PHP 8.3+.
  * Re-running the same command → `Already patched.`
  * With a pending update for the extension → the command refuses and asks to update instead.
  * With a vendor version whose bytes don't match the patch → the command errors with expected/found match counts and leaves the file untouched.
* `wp wpcomsh php83-theme-patch tusant-secondline` behaves the same way for themes.