### PR TITLE
Social: add in-dashboard module toggle; fix Atomic dead-end when Social is off

### DIFF
--- a/projects/packages/publicize/_inc/components/settings-tab/index.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/index.tsx
@@ -9,6 +9,8 @@ import CustomizeLinksCard from './customize-links-card';
 import CustomizeMediaCard from './customize-media-card';
 import DefaultShareMessageCard from './default-share-message-card';
 import PublicizeInactiveEmptyState from './publicize-inactive-empty-state';
+import SocialModuleCard from './social-module-card';
+import { useTurnOnSocial } from './turn-on-social-context';
 import './style.scss';
 
 /**
@@ -21,12 +23,13 @@ import './style.scss';
  * - **Customize media** — Social Image Generator (paid).
  * - **Customize links** — UTM parameters.
  *
- * The legacy master Publicize on/off toggle (`SocialModuleToggle`) is
- * intentionally not ported; product visibility lives on the wp-admin
- * module-toggles surface. When an admin lands on the page while
- * Publicize is inactive on a self-hosted site, the empty state points
- * them back there. WPCOM Simple sites never hit that state — Publicize
- * is always on, and `canToggleSocialModule()` returns false.
+ * A compact master on/off (`SocialModuleCard`) sits at the top whenever the
+ * current user can toggle the module (`canToggleSocialModule()`), and when the
+ * module is off the tab collapses to `PublicizeInactiveEmptyState`, which turns
+ * it on in place. This replaces the old link-out to the wp-admin module-toggles
+ * surface (umbrella #48824), which is unreachable on WordPress.com Atomic sites
+ * using the Calypso interface. WPCOM Simple sites never see the toggle —
+ * Publicize is always on there and `canToggleSocialModule()` returns false.
  *
  * @return The Settings tab body.
  */
@@ -36,7 +39,12 @@ export default function SettingsTab(): JSX.Element {
 		[]
 	);
 
-	if ( ! isPublicizeActive && canToggleSocialModule() ) {
+	// While turning Social on we keep showing the turn-on surface until the
+	// reload — the store flips `publicize` on optimistically, but rendering the
+	// settings cards for that sub-second gap before the reload just flickers.
+	const { isEnabling } = useTurnOnSocial();
+
+	if ( ( ! isPublicizeActive || isEnabling ) && canToggleSocialModule() ) {
 		return (
 			<div className="jetpack-social-settings">
 				<Card.Root>
@@ -55,6 +63,7 @@ export default function SettingsTab(): JSX.Element {
 
 	return (
 		<Stack direction="column" gap="lg" className="jetpack-social-settings">
+			{ canToggleSocialModule() && <SocialModuleCard /> }
 			{ hasMessageTemplates && <DefaultShareMessageCard /> }
 			{ hasSocialPlugin && <ContentCreationCard /> }
 			{ hasImageGenerator && <CustomizeMediaCard /> }

--- a/projects/packages/publicize/_inc/components/settings-tab/publicize-inactive-empty-state.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/publicize-inactive-empty-state.tsx
@@ -1,31 +1,24 @@
-import { getAdminUrl } from '@automattic/jetpack-script-data';
-import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { Button, EmptyState } from '@wordpress/ui';
+import { useTurnOnSocial } from './turn-on-social-context';
 
 /**
- * Shown on the Settings tab when the Publicize module is inactive AND
- * the current user has the capability to flip it on. The chassis no
- * longer ships an in-product master toggle (umbrella decision #48824) —
- * product visibility lives on the wp-admin module-toggles surface — so
- * the empty state's job is to point admins at the place where they can
- * turn Publicize back on without leaving any breadcrumbs about a toggle
- * that's intentionally not present.
+ * Shown on the Settings tab when the Social module is inactive AND the current
+ * user can toggle it. Turns Social on in place: the chassis used to link out to
+ * the wp-admin module-toggles surface (`admin.php?page=jetpack#/sharing`, per
+ * umbrella decision #48824), but that page has no menu entry on WordPress.com
+ * Atomic sites using the Calypso interface — a dead end. Enabling reloads the
+ * page so the tabs, connection list and settings hydrate.
  *
- * The `__empty` wrapper centers the icon/title/description/CTA stack on
- * the card's centerline, mirroring the Overview tab's no-connections
- * state so the two tabs read consistently. The CTA navigates via
- * `onClick` rather than `render={ <a> }`: a `solid` button rendered as
- * an anchor inherits wp-admin's global link color over its own white
- * label, leaving the text near-invisible on the blue fill.
+ * The `__empty` wrapper centers the icon/title/description/CTA stack on the
+ * card's centerline, mirroring the Overview tab's no-connections state so the
+ * two tabs read consistently.
  *
  * @return The empty-state body.
  */
 export default function PublicizeInactiveEmptyState(): JSX.Element {
-	const onManageModules = useCallback( () => {
-		window.location.href = getAdminUrl( 'admin.php?page=jetpack#/sharing' );
-	}, [] );
+	const { isEnabling, turnOn } = useTurnOnSocial();
 
 	return (
 		<div className="jetpack-social-settings__empty">
@@ -36,13 +29,15 @@ export default function PublicizeInactiveEmptyState(): JSX.Element {
 				</EmptyState.Title>
 				<EmptyState.Description>
 					{ __(
-						"Turn the Publicize module on from Jetpack's module settings to customize how your posts are shared.",
+						'Turn on Social to connect your social accounts and automatically share your posts as you publish.',
 						'jetpack-publicize-pkg'
 					) }
 				</EmptyState.Description>
 				<EmptyState.Actions>
-					<Button variant="solid" onClick={ onManageModules }>
-						{ __( 'Manage modules', 'jetpack-publicize-pkg' ) }
+					<Button variant="solid" disabled={ isEnabling } onClick={ turnOn }>
+						{ isEnabling
+							? __( 'Turning on Social…', 'jetpack-publicize-pkg' )
+							: __( 'Turn on Social', 'jetpack-publicize-pkg' ) }
 					</Button>
 				</EmptyState.Actions>
 			</EmptyState.Root>

--- a/projects/packages/publicize/_inc/components/settings-tab/social-module-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/social-module-card.tsx
@@ -1,0 +1,42 @@
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Card } from '@wordpress/ui';
+import useToggleSocialModule from './use-toggle-social-module';
+
+/**
+ * Master on/off for the Social (Publicize) module, surfaced at the top of the
+ * Settings tab so the module can be turned back off from within the product.
+ * Pairs with `PublicizeInactiveEmptyState` (the enable surface shown when it's
+ * off). Present because the wp-admin module-toggles surface is unreachable on
+ * some hosts — WordPress.com Atomic sites on the Calypso interface — so relying
+ * on it (umbrella #48824) leaves those users unable to toggle Social at all.
+ *
+ * @return The card.
+ */
+export default function SocialModuleCard(): JSX.Element {
+	const { isModuleActive, isUpdating, toggleModule } = useToggleSocialModule();
+
+	return (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>{ __( 'Auto-share to social media', 'jetpack-publicize-pkg' ) }</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __(
+						'Automatically share your posts to your connected social accounts',
+						'jetpack-publicize-pkg'
+					) }
+					checked={ isModuleActive }
+					disabled={ isUpdating }
+					onChange={ toggleModule }
+					help={ __(
+						'When off, the Social tools stay available here but your posts won’t be shared automatically.',
+						'jetpack-publicize-pkg'
+					) }
+				/>
+			</Card.Content>
+		</Card.Root>
+	);
+}

--- a/projects/packages/publicize/_inc/components/settings-tab/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/index.test.tsx
@@ -4,22 +4,28 @@ import { useSelect } from '@wordpress/data';
 import SettingsTab from '..';
 import { getSocialScriptData } from '../../../utils';
 import { canToggleSocialModule } from '../../../utils/misc';
+import { useTurnOnSocial } from '../turn-on-social-context';
 
 // Avoid pulling the real social store (and its @wordpress/editor imports)
 // into the test.
 jest.mock( '../../../social-store', () => ( { store: 'jetpack-social' } ) );
 
 // Stub the card children + empty state so this test isolates SettingsTab's
-// gating matrix — which cards render under which site conditions.
+// gating matrix — which cards render under which site conditions. Stubbing
+// social-module-card also keeps the @wordpress/components barrel (which it
+// pulls in for ToggleControl) out of this suite's module graph.
 jest.mock( '../default-share-message-card', () => () => (
 	<div data-testid="default-share-message-card" />
 ) );
 jest.mock( '../content-creation-card', () => () => <div data-testid="content-creation-card" /> );
 jest.mock( '../customize-media-card', () => () => <div data-testid="customize-media-card" /> );
 jest.mock( '../customize-links-card', () => () => <div data-testid="customize-links-card" /> );
+jest.mock( '../social-module-card', () => () => <div data-testid="social-module-card" /> );
 jest.mock( '../publicize-inactive-empty-state', () => () => (
 	<div data-testid="publicize-inactive-empty-state" />
 ) );
+
+jest.mock( '../turn-on-social-context', () => ( { useTurnOnSocial: jest.fn() } ) );
 
 jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn() } ) );
 
@@ -43,6 +49,7 @@ const mockCurrentUserCan = currentUserCan as jest.Mock;
 const mockSiteHasFeature = siteHasFeature as jest.Mock;
 const mockGetSocialScriptData = getSocialScriptData as jest.Mock;
 const mockCanToggleSocialModule = canToggleSocialModule as jest.Mock;
+const mockUseTurnOnSocial = useTurnOnSocial as jest.Mock;
 
 /**
  * Configure the site conditions SettingsTab reads. Unset keys default to a
@@ -54,6 +61,7 @@ const mockCanToggleSocialModule = canToggleSocialModule as jest.Mock;
  * @param overrides.socialPluginVersion - The Social plugin version (null when the plugin is inactive).
  * @param overrides.manageOptions       - Whether the current user has the manage_options capability.
  * @param overrides.features            - Map of paid feature slugs to whether the site has them.
+ * @param overrides.isEnabling          - Whether Social is mid-way through being turned on.
  */
 function setupSite(
 	overrides: {
@@ -62,6 +70,7 @@ function setupSite(
 		socialPluginVersion?: string | null;
 		manageOptions?: boolean;
 		features?: Record< string, boolean >;
+		isEnabling?: boolean;
 	} = {}
 ) {
 	const {
@@ -70,6 +79,7 @@ function setupSite(
 		socialPluginVersion = '1.0.0',
 		manageOptions = true,
 		features = { 'social-image-generator': true, 'social-message-templates': true },
+		isEnabling = false,
 	} = overrides;
 
 	// SettingsTab's single useSelect derives `publicize` from the store.
@@ -86,6 +96,7 @@ function setupSite(
 		cap === 'manage_options' ? manageOptions : false
 	);
 	mockSiteHasFeature.mockImplementation( feature => features[ feature ] ?? false );
+	mockUseTurnOnSocial.mockReturnValue( { isEnabling, turnOn: jest.fn() } );
 }
 
 afterEach( () => {
@@ -108,6 +119,34 @@ describe( 'SettingsTab', () => {
 		render( <SettingsTab /> );
 
 		expect( screen.queryByTestId( 'publicize-inactive-empty-state' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'customize-links-card' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the empty state (not the cards) while Social is being turned on, even though the store already reports it active', () => {
+		// During enable the module flips active optimistically; the turn-on latch
+		// must hold the empty state until the reload so the cards don't flicker in.
+		setupSite( { publicizeActive: true, canToggle: true, isEnabling: true } );
+
+		render( <SettingsTab /> );
+
+		expect( screen.getByTestId( 'publicize-inactive-empty-state' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'customize-links-card' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the Social module toggle card when Publicize is active and the user can toggle modules', () => {
+		setupSite( { publicizeActive: true, canToggle: true } );
+
+		render( <SettingsTab /> );
+
+		expect( screen.getByTestId( 'social-module-card' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the Social module toggle card when the user cannot toggle modules', () => {
+		setupSite( { publicizeActive: true, canToggle: false } );
+
+		render( <SettingsTab /> );
+
+		expect( screen.queryByTestId( 'social-module-card' ) ).not.toBeInTheDocument();
 		expect( screen.getByTestId( 'customize-links-card' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/publicize/_inc/components/settings-tab/test/publicize-inactive-empty-state.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/publicize-inactive-empty-state.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PublicizeInactiveEmptyState from '../publicize-inactive-empty-state';
+import { useTurnOnSocial } from '../turn-on-social-context';
+
+// Drive the empty state purely through the turn-on context so this suite
+// isolates its render + click behavior from the enable/reload plumbing.
+jest.mock( '../turn-on-social-context', () => ( { useTurnOnSocial: jest.fn() } ) );
+
+const mockUseTurnOnSocial = useTurnOnSocial as jest.Mock;
+
+describe( 'PublicizeInactiveEmptyState', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the turn-on CTA and calls turnOn when clicked', async () => {
+		const turnOn = jest.fn();
+		mockUseTurnOnSocial.mockReturnValue( { isEnabling: false, turnOn } );
+
+		render( <PublicizeInactiveEmptyState /> );
+
+		expect( screen.getByText( 'Auto-sharing is turned off' ) ).toBeInTheDocument();
+		const button = screen.getByRole( 'button', { name: 'Turn on Social' } );
+		expect( button ).toBeEnabled();
+
+		await userEvent.click( button );
+		expect( turnOn ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows a busy, disabled button while enabling', () => {
+		mockUseTurnOnSocial.mockReturnValue( { isEnabling: true, turnOn: jest.fn() } );
+
+		render( <PublicizeInactiveEmptyState /> );
+
+		// The WPDS Button stays focusable and marks itself busy via aria-disabled
+		// rather than the native disabled attribute.
+		expect( screen.getByRole( 'button', { name: 'Turning on Social…' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/settings-tab/test/social-module-card.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/social-module-card.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SocialModuleCard from '../social-module-card';
+import useToggleSocialModule from '../use-toggle-social-module';
+
+// Stub the toggle hook so this suite isolates the card's rendering + wiring
+// (and keeps the hook's store/script-data imports out of the module graph).
+jest.mock( '../use-toggle-social-module', () => ( { __esModule: true, default: jest.fn() } ) );
+
+const mockUseToggleSocialModule = useToggleSocialModule as jest.Mock;
+
+describe( 'SocialModuleCard', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'reflects the active module state and toggles on change', async () => {
+		const toggleModule = jest.fn();
+		mockUseToggleSocialModule.mockReturnValue( {
+			isModuleActive: true,
+			isUpdating: false,
+			toggleModule,
+		} );
+
+		render( <SocialModuleCard /> );
+
+		const toggle = screen.getByRole( 'checkbox' );
+		expect( toggle ).toBeChecked();
+
+		await userEvent.click( toggle );
+		expect( toggleModule ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'disables the toggle while updating', () => {
+		mockUseToggleSocialModule.mockReturnValue( {
+			isModuleActive: false,
+			isUpdating: true,
+			toggleModule: jest.fn(),
+		} );
+
+		render( <SocialModuleCard /> );
+
+		const toggle = screen.getByRole( 'checkbox' );
+		expect( toggle ).not.toBeChecked();
+		expect( toggle ).toBeDisabled();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/settings-tab/test/turn-on-social-context.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/turn-on-social-context.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+import { TurnOnSocialProvider, useTurnOnSocial } from '../turn-on-social-context';
+import type { ReactNode } from 'react';
+
+describe( 'useTurnOnSocial', () => {
+	it( 'returns an inert default outside a provider', () => {
+		const { result } = renderHook( () => useTurnOnSocial() );
+
+		expect( result.current.isEnabling ).toBe( false );
+		expect( () => result.current.turnOn() ).not.toThrow();
+	} );
+
+	it( 'exposes the provided value inside a provider', () => {
+		const turnOn = jest.fn();
+		const wrapper = ( { children }: { children: ReactNode } ) => (
+			<TurnOnSocialProvider value={ { isEnabling: true, turnOn } }>
+				{ children }
+			</TurnOnSocialProvider>
+		);
+
+		const { result } = renderHook( () => useTurnOnSocial(), { wrapper } );
+
+		expect( result.current.isEnabling ).toBe( true );
+		result.current.turnOn();
+		expect( turnOn ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/settings-tab/test/use-toggle-social-module.test.ts
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/use-toggle-social-module.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { getSocialScriptData } from '../../../utils';
+import useToggleSocialModule from '../use-toggle-social-module';
+
+jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: jest.fn() } ) );
+jest.mock( '../../../social-store', () => ( { store: 'jetpack-social' } ) );
+jest.mock( '../../../utils', () => ( { getSocialScriptData: jest.fn() } ) );
+
+const mockUseSelect = useSelect as jest.Mock;
+const mockUseDispatch = useDispatch as jest.Mock;
+const mockGetSocialScriptData = getSocialScriptData as jest.Mock;
+
+/**
+ * Wire the store selectors + dispatch the hook reads.
+ *
+ * @param options                    - Store state to simulate.
+ * @param options.publicize          - Whether the module is currently active.
+ * @param options.isSaving           - Whether a settings save is in flight.
+ * @param options.isPublicizeEnabled - The `is_publicize_enabled` script-data flag (module state at page load).
+ * @return The dispatch spy the hook calls.
+ */
+function setup( {
+	publicize,
+	isSaving = false,
+	isPublicizeEnabled = publicize,
+}: {
+	publicize: boolean;
+	isSaving?: boolean;
+	isPublicizeEnabled?: boolean;
+} ) {
+	mockUseSelect.mockImplementation( ( map: ( select: unknown ) => unknown ) =>
+		map( () => ( {
+			getSocialModuleSettings: () => ( { publicize } ),
+			isSavingSocialModuleSettings: () => isSaving,
+		} ) )
+	);
+	mockGetSocialScriptData.mockReturnValue( { is_publicize_enabled: isPublicizeEnabled } );
+
+	const updateSocialModuleSettings = jest.fn().mockResolvedValue( undefined );
+	mockUseDispatch.mockReturnValue( { updateSocialModuleSettings } );
+
+	return { updateSocialModuleSettings };
+}
+
+describe( 'useToggleSocialModule', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'enables the module (and reloads) when it was off at page load', async () => {
+		// `isPublicizeEnabled: false` takes the reload branch. jsdom's
+		// `window.location.reload` is a locked no-op, so we exercise the branch
+		// without being able to spy on it.
+		const { updateSocialModuleSettings } = setup( {
+			publicize: false,
+			isPublicizeEnabled: false,
+		} );
+
+		const { result } = renderHook( () => useToggleSocialModule() );
+		await act( async () => {
+			await result.current.toggleModule();
+		} );
+
+		expect( updateSocialModuleSettings ).toHaveBeenCalledWith( { publicize: true } );
+	} );
+
+	it( 'disables the module when it was on', async () => {
+		const { updateSocialModuleSettings } = setup( { publicize: true } );
+
+		const { result } = renderHook( () => useToggleSocialModule() );
+		await act( async () => {
+			await result.current.toggleModule();
+		} );
+
+		expect( updateSocialModuleSettings ).toHaveBeenCalledWith( { publicize: false } );
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/settings-tab/test/use-toggle-social-module.test.ts
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/use-toggle-social-module.test.ts
@@ -1,41 +1,28 @@
 import { act, renderHook } from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { getSocialScriptData } from '../../../utils';
 import useToggleSocialModule from '../use-toggle-social-module';
 
 jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: jest.fn() } ) );
 jest.mock( '../../../social-store', () => ( { store: 'jetpack-social' } ) );
-jest.mock( '../../../utils', () => ( { getSocialScriptData: jest.fn() } ) );
 
 const mockUseSelect = useSelect as jest.Mock;
 const mockUseDispatch = useDispatch as jest.Mock;
-const mockGetSocialScriptData = getSocialScriptData as jest.Mock;
 
 /**
  * Wire the store selectors + dispatch the hook reads.
  *
- * @param options                    - Store state to simulate.
- * @param options.publicize          - Whether the module is currently active.
- * @param options.isSaving           - Whether a settings save is in flight.
- * @param options.isPublicizeEnabled - The `is_publicize_enabled` script-data flag (module state at page load).
+ * @param options           - Store state to simulate.
+ * @param options.publicize - Whether the module is currently active.
+ * @param options.isSaving  - Whether a settings save is in flight.
  * @return The dispatch spy the hook calls.
  */
-function setup( {
-	publicize,
-	isSaving = false,
-	isPublicizeEnabled = publicize,
-}: {
-	publicize: boolean;
-	isSaving?: boolean;
-	isPublicizeEnabled?: boolean;
-} ) {
+function setup( { publicize, isSaving = false }: { publicize: boolean; isSaving?: boolean } ) {
 	mockUseSelect.mockImplementation( ( map: ( select: unknown ) => unknown ) =>
 		map( () => ( {
 			getSocialModuleSettings: () => ( { publicize } ),
 			isSavingSocialModuleSettings: () => isSaving,
 		} ) )
 	);
-	mockGetSocialScriptData.mockReturnValue( { is_publicize_enabled: isPublicizeEnabled } );
 
 	const updateSocialModuleSettings = jest.fn().mockResolvedValue( undefined );
 	mockUseDispatch.mockReturnValue( { updateSocialModuleSettings } );
@@ -48,14 +35,17 @@ describe( 'useToggleSocialModule', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'enables the module (and reloads) when it was off at page load', async () => {
-		// `isPublicizeEnabled: false` takes the reload branch. jsdom's
-		// `window.location.reload` is a locked no-op, so we exercise the branch
-		// without being able to spy on it.
-		const { updateSocialModuleSettings } = setup( {
-			publicize: false,
-			isPublicizeEnabled: false,
-		} );
+	it( 'exposes the module state and saving flag', () => {
+		setup( { publicize: true, isSaving: true } );
+
+		const { result } = renderHook( () => useToggleSocialModule() );
+
+		expect( result.current.isModuleActive ).toBe( true );
+		expect( result.current.isUpdating ).toBe( true );
+	} );
+
+	it( 'inverts the current state for no-arg callers', async () => {
+		const { updateSocialModuleSettings } = setup( { publicize: false } );
 
 		const { result } = renderHook( () => useToggleSocialModule() );
 		await act( async () => {
@@ -65,12 +55,12 @@ describe( 'useToggleSocialModule', () => {
 		expect( updateSocialModuleSettings ).toHaveBeenCalledWith( { publicize: true } );
 	} );
 
-	it( 'disables the module when it was on', async () => {
+	it( 'prefers the target state passed by ToggleControl', async () => {
 		const { updateSocialModuleSettings } = setup( { publicize: true } );
 
 		const { result } = renderHook( () => useToggleSocialModule() );
 		await act( async () => {
-			await result.current.toggleModule();
+			await result.current.toggleModule( false );
 		} );
 
 		expect( updateSocialModuleSettings ).toHaveBeenCalledWith( { publicize: false } );

--- a/projects/packages/publicize/_inc/components/settings-tab/turn-on-social-context.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/turn-on-social-context.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from '@wordpress/element';
+
+export type TurnOnSocialContextValue = {
+	/** True from the moment "Turn on Social" is clicked until the page reloads. */
+	isEnabling: boolean;
+	/** Enable the Social module, then reload once the save resolves. */
+	turnOn: () => void;
+};
+
+/**
+ * Shares the "turning Social on" latch between the page shell — which decides
+ * whether to collapse to the turn-on surface — and the turn-on button, which
+ * triggers the enable + reload. The latch stays true from click until the
+ * reload, so the dashboard never flashes the enabled tabs during the save: we
+ * wait on the toggle, keep the button busy, then reload straight onto Overview.
+ */
+const TurnOnSocialContext = createContext< TurnOnSocialContextValue >( {
+	isEnabling: false,
+	turnOn: () => {},
+} );
+
+export const TurnOnSocialProvider = TurnOnSocialContext.Provider;
+
+export const useTurnOnSocial = () => useContext( TurnOnSocialContext );

--- a/projects/packages/publicize/_inc/components/settings-tab/use-toggle-social-module.ts
+++ b/projects/packages/publicize/_inc/components/settings-tab/use-toggle-social-module.ts
@@ -1,17 +1,17 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
-import { getSocialScriptData } from '../../utils';
 
 /**
- * Enable/disable the Social (Publicize) module from within the modernized
- * dashboard. Restores an in-product path to toggle the module for hosts where
- * the wp-admin module-toggles surface is unreachable — e.g. WordPress.com
- * Atomic sites on the Calypso interface, where Jetpack Settings → Sharing has
- * no menu entry (see umbrella #48824, which moved product visibility onto that
- * now-unreachable surface). Reloads on enable so the tabs, connection list and
- * settings hydrate for the freshly-active module, mirroring the legacy master
- * toggle.
+ * Read the Social (Publicize) module state and toggle it from within the
+ * modernized dashboard. Used by the Settings tab's master on/off card, which
+ * only renders while the module is active — so in practice this turns it *off*;
+ * the enable-and-reload flow lives in the page shell (`stage.tsx`). Restores an
+ * in-product path to toggle the module for hosts where the wp-admin
+ * module-toggles surface is unreachable — e.g. WordPress.com Atomic sites on the
+ * Calypso interface, where Jetpack Settings → Sharing has no menu entry (see
+ * umbrella #48824, which moved product visibility onto that now-unreachable
+ * surface).
  *
  * @return The module state, a saving flag, and a toggle callback.
  */
@@ -27,17 +27,15 @@ export default function useToggleSocialModule() {
 
 	const { updateSocialModuleSettings } = useDispatch( socialStore );
 
-	const toggleModule = useCallback( async () => {
-		const enabling = ! isModuleActive;
+	// `next` is the target state ToggleControl hands us; fall back to inverting
+	// the current state for no-arg callers.
+	const toggleModule = useCallback(
+		( next?: boolean ) => updateSocialModuleSettings( { publicize: next ?? ! isModuleActive } ),
+		[ isModuleActive, updateSocialModuleSettings ]
+	);
 
-		await updateSocialModuleSettings( { publicize: enabling } );
-
-		// Reload when enabling so the connection list and settings hydrate for
-		// the freshly-active module.
-		if ( enabling && ! getSocialScriptData().is_publicize_enabled ) {
-			window.location.reload();
-		}
-	}, [ isModuleActive, updateSocialModuleSettings ] );
-
-	return { isModuleActive, isUpdating, toggleModule };
+	return useMemo(
+		() => ( { isModuleActive, isUpdating, toggleModule } ),
+		[ isModuleActive, isUpdating, toggleModule ]
+	);
 }

--- a/projects/packages/publicize/_inc/components/settings-tab/use-toggle-social-module.ts
+++ b/projects/packages/publicize/_inc/components/settings-tab/use-toggle-social-module.ts
@@ -1,0 +1,43 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { getSocialScriptData } from '../../utils';
+
+/**
+ * Enable/disable the Social (Publicize) module from within the modernized
+ * dashboard. Restores an in-product path to toggle the module for hosts where
+ * the wp-admin module-toggles surface is unreachable — e.g. WordPress.com
+ * Atomic sites on the Calypso interface, where Jetpack Settings → Sharing has
+ * no menu entry (see umbrella #48824, which moved product visibility onto that
+ * now-unreachable surface). Reloads on enable so the tabs, connection list and
+ * settings hydrate for the freshly-active module, mirroring the legacy master
+ * toggle.
+ *
+ * @return The module state, a saving flag, and a toggle callback.
+ */
+export default function useToggleSocialModule() {
+	const { isModuleActive, isUpdating } = useSelect( select => {
+		const store = select( socialStore );
+
+		return {
+			isModuleActive: store.getSocialModuleSettings().publicize,
+			isUpdating: store.isSavingSocialModuleSettings(),
+		};
+	}, [] );
+
+	const { updateSocialModuleSettings } = useDispatch( socialStore );
+
+	const toggleModule = useCallback( async () => {
+		const enabling = ! isModuleActive;
+
+		await updateSocialModuleSettings( { publicize: enabling } );
+
+		// Reload when enabling so the connection list and settings hydrate for
+		// the freshly-active module.
+		if ( enabling && ! getSocialScriptData().is_publicize_enabled ) {
+			window.location.reload();
+		}
+	}, [ isModuleActive, updateSocialModuleSettings ] );
+
+	return { isModuleActive, isUpdating, toggleModule };
+}

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -23,6 +23,12 @@ type Props = {
 	activeTab: SocialTab;
 	actions?: ReactNode;
 	children: ReactNode;
+	/**
+	 * Hide the Overview/Settings tab chrome and render `children` on their own.
+	 * Used when Social is off: there's nothing to switch between, so the page
+	 * collapses to the single turn-on surface.
+	 */
+	hideTabs?: boolean;
 };
 
 const PRODUCT_NAME = 'Social'; /** "Social" is a product name, do not translate. */
@@ -48,9 +54,15 @@ const SUBTITLES: Record< SocialTab, () => string > = {
  * @param props.activeTab - Which tab the current route represents.
  * @param props.actions   - Optional actions slot (top-right of the Page header).
  * @param props.children  - `Tabs.Panel` children.
+ * @param props.hideTabs  - Hide the tab chrome and render children on their own.
  * @return The unified Social page shell.
  */
-export default function SocialPage( { activeTab, actions, children }: Props ): JSX.Element {
+export default function SocialPage( {
+	activeTab,
+	actions,
+	children,
+	hideTabs = false,
+}: Props ): JSX.Element {
 	const navigate = useNavigate();
 
 	const { gate, dismissPricing } = useSocialGate();
@@ -59,8 +71,9 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 	// Both the Settings tab and the Overview stats chart require admin-only
 	// capabilities (`manage_options` / stats reads), so non-admins have nothing
 	// to switch between — drop the tab chrome entirely and show the lone
-	// connection-management surface the Overview route hands us.
-	const canManageOptions = currentUserCan( 'manage_options' );
+	// connection-management surface the Overview route hands us. `hideTabs` does
+	// the same when Social is off (single turn-on surface).
+	const showTabs = currentUserCan( 'manage_options' ) && ! hideTabs;
 
 	// Keep the route at `/` and toggle tabs via a `?tab=` search param so the
 	// `Tabs.Root` mounts once and the active-tab indicator can animate.
@@ -89,7 +102,7 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 					actions={ headerActions }
 				>
 					<SocialGate gate={ gate } onDismissPricing={ dismissPricing }>
-						{ canManageOptions ? (
+						{ showTabs ? (
 							<Tabs.Root
 								className="jetpack-social-tabs"
 								value={ activeTab }

--- a/projects/packages/publicize/changelog/add-social-module-dashboard-toggle
+++ b/projects/packages/publicize/changelog/add-social-module-dashboard-toggle
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).
+Social: Enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).

--- a/projects/packages/publicize/changelog/add-social-module-dashboard-toggle
+++ b/projects/packages/publicize/changelog/add-social-module-dashboard-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -82,14 +82,11 @@ const Stage = () => {
 	const [ isEnabling, setIsEnabling ] = useState( false );
 	const turnOn = useCallback( async () => {
 		setIsEnabling( true );
-		try {
-			await updateSocialModuleSettings( { publicize: true } );
-			window.location.reload();
-		} catch {
-			// Enable failed — drop the latch so the user can retry. Surfacing the
-			// error is a follow-up (out of scope for now).
-			setIsEnabling( false );
-		}
+		await updateSocialModuleSettings( { publicize: true } );
+		// `saveEntityRecord` (jetpack/v4) resolves even on API error rather than
+		// throwing, so we always reload here; a failed enable just reloads back
+		// onto this turn-on surface. Surfacing the error is a follow-up.
+		window.location.reload();
 	}, [ updateSocialModuleSettings ] );
 
 	const socialOff = canToggleSocialModule() && ( ! isModuleActive || isEnabling );

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -1,15 +1,17 @@
 import analytics from '@automattic/jetpack-analytics';
 import { currentUserCan, getScriptData } from '@automattic/jetpack-script-data';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSearch } from '@wordpress/route';
 import { Button, Tabs } from '@wordpress/ui';
 import OverviewTab from '../../_inc/components/overview-tab';
 import SettingsTab from '../../_inc/components/settings-tab';
+import { TurnOnSocialProvider } from '../../_inc/components/settings-tab/turn-on-social-context';
 import SocialPage, { type SocialTab } from '../../_inc/components/social-page';
 import { store as socialStore } from '../../_inc/social-store';
+import { canToggleSocialModule } from '../../_inc/utils/misc';
 
 type StageSearch = Record< string, unknown > & {
 	tab?: string;
@@ -61,8 +63,39 @@ const Stage = () => {
 	// chrome for them, and we ignore any stale `?tab=settings` left in the URL.
 	const canManageOptions = currentUserCan( 'manage_options' );
 
+	// When Social is off and this user can turn it on, there are no connections
+	// to manage — so collapse to the Settings tab (which hosts the turn-on
+	// surface), hide the Overview tab, and drop the "Add account" action. Keeps
+	// the user off a dead Overview and out of the enable → Overview → "Add
+	// account points to the editor" friction loop.
+	const isModuleActive = useSelect(
+		select => select( socialStore ).getSocialModuleSettings().publicize,
+		[]
+	);
+
+	// `turnOn` latches `isEnabling` until the reload. We keep the page collapsed
+	// while enabling (`|| isEnabling`) even though the store flips the module on
+	// optimistically — otherwise the dashboard would flash the enabled tabs
+	// during the save, right before reloading. On enable we reload so the tabs,
+	// connection list and settings hydrate; the reload lands on Overview.
+	const { updateSocialModuleSettings } = useDispatch( socialStore );
+	const [ isEnabling, setIsEnabling ] = useState( false );
+	const turnOn = useCallback( async () => {
+		setIsEnabling( true );
+		try {
+			await updateSocialModuleSettings( { publicize: true } );
+			window.location.reload();
+		} catch {
+			// Enable failed — drop the latch so the user can retry. Surfacing the
+			// error is a follow-up (out of scope for now).
+			setIsEnabling( false );
+		}
+	}, [ updateSocialModuleSettings ] );
+
+	const socialOff = canToggleSocialModule() && ( ! isModuleActive || isEnabling );
+
 	const activeTab: SocialTab =
-		canManageOptions && search.tab === 'settings' ? 'settings' : 'overview';
+		socialOff || ( canManageOptions && search.tab === 'settings' ) ? 'settings' : 'overview';
 
 	const actions = activeTab === 'overview' ? <AddAccountAction /> : null;
 
@@ -90,22 +123,33 @@ const Stage = () => {
 		analytics.tracks.recordEvent( 'jetpack_social_tab_view', { tab: activeTab } );
 	}, [ activeTab ] );
 
+	// Social off → the lone turn-on surface; admins → the two tab panels;
+	// non-admins → the bare Overview (connection management) the shell hands us.
+	let content;
+	if ( socialOff ) {
+		content = <SettingsTab />;
+	} else if ( canManageOptions ) {
+		content = (
+			<>
+				<Tabs.Panel value="overview">
+					{ activeTab === 'overview' ? <OverviewTab /> : null }
+				</Tabs.Panel>
+				<Tabs.Panel value="settings">
+					{ activeTab === 'settings' ? <SettingsTab /> : null }
+				</Tabs.Panel>
+			</>
+		);
+	} else {
+		content = <OverviewTab />;
+	}
+
 	return (
 		<QueryClientProvider client={ queryClient }>
-			<SocialPage activeTab={ activeTab } actions={ actions }>
-				{ canManageOptions ? (
-					<>
-						<Tabs.Panel value="overview">
-							{ activeTab === 'overview' ? <OverviewTab /> : null }
-						</Tabs.Panel>
-						<Tabs.Panel value="settings">
-							{ activeTab === 'settings' ? <SettingsTab /> : null }
-						</Tabs.Panel>
-					</>
-				) : (
-					<OverviewTab />
-				) }
-			</SocialPage>
+			<TurnOnSocialProvider value={ { isEnabling, turnOn } }>
+				<SocialPage activeTab={ activeTab } actions={ actions } hideTabs={ socialOff }>
+					{ content }
+				</SocialPage>
+			</TurnOnSocialProvider>
 		</QueryClientProvider>
 	);
 };

--- a/projects/plugins/jetpack/changelog/add-social-module-dashboard-toggle
+++ b/projects/plugins/jetpack/changelog/add-social-module-dashboard-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).

--- a/projects/plugins/jetpack/changelog/add-social-module-dashboard-toggle
+++ b/projects/plugins/jetpack/changelog/add-social-module-dashboard-toggle
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).
+Social: Enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).

--- a/projects/plugins/social/changelog/add-social-module-dashboard-toggle
+++ b/projects/plugins/social/changelog/add-social-module-dashboard-toggle
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).
+Dashboard: Enable or disable Social directly from the dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).

--- a/projects/plugins/social/changelog/add-social-module-dashboard-toggle
+++ b/projects/plugins/social/changelog/add-social-module-dashboard-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: enable or disable the Social module directly from the Social dashboard, so it can be turned back on where Jetpack Settings is unreachable (e.g. WordPress.com Atomic sites).


### PR DESCRIPTION
## Proposed changes

The modernized Social dashboard dropped the in-product master toggle (umbrella #48824) on the assumption that the wp-admin module-toggles surface — Jetpack Settings → Sharing — is always reachable. On WordPress.com Atomic sites using the Calypso interface there's no menu entry for that page, so once the Social (`publicize`) module is off there's no in-product way to turn it back on, and the Settings-tab empty state linked to a page those users can't reach.

This restores an in-product path, scoped by `canToggleSocialModule()` (so WPCOM Simple sites and non-admins are unaffected, and it behaves identically across plan tiers since it no longer depends on a wp-admin menu entry):

* **Settings tab:** the module-off empty state now turns Social on **in place** ("Turn on Social") instead of linking out to `admin.php?page=jetpack#/sharing`. A master on/off card ("Auto-share to social media") is added so the module can also be turned back **off** from within the product.
* **Module off → single turn-on surface:** when Social is off and the user can toggle it, the page collapses to the Settings turn-on surface — the Overview tab and the "Add account" action are hidden (there are no connections to manage yet).
* **No flash on enable:** an `isEnabling` latch keeps the page on the turn-on surface (button busy) until the reload, instead of flashing the enabled tabs while the store optimistically marks the module active.

This partially and deliberately reverses the "no in-product master toggle" decision from #48824 — intended as a scoped fix until My Jetpack is available everywhere. Related prior art: #49640.


https://github.com/user-attachments/assets/cc053aca-af1c-4a00-b178-46e96a4833f3



## Related product discussion/links

* Reported internally during the Social modernization rollout; see umbrella #48824.

## Does this pull request change what data or activity we track or use?

No. No new tracking; the existing `jetpack_social_tab_view` event is unchanged.

## Testing instructions

On a connected site where the modernized Social dashboard is active (the default) and the current user can toggle modules (an admin on a non-WPCOM-Simple site):

1. Turn the Social module off: `wp jetpack module deactivate publicize`.
2. Go to **Jetpack → Social**. Confirm the page collapses to a single surface — **no Overview tab, no "Add account"** — showing *"Auto-sharing is turned off"* with a **Turn on Social** button (previously this linked out to Jetpack Settings → Sharing).
3. Click **Turn on Social**. The button shows *"Turning on Social…"*, the page does **not** flash the enabled tabs, then reloads onto **Overview** with Social enabled.
4. Open the **Settings** tab. Confirm the new **"Auto-share to social media"** toggle is present. Toggle it **off** → the page collapses back to the turn-on surface.
5. As a non-admin (or on a WordPress.com Simple site), confirm none of the above toggle UI appears.

Automated: `jetpack test js packages/publicize` (settings-tab suite covers the empty-state/latch/toggle gating).
