### PR TITLE
Premium Analytics: replace dashboard page title with breadcrumbs

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-replace-title-by-breadcrumbs
+++ b/projects/packages/premium-analytics/changelog/update-replace-title-by-breadcrumbs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace the Analytics dashboard page title with breadcrumbs.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,7 +1,7 @@
 import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { Page } from '@wordpress/admin-ui';
+import { Page, Breadcrumbs } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -78,7 +78,9 @@ function Dashboard(): JSX.Element {
 				onEditChange={ setEditMode }
 			>
 				<Page
-					title={ __( 'Analytics', 'jetpack-premium-analytics' ) }
+					breadcrumbs={
+						<Breadcrumbs items={ [ { label: __( 'Analytics', 'jetpack-premium-analytics' ) } ] } />
+					}
 					subTitle={ __(
 						'Track your site performance and visitor insights.',
 						'jetpack-premium-analytics'


### PR DESCRIPTION
Fixes WOOA7S-1686

## Proposed changes

* On the Analytics dashboard page, replace the `<Page title>` prop with the `breadcrumbs` prop, rendering an `@wordpress/admin-ui` `<Breadcrumbs>` with a single "Analytics" item.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package: `jetpack build --deps packages/premium-analytics`
* Go to wp-admin → **Analytics** (`admin.php?page=jetpack-premium-analytics`)
* Confirm the page header renders "Analytics" as a breadcrumb instead of the previous plain page title, with the "Track your site performance and visitor insights." subtitle still below it.

<img width="639" height="312" alt="image" src="https://github.com/user-attachments/assets/1e613de2-8143-425d-8427-7c9ad1f3b677" />
