### PR TITLE
SEO: add site-level LocalBusiness schema extending the Organization node

### DIFF
--- a/projects/packages/seo/_inc/data/schema-settings-types.ts
+++ b/projects/packages/seo/_inc/data/schema-settings-types.ts
@@ -1,7 +1,7 @@
 // Site-level Schema.org settings: the *stored overrides* (empty where unset) plus
 // the site-identity *defaults* shown as field placeholders, so an empty field
 // tracks the Site Title / Tagline instead of freezing its value. A container keyed
-// by schema type for future types; only `organization` is implemented today.
+// by schema type for future types.
 // Written through the package's own route (`Schema_Settings_Controller`).
 
 export interface OrganizationSettings {
@@ -20,11 +20,45 @@ export interface OrganizationSettings {
 // (`name`) and Tagline (`description`).
 export type OrganizationDefaults = Pick< OrganizationSettings, 'name' | 'description' >;
 
+export interface LocalBusinessAddress {
+	streetAddress: string;
+	addressLocality: string;
+	addressRegion: string;
+	postalCode: string;
+	addressCountry: string;
+}
+
+export type OpeningHoursDay = 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa' | 'Su';
+
+export interface OpeningHoursEntry {
+	opens: string;
+	closes: string;
+}
+
+export interface LocalBusinessSettings {
+	enabled: boolean;
+	address: LocalBusinessAddress;
+	telephone: string;
+	geo: {
+		latitude: string;
+		longitude: string;
+	};
+	openingHours: Record< OpeningHoursDay, OpeningHoursEntry >;
+	priceRange: string;
+}
+
+export interface LocalBusinessDefaults {
+	address: LocalBusinessAddress;
+}
+
 export interface SchemaSettings {
 	/** The stored overrides; empty fields fall back to the matching default. */
 	organization: OrganizationSettings;
+	/** LocalBusiness details stored as overrides; address fields can fall back to WooCommerce defaults. */
+	localBusiness: LocalBusinessSettings;
 	/** Site-identity values used as placeholders. */
 	defaults: {
 		organization: OrganizationDefaults;
+		localBusiness: LocalBusinessDefaults;
 	};
 }

--- a/projects/packages/seo/_inc/data/schema-settings-utils.ts
+++ b/projects/packages/seo/_inc/data/schema-settings-utils.ts
@@ -1,4 +1,8 @@
-import type { OrganizationSettings } from './schema-settings-types';
+import type {
+	LocalBusinessSettings,
+	OpeningHoursDay,
+	OrganizationSettings,
+} from './schema-settings-types';
 
 export const normalizeProfileUrl = ( profile: string ): string => {
 	const trimmed = profile.trim();
@@ -23,4 +27,36 @@ export const cleanProfileUrls = ( sameAs: string[] ): string[] =>
 export const cleanOrganization = ( organization: OrganizationSettings ): OrganizationSettings => ( {
 	...organization,
 	sameAs: cleanProfileUrls( organization.sameAs ),
+} );
+
+const trim = ( value: string ): string => value.trim();
+
+const OPENING_DAYS: OpeningHoursDay[] = [ 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su' ];
+
+export const cleanLocalBusiness = (
+	localBusiness: LocalBusinessSettings
+): LocalBusinessSettings => ( {
+	enabled: localBusiness.enabled,
+	address: {
+		streetAddress: trim( localBusiness.address.streetAddress ),
+		addressLocality: trim( localBusiness.address.addressLocality ),
+		addressRegion: trim( localBusiness.address.addressRegion ),
+		postalCode: trim( localBusiness.address.postalCode ),
+		addressCountry: trim( localBusiness.address.addressCountry ),
+	},
+	telephone: trim( localBusiness.telephone ),
+	geo: {
+		latitude: trim( localBusiness.geo.latitude ),
+		longitude: trim( localBusiness.geo.longitude ),
+	},
+	openingHours: Object.fromEntries(
+		OPENING_DAYS.map( day => [
+			day,
+			{
+				opens: trim( localBusiness.openingHours[ day ].opens ),
+				closes: trim( localBusiness.openingHours[ day ].closes ),
+			},
+		] )
+	) as LocalBusinessSettings[ 'openingHours' ],
+	priceRange: trim( localBusiness.priceRange ),
 } );

--- a/projects/packages/seo/_inc/data/schema-settings-utils.ts
+++ b/projects/packages/seo/_inc/data/schema-settings-utils.ts
@@ -31,6 +31,11 @@ export const cleanOrganization = ( organization: OrganizationSettings ): Organiz
 
 const trim = ( value: string ): string => value.trim();
 
+const normalizeCountryCode = ( value: string ): string => {
+	const trimmed = trim( value );
+	return /^[A-Za-z]{2}$/.test( trimmed ) ? trimmed.toUpperCase() : trimmed;
+};
+
 const OPENING_DAYS: OpeningHoursDay[] = [ 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su' ];
 
 export const cleanLocalBusiness = (
@@ -42,7 +47,7 @@ export const cleanLocalBusiness = (
 		addressLocality: trim( localBusiness.address.addressLocality ),
 		addressRegion: trim( localBusiness.address.addressRegion ),
 		postalCode: trim( localBusiness.address.postalCode ),
-		addressCountry: trim( localBusiness.address.addressCountry ),
+		addressCountry: normalizeCountryCode( localBusiness.address.addressCountry ),
 	},
 	telephone: trim( localBusiness.telephone ),
 	geo: {

--- a/projects/packages/seo/_inc/data/test/build-payload.test.ts
+++ b/projects/packages/seo/_inc/data/test/build-payload.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import { buildCorePayload, buildJetpackPayload } from '../build-payload';
+import { makeSchemaSettings } from './fixtures/schema-settings-fixtures';
 import type { SettingsResponse } from '../settings-types';
 
 const makeSettings = ( overrides: Partial< SettingsResponse > = {} ): SettingsResponse => ( {
@@ -12,10 +13,7 @@ const makeSettings = ( overrides: Partial< SettingsResponse > = {} ): SettingsRe
 	sitemap_active: false,
 	sitemap_url: '',
 	canonical_active: false,
-	schema: {
-		organization: { name: '', description: '', sameAs: [], email: '' },
-		defaults: { organization: { name: 'Acme Co', description: 'We make things' } },
-	},
+	schema: makeSchemaSettings(),
 	...overrides,
 } );
 

--- a/projects/packages/seo/_inc/data/test/fixtures/schema-settings-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/schema-settings-fixtures.ts
@@ -41,10 +41,10 @@ export const makeSchemaSettings = (
 	overrides: Partial< SchemaSettings > = {}
 ): SchemaSettings => ( {
 	organization: { name: '', description: '', sameAs: [], email: '' },
-	localBusiness: EMPTY_LOCAL_BUSINESS,
+	localBusiness: structuredClone( EMPTY_LOCAL_BUSINESS ),
 	defaults: {
 		organization: { name: 'Acme Co', description: 'We make things' },
-		localBusiness: EMPTY_LOCAL_BUSINESS_DEFAULTS,
+		localBusiness: structuredClone( EMPTY_LOCAL_BUSINESS_DEFAULTS ),
 	},
 	...overrides,
 } );

--- a/projects/packages/seo/_inc/data/test/fixtures/schema-settings-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/schema-settings-fixtures.ts
@@ -1,0 +1,50 @@
+import type {
+	LocalBusinessDefaults,
+	LocalBusinessSettings,
+	SchemaSettings,
+} from '../../schema-settings-types';
+
+export const EMPTY_LOCAL_BUSINESS: LocalBusinessSettings = {
+	enabled: false,
+	address: {
+		streetAddress: '',
+		addressLocality: '',
+		addressRegion: '',
+		postalCode: '',
+		addressCountry: '',
+	},
+	telephone: '',
+	geo: { latitude: '', longitude: '' },
+	openingHours: {
+		Mo: { opens: '', closes: '' },
+		Tu: { opens: '', closes: '' },
+		We: { opens: '', closes: '' },
+		Th: { opens: '', closes: '' },
+		Fr: { opens: '', closes: '' },
+		Sa: { opens: '', closes: '' },
+		Su: { opens: '', closes: '' },
+	},
+	priceRange: '',
+};
+
+export const EMPTY_LOCAL_BUSINESS_DEFAULTS: LocalBusinessDefaults = {
+	address: {
+		streetAddress: '',
+		addressLocality: '',
+		addressRegion: '',
+		postalCode: '',
+		addressCountry: '',
+	},
+};
+
+export const makeSchemaSettings = (
+	overrides: Partial< SchemaSettings > = {}
+): SchemaSettings => ( {
+	organization: { name: '', description: '', sameAs: [], email: '' },
+	localBusiness: EMPTY_LOCAL_BUSINESS,
+	defaults: {
+		organization: { name: 'Acme Co', description: 'We make things' },
+		localBusiness: EMPTY_LOCAL_BUSINESS_DEFAULTS,
+	},
+	...overrides,
+} );

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -1,7 +1,7 @@
 import { AI_PATH, OVERVIEW_PATH, SETTINGS_PATH } from '../../get-preloaded';
+import { makeSchemaSettings } from './schema-settings-fixtures';
 import type { AiState } from '../../ai-types';
 import type { ContentCoverage } from '../../overview-types';
-import type { SchemaSettings } from '../../schema-settings-types';
 import type { SettingsResponse } from '../../settings-types';
 
 /**
@@ -21,10 +21,7 @@ export const SEEDED_COVERAGE: ContentCoverage = {
 	with_search_visible: 8,
 };
 
-export const SEEDED_SCHEMA: SchemaSettings = {
-	organization: { name: '', description: '', sameAs: [], email: '' },
-	defaults: { organization: { name: 'Acme Co', description: 'We make things' } },
-};
+export const SEEDED_SCHEMA = makeSchemaSettings();
 
 export const SEEDED_SETTINGS: SettingsResponse = {
 	front_page_description: 'Welcome to the site.',

--- a/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { cleanLocalBusiness } from '../schema-settings-utils';
 import { makeSchemaSettings } from './fixtures/schema-settings-fixtures';
 import type { SchemaSettings } from '../schema-settings-types';
 
@@ -105,6 +106,43 @@ describe( 'useSchemaSettings', () => {
 		expect( options.data.localBusiness.enabled ).toBe( true );
 		expect( options.data.localBusiness.address.streetAddress ).toBe( '123 Main St' );
 		expect( result.current.localBusiness ).toEqual( saved.localBusiness );
+	} );
+
+	it( 'trims and uppercases the country code when saving LocalBusiness settings', async () => {
+		const { result } = renderHook( () => useSchemaSettings( RESPONSE ) );
+
+		act( () =>
+			result.current.setLocalBusinessField( {
+				address: { ...RESPONSE.localBusiness.address, addressCountry: ' us ' },
+			} )
+		);
+
+		const saved: SchemaSettings = {
+			...RESPONSE,
+			localBusiness: {
+				...RESPONSE.localBusiness,
+				address: { ...RESPONSE.localBusiness.address, addressCountry: 'US' },
+			},
+		};
+		mockApiFetch.mockResolvedValueOnce( saved );
+		act( () => result.current.save() );
+		await waitFor( () => expect( createSuccessNotice ).toHaveBeenCalled() );
+
+		const post = mockApiFetch.mock.calls.find(
+			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
+		);
+		const options = post![ 0 ] as {
+			data: { localBusiness: { address: { addressCountry: string } } };
+		};
+		expect( options.data.localBusiness.address.addressCountry ).toBe( 'US' );
+		expect( result.current.localBusiness.address.addressCountry ).toBe( 'US' );
+	} );
+
+	it( 'does not normalize non-ASCII country input into a valid code', () => {
+		const localBusiness = structuredClone( RESPONSE.localBusiness );
+		localBusiness.address.addressCountry = ' ſs ';
+
+		expect( cleanLocalBusiness( localBusiness ).address.addressCountry ).toBe( 'ſs' );
 	} );
 
 	it( 'drops empty, invalid, and duplicate profile rows when tracking dirtiness and saving', async () => {

--- a/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { makeSchemaSettings } from './fixtures/schema-settings-fixtures';
 import type { SchemaSettings } from '../schema-settings-types';
 
 // True-ESM Jest (`--experimental-vm-modules`): register mocks with
@@ -12,10 +13,7 @@ const createErrorNotice = jest.fn();
 
 // A site with no stored overrides: empty editable values, site identity exposed
 // as the placeholder defaults.
-const RESPONSE: SchemaSettings = {
-	organization: { name: '', description: '', sameAs: [], email: '' },
-	defaults: { organization: { name: 'Acme Co', description: 'We make things' } },
-};
+const RESPONSE: SchemaSettings = makeSchemaSettings();
 
 jest.unstable_mockModule( '@wordpress/api-fetch', () => ( { default: mockApiFetch } ) );
 jest.unstable_mockModule( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
@@ -35,7 +33,9 @@ describe( 'useSchemaSettings', () => {
 
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( result.current.organization ).toEqual( RESPONSE.organization );
+		expect( result.current.localBusiness ).toEqual( RESPONSE.localBusiness );
 		expect( result.current.defaults ).toEqual( RESPONSE.defaults.organization );
+		expect( result.current.localBusinessDefaults ).toEqual( RESPONSE.defaults.localBusiness );
 		expect( result.current.isDirty ).toBe( false );
 	} );
 
@@ -48,6 +48,7 @@ describe( 'useSchemaSettings', () => {
 
 		const saved = {
 			organization: { ...RESPONSE.organization, sameAs: [ 'https://twitter.com/acme' ] },
+			localBusiness: RESPONSE.localBusiness,
 			defaults: RESPONSE.defaults,
 		};
 		mockApiFetch.mockResolvedValueOnce( saved );
@@ -59,11 +60,51 @@ describe( 'useSchemaSettings', () => {
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
 		);
-		const options = post![ 0 ] as { path: string; data: { organization: { sameAs: string[] } } };
+		const options = post![ 0 ] as {
+			path: string;
+			data: { organization: { sameAs: string[] }; localBusiness: typeof RESPONSE.localBusiness };
+		};
 		expect( options.path ).toBe( '/jetpack/v4/seo/schema-settings' );
 		expect( options.data.organization.sameAs ).toEqual( [ 'https://twitter.com/acme' ] );
+		expect( options.data.localBusiness ).toEqual( RESPONSE.localBusiness );
+		expect( result.current.localBusiness ).toEqual( saved.localBusiness );
 		expect( onSave ).toHaveBeenCalledWith( saved );
 		expect( createSuccessNotice ).toHaveBeenCalled();
+	} );
+
+	it( 'tracks dirty state and re-seeds localBusiness after saving', async () => {
+		const { result } = renderHook( () => useSchemaSettings( RESPONSE ) );
+
+		act( () =>
+			result.current.setLocalBusinessField( {
+				enabled: true,
+				address: { ...RESPONSE.localBusiness.address, streetAddress: '123 Main St' },
+			} )
+		);
+		expect( result.current.isDirty ).toBe( true );
+
+		const saved: SchemaSettings = {
+			...RESPONSE,
+			localBusiness: {
+				...RESPONSE.localBusiness,
+				enabled: true,
+				address: { ...RESPONSE.localBusiness.address, streetAddress: '123 Main St' },
+			},
+		};
+		mockApiFetch.mockResolvedValueOnce( saved );
+
+		act( () => result.current.save() );
+		await waitFor( () => expect( result.current.isDirty ).toBe( false ) );
+
+		const post = mockApiFetch.mock.calls.find(
+			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
+		);
+		const options = post![ 0 ] as {
+			data: { localBusiness: { enabled: boolean; address: { streetAddress: string } } };
+		};
+		expect( options.data.localBusiness.enabled ).toBe( true );
+		expect( options.data.localBusiness.address.streetAddress ).toBe( '123 Main St' );
+		expect( result.current.localBusiness ).toEqual( saved.localBusiness );
 	} );
 
 	it( 'drops empty, invalid, and duplicate profile rows when tracking dirtiness and saving', async () => {
@@ -87,7 +128,10 @@ describe( 'useSchemaSettings', () => {
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
 		);
-		const options = post![ 0 ] as { data: { organization: { sameAs: string[] } } };
+		const options = post![ 0 ] as {
+			data: { organization: { sameAs: string[] }; localBusiness: typeof RESPONSE.localBusiness };
+		};
 		expect( options.data.organization.sameAs ).toEqual( [ 'https://twitter.com/acme' ] );
+		expect( options.data.localBusiness ).toEqual( RESPONSE.localBusiness );
 	} );
 } );

--- a/projects/packages/seo/_inc/data/test/use-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-settings.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { makeSchemaSettings } from './fixtures/schema-settings-fixtures';
 import type { SettingsResponse } from '../settings-types';
 
 // True-ESM Jest (`--experimental-vm-modules`): register mocks with
@@ -19,10 +20,7 @@ const SEED: SettingsResponse = {
 	sitemap_active: false,
 	sitemap_url: '',
 	canonical_active: false,
-	schema: {
-		organization: { name: '', description: '', sameAs: [], email: '' },
-		defaults: { organization: { name: 'Acme Co', description: 'We make things' } },
-	},
+	schema: makeSchemaSettings(),
 };
 
 const SETTINGS_STORE = 'seo/settings';

--- a/projects/packages/seo/_inc/data/use-schema-settings.ts
+++ b/projects/packages/seo/_inc/data/use-schema-settings.ts
@@ -3,8 +3,10 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { cleanOrganization } from './schema-settings-utils';
+import { cleanLocalBusiness, cleanOrganization } from './schema-settings-utils';
 import type {
+	LocalBusinessDefaults,
+	LocalBusinessSettings,
 	OrganizationDefaults,
 	OrganizationSettings,
 	SchemaSettings,
@@ -14,17 +16,30 @@ const ENDPOINT = '/jetpack/v4/seo/schema-settings';
 // Single snackbar id reused across a save so "Saving…" is replaced in place by the result.
 const NOTICE_ID = 'jetpack-seo-schema-settings-save';
 
+type EditableSchemaSections = Pick< SchemaSettings, 'organization' | 'localBusiness' >;
+
+const cleanSections = ( sections: EditableSchemaSections ): EditableSchemaSections => ( {
+	organization: cleanOrganization( sections.organization ),
+	localBusiness: cleanLocalBusiness( sections.localBusiness ),
+} );
+
 export interface SchemaSettingsForm {
 	/** The editable Organization overrides. */
 	organization: OrganizationSettings;
 	/** Site-identity values shown as field placeholders (what an empty override falls back to). */
 	defaults: OrganizationDefaults;
+	/** The editable LocalBusiness overrides. */
+	localBusiness: LocalBusinessSettings;
+	/** LocalBusiness defaults shown as field placeholders. */
+	localBusinessDefaults: LocalBusinessDefaults;
 	isSaving: boolean;
-	/** Whether the local Organization values differ from the last-saved baseline. */
+	/** Whether the local schema values differ from the last-saved baseline. */
 	isDirty: boolean;
 	/** Patch one or more Organization fields locally (persisted by `save()`). */
 	setOrganizationField: ( patch: Partial< OrganizationSettings > ) => void;
-	/** Persist the current Organization values through the schema-settings route. */
+	/** Patch one or more LocalBusiness fields locally (persisted by `save()`). */
+	setLocalBusinessField: ( patch: Partial< LocalBusinessSettings > ) => void;
+	/** Persist the current schema values through the schema-settings route. */
 	save: () => void;
 }
 
@@ -40,24 +55,44 @@ export function useSchemaSettings(
 	initialSettings: SchemaSettings,
 	onSave?: ( settings: SchemaSettings ) => void
 ): SchemaSettingsForm {
-	const [ organization, setOrganization ] = useState< OrganizationSettings >(
-		initialSettings.organization
-	);
+	const [ sections, setSections ] = useState< EditableSchemaSections >( {
+		organization: initialSettings.organization,
+		localBusiness: initialSettings.localBusiness,
+	} );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const { createInfoNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	// The last-saved baseline, kept in a ref so save() compares against the freshest
 	// value without re-creating its callback.
-	const baselineRef = useRef< OrganizationSettings >(
-		cleanOrganization( initialSettings.organization )
+	const baselineRef = useRef< EditableSchemaSections >(
+		cleanSections( {
+			organization: initialSettings.organization,
+			localBusiness: initialSettings.localBusiness,
+		} )
 	);
 
 	const setOrganizationField = useCallback( ( patch: Partial< OrganizationSettings > ) => {
-		setOrganization( current => {
-			const next = { ...current, ...patch };
+		setSections( current => {
+			const next = {
+				...current,
+				organization: { ...current.organization, ...patch },
+			};
 			setIsDirty(
-				JSON.stringify( cleanOrganization( next ) ) !== JSON.stringify( baselineRef.current )
+				JSON.stringify( cleanSections( next ) ) !== JSON.stringify( baselineRef.current )
+			);
+			return next;
+		} );
+	}, [] );
+
+	const setLocalBusinessField = useCallback( ( patch: Partial< LocalBusinessSettings > ) => {
+		setSections( current => {
+			const next = {
+				...current,
+				localBusiness: { ...current.localBusiness, ...patch },
+			};
+			setIsDirty(
+				JSON.stringify( cleanSections( next ) ) !== JSON.stringify( baselineRef.current )
 			);
 			return next;
 		} );
@@ -76,14 +111,17 @@ export function useSchemaSettings(
 		apiFetch< SchemaSettings >( {
 			path: ENDPOINT,
 			method: 'POST',
-			data: { organization: cleanOrganization( organization ) },
+			data: cleanSections( sections ),
 		} )
 			.then( settings => {
 				// Re-seed from the server's response so the form reflects any sanitization
 				// (e.g. dropped/deduped URLs); a cleared field comes back empty and shows
 				// the placeholder again rather than re-freezing.
-				baselineRef.current = cleanOrganization( settings.organization );
-				setOrganization( settings.organization );
+				baselineRef.current = cleanSections( settings );
+				setSections( {
+					organization: settings.organization,
+					localBusiness: settings.localBusiness,
+				} );
 				onSave?.( settings );
 				setIsDirty( false );
 				createSuccessNotice( __( 'Schema settings saved.', 'jetpack-seo' ), {
@@ -99,14 +137,17 @@ export function useSchemaSettings(
 				);
 			} )
 			.finally( () => setIsSaving( false ) );
-	}, [ organization, isSaving, createInfoNotice, createSuccessNotice, createErrorNotice, onSave ] );
+	}, [ sections, isSaving, createInfoNotice, createSuccessNotice, createErrorNotice, onSave ] );
 
 	return {
-		organization,
+		organization: sections.organization,
 		defaults: initialSettings.defaults.organization,
+		localBusiness: sections.localBusiness,
+		localBusinessDefaults: initialSettings.defaults.localBusiness,
 		isSaving,
 		isDirty,
 		setOrganizationField,
+		setLocalBusinessField,
 		save,
 	};
 }

--- a/projects/packages/seo/_inc/screens/settings/schema-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-card.tsx
@@ -37,17 +37,21 @@ interface Props {
  */
 function SchemaCard( { initialSettings, onSave }: Props ) {
 	const form = useSchemaSettings( initialSettings, onSave );
-	const { organization, defaults } = form;
+	const { organization, defaults, localBusiness, localBusinessDefaults } = form;
 
 	// Whether each Organization field counts as "set" for the header badge: `name` /
 	// `description` count when overridden here OR present in site identity (Site Title /
 	// Tagline); `sameAs` when it has a profile; `email` when filled. So a typical site
 	// reads "2 of 4 set" before the admin adds anything.
+	const localBusinessAddressSet =
+		Object.values( localBusiness.address ).some( Boolean ) ||
+		Object.values( localBusinessDefaults.address ).some( Boolean );
 	const fieldsSet = [
 		organization.name || defaults.name,
 		organization.description || defaults.description,
 		organization.sameAs.length > 0,
 		organization.email,
+		...( localBusiness.enabled ? [ localBusinessAddressSet ] : [] ),
 	];
 	const setCount = fieldsSet.filter( Boolean ).length;
 

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -9,7 +9,7 @@ import type {
 	OpeningHoursDay,
 } from '../../../data/schema-settings-types';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
-import type { FC } from 'react';
+import type { FC, FocusEvent } from 'react';
 
 const OPENING_DAYS: Array< { code: OpeningHoursDay; label: string } > = [
 	{ code: 'Mo', label: __( 'Monday', 'jetpack-seo' ) },
@@ -57,6 +57,17 @@ const GEO_PAIR_ERROR = __(
 	'Enter both latitude and longitude, or leave both blank.',
 	'jetpack-seo'
 );
+const GEO_ERROR_ID = 'jetpack-seo-settings-geo-error';
+const COUNTRY_CODE_ERROR = __( 'Enter a two-letter country code (for example US).', 'jetpack-seo' );
+const PHONE_ERROR = __(
+	'Enter a phone number with at least one digit, using only spaces, parentheses, hyphens, and an optional leading +.',
+	'jetpack-seo'
+);
+const PRICE_RANGE_ERROR = __( 'Enter fewer than 100 characters.', 'jetpack-seo' );
+const OPENING_HOURS_PAIR_ERROR = __(
+	'Enter both opening and closing times, or leave both blank.',
+	'jetpack-seo'
+);
 
 interface Props {
 	/** The schema-settings form controller, owned by the Schema card. */
@@ -71,10 +82,40 @@ const isCoordinate = ( value: string, max: number ) => {
 	return Number.isFinite( number ) && Math.abs( number ) <= max;
 };
 
+const isCountryCode = ( value: string ) => {
+	const trimmed = value.trim();
+	return ! trimmed || /^[A-Za-z]{2}$/.test( trimmed );
+};
+
+const uppercaseAscii = ( value: string ) =>
+	value.replace( /[a-z]/g, character => character.toUpperCase() );
+
+const isPhoneNumber = ( value: string ) => {
+	const trimmed = value.trim();
+	return ! trimmed || ( /^\+?[0-9 ()-]*$/.test( trimmed ) && /[0-9]/.test( trimmed ) );
+};
+
+const isPriceRange = ( value: string ) => [ ...value.trim() ].length < 100;
+
+const hasIncompleteOpeningHours = ( localBusiness: LocalBusinessSettings ) =>
+	OPENING_DAYS.some( ( { code } ) => {
+		const { opens, closes } = localBusiness.openingHours[ code ];
+		return Boolean( opens.trim() ) !== Boolean( closes.trim() );
+	} );
+
 export const hasLocalBusinessErrors = ( form: SchemaSettingsForm ) => {
+	const { localBusiness } = form;
 	const { latitude, longitude } = form.localBusiness.geo;
 	const hasPartialGeo = Boolean( latitude.trim() ) !== Boolean( longitude.trim() );
-	return hasPartialGeo || ! isCoordinate( latitude, 90 ) || ! isCoordinate( longitude, 180 );
+	return (
+		hasPartialGeo ||
+		! isCoordinate( latitude, 90 ) ||
+		! isCoordinate( longitude, 180 ) ||
+		! isCountryCode( localBusiness.address.addressCountry ) ||
+		! isPhoneNumber( localBusiness.telephone ) ||
+		! isPriceRange( localBusiness.priceRange ) ||
+		hasIncompleteOpeningHours( localBusiness )
+	);
 };
 
 /**
@@ -91,6 +132,11 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 	const defaultAddressEmpty = Object.values( localBusinessDefaults.address ).every(
 		value => ! value
 	);
+	const hasPartialGeo = Boolean( geo.latitude.trim() ) !== Boolean( geo.longitude.trim() );
+	const geoRangeErrors = GEO_FIELDS.filter(
+		( { field, max } ) => Boolean( geo[ field ].trim() ) && ! isCoordinate( geo[ field ], max )
+	).map( ( { error } ) => error );
+	const geoError = hasPartialGeo ? GEO_PAIR_ERROR : geoRangeErrors.join( ' ' );
 
 	const setAddress = ( field: keyof typeof address, value: string ) =>
 		setLocalBusinessField( { address: { ...address, [ field ]: value } } );
@@ -106,6 +152,22 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 			},
 		} );
 
+	const clearInvalidTime = (
+		day: OpeningHoursDay,
+		field: 'opens' | 'closes',
+		event: FocusEvent< HTMLInputElement >
+	) => {
+		if ( ! event.currentTarget.validity.badInput ) {
+			return;
+		}
+
+		// Browsers can retain an incomplete segmented time (for example `10:--`)
+		// without emitting an onChange value. Clear that native editing state and
+		// re-sync the controlled field when focus leaves the input.
+		event.currentTarget.value = '';
+		setHours( day, field, '' );
+	};
+
 	return (
 		<Stack direction="column" gap="lg">
 			{ storedAddressEmpty && defaultAddressEmpty && (
@@ -117,112 +179,175 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 				</span>
 			) }
 
-			{ ADDRESS_FIELDS.map( ( { field, label, help } ) => (
+			{ ADDRESS_FIELDS.map( ( { field, label, help } ) => {
+				const fieldError = field === 'addressCountry' && ! isCountryCode( address[ field ] );
+				return (
+					<div
+						key={ field }
+						className={ fieldError ? 'jetpack-seo-settings__schema-field--error' : undefined }
+					>
+						<TextControl
+							label={ label }
+							help={ fieldError ? COUNTRY_CODE_ERROR : help }
+							placeholder={ localBusinessDefaults.address[ field ] }
+							value={ address[ field ] }
+							onChange={ next =>
+								setAddress( field, field === 'addressCountry' ? uppercaseAscii( next ) : next )
+							}
+							disabled={ isSaving }
+							aria-invalid={ Boolean( fieldError ) }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</div>
+				);
+			} ) }
+
+			<div
+				className={
+					! isPhoneNumber( localBusiness.telephone )
+						? 'jetpack-seo-settings__schema-field--error'
+						: undefined
+				}
+			>
 				<TextControl
-					key={ field }
-					label={ label }
-					help={ help }
-					placeholder={ localBusinessDefaults.address[ field ] }
-					value={ address[ field ] }
-					onChange={ next => setAddress( field, next ) }
+					label={ __( 'Phone', 'jetpack-seo' ) }
+					type="tel"
+					help={
+						! isPhoneNumber( localBusiness.telephone )
+							? PHONE_ERROR
+							: __( 'Include the country and area codes when possible.', 'jetpack-seo' )
+					}
+					value={ localBusiness.telephone }
+					onChange={ next => setLocalBusinessField( { telephone: next } ) }
 					disabled={ isSaving }
+					aria-invalid={ ! isPhoneNumber( localBusiness.telephone ) }
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
-			) ) }
+			</div>
 
-			<TextControl
-				label={ __( 'Phone', 'jetpack-seo' ) }
-				type="tel"
-				value={ localBusiness.telephone }
-				onChange={ next => setLocalBusinessField( { telephone: next } ) }
-				disabled={ isSaving }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-			/>
+			<div
+				className={
+					! isPriceRange( localBusiness.priceRange )
+						? 'jetpack-seo-settings__schema-field--error'
+						: undefined
+				}
+			>
+				<TextControl
+					label={ __( 'Price range', 'jetpack-seo' ) }
+					placeholder="$$"
+					help={
+						! isPriceRange( localBusiness.priceRange )
+							? PRICE_RANGE_ERROR
+							: __(
+									'Use a numerical range (for example $10–$20) or a relative price level (for example $$).',
+									'jetpack-seo'
+							  )
+					}
+					value={ localBusiness.priceRange }
+					onChange={ next => setLocalBusinessField( { priceRange: next } ) }
+					disabled={ isSaving }
+					aria-invalid={ ! isPriceRange( localBusiness.priceRange ) }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</div>
 
-			<TextControl
-				label={ __( 'Price range', 'jetpack-seo' ) }
-				placeholder="$$"
-				help={ __( 'How expensive the business is, from $ to $$$$.', 'jetpack-seo' ) }
-				value={ localBusiness.priceRange }
-				onChange={ next => setLocalBusinessField( { priceRange: next } ) }
-				disabled={ isSaving }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-			/>
-
-			<Stack direction="row" gap="sm" align="flex-start" wrap="wrap">
-				{ GEO_FIELDS.map( ( { field, label, max, error } ) => {
-					const hasPartialGeo = Boolean( geo.latitude.trim() ) !== Boolean( geo.longitude.trim() );
-					const fieldError =
-						hasPartialGeo ||
-						( Boolean( geo[ field ].trim() ) && ! isCoordinate( geo[ field ], max ) );
-					const helpText = hasPartialGeo ? GEO_PAIR_ERROR : error;
+			<div className="jetpack-seo-settings__schema-paired-fields">
+				{ GEO_FIELDS.map( ( { field, label, max } ) => {
+					const fieldError = hasPartialGeo || ! isCoordinate( geo[ field ], max );
 					return (
-						<div
-							key={ field }
-							className={
-								'jetpack-seo-settings__schema-profile-input' +
-								( fieldError ? ' jetpack-seo-settings__schema-profile-input--error' : '' )
-							}
-						>
+						<div key={ field } className="jetpack-seo-settings__schema-paired-field">
 							<TextControl
 								label={ label }
 								inputMode="decimal"
 								value={ geo[ field ] }
 								onChange={ next => setGeo( field, next ) }
 								disabled={ isSaving }
-								help={ fieldError ? helpText : undefined }
 								aria-invalid={ Boolean( fieldError ) }
+								aria-describedby={ geoError ? GEO_ERROR_ID : undefined }
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 							/>
 						</div>
 					);
 				} ) }
-			</Stack>
+				{ geoError && (
+					<span id={ GEO_ERROR_ID } className="jetpack-seo-settings__schema-pair-error">
+						{ geoError }
+					</span>
+				) }
+			</div>
 
 			<Stack direction="column" gap="sm">
 				<span className="jetpack-seo-settings__schema-field-label">
 					{ __( 'Opening hours', 'jetpack-seo' ) }
 				</span>
 				<span className="jetpack-seo-settings__title-tokens-label">
-					{ __( "Leave a day blank if it's closed.", 'jetpack-seo' ) }
+					{ __(
+						"Leave a day blank if it's closed. A closing time earlier than opening means the business closes the following day.",
+						'jetpack-seo'
+					) }
 				</span>
-				{ OPENING_DAYS.map( ( { code, label } ) => (
-					<Stack key={ code } direction="row" gap="sm" align="center" wrap="wrap">
-						<span className="jetpack-seo-settings__schema-day-label">{ label }</span>
-						<TextControl
-							label={ sprintf(
-								/* translators: %s: day of week. */
-								__( '%s opens', 'jetpack-seo' ),
-								label
-							) }
-							hideLabelFromVision
-							type="time"
-							value={ openingHours[ code ].opens }
-							onChange={ next => setHours( code, 'opens', next ) }
-							disabled={ isSaving }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-						<TextControl
-							label={ sprintf(
-								/* translators: %s: day of week. */
-								__( '%s closes', 'jetpack-seo' ),
-								label
-							) }
-							hideLabelFromVision
-							type="time"
-							value={ openingHours[ code ].closes }
-							onChange={ next => setHours( code, 'closes', next ) }
-							disabled={ isSaving }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					</Stack>
-				) ) }
+				{ OPENING_DAYS.map( ( { code, label } ) => {
+					const hasOpens = Boolean( openingHours[ code ].opens.trim() );
+					const hasCloses = Boolean( openingHours[ code ].closes.trim() );
+					const opensError = ! hasOpens && hasCloses;
+					const closesError = hasOpens && ! hasCloses;
+					const hasPairError = opensError || closesError;
+					const errorId = `jetpack-seo-settings-opening-hours-${ code }-error`;
+					return (
+						<div key={ code } className="jetpack-seo-settings__schema-opening-hours-row">
+							<span className="jetpack-seo-settings__schema-day-label">{ label }</span>
+							<div className="jetpack-seo-settings__schema-paired-fields">
+								<div className="jetpack-seo-settings__schema-paired-field">
+									<TextControl
+										label={ sprintf(
+											/* translators: %s: day of week. */
+											__( '%s opens', 'jetpack-seo' ),
+											label
+										) }
+										hideLabelFromVision
+										type="time"
+										value={ openingHours[ code ].opens }
+										onChange={ next => setHours( code, 'opens', next ) }
+										onBlur={ event => clearInvalidTime( code, 'opens', event ) }
+										disabled={ isSaving }
+										aria-invalid={ opensError }
+										aria-describedby={ hasPairError ? errorId : undefined }
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								</div>
+								<div className="jetpack-seo-settings__schema-paired-field">
+									<TextControl
+										label={ sprintf(
+											/* translators: %s: day of week. */
+											__( '%s closes', 'jetpack-seo' ),
+											label
+										) }
+										hideLabelFromVision
+										type="time"
+										value={ openingHours[ code ].closes }
+										onChange={ next => setHours( code, 'closes', next ) }
+										onBlur={ event => clearInvalidTime( code, 'closes', event ) }
+										disabled={ isSaving }
+										aria-invalid={ closesError }
+										aria-describedby={ hasPairError ? errorId : undefined }
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								</div>
+								{ hasPairError && (
+									<span id={ errorId } className="jetpack-seo-settings__schema-pair-error">
+										{ OPENING_HOURS_PAIR_ERROR }
+									</span>
+								) }
+							</div>
+						</div>
+					);
+				} ) }
 			</Stack>
 		</Stack>
 	);

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -1,0 +1,232 @@
+/* eslint-disable react/jsx-no-bind */
+
+import { TextControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import type {
+	LocalBusinessAddress,
+	LocalBusinessSettings,
+	OpeningHoursDay,
+} from '../../../data/schema-settings-types';
+import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
+import type { FC } from 'react';
+
+const OPENING_DAYS: Array< { code: OpeningHoursDay; label: string } > = [
+	{ code: 'Mo', label: __( 'Monday', 'jetpack-seo' ) },
+	{ code: 'Tu', label: __( 'Tuesday', 'jetpack-seo' ) },
+	{ code: 'We', label: __( 'Wednesday', 'jetpack-seo' ) },
+	{ code: 'Th', label: __( 'Thursday', 'jetpack-seo' ) },
+	{ code: 'Fr', label: __( 'Friday', 'jetpack-seo' ) },
+	{ code: 'Sa', label: __( 'Saturday', 'jetpack-seo' ) },
+	{ code: 'Su', label: __( 'Sunday', 'jetpack-seo' ) },
+];
+
+const ADDRESS_FIELDS: Array< { field: keyof LocalBusinessAddress; label: string; help?: string } > =
+	[
+		{ field: 'streetAddress', label: __( 'Street address', 'jetpack-seo' ) },
+		{ field: 'addressLocality', label: __( 'City', 'jetpack-seo' ) },
+		{ field: 'addressRegion', label: __( 'State/Region', 'jetpack-seo' ) },
+		{ field: 'postalCode', label: __( 'Postal code', 'jetpack-seo' ) },
+		{
+			field: 'addressCountry',
+			label: __( 'Country', 'jetpack-seo' ),
+			help: __( 'Two-letter country code (for example US).', 'jetpack-seo' ),
+		},
+	];
+
+const GEO_FIELDS: Array< {
+	field: keyof LocalBusinessSettings[ 'geo' ];
+	label: string;
+	max: number;
+	error: string;
+} > = [
+	{
+		field: 'latitude',
+		label: __( 'Latitude', 'jetpack-seo' ),
+		max: 90,
+		error: __( 'Enter a latitude between -90 and 90.', 'jetpack-seo' ),
+	},
+	{
+		field: 'longitude',
+		label: __( 'Longitude', 'jetpack-seo' ),
+		max: 180,
+		error: __( 'Enter a longitude between -180 and 180.', 'jetpack-seo' ),
+	},
+];
+const GEO_PAIR_ERROR = __(
+	'Enter both latitude and longitude, or leave both blank.',
+	'jetpack-seo'
+);
+
+interface Props {
+	/** The schema-settings form controller, owned by the Schema card. */
+	form: SchemaSettingsForm;
+}
+
+const isCoordinate = ( value: string, max: number ) => {
+	if ( ! value.trim() ) {
+		return true;
+	}
+	const number = Number( value );
+	return Number.isFinite( number ) && Math.abs( number ) <= max;
+};
+
+export const hasLocalBusinessErrors = ( form: SchemaSettingsForm ) => {
+	const { latitude, longitude } = form.localBusiness.geo;
+	const hasPartialGeo = Boolean( latitude.trim() ) !== Boolean( longitude.trim() );
+	return hasPartialGeo || ! isCoordinate( latitude, 90 ) || ! isCoordinate( longitude, 180 );
+};
+
+/**
+ * LocalBusiness settings fields shown when the LocalBusiness toggle is enabled.
+ *
+ * @param props      - Component props.
+ * @param props.form - The schema-settings form controller from the card.
+ * @return LocalBusiness settings fields.
+ */
+const LocalBusinessFields: FC< Props > = ( { form } ) => {
+	const { localBusiness, localBusinessDefaults, isSaving, setLocalBusinessField } = form;
+	const { address, geo, openingHours } = localBusiness;
+	const storedAddressEmpty = Object.values( address ).every( value => ! value );
+	const defaultAddressEmpty = Object.values( localBusinessDefaults.address ).every(
+		value => ! value
+	);
+
+	const setAddress = ( field: keyof typeof address, value: string ) =>
+		setLocalBusinessField( { address: { ...address, [ field ]: value } } );
+
+	const setGeo = ( field: keyof typeof geo, value: string ) =>
+		setLocalBusinessField( { geo: { ...geo, [ field ]: value } } );
+
+	// ponytail: single interval per day; split shifts when someone asks.
+	const setHours = ( day: OpeningHoursDay, field: 'opens' | 'closes', value: string ) =>
+		setLocalBusinessField( {
+			openingHours: {
+				...openingHours,
+				[ day ]: { ...openingHours[ day ], [ field ]: value },
+			},
+		} );
+
+	return (
+		<Stack direction="column" gap="lg">
+			{ storedAddressEmpty && defaultAddressEmpty && (
+				<span className="jetpack-seo-settings__title-tokens-label">
+					{ __(
+						'Add your business address — Google requires it before LocalBusiness info is shown.',
+						'jetpack-seo'
+					) }
+				</span>
+			) }
+
+			{ ADDRESS_FIELDS.map( ( { field, label, help } ) => (
+				<TextControl
+					key={ field }
+					label={ label }
+					help={ help }
+					placeholder={ localBusinessDefaults.address[ field ] }
+					value={ address[ field ] }
+					onChange={ next => setAddress( field, next ) }
+					disabled={ isSaving }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) ) }
+
+			<TextControl
+				label={ __( 'Phone', 'jetpack-seo' ) }
+				type="tel"
+				value={ localBusiness.telephone }
+				onChange={ next => setLocalBusinessField( { telephone: next } ) }
+				disabled={ isSaving }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+
+			<TextControl
+				label={ __( 'Price range', 'jetpack-seo' ) }
+				placeholder="$$"
+				help={ __( 'How expensive the business is, from $ to $$$$.', 'jetpack-seo' ) }
+				value={ localBusiness.priceRange }
+				onChange={ next => setLocalBusinessField( { priceRange: next } ) }
+				disabled={ isSaving }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+
+			<Stack direction="row" gap="sm" align="flex-start" wrap="wrap">
+				{ GEO_FIELDS.map( ( { field, label, max, error } ) => {
+					const hasPartialGeo = Boolean( geo.latitude.trim() ) !== Boolean( geo.longitude.trim() );
+					const fieldError =
+						hasPartialGeo ||
+						( Boolean( geo[ field ].trim() ) && ! isCoordinate( geo[ field ], max ) );
+					const helpText = hasPartialGeo ? GEO_PAIR_ERROR : error;
+					return (
+						<div
+							key={ field }
+							className={
+								'jetpack-seo-settings__schema-profile-input' +
+								( fieldError ? ' jetpack-seo-settings__schema-profile-input--error' : '' )
+							}
+						>
+							<TextControl
+								label={ label }
+								inputMode="decimal"
+								value={ geo[ field ] }
+								onChange={ next => setGeo( field, next ) }
+								disabled={ isSaving }
+								help={ fieldError ? helpText : undefined }
+								aria-invalid={ Boolean( fieldError ) }
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+							/>
+						</div>
+					);
+				} ) }
+			</Stack>
+
+			<Stack direction="column" gap="sm">
+				<span className="jetpack-seo-settings__schema-field-label">
+					{ __( 'Opening hours', 'jetpack-seo' ) }
+				</span>
+				<span className="jetpack-seo-settings__title-tokens-label">
+					{ __( "Leave a day blank if it's closed.", 'jetpack-seo' ) }
+				</span>
+				{ OPENING_DAYS.map( ( { code, label } ) => (
+					<Stack key={ code } direction="row" gap="sm" align="center" wrap="wrap">
+						<span className="jetpack-seo-settings__schema-day-label">{ label }</span>
+						<TextControl
+							label={ sprintf(
+								/* translators: %s: day of week. */
+								__( '%s opens', 'jetpack-seo' ),
+								label
+							) }
+							hideLabelFromVision
+							type="time"
+							value={ openingHours[ code ].opens }
+							onChange={ next => setHours( code, 'opens', next ) }
+							disabled={ isSaving }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<TextControl
+							label={ sprintf(
+								/* translators: %s: day of week. */
+								__( '%s closes', 'jetpack-seo' ),
+								label
+							) }
+							hideLabelFromVision
+							type="time"
+							value={ openingHours[ code ].closes }
+							onChange={ next => setHours( code, 'closes', next ) }
+							disabled={ isSaving }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</Stack>
+				) ) }
+			</Stack>
+		</Stack>
+	);
+};
+
+export default LocalBusinessFields;

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -98,7 +98,6 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 	const setGeo = ( field: keyof typeof geo, value: string ) =>
 		setLocalBusinessField( { geo: { ...geo, [ field ]: value } } );
 
-	// ponytail: single interval per day; split shifts when someone asks.
 	const setHours = ( day: OpeningHoursDay, field: 'opens' | 'closes', value: string ) =>
 		setLocalBusinessField( {
 			openingHours: {

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/organization-business-section.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { TextControl, TextareaControl } from '@wordpress/components';
+import { TextControl, TextareaControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
+import LocalBusinessFields, { hasLocalBusinessErrors } from './local-business-fields';
 import ProfileUrlList, { hasProfileUrlErrors } from './profile-url-list';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 import type { FC } from 'react';
@@ -29,9 +30,19 @@ interface Props {
  * @return The Organization settings form.
  */
 const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
-	const { organization, defaults, isSaving, isDirty, setOrganizationField, save } = form;
+	const {
+		organization,
+		defaults,
+		localBusiness,
+		isSaving,
+		isDirty,
+		setOrganizationField,
+		setLocalBusinessField,
+		save,
+	} = form;
 	const { name, description, sameAs, email } = organization;
 	const hasProfileErrors = hasProfileUrlErrors( sameAs );
+	const hasErrors = hasProfileErrors || ( localBusiness.enabled && hasLocalBusinessErrors( form ) );
 
 	return (
 		<Stack direction="column" gap="lg">
@@ -85,8 +96,22 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 				__nextHasNoMarginBottom
 			/>
 
+			<ToggleControl
+				label={ __( 'This site represents a local business', 'jetpack-seo' ) }
+				help={ __(
+					"Adds your business details (address, phone, hours) to the site's schema so search engines can show local info.",
+					'jetpack-seo'
+				) }
+				checked={ localBusiness.enabled }
+				onChange={ next => setLocalBusinessField( { enabled: next } ) }
+				disabled={ isSaving }
+				__nextHasNoMarginBottom
+			/>
+
+			{ localBusiness.enabled && <LocalBusinessFields form={ form } /> }
+
 			<div className="jetpack-seo-settings__save">
-				<Button onClick={ save } disabled={ isSaving || ! isDirty || hasProfileErrors }>
+				<Button onClick={ save } disabled={ isSaving || ! isDirty || hasErrors }>
 					{ saveLabel }
 				</Button>
 			</div>

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -138,6 +138,10 @@
 	}
 }
 
+.jetpack-seo-settings__schema-day-label {
+	min-inline-size: 84px;
+}
+
 // Intro copy above the preview list.
 .jetpack-seo-settings__preview-intro {
 	margin: 0 0 var(--wpds-dimension-gap-xl, 24px);

--- a/projects/packages/seo/_inc/screens/settings/style.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.scss
@@ -122,8 +122,36 @@
 	min-inline-size: 0;
 }
 
-.jetpack-seo-settings__schema-profile-input--error .components-base-control__help {
-	color: var(--wpds-color-foreground-content-error, #d63638);
+.jetpack-seo-settings__schema-profile-input--error .components-base-control__help,
+.jetpack-seo-settings__schema-field--error .components-base-control__help {
+	color: var(--wpds-color-foreground-content-error-weak, #cc1818);
+}
+
+// Keep paired controls on one row and place their shared validation message
+// beneath both fields so helper text cannot change either control's width.
+.jetpack-seo-settings__schema-paired-fields {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	min-inline-size: 0;
+}
+
+.jetpack-seo-settings__schema-paired-field {
+	min-inline-size: 0;
+}
+
+.jetpack-seo-settings__schema-pair-error {
+	grid-column: 1 / -1;
+	margin: 0;
+	font-size: 12px;
+	color: var(--wpds-color-foreground-content-error-weak, #cc1818);
+}
+
+.jetpack-seo-settings__schema-opening-hours-row {
+	display: grid;
+	grid-template-columns: 84px minmax(0, 1fr);
+	gap: var(--wpds-dimension-gap-sm, 8px);
+	align-items: start;
 }
 
 .jetpack-seo-settings__schema-avatar {
@@ -139,7 +167,10 @@
 }
 
 .jetpack-seo-settings__schema-day-label {
+	display: flex;
+	align-items: center;
 	min-inline-size: 84px;
+	min-block-size: 40px;
 }
 
 // Intro copy above the preview list.

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
 import { fireEvent, render, screen } from '@testing-library/react';
+import {
+	EMPTY_LOCAL_BUSINESS,
+	EMPTY_LOCAL_BUSINESS_DEFAULTS,
+	makeSchemaSettings,
+} from '../../../data/test/fixtures/schema-settings-fixtures';
 import type { SchemaSettings } from '../../../data/schema-settings-types';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 
@@ -8,6 +13,7 @@ import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 // `jest.unstable_mockModule`, then import the card dynamically. Mocking the hook
 // keeps the card test off the network while exercising the real section + card UI.
 const setOrganizationField = jest.fn();
+const setLocalBusinessField = jest.fn();
 const save = jest.fn();
 
 // Resettable per test so each can vary the configured state the header badge reflects.
@@ -17,9 +23,12 @@ const makeForm = ( overrides: Partial< SchemaSettingsForm > = {} ): SchemaSettin
 	// No stored override; the Site Title / Tagline come through as placeholder defaults.
 	organization: { name: '', description: '', sameAs: [], email: '' },
 	defaults: { name: 'Acme Co', description: 'We make things' },
+	localBusiness: EMPTY_LOCAL_BUSINESS,
+	localBusinessDefaults: EMPTY_LOCAL_BUSINESS_DEFAULTS,
 	isSaving: false,
 	isDirty: false,
 	setOrganizationField,
+	setLocalBusinessField,
 	save,
 	...overrides,
 } );
@@ -31,10 +40,7 @@ jest.unstable_mockModule( '../../../data/use-schema-settings', () => ( {
 const { default: SchemaCard } = await import( '../schema-card' );
 
 // The hook is mocked, so the bootstrap value is only here to satisfy the prop type.
-const bootstrap: SchemaSettings = {
-	organization: { name: '', description: '', sameAs: [], email: '' },
-	defaults: { organization: { name: 'Acme Co', description: 'We make things' } },
-};
+const bootstrap: SchemaSettings = makeSchemaSettings();
 
 const renderCard = () => render( <SchemaCard initialSettings={ bootstrap } /> );
 
@@ -76,6 +82,54 @@ describe( 'SchemaCard', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: /Add profile/ } ) );
 
 		expect( setOrganizationField ).toHaveBeenCalledWith( { sameAs: [ '' ] } );
+	} );
+
+	it( 'hides LocalBusiness fields until the toggle is enabled', () => {
+		const view = renderCard();
+		expand();
+
+		expect( screen.queryByRole( 'textbox', { name: /Street address/ } ) ).not.toBeInTheDocument();
+
+		view.unmount();
+		mockForm = makeForm( {
+			localBusiness: { ...mockForm.localBusiness, enabled: true },
+		} );
+		renderCard();
+		expand();
+
+		expect( screen.getByRole( 'textbox', { name: /Street address/ } ) ).toBeInTheDocument();
+		expect( screen.getByText( /Google requires it/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'updates the LocalBusiness toggle through the hook', () => {
+		renderCard();
+		expand();
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
+		fireEvent.click( screen.getByRole( 'checkbox', { name: /local business/ } ) );
+
+		expect( setLocalBusinessField ).toHaveBeenCalledWith( { enabled: true } );
+	} );
+
+	it( 'disables saving when only one geo coordinate is filled', () => {
+		mockForm = makeForm( {
+			isDirty: true,
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				geo: { latitude: '40.7128', longitude: '' },
+			},
+		} );
+		renderCard();
+		expand();
+
+		expect(
+			screen.getAllByText( 'Enter both latitude and longitude, or leave both blank.' )
+		).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'disables saving when a social profile URL is invalid', () => {
@@ -154,6 +208,28 @@ describe( 'SchemaCard', () => {
 		renderCard();
 
 		expect( screen.getByText( '3 of 4 set' ) ).toBeInTheDocument();
+	} );
+
+	it( 'counts LocalBusiness address as a fifth badge item only when enabled', () => {
+		mockForm = makeForm( {
+			localBusiness: {
+				...mockForm.localBusiness,
+				address: { ...mockForm.localBusiness.address, streetAddress: '123 Main St' },
+			},
+		} );
+		const view = renderCard();
+		expect( screen.getByText( '2 of 4 set' ) ).toBeInTheDocument();
+
+		view.unmount();
+		mockForm = makeForm( {
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				address: { ...mockForm.localBusiness.address, streetAddress: '123 Main St' },
+			},
+		} );
+		renderCard();
+		expect( screen.getByText( '3 of 5 set' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows "Not set" when nothing is configured (no site identity either)', () => {

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -123,13 +123,158 @@ describe( 'SchemaCard', () => {
 		renderCard();
 		expand();
 
-		expect(
-			screen.getAllByText( 'Enter both latitude and longitude, or leave both blank.' )
-		).toHaveLength( 2 );
+		const error = screen.getByText( 'Enter both latitude and longitude, or leave both blank.' );
+		expect( error ).toHaveClass( 'jetpack-seo-settings__schema-pair-error' );
+		expect( screen.getByRole( 'textbox', { name: 'Latitude' } ) ).toHaveAttribute(
+			'aria-describedby',
+			error.id
+		);
+		expect( screen.getByRole( 'textbox', { name: 'Longitude' } ) ).toHaveAttribute(
+			'aria-describedby',
+			error.id
+		);
 		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
+	} );
+
+	it( 'disables saving and marks invalid LocalBusiness text fields', () => {
+		mockForm = makeForm( {
+			isDirty: true,
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				address: { ...mockForm.localBusiness.address, addressCountry: 'USA' },
+				telephone: 'Call me',
+				priceRange: 'x'.repeat( 100 ),
+			},
+		} );
+		renderCard();
+		expand();
+
+		expect( screen.getByRole( 'textbox', { name: 'Country' } ) ).toHaveAttribute(
+			'aria-invalid',
+			'true'
+		);
+		expect( screen.getByRole( 'textbox', { name: 'Phone' } ) ).toHaveAttribute(
+			'aria-invalid',
+			'true'
+		);
+		expect( screen.getByRole( 'textbox', { name: 'Price range' } ) ).toHaveAttribute(
+			'aria-invalid',
+			'true'
+		);
+		expect( screen.getByText( 'Enter fewer than 100 characters.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'uppercases country codes as they are entered', () => {
+		mockForm = makeForm( {
+			localBusiness: { ...mockForm.localBusiness, enabled: true },
+		} );
+		renderCard();
+		expand();
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- single controlled change; see note above.
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Country' } ), {
+			target: { value: 'us' },
+		} );
+		expect( setLocalBusinessField ).toHaveBeenCalledWith( {
+			address: { ...mockForm.localBusiness.address, addressCountry: 'US' },
+		} );
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- single controlled change; see note above.
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Country' } ), {
+			target: { value: 'uſ' },
+		} );
+		expect( setLocalBusinessField ).toHaveBeenLastCalledWith( {
+			address: { ...mockForm.localBusiness.address, addressCountry: 'Uſ' },
+		} );
+	} );
+
+	it.each( [
+		[ { opens: '09:00', closes: '' }, 'Monday closes' ],
+		[ { opens: '', closes: '17:00' }, 'Monday opens' ],
+	] )( 'disables saving when an opening-hours pair is incomplete', ( monday, missingField ) => {
+		mockForm = makeForm( {
+			isDirty: true,
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				openingHours: { ...mockForm.localBusiness.openingHours, Mo: monday },
+			},
+		} );
+		renderCard();
+		expand();
+
+		expect( screen.getByLabelText( missingField ) ).toHaveAttribute( 'aria-invalid', 'true' );
+		const error = screen.getByText( 'Enter both opening and closing times, or leave both blank.' );
+		expect( error ).toHaveClass( 'jetpack-seo-settings__schema-pair-error' );
+		expect( screen.getByLabelText( 'Monday opens' ) ).toHaveAttribute(
+			'aria-describedby',
+			error.id
+		);
+		expect( screen.getByLabelText( 'Monday closes' ) ).toHaveAttribute(
+			'aria-describedby',
+			error.id
+		);
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'allows valid international details and overnight hours', () => {
+		mockForm = makeForm( {
+			isDirty: true,
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				address: { ...mockForm.localBusiness.address, addressCountry: 'US' },
+				telephone: '+1 (555) 123-4567',
+				priceRange: '💶'.repeat( 99 ),
+				openingHours: {
+					...mockForm.localBusiness.openingHours,
+					Mo: { opens: '20:45', closes: '06:15' },
+				},
+			},
+		} );
+		renderCard();
+		expand();
+
+		expect( screen.getByText( /closing time earlier than opening/ ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'clears a native partial time value on blur', () => {
+		mockForm = makeForm( {
+			localBusiness: { ...mockForm.localBusiness, enabled: true },
+		} );
+		renderCard();
+		expand();
+
+		const input = screen.getByLabelText( 'Monday opens' ) as HTMLInputElement;
+		input.value = '09:00';
+		Object.defineProperty( input, 'validity', {
+			configurable: true,
+			value: { badInput: true },
+		} );
+		fireEvent.blur( input );
+
+		expect( input ).toHaveValue( '' );
+		expect( setLocalBusinessField ).toHaveBeenCalledWith( {
+			openingHours: {
+				...mockForm.localBusiness.openingHours,
+				Mo: { opens: '', closes: '' },
+			},
+		} );
 	} );
 
 	it( 'disables saving when a social profile URL is invalid', () => {

--- a/projects/packages/seo/changelog/add-seo-schema-local-business
+++ b/projects/packages/seo/changelog/add-seo-schema-local-business
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add LocalBusiness details to the site Organization schema, with settings and a local-business toggle.

--- a/projects/packages/seo/src/class-local-business-schema-node.php
+++ b/projects/packages/seo/src/class-local-business-schema-node.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * LocalBusiness Schema.org decorator for the site-level Organization node.
+ *
+ * Adds LocalBusiness properties to the existing Organization entity when the
+ * admin has enabled local-business schema and configured an address. This keeps
+ * all publisher references pointing at the same stable `#organization` node
+ * instead of introducing a second business entity.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+/**
+ * Decorates the site-level Organization node with LocalBusiness details.
+ */
+class Local_Business_Schema_Node {
+
+	/**
+	 * Schema.org opening-hours day-code order and emitted day names.
+	 *
+	 * @var array<string, string>
+	 */
+	const DAY_NAMES = array(
+		'Mo' => 'Monday',
+		'Tu' => 'Tuesday',
+		'We' => 'Wednesday',
+		'Th' => 'Thursday',
+		'Fr' => 'Friday',
+		'Sa' => 'Saturday',
+		'Su' => 'Sunday',
+	);
+
+	/**
+	 * Extend an Organization node with LocalBusiness properties.
+	 *
+	 * @param array|null $organization Built Organization node (null passes through).
+	 * @param array      $settings     Effective values from Schema_Settings::get_local_business().
+	 * @return array|null
+	 */
+	public static function extend( $organization, array $settings ) {
+		if ( null === $organization || ! is_array( $organization ) ) {
+			return $organization;
+		}
+
+		if ( empty( $settings['enabled'] ) ) {
+			return $organization;
+		}
+
+		$address = self::postal_address( isset( $settings['address'] ) && is_array( $settings['address'] ) ? $settings['address'] : array() );
+		if ( null === $address ) {
+			return $organization;
+		}
+
+		$organization['@type']   = array( 'Organization', 'LocalBusiness' );
+		$organization['address'] = $address;
+
+		foreach ( array( 'telephone', 'priceRange' ) as $field ) {
+			if ( ! empty( $settings[ $field ] ) && is_string( $settings[ $field ] ) ) {
+				$organization[ $field ] = $settings[ $field ];
+			}
+		}
+
+		if ( isset( $settings['geo'] ) && is_array( $settings['geo'] ) ) {
+			$latitude  = $settings['geo']['latitude'] ?? '';
+			$longitude = $settings['geo']['longitude'] ?? '';
+			if ( is_numeric( $latitude ) && is_numeric( $longitude ) ) {
+				$organization['geo'] = array(
+					'@type'     => 'GeoCoordinates',
+					'latitude'  => (float) $latitude,
+					'longitude' => (float) $longitude,
+				);
+			}
+		}
+
+		$hours = self::opening_hours_specification( isset( $settings['openingHours'] ) && is_array( $settings['openingHours'] ) ? $settings['openingHours'] : array() );
+		if ( ! empty( $hours ) ) {
+			$organization['openingHoursSpecification'] = $hours;
+		}
+
+		return $organization;
+	}
+
+	/**
+	 * Build a PostalAddress from non-empty address subfields.
+	 *
+	 * @param array $address Address settings.
+	 * @return array|null
+	 */
+	private static function postal_address( array $address ) {
+		$postal_address = array( '@type' => 'PostalAddress' );
+		foreach ( array( 'streetAddress', 'addressLocality', 'addressRegion', 'postalCode', 'addressCountry' ) as $field ) {
+			if ( ! empty( $address[ $field ] ) && is_string( $address[ $field ] ) ) {
+				$postal_address[ $field ] = $address[ $field ];
+			}
+		}
+
+		return count( $postal_address ) > 1 ? $postal_address : null;
+	}
+
+	/**
+	 * Build OpeningHoursSpecification rows for fully configured days.
+	 *
+	 * @param array $opening_hours Opening-hours settings keyed by schema.org day code.
+	 * @return array<int, array<string, string>>
+	 */
+	private static function opening_hours_specification( array $opening_hours ) {
+		$specification = array();
+		foreach ( self::DAY_NAMES as $code => $day_name ) {
+			$entry  = isset( $opening_hours[ $code ] ) && is_array( $opening_hours[ $code ] ) ? $opening_hours[ $code ] : array();
+			$opens  = isset( $entry['opens'] ) && is_string( $entry['opens'] ) ? $entry['opens'] : '';
+			$closes = isset( $entry['closes'] ) && is_string( $entry['closes'] ) ? $entry['closes'] : '';
+
+			if ( '' === $opens || '' === $closes ) {
+				continue;
+			}
+
+			$specification[] = array(
+				'@type'     => 'OpeningHoursSpecification',
+				'dayOfWeek' => $day_name,
+				'opens'     => $opens,
+				'closes'    => $closes,
+			);
+		}
+
+		return $specification;
+	}
+}

--- a/projects/packages/seo/src/class-schema-builder.php
+++ b/projects/packages/seo/src/class-schema-builder.php
@@ -4,20 +4,20 @@
  *
  * Serializes a Schema.org `@graph` document into the document `<head>`. The graph
  * is assembled from independent, condition-gated contributions: the site-level
- * Organization and WebSite nodes, emitted on the home page only (Google treats
- * them as single canonical site entities), the page node (Article or FAQPage)
- * built by {@see Post_Schema_Node} on singular requests, and Person/ProfilePage
- * nodes on author archives. An Article references its author's full Person node
- * (added to the same graph) by `@id`, and — like the WebSite node — references
- * the home-page Organization as its `publisher` by stable `@id` rather than
- * duplicating the node. Emission is gated on
- * `Jetpack_SEO_Utils::is_enabled_jetpack_seo()`.
+ * Organization node (optionally extended as LocalBusiness) and WebSite node,
+ * emitted on the home page only (Google treats them as single canonical site
+ * entities), the page node (Article or FAQPage) built by {@see Post_Schema_Node}
+ * on singular requests, and Person/ProfilePage nodes on author archives. An
+ * Article references its author's full Person node (added to the same graph) by
+ * `@id`, and — like the WebSite node — references the home-page Organization as
+ * its `publisher` by stable `@id` rather than duplicating the node. Emission is
+ * gated on `Jetpack_SEO_Utils::is_enabled_jetpack_seo()`.
  *
  * This class owns only the gating and serialization; the individual nodes and
  * their stable `@id`s live in their own builders ({@see Post_Schema_Node},
- * {@see Organization_Schema_Node}, {@see Website_Schema_Node},
- * {@see Author_Schema_Node}, {@see Schema_Node_Ids}) and are assembled by
- * {@see Schema_Graph}.
+ * {@see Organization_Schema_Node}, {@see Local_Business_Schema_Node},
+ * {@see Website_Schema_Node}, {@see Author_Schema_Node}, {@see Schema_Node_Ids})
+ * and are assembled by {@see Schema_Graph}.
  *
  * @package automattic/jetpack-seo-package
  */
@@ -98,6 +98,7 @@ class Schema_Builder {
 		// it regardless so we know whether `@id` references to it (publisher, worksFor)
 		// will resolve, but only add the full node on the home page.
 		$organization = Organization_Schema_Node::build( Schema_Settings::get_organization() );
+		$organization = Local_Business_Schema_Node::extend( $organization, Schema_Settings::get_local_business() );
 
 		// Site-level nodes (Organization, WebSite) describe a single canonical
 		// entity, so they belong on the home page only (Google's guidance) — never

--- a/projects/packages/seo/src/class-schema-settings.php
+++ b/projects/packages/seo/src/class-schema-settings.php
@@ -3,15 +3,16 @@
  * Package-owned store for the site-level Schema.org settings.
  *
  * Persists the admin-configurable values WordPress has no native source for —
- * social profiles (`sameAs`), a contact `email`, and optional `name` /
- * `description` overrides. The Organization node reads the effective values via
- * {@see self::get_organization()}; the Settings UI round-trips them through
+ * social profiles (`sameAs`), a contact `email`, optional `name` /
+ * `description` overrides, and LocalBusiness details. The Organization node
+ * reads the effective values via {@see self::get_organization()} and
+ * {@see self::get_local_business()}; the Settings UI round-trips them through
  * {@see Schema_Settings_Controller}.
  *
- * The option is a container keyed by schema type so later types (LocalBusiness,
- * Breadcrumb) slot in without breaking the contract; only `organization` exists
- * today. Empty overrides fall back to site identity at read time, so an
- * unconfigured site still emits a valid node and later Site Title changes track.
+ * The option is a container keyed by schema type so later types slot in without
+ * breaking the contract. Empty Organization overrides fall back to site identity
+ * at read time, so an unconfigured site still emits a valid node and later Site
+ * Title changes track.
  *
  * @package automattic/jetpack-seo-package
  */
@@ -32,22 +33,34 @@ class Schema_Settings {
 	const OPTION_NAME = 'jetpack_seo_schema_settings_v1';
 
 	/**
+	 * Schema.org day-code order for stored opening-hours settings.
+	 *
+	 * @var array<int, string>
+	 */
+	const OPENING_DAYS = array( 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su' );
+
+	/**
 	 * The editing payload for the Settings form / REST route: the raw stored
 	 * overrides (empty where unset) plus the site-identity defaults the form shows
 	 * as field placeholders. Keeping the two separate lets an empty field track the
 	 * Site Title instead of freezing its value.
 	 *
-	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, defaults: array{organization: array{name: string, description: string}}}
+	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, localBusiness: array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}, defaults: array{organization: array{name: string, description: string}, localBusiness: array{address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}}}}
 	 */
 	public static function get_editable() {
 		$defaults = self::get_defaults();
+		$stored   = self::get_stored();
 
 		return array(
-			'organization' => self::get_stored()['organization'],
-			'defaults'     => array(
-				'organization' => array(
+			'organization'  => $stored['organization'],
+			'localBusiness' => $stored['localBusiness'],
+			'defaults'      => array(
+				'organization'  => array(
 					'name'        => $defaults['organization']['name'],
 					'description' => $defaults['organization']['description'],
+				),
+				'localBusiness' => array(
+					'address' => $defaults['localBusiness']['address'],
 				),
 			),
 		);
@@ -56,15 +69,21 @@ class Schema_Settings {
 	/**
 	 * Site-identity defaults for the fields WordPress has a source for: `name` /
 	 * `description` from the Site Title and Tagline. Shown as placeholders and used
-	 * as the fallback. `sameAs` / `email` have no source, so they aren't defaulted.
+	 * as the fallback. WooCommerce store address settings, when WooCommerce is
+	 * active, provide LocalBusiness address placeholders and read-time fallbacks.
+	 * `sameAs` / `email` and the other LocalBusiness fields have no source, so they
+	 * aren't defaulted.
 	 *
-	 * @return array{organization: array{name: string, description: string}}
+	 * @return array{organization: array{name: string, description: string}, localBusiness: array{address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}}}
 	 */
 	public static function get_defaults() {
 		return array(
-			'organization' => array(
+			'organization'  => array(
 				'name'        => self::text( get_bloginfo( 'name' ) ),
 				'description' => self::text( get_bloginfo( 'description' ) ),
+			),
+			'localBusiness' => array(
+				'address' => self::woo_address_defaults(),
 			),
 		);
 	}
@@ -92,13 +111,44 @@ class Schema_Settings {
 	}
 
 	/**
+	 * The effective LocalBusiness settings the node consumes: stored values, with
+	 * each address subfield falling back to WooCommerce store-address defaults when
+	 * the stored value is empty. Other LocalBusiness properties are stored-only.
+	 *
+	 * @return array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}
+	 */
+	public static function get_local_business() {
+		$defaults = self::get_defaults();
+		$stored   = self::get_stored();
+
+		$local_business = $stored['localBusiness'];
+		$fallbacks      = $defaults['localBusiness']['address'];
+
+		foreach ( array( 'streetAddress', 'addressLocality', 'addressRegion', 'postalCode', 'addressCountry' ) as $field ) {
+			if ( '' === $local_business['address'][ $field ] ) {
+				$local_business['address'][ $field ] = $fallbacks[ $field ];
+			}
+		}
+
+		return $local_business;
+	}
+
+	/**
 	 * Sanitize a raw submission and persist it, then return the new editing payload
 	 * (so the caller can hand it straight back to the client).
 	 *
 	 * @param mixed $raw Raw input (expected to be the container array).
-	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, defaults: array{organization: array{name: string, description: string}}}
+	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, localBusiness: array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}, defaults: array{organization: array{name: string, description: string}, localBusiness: array{address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}}}}
 	 */
 	public static function update( $raw ) {
+		$raw    = is_array( $raw ) ? $raw : array();
+		$stored = self::get_stored();
+		foreach ( array( 'organization', 'localBusiness' ) as $section ) {
+			if ( ! array_key_exists( $section, $raw ) ) {
+				$raw[ $section ] = $stored[ $section ];
+			}
+		}
+
 		update_option( self::OPTION_NAME, self::sanitize( $raw ) );
 		return self::get_editable();
 	}
@@ -106,10 +156,11 @@ class Schema_Settings {
 	/**
 	 * Normalize and sanitize raw input into the stored option shape: trimmed plain
 	 * text for `name` / `description`, validated + deduped URLs for `sameAs`, a
-	 * sanitized `email`. Defensive against non-array / non-string input.
+	 * sanitized `email`, and normalized LocalBusiness fields. Defensive against
+	 * non-array / non-string input.
 	 *
 	 * @param mixed $raw Raw input.
-	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}}
+	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, localBusiness: array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}}
 	 */
 	public static function sanitize( $raw ) {
 		$raw          = is_array( $raw ) ? $raw : array();
@@ -118,12 +169,13 @@ class Schema_Settings {
 			: array();
 
 		return array(
-			'organization' => array(
+			'organization'  => array(
 				'name'        => self::text( $organization['name'] ?? '' ),
 				'description' => self::text( $organization['description'] ?? '' ),
 				'sameAs'      => self::sanitize_url_list( $organization['sameAs'] ?? array() ),
 				'email'       => self::email( $organization['email'] ?? '' ),
 			),
+			'localBusiness' => self::sanitize_local_business( $raw['localBusiness'] ?? array() ),
 		);
 	}
 
@@ -173,10 +225,172 @@ class Schema_Settings {
 	 * The stored settings, normalized to the full option shape (so callers can
 	 * rely on every key being present even when the option is absent or partial).
 	 *
-	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}}
+	 * @return array{organization: array{name: string, description: string, sameAs: array<int, string>, email: string}, localBusiness: array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}}
 	 */
 	private static function get_stored() {
 		return self::sanitize( get_option( self::OPTION_NAME, array() ) );
+	}
+
+	/**
+	 * Normalize and sanitize raw LocalBusiness input into the stored option shape.
+	 *
+	 * @param mixed $raw Raw LocalBusiness input.
+	 * @return array{enabled: bool, address: array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}, telephone: string, geo: array{latitude: string, longitude: string}, openingHours: array<string, array{opens: string, closes: string}>, priceRange: string}
+	 */
+	private static function sanitize_local_business( $raw ) {
+		$raw     = is_array( $raw ) ? $raw : array();
+		$address = isset( $raw['address'] ) && is_array( $raw['address'] ) ? $raw['address'] : array();
+
+		return array(
+			'enabled'      => ! empty( $raw['enabled'] ),
+			'address'      => array(
+				'streetAddress'   => self::text( $address['streetAddress'] ?? '' ),
+				'addressLocality' => self::text( $address['addressLocality'] ?? '' ),
+				'addressRegion'   => self::text( $address['addressRegion'] ?? '' ),
+				'postalCode'      => self::text( $address['postalCode'] ?? '' ),
+				'addressCountry'  => self::text( $address['addressCountry'] ?? '' ),
+			),
+			'telephone'    => self::text( $raw['telephone'] ?? '' ),
+			'geo'          => self::geo( $raw['geo'] ?? array() ),
+			'openingHours' => self::opening_hours( $raw['openingHours'] ?? array() ),
+			'priceRange'   => self::text( $raw['priceRange'] ?? '' ),
+		);
+	}
+
+	/**
+	 * WooCommerce store-address defaults for LocalBusiness address placeholders.
+	 *
+	 * @return array{streetAddress: string, addressLocality: string, addressRegion: string, postalCode: string, addressCountry: string}
+	 */
+	private static function woo_address_defaults() {
+		$address = array(
+			'streetAddress'   => '',
+			'addressLocality' => '',
+			'addressRegion'   => '',
+			'postalCode'      => '',
+			'addressCountry'  => '',
+		);
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return $address;
+		}
+
+		$street_1 = self::text( (string) get_option( 'woocommerce_store_address', '' ) );
+		$street_2 = self::text( (string) get_option( 'woocommerce_store_address_2', '' ) );
+		if ( '' !== $street_1 ) {
+			$address['streetAddress'] = $street_1;
+		}
+		if ( '' !== $street_2 ) {
+			$address['streetAddress'] = '' !== $address['streetAddress'] ? $address['streetAddress'] . ', ' . $street_2 : $street_2;
+		}
+
+		$address['addressLocality'] = self::text( (string) get_option( 'woocommerce_store_city', '' ) );
+		$address['postalCode']      = self::text( (string) get_option( 'woocommerce_store_postcode', '' ) );
+
+		$country_region            = explode( ':', self::text( (string) get_option( 'woocommerce_default_country', '' ) ), 2 );
+		$address['addressCountry'] = $country_region[0] ?? '';
+		$address['addressRegion']  = $country_region[1] ?? '';
+
+		return $address;
+	}
+
+	/**
+	 * Normalize latitude/longitude settings. A half-coordinate is useless, so any
+	 * invalid or missing endpoint clears both.
+	 *
+	 * @param mixed $raw Raw geo input.
+	 * @return array{latitude: string, longitude: string}
+	 */
+	private static function geo( $raw ) {
+		$empty = array(
+			'latitude'  => '',
+			'longitude' => '',
+		);
+
+		if ( ! is_array( $raw ) ) {
+			return $empty;
+		}
+
+		$latitude  = self::coordinate( $raw['latitude'] ?? null, 90 );
+		$longitude = self::coordinate( $raw['longitude'] ?? null, 180 );
+
+		if ( null === $latitude || null === $longitude ) {
+			return $empty;
+		}
+
+		return array(
+			'latitude'  => $latitude,
+			'longitude' => $longitude,
+		);
+	}
+
+	/**
+	 * Validate and normalize one coordinate.
+	 *
+	 * @param mixed $value Raw coordinate.
+	 * @param int   $max   Absolute allowed bound.
+	 * @return string|null
+	 */
+	private static function coordinate( $value, $max ) {
+		if ( ! is_scalar( $value ) ) {
+			return null;
+		}
+
+		$value = trim( (string) $value );
+		if ( '' === $value || ! is_numeric( $value ) ) {
+			return null;
+		}
+
+		$number = (float) $value;
+		if ( abs( $number ) > $max ) {
+			return null;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Normalize opening hours to all seven schema.org day codes.
+	 *
+	 * @param mixed $raw Raw opening-hours input.
+	 * @return array<string, array{opens: string, closes: string}>
+	 */
+	private static function opening_hours( $raw ) {
+		$raw   = is_array( $raw ) ? $raw : array();
+		$hours = array();
+
+		foreach ( self::OPENING_DAYS as $day ) {
+			$entry  = isset( $raw[ $day ] ) && is_array( $raw[ $day ] ) ? $raw[ $day ] : array();
+			$opens  = self::time( $entry['opens'] ?? '' );
+			$closes = self::time( $entry['closes'] ?? '' );
+
+			if ( '' === $opens || '' === $closes ) {
+				$opens  = '';
+				$closes = '';
+			}
+
+			$hours[ $day ] = array(
+				'opens'  => $opens,
+				'closes' => $closes,
+			);
+		}
+
+		return $hours;
+	}
+
+	/**
+	 * Validate an `HH:MM` 24-hour time value.
+	 *
+	 * @param mixed $value Raw time value.
+	 * @return string
+	 */
+	private static function time( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$value = trim( $value );
+		return preg_match( '/^([01][0-9]|2[0-3]):[0-5][0-9]$/', $value ) ? $value : '';
 	}
 
 	/**

--- a/projects/packages/seo/src/class-schema-settings.php
+++ b/projects/packages/seo/src/class-schema-settings.php
@@ -248,12 +248,12 @@ class Schema_Settings {
 				'addressLocality' => self::text( $address['addressLocality'] ?? '' ),
 				'addressRegion'   => self::text( $address['addressRegion'] ?? '' ),
 				'postalCode'      => self::text( $address['postalCode'] ?? '' ),
-				'addressCountry'  => self::text( $address['addressCountry'] ?? '' ),
+				'addressCountry'  => self::country_code( $address['addressCountry'] ?? '' ),
 			),
-			'telephone'    => self::text( $raw['telephone'] ?? '' ),
+			'telephone'    => self::telephone( $raw['telephone'] ?? '' ),
 			'geo'          => self::geo( $raw['geo'] ?? array() ),
 			'openingHours' => self::opening_hours( $raw['openingHours'] ?? array() ),
-			'priceRange'   => self::text( $raw['priceRange'] ?? '' ),
+			'priceRange'   => self::price_range( $raw['priceRange'] ?? '' ),
 		);
 	}
 
@@ -288,7 +288,7 @@ class Schema_Settings {
 		$address['postalCode']      = self::text( (string) get_option( 'woocommerce_store_postcode', '' ) );
 
 		$country_region            = explode( ':', self::text( (string) get_option( 'woocommerce_default_country', '' ) ), 2 );
-		$address['addressCountry'] = $country_region[0] ?? '';
+		$address['addressCountry'] = self::country_code( $country_region[0] ?? '' );
 		$address['addressRegion']  = $country_region[1] ?? '';
 
 		return $address;
@@ -391,6 +391,65 @@ class Schema_Settings {
 
 		$value = trim( $value );
 		return preg_match( '/^([01][0-9]|2[0-3]):[0-5][0-9]$/', $value ) ? $value : '';
+	}
+
+	/**
+	 * Normalize an optional ISO 3166-1 alpha-2 country code.
+	 *
+	 * @param mixed $value Raw country code.
+	 * @return string
+	 */
+	private static function country_code( $value ) {
+		$value = self::text( $value );
+		if ( '' === $value || 1 !== preg_match( '/^[A-Za-z]{2}$/D', $value ) ) {
+			return '';
+		}
+
+		return strtoupper( $value );
+	}
+
+	/**
+	 * Normalize an optional telephone number using a permissive common format.
+	 *
+	 * @param mixed $value Raw telephone number.
+	 * @return string
+	 */
+	private static function telephone( $value ) {
+		$value = self::text( $value );
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$has_valid_characters = 1 === preg_match( '/^\+?[0-9 ()-]+$/D', $value );
+		$has_digit            = 1 === preg_match( '/[0-9]/', $value );
+
+		return $has_valid_characters && $has_digit ? $value : '';
+	}
+
+	/**
+	 * Normalize an optional LocalBusiness price range.
+	 *
+	 * @param mixed $value Raw price range.
+	 * @return string
+	 */
+	private static function price_range( $value ) {
+		$value = self::text( $value );
+		return self::unicode_length( $value ) < 100 ? $value : '';
+	}
+
+	/**
+	 * Count Unicode code points, including when the mbstring extension is absent.
+	 *
+	 * @param string $value Value to measure.
+	 * @return int
+	 */
+	private static function unicode_length( $value ) {
+		if ( function_exists( 'mb_strlen' ) ) {
+			return mb_strlen( $value, 'UTF-8' );
+		}
+
+		$length = preg_match_all( '/./us', $value, $matches );
+		return false === $length ? strlen( $value ) : $length;
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/LocalBusinessSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/LocalBusinessSchemaNodeTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Tests for the Jetpack SEO Local_Business_Schema_Node decorator.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Local_Business_Schema_Node
+ */
+#[CoversClass( Local_Business_Schema_Node::class )]
+class LocalBusinessSchemaNodeTest extends TestCase {
+
+	/**
+	 * Base Organization node fixture.
+	 *
+	 * @return array
+	 */
+	private function organization() {
+		return array(
+			'@type' => 'Organization',
+			'@id'   => 'https://example.test/#organization',
+			'name'  => 'Acme Co',
+			'url'   => 'https://example.test/',
+		);
+	}
+
+	/**
+	 * Base LocalBusiness settings fixture.
+	 *
+	 * @return array
+	 */
+	private function settings() {
+		return array(
+			'enabled'      => true,
+			'address'      => array(
+				'streetAddress'   => '',
+				'addressLocality' => '',
+				'addressRegion'   => '',
+				'postalCode'      => '',
+				'addressCountry'  => '',
+			),
+			'telephone'    => '',
+			'geo'          => array(
+				'latitude'  => '',
+				'longitude' => '',
+			),
+			'openingHours' => array(
+				'Mo' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'Tu' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'We' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'Th' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'Fr' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'Sa' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+				'Su' => array(
+					'opens'  => '',
+					'closes' => '',
+				),
+			),
+			'priceRange'   => '',
+		);
+	}
+
+	/**
+	 * Null Organization nodes pass through unchanged.
+	 */
+	public function test_null_organization_passes_through() {
+		$this->assertNull( Local_Business_Schema_Node::extend( null, $this->settings() ) );
+	}
+
+	/**
+	 * Disabled settings leave the Organization node unchanged.
+	 */
+	public function test_disabled_settings_pass_through() {
+		$organization                         = $this->organization();
+		$settings                             = $this->settings();
+		$settings['enabled']                  = false;
+		$settings['address']['streetAddress'] = '123 Main St';
+
+		$this->assertSame( $organization, Local_Business_Schema_Node::extend( $organization, $settings ) );
+	}
+
+	/**
+	 * Enabled but address-less settings leave the Organization node unchanged.
+	 */
+	public function test_enabled_with_empty_address_passes_through() {
+		$organization = $this->organization();
+
+		$extended = Local_Business_Schema_Node::extend( $organization, $this->settings() );
+
+		$this->assertSame( $organization, $extended );
+		$this->assertSame( 'Organization', $extended['@type'] );
+	}
+
+	/**
+	 * A configured address decorates the existing Organization node as LocalBusiness.
+	 */
+	public function test_address_decorates_organization_node() {
+		$settings                             = $this->settings();
+		$settings['address']['streetAddress'] = '123 Main St';
+		$settings['address']['postalCode']    = '10001';
+
+		$extended = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+
+		$this->assertSame( array( 'Organization', 'LocalBusiness' ), $extended['@type'] );
+		$this->assertSame(
+			array(
+				'@type'         => 'PostalAddress',
+				'streetAddress' => '123 Main St',
+				'postalCode'    => '10001',
+			),
+			$extended['address']
+		);
+		$this->assertSame( 'https://example.test/#organization', $extended['@id'] );
+	}
+
+	/**
+	 * Optional string props are attached only when non-empty.
+	 */
+	public function test_telephone_and_price_range_attach_only_when_non_empty() {
+		$settings                             = $this->settings();
+		$settings['address']['streetAddress'] = '123 Main St';
+		$settings['telephone']                = '+1 555 123 4567';
+		$settings['priceRange']               = '$$';
+
+		$extended = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+
+		$this->assertSame( '+1 555 123 4567', $extended['telephone'] );
+		$this->assertSame( '$$', $extended['priceRange'] );
+
+		$settings['telephone']  = '';
+		$settings['priceRange'] = '';
+		$extended               = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+
+		$this->assertArrayNotHasKey( 'telephone', $extended );
+		$this->assertArrayNotHasKey( 'priceRange', $extended );
+	}
+
+	/**
+	 * Geo coordinates require both numeric endpoints and emit as floats.
+	 */
+	public function test_geo_requires_both_coordinates() {
+		$settings                             = $this->settings();
+		$settings['address']['streetAddress'] = '123 Main St';
+		$settings['geo']                      = array(
+			'latitude'  => '40.7128',
+			'longitude' => '-74.0060',
+		);
+
+		$extended = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+
+		$this->assertSame( 'GeoCoordinates', $extended['geo']['@type'] );
+		$this->assertSame( 40.7128, $extended['geo']['latitude'] );
+		$this->assertSame( -74.006, $extended['geo']['longitude'] );
+
+		$settings['geo']['longitude'] = '';
+		$extended                     = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+		$this->assertArrayNotHasKey( 'geo', $extended );
+	}
+
+	/**
+	 * Opening hours emit only fully configured days, in canonical Mo-Su order.
+	 */
+	public function test_opening_hours_emit_full_days_in_order() {
+		$settings                             = $this->settings();
+		$settings['address']['streetAddress'] = '123 Main St';
+		$settings['openingHours']['We']       = array(
+			'opens'  => '10:00',
+			'closes' => '16:00',
+		);
+		$settings['openingHours']['Mo']       = array(
+			'opens'  => '09:00',
+			'closes' => '17:00',
+		);
+		$settings['openingHours']['Tu']       = array(
+			'opens'  => '09:00',
+			'closes' => '',
+		);
+
+		$extended = Local_Business_Schema_Node::extend( $this->organization(), $settings );
+
+		$this->assertSame(
+			array(
+				array(
+					'@type'     => 'OpeningHoursSpecification',
+					'dayOfWeek' => 'Monday',
+					'opens'     => '09:00',
+					'closes'    => '17:00',
+				),
+				array(
+					'@type'     => 'OpeningHoursSpecification',
+					'dayOfWeek' => 'Wednesday',
+					'opens'     => '10:00',
+					'closes'    => '16:00',
+				),
+			),
+			$extended['openingHoursSpecification']
+		);
+	}
+}

--- a/projects/packages/seo/tests/php/LocalBusinessSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/LocalBusinessSchemaNodeTest.php
@@ -199,6 +199,10 @@ class LocalBusinessSchemaNodeTest extends TestCase {
 			'opens'  => '09:00',
 			'closes' => '',
 		);
+		$settings['openingHours']['Fr']       = array(
+			'opens'  => '20:45',
+			'closes' => '06:15',
+		);
 
 		$extended = Local_Business_Schema_Node::extend( $this->organization(), $settings );
 
@@ -215,6 +219,12 @@ class LocalBusinessSchemaNodeTest extends TestCase {
 					'dayOfWeek' => 'Wednesday',
 					'opens'     => '10:00',
 					'closes'    => '16:00',
+				),
+				array(
+					'@type'     => 'OpeningHoursSpecification',
+					'dayOfWeek' => 'Friday',
+					'opens'     => '20:45',
+					'closes'    => '06:15',
 				),
 			),
 			$extended['openingHoursSpecification']

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -221,7 +221,8 @@ class SchemaBuilderTest extends TestCase {
 	 */
 	private function node_of_type( array $document, string $type ) {
 		foreach ( $document['@graph'] as $node ) {
-			if ( is_array( $node ) && ( $node['@type'] ?? '' ) === $type ) {
+			$node_type = is_array( $node ) ? ( $node['@type'] ?? '' ) : '';
+			if ( $type === $node_type || ( is_array( $node_type ) && in_array( $type, $node_type, true ) ) ) {
 				return $node;
 			}
 		}
@@ -479,6 +480,58 @@ class SchemaBuilderTest extends TestCase {
 		$this->assertSame( 'Acme Co', $organization['name'] );
 		$this->assertArrayNotHasKey( 'sameAs', $organization );
 		$this->assertArrayNotHasKey( 'email', $organization );
+	}
+
+	/**
+	 * Enabled LocalBusiness settings with an address decorate the front-page
+	 * Organization node in place.
+	 */
+	public function test_front_page_organization_emits_local_business_details_when_configured() {
+		$this->set_site_name( 'Acme Co' );
+		Schema_Settings::update(
+			array(
+				'localBusiness' => array(
+					'enabled' => true,
+					'address' => array(
+						'streetAddress' => '123 Main St',
+					),
+				),
+			)
+		);
+
+		$doc = $this->emit_front_page_document();
+
+		$organization   = $this->node_of_type( $doc, 'Organization' );
+		$local_business = $this->node_of_type( $doc, 'LocalBusiness' );
+		$this->assertIsArray( $organization, 'Expected the Organization node to remain findable.' );
+		$this->assertSame( $organization, $local_business );
+		$this->assertSame( array( 'Organization', 'LocalBusiness' ), $organization['@type'] );
+		$this->assertSame( 'PostalAddress', $organization['address']['@type'] );
+		$this->assertSame( '123 Main St', $organization['address']['streetAddress'] );
+	}
+
+	/**
+	 * Disabled LocalBusiness settings keep the front-page Organization node plain.
+	 */
+	public function test_front_page_organization_stays_plain_when_local_business_disabled() {
+		$this->set_site_name( 'Acme Co' );
+		Schema_Settings::update(
+			array(
+				'localBusiness' => array(
+					'enabled' => false,
+					'address' => array(
+						'streetAddress' => '123 Main St',
+					),
+				),
+			)
+		);
+
+		$doc = $this->emit_front_page_document();
+
+		$organization = $this->node_of_type( $doc, 'Organization' );
+		$this->assertSame( 'Organization', $organization['@type'] );
+		$this->assertArrayNotHasKey( 'address', $organization );
+		$this->assertNull( $this->node_of_type( $doc, 'LocalBusiness' ) );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/SchemaSettingsControllerTest.php
+++ b/projects/packages/seo/tests/php/SchemaSettingsControllerTest.php
@@ -183,6 +183,31 @@ class SchemaSettingsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Invalid LocalBusiness values are cleared in a successful REST response.
+	 */
+	public function test_update_item_sanitizes_invalid_local_business_values() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/seo/schema-settings' );
+		$request->set_body_params(
+			array(
+				'localBusiness' => array(
+					'address'    => array( 'addressCountry' => 'United States' ),
+					'telephone'  => '555.123.4567',
+					'priceRange' => str_repeat( '€', 100 ),
+				),
+			)
+		);
+
+		$response = Schema_Settings_Controller::update_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( '', $data['localBusiness']['address']['addressCountry'] );
+		$this->assertSame( '', $data['localBusiness']['telephone'] );
+		$this->assertSame( '', $data['localBusiness']['priceRange'] );
+	}
+
+	/**
 	 * Posting only Organization preserves stored LocalBusiness settings.
 	 */
 	public function test_update_item_with_organization_only_preserves_local_business() {

--- a/projects/packages/seo/tests/php/SchemaSettingsControllerTest.php
+++ b/projects/packages/seo/tests/php/SchemaSettingsControllerTest.php
@@ -108,6 +108,10 @@ class SchemaSettingsControllerTest extends TestCase {
 		// ...and the site identity is exposed as placeholder defaults.
 		$this->assertSame( 'Acme Co', $data['defaults']['organization']['name'] );
 		$this->assertSame( 'We make things', $data['defaults']['organization']['description'] );
+		$this->assertArrayHasKey( 'localBusiness', $data );
+		$this->assertArrayHasKey( 'localBusiness', $data['defaults'] );
+		$this->assertFalse( $data['localBusiness']['enabled'] );
+		$this->assertSame( '', $data['localBusiness']['address']['streetAddress'] );
 	}
 
 	/**
@@ -141,5 +145,72 @@ class SchemaSettingsControllerTest extends TestCase {
 
 		// Persisted: the store now returns the saved override.
 		$this->assertSame( 'Acme Corporation', Schema_Settings::get_organization()['name'] );
+	}
+
+	/**
+	 * A LocalBusiness write sanitizes, persists, and returns the stored payload.
+	 */
+	public function test_update_item_round_trips_local_business_payload() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/seo/schema-settings' );
+		$request->set_body_params(
+			array(
+				'localBusiness' => array(
+					'enabled' => true,
+					'address' => array(
+						'streetAddress' => '123 Main St',
+					),
+					'geo'     => array(
+						'latitude'  => '40.7128',
+						'longitude' => '-74.0060',
+					),
+				),
+			)
+		);
+
+		$response = Schema_Settings_Controller::update_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['localBusiness']['enabled'] );
+		$this->assertSame( '123 Main St', $data['localBusiness']['address']['streetAddress'] );
+		$this->assertSame(
+			array(
+				'latitude'  => '40.7128',
+				'longitude' => '-74.0060',
+			),
+			$data['localBusiness']['geo']
+		);
+	}
+
+	/**
+	 * Posting only Organization preserves stored LocalBusiness settings.
+	 */
+	public function test_update_item_with_organization_only_preserves_local_business() {
+		Schema_Settings::update(
+			array(
+				'localBusiness' => array(
+					'enabled' => true,
+					'address' => array(
+						'streetAddress' => '123 Main St',
+					),
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/seo/schema-settings' );
+		$request->set_body_params(
+			array(
+				'organization' => array(
+					'name' => 'Acme Corporation',
+				),
+			)
+		);
+
+		$response = Schema_Settings_Controller::update_item( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 'Acme Corporation', $data['organization']['name'] );
+		$this->assertTrue( $data['localBusiness']['enabled'] );
+		$this->assertSame( '123 Main St', $data['localBusiness']['address']['streetAddress'] );
 	}
 }

--- a/projects/packages/seo/tests/php/SchemaSettingsTest.php
+++ b/projects/packages/seo/tests/php/SchemaSettingsTest.php
@@ -40,6 +40,25 @@ class SchemaSettingsTest extends TestCase {
 	}
 
 	/**
+	 * Remove WooCommerce store options used by LocalBusiness defaults.
+	 *
+	 * @return void
+	 */
+	private function delete_woo_options() {
+		foreach (
+			array(
+				'woocommerce_store_address',
+				'woocommerce_store_address_2',
+				'woocommerce_store_city',
+				'woocommerce_store_postcode',
+				'woocommerce_default_country',
+			) as $option
+		) {
+			delete_option( $option );
+		}
+	}
+
+	/**
 	 * Start each test from a clean option.
 	 *
 	 * @return void
@@ -47,6 +66,7 @@ class SchemaSettingsTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		delete_option( Schema_Settings::OPTION_NAME );
+		$this->delete_woo_options();
 	}
 
 	/**
@@ -58,6 +78,7 @@ class SchemaSettingsTest extends TestCase {
 		remove_all_filters( 'pre_option_blogname' );
 		remove_all_filters( 'pre_option_blogdescription' );
 		delete_option( Schema_Settings::OPTION_NAME );
+		$this->delete_woo_options();
 		parent::tearDown();
 	}
 
@@ -71,6 +92,16 @@ class SchemaSettingsTest extends TestCase {
 
 		$this->assertSame( 'Acme Co', $defaults['organization']['name'] );
 		$this->assertSame( 'We make things', $defaults['organization']['description'] );
+		$this->assertSame(
+			array(
+				'streetAddress'   => '',
+				'addressLocality' => '',
+				'addressRegion'   => '',
+				'postalCode'      => '',
+				'addressCountry'  => '',
+			),
+			$defaults['localBusiness']['address']
+		);
 	}
 
 	/**
@@ -85,6 +116,33 @@ class SchemaSettingsTest extends TestCase {
 		$this->assertSame( 'We make things', $effective['description'] );
 		$this->assertSame( array(), $effective['sameAs'] );
 		$this->assertSame( '', $effective['email'] );
+	}
+
+	/**
+	 * The editable payload includes the stored LocalBusiness section and defaults.
+	 */
+	public function test_editable_payload_includes_local_business_shape() {
+		$editable = Schema_Settings::get_editable();
+
+		$this->assertFalse( $editable['localBusiness']['enabled'] );
+		$this->assertSame( '', $editable['localBusiness']['address']['streetAddress'] );
+		$this->assertSame( '', $editable['localBusiness']['telephone'] );
+		$this->assertSame(
+			array(
+				'latitude'  => '',
+				'longitude' => '',
+			),
+			$editable['localBusiness']['geo']
+		);
+		$this->assertSame(
+			array(
+				'opens'  => '',
+				'closes' => '',
+			),
+			$editable['localBusiness']['openingHours']['Mo']
+		);
+		$this->assertSame( '', $editable['localBusiness']['priceRange'] );
+		$this->assertArrayHasKey( 'localBusiness', $editable['defaults'] );
 	}
 
 	/**
@@ -154,6 +212,153 @@ class SchemaSettingsTest extends TestCase {
 			array( 'organization' => array( 'sameAs' => 'https://twitter.com/acme' ) )
 		);
 		$this->assertSame( array(), $bad_same_as['organization']['sameAs'] );
+
+		$bad_local_business = Schema_Settings::sanitize(
+			array(
+				'localBusiness' => array(
+					'address'      => 'not-address',
+					'geo'          => 'not-geo',
+					'openingHours' => 'not-hours',
+				),
+			)
+		);
+		$this->assertSame( '', $bad_local_business['localBusiness']['address']['streetAddress'] );
+		$this->assertSame(
+			array(
+				'latitude'  => '',
+				'longitude' => '',
+			),
+			$bad_local_business['localBusiness']['geo']
+		);
+		$this->assertSame(
+			array(
+				'opens'  => '',
+				'closes' => '',
+			),
+			$bad_local_business['localBusiness']['openingHours']['Su']
+		);
+	}
+
+	/**
+	 * LocalBusiness sanitization normalizes text, coordinates, and hours.
+	 */
+	public function test_sanitize_normalizes_local_business() {
+		$clean = Schema_Settings::sanitize(
+			array(
+				'localBusiness' => array(
+					'enabled'      => '1',
+					'address'      => array(
+						'streetAddress'   => '  123 <b>Main</b> St  ',
+						'addressLocality' => '  New York  ',
+						'addressRegion'   => '  NY  ',
+						'postalCode'      => '  10001  ',
+						'addressCountry'  => '  US  ',
+					),
+					'telephone'    => '  +1 555 123 4567  ',
+					'geo'          => array(
+						'latitude'  => '91',
+						'longitude' => '-74.0060',
+					),
+					'openingHours' => array(
+						'Mo' => array(
+							'opens'  => ' 09:00 ',
+							'closes' => '17:00',
+						),
+						'Tu' => array(
+							'opens'  => '9:00',
+							'closes' => '17:00',
+						),
+						'We' => array(
+							'opens'  => '09:00',
+							'closes' => '',
+						),
+						'XX' => array(
+							'opens'  => '09:00',
+							'closes' => '17:00',
+						),
+					),
+					'priceRange'   => '  $$  ',
+				),
+			)
+		);
+
+		$local_business = $clean['localBusiness'];
+		$this->assertTrue( $local_business['enabled'] );
+		$this->assertSame( '123 Main St', $local_business['address']['streetAddress'] );
+		$this->assertSame( 'New York', $local_business['address']['addressLocality'] );
+		$this->assertSame( '+1 555 123 4567', $local_business['telephone'] );
+		$this->assertSame( '$$', $local_business['priceRange'] );
+		$this->assertSame(
+			array(
+				'latitude'  => '',
+				'longitude' => '',
+			),
+			$local_business['geo']
+		);
+		$this->assertSame(
+			array(
+				'opens'  => '09:00',
+				'closes' => '17:00',
+			),
+			$local_business['openingHours']['Mo']
+		);
+		$this->assertSame(
+			array(
+				'opens'  => '',
+				'closes' => '',
+			),
+			$local_business['openingHours']['Tu']
+		);
+		$this->assertSame(
+			array(
+				'opens'  => '',
+				'closes' => '',
+			),
+			$local_business['openingHours']['We']
+		);
+		$this->assertArrayNotHasKey( 'XX', $local_business['openingHours'] );
+		$this->assertSame( array( 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su' ), array_keys( $local_business['openingHours'] ) );
+	}
+
+	/**
+	 * Invalid or partial geo input clears both endpoints; valid input is preserved.
+	 */
+	public function test_sanitize_geo_requires_valid_pair() {
+		$clean = Schema_Settings::sanitize(
+			array(
+				'localBusiness' => array(
+					'geo' => array(
+						'latitude'  => '40.7128',
+						'longitude' => '-74.0060',
+					),
+				),
+			)
+		);
+		$this->assertSame(
+			array(
+				'latitude'  => '40.7128',
+				'longitude' => '-74.0060',
+			),
+			$clean['localBusiness']['geo']
+		);
+
+		$clean = Schema_Settings::sanitize(
+			array(
+				'localBusiness' => array(
+					'geo' => array(
+						'latitude'  => '40.7128',
+						'longitude' => 'not-a-number',
+					),
+				),
+			)
+		);
+		$this->assertSame(
+			array(
+				'latitude'  => '',
+				'longitude' => '',
+			),
+			$clean['localBusiness']['geo']
+		);
 	}
 
 	/**
@@ -184,6 +389,113 @@ class SchemaSettingsTest extends TestCase {
 		$reread = Schema_Settings::get_organization();
 		$this->assertSame( 'Acme Corporation', $reread['name'] );
 		$this->assertSame( array( 'https://twitter.com/acme' ), $reread['sameAs'] );
+	}
+
+	/**
+	 * Updating one schema section preserves the other stored section.
+	 */
+	public function test_update_replaces_only_present_sections() {
+		Schema_Settings::update(
+			array(
+				'organization'  => array(
+					'name'   => 'Acme Corporation',
+					'sameAs' => array( 'https://twitter.com/acme' ),
+				),
+				'localBusiness' => array(
+					'enabled' => true,
+					'address' => array(
+						'streetAddress' => '123 Main St',
+					),
+				),
+			)
+		);
+
+		Schema_Settings::update(
+			array(
+				'organization' => array(
+					'name' => 'Acme Labs',
+				),
+			)
+		);
+		$editable = Schema_Settings::get_editable();
+		$this->assertSame( 'Acme Labs', $editable['organization']['name'] );
+		$this->assertSame( '123 Main St', $editable['localBusiness']['address']['streetAddress'] );
+
+		Schema_Settings::update(
+			array(
+				'localBusiness' => array(
+					'enabled' => true,
+					'address' => array(
+						'streetAddress' => '456 Oak Ave',
+					),
+				),
+			)
+		);
+		$editable = Schema_Settings::get_editable();
+		$this->assertSame( 'Acme Labs', $editable['organization']['name'] );
+		$this->assertSame( '456 Oak Ave', $editable['localBusiness']['address']['streetAddress'] );
+	}
+
+	/**
+	 * WooCommerce store options provide LocalBusiness address defaults.
+	 */
+	public function test_woo_address_defaults_map_store_options() {
+		update_option( 'woocommerce_store_address', '123 Main St' );
+		update_option( 'woocommerce_store_address_2', 'Suite 5' );
+		update_option( 'woocommerce_store_city', 'New York' );
+		update_option( 'woocommerce_store_postcode', '10001' );
+		update_option( 'woocommerce_default_country', 'US:NY' );
+
+		$defaults = Schema_Settings::get_defaults();
+
+		$this->assertSame(
+			array(
+				'streetAddress'   => '123 Main St, Suite 5',
+				'addressLocality' => 'New York',
+				'addressRegion'   => 'NY',
+				'postalCode'      => '10001',
+				'addressCountry'  => 'US',
+			),
+			$defaults['localBusiness']['address']
+		);
+
+		// Woo stores a country with no state as just the country code (no colon).
+		update_option( 'woocommerce_default_country', 'US' );
+		$address = Schema_Settings::get_defaults()['localBusiness']['address'];
+		$this->assertSame( 'US', $address['addressCountry'] );
+		$this->assertSame( '', $address['addressRegion'] );
+	}
+
+	/**
+	 * Effective LocalBusiness address falls back per subfield to Woo defaults.
+	 */
+	public function test_get_local_business_falls_back_per_address_subfield() {
+		update_option( 'woocommerce_store_address', '123 Main St' );
+		update_option( 'woocommerce_store_city', 'New York' );
+		update_option( 'woocommerce_store_postcode', '10001' );
+		update_option( 'woocommerce_default_country', 'US:NY' );
+
+		Schema_Settings::update(
+			array(
+				'localBusiness' => array(
+					'enabled'   => true,
+					'address'   => array(
+						'streetAddress' => '456 Oak Ave',
+					),
+					'telephone' => '+1 555 123 4567',
+				),
+			)
+		);
+
+		$local_business = Schema_Settings::get_local_business();
+
+		$this->assertTrue( $local_business['enabled'] );
+		$this->assertSame( '456 Oak Ave', $local_business['address']['streetAddress'] );
+		$this->assertSame( 'New York', $local_business['address']['addressLocality'] );
+		$this->assertSame( 'NY', $local_business['address']['addressRegion'] );
+		$this->assertSame( '10001', $local_business['address']['postalCode'] );
+		$this->assertSame( 'US', $local_business['address']['addressCountry'] );
+		$this->assertSame( '+1 555 123 4567', $local_business['telephone'] );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/SchemaSettingsTest.php
+++ b/projects/packages/seo/tests/php/SchemaSettingsTest.php
@@ -252,7 +252,7 @@ class SchemaSettingsTest extends TestCase {
 						'addressLocality' => '  New York  ',
 						'addressRegion'   => '  NY  ',
 						'postalCode'      => '  10001  ',
-						'addressCountry'  => '  US  ',
+						'addressCountry'  => '  us  ',
 					),
 					'telephone'    => '  +1 555 123 4567  ',
 					'geo'          => array(
@@ -272,6 +272,10 @@ class SchemaSettingsTest extends TestCase {
 							'opens'  => '09:00',
 							'closes' => '',
 						),
+						'Th' => array(
+							'opens'  => '20:45',
+							'closes' => '06:15',
+						),
 						'XX' => array(
 							'opens'  => '09:00',
 							'closes' => '17:00',
@@ -286,6 +290,7 @@ class SchemaSettingsTest extends TestCase {
 		$this->assertTrue( $local_business['enabled'] );
 		$this->assertSame( '123 Main St', $local_business['address']['streetAddress'] );
 		$this->assertSame( 'New York', $local_business['address']['addressLocality'] );
+		$this->assertSame( 'US', $local_business['address']['addressCountry'] );
 		$this->assertSame( '+1 555 123 4567', $local_business['telephone'] );
 		$this->assertSame( '$$', $local_business['priceRange'] );
 		$this->assertSame(
@@ -316,8 +321,99 @@ class SchemaSettingsTest extends TestCase {
 			),
 			$local_business['openingHours']['We']
 		);
+		$this->assertSame(
+			array(
+				'opens'  => '20:45',
+				'closes' => '06:15',
+			),
+			$local_business['openingHours']['Th']
+		);
 		$this->assertArrayNotHasKey( 'XX', $local_business['openingHours'] );
 		$this->assertSame( array( 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su' ), array_keys( $local_business['openingHours'] ) );
+	}
+
+	/**
+	 * Country codes are optional, limited to two ASCII letters, and uppercased.
+	 */
+	public function test_sanitize_validates_country_code() {
+		foreach (
+			array(
+				''              => '',
+				' us '          => 'US',
+				'zz'            => 'ZZ',
+				'USA'           => '',
+				'U1'            => '',
+				'Mé'            => '',
+				'United States' => '',
+			) as $input => $expected
+		) {
+			$clean = Schema_Settings::sanitize(
+				array(
+					'localBusiness' => array(
+						'address' => array( 'addressCountry' => $input ),
+					),
+				)
+			);
+
+			$this->assertSame( $expected, $clean['localBusiness']['address']['addressCountry'], $input );
+		}
+	}
+
+	/**
+	 * Telephone numbers require a digit and use the permissive Forms-compatible
+	 * character set, with `+` allowed only as the first character.
+	 */
+	public function test_sanitize_validates_telephone() {
+		foreach (
+			array(
+				''                   => '',
+				' +36 (1) 234-5678 ' => '+36 (1) 234-5678',
+				' 1 '                => '1',
+				'(555) 123-4567'     => '(555) 123-4567',
+				'+'                  => '',
+				'()- '               => '',
+				'555.123.4567'       => '',
+				'+1 ext 2'           => '',
+				'12+34'              => '',
+				"555\t123"           => '',
+			) as $input => $expected
+		) {
+			$clean = Schema_Settings::sanitize(
+				array(
+					'localBusiness' => array( 'telephone' => $input ),
+				)
+			);
+
+			$this->assertSame( $expected, $clean['localBusiness']['telephone'], $input );
+		}
+	}
+
+	/**
+	 * Price ranges accept free text shorter than 100 Unicode code points.
+	 */
+	public function test_sanitize_validates_price_range_length() {
+		$ascii_99    = str_repeat( '$', 99 );
+		$ascii_100   = str_repeat( '$', 100 );
+		$unicode_99  = str_repeat( '€', 99 );
+		$unicode_100 = str_repeat( '€', 100 );
+
+		foreach (
+			array(
+				''           => '',
+				$ascii_99    => $ascii_99,
+				$ascii_100   => '',
+				$unicode_99  => $unicode_99,
+				$unicode_100 => '',
+			) as $input => $expected
+		) {
+			$clean = Schema_Settings::sanitize(
+				array(
+					'localBusiness' => array( 'priceRange' => $input ),
+				)
+			);
+
+			$this->assertSame( $expected, $clean['localBusiness']['priceRange'] );
+		}
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -18,3 +18,4 @@ define( 'WP_DEBUG', true );
 require_once __DIR__ . '/stubs/class-jetpack-seo-utils.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-posts.php';
 require_once __DIR__ . '/stubs/class-jetpack-options.php';
+require_once __DIR__ . '/stubs/class-woocommerce.php';

--- a/projects/packages/seo/tests/php/stubs/class-woocommerce.php
+++ b/projects/packages/seo/tests/php/stubs/class-woocommerce.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Minimal WooCommerce class stub for schema settings tests.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+/**
+ * Stand-in for the WooCommerce plugin class.
+ */
+class WooCommerce {}

--- a/projects/packages/seo/tests/php/stubs/class-woocommerce.php
+++ b/projects/packages/seo/tests/php/stubs/class-woocommerce.php
@@ -5,7 +5,10 @@
  * @package automattic/jetpack-seo
  */
 
-/**
- * Stand-in for the WooCommerce plugin class.
- */
-class WooCommerce {}
+if ( ! class_exists( 'WooCommerce' ) ) {
+
+	/**
+	 * Stand-in for the WooCommerce plugin class.
+	 */
+	class WooCommerce {}
+}


### PR DESCRIPTION
Fixes JETPACK-1781

Adds a site-level LocalBusiness JSON-LD node that decorates the existing Organization entity (same `@id`, `@type: ["Organization", "LocalBusiness"]`) when the admin enables it and configures an address.

## Proposed changes

* New `Local_Business_Schema_Node` decorator: extends the Organization node with `address` (PostalAddress), `telephone`, `geo` (GeoCoordinates), `openingHoursSpecification`, and `priceRange` — only when the toggle is on and at least one address subfield is set.
* Extend `Schema_Settings` with LocalBusiness storage, sanitization (text stripping, coordinate bounds, HH:MM validation, partial-pair clearing), and per-subfield WooCommerce address fallback (`woocommerce_store_address`, `_store_city`, `_store_postcode`, `_default_country`).
* "This site represents a local business" toggle in the Organization / Business info settings section, gating address, phone, price range, geo, and opening hours fields.
* WooCommerce store address pre-fills as placeholder defaults when Woo is active (Option 3 from the issue).
* Section-level update preservation: posting only `organization` or only `localBusiness` keeps the other section intact.

## Related product discussion/links

* JETPACK-1781

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a connected site with `add_filter( 'rsm_jetpack_seo', '__return_true' );`. Go to Jetpack → SEO → Settings.

**LocalBusiness toggle + fields:**

* Expand the Schema card. Confirm the "This site represents a local business" toggle is off and no address/phone/hours fields are visible.
* Enable the toggle. Address, phone, price range, geo, and opening hours fields appear. The "Google requires it" hint shows when address is empty.
* Fill a street address and save. Refresh and confirm the values persist and the badge counts "X of 5 set".

**WooCommerce address fallback (if WooCommerce is installed):**

* Set a store address in WooCommerce → Settings → General.
* In SEO Settings, enable the LocalBusiness toggle. The address fields show WooCommerce values as placeholders.
* Save without overriding — the JSON-LD output uses the Woo address.
* Override one field (e.g. street address), save. The overridden field uses your value; the rest fall back to Woo.

**Geo validation:**

* Enter only a latitude (no longitude). Both fields show "Enter both latitude and longitude, or leave both blank." and Save is disabled.
* Enter an out-of-range latitude (e.g. 91). The field shows its range error and Save is disabled.
* Enter valid lat/lng and save. Confirm they appear as floats in the JSON-LD `geo` node.

**JSON-LD output:**

* View the front page source and find the `application/ld+json` script. Confirm the Organization node has `@type: ["Organization", "LocalBusiness"]`, a `PostalAddress` address, and any other filled fields (telephone, geo, openingHoursSpecification, priceRange).
* Disable the toggle, save, refresh. The Organization node reverts to plain `@type: "Organization"` with no address/phone/hours.
* Non-front pages should not contain the Organization node at all (existing behavior, unchanged).


https://github.com/user-attachments/assets/3b8c111f-a96e-406b-8732-d9739aa56bd4



**Tests:**

* `cd projects/packages/seo && composer phpunit` — PHP tests pass.
* `cd projects/packages/seo && pnpm test` — JS tests pass.