### PR TITLE
Premium Analytics: add WooCommerce dashboard section

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-woocommerce-dashboard-section
+++ b/projects/packages/premium-analytics/changelog/add-woocommerce-dashboard-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard sections: Add a WooCommerce section with default store widgets.

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -13,6 +13,11 @@ require_once __DIR__ . '/class-dashboard-section.php';
 require_once __DIR__ . '/class-dashboard-section-registry.php';
 
 /**
+ * Filter through which WooCommerce section availability is resolved.
+ */
+const WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER = 'jetpack_premium_analytics_woocommerce_dashboard_section_available';
+
+/**
  * Registers a dashboard section.
  *
  * @param string $dashboard_name Dashboard identifier.
@@ -46,6 +51,86 @@ function get_available_dashboard_sections( $dashboard_name ) {
 }
 
 /**
+ * Whether the WooCommerce dashboard section should be exposed.
+ *
+ * @return bool True when WooCommerce is active.
+ */
+function is_woocommerce_dashboard_section_available() {
+	$is_available = class_exists( 'WooCommerce' ) || function_exists( 'WC' );
+
+	/**
+	 * Filters whether the WooCommerce dashboard section is available.
+	 *
+	 * @param bool $is_available Whether WooCommerce was detected in the current request.
+	 */
+	return (bool) apply_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, $is_available );
+}
+
+/**
+ * Returns the default widget layout for the WooCommerce dashboard section.
+ *
+ * @return array Array of widget instances.
+ */
+function get_woocommerce_dashboard_section_default_layout() {
+	return array(
+		array(
+			'uuid'      => 'default-woocommerce-net-sales-over-time-widget-instance',
+			'type'      => 'jpa/net-sales-over-time',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 0,
+			),
+		),
+		array(
+			'uuid'      => 'default-woocommerce-gross-sales-over-time-widget-instance',
+			'type'      => 'jpa/gross-sales-over-time',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 1,
+			),
+		),
+		array(
+			'uuid'      => 'default-woocommerce-average-order-value-widget-instance',
+			'type'      => 'jpa/average-order-value',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 2,
+			),
+		),
+		array(
+			'uuid'      => 'default-woocommerce-orders-over-time-widget-instance',
+			'type'      => 'jpa/orders-over-time',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 3,
+			),
+		),
+		array(
+			'uuid'      => 'default-woocommerce-average-items-per-order-widget-instance',
+			'type'      => 'jpa/average-items-per-order',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 4,
+			),
+		),
+		array(
+			'uuid'      => 'default-woocommerce-top-performing-products-widget-instance',
+			'type'      => 'jpa/top-performing-products',
+			'placement' => array(
+				'width'  => 1,
+				'height' => 1,
+				'order'  => 5,
+			),
+		),
+	);
+}
+
+/**
  * Registers the default Premium Analytics dashboard sections.
  *
  * @return void
@@ -68,6 +153,12 @@ function register_default_dashboard_sections() {
 		'analytics/subscribers' => array(
 			'label' => __( 'Subscribers', 'jetpack-premium-analytics' ),
 			'order' => 30,
+		),
+		'woocommerce/store'     => array(
+			'label'          => __( 'WooCommerce', 'jetpack-premium-analytics' ),
+			'order'          => 40,
+			'is_available'   => __NAMESPACE__ . '\\is_woocommerce_dashboard_section_available',
+			'default_layout' => __NAMESPACE__ . '\\get_woocommerce_dashboard_section_default_layout',
 		),
 	);
 

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -55,6 +55,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 
 		remove_all_filters( 'doing_it_wrong_trigger_error' );
 		remove_all_actions( 'doing_it_wrong_run' );
+		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
 
 		parent::tear_down();
 	}
@@ -311,6 +312,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 	 * Built-in Premium Analytics sections are registered in the expected order.
 	 */
 	public function test_registers_built_in_dashboard_sections() {
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_false' );
+
 		register_default_dashboard_sections();
 
 		$this->assertSame(
@@ -334,6 +337,122 @@ class Dashboard_Section_Test extends BaseTestCase {
 			array_map(
 				static function ( Dashboard_Section $section ) {
 					return $section->to_array();
+				},
+				get_available_dashboard_sections( DASHBOARD_NAME )
+			)
+		);
+	}
+
+	/**
+	 * The WooCommerce section is registered when WooCommerce is available.
+	 */
+	public function test_registers_woocommerce_dashboard_section_when_available() {
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		register_default_dashboard_sections();
+
+		$woocommerce = get_registered_dashboard_section( DASHBOARD_NAME, 'woocommerce/store' );
+
+		$this->assertInstanceOf( Dashboard_Section::class, $woocommerce );
+		$this->assertTrue( $woocommerce->is_available() );
+		$this->assertSame( 'WooCommerce', $woocommerce->label );
+		$this->assertSame( 40, $woocommerce->order );
+		$this->assertSame(
+			array(
+				'analytics/traffic',
+				'analytics/insights',
+				'analytics/subscribers',
+				'woocommerce/store',
+			),
+			array_map(
+				static function ( Dashboard_Section $section ) {
+					return $section->id;
+				},
+				get_available_dashboard_sections( DASHBOARD_NAME )
+			)
+		);
+		$this->assertSame(
+			array(
+				array(
+					'uuid'      => 'default-woocommerce-net-sales-over-time-widget-instance',
+					'type'      => 'jpa/net-sales-over-time',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 0,
+					),
+				),
+				array(
+					'uuid'      => 'default-woocommerce-gross-sales-over-time-widget-instance',
+					'type'      => 'jpa/gross-sales-over-time',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 1,
+					),
+				),
+				array(
+					'uuid'      => 'default-woocommerce-average-order-value-widget-instance',
+					'type'      => 'jpa/average-order-value',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 2,
+					),
+				),
+				array(
+					'uuid'      => 'default-woocommerce-orders-over-time-widget-instance',
+					'type'      => 'jpa/orders-over-time',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 3,
+					),
+				),
+				array(
+					'uuid'      => 'default-woocommerce-average-items-per-order-widget-instance',
+					'type'      => 'jpa/average-items-per-order',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 4,
+					),
+				),
+				array(
+					'uuid'      => 'default-woocommerce-top-performing-products-widget-instance',
+					'type'      => 'jpa/top-performing-products',
+					'placement' => array(
+						'width'  => 1,
+						'height' => 1,
+						'order'  => 5,
+					),
+				),
+			),
+			$woocommerce->get_default_layout()
+		);
+	}
+
+	/**
+	 * The WooCommerce section is omitted from available sections when WooCommerce is unavailable.
+	 */
+	public function test_omits_woocommerce_dashboard_section_when_unavailable() {
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_false' );
+
+		register_default_dashboard_sections();
+
+		$woocommerce = get_registered_dashboard_section( DASHBOARD_NAME, 'woocommerce/store' );
+
+		$this->assertInstanceOf( Dashboard_Section::class, $woocommerce );
+		$this->assertFalse( $woocommerce->is_available() );
+		$this->assertSame(
+			array(
+				'analytics/traffic',
+				'analytics/insights',
+				'analytics/subscribers',
+			),
+			array_map(
+				static function ( Dashboard_Section $section ) {
+					return $section->id;
 				},
 				get_available_dashboard_sections( DASHBOARD_NAME )
 			)


### PR DESCRIPTION
Fixes #

## Proposed changes
* Follow-up to [Automattic/jetpack#50205](https://github.com/Automattic/jetpack/pull/50205), which added the dashboard section layout persistence API.
* Add a conditional `woocommerce/store` dashboard section to Premium Analytics.
* Show the section only when WooCommerce is available.
* Seed the section with default store widgets for net sales, gross sales, average order value, orders, average items per order, and top products.
* Add PHP coverage for WooCommerce section availability and default layout registration.
* Add a Premium Analytics changelog entry.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm jetpack test php packages/premium-analytics`.
* Run `pnpm jetpack test js packages/premium-analytics` and confirm it skips because the package has no `test-js` script.
* Run `pnpm jetpack phan packages/premium-analytics --allow-polyfill-parser -v`.
* With WooCommerce enabled, open an authenticated wp-admin page and run this in the browser console:
  ```js
  const sections = await wp.apiFetch( {
    path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections',
  } );
  sections.find( ( section ) => section.id === 'woocommerce/store' );
  ```
  Confirm the result is a `WooCommerce` section with `order: 40` and a layout containing `jpa/net-sales-over-time`, `jpa/gross-sales-over-time`, `jpa/average-order-value`, `jpa/orders-over-time`, `jpa/average-items-per-order`, and `jpa/top-performing-products`.
* With WooCommerce still enabled, run:
  ```js
  await wp.apiFetch( {
    path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections/woocommerce/store/default-layout',
  } );
  ```
  Confirm the response contains the same default WooCommerce widget layout.
* Disable WooCommerce, reload an authenticated wp-admin page, and run:
  ```js
  const sections = await wp.apiFetch( {
    path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections',
  } );
  sections.find( ( section ) => section.id === 'woocommerce/store' );
  ```
  Confirm the result is `undefined`.
* With WooCommerce disabled, run:
  ```js
  await wp.apiFetch( {
    path: '/jetpack/v4/dashboards/jetpack-premium-analytics_dashboard/sections/woocommerce/store/default-layout',
  } );
  ```
  Confirm the request rejects with a `dashboard_section_unavailable` 404 response.
