### PR TITLE
Premium Analytics: migrate All-time stats metrics to array attribute

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-all-time-stats-metrics-field
+++ b/projects/packages/premium-analytics/changelog/update-all-time-stats-metrics-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+All-time stats: Define the visible metrics as a metrics array attribute with an inline header control.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/package.json
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/fields": "link:../../packages/fields",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",

--- a/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
@@ -16,7 +16,12 @@ import { useMemo } from 'react';
  * Internal dependencies
  */
 import styles from './style.module.css';
-import type { AllTimeStatsAttributes } from './widget';
+import {
+	ALL_TIME_STATS_METRICS,
+	DEFAULT_ALL_TIME_STATS_METRICS,
+	type AllTimeStatsAttributes,
+	type AllTimeStatsMetricId,
+} from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 // The host (and Storybook) may inject report params via `attributes`, but the
@@ -37,14 +42,24 @@ const COUNT_FORMAT = {
 	options: { decimals: 0 },
 };
 
-// Lifetime totals shown, in display order, each keyed to its summary field and
-// Stats icon. Rows whose field is absent from the response are skipped.
-const ROWS = [
-	{ key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ), icon: seen },
-	{ key: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics' ), icon: people },
-	{ key: 'posts', label: __( 'Posts', 'jetpack-premium-analytics' ), icon: postContent },
-	{ key: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ), icon: comment },
-] as const;
+/**
+ * Render-only config per metric: the row icon. Ids and labels are shared with
+ * the settings checkboxes via `ALL_TIME_STATS_METRICS` in `widget.ts`; the id
+ * doubles as the summary field the row reads.
+ */
+const ROW_CONFIG: Record< AllTimeStatsMetricId, { icon: typeof seen } > = {
+	views: { icon: seen },
+	visitors: { icon: people },
+	posts: { icon: postContent },
+	comments: { icon: comment },
+};
+
+type AllTimeStatsRow = {
+	key: AllTimeStatsMetricId;
+	label: string;
+	icon: typeof seen;
+	value: number;
+};
 
 /**
  * Reads a numeric summary field, returning `undefined` when the key is absent
@@ -63,25 +78,41 @@ function readCount( summary: StatsSummary | undefined, key: string ): number | u
 
 /**
  * Fetches the all-time site summary through the designated `useStatsSite` hook
- * and renders the lifetime totals as a labelled list of icon rows. Only fields
- * present in the response are shown. There is no comparison period for this
- * module, so each value renders as a bare number.
+ * and renders the lifetime totals as a labelled list of icon rows. Which rows
+ * appear is controlled by the `metrics` attribute; fields absent from the
+ * response are skipped. There is no comparison period for this module, so each
+ * value renders as a bare number.
  *
+ * @param {AllTimeStatsMetricId[]} metrics - Enabled metric row ids.
  * @return The widget content.
  */
-function AllTimeStatsReport() {
+function AllTimeStatsReport( {
+	metrics = DEFAULT_ALL_TIME_STATS_METRICS,
+}: {
+	metrics?: AllTimeStatsMetricId[];
+} ) {
 	// The summary is all-time, so the query takes no date params — its key stays
 	// stable across dashboard date-range and comparison changes.
 	const { data, isLoading, isError } = useStatsSite();
 
 	const summary = ( data as { stats?: StatsSummary } | undefined )?.stats;
 
+	// Resolve selected ids against the canonical definitions so the row order
+	// stays stable regardless of the order the ids were toggled in.
+	const enabledMetrics = useMemo( () => {
+		const selected = new Set( metrics );
+		return ALL_TIME_STATS_METRICS.filter( metric => selected.has( metric.id ) );
+	}, [ metrics ] );
+
 	const rows = useMemo(
 		() =>
-			ROWS.map( row => ( { ...row, value: readCount( summary, row.key ) } ) ).filter(
-				( row ): row is ( typeof ROWS )[ number ] & { value: number } => row.value !== undefined
-			),
-		[ summary ]
+			enabledMetrics.flatMap( ( { id, label } ): AllTimeStatsRow[] => {
+				const value = readCount( summary, id );
+				return value === undefined
+					? []
+					: [ { key: id, label, icon: ROW_CONFIG[ id ].icon, value } ];
+			} ),
+		[ enabledMetrics, summary ]
 	);
 
 	let content;
@@ -96,7 +127,11 @@ function AllTimeStatsReport() {
 	} else if ( rows.length === 0 ) {
 		content = (
 			<div className={ styles.state }>
-				<Text>{ __( 'No stats recorded yet.', 'jetpack-premium-analytics' ) }</Text>
+				<Text>
+					{ enabledMetrics.length === 0
+						? __( 'Select at least one metric to display.', 'jetpack-premium-analytics' )
+						: __( 'No stats recorded yet.', 'jetpack-premium-analytics' ) }
+				</Text>
 			</div>
 		);
 	} else {
@@ -137,7 +172,7 @@ function AllTimeStatsReport() {
 export default function AllTimeStats( { attributes = {} }: AllTimeStatsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<AllTimeStatsReport />
+			<AllTimeStatsReport metrics={ attributes.metrics } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -22,32 +22,65 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import AllTimeStatsRender from '../render';
-import widgetDefinition from '../widget';
+import widgetDefinition, {
+	DEFAULT_ALL_TIME_STATS_METRICS,
+	type AllTimeStatsMetricId,
+} from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const ALL_TIME_STATS_RENDER_MODULE = 'storybook/all-time-stats';
 
+// Carry the widget's metadata, including the metric-visibility attribute schema
+// so the dashboard story's settings drawer renders the real checkboxes. The
+// attribute schema is typed loosely on the widget definition, so it is cast to
+// the WidgetType shape.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
+};
+
 interface AllTimeStatsStoryControls {
 	/**
 	 * Whether to include comparison report params.
 	 */
 	withComparison: boolean;
+	/**
+	 * Lifetime totals to show in the widget body.
+	 */
+	metrics: AllTimeStatsMetricId[];
 }
+
+const METRIC_ARG_TYPES = {
+	metrics: {
+		control: 'check',
+		options: DEFAULT_ALL_TIME_STATS_METRICS,
+	},
+} as const;
+
+const ALL_METRICS_ARGS = {
+	metrics: DEFAULT_ALL_TIME_STATS_METRICS,
+} as const;
 
 /**
  * Renders the data-connected widget with report params derived from the
- * date-range picker preset.
+ * date-range picker preset and the selected metrics.
  *
  * @param {AllTimeStatsStoryControls} props - The story controls.
  * @return The rendered widget.
  */
-function renderAllTimeStats( { withComparison }: AllTimeStatsStoryControls ) {
+function renderAllTimeStats( { withComparison, metrics }: AllTimeStatsStoryControls ) {
 	return (
-		<AllTimeStatsRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
+		<AllTimeStatsRender
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
+		/>
 	);
 }
 
@@ -64,12 +97,13 @@ const meta = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a labelled list of icon rows, sourced from the Jetpack Stats site-summary endpoint. This module has no comparison period, so the values render as bare numbers and the `WithComparison` story looks identical to `Default`.',
+					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a labelled list of icon rows, sourced from the Jetpack Stats site-summary endpoint. Which rows appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. This module has no comparison period, so the values render as bare numbers and the `WithComparison` story looks identical to `Default`.',
 			},
 		},
 	},
@@ -84,7 +118,7 @@ type Story = StoryObj< AllTimeStatsStoryControls >;
  */
 export const Default: Story = {
 	render: renderAllTimeStats,
-	args: { withComparison: false },
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -95,7 +129,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderAllTimeStats,
-	args: { withComparison: true },
+	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -112,20 +146,16 @@ interface AllTimeStatsDashboardStoryProps
  */
 function AllTimeStatsDashboardStory( {
 	withComparison,
+	metrics,
 	...dashboardArgs
 }: AllTimeStatsDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ {
-				name: widgetDefinition.name,
-				title: widgetDefinition.title,
-				icon: widgetDefinition.icon,
-				presentation: 'framed',
-			} }
+			widgetType={ storyWidgetType }
 			renderModule={ ALL_TIME_STATS_RENDER_MODULE }
 			renderComponent={ AllTimeStatsRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
 		/>
 	);
 }
@@ -135,9 +165,11 @@ export const WidgetDashboardWithWidget: StoryObj< AllTimeStatsDashboardStoryProp
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
+		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -3,28 +3,80 @@
  */
 import { __ } from '@wordpress/i18n';
 import { trendingUp } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
- * The widget has no user-configurable attributes, and it does not read the
- * dashboard date range: the site summary is all-time, so `useStatsSite()` is
- * queried without report params. Host-injected `attributes.reportParams` still
- * flow into WidgetRoot for parity with the other Stats widgets, but they do not
- * affect what this widget fetches or shows.
+ * Internal dependencies
  */
-export type AllTimeStatsAttributes = Record< never, never >;
+import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
+
+/**
+ * The lifetime totals the widget can show, in display order: the persisted id
+ * and label of each metric. Single source for the settings checkboxes and the
+ * rendered rows so the two cannot drift apart; `render.tsx` maps the ids to
+ * icons and summary fields.
+ */
+export const ALL_TIME_STATS_METRICS = [
+	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics' ) },
+	{ id: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics' ) },
+	{ id: 'posts', label: __( 'Posts', 'jetpack-premium-analytics' ) },
+	{ id: 'comments', label: __( 'Comments', 'jetpack-premium-analytics' ) },
+] as const satisfies readonly { id: string; label: string }[];
+
+/**
+ * Identifier persisted in the widget's `metrics` attribute for one total row.
+ * Each id doubles as the summary field the row reads.
+ */
+export type AllTimeStatsMetricId = ( typeof ALL_TIME_STATS_METRICS )[ number ][ 'id' ];
+
+/**
+ * Configurable attributes for the All-time stats widget. The widget does not
+ * read the dashboard date range: the site summary is all-time, so
+ * `useStatsSite()` is queried without report params. Host-injected
+ * `attributes.reportParams` still flow into WidgetRoot for parity with the
+ * other Stats widgets.
+ */
+export type AllTimeStatsAttributes = {
+	/**
+	 * Lifetime totals to show in the widget body.
+	 */
+	metrics?: AllTimeStatsMetricId[];
+};
+
+/**
+ * Default selection for new widget instances: every metric enabled.
+ */
+export const DEFAULT_ALL_TIME_STATS_METRICS: AllTimeStatsMetricId[] = ALL_TIME_STATS_METRICS.map(
+	metric => metric.id
+);
 
 /**
  * Widget type definition.
  *
  * Ported from the Jetpack Stats "All-time stats" card: a labelled list of
- * lifetime totals — views, visitors, posts, and comments.
+ * lifetime totals — views, visitors, posts, and comments. `example.attributes`
+ * doubles as the defaults applied to new instances: every metric enabled.
  */
 export default {
 	name: 'jpa/all-time-stats',
 	title: __( 'All-time stats', 'jetpack-premium-analytics' ),
-	description: __(
-		'Show lifetime totals for your site: views, visitors, posts, and comments.',
-		'jetpack-premium-analytics'
-	),
 	icon: trendingUp,
+	attributes: [
+		{
+			id: 'metrics',
+			label: __( 'Metrics', 'jetpack-premium-analytics' ),
+			type: 'array',
+			relevance: 'high',
+			Edit: ArrayCheckboxField,
+			elements: ALL_TIME_STATS_METRICS.map( metric => ( {
+				value: metric.id,
+				label: metric.label,
+			} ) ),
+		},
+	] as WidgetAttributeField< AllTimeStatsAttributes >[],
+	example: {
+		attributes: {
+			metrics: DEFAULT_ALL_TIME_STATS_METRICS,
+		},
+	},
 };


### PR DESCRIPTION
Fixes WOOA7S-1684

## Proposed changes
* Declare a `metrics` array attribute on the All-time stats widget (`Edit: ArrayCheckboxField`, `relevance: 'high'`), keyed by persistable ids (`views`, `visitors`, `posts`, `comments`) that double as the summary fields each row reads. The widget previously declared no attributes. `example.attributes` doubles as the defaults for new instances (all metrics enabled).
* Resolve the selected ids against `ALL_TIME_STATS_METRICS` in `render.tsx` so the row order stays canonical; a missing attribute renders all rows, and rows whose summary field is absent keep being skipped.
* Show a "Select at least one metric" message when the selection is empty, distinct from the existing "No stats recorded yet" state.
* Stories: add a `metrics` check control and pass the real attribute schema so the dashboard story's settings drawer renders the actual checkboxes.
* Drop the redundant `description` from `widget.ts`: `widget.json` is the source of truth for static widget metadata, and the two copies had already drifted apart.

## Related product discussion/links
* https://linear.app/a8c/issue/WOOA7S-1684/migrate-all-time-stats-metric-tiles-to-array-attribute
* Follows WOOA7S-1669 (Annual highlights), WOOA7S-1682 (Store performance), and WOOA7S-1683 (Subscriber highlights).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Build Premium Analytics with dependencies: `jp build packages/premium-analytics --deps`
2. Open the Premium Analytics dashboard and add or edit an **All-time stats** widget.
3. In the widget header, confirm the **Metrics** control appears inline as a compact menu with checkboxes for Views, Visitors, Posts, and Comments.
4. Toggle metrics and verify the widget body shows/hides the matching rows.
5. Uncheck all metrics and confirm the "Select at least one metric to display." message.
6. Open the widget settings drawer and confirm the same metrics appear as a vertical checkbox list.
7. Add a new widget instance and confirm all four metrics are selected by default.
