### PR TITLE
Feedback: parse versionless JSON post_content as JSON

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-versionless-json
+++ b/projects/packages/forms/changelog/fix-feedback-versionless-json
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Feedback: parse versionless JSON post_content as JSON instead of falling through to the legacy plain-text parser.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1601,7 +1601,48 @@ class Feedback {
 		if ( $version === 'v2' ) {
 			return $this->parse_content_v2( $post_content );
 		}
+
+		// Some feedback posts store JSON content without a version marker
+		// (empty post_mime_type). Parse those as the current (v3) format instead
+		// of falling through to the legacy plain-text parser.
+		if ( self::is_json( $post_content ) ) {
+			$decoded_content = json_decode( $post_content, true );
+			if ( $decoded_content === null ) {
+				// Content may be slash-escaped as stored by WordPress; retry,
+				// mirroring the fallback used by the v2/v3 parsers.
+				$decoded_content = json_decode( stripslashes( trim( $post_content ) ), true );
+			}
+			if ( isset( $decoded_content['fields'] ) && is_array( $decoded_content['fields'] ) ) {
+				return $this->parse_content_v3( $post_content );
+			}
+		}
+
 		return $this->parse_legacy_content( $post_content );
+	}
+
+	/**
+	 * Check whether a string looks like and decodes as valid JSON.
+	 *
+	 * Accepts slash-escaped JSON (as WordPress may store it), mirroring the
+	 * stripslashes fallback used by the v2/v3 parsers.
+	 *
+	 * @param string $string The string to test.
+	 * @return bool True if the string is a JSON object or array.
+	 */
+	private static function is_json( $string ) {
+		if ( ! is_string( $string ) || $string === '' ) {
+			return false;
+		}
+		$string = trim( $string );
+		if ( ! str_starts_with( $string, '{' ) && ! str_starts_with( $string, '[' ) ) {
+			return false;
+		}
+		json_decode( $string );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return true;
+		}
+		json_decode( stripslashes( $string ) );
+		return json_last_error() === JSON_ERROR_NONE;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1637,12 +1637,12 @@ class Feedback {
 		if ( ! str_starts_with( $string, '{' ) && ! str_starts_with( $string, '[' ) ) {
 			return false;
 		}
-		json_decode( $string );
-		if ( json_last_error() === JSON_ERROR_NONE ) {
+		$decoded = json_decode( $string );
+		if ( $decoded !== null && json_last_error() === JSON_ERROR_NONE ) {
 			return true;
 		}
-		json_decode( stripslashes( $string ) );
-		return json_last_error() === JSON_ERROR_NONE;
+		$decoded = json_decode( stripslashes( $string ) );
+		return $decoded !== null && json_last_error() === JSON_ERROR_NONE;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
@@ -434,6 +434,29 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Feedback whose post_content is JSON but has no version marker (empty
+	 * post_mime_type) should be parsed as JSON, not run through the legacy
+	 * plain-text parser.
+	 */
+	public function test_versionless_json_content_is_parsed_as_json() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Feedback::POST_TYPE,
+				'post_title'   => 'Versionless JSON Feedback',
+				'post_content' => '{"subject":"Contact us!","entry_title":"Contact us!","entry_page":1,"fields":[{"key":"1_name","label":"Name","value":"Jane Doe","type":"name","meta":[],"form_field_id":"g1-name"},{"key":"2_email","label":"Email","value":"jane@example.com","type":"email","meta":[],"form_field_id":"g1-email"}]}',
+				'post_status'  => 'publish',
+				// Intentionally NO post_mime_type -> versionless.
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+		$this->assertSame( 'Contact us!', $response->get_subject() );
+		$this->assertSame( 'Jane Doe', $response->get_field_value_by_label( 'Name' ) );
+		$this->assertSame( 'jane@example.com', $response->get_field_value_by_label( 'Email' ) );
+	}
+
+	/**
 	 * Test that new lines are not stripped from the field value.
 	 */
 	public function test_new_lines_dont_get_stripped() {


### PR DESCRIPTION
## Proposed changes

Feedback posts store their submission data in `post_content`, and `Feedback::parse_content()` picks a parser based on the post's `post_mime_type` (`v3`, `v2`, or absent). When the version marker is absent it fell straight through to the **legacy plain-text parser** — but some feedback posts store **JSON** content with no version marker (empty `post_mime_type`). Those were being garbled by the legacy parser.

* `parse_content()` now detects versionless-but-JSON `post_content` and routes it to the current (v3) JSON parser instead of the legacy parser. Non-JSON content still falls through to legacy as before.
* Added a private `is_json()` helper (native `str_starts_with()` prefix check + `json_decode`). It tolerates slash-escaped JSON as WordPress may store it, mirroring the existing `stripslashes` fallback in the v2/v3 parsers.
* Note: v2 and v3 JSON are byte-identical at the top level (the difference is per-field unicode handling inside `Feedback_Field`), so versionless JSON cannot be distinguished by shape and defaults to v3, the current canonical format. v2 remains reachable only via an explicit `post_mime_type = 'v2'`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the forms package test:
  ```
  composer --working-dir=projects/packages/forms phpunit -- --filter test_versionless_json_content_is_parsed_as_json
  ```
* New test `Feedback_Data_Integrity_Test::test_versionless_json_content_is_parsed_as_json` inserts a feedback post with JSON `post_content` and **no** `post_mime_type`, then asserts the subject and field values parse correctly (proving it no longer goes through the legacy parser).
* The pre-existing failures in `Feedback_Data_Integrity_Test.php` (notification-recipients / radio-validation) are unrelated to this change and also fail on `trunk`.
