### PR TITLE
Premium Analytics: remove legend from VideoPress widget leaderboard

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-videopress-widget-remove-legend
+++ b/projects/packages/premium-analytics/changelog/update-videopress-widget-remove-legend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress widget: remove the legend from the video plays leaderboard.

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -7,7 +7,6 @@ import {
 	WidgetRoot,
 	WidgetState,
 	calculateDelta,
-	formatLegendLabels,
 	toMaxRows,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -124,8 +123,6 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 		[ rows, withComparison ]
 	);
 
-	const legendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
-
 	return (
 		<WidgetState
 			isLoading={ isInitialLoading }
@@ -151,8 +148,7 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 				data={ chartData }
 				withComparison={ withComparison }
 				withOverlayLabel
-				showLegend={ withComparison }
-				legendLabels={ legendLabels }
+				showLegend={ false }
 				dataFormat={ {
 					type: 'number',
 					options: { useMultipliers: true, decimals: 0 },


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to #50311. During review, [it was suggested](https://github.com/Automattic/jetpack/pull/50311#discussion_r3553148423) that the comparison legend doesn't belong on the VideoPress video plays leaderboard — each row already shows its own period-over-period delta, so the legend adds noise without information.

* Remove the legend from the `jpa/videopress` widget's `LeaderboardChart` (`showLegend={ false }`, matching the other leaderboard widgets like Referrers and Clicks).
* Drop the now-unused `formatLegendLabels` wiring from the widget's render component.

## Related product discussion/links

* WOOA7S-1519
* Follow-up to #50311

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open Storybook → **Packages / Premium Analytics / Widgets / VideoPress** → `WithComparison`.
* The leaderboard should render the per-row deltas but no legend row above/below the chart.
* `Default` and the dashboard story are unchanged.
* `pnpm jest --config=tests/jest.config.cjs widgets/videopress` passes (9 tests).

<img width="589" height="828" alt="Screenshot 2026-07-10 at 10 38 05 AM" src="https://github.com/user-attachments/assets/e8b83f45-8703-4579-b797-f608ddd10234" />
