### PR TITLE
Premium Analytics: Surface external API errors in local CSV export endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-csv-export-external-api-errors
+++ b/projects/packages/premium-analytics/changelog/fix-pa-csv-export-external-api-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV exports: Surface external API error details.

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
@@ -441,9 +441,14 @@ class Report_Data_Fetcher {
 
 		// Check for errors.
 		if ( $response->is_error() ) {
-			$error_data = $response->as_error();
+			$error_data = $this->build_external_api_error( $response );
+			$error_meta = $error_data->get_error_data();
+			$message    = is_array( $error_meta ) && ! empty( $error_meta['message'] )
+				? $error_meta['message']
+				: $error_data->get_error_message();
+
 			$this->logger->log_error(
-				'Proxy request failed: ' . $error_data->get_error_message(),
+				'Proxy request failed: ' . $message,
 				__METHOD__
 			);
 			return $error_data;
@@ -474,6 +479,59 @@ class Report_Data_Fetcher {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Build a stable local error from an external API error response.
+	 *
+	 * WP_REST_Response::as_error() can lose the upstream message for proxied error
+	 * payloads represented as stdClass. Preserve the external details in data while
+	 * keeping a consistent local error message for the CSV export route.
+	 *
+	 * @param \WP_REST_Response $response Error response from the local proxy route.
+	 * @return WP_Error Normalized external API error.
+	 */
+	private function build_external_api_error( \WP_REST_Response $response ): WP_Error {
+		$data = $this->normalize_response_data( $response->get_data() );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$status           = (int) $response->get_status();
+		$external_code    = null;
+		$external_message = null;
+
+		if ( is_array( $data ) ) {
+			if ( isset( $data['data']['status'] ) ) {
+				$status = (int) $data['data']['status'];
+			}
+
+			if ( isset( $data['code'] ) && is_scalar( $data['code'] ) ) {
+				$external_code = (string) $data['code'];
+			}
+
+			if ( isset( $data['message'] ) && is_scalar( $data['message'] ) ) {
+				$external_message = (string) $data['message'];
+			}
+		}
+
+		$error_data = array(
+			'status' => $status ?: 500,
+		);
+
+		if ( null !== $external_message && '' !== $external_message ) {
+			$error_data['message'] = $external_message;
+		}
+
+		if ( null !== $external_code && '' !== $external_code ) {
+			$error_data['external_code'] = $external_code;
+		}
+
+		return new WP_Error(
+			'external_api_error',
+			__( 'External API error', 'jetpack-premium-analytics' ),
+			$error_data
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use WP_Error;
+use WP_REST_Response;
 
 require_once __DIR__ . '/fixtures/class-spy-logger.php';
 
@@ -110,5 +111,32 @@ class ReportDataFetcher_Test extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'proxy_response_encode_failed', $result->get_error_code() );
+	}
+
+	public function test_build_external_api_error_preserves_external_message() {
+		$response = new WP_REST_Response(
+			(object) array(
+				'code'    => 'woocommerce_analytics_bookings_error',
+				'message' => 'Failed to retrieve bookings data. Please try again later.',
+				'data'    => (object) array(
+					'status' => 500,
+				),
+			),
+			500
+		);
+
+		$result = $this->invoke( 'build_external_api_error', array( $response ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame( 'External API error', $result->get_error_message() );
+		$this->assertSame(
+			array(
+				'status'        => 500,
+				'message'       => 'Failed to retrieve bookings data. Please try again later.',
+				'external_code' => 'woocommerce_analytics_bookings_error',
+			),
+			$result->get_error_data()
+		);
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Normalize failed CSV export proxy responses into a stable `external_api_error` response.
* Preserve the upstream API error message and code in `data.message` and `data.external_code`.
* Add regression coverage for proxied external API errors and a Premium Analytics changelog entry.

## Related product discussion/links
* Builds on #50356.

## Does this pull request change what data or activity we track or use?
No. This only changes how existing CSV export errors are surfaced to callers.

## Testing instructions
* With Premium Analytics and WooCommerce active, POST to `/wp-json/jetpack-premium-analytics/v1/reports/csv-export` using a report whose external API request fails, for example `bookingstatusbreakdown` on a site where `reports/bookings/by-date` returns an upstream error.
* Confirm the response keeps HTTP `500` and returns `code: "external_api_error"`, `message: "External API error"`, `data.message` with the external API message, and `data.external_code` with the upstream error code.
* Run `composer phpunit` from `projects/packages/premium-analytics`.
* Run `composer phpcs:changed -- projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php` from the monorepo root.
* Run `composer php:lint` from the monorepo root.
