### PR TITLE
ci: Post-Build: Handle undocumented `job.status`

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -473,7 +473,7 @@ jobs:
         uses: ./trunk/.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.wpcom_filename_check }}
-          conclusion: ${{ job.status }}
+          conclusion: ${{ case( job.status == 'abandoned', 'cancelled', job.status ) }}
           title: ${{ case( job.status == 'success', 'Tests passed', job.status == 'cancelled', 'Cancelled', 'Tests failed' ) }}
           summary: |
             ${{ env.SUMMARY }}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
While GitHub documents that `job.status` can have values `success`, `failure`, and `cancelled`, apparently there's also `abandoned`. Handle that when setting the check run status, which doesn't accept "abandoned".

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1783609041553179/1783602097.292619-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷