### PR TITLE
CHARTS-241: Charts: reserve y-axis tick label dx offset in auto margin

### DIFF
--- a/projects/js-packages/charts/changelog/2026-07-09-13-42-02-356262
+++ b/projects/js-packages/charts/changelog/2026-07-09-13-42-02-356262
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: reserve the y-axis tick label dx offset in the auto margin so the widest label no longer clips at the chart edge.
+Charts: Reserve the y-axis tick label dx offset in the auto margin so the widest label no longer clips at the chart edge.

--- a/projects/js-packages/charts/changelog/2026-07-09-13-42-02-356262
+++ b/projects/js-packages/charts/changelog/2026-07-09-13-42-02-356262
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: reserve the y-axis tick label dx offset in the auto margin so the widest label no longer clips at the chart edge.

--- a/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
@@ -64,7 +64,8 @@ describe( 'useChartMargin', () => {
 			options.axis.y.tickFormat,
 			theme.axisStyles.y.left.axisLabel
 		);
-		expect( result.current.left ).toBe( 48 ); // 40 + 8
+		// 40 label width + 8 tick length + ceil(11 * 0.25) label dx offset
+		expect( result.current.left ).toBe( 51 );
 	} );
 
 	it( 'calculates right margin for right y axis', () => {
@@ -86,7 +87,8 @@ describe( 'useChartMargin', () => {
 			options.axis.y.tickFormat,
 			theme.axisStyles.y.right.axisLabel
 		);
-		expect( result.current.right ).toBe( 48 ); // 40 + 8
+		// 40 label width + 8 tick length + ceil(11 * 0.25) label dx offset
+		expect( result.current.right ).toBe( 51 );
 	} );
 
 	it( 'uses explicit y tickValues when provided', () => {
@@ -133,7 +135,8 @@ describe( 'useChartMargin', () => {
 		const height = 300;
 		const theme = baseTheme;
 		const { result } = renderHook( () => useChartMargin( height, options, data, theme ) );
-		expect( result.current.left ).toBe( 48 );
+		// 40 label width + 8 tick length + ceil(11 * 0.25) label dx offset
+		expect( result.current.left ).toBe( 51 );
 		expect( result.current.top ).toBe( 10 );
 		// 12px font + 8 tick length = 20
 		expect( result.current.bottom ).toBe( 20 );

--- a/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
@@ -13,8 +13,8 @@ describe( 'useChartMargin', () => {
 	const baseTheme = {
 		axisStyles: {
 			y: {
-				left: { axisLabel: { fontSize: 11 }, tickLength: 8 },
-				right: { axisLabel: { fontSize: 11 }, tickLength: 8 },
+				left: { axisLabel: { fontSize: 12 }, tickLabel: { fontSize: 11 }, tickLength: 8 },
+				right: { axisLabel: { fontSize: 12 }, tickLabel: { fontSize: 11 }, tickLength: 8 },
 			},
 		},
 	} as XYChartTheme;

--- a/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
+++ b/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
@@ -114,7 +114,14 @@ export const useChartMargin = (
 			options.axis?.y?.tickFormat,
 			yAxisStyles.axisLabel
 		);
-		const yMarginValue = ( yTickWidth ?? DEFAULT_Y_TICK_WIDTH ) + ( yAxisStyles?.tickLength ?? 0 );
+		// visx's default axis theme offsets y tick labels a further 0.25em away
+		// from the axis (dx: '∓0.25em'), so reserve that on top of the measured
+		// label width — without it the widest label clips at the svg edge.
+		const yLabelFontSize = resolveFontSize( yAxisStyles?.axisLabel?.fontSize ) || DEFAULT_FONT_SIZE;
+		const yMarginValue =
+			( yTickWidth ?? DEFAULT_Y_TICK_WIDTH ) +
+			( yAxisStyles?.tickLength ?? 0 ) +
+			Math.ceil( yLabelFontSize * 0.25 );
 
 		if ( yAxisOrientation === 'right' ) {
 			defaultMargin.right = yMarginValue;

--- a/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
+++ b/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
@@ -114,14 +114,17 @@ export const useChartMargin = (
 			options.axis?.y?.tickFormat,
 			yAxisStyles.axisLabel
 		);
-		// visx's default axis theme offsets y tick labels a further 0.25em away
-		// from the axis (dx: '∓0.25em'), so reserve that on top of the measured
-		// label width — without it the widest label clips at the svg edge.
-		const yLabelFontSize = resolveFontSize( yAxisStyles?.axisLabel?.fontSize ) || DEFAULT_FONT_SIZE;
+		// visx's default axis theme pushes y-axis tick labels a further 0.25em
+		// away from the axis (dx of -0.25em on the left, 0.25em on the right), so
+		// reserve that on top of the measured label width — without it the widest
+		// label clips at the SVG edge. The em resolves against the tick label's own
+		// font size (theme tickLabel), not the axis-title font size (axisLabel).
+		const yTickLabelFontSize =
+			resolveFontSize( yAxisStyles?.tickLabel?.fontSize ) || DEFAULT_FONT_SIZE;
 		const yMarginValue =
 			( yTickWidth ?? DEFAULT_Y_TICK_WIDTH ) +
 			( yAxisStyles?.tickLength ?? 0 ) +
-			Math.ceil( yLabelFontSize * 0.25 );
+			Math.ceil( yTickLabelFontSize * 0.25 );
 
 		if ( yAxisOrientation === 'right' ) {
 			defaultMargin.right = yMarginValue;


### PR DESCRIPTION
Fixes CHARTS-241

## Proposed changes
* visx's default axis theme shifts y-axis tick labels a further `0.25em` away from the axis (`dx`), which the auto margin calculation didn't account for — so the widest tick label could clip at the SVG edge.
* `useChartMargin` now adds `ceil(fontSize * 0.25)` on top of the measured label width when computing the left/right margin.

## Related product discussion/links
* CHARTS-241

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the charts Storybook (`pnpm storybook` from `projects/js-packages/charts`).
* Open a line/bar chart story with auto margins and y-axis values wide enough to produce long tick labels (e.g. thousands).
* Confirm the widest y-axis tick label is fully visible and no longer clipped at the left (or right, for right-oriented axes) edge of the chart.

| Before | After |
| :---: | :---: |
| <img alt="Before" src="https://github.com/user-attachments/assets/83d598aa-852b-4ecd-8105-1ffafd063290" /> | <img alt="After" src="https://github.com/user-attachments/assets/e681198d-c595-40b0-a0a6-c1d20af21a9a" /> |
