### PR TITLE
Premium Analytics: per-tab default widget layouts

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-dashboard-tab-default-widgets
+++ b/projects/packages/premium-analytics/changelog/update-dashboard-tab-default-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Add tab-specific default widget layouts.

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -20,9 +20,9 @@ type PreferencesActions = {
  * Manage the customizable widget layout for the currently active dashboard section.
  *
  * The shared `useDashboardLayout` hook stores one dashboard-wide layout. This
- * route layers a section map on top of that hook so each section can commit its
- * own customized layout while still using the registered dashboard default as
- * the initial/reset layout.
+ * route layers a section map on top of that hook so each section can commit
+ * its own customized layout while reset can fetch the active section's bundled
+ * default.
  *
  * @param dashboardName   - Dashboard registration name for fetching defaults.
  * @param activeSectionId - Currently active section ID.
@@ -63,14 +63,14 @@ export function useDashboardSectionLayout(
 
 	const resetLayout = useCallback( async () => {
 		const fresh = ( await apiFetch( {
-			path: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ dashboardName }/default-layout`,
+			path: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ activeSectionId }/default-layout`,
 		} ) ) as DashboardWidget[];
 
 		void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
 			...sectionLayouts,
 			[ activeSectionId ]: fresh,
 		} );
-	}, [ activeSectionId, dashboardName, sectionLayouts, set ] );
+	}, [ activeSectionId, sectionLayouts, set ] );
 
 	return [ layout, setLayout, resetLayout ];
 }

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -128,7 +128,7 @@ function inject_dashboard_default_layout( $value, $user_id, $meta_key ) {
 
 		if ( ! empty( $section_default ) ) {
 			$section_layouts[ $section_id ] = $section_default;
-			$updated = true;
+			$updated                        = true;
 		}
 	}
 
@@ -539,15 +539,15 @@ function get_dashboard_default_section_layouts() {
  */
 function get_dashboard_default_section_id_for( $dashboard_name ) {
 	$aliases = array(
-		DASHBOARD_NAME                    => DASHBOARD_TRAFFIC_SECTION_ID,
-		DASHBOARD_TRAFFIC_SECTION_ID      => DASHBOARD_TRAFFIC_SECTION_ID,
-		'analytics/traffic'               => DASHBOARD_TRAFFIC_SECTION_ID,
-		DASHBOARD_INSIGHTS_SECTION_ID     => DASHBOARD_INSIGHTS_SECTION_ID,
-		'analytics/insights'              => DASHBOARD_INSIGHTS_SECTION_ID,
-		DASHBOARD_SUBSCRIBERS_SECTION_ID  => DASHBOARD_SUBSCRIBERS_SECTION_ID,
-		'analytics/subscribers'           => DASHBOARD_SUBSCRIBERS_SECTION_ID,
-		DASHBOARD_STORE_SECTION_ID        => DASHBOARD_STORE_SECTION_ID,
-		'woocommerce/store'               => DASHBOARD_STORE_SECTION_ID,
+		DASHBOARD_NAME                   => DASHBOARD_TRAFFIC_SECTION_ID,
+		DASHBOARD_TRAFFIC_SECTION_ID     => DASHBOARD_TRAFFIC_SECTION_ID,
+		'analytics/traffic'              => DASHBOARD_TRAFFIC_SECTION_ID,
+		DASHBOARD_INSIGHTS_SECTION_ID    => DASHBOARD_INSIGHTS_SECTION_ID,
+		'analytics/insights'             => DASHBOARD_INSIGHTS_SECTION_ID,
+		DASHBOARD_SUBSCRIBERS_SECTION_ID => DASHBOARD_SUBSCRIBERS_SECTION_ID,
+		'analytics/subscribers'          => DASHBOARD_SUBSCRIBERS_SECTION_ID,
+		DASHBOARD_STORE_SECTION_ID       => DASHBOARD_STORE_SECTION_ID,
+		'woocommerce/store'              => DASHBOARD_STORE_SECTION_ID,
 	);
 
 	return $aliases[ $dashboard_name ] ?? null;
@@ -578,7 +578,7 @@ function seed_default_dashboard_layout( $dashboard_layout, $dashboard_name = '' 
 	foreach ( $layouts[ $section_id ] as $widget ) {
 		if ( ! in_array( $widget['uuid'], $uuids, true ) ) {
 			$dashboard_layout[] = $widget;
-			$uuids[] = $widget['uuid'];
+			$uuids[]            = $widget['uuid'];
 		}
 	}
 

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -55,6 +55,14 @@ const DASHBOARD_REST_NAMESPACE = 'jetpack/v4';
 const DASHBOARD_DEFAULT_LAYOUT_FILTER = 'jetpack_premium_analytics_dashboard_default_layout';
 
 /**
+ * Preference keys used by the dashboard route's tabbed sections.
+ */
+const DASHBOARD_TRAFFIC_SECTION_ID     = 'traffic';
+const DASHBOARD_INSIGHTS_SECTION_ID    = 'insights';
+const DASHBOARD_SUBSCRIBERS_SECTION_ID = 'subscribers';
+const DASHBOARD_STORE_SECTION_ID       = 'store';
+
+/**
  * Injects the registered default dashboard layout into the user's
  * `persisted_preferences` read when the stored layout is empty.
  *
@@ -90,24 +98,47 @@ function inject_dashboard_default_layout( $value, $user_id, $meta_key ) {
 	}
 
 	$committed = $base[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_LAYOUT_KEY ] ?? array();
-
-	if ( ! empty( $committed ) ) {
-		return $value;
-	}
-
-	$default = get_dashboard_default_layout_for( DASHBOARD_NAME );
-
-	if ( empty( $default ) ) {
-		return $value;
-	}
+	$updated   = false;
 
 	if ( ! isset( $base[ DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $base[ DASHBOARD_LAYOUT_SCOPE ] ) ) {
 		$base[ DASHBOARD_LAYOUT_SCOPE ] = array();
 	}
 
-	$base[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_LAYOUT_KEY ] = $default;
+	if ( empty( $committed ) ) {
+		$default = get_dashboard_default_layout_for( DASHBOARD_NAME );
 
-	return array( $base );
+		if ( ! empty( $default ) ) {
+			$base[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_LAYOUT_KEY ] = $default;
+			$updated = true;
+		}
+	}
+
+	$section_layouts = $base[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] ?? array();
+
+	if ( ! is_array( $section_layouts ) ) {
+		$section_layouts = array();
+	}
+
+	foreach ( array_keys( get_dashboard_default_section_layouts() ) as $section_id ) {
+		if ( array_key_exists( $section_id, $section_layouts ) ) {
+			continue;
+		}
+
+		$section_default = get_dashboard_default_layout_for( $section_id );
+
+		if ( ! empty( $section_default ) ) {
+			$section_layouts[ $section_id ] = $section_default;
+			$updated = true;
+		}
+	}
+
+	if ( $updated ) {
+		$base[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] = $section_layouts;
+
+		return array( $base );
+	}
+
+	return $value;
 }
 add_filter( 'get_user_metadata', __NAMESPACE__ . '\\inject_dashboard_default_layout', 99, 3 );
 
@@ -117,7 +148,7 @@ add_filter( 'get_user_metadata', __NAMESPACE__ . '\\inject_dashboard_default_lay
  * Returns a fresh evaluation of the filter chain each call, so callers always
  * see the current code default rather than a hydrated copy.
  *
- * @param string $dashboard_name Identifier of the dashboard.
+ * @param string $dashboard_name Identifier of the dashboard or dashboard section.
  * @return array Array of widget instances (possibly empty).
  */
 function get_dashboard_default_layout_for( $dashboard_name ) {
@@ -129,9 +160,10 @@ function get_dashboard_default_layout_for( $dashboard_name ) {
 	 * `type`, optional `attributes`, optional `placement`.
 	 *
 	 * @param array  $default_layout Default array of widget instances.
-	 * @param string $dashboard_name Identifier of the dashboard receiving the
-	 *                               default. Callbacks targeting a specific
-	 *                               dashboard should switch on this value.
+	 * @param string $dashboard_name Identifier of the dashboard or dashboard
+	 *                               section receiving the default. Callbacks
+	 *                               targeting a specific default should switch
+	 *                               on this value.
 	 */
 	$default = apply_filters( DASHBOARD_DEFAULT_LAYOUT_FILTER, array(), $dashboard_name );
 
@@ -175,10 +207,358 @@ function register_dashboard_default_layout_route() {
 add_action( 'rest_api_init', __NAMESPACE__ . '\\register_dashboard_default_layout_route' );
 
 /**
- * Seeds the bundled default layout for the Premium Analytics dashboard.
+ * Builds a widget instance for bundled dashboard defaults.
  *
- * Only contributes to DASHBOARD_NAME; other dashboards are left untouched so
- * the filter can be reused if more dashboards are added later.
+ * @param string $uuid       Widget instance UUID.
+ * @param string $type       Widget type.
+ * @param int    $order      Widget placement order.
+ * @param int    $width      Widget placement width.
+ * @param int    $height     Widget placement height.
+ * @param array  $attributes Optional widget attributes.
+ * @return array Widget instance.
+ */
+function get_dashboard_default_widget_instance(
+	$uuid,
+	$type,
+	$order,
+	$width = 1,
+	$height = 1,
+	$attributes = array()
+) {
+	$widget = array(
+		'uuid' => $uuid,
+		'type' => $type,
+	);
+
+	if ( ! empty( $attributes ) ) {
+		$widget['attributes'] = $attributes;
+	}
+
+	$widget['placement'] = array(
+		'width'  => $width,
+		'height' => $height,
+		'order'  => $order,
+	);
+
+	return $widget;
+}
+
+/**
+ * Returns the bundled default widget layouts keyed by dashboard tab.
+ *
+ * @return array Map of tab IDs to widget layout arrays.
+ */
+function get_dashboard_default_section_layouts() {
+	return array(
+		DASHBOARD_TRAFFIC_SECTION_ID     => array(
+			get_dashboard_default_widget_instance(
+				'default-traffic-chart-widget-instance',
+				'jpa/traffic-chart',
+				0,
+				2,
+				2,
+				array(
+					'granularity' => 'auto',
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-stats-top-posts-widget-instance',
+				'jpa/stats-top-posts',
+				1,
+				1,
+				2,
+				array(
+					'num' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-referrers-widget-instance',
+				'jpa/referrers',
+				2,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-locations-widget-instance',
+				'jpa/locations',
+				3,
+				2,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-devices-widget-instance',
+				'jpa/devices',
+				4,
+				1,
+				2,
+				array(
+					'max' => 5,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-top-platforms-widget-instance',
+				'jpa/top-platforms',
+				5,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-search-terms-widget-instance',
+				'jpa/search-terms',
+				6,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-utm-insights-widget-instance',
+				'jpa/utm-insights',
+				7,
+				1,
+				2,
+				array(
+					'utmDimension' => 'utm_source,utm_medium',
+					'max'          => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-file-downloads-widget-instance',
+				'jpa/file-downloads',
+				8,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-clicks-widget-instance',
+				'jpa/clicks',
+				9,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+		),
+		DASHBOARD_INSIGHTS_SECTION_ID    => array(
+			get_dashboard_default_widget_instance(
+				'default-annual-highlights-widget-instance',
+				'jpa/annual-highlights',
+				0,
+				2,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-all-time-stats-widget-instance',
+				'jpa/all-time-stats',
+				1,
+				2,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-latest-post-widget-instance',
+				'jpa/latest-post',
+				2,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-posting-activity-widget-instance',
+				'jpa/posting-activity',
+				3,
+				2,
+				2
+			),
+			get_dashboard_default_widget_instance(
+				'default-authors-widget-instance',
+				'jpa/authors',
+				4,
+				1,
+				2,
+				array(
+					'max' => 7,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-videos-widget-instance',
+				'jpa/videos',
+				5,
+				1,
+				2,
+				array(
+					'max' => 7,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-emails-widget-instance',
+				'jpa/stats-emails',
+				6,
+				1,
+				2,
+				array(
+					'max'    => 10,
+					'metric' => 'opens',
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-most-popular-day-widget-instance',
+				'jpa/most-popular-day',
+				7,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-most-popular-time-widget-instance',
+				'jpa/most-popular-time',
+				8,
+				1,
+				1
+			),
+		),
+		DASHBOARD_SUBSCRIBERS_SECTION_ID => array(
+			get_dashboard_default_widget_instance(
+				'default-subscriber-highlights-widget-instance',
+				'jpa/subscriber-highlights',
+				0,
+				2,
+				1,
+				array(
+					'showTotal'  => true,
+					'showPaid'   => true,
+					'showFree'   => true,
+					'showSocial' => true,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-subscribers-chart-widget-instance',
+				'jpa/subscribers-chart',
+				1,
+				2,
+				2,
+				array(
+					'granularity' => 'auto',
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-subscribers-list-widget-instance',
+				'jpa/subscribers-list',
+				2,
+				1,
+				2,
+				array(
+					'num' => 6,
+				)
+			),
+		),
+		DASHBOARD_STORE_SECTION_ID       => array(
+			get_dashboard_default_widget_instance(
+				'default-store-performance-widget-instance',
+				'jpa/store-performance',
+				0,
+				2,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-total-sales-over-time-widget-instance',
+				'jpa/total-sales-over-time',
+				1,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-conversion-rate-widget-instance',
+				'jpa/conversion-rate',
+				2,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-orders-over-time-widget-instance',
+				'jpa/orders-over-time',
+				3,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-average-order-value-widget-instance',
+				'jpa/average-order-value',
+				4,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-top-performing-products-widget-instance',
+				'jpa/top-performing-products',
+				5,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-new-vs-returning-customer-widget-instance',
+				'jpa/new-vs-returning-customer',
+				6,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-payment-status-widget-instance',
+				'jpa/payment-status',
+				7,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-orders-fulfillment-widget-instance',
+				'jpa/orders-fulfillment',
+				8,
+				1,
+				1
+			),
+		),
+	);
+}
+
+/**
+ * Resolves a dashboard or section identifier to one of the bundled tab IDs.
+ *
+ * @param string $dashboard_name Dashboard or section identifier.
+ * @return string|null Bundled tab ID, or null when the identifier is unsupported.
+ */
+function get_dashboard_default_section_id_for( $dashboard_name ) {
+	$aliases = array(
+		DASHBOARD_NAME                    => DASHBOARD_TRAFFIC_SECTION_ID,
+		DASHBOARD_TRAFFIC_SECTION_ID      => DASHBOARD_TRAFFIC_SECTION_ID,
+		'analytics/traffic'               => DASHBOARD_TRAFFIC_SECTION_ID,
+		DASHBOARD_INSIGHTS_SECTION_ID     => DASHBOARD_INSIGHTS_SECTION_ID,
+		'analytics/insights'              => DASHBOARD_INSIGHTS_SECTION_ID,
+		DASHBOARD_SUBSCRIBERS_SECTION_ID  => DASHBOARD_SUBSCRIBERS_SECTION_ID,
+		'analytics/subscribers'           => DASHBOARD_SUBSCRIBERS_SECTION_ID,
+		DASHBOARD_STORE_SECTION_ID        => DASHBOARD_STORE_SECTION_ID,
+		'woocommerce/store'               => DASHBOARD_STORE_SECTION_ID,
+	);
+
+	return $aliases[ $dashboard_name ] ?? null;
+}
+
+/**
+ * Seeds the bundled default layouts for the Premium Analytics dashboard tabs.
+ *
+ * Only contributes to the known Premium Analytics dashboard and tab aliases;
+ * other dashboards are left untouched so the filter can be reused if more
+ * dashboards are added later.
  *
  * @param array  $dashboard_layout Default layout from earlier callbacks.
  * @param string $dashboard_name   Identifier of the dashboard receiving the
@@ -186,119 +566,20 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\register_dashboard_default_layou
  * @return array The layout extended with the bundled widget instances.
  */
 function seed_default_dashboard_layout( $dashboard_layout, $dashboard_name = '' ) {
-	if ( DASHBOARD_NAME !== $dashboard_name ) {
+	$section_id = get_dashboard_default_section_id_for( $dashboard_name );
+
+	if ( null === $section_id ) {
 		return $dashboard_layout;
 	}
 
-	$uuids = array_column( $dashboard_layout, 'uuid' );
+	$uuids   = array_column( $dashboard_layout, 'uuid' );
+	$layouts = get_dashboard_default_section_layouts();
 
-	if ( ! in_array( 'default-hello-world-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'      => 'default-hello-world-widget-instance',
-			'type'      => 'jpa/hello-world',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 0,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-locations-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'      => 'default-locations-widget-instance',
-			'type'      => 'jpa/locations',
-			'placement' => array(
-				'width'  => 2,
-				'height' => 1,
-				'order'  => 1,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-devices-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'      => 'default-devices-widget-instance',
-			'type'      => 'jpa/devices',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 2,
-				'order'  => 2,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-top-platforms-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'      => 'default-top-platforms-widget-instance',
-			'type'      => 'jpa/top-platforms',
-			'placement' => array(
-				'width'  => 2,
-				'height' => 2,
-				'order'  => 3,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-search-terms-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'       => 'default-search-terms-widget-instance',
-			'type'       => 'jpa/search-terms',
-			'attributes' => array(
-				'max' => 10,
-			),
-			'placement'  => array(
-				'width'  => 1,
-				'height' => 2,
-				'order'  => 4,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-utm-insights-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'       => 'default-utm-insights-widget-instance',
-			'type'       => 'jpa/utm-insights',
-			'attributes' => array(
-				'utmParam' => 'utm_source,utm_medium',
-				'max'      => 10,
-			),
-			'placement'  => array(
-				'width'  => 1,
-				'height' => 2,
-				'order'  => 5,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-file-downloads-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'       => 'default-file-downloads-widget-instance',
-			'type'       => 'jpa/file-downloads',
-			'attributes' => array(
-				'max' => 10,
-			),
-			'placement'  => array(
-				'width'  => 1,
-				'height' => 2,
-				'order'  => 6,
-			),
-		);
-	}
-
-	if ( ! in_array( 'default-clicks-widget-instance', $uuids, true ) ) {
-		$dashboard_layout[] = array(
-			'uuid'       => 'default-clicks-widget-instance',
-			'type'       => 'jpa/clicks',
-			'attributes' => array(
-				'max' => 10,
-			),
-			'placement'  => array(
-				'width'  => 1,
-				'height' => 2,
-				'order'  => 7,
-			),
-		);
+	foreach ( $layouts[ $section_id ] as $widget ) {
+		if ( ! in_array( $widget['uuid'], $uuids, true ) ) {
+			$dashboard_layout[] = $widget;
+			$uuids[] = $widget['uuid'];
+		}
 	}
 
 	return $dashboard_layout;

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -72,62 +72,7 @@ function is_woocommerce_dashboard_section_available() {
  * @return array Array of widget instances.
  */
 function get_woocommerce_dashboard_section_default_layout() {
-	return array(
-		array(
-			'uuid'      => 'default-woocommerce-net-sales-over-time-widget-instance',
-			'type'      => 'jpa/net-sales-over-time',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 0,
-			),
-		),
-		array(
-			'uuid'      => 'default-woocommerce-gross-sales-over-time-widget-instance',
-			'type'      => 'jpa/gross-sales-over-time',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 1,
-			),
-		),
-		array(
-			'uuid'      => 'default-woocommerce-average-order-value-widget-instance',
-			'type'      => 'jpa/average-order-value',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 2,
-			),
-		),
-		array(
-			'uuid'      => 'default-woocommerce-orders-over-time-widget-instance',
-			'type'      => 'jpa/orders-over-time',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 3,
-			),
-		),
-		array(
-			'uuid'      => 'default-woocommerce-average-items-per-order-widget-instance',
-			'type'      => 'jpa/average-items-per-order',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 4,
-			),
-		),
-		array(
-			'uuid'      => 'default-woocommerce-top-performing-products-widget-instance',
-			'type'      => 'jpa/top-performing-products',
-			'placement' => array(
-				'width'  => 1,
-				'height' => 1,
-				'order'  => 5,
-			),
-		),
-	);
+	return get_dashboard_default_layout_for( 'woocommerce/store' );
 }
 
 /**
@@ -143,16 +88,22 @@ function register_default_dashboard_sections() {
 			'label'          => __( 'Traffic', 'jetpack-premium-analytics' ),
 			'order'          => 10,
 			'default_layout' => static function () {
-				return get_dashboard_default_layout_for( DASHBOARD_NAME );
+				return get_dashboard_default_layout_for( 'analytics/traffic' );
 			},
 		),
 		'analytics/insights'    => array(
-			'label' => __( 'Insights', 'jetpack-premium-analytics' ),
-			'order' => 20,
+			'label'          => __( 'Insights', 'jetpack-premium-analytics' ),
+			'order'          => 20,
+			'default_layout' => static function () {
+				return get_dashboard_default_layout_for( 'analytics/insights' );
+			},
 		),
 		'analytics/subscribers' => array(
-			'label' => __( 'Subscribers', 'jetpack-premium-analytics' ),
-			'order' => 30,
+			'label'          => __( 'Subscribers', 'jetpack-premium-analytics' ),
+			'order'          => 30,
+			'default_layout' => static function () {
+				return get_dashboard_default_layout_for( 'analytics/subscribers' );
+			},
 		),
 		'woocommerce/store'     => array(
 			'label'          => __( 'WooCommerce', 'jetpack-premium-analytics' ),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -31,78 +31,54 @@ class Dashboard_Layout_Test extends TestCase {
 	}
 
 	/**
-	 * The Premium Analytics dashboard receives the UTM Insights widget.
+	 * The base Premium Analytics dashboard keeps using the traffic tab default.
 	 */
-	public function test_seed_default_dashboard_layout_adds_utm_insights_widget() {
-		$layout          = seed_default_dashboard_layout( array(), DASHBOARD_NAME );
-		$layout_by_uuid  = array_column( $layout, null, 'uuid' );
-		$utm_widget_uuid = 'default-utm-insights-widget-instance';
+	public function test_dashboard_name_resolves_traffic_default() {
+		$layout       = get_dashboard_default_layout_for( DASHBOARD_NAME );
+		$traffic      = get_dashboard_default_layout_for( DASHBOARD_TRAFFIC_SECTION_ID );
+		$layout_types = array_column( $layout, 'type' );
 
-		$this->assertArrayHasKey( 'default-hello-world-widget-instance', $layout_by_uuid );
+		$this->assertSame( $traffic, $layout );
+		$this->assertContains( 'jpa/traffic-chart', $layout_types );
+		$this->assertNotContains( 'jpa/hello-world', $layout_types );
+	}
+
+	/**
+	 * Traffic section aliases resolve to the same default layout.
+	 */
+	public function test_traffic_aliases_resolve_same_default_layout() {
+		$this->assertSame(
+			get_dashboard_default_layout_for( DASHBOARD_TRAFFIC_SECTION_ID ),
+			get_dashboard_default_layout_for( 'analytics/traffic' )
+		);
+	}
+
+	/**
+	 * The traffic tab receives its bundled traffic widgets.
+	 */
+	public function test_seed_default_dashboard_layout_adds_traffic_widgets() {
+		$layout              = seed_default_dashboard_layout( array(), DASHBOARD_TRAFFIC_SECTION_ID );
+		$layout_by_uuid      = array_column( $layout, null, 'uuid' );
+		$layout_types        = array_column( $layout, 'type' );
+		$utm_widget_uuid     = 'default-utm-insights-widget-instance';
+		$top_posts_uuid      = 'default-stats-top-posts-widget-instance';
+		$traffic_chart_uuid  = 'default-traffic-chart-widget-instance';
+		$file_downloads_uuid = 'default-file-downloads-widget-instance';
+
+		$this->assertContains( 'jpa/traffic-chart', $layout_types );
+		$this->assertContains( 'jpa/stats-top-posts', $layout_types );
+		$this->assertContains( 'jpa/referrers', $layout_types );
 		$this->assertArrayHasKey( 'default-locations-widget-instance', $layout_by_uuid );
 		$this->assertArrayHasKey( $utm_widget_uuid, $layout_by_uuid );
+		$this->assertArrayHasKey( $file_downloads_uuid, $layout_by_uuid );
 
 		$this->assertSame(
 			array(
 				'uuid'       => $utm_widget_uuid,
 				'type'       => 'jpa/utm-insights',
 				'attributes' => array(
-					'utmParam' => 'utm_source,utm_medium',
-					'max'      => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 5,
-				),
-			),
-			$layout_by_uuid[ $utm_widget_uuid ]
-		);
-	}
-
-	/**
-	 * The Premium Analytics dashboard receives the File Downloads widget.
-	 */
-	public function test_seed_default_dashboard_layout_adds_file_downloads_widget() {
-		$layout                     = seed_default_dashboard_layout( array(), DASHBOARD_NAME );
-		$layout_by_uuid             = array_column( $layout, null, 'uuid' );
-		$file_downloads_widget_uuid = 'default-file-downloads-widget-instance';
-
-		$this->assertArrayHasKey( $file_downloads_widget_uuid, $layout_by_uuid );
-
-		$this->assertSame(
-			array(
-				'uuid'       => $file_downloads_widget_uuid,
-				'type'       => 'jpa/file-downloads',
-				'attributes' => array(
-					'max' => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 6,
-				),
-			),
-			$layout_by_uuid[ $file_downloads_widget_uuid ]
-		);
-	}
-
-	/**
-	 * The Premium Analytics dashboard receives the Clicks widget.
-	 */
-	public function test_seed_default_dashboard_layout_adds_clicks_widget() {
-		$layout             = seed_default_dashboard_layout( array(), DASHBOARD_NAME );
-		$layout_by_uuid     = array_column( $layout, null, 'uuid' );
-		$clicks_widget_uuid = 'default-clicks-widget-instance';
-
-		$this->assertArrayHasKey( $clicks_widget_uuid, $layout_by_uuid );
-
-		$this->assertSame(
-			array(
-				'uuid'       => $clicks_widget_uuid,
-				'type'       => 'jpa/clicks',
-				'attributes' => array(
-					'max' => 10,
+					'utmDimension' => 'utm_source,utm_medium',
+					'max'          => 10,
 				),
 				'placement'  => array(
 					'width'  => 1,
@@ -110,74 +86,115 @@ class Dashboard_Layout_Test extends TestCase {
 					'order'  => 7,
 				),
 			),
-			$layout_by_uuid[ $clicks_widget_uuid ]
+			$layout_by_uuid[ $utm_widget_uuid ]
+		);
+
+		$this->assertSame(
+			array(
+				'uuid'       => $top_posts_uuid,
+				'type'       => 'jpa/stats-top-posts',
+				'attributes' => array(
+					'num' => 10,
+				),
+				'placement'  => array(
+					'width'  => 1,
+					'height' => 2,
+					'order'  => 1,
+				),
+			),
+			$layout_by_uuid[ $top_posts_uuid ]
+		);
+
+		$this->assertSame( 'jpa/traffic-chart', $layout_by_uuid[ $traffic_chart_uuid ]['type'] );
+	}
+
+	/**
+	 * The insights tab receives its bundled stats widgets.
+	 */
+	public function test_seed_default_dashboard_layout_adds_insights_widgets() {
+		$layout       = seed_default_dashboard_layout( array(), DASHBOARD_INSIGHTS_SECTION_ID );
+		$layout_types = array_column( $layout, 'type' );
+
+		$this->assertContains( 'jpa/annual-highlights', $layout_types );
+		$this->assertContains( 'jpa/all-time-stats', $layout_types );
+		$this->assertContains( 'jpa/latest-post', $layout_types );
+		$this->assertContains( 'jpa/posting-activity', $layout_types );
+		$this->assertContains( 'jpa/authors', $layout_types );
+		$this->assertContains( 'jpa/stats-emails', $layout_types );
+		$this->assertSame(
+			get_dashboard_default_layout_for( DASHBOARD_INSIGHTS_SECTION_ID ),
+			get_dashboard_default_layout_for( 'analytics/insights' )
 		);
 	}
 
 	/**
-	 * An existing UTM Insights default instance is not duplicated.
+	 * The subscribers tab receives its bundled subscriber widgets.
 	 */
-	public function test_seed_default_dashboard_layout_does_not_duplicate_utm_insights_widget() {
-		$existing_utm_widget = array(
+	public function test_seed_default_dashboard_layout_adds_subscribers_widgets() {
+		$layout         = seed_default_dashboard_layout( array(), DASHBOARD_SUBSCRIBERS_SECTION_ID );
+		$layout_by_uuid = array_column( $layout, null, 'uuid' );
+		$layout_types   = array_column( $layout, 'type' );
+
+		$this->assertContains( 'jpa/subscriber-highlights', $layout_types );
+		$this->assertContains( 'jpa/subscribers-chart', $layout_types );
+		$this->assertContains( 'jpa/subscribers-list', $layout_types );
+		$this->assertSame(
+			array(
+				'uuid'       => 'default-subscribers-list-widget-instance',
+				'type'       => 'jpa/subscribers-list',
+				'attributes' => array(
+					'num' => 6,
+				),
+				'placement'  => array(
+					'width'  => 1,
+					'height' => 2,
+					'order'  => 2,
+				),
+			),
+			$layout_by_uuid['default-subscribers-list-widget-instance']
+		);
+		$this->assertSame(
+			get_dashboard_default_layout_for( DASHBOARD_SUBSCRIBERS_SECTION_ID ),
+			get_dashboard_default_layout_for( 'analytics/subscribers' )
+		);
+	}
+
+	/**
+	 * The store tab receives its bundled store widgets.
+	 */
+	public function test_seed_default_dashboard_layout_adds_store_widgets() {
+		$layout       = seed_default_dashboard_layout( array(), DASHBOARD_STORE_SECTION_ID );
+		$layout_types = array_column( $layout, 'type' );
+
+		$this->assertContains( 'jpa/store-performance', $layout_types );
+		$this->assertContains( 'jpa/total-sales-over-time', $layout_types );
+		$this->assertContains( 'jpa/conversion-rate', $layout_types );
+		$this->assertContains( 'jpa/orders-over-time', $layout_types );
+		$this->assertContains( 'jpa/top-performing-products', $layout_types );
+		$this->assertSame(
+			get_dashboard_default_layout_for( DASHBOARD_STORE_SECTION_ID ),
+			get_dashboard_default_layout_for( 'woocommerce/store' )
+		);
+	}
+
+	/**
+	 * An existing default instance is not duplicated.
+	 */
+	public function test_seed_default_dashboard_layout_does_not_duplicate_existing_widget() {
+		$existing_widget = array(
 			'uuid' => 'default-utm-insights-widget-instance',
 			'type' => 'jpa/utm-insights',
 		);
 
-		$layout      = seed_default_dashboard_layout( array( $existing_utm_widget ), DASHBOARD_NAME );
-		$utm_widgets = array_filter(
+		$layout  = seed_default_dashboard_layout( array( $existing_widget ), DASHBOARD_TRAFFIC_SECTION_ID );
+		$widgets = array_filter(
 			$layout,
 			static function ( $widget ) {
 				return 'default-utm-insights-widget-instance' === $widget['uuid'];
 			}
 		);
 
-		$this->assertCount( 1, $utm_widgets );
-	}
-
-	/**
-	 * An existing File Downloads default instance is not duplicated.
-	 */
-	public function test_seed_default_dashboard_layout_does_not_duplicate_file_downloads_widget() {
-		$existing_file_downloads_widget = array(
-			'uuid'       => 'default-file-downloads-widget-instance',
-			'type'       => 'jpa/file-downloads',
-			'attributes' => array( 'max' => 5 ),
-			'placement'  => array(
-				'width'  => 2,
-				'height' => 1,
-				'order'  => 9,
-			),
-		);
-
-		$layout                 = seed_default_dashboard_layout( array( $existing_file_downloads_widget ), DASHBOARD_NAME );
-		$file_downloads_widgets = array_filter(
-			$layout,
-			static function ( $widget ) {
-				return 'default-file-downloads-widget-instance' === $widget['uuid'];
-			}
-		);
-
-		$this->assertCount( 1, $file_downloads_widgets );
-		$this->assertSame( $existing_file_downloads_widget, reset( $file_downloads_widgets ) );
-	}
-
-	/**
-	 * An existing Clicks default instance is not duplicated.
-	 */
-	public function test_seed_default_dashboard_layout_does_not_duplicate_clicks_widget() {
-		$existing_clicks_widget = array(
-			'uuid' => 'default-clicks-widget-instance',
-			'type' => 'jpa/clicks',
-		);
-
-		$layout         = seed_default_dashboard_layout( array( $existing_clicks_widget ), DASHBOARD_NAME );
-		$clicks_widgets = array_filter(
-			$layout,
-			static function ( $widget ) {
-				return 'default-clicks-widget-instance' === $widget['uuid'];
-			}
-		);
-
-		$this->assertCount( 1, $clicks_widgets );
+		$this->assertCount( 1, $widgets );
+		$this->assertSame( $existing_widget, reset( $widgets ) );
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -984,7 +984,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 			$response->get_data()
 		);
 
-		$stored = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
+		$stored = get_stored_persisted_preferences_for_user( $user_id );
 
 		$this->assertArrayNotHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
 		$this->assertSame( 'keep-me', $stored[ DASHBOARD_LAYOUT_SCOPE ]['unrelatedPreference'] );

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -179,6 +179,29 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The built-in insights and subscribers sections resolve their tab defaults.
+	 */
+	public function test_non_traffic_section_default_layouts_use_tab_defaults() {
+		register_default_dashboard_sections();
+
+		$insights    = get_registered_dashboard_section( DASHBOARD_NAME, 'analytics/insights' );
+		$subscribers = get_registered_dashboard_section( DASHBOARD_NAME, 'analytics/subscribers' );
+
+		$this->assertInstanceOf( Dashboard_Section::class, $insights );
+		$this->assertInstanceOf( Dashboard_Section::class, $subscribers );
+		$this->assertSame(
+			get_dashboard_default_layout_for( 'analytics/insights' ),
+			$insights->get_default_layout()
+		);
+		$this->assertSame(
+			get_dashboard_default_layout_for( 'analytics/subscribers' ),
+			$subscribers->get_default_layout()
+		);
+		$this->assertNotEmpty( $insights->get_default_layout() );
+		$this->assertNotEmpty( $subscribers->get_default_layout() );
+	}
+
+	/**
 	 * Dashboard names can omit underscores when they match the REST route grammar.
 	 */
 	public function test_accepts_dashboard_names_without_underscores() {
@@ -372,62 +395,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 			)
 		);
 		$this->assertSame(
-			array(
-				array(
-					'uuid'      => 'default-woocommerce-net-sales-over-time-widget-instance',
-					'type'      => 'jpa/net-sales-over-time',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 0,
-					),
-				),
-				array(
-					'uuid'      => 'default-woocommerce-gross-sales-over-time-widget-instance',
-					'type'      => 'jpa/gross-sales-over-time',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 1,
-					),
-				),
-				array(
-					'uuid'      => 'default-woocommerce-average-order-value-widget-instance',
-					'type'      => 'jpa/average-order-value',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 2,
-					),
-				),
-				array(
-					'uuid'      => 'default-woocommerce-orders-over-time-widget-instance',
-					'type'      => 'jpa/orders-over-time',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 3,
-					),
-				),
-				array(
-					'uuid'      => 'default-woocommerce-average-items-per-order-widget-instance',
-					'type'      => 'jpa/average-items-per-order',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 4,
-					),
-				),
-				array(
-					'uuid'      => 'default-woocommerce-top-performing-products-widget-instance',
-					'type'      => 'jpa/top-performing-products',
-					'placement' => array(
-						'width'  => 1,
-						'height' => 1,
-						'order'  => 5,
-					),
-				),
-			),
+			get_dashboard_default_layout_for( 'woocommerce/store' ),
 			$woocommerce->get_default_layout()
 		);
 	}
@@ -752,7 +720,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 			$response->get_data()
 		);
 
-		$stored = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
+		$stored = get_stored_persisted_preferences_for_user( $user_id );
 
 		$this->assertSame(
 			$custom_layout,


### PR DESCRIPTION
## Proposed changes

Refactors the Premium Analytics dashboard so each tab/section has its own default widget layout instead of sharing a single dashboard-wide default.

* Register a per-section `default_layout` for every analytics tab (`analytics/traffic`, `analytics/insights`, `analytics/subscribers`) and WooCommerce (`woocommerce/store`), each resolved via `get_dashboard_default_layout_for( <section-id> )`.
* `get_woocommerce_dashboard_section_default_layout()` now delegates to the shared `get_dashboard_default_layout_for( 'woocommerce/store' )` helper instead of hardcoding its own widget list.
* `useDashboardSectionLayout`'s reset now fetches the **active section's** default layout (`/dashboards/${activeSectionId}/default-layout`) rather than the dashboard-wide default, so "reset to default" restores the correct per-tab widgets.
* Updates PHP unit tests (`Dashboard_Layout_Test`, `Dashboard_Section_Test`) for the per-section defaults.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the Premium Analytics package/plugin.
* In wp-admin, open the Premium Analytics dashboard.
* Switch between the Traffic, Insights, Subscribers, and WooCommerce tabs — each should present its own default set of widgets.
* Customize a tab's layout, then use "reset to default" and confirm it restores that tab's specific default (not another tab's).
* Existing users may need their stored dashboard preferences cleared to see the new per-tab defaults.
