### PR TITLE
CLI build: gate timing summary behind a separate --timing-summary flag

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -70,7 +70,11 @@ export function builder( yargs ) {
 		} )
 		.option( 'timing', {
 			type: 'boolean',
-			description: 'Output timing information.',
+			description: 'Output per-line/per-task timing information during the build.',
+		} )
+		.option( 'timing-summary', {
+			type: 'boolean',
+			description: 'Print an aggregated phase-level timing summary table at the end of the build.',
 		} )
 		.option( 'use-uncommitted-composer-lock', { type: 'boolean', hidden: true } )
 		.option( 'no-use-uncommitted-composer-lock', {
@@ -80,7 +84,8 @@ export function builder( yargs ) {
 		.option( 'timing-output', {
 			type: 'string',
 			normalize: true,
-			description: 'Write machine-readable timing data (JSON) to the given file. Implies --timing.',
+			description:
+				'Write machine-readable timing data (JSON) to the given file. Implies --timing-summary.',
 		} );
 }
 
@@ -103,7 +108,7 @@ export async function handler( argv ) {
 
 	// `--timing-output` writes JSON, which requires the timing data to be collected.
 	if ( argv.timingOutput ) {
-		argv.timing = true;
+		argv.timingSummary = true;
 	}
 
 	let dependencies = await getDependencies( process.cwd(), 'build' );
@@ -233,8 +238,8 @@ export async function handler( argv ) {
 		promises: {},
 		mirrorMutex: pLimit( 1 ),
 		versions: {},
-		// When `--timing` is set, collect a flat list of phase timings to summarize at the end.
-		timings: argv.timing ? { overallStart: Date.now(), entries: [], buildOrder } : null,
+		// When `--timing-summary` is set, collect a flat list of phase timings to summarize at the end.
+		timings: argv.timingSummary ? { overallStart: Date.now(), entries: [], buildOrder } : null,
 	};
 	await listr
 		.run( ctx )


### PR DESCRIPTION
## Proposed changes

Splits the `jetpack build` CLI's single `--timing` flag into two independent flags so the aggregated timing summary table is no longer printed as a side effect of enabling timestamped build output.

* **`--timing`** (unchanged behavior) — live per-line / per-task timing during the build: the timestamp prefix on streamed output lines, the per-task duration shown in the status line, and the abort-line prefix.
* **`--timing-summary`** (new) — gates the aggregated phase-level summary table printed at the end of the build (the `ctx.timings` collection + `printTimingSummary()`).
* **`--timing-output`** now implies `--timing-summary` instead of `--timing`, since the JSON report is built from the summary's collected timing data.
* **Mirror builds** (`--for-mirrors`) still force `--timing` on (so mirror/CI logs keep their timestamps) but no longer force the summary table.

### Why

Mirror builds force timing on, and under the old single flag that also printed the full phase-level summary table at the end of the build. When a build failed in CI, that summary table was printed *after* the failure, pushing the actual build failure down and out of easy view in the logs — making failures hard to spot. Separating the summary into its own opt-in flag means CI mirror builds no longer emit it, so the build failure stays visible at the end of the output. The summary table now only appears when explicitly requested with `--timing-summary`.

## Related product discussion/links

* Fixes [JETPACK-1855: Show build failure before timing output](https://linear.app/a8c/issue/JETPACK-1855/show-build-failure-before-timing-output)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jetpack build jetpack --help` — confirm both `--timing` and `--timing-summary` are listed, and that `--timing-output` notes it implies `--timing-summary`.
* `jetpack build <project> --timing` — build output shows per-line/per-task timestamps, and **no** summary table is printed at the end.
* `jetpack build <project> --timing-summary` — the aggregated phase-level summary table prints at the end.
* `jetpack build <project> --timing-output=/tmp/t.json` — the JSON file is written and the summary table prints (timing-output implies --timing-summary).
* To confirm the fix: run a mirror-style build that fails (e.g. `jetpack build <project> --for-mirrors=<empty-dir>` with a failing build) and verify the build failure appears at the end of the output, no longer followed by the timing summary table.
* `cd tools/cli && NODE_OPTIONS=--experimental-vm-modules pnpm jest` — unit tests pass (167 passed).
