### PR TITLE
Premium Analytics: show Stats menu alongside Analytics

### DIFF
--- a/projects/packages/premium-analytics/changelog/show-stats-menu
+++ b/projects/packages/premium-analytics/changelog/show-stats-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: keep the standalone Jetpack "Stats" menu visible so Analytics and Stats appear side by side.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -127,9 +127,6 @@ class Analytics {
 		}
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
-		// Remove the standalone Jetpack "Stats" menu so Premium Analytics takes its
-		// place. Runs after Stats registers itself (admin_menu priority 999).
-		add_action( 'admin_menu', array( static::class, 'remove_stats_menu' ), 1001 );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'ensure_script_data' ) );
 	}
@@ -187,20 +184,6 @@ class Analytics {
 			'dashicons-chart-bar',
 			2
 		);
-	}
-
-	/**
-	 * Remove the standalone Jetpack "Stats" top-level menu so Premium Analytics
-	 * replaces it, but only when Stats actually registered its menu.
-	 *
-	 * @return void
-	 */
-	public static function remove_stats_menu() {
-		if ( ! isset( $GLOBALS['admin_page_hooks']['stats'] ) ) {
-			return;
-		}
-
-		remove_menu_page( 'stats' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Premium Analytics currently hides the standalone Jetpack **Stats** admin menu so it takes Stats' place. This PR removes that behavior so **Analytics** and **Stats** are both shown as separate top-level menu items (one below the other).

## Changes

- Removed the `admin_menu` hook (priority 1001) that called `remove_stats_menu()`.
- Removed the now-unused `remove_stats_menu()` method, which invoked `remove_menu_page( 'stats' )`.

Analytics continues to register its own top-level menu (`jetpack-premium-analytics-wp-admin`) unchanged. The Stats menu now registers and displays normally.

## Testing

- `php -l` passes on the modified file.
- On a site with Premium Analytics active, both **Analytics** and **Stats** should now appear in the wp-admin sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnuhF2ZWMPurcZwzymXUYs