### PR TITLE
Masterbar: make sidebar notice dismiss icon adapt to its background

### DIFF
--- a/projects/packages/masterbar/changelog/fix-jitm-sidebar-dismiss-icon-contrast
+++ b/projects/packages/masterbar/changelog/fix-jitm-sidebar-dismiss-icon-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sidebar notice: Fix the dismiss icon being invisible against the dark admin menu background.

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -126,6 +126,10 @@
 	height: 24px;
 	width: 24px;
 	margin-left: 10px;
+
+	/* Track the banner's text color: the banner sits on a light card when a color
+	   scheme sets one, and on the dark admin menu otherwise. */
+	fill: currentColor;
 }
 
 @media screen and (min-width: 782px) {

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -126,9 +126,6 @@
 	height: 24px;
 	width: 24px;
 	margin-left: 10px;
-
-	/* Track the banner's text color: the banner sits on a light card when a color
-	   scheme sets one, and on the dark admin menu otherwise. */
 	fill: currentColor;
 }
 


### PR DESCRIPTION
## Proposed changes

* The dismiss "×" on the wp-admin sidebar notice (the JITM upsell banner) is an inline SVG with no `fill`, so it always painted black. It only looked right because the per-color-scheme stylesheet gives the banner a white card background — and that stylesheet is enqueued conditionally. When it doesn't apply, the banner falls through to the dark admin menu and the icon becomes invisible.
* Fill the icon with `currentColor` so it tracks the banner's own text color instead of hardcoding black. On the white card it stays black; on the dark admin menu it picks up the sidebar's light text color.

Note that this only addresses the dismiss icon. It does not change the banner's own background or text colors.

## Related product discussion/links

* Reported internally: the email upsell nudge in wp-admin rendered with an unreadable dismiss control.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site that shows the sidebar upsell nudge in wp-admin (an Atomic or WordPress.com site with a `calypso:sites:sidebar_notice` JITM active), open any wp-admin screen and look at the nudge at the top of the admin sidebar.
* Confirm the dismiss "×" at the right edge of the banner is clearly visible, and that clicking it still dismisses the notice.
* Check it under a few admin color schemes (Users → Profile → Admin Color Scheme), including at least one dark scheme such as Midnight or Nightfall, and one where the banner renders directly against the dark sidebar rather than on a white card.
* Before this change the icon was black-on-dark and effectively invisible in the latter case; after it, it inherits the sidebar's light text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
